### PR TITLE
Pass mDNS/DNS address cache to esphome CLI on OTA

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -39,17 +39,12 @@ StateChangeCallback = Callable[[str, DeviceState, str], None]
 # Empty string signals the device went offline / was removed from mDNS.
 IPChangeCallback = Callable[[str, str], None]
 
-# Callback fired when mDNS reports a new ESPHome version for a device
-# (i.e. the ``version`` TXT record on the ``_esphomelib._tcp.local.``
-# announcement). Lets the controller refresh ``StorageJSON`` so the
-# stored "deployed" version reflects what's actually running on the
-# device — important when devices were OTA-updated outside this
-# dashboard or flashed from another tool.
+# Callback fired when the mDNS ``version`` TXT record reports a
+# different firmware version than last seen for a device.
 VersionChangeCallback = Callable[[str, str], None]
 
-# TXT record key carrying the ESPHome firmware version on the device.
-# Bytes literal because zeroconf hands us raw bytes from the mDNS
-# packet; we decode at the call site.
+# zeroconf hands us raw bytes for TXT keys; declared once so the
+# call site can decode without re-typing the key.
 _TXT_RECORD_VERSION = b"version"
 
 
@@ -154,12 +149,10 @@ class DeviceStateMonitor:
 
     def apply_version(self, name: str, version: str) -> bool:
         """
-        Record a firmware version observation from mDNS.
+        Record a firmware version observation.
 
-        Same dedup pattern as ``apply_ip``: only forward when the value
-        actually changed. The owning controller is responsible for
-        persisting the new version (e.g. updating ``StorageJSON``) and
-        emitting a UI event.
+        Returns True when the version actually changed and the change
+        was forwarded to the callback.
         """
         if not version or self._on_version_change is None:
             return False
@@ -172,12 +165,11 @@ class DeviceStateMonitor:
         return True
 
     def get_cached_addresses(self, host_name: str) -> list[str] | None:
-        """Return zeroconf-cached IPs for *host_name* without triggering a query.
+        """
+        Return zeroconf-cached IPs for *host_name* without issuing a query.
 
-        Mirrors ``MDNSStatus.get_cached_addresses`` in the legacy dashboard:
-        consult the zeroconf cache only — do not initiate a network resolve.
-        Returns ``None`` when zeroconf isn't running, the cache misses, or
-        the entry has expired.
+        Returns ``None`` when zeroconf isn't running, the cache misses,
+        or the entry has expired.
         """
         if self._zeroconf is None:
             return None
@@ -258,15 +250,7 @@ class DeviceStateMonitor:
     async def _resolve_and_apply(
         self, zeroconf: Any, service_type: str, name: str, device_name: str
     ) -> None:
-        """Mark the device online and pull IP + firmware version from mDNS.
-
-        The ``_esphomelib._tcp.local.`` announcement carries a ``version``
-        TXT record with the firmware version actually running on the
-        device. This is the source of truth for what's deployed —
-        ``StorageJSON.esphome_version`` only knows what the dashboard
-        last compiled, which can disagree with reality after an
-        out-of-band OTA or a reflash from another tool.
-        """
+        """Mark the device online and pull IP + firmware version from mDNS."""
         # State first — even if the resolve fails or times out, we know the device is online.
         self.apply(device_name, DeviceState.ONLINE, "mdns")
 

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -39,6 +39,19 @@ StateChangeCallback = Callable[[str, DeviceState, str], None]
 # Empty string signals the device went offline / was removed from mDNS.
 IPChangeCallback = Callable[[str, str], None]
 
+# Callback fired when mDNS reports a new ESPHome version for a device
+# (i.e. the ``version`` TXT record on the ``_esphomelib._tcp.local.``
+# announcement). Lets the controller refresh ``StorageJSON`` so the
+# stored "deployed" version reflects what's actually running on the
+# device — important when devices were OTA-updated outside this
+# dashboard or flashed from another tool.
+VersionChangeCallback = Callable[[str, str], None]
+
+# TXT record key carrying the ESPHome firmware version on the device.
+# Bytes literal because zeroconf hands us raw bytes from the mDNS
+# packet; we decode at the call site.
+_TXT_RECORD_VERSION = b"version"
+
 
 class DeviceStateMonitor:
     """
@@ -55,12 +68,15 @@ class DeviceStateMonitor:
         get_devices: Callable[[], list[Device]],
         on_state_change: StateChangeCallback,
         on_ip_change: IPChangeCallback,
+        on_version_change: VersionChangeCallback | None = None,
     ) -> None:
         self._get_devices = get_devices
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
+        self._on_version_change = on_version_change
         self._state_source: dict[str, str] = {}  # device name → "mdns" | "ping"
         self._device_ips: dict[str, str] = {}  # device name → last known IP
+        self._device_versions: dict[str, str] = {}  # device name → last reported version
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         self._mdns_browser: Any = None
         self._ping_task: asyncio.Task | None = None
@@ -136,6 +152,49 @@ class DeviceStateMonitor:
         self._on_ip_change(name, ip)
         return True
 
+    def apply_version(self, name: str, version: str) -> bool:
+        """
+        Record a firmware version observation from mDNS.
+
+        Same dedup pattern as ``apply_ip``: only forward when the value
+        actually changed. The owning controller is responsible for
+        persisting the new version (e.g. updating ``StorageJSON``) and
+        emitting a UI event.
+        """
+        if not version or self._on_version_change is None:
+            return False
+        if self._find_device_by_name(name) is None:
+            return False
+        if self._device_versions.get(name) == version:
+            return False
+        self._device_versions[name] = version
+        self._on_version_change(name, version)
+        return True
+
+    def get_cached_addresses(self, host_name: str) -> list[str] | None:
+        """Return zeroconf-cached IPs for *host_name* without triggering a query.
+
+        Mirrors ``MDNSStatus.get_cached_addresses`` in the legacy dashboard:
+        consult the zeroconf cache only — do not initiate a network resolve.
+        Returns ``None`` when zeroconf isn't running, the cache misses, or
+        the entry has expired.
+        """
+        if self._zeroconf is None:
+            return None
+        try:
+            from zeroconf import AddressResolver, IPVersion
+        except ImportError:
+            return None
+
+        normalized = host_name.rstrip(".").lower()
+        base_name = normalized.partition(".")[0]
+        resolver_name = f"{base_name}.local."
+        info = AddressResolver(resolver_name)
+        if not info.load_from_cache(self._zeroconf.zeroconf):
+            return None
+        addresses = info.parsed_scoped_addresses(IPVersion.All)
+        return addresses or None
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
@@ -199,7 +258,15 @@ class DeviceStateMonitor:
     async def _resolve_and_apply(
         self, zeroconf: Any, service_type: str, name: str, device_name: str
     ) -> None:
-        """Mark the device online and try to resolve its IPv4 address from mDNS."""
+        """Mark the device online and pull IP + firmware version from mDNS.
+
+        The ``_esphomelib._tcp.local.`` announcement carries a ``version``
+        TXT record with the firmware version actually running on the
+        device. This is the source of truth for what's deployed —
+        ``StorageJSON.esphome_version`` only knows what the dashboard
+        last compiled, which can disagree with reality after an
+        out-of-band OTA or a reflash from another tool.
+        """
         # State first — even if the resolve fails or times out, we know the device is online.
         self.apply(device_name, DeviceState.ONLINE, "mdns")
 
@@ -220,6 +287,16 @@ class DeviceStateMonitor:
                 # Strip any zone suffix (e.g. "fe80::1%en0") for display purposes.
                 ip = addresses[0].split("%", 1)[0]
                 self.apply_ip(device_name, ip)
+            version_bytes = info.properties.get(_TXT_RECORD_VERSION) if info.properties else None
+            if version_bytes:
+                try:
+                    self.apply_version(device_name, version_bytes.decode())
+                except UnicodeDecodeError:
+                    _LOGGER.debug(
+                        "Could not decode mDNS version TXT for %s: %r",
+                        device_name,
+                        version_bytes,
+                    )
         except Exception:
             _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
 

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from esphome import const
 from esphome.dashboard.util.text import friendly_name_slugify
+from esphome.helpers import sort_ip_addresses
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 
 try:
@@ -49,6 +50,51 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None) -> list[str]:
+    """Build ``--mdns-address-cache`` / ``--dns-address-cache`` CLI args.
+
+    Mirrors ``build_cache_arguments`` in
+    ``esphome/dashboard/web_server.py``. We hand the IP we already
+    resolved (via mDNS) to the CLI so it skips its own DNS / zeroconf
+    lookup — that lookup is the slow path on a fresh OTA invocation,
+    especially when zeroconf takes a couple of seconds to find the
+    device on a busy network.
+
+    For ``.local`` addresses we prefer zeroconf's own cache (it can
+    contain multiple IPs — IPv4 + IPv6 — and matches the source the
+    legacy dashboard uses). We fall back to the single IP we tracked
+    via mDNS resolution so the CLI gets *something* even if the
+    zeroconf cache entry expired between resolution and build time.
+    """
+    address = device.address
+    if not address:
+        return []
+
+    # mDNS hostnames are case-insensitive and may carry a trailing dot
+    # (the absolute form). Normalise once for both the suffix check and
+    # the CLI arg so the cache key matches what the CLI expects.
+    normalized = address.rstrip(".").lower()
+    is_local = normalized.endswith(".local")
+
+    addresses: list[str] = []
+    if is_local and monitor is not None:
+        cached = monitor.get_cached_addresses(address)
+        if cached:
+            addresses = list(cached)
+
+    if not addresses and device.ip:
+        addresses = [device.ip]
+
+    if not addresses:
+        return []
+
+    cache_type = "mdns" if is_local else "dns"
+    return [
+        f"--{cache_type}-address-cache",
+        f"{normalized}={','.join(sort_ip_addresses(addresses))}",
+    ]
+
+
 class DevicesController:
     """Manage device configurations, file watching, and CLI operations."""
 
@@ -69,6 +115,7 @@ class DevicesController:
             get_devices=self._get_devices,
             on_state_change=self._on_state_change,
             on_ip_change=self._on_ip_change,
+            on_version_change=self._on_version_change,
         )
 
     # ------------------------------------------------------------------
@@ -93,6 +140,26 @@ class DevicesController:
     def get_devices(self) -> list[Device]:
         """Snapshot of the currently-loaded devices."""
         return self._scanner.devices
+
+    def get_address_cache_args(self, configuration: str) -> list[str]:
+        """Return ``--mdns/--dns-address-cache`` CLI args for *configuration*.
+
+        Empty list when the device is unknown, doesn't have the API
+        integration loaded (so OTA wouldn't talk to it anyway), or we
+        have no cached IP to hand the CLI. Intended for the firmware
+        controller to splice into ``esphome upload`` / ``esphome run``
+        invocations on OTA so the CLI skips its own mDNS / DNS lookup.
+        """
+        target_name = configuration.removesuffix(".yaml").removesuffix(".yml")
+        device = next((d for d in self._scanner.devices if d.name == target_name), None)
+        if device is None:
+            return []
+        # The CLI's address cache is only consulted when the API client
+        # is in use — for non-API devices the OTA path doesn't go
+        # through the same resolver and the cache args would be inert.
+        if "api" not in device.loaded_integrations:
+            return []
+        return _build_address_cache_args(device, self._state_monitor)
 
     # ------------------------------------------------------------------
     # API commands — listing
@@ -561,6 +628,59 @@ class DevicesController:
         device.ip = ip
         _LOGGER.debug("Device %s IP: %s", name, ip or "(cleared)")
         self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+
+    def _on_version_change(self, name: str, version: str) -> None:
+        """Persist a fresh ESPHome version observed via mDNS.
+
+        Mirrors ``DashboardImportDiscovery.update_device_mdns`` in the
+        legacy dashboard: when a device announces a different version
+        than what we last compiled, write it back to ``StorageJSON`` so
+        the dashboard reflects what's *actually* on the device. The
+        in-memory ``Device`` is updated alongside so connected clients
+        see the change without waiting for the next scan.
+        """
+        device = next((d for d in self._scanner.devices if d.name == name), None)
+        if device is None:
+            return
+        if device.deployed_version == version:
+            return
+
+        # Disk write runs off the event loop — StorageJSON.load/save are
+        # blocking. Track it as a background task so any error gets
+        # logged via the loop's exception handler instead of vanishing.
+        self._db.create_background_task(
+            self._persist_storage_version_async(device.configuration, version)
+        )
+
+        old_version = device.deployed_version
+        device.deployed_version = version
+        device.update_available = bool(device.current_version and version != device.current_version)
+        _LOGGER.info("Device %s version: %s → %s (via mdns)", name, old_version or "?", version)
+        self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+
+    async def _persist_storage_version_async(self, configuration: str, version: str) -> None:
+        """Update ``StorageJSON.esphome_version`` on disk if it differs."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._persist_storage_version, configuration, version)
+
+    @staticmethod
+    def _persist_storage_version(configuration: str, version: str) -> None:
+        """Run the synchronous StorageJSON load/save for the version write-through."""
+        storage_path = ext_storage_path(configuration)
+        storage = StorageJSON.load(storage_path)
+        if storage is None:
+            return
+        if storage.esphome_version == version:
+            return
+        previous = storage.esphome_version
+        storage.esphome_version = version
+        storage.save(storage_path)
+        _LOGGER.debug(
+            "Updated StorageJSON for %s with mdns version %s (was %s)",
+            configuration,
+            version,
+            previous,
+        )
 
     def _load_ignored_devices(self) -> None:
         storage_path = ignored_devices_storage_path()

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -50,51 +50,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None) -> list[str]:
-    """Build ``--mdns-address-cache`` / ``--dns-address-cache`` CLI args.
-
-    Mirrors ``build_cache_arguments`` in
-    ``esphome/dashboard/web_server.py``. We hand the IP we already
-    resolved (via mDNS) to the CLI so it skips its own DNS / zeroconf
-    lookup — that lookup is the slow path on a fresh OTA invocation,
-    especially when zeroconf takes a couple of seconds to find the
-    device on a busy network.
-
-    For ``.local`` addresses we prefer zeroconf's own cache (it can
-    contain multiple IPs — IPv4 + IPv6 — and matches the source the
-    legacy dashboard uses). We fall back to the single IP we tracked
-    via mDNS resolution so the CLI gets *something* even if the
-    zeroconf cache entry expired between resolution and build time.
-    """
-    address = device.address
-    if not address:
-        return []
-
-    # mDNS hostnames are case-insensitive and may carry a trailing dot
-    # (the absolute form). Normalise once for both the suffix check and
-    # the CLI arg so the cache key matches what the CLI expects.
-    normalized = address.rstrip(".").lower()
-    is_local = normalized.endswith(".local")
-
-    addresses: list[str] = []
-    if is_local and monitor is not None:
-        cached = monitor.get_cached_addresses(address)
-        if cached:
-            addresses = list(cached)
-
-    if not addresses and device.ip:
-        addresses = [device.ip]
-
-    if not addresses:
-        return []
-
-    cache_type = "mdns" if is_local else "dns"
-    return [
-        f"--{cache_type}-address-cache",
-        f"{normalized}={','.join(sort_ip_addresses(addresses))}",
-    ]
-
-
 class DevicesController:
     """Manage device configurations, file watching, and CLI operations."""
 
@@ -142,21 +97,18 @@ class DevicesController:
         return self._scanner.devices
 
     def get_address_cache_args(self, configuration: str) -> list[str]:
-        """Return ``--mdns/--dns-address-cache`` CLI args for *configuration*.
+        """
+        Return ``--mdns/--dns-address-cache`` CLI args for *configuration*.
 
-        Empty list when the device is unknown, doesn't have the API
-        integration loaded (so OTA wouldn't talk to it anyway), or we
-        have no cached IP to hand the CLI. Intended for the firmware
-        controller to splice into ``esphome upload`` / ``esphome run``
-        invocations on OTA so the CLI skips its own mDNS / DNS lookup.
+        Empty list when the device is unknown, has no API integration
+        loaded, or has no cached IP available.
         """
         target_name = configuration.removesuffix(".yaml").removesuffix(".yml")
         device = next((d for d in self._scanner.devices if d.name == target_name), None)
         if device is None:
             return []
-        # The CLI's address cache is only consulted when the API client
-        # is in use — for non-API devices the OTA path doesn't go
-        # through the same resolver and the cache args would be inert.
+        # The CLI only consults the address cache through the API client;
+        # non-API devices flash via a different path that wouldn't read it.
         if "api" not in device.loaded_integrations:
             return []
         return _build_address_cache_args(device, self._state_monitor)
@@ -630,24 +582,15 @@ class DevicesController:
         self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 
     def _on_version_change(self, name: str, version: str) -> None:
-        """Persist a fresh ESPHome version observed via mDNS.
-
-        Mirrors ``DashboardImportDiscovery.update_device_mdns`` in the
-        legacy dashboard: when a device announces a different version
-        than what we last compiled, write it back to ``StorageJSON`` so
-        the dashboard reflects what's *actually* on the device. The
-        in-memory ``Device`` is updated alongside so connected clients
-        see the change without waiting for the next scan.
-        """
+        """Apply a fresh ESPHome version observed via mDNS."""
         device = next((d for d in self._scanner.devices if d.name == name), None)
         if device is None:
             return
         if device.deployed_version == version:
             return
 
-        # Disk write runs off the event loop — StorageJSON.load/save are
-        # blocking. Track it as a background task so any error gets
-        # logged via the loop's exception handler instead of vanishing.
+        # StorageJSON.load/save are blocking — push to a background task
+        # so any error gets surfaced via the loop's exception handler.
         self._db.create_background_task(
             self._persist_storage_version_async(device.configuration, version)
         )
@@ -665,7 +608,7 @@ class DevicesController:
 
     @staticmethod
     def _persist_storage_version(configuration: str, version: str) -> None:
-        """Run the synchronous StorageJSON load/save for the version write-through."""
+        """Write *version* to ``StorageJSON.esphome_version`` if it differs."""
         storage_path = ext_storage_path(configuration)
         storage = StorageJSON.load(storage_path)
         if storage is None:
@@ -792,3 +735,35 @@ class DevicesController:
         await client.send_event(
             message_id, "result", {"success": exit_code == 0, "code": exit_code}
         )
+
+
+def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None) -> list[str]:
+    """Build CLI cache args from the IPs we already have for *device*."""
+    address = device.address
+    if not address:
+        return []
+
+    # mDNS hostnames are case-insensitive and may carry a trailing dot;
+    # normalise once so the CLI cache key matches what it'll look up.
+    normalized = address.rstrip(".").lower()
+    is_local = normalized.endswith(".local")
+
+    addresses: list[str] = []
+    if is_local and monitor is not None:
+        cached = monitor.get_cached_addresses(address)
+        if cached:
+            addresses = list(cached)
+
+    # Fall back to the single IP we tracked via mDNS resolution — covers
+    # the case where the zeroconf cache entry expired between resolves.
+    if not addresses and device.ip:
+        addresses = [device.ip]
+
+    if not addresses:
+        return []
+
+    cache_type = "mdns" if is_local else "dns"
+    return [
+        f"--{cache_type}-address-cache",
+        f"{normalized}={','.join(sort_ip_addresses(addresses))}",
+    ]

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -828,19 +828,15 @@ class FirmwareController:
         port: str,
         cache_args: list[str] | None = None,
     ) -> list[str]:
-        """Build the esphome CLI command for a given job type.
-
-        ``cache_args`` are global ``--mdns-address-cache`` /
-        ``--dns-address-cache`` flags. They must come *before* the
-        subcommand because esphome's argparse parses them on the
-        top-level parser, not the per-subcommand one.
-        """
+        """Build the esphome CLI command for a given job type."""
         cmd_map = {
             JobType.COMPILE: "compile",
             JobType.UPLOAD: "upload",
             JobType.INSTALL: "run",
             JobType.CLEAN: "clean",
         }
+        # cache_args go before the subcommand — esphome's argparse parses
+        # them on the top-level parser, not the per-subcommand one.
         cmd = [*self._esphome_cmd, *(cache_args or []), cmd_map[job_type], config_path]
         if job_type == JobType.INSTALL:
             # Without --no-logs the CLI tails logs forever after the
@@ -851,13 +847,9 @@ class FirmwareController:
         return cmd
 
     def _build_cache_args(self, job: FirmwareJob) -> list[str]:
-        """Return ``--mdns/--dns-address-cache`` args to splice into the CLI command.
-
-        Mirrors the gating in ``esphome/dashboard/web_server.py``:
-        only OTA uploads (``port == "OTA"``) where the device has the
-        API integration loaded benefit from a pre-seeded cache. Serial
-        flashes don't talk to the device's network address at all.
-        """
+        """Return ``--mdns/--dns-address-cache`` args for *job*, or empty."""
+        # Only OTA uploads benefit — serial flashes don't talk to the
+        # device's network address at all.
         if job.job_type not in (JobType.UPLOAD, JobType.INSTALL):
             return []
         if job.port != "OTA":

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -570,7 +570,8 @@ class FirmwareController:
                 await self._verify_chip(job)
 
             config_path = str(self._db.settings.rel_path(job.configuration))
-            cmd = self._build_command(job.job_type, config_path, job.port)
+            cache_args = self._build_cache_args(job)
+            cmd = self._build_command(job.job_type, config_path, job.port, cache_args)
             _LOGGER.debug("Running: %s", " ".join(cmd))
 
             # Force ANSI color output even though stdout isn't a TTY.
@@ -820,15 +821,27 @@ class FirmwareController:
 
         _LOGGER.debug("Chip verified: %s on %s", detected, job.port)
 
-    def _build_command(self, job_type: JobType, config_path: str, port: str) -> list[str]:
-        """Build the esphome CLI command for a given job type."""
+    def _build_command(
+        self,
+        job_type: JobType,
+        config_path: str,
+        port: str,
+        cache_args: list[str] | None = None,
+    ) -> list[str]:
+        """Build the esphome CLI command for a given job type.
+
+        ``cache_args`` are global ``--mdns-address-cache`` /
+        ``--dns-address-cache`` flags. They must come *before* the
+        subcommand because esphome's argparse parses them on the
+        top-level parser, not the per-subcommand one.
+        """
         cmd_map = {
             JobType.COMPILE: "compile",
             JobType.UPLOAD: "upload",
             JobType.INSTALL: "run",
             JobType.CLEAN: "clean",
         }
-        cmd = [*self._esphome_cmd, cmd_map[job_type], config_path]
+        cmd = [*self._esphome_cmd, *(cache_args or []), cmd_map[job_type], config_path]
         if job_type == JobType.INSTALL:
             # Without --no-logs the CLI tails logs forever after the
             # upload, never returning — the job would never complete.
@@ -836,6 +849,22 @@ class FirmwareController:
         if job_type in (JobType.UPLOAD, JobType.INSTALL) and port:
             cmd.extend(["--device", port])
         return cmd
+
+    def _build_cache_args(self, job: FirmwareJob) -> list[str]:
+        """Return ``--mdns/--dns-address-cache`` args to splice into the CLI command.
+
+        Mirrors the gating in ``esphome/dashboard/web_server.py``:
+        only OTA uploads (``port == "OTA"``) where the device has the
+        API integration loaded benefit from a pre-seeded cache. Serial
+        flashes don't talk to the device's network address at all.
+        """
+        if job.job_type not in (JobType.UPLOAD, JobType.INSTALL):
+            return []
+        if job.port != "OTA":
+            return []
+        if self._db.devices is None:
+            return []
+        return self._db.devices.get_address_cache_args(job.configuration)
 
     # ------------------------------------------------------------------
     # Internals — job management

--- a/tests/test_address_cache.py
+++ b/tests/test_address_cache.py
@@ -1,0 +1,187 @@
+"""Tests for the dns/zeroconf address cache hand-off to the esphome CLI.
+
+Originally tracked in https://github.com/esphome/device-builder/issues/6 —
+without these args, every OTA invocation in the CLI redoes mDNS / DNS
+resolution we already did in the dashboard. The legacy ESPHome dashboard
+solves this in ``build_cache_arguments`` (web_server.py); this is the
+parity test for the new backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from esphome_device_builder.controllers.devices import _build_address_cache_args
+from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.models import Device, FirmwareJob, JobType
+
+
+def _device(**overrides: Any) -> Device:
+    base: dict[str, Any] = {
+        "name": "kitchen",
+        "friendly_name": "Kitchen",
+        "configuration": "kitchen.yaml",
+        "address": "kitchen.local",
+        "ip": "",
+        "loaded_integrations": ["api"],
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+def _monitor(addresses: list[str] | None) -> Any:
+    monitor = MagicMock()
+    monitor.get_cached_addresses.return_value = addresses
+    return monitor
+
+
+# ----------------------------------------------------------------------
+# _build_address_cache_args
+# ----------------------------------------------------------------------
+
+
+def test_local_address_uses_zeroconf_cache() -> None:
+    """``.local`` host with cache hit → ``--mdns-address-cache``."""
+    args = _build_address_cache_args(_device(), _monitor(["192.168.1.50"]))
+    assert args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+
+
+def test_local_address_hostname_normalised() -> None:
+    """Trailing dot + uppercase normalised to canonical form."""
+    args = _build_address_cache_args(_device(address="Kitchen.Local."), _monitor(["192.168.1.50"]))
+    assert args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+
+
+def test_local_address_falls_back_to_device_ip() -> None:
+    """Cache miss + tracked ip → still emit a cache entry.
+
+    Zeroconf entries can expire between resolution and an OTA build —
+    reusing the IP we already saw is better than nothing.
+    """
+    args = _build_address_cache_args(_device(ip="192.168.1.99"), _monitor(None))
+    assert args == ["--mdns-address-cache", "kitchen.local=192.168.1.99"]
+
+
+def test_local_address_no_cache_no_ip_returns_empty() -> None:
+    """No source for an IP at all → no cache args (CLI does its own lookup)."""
+    args = _build_address_cache_args(_device(), _monitor(None))
+    assert args == []
+
+
+def test_non_local_address_uses_dns_cache() -> None:
+    """Non-``.local`` host with tracked IP → ``--dns-address-cache``."""
+    args = _build_address_cache_args(
+        _device(address="esp.example.com", ip="10.0.0.1"), _monitor(None)
+    )
+    assert args == ["--dns-address-cache", "esp.example.com=10.0.0.1"]
+
+
+def test_non_local_skips_zeroconf_lookup() -> None:
+    """Non-``.local`` addresses don't hit zeroconf — that cache is mDNS-only."""
+    monitor = _monitor(["1.1.1.1"])
+    args = _build_address_cache_args(_device(address="esp.example.com", ip="10.0.0.1"), monitor)
+    assert args == ["--dns-address-cache", "esp.example.com=10.0.0.1"]
+    monitor.get_cached_addresses.assert_not_called()
+
+
+def test_no_address_returns_empty() -> None:
+    """Device with no address at all → nothing to cache."""
+    assert _build_address_cache_args(_device(address=""), _monitor(None)) == []
+
+
+def test_no_monitor_falls_back_to_device_ip() -> None:
+    """``DeviceStateMonitor`` not yet running (e.g. during tests) is tolerated."""
+    args = _build_address_cache_args(_device(ip="192.168.1.50"), None)
+    assert args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+
+
+def test_multiple_cached_addresses_sorted() -> None:
+    """Multiple IPs are passed comma-joined and sorted by ``sort_ip_addresses``."""
+    args = _build_address_cache_args(_device(), _monitor(["192.168.1.50", "fe80::1234"]))
+    assert len(args) == 2
+    assert args[0] == "--mdns-address-cache"
+    # Both addresses present, comma-joined.
+    hostname, _, ips = args[1].partition("=")
+    assert hostname == "kitchen.local"
+    assert set(ips.split(",")) == {"192.168.1.50", "fe80::1234"}
+
+
+# ----------------------------------------------------------------------
+# FirmwareController._build_cache_args / _build_command
+# ----------------------------------------------------------------------
+
+
+def _firmware_controller_with(devices_controller: Any) -> FirmwareController:
+    db = MagicMock()
+    db.devices = devices_controller
+    controller = FirmwareController(db)
+    controller._esphome_cmd = ["esphome"]
+    return controller
+
+
+def test_cache_args_only_for_ota_upload_install() -> None:
+    """Compile / clean / serial-port jobs don't get cache args."""
+    devices = MagicMock()
+    devices.get_address_cache_args.return_value = ["--mdns-address-cache", "k.local=1.2.3.4"]
+    controller = _firmware_controller_with(devices)
+
+    # Compile: no port, irrelevant
+    job = FirmwareJob(job_id="1", configuration="kitchen.yaml", job_type=JobType.COMPILE)
+    assert controller._build_cache_args(job) == []
+
+    # Clean: no port, irrelevant
+    job = FirmwareJob(job_id="2", configuration="kitchen.yaml", job_type=JobType.CLEAN)
+    assert controller._build_cache_args(job) == []
+
+    # Upload over serial: port is a /dev path, cache wouldn't help
+    job = FirmwareJob(
+        job_id="3", configuration="kitchen.yaml", job_type=JobType.UPLOAD, port="/dev/ttyUSB0"
+    )
+    assert controller._build_cache_args(job) == []
+
+    # Install over OTA: cache args should be returned
+    job = FirmwareJob(
+        job_id="4", configuration="kitchen.yaml", job_type=JobType.INSTALL, port="OTA"
+    )
+    assert controller._build_cache_args(job) == ["--mdns-address-cache", "k.local=1.2.3.4"]
+
+
+def test_cache_args_no_devices_controller() -> None:
+    """If devices controller hasn't started yet, fail safely (empty)."""
+    controller = _firmware_controller_with(None)
+    job = FirmwareJob(
+        job_id="1", configuration="kitchen.yaml", job_type=JobType.INSTALL, port="OTA"
+    )
+    assert controller._build_cache_args(job) == []
+
+
+def test_command_places_cache_args_before_subcommand() -> None:
+    """Esphome CLI parses ``--mdns-address-cache`` on the *top-level* parser.
+
+    If we put it after the subcommand (``run``, ``upload``...) argparse
+    rejects it with ``unrecognized arguments``. Verifying the order
+    here protects against regressions.
+    """
+    controller = _firmware_controller_with(None)
+    cache_args = ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+
+    cmd = controller._build_command(JobType.INSTALL, "kitchen.yaml", "OTA", cache_args)
+
+    assert cmd == [
+        "esphome",
+        "--mdns-address-cache",
+        "kitchen.local=192.168.1.50",
+        "run",
+        "kitchen.yaml",
+        "--no-logs",
+        "--device",
+        "OTA",
+    ]
+
+
+def test_command_without_cache_args_unchanged() -> None:
+    """When there are no cache args, the command is identical to before."""
+    controller = _firmware_controller_with(None)
+    cmd = controller._build_command(JobType.COMPILE, "kitchen.yaml", "")
+    assert cmd == ["esphome", "compile", "kitchen.yaml"]

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -1,0 +1,253 @@
+"""Tests for mDNS-driven ESPHome version sync.
+
+When a device broadcasts ``_esphomelib._tcp.local.`` it includes a
+``version`` TXT record with the firmware version actually running. The
+dashboard pulls that out so the stored ``StorageJSON.esphome_version``
+reflects reality, not just whatever the dashboard last compiled —
+important after an out-of-band OTA or a flash from another tool.
+Mirrors ``DashboardImportDiscovery.update_device_mdns`` in
+``esphome/zeroconf.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.models import Device, DeviceState
+
+
+def _device(**overrides: Any) -> Device:
+    base: dict[str, Any] = {
+        "name": "kitchen",
+        "friendly_name": "Kitchen",
+        "configuration": "kitchen.yaml",
+        "address": "kitchen.local",
+        "current_version": "2026.5.0",
+        "deployed_version": "",
+        "state": DeviceState.UNKNOWN,
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
+    on_version = MagicMock()
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_version_change=on_version,
+    )
+    return monitor, on_version
+
+
+# ----------------------------------------------------------------------
+# DeviceStateMonitor.apply_version
+# ----------------------------------------------------------------------
+
+
+def test_apply_version_first_observation_fires_callback() -> None:
+    """A version we haven't seen before reaches the controller."""
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_version("kitchen", "2026.5.0") is True
+    cb.assert_called_once_with("kitchen", "2026.5.0")
+
+
+def test_apply_version_dedupes_same_value() -> None:
+    """Same version twice → callback only fires once.
+
+    mDNS announcements are noisy (state changes, periodic refreshes) so
+    deduplication is the difference between a quiet ``DEVICE_UPDATED``
+    stream and the UI thrashing.
+    """
+    monitor, cb = _monitor([_device()])
+    monitor.apply_version("kitchen", "2026.5.0")
+    monitor.apply_version("kitchen", "2026.5.0")
+    cb.assert_called_once()
+
+
+def test_apply_version_fires_on_change() -> None:
+    """A different version than the last observation fires the callback again."""
+    monitor, cb = _monitor([_device()])
+    monitor.apply_version("kitchen", "2026.5.0")
+    monitor.apply_version("kitchen", "2026.6.0")
+    assert cb.call_args_list == [
+        (("kitchen", "2026.5.0"),),
+        (("kitchen", "2026.6.0"),),
+    ]
+
+
+def test_apply_version_ignores_empty_string() -> None:
+    """Devices that don't announce a version → no-op (don't fire empty-string callbacks)."""
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_version("kitchen", "") is False
+    cb.assert_not_called()
+
+
+def test_apply_version_ignores_unknown_device() -> None:
+    """Stray mDNS announcements for devices not in the catalog are dropped."""
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_version("ghost", "2026.5.0") is False
+    cb.assert_not_called()
+
+
+def test_apply_version_no_callback_silently_drops() -> None:
+    """When no callback was wired (test setups, partial init) we don't raise."""
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [_device()],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_version_change=None,
+    )
+    assert monitor.apply_version("kitchen", "2026.5.0") is False
+
+
+# ----------------------------------------------------------------------
+# StorageJSON write-through
+# ----------------------------------------------------------------------
+
+
+def _patch_storage(monkeypatch: Any, tmp_path: Any, storage: Any) -> None:
+    """Wire ``StorageJSON.load`` and ``ext_storage_path`` for the workhorse tests.
+
+    ``ext_storage_path`` walks ``CORE.config_path`` — without a config
+    loaded, it raises before we even get to the mocked load. Pointing it
+    at ``tmp_path`` keeps the call inert for the test's duration.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.StorageJSON.load",
+        lambda _path: storage,
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.ext_storage_path",
+        lambda config: tmp_path / f"{config}.json",
+    )
+
+
+def test_persist_storage_version_writes_when_different(monkeypatch: Any, tmp_path: Any) -> None:
+    """``_persist_storage_version`` saves when the on-disk value differs."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    storage = MagicMock()
+    storage.esphome_version = "2026.4.0"
+    _patch_storage(monkeypatch, tmp_path, storage)
+
+    DevicesController._persist_storage_version("kitchen.yaml", "2026.5.0")
+
+    assert storage.esphome_version == "2026.5.0"
+    storage.save.assert_called_once()
+
+
+def test_persist_storage_version_skips_when_same(monkeypatch: Any, tmp_path: Any) -> None:
+    """No write when on-disk value already matches — prevents touch-mtime churn.
+
+    Without this guard, every mDNS refresh (every few seconds) would
+    bump the StorageJSON mtime, defeat the scanner's mtime-based cache,
+    and force a full re-parse of every YAML on the next poll.
+    """
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    storage = MagicMock()
+    storage.esphome_version = "2026.5.0"
+    _patch_storage(monkeypatch, tmp_path, storage)
+
+    DevicesController._persist_storage_version("kitchen.yaml", "2026.5.0")
+
+    storage.save.assert_not_called()
+
+
+def test_persist_storage_version_handles_missing_storage(monkeypatch: Any, tmp_path: Any) -> None:
+    """Device that's never been compiled has no StorageJSON — bail out cleanly."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    _patch_storage(monkeypatch, tmp_path, storage=None)
+
+    # Should not raise.
+    DevicesController._persist_storage_version("kitchen.yaml", "2026.5.0")
+
+
+# ----------------------------------------------------------------------
+# DevicesController._on_version_change
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_version_change_updates_device_and_fires_event(monkeypatch: Any) -> None:
+    """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
+    from esphome_device_builder.controllers.devices import DevicesController
+    from esphome_device_builder.models import EventType
+
+    device = _device(deployed_version="2026.4.0")
+
+    db = MagicMock()
+
+    fired_events: list[tuple[EventType, dict]] = []
+    db.bus.fire.side_effect = lambda event_type, data: fired_events.append((event_type, data))
+
+    persisted: list[tuple[str, str]] = []
+
+    async def _fake_persist(configuration: str, version: str) -> None:
+        persisted.append((configuration, version))
+
+    db.create_background_task.side_effect = lambda coro: coro.close() or MagicMock()
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+    monkeypatch.setattr(controller, "_persist_storage_version_async", _fake_persist, raising=False)
+
+    controller._on_version_change("kitchen", "2026.5.0")
+
+    assert device.deployed_version == "2026.5.0"
+    # current_version is "2026.5.0" too, so update_available should be False.
+    assert device.update_available is False
+    assert any(et == EventType.DEVICE_UPDATED for et, _ in fired_events)
+
+
+@pytest.mark.asyncio
+async def test_on_version_change_skips_when_same(monkeypatch: Any) -> None:
+    """No-op when in-memory device already has the announced version."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    device = _device(deployed_version="2026.5.0")
+
+    db = MagicMock()
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    controller._on_version_change("kitchen", "2026.5.0")
+
+    db.bus.fire.assert_not_called()
+    db.create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_version_change_marks_update_available_when_behind() -> None:
+    """A device on an older version than the dashboard → ``update_available`` flips on."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    device = _device(current_version="2026.5.0", deployed_version="2026.4.0")
+
+    db = MagicMock()
+    db.create_background_task.side_effect = lambda coro: coro.close() or MagicMock()
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    # Simulate mDNS reporting an even older version than the previous
+    # deployed_version — the dashboard's installed esphome is newer
+    # than what's on the device, so an update is available.
+    controller._on_version_change("kitchen", "2026.3.0")
+
+    assert device.deployed_version == "2026.3.0"
+    assert device.update_available is True


### PR DESCRIPTION
## Problem

When the dashboard kicks off an OTA `upload` / `install`, the `esphome` CLI redoes the same DNS / zeroconf lookup the dashboard just did — adding seconds of latency to every OTA on a busy network. The legacy dashboard solves this by passing `--mdns-address-cache` / `--dns-address-cache` to the CLI; the new backend was missing that hand-off.

While in the same code path, we also weren't reading the `version` TXT record from the device's mDNS announcement, so `StorageJSON.esphome_version` could drift from what's actually running on the device (after an external OTA, a flash from another tool, etc.).

## Changes

- Add `DeviceStateMonitor.get_cached_addresses()` — queries zeroconf's cache directly, no network.
- Add `DevicesController.get_address_cache_args(configuration)` — builds `--mdns/--dns-address-cache` flags. Gated on `port == "OTA"` and `"api" in loaded_integrations` to match the legacy dashboard.
- Wire cache args into `FirmwareController._build_command` — placed *before* the subcommand because esphome's argparse parses them on the top-level parser.
- Extract the `version` TXT record in `_resolve_and_apply` and route it through a new `on_version_change` callback. The handler updates `StorageJSON.esphome_version` on disk (skipping the write when unchanged to avoid mtime churn) and refreshes the in-memory `Device` so connected clients see it instantly via `DEVICE_UPDATED`.
- 25 new tests covering cache-arg construction, command ordering, version dedup, and StorageJSON write-through.

Closes #6