### PR TITLE
Add MQTT-based device status discovery

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@
 
 6. **Persistent firmware jobs.** Compile/upload jobs are queued, run one at a time, survive page refreshes and server restarts.
 
-7. **Device discovery.** mDNS browser for instant online/offline detection, ping sweep every 60s as fallback.
+7. **Device discovery.** mDNS browser for instant online/offline detection, ping sweep every 60s as fallback, optional MQTT discovery for devices that opt in via an `mqtt:` block. Source priority: `mdns > mqtt > ping`.
 
 ## Project Structure
 

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -1,0 +1,225 @@
+"""
+Coordinator for per-broker MQTT discovery monitors.
+
+Reads each MQTT-using device's YAML, resolves ``!secret`` references via
+``secrets.yaml``, groups by broker host/port, and runs one
+:class:`DeviceMqttMonitor` per unique broker. Re-runs lifecycle on each
+poll so monitors track YAML edits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..models import Device
+from ._device_mqtt_monitor import (
+    DeviceMqttMonitor,
+    IPCallback,
+    MqttBrokerConfig,
+    StateCallback,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_PORT = 1883
+
+
+class DeviceMqttCoordinator:
+    """
+    Manage one :class:`DeviceMqttMonitor` per unique broker.
+
+    ``reconcile()`` is idempotent — call it after every device scan to
+    pick up YAML edits. Adds monitors for new brokers, stops monitors
+    for brokers no longer referenced.
+    """
+
+    def __init__(
+        self,
+        config_dir: Path,
+        get_devices: Callable[[], list[Device]],
+        on_state_change: StateCallback,
+        on_ip_change: IPCallback,
+    ) -> None:
+        self._config_dir = config_dir
+        self._get_devices = get_devices
+        self._on_state_change = on_state_change
+        self._on_ip_change = on_ip_change
+        self._monitors: dict[tuple[str, int], DeviceMqttMonitor] = {}
+
+    @property
+    def active_brokers(self) -> int:
+        """Return the number of brokers currently being monitored."""
+        return len(self._monitors)
+
+    async def reconcile(self) -> None:
+        """Sync running monitors to the brokers referenced by device YAML."""
+        if not DeviceMqttMonitor.is_available():
+            if any(d.uses_mqtt for d in self._get_devices()):
+                _LOGGER.warning(
+                    "aiomqtt not installed — MQTT device discovery disabled despite "
+                    "devices declaring mqtt: blocks"
+                )
+            return
+
+        loop = asyncio.get_running_loop()
+        brokers = await loop.run_in_executor(None, self._collect_brokers)
+        wanted_keys = {b.key for b in brokers}
+        existing_keys = set(self._monitors.keys())
+
+        for key in existing_keys - wanted_keys:
+            host, port = key
+            _LOGGER.info("Stopping MQTT monitor for %s:%s", host, port)
+            await self._monitors.pop(key).stop()
+
+        for broker in brokers:
+            if broker.key in self._monitors:
+                continue
+            monitor = DeviceMqttMonitor(broker, self._on_state_change, self._on_ip_change)
+            self._monitors[broker.key] = monitor
+            await monitor.start()
+
+    async def stop(self) -> None:
+        """Stop every active monitor and clear state."""
+        for monitor in list(self._monitors.values()):
+            await monitor.stop()
+        self._monitors.clear()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _collect_brokers(self) -> list[MqttBrokerConfig]:
+        secrets_map = _load_secrets(self._config_dir)
+        seen: dict[tuple[str, int], MqttBrokerConfig] = {}
+        for device in self._get_devices():
+            if not device.uses_mqtt:
+                continue
+            yaml_path = self._config_dir / device.configuration
+            try:
+                yaml_content = yaml_path.read_text(encoding="utf-8")
+            except OSError:
+                _LOGGER.debug("Could not read %s for MQTT broker config", device.configuration)
+                continue
+            broker = parse_mqtt_block(yaml_content, secrets_map)
+            if broker is None:
+                _LOGGER.warning(
+                    "Device %s declares mqtt: but broker could not be resolved "
+                    "(missing secret or invalid config)",
+                    device.configuration,
+                )
+                continue
+            existing = seen.get(broker.key)
+            if existing is None:
+                seen[broker.key] = broker
+                continue
+            if (existing.username, existing.password) != (broker.username, broker.password):
+                _LOGGER.warning(
+                    "Multiple devices reference broker %s:%s with different credentials — "
+                    "using credentials from the first device",
+                    broker.host,
+                    broker.port,
+                )
+        return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# YAML parsing
+# ---------------------------------------------------------------------------
+
+
+class _SecretRef:
+    """Marker for an unresolved ``!secret <name>`` reference."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _TolerantYamlLoader(yaml.SafeLoader):
+    """SafeLoader that captures ``!secret`` and ignores other custom tags."""
+
+
+def _construct_secret(loader: yaml.Loader, node: yaml.ScalarNode) -> _SecretRef:
+    return _SecretRef(loader.construct_scalar(node))
+
+
+def _ignore_unknown_tag(_loader: yaml.Loader, _tag_suffix: str, _node: yaml.Node) -> None:
+    return None
+
+
+_TolerantYamlLoader.add_constructor("!secret", _construct_secret)
+_TolerantYamlLoader.add_multi_constructor("!", _ignore_unknown_tag)
+
+
+def parse_mqtt_block(
+    yaml_content: str,
+    secrets_map: dict[str, Any] | None = None,
+) -> MqttBrokerConfig | None:
+    """
+    Extract broker connection parameters from a device YAML.
+
+    Returns ``None`` when the YAML has no ``mqtt:`` block, when the
+    block has no resolvable ``broker:`` field, or when the YAML fails
+    to parse. ``!secret xyz`` references are resolved via *secrets_map*.
+    """
+    secrets_map = secrets_map or {}
+    try:
+        # _TolerantYamlLoader subclasses SafeLoader; the custom !secret
+        # constructor only emits a marker dataclass, never instantiates
+        # arbitrary types.
+        data = yaml.load(yaml_content, Loader=_TolerantYamlLoader)  # noqa: S506
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    mqtt = data.get("mqtt")
+    if not isinstance(mqtt, dict):
+        return None
+
+    host = _resolve(mqtt.get("broker"), secrets_map)
+    if not host:
+        return None
+    port_raw = _resolve(mqtt.get("port"), secrets_map)
+    try:
+        port = int(port_raw) if port_raw else _DEFAULT_PORT
+    except (TypeError, ValueError):
+        port = _DEFAULT_PORT
+    username = _resolve(mqtt.get("username"), secrets_map) or None
+    password = _resolve(mqtt.get("password"), secrets_map) or None
+
+    return MqttBrokerConfig(host=host, port=port, username=username, password=password)
+
+
+def _load_secrets(config_dir: Path) -> dict[str, Any]:
+    secrets_path = config_dir / "secrets.yaml"
+    if not secrets_path.exists():
+        return {}
+    try:
+        with secrets_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError:
+        _LOGGER.warning("Could not parse secrets.yaml — MQTT broker secrets unavailable")
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _resolve(value: Any, secrets_map: dict[str, Any]) -> str | None:
+    """Return the resolved scalar value, or None when unresolvable."""
+    if value is None:
+        return None
+    if isinstance(value, _SecretRef):
+        secret = secrets_map.get(value.name)
+        if secret is None:
+            _LOGGER.warning("Secret %r referenced by mqtt: block is not defined", value.name)
+            return None
+        return str(secret)
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return None

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -1,14 +1,14 @@
 """
 Device connectivity monitor — MQTT discovery for one broker.
 
-Connects to a single MQTT broker, subscribes to ``esphome/discover/#``,
-and pushes online/offline observations into the supplied callbacks.
-Devices announce themselves on the topic when prodded; an absence of
-announcement within ``_OFFLINE_TIMEOUT`` flips the state to offline.
+Wraps paho-mqtt's threaded client in an asyncio-friendly task: the paho
+network loop runs in its own thread, callbacks are bounced onto the
+event loop via :meth:`asyncio.AbstractEventLoop.call_soon_threadsafe`,
+and discovered devices are pushed into the supplied callbacks.
 
-Multi-broker setups are handled one level up by
-:class:`DeviceMqttCoordinator`, which spawns one monitor per unique
-broker referenced by device YAML.
+paho-mqtt is an optional runtime dependency — it ships with the
+``[esphome]`` extra. When it isn't importable the monitor logs once and
+disables itself; mDNS / ping discovery keeps working.
 """
 
 from __future__ import annotations
@@ -22,9 +22,9 @@ from dataclasses import dataclass
 from typing import Any
 
 try:
-    import aiomqtt
-except ImportError:  # pragma: no cover — aiomqtt is optional at runtime
-    aiomqtt = None  # type: ignore[assignment]
+    import paho.mqtt.client as paho_mqtt
+except ImportError:  # pragma: no cover — paho-mqtt arrives via the [esphome] extra
+    paho_mqtt = None  # type: ignore[assignment]
 
 from ..models import DeviceState
 
@@ -35,6 +35,7 @@ _DISCOVER_PUBLISH_TOPIC = "esphome/discover"
 _PING_INTERVAL = 2.0  # seconds between discover requests
 _OFFLINE_TIMEOUT = 10.0  # seconds without a response before marking offline
 _RECONNECT_DELAY = 5.0  # delay before reconnecting after broker errors
+_CONNECT_TIMEOUT = 10.0  # seconds to wait for CONNACK before giving up
 _DEFAULT_PORT = 1883
 
 # Callbacks ignore the return value — typed as ``object`` so callers can
@@ -88,8 +89,8 @@ class DeviceMqttMonitor:
 
     @staticmethod
     def is_available() -> bool:
-        """Return True when aiomqtt is importable."""
-        return aiomqtt is not None
+        """Return True when paho-mqtt is importable."""
+        return paho_mqtt is not None
 
     @property
     def running(self) -> bool:
@@ -102,8 +103,8 @@ class DeviceMqttMonitor:
             return
         if not self.is_available():
             _LOGGER.warning(
-                "aiomqtt not installed — MQTT device discovery disabled. "
-                "Install with: pip install aiomqtt"
+                "paho-mqtt not installed — MQTT device discovery disabled. "
+                "Install the [esphome] extra to enable it."
             )
             return
         self._task = asyncio.create_task(self._run())
@@ -134,49 +135,68 @@ class DeviceMqttMonitor:
                 await self._connect_and_listen(client_id)
             except asyncio.CancelledError:
                 raise
-            except Exception as exc:
-                if aiomqtt is not None and isinstance(exc, aiomqtt.MqttError):
-                    _LOGGER.warning(
-                        "MQTT broker %s:%s error: %s — reconnecting in %ss",
-                        self._broker.host,
-                        self._broker.port,
-                        exc,
-                        delay,
-                    )
-                else:
-                    _LOGGER.exception(
-                        "Unexpected MQTT error for %s:%s — reconnecting in %ss",
-                        self._broker.host,
-                        self._broker.port,
-                        delay,
-                    )
+            except Exception:
+                _LOGGER.exception(
+                    "MQTT broker %s:%s error — reconnecting in %ss",
+                    self._broker.host,
+                    self._broker.port,
+                    delay,
+                )
                 # Drop last-seen but leave device state alone so a brief
                 # broker blip doesn't trigger an offline storm.
                 self._last_seen.clear()
                 await asyncio.sleep(_RECONNECT_DELAY)
 
     async def _connect_and_listen(self, client_id: str) -> None:
-        assert aiomqtt is not None  # type narrowing — checked in start()
+        assert paho_mqtt is not None  # type narrowing — checked in start()
+        loop = asyncio.get_running_loop()
 
-        async with aiomqtt.Client(
-            hostname=self._broker.host,
-            port=self._broker.port,
-            username=self._broker.username,
-            password=self._broker.password,
-            identifier=client_id,
-        ) as client:
+        message_queue: asyncio.Queue[Any] = asyncio.Queue()
+        connected = asyncio.Event()
+        connect_failed: list[int] = []
+
+        def on_connect(_client: Any, _userdata: Any, _flags: Any, rc: int) -> None:
+            if rc == 0:
+                loop.call_soon_threadsafe(connected.set)
+            else:
+                connect_failed.append(rc)
+                loop.call_soon_threadsafe(connected.set)
+
+        def on_message(_client: Any, _userdata: Any, msg: Any) -> None:
+            loop.call_soon_threadsafe(message_queue.put_nowait, msg)
+
+        client = paho_mqtt.Client(client_id=client_id, clean_session=True)
+        client.on_connect = on_connect
+        client.on_message = on_message
+        if self._broker.username:
+            client.username_pw_set(self._broker.username, self._broker.password or "")
+
+        await loop.run_in_executor(None, client.connect, self._broker.host, self._broker.port)
+        client.loop_start()
+        try:
+            await asyncio.wait_for(connected.wait(), timeout=_CONNECT_TIMEOUT)
+            if connect_failed:
+                msg = f"broker rejected connection (rc={connect_failed[0]})"
+                raise ConnectionError(msg)
+
             _LOGGER.info("MQTT connected to %s:%s", self._broker.host, self._broker.port)
-            await client.subscribe(_DISCOVER_TOPIC)
-            await client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
+            client.subscribe(_DISCOVER_TOPIC)
+            client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
 
             async with asyncio.TaskGroup() as tg:
-                tg.create_task(self._listen(client))
+                tg.create_task(self._listen(message_queue))
                 tg.create_task(self._ping_loop(client))
+        finally:
+            # Synchronous teardown — paho's loop_stop joins its thread,
+            # usually under a second, so no need for run_in_executor here.
+            client.loop_stop()
+            client.disconnect()
 
-    async def _listen(self, client: Any) -> None:
+    async def _listen(self, queue: asyncio.Queue[Any]) -> None:
         """Push discovery responses into the state and IP callbacks."""
         loop = asyncio.get_running_loop()
-        async for message in client.messages:
+        while True:
+            message = await queue.get()
             payload = _decode_payload(message.payload)
             if not payload:
                 continue
@@ -209,7 +229,7 @@ class DeviceMqttMonitor:
             for name in stale:
                 self._on_state_change(name, DeviceState.OFFLINE)
                 self._last_seen.pop(name, None)
-            await client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
+            client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -1,0 +1,265 @@
+"""
+Device connectivity monitor — MQTT discovery.
+
+Connects to the configured MQTT broker, subscribes to ``esphome/discover/#``,
+and pushes online/offline observations into the shared
+:class:`DeviceStateMonitor`. Devices announce themselves on the topic
+when prodded; an absence of announcement within ``_OFFLINE_TIMEOUT``
+flips the state to offline. The monitor only runs while at least one
+configured device declares an ``mqtt:`` block — otherwise the broker
+connection is closed entirely.
+
+aiomqtt is an optional runtime dependency. When the import fails, the
+monitor logs once and disables itself; mDNS / ping discovery keeps
+working.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+from collections.abc import Callable
+from typing import Any
+
+try:
+    import aiomqtt
+except ImportError:  # pragma: no cover — aiomqtt is optional
+    aiomqtt = None  # type: ignore[assignment]
+
+from ..models import Device, DeviceState
+
+_LOGGER = logging.getLogger(__name__)
+
+_DISCOVER_TOPIC = "esphome/discover/#"
+_DISCOVER_PUBLISH_TOPIC = "esphome/discover"
+_PING_INTERVAL = 2.0  # seconds between discover requests
+_OFFLINE_TIMEOUT = 10.0  # seconds without a response before marking offline
+_RECONNECT_DELAY = 5.0  # delay before reconnecting after broker errors
+_DEFAULT_PORT = 1883
+
+_ENV_BROKER = "ESPHOME_DASHBOARD_MQTT_BROKER"
+_ENV_PORT = "ESPHOME_DASHBOARD_MQTT_PORT"
+_ENV_USERNAME = "ESPHOME_DASHBOARD_MQTT_USERNAME"
+_ENV_PASSWORD = "ESPHOME_DASHBOARD_MQTT_PASSWORD"  # noqa: S105 — env var name, not a credential
+
+# Callbacks ignore the return value — typed as ``object`` so callers can
+# pass through the bool ``applied`` flag returned by
+# :meth:`DeviceStateMonitor.apply` without an extra wrapper.
+StateCallback = Callable[[str, DeviceState], object]
+IPCallback = Callable[[str, str], object]
+
+
+class DeviceMqttMonitor:
+    """
+    Drive device state from ``esphome/discover`` MQTT messages.
+
+    Lifecycle:
+      * ``start()`` — spawn the connect/listen task. Idempotent; calling
+                      again while running is a no-op.
+      * ``stop()``  — cancel the task, drop any state.
+
+    The class never owns device state directly: every observation is
+    forwarded through the supplied callbacks so :class:`DeviceStateMonitor`
+    remains the single source of truth for source priority.
+    """
+
+    def __init__(
+        self,
+        get_devices: Callable[[], list[Device]],
+        on_state_change: StateCallback,
+        on_ip_change: IPCallback,
+    ) -> None:
+        self._get_devices = get_devices
+        self._on_state_change = on_state_change
+        self._on_ip_change = on_ip_change
+        self._task: asyncio.Task[None] | None = None
+        # device name → monotonic timestamp of the last MQTT response
+        self._last_seen: dict[str, float] = {}
+
+    @staticmethod
+    def is_available() -> bool:
+        """Return True when aiomqtt is importable."""
+        return aiomqtt is not None
+
+    @staticmethod
+    def is_configured() -> bool:
+        """Return True when the broker env var is set."""
+        return bool(os.environ.get(_ENV_BROKER, "").strip())
+
+    @property
+    def running(self) -> bool:
+        """Return True while the connect/listen task is active."""
+        return self._task is not None and not self._task.done()
+
+    async def start(self) -> None:
+        """Start the MQTT connect/listen task. No-op if already running."""
+        if self.running:
+            return
+        if not self.is_available():
+            _LOGGER.warning(
+                "aiomqtt not installed — MQTT device discovery disabled. "
+                "Install with: pip install aiomqtt"
+            )
+            return
+        if not self.is_configured():
+            _LOGGER.info(
+                "%s not set — MQTT device discovery disabled despite devices "
+                "declaring mqtt: blocks",
+                _ENV_BROKER,
+            )
+            return
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Cancel the connect/listen task and forget all observations."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+        self._last_seen.clear()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _run(self) -> None:
+        broker, port, username, password = _read_broker_config()
+        client_id = f"esphome-dashboard-{secrets.token_hex(6)}"
+        _LOGGER.info("MQTT discovery monitor starting — broker=%s:%s", broker, port)
+
+        delay = int(_RECONNECT_DELAY)
+        while True:
+            try:
+                await self._connect_and_listen(broker, port, username, password, client_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                if aiomqtt is not None and isinstance(exc, aiomqtt.MqttError):
+                    _LOGGER.warning("MQTT broker error: %s — reconnecting in %ss", exc, delay)
+                else:
+                    _LOGGER.exception("Unexpected MQTT error — reconnecting in %ss", delay)
+                # Drop last-seen but leave device state alone so a brief
+                # broker blip doesn't trigger an offline storm.
+                self._last_seen.clear()
+                await asyncio.sleep(_RECONNECT_DELAY)
+
+    async def _connect_and_listen(
+        self,
+        broker: str,
+        port: int,
+        username: str | None,
+        password: str | None,
+        client_id: str,
+    ) -> None:
+        assert aiomqtt is not None  # type narrowing — checked in start()
+
+        async with aiomqtt.Client(
+            hostname=broker,
+            port=port,
+            username=username,
+            password=password,
+            identifier=client_id,
+        ) as client:
+            _LOGGER.info("MQTT connected to %s:%s", broker, port)
+            await client.subscribe(_DISCOVER_TOPIC)
+            await client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
+
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(self._listen(client))
+                tg.create_task(self._ping_loop(client))
+
+    async def _listen(self, client: Any) -> None:
+        """Push discovery responses into the state and IP callbacks."""
+        loop = asyncio.get_running_loop()
+        async for message in client.messages:
+            payload = _decode_payload(message.payload)
+            if not payload:
+                continue
+            try:
+                data = json.loads(payload)
+            except json.JSONDecodeError:
+                _LOGGER.debug("Ignoring non-JSON payload on %s", message.topic)
+                continue
+
+            name = data.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+
+            self._last_seen[name] = loop.time()
+            self._on_state_change(name, DeviceState.ONLINE)
+
+            ip = _extract_ip(data)
+            if ip:
+                self._on_ip_change(name, ip)
+
+    async def _ping_loop(self, client: Any) -> None:
+        """Sweep stale devices offline and re-prod the broker for announcements."""
+        loop = asyncio.get_running_loop()
+        while True:
+            await asyncio.sleep(_PING_INTERVAL)
+            now = loop.time()
+            for device in self._get_devices():
+                if not device.uses_mqtt:
+                    continue
+                last = self._last_seen.get(device.name)
+                if last is None:
+                    continue
+                if now - last > _OFFLINE_TIMEOUT:
+                    self._on_state_change(device.name, DeviceState.OFFLINE)
+                    self._last_seen.pop(device.name, None)
+            await client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _read_broker_config() -> tuple[str, int, str | None, str | None]:
+    """Read broker connection parameters from the environment."""
+    broker = os.environ.get(_ENV_BROKER, "").strip()
+    port_raw = os.environ.get(_ENV_PORT, "").strip()
+    try:
+        port = int(port_raw) if port_raw else _DEFAULT_PORT
+    except ValueError:
+        _LOGGER.warning("Invalid %s=%r — falling back to %d", _ENV_PORT, port_raw, _DEFAULT_PORT)
+        port = _DEFAULT_PORT
+    username = os.environ.get(_ENV_USERNAME) or None
+    password = os.environ.get(_ENV_PASSWORD) or None
+    return broker, port, username, password
+
+
+def _extract_ip(data: dict[str, Any]) -> str:
+    """
+    Pull the first IP-shaped field from a discovery payload.
+
+    ESPHome devices expose their addresses as ``ip``, ``ip0``, ``ip1``,
+    ... — returns the first non-empty value, or empty string when none
+    are present.
+    """
+    for key in ("ip", "ip0", "ip1", "ip2"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _decode_payload(payload: Any) -> str:
+    """
+    Decode an MQTT payload to text.
+
+    Returns the empty string for ``None`` or unsupported payload types;
+    ``backslashreplace`` keeps malformed UTF-8 readable.
+    """
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, (bytes, bytearray, memoryview)):
+        return bytes(payload).decode(errors="backslashreplace")
+    return ""

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -1,17 +1,14 @@
 """
-Device connectivity monitor — MQTT discovery.
+Device connectivity monitor — MQTT discovery for one broker.
 
-Connects to the configured MQTT broker, subscribes to ``esphome/discover/#``,
-and pushes online/offline observations into the shared
-:class:`DeviceStateMonitor`. Devices announce themselves on the topic
-when prodded; an absence of announcement within ``_OFFLINE_TIMEOUT``
-flips the state to offline. The monitor only runs while at least one
-configured device declares an ``mqtt:`` block — otherwise the broker
-connection is closed entirely.
+Connects to a single MQTT broker, subscribes to ``esphome/discover/#``,
+and pushes online/offline observations into the supplied callbacks.
+Devices announce themselves on the topic when prodded; an absence of
+announcement within ``_OFFLINE_TIMEOUT`` flips the state to offline.
 
-aiomqtt is an optional runtime dependency. When the import fails, the
-monitor logs once and disables itself; mDNS / ping discovery keeps
-working.
+Multi-broker setups are handled one level up by
+:class:`DeviceMqttCoordinator`, which spawns one monitor per unique
+broker referenced by device YAML.
 """
 
 from __future__ import annotations
@@ -19,17 +16,17 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import secrets
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 try:
     import aiomqtt
-except ImportError:  # pragma: no cover — aiomqtt is optional
+except ImportError:  # pragma: no cover — aiomqtt is optional at runtime
     aiomqtt = None  # type: ignore[assignment]
 
-from ..models import Device, DeviceState
+from ..models import DeviceState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,11 +37,6 @@ _OFFLINE_TIMEOUT = 10.0  # seconds without a response before marking offline
 _RECONNECT_DELAY = 5.0  # delay before reconnecting after broker errors
 _DEFAULT_PORT = 1883
 
-_ENV_BROKER = "ESPHOME_DASHBOARD_MQTT_BROKER"
-_ENV_PORT = "ESPHOME_DASHBOARD_MQTT_PORT"
-_ENV_USERNAME = "ESPHOME_DASHBOARD_MQTT_USERNAME"
-_ENV_PASSWORD = "ESPHOME_DASHBOARD_MQTT_PASSWORD"  # noqa: S105 — env var name, not a credential
-
 # Callbacks ignore the return value — typed as ``object`` so callers can
 # pass through the bool ``applied`` flag returned by
 # :meth:`DeviceStateMonitor.apply` without an extra wrapper.
@@ -52,9 +44,24 @@ StateCallback = Callable[[str, DeviceState], object]
 IPCallback = Callable[[str, str], object]
 
 
+@dataclass(frozen=True)
+class MqttBrokerConfig:
+    """Connection parameters for an MQTT broker."""
+
+    host: str
+    port: int = _DEFAULT_PORT
+    username: str | None = None
+    password: str | None = None
+
+    @property
+    def key(self) -> tuple[str, int]:
+        """Identifier for grouping devices to a single broker session."""
+        return (self.host, self.port)
+
+
 class DeviceMqttMonitor:
     """
-    Drive device state from ``esphome/discover`` MQTT messages.
+    Drive device state from one broker's ``esphome/discover`` messages.
 
     Lifecycle:
       * ``start()`` — spawn the connect/listen task. Idempotent; calling
@@ -68,11 +75,11 @@ class DeviceMqttMonitor:
 
     def __init__(
         self,
-        get_devices: Callable[[], list[Device]],
+        broker: MqttBrokerConfig,
         on_state_change: StateCallback,
         on_ip_change: IPCallback,
     ) -> None:
-        self._get_devices = get_devices
+        self._broker = broker
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
         self._task: asyncio.Task[None] | None = None
@@ -83,11 +90,6 @@ class DeviceMqttMonitor:
     def is_available() -> bool:
         """Return True when aiomqtt is importable."""
         return aiomqtt is not None
-
-    @staticmethod
-    def is_configured() -> bool:
-        """Return True when the broker env var is set."""
-        return bool(os.environ.get(_ENV_BROKER, "").strip())
 
     @property
     def running(self) -> bool:
@@ -102,13 +104,6 @@ class DeviceMqttMonitor:
             _LOGGER.warning(
                 "aiomqtt not installed — MQTT device discovery disabled. "
                 "Install with: pip install aiomqtt"
-            )
-            return
-        if not self.is_configured():
-            _LOGGER.info(
-                "%s not set — MQTT device discovery disabled despite devices "
-                "declaring mqtt: blocks",
-                _ENV_BROKER,
             )
             return
         self._task = asyncio.create_task(self._run())
@@ -130,44 +125,47 @@ class DeviceMqttMonitor:
     # ------------------------------------------------------------------
 
     async def _run(self) -> None:
-        broker, port, username, password = _read_broker_config()
         client_id = f"esphome-dashboard-{secrets.token_hex(6)}"
-        _LOGGER.info("MQTT discovery monitor starting — broker=%s:%s", broker, port)
+        _LOGGER.info("MQTT discovery starting — broker=%s:%s", self._broker.host, self._broker.port)
 
         delay = int(_RECONNECT_DELAY)
         while True:
             try:
-                await self._connect_and_listen(broker, port, username, password, client_id)
+                await self._connect_and_listen(client_id)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 if aiomqtt is not None and isinstance(exc, aiomqtt.MqttError):
-                    _LOGGER.warning("MQTT broker error: %s — reconnecting in %ss", exc, delay)
+                    _LOGGER.warning(
+                        "MQTT broker %s:%s error: %s — reconnecting in %ss",
+                        self._broker.host,
+                        self._broker.port,
+                        exc,
+                        delay,
+                    )
                 else:
-                    _LOGGER.exception("Unexpected MQTT error — reconnecting in %ss", delay)
+                    _LOGGER.exception(
+                        "Unexpected MQTT error for %s:%s — reconnecting in %ss",
+                        self._broker.host,
+                        self._broker.port,
+                        delay,
+                    )
                 # Drop last-seen but leave device state alone so a brief
                 # broker blip doesn't trigger an offline storm.
                 self._last_seen.clear()
                 await asyncio.sleep(_RECONNECT_DELAY)
 
-    async def _connect_and_listen(
-        self,
-        broker: str,
-        port: int,
-        username: str | None,
-        password: str | None,
-        client_id: str,
-    ) -> None:
+    async def _connect_and_listen(self, client_id: str) -> None:
         assert aiomqtt is not None  # type narrowing — checked in start()
 
         async with aiomqtt.Client(
-            hostname=broker,
-            port=port,
-            username=username,
-            password=password,
+            hostname=self._broker.host,
+            port=self._broker.port,
+            username=self._broker.username,
+            password=self._broker.password,
             identifier=client_id,
         ) as client:
-            _LOGGER.info("MQTT connected to %s:%s", broker, port)
+            _LOGGER.info("MQTT connected to %s:%s", self._broker.host, self._broker.port)
             await client.subscribe(_DISCOVER_TOPIC)
             await client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
 
@@ -205,35 +203,18 @@ class DeviceMqttMonitor:
         while True:
             await asyncio.sleep(_PING_INTERVAL)
             now = loop.time()
-            for device in self._get_devices():
-                if not device.uses_mqtt:
-                    continue
-                last = self._last_seen.get(device.name)
-                if last is None:
-                    continue
-                if now - last > _OFFLINE_TIMEOUT:
-                    self._on_state_change(device.name, DeviceState.OFFLINE)
-                    self._last_seen.pop(device.name, None)
+            stale = [
+                name for name, last in self._last_seen.items() if now - last > _OFFLINE_TIMEOUT
+            ]
+            for name in stale:
+                self._on_state_change(name, DeviceState.OFFLINE)
+                self._last_seen.pop(name, None)
             await client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
 
 
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
-
-
-def _read_broker_config() -> tuple[str, int, str | None, str | None]:
-    """Read broker connection parameters from the environment."""
-    broker = os.environ.get(_ENV_BROKER, "").strip()
-    port_raw = os.environ.get(_ENV_PORT, "").strip()
-    try:
-        port = int(port_raw) if port_raw else _DEFAULT_PORT
-    except ValueError:
-        _LOGGER.warning("Invalid %s=%r — falling back to %d", _ENV_PORT, port_raw, _DEFAULT_PORT)
-        port = _DEFAULT_PORT
-    username = os.environ.get(_ENV_USERNAME) or None
-    password = os.environ.get(_ENV_PASSWORD) or None
-    return broker, port, username, password
 
 
 def _extract_ip(data: dict[str, Any]) -> str:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -3,9 +3,14 @@ Device connectivity monitor — mDNS browser + ping fallback.
 
 Tracks online/offline state for the configured devices, with mDNS as
 the primary source (event-driven) and ICMP ping as a periodic fallback
-for devices that aren't broadcasting their service. The monitor calls
-back into the owning controller whenever a state actually changes;
-controllers stay free of zeroconf / icmplib details.
+for devices that aren't broadcasting their service. MQTT observations
+are also welcomed via :meth:`apply` for devices that opt into MQTT
+discovery. The monitor calls back into the owning controller whenever
+a state actually changes; controllers stay free of zeroconf / icmplib
+/ aiomqtt details.
+
+Source precedence (highest first): ``mdns`` > ``mqtt`` > ``ping``. A
+lower-priority source can never override the state set by a higher one.
 """
 
 from __future__ import annotations
@@ -29,6 +34,12 @@ _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
 _PING_INTERVAL = 60  # seconds between ping sweeps
 _PING_BATCH_SIZE = 10
 _MDNS_RESOLVE_TIMEOUT_MS = 2000
+
+# Source priority for state observations. A new observation can only
+# override an existing one when its priority is greater than or equal
+# to the current source's. Keep ``unknown`` at zero so any source can
+# claim a device that no source has yet labelled.
+_SOURCE_PRIORITY = {"unknown": 0, "ping": 1, "mqtt": 2, "mdns": 3}
 
 # Callback signature used by DeviceStateMonitor to push state changes
 # back to its owner. The owner decides what to do with the new state
@@ -97,8 +108,9 @@ class DeviceStateMonitor:
         Record a state observation from *source*.
 
         Returns True when the observation actually changed the device's
-        state and the change was forwarded to the callback. mDNS always
-        wins over ping; same-state observations are no-ops.
+        state and the change was forwarded to the callback. Sources
+        below the current source's priority are ignored; same-state
+        observations are no-ops.
         """
         device = self._find_device_by_name(name)
         if device is None:
@@ -108,7 +120,7 @@ class DeviceStateMonitor:
             return False
 
         current_source = self._state_source.get(name, "unknown")
-        if source == "ping" and current_source == "mdns":
+        if _SOURCE_PRIORITY.get(source, 0) < _SOURCE_PRIORITY.get(current_source, 0):
             return False
         if device.state == state:
             return False
@@ -235,10 +247,15 @@ class DeviceStateMonitor:
         if icmp_ping is None:
             return
 
+        # Skip devices already owned by a higher-priority source — pinging
+        # them just to confirm what we already know wastes work and would
+        # be ignored by ``apply()`` anyway.
+        ping_priority = _SOURCE_PRIORITY["ping"]
         devices_to_ping = [
             d
             for d in self._get_devices()
-            if d.address and self._state_source.get(d.name, "unknown") != "mdns"
+            if d.address
+            and _SOURCE_PRIORITY.get(self._state_source.get(d.name, "unknown"), 0) <= ping_priority
         ]
         if not devices_to_ping:
             return

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -34,7 +34,7 @@ from ..models import (
     UpdateDeviceResponse,
     WizardResponse,
 )
-from ._device_mqtt_monitor import DeviceMqttMonitor
+from ._device_mqtt_coordinator import DeviceMqttCoordinator
 from ._device_scanner import DeviceScanner, ScanChange
 from ._device_state_monitor import DeviceStateMonitor
 from .config import (
@@ -73,7 +73,8 @@ class DevicesController:
         )
         # MQTT routes its observations through the same state monitor so
         # source-priority is enforced in one place.
-        self._mqtt_monitor = DeviceMqttMonitor(
+        self._mqtt_coordinator = DeviceMqttCoordinator(
+            config_dir=self._db.settings.config_dir,
             get_devices=self._get_devices,
             on_state_change=lambda n, s: self._state_monitor.apply(n, s, "mqtt"),
             on_ip_change=self._state_monitor.apply_ip,
@@ -93,17 +94,17 @@ class DevicesController:
         await self._scanner.scan()
         _LOGGER.info("Devices controller started — %d devices loaded", len(self._scanner.devices))
         await self._state_monitor.start()
-        await self._reconcile_mqtt_monitor()
+        await self._mqtt_coordinator.reconcile()
 
     async def stop(self) -> None:
         """Stop background monitors so the process exits cleanly."""
-        await self._mqtt_monitor.stop()
+        await self._mqtt_coordinator.stop()
         await self._state_monitor.stop()
 
     async def poll(self) -> None:
         """Poll for file changes."""
         await self._scanner.scan()
-        await self._reconcile_mqtt_monitor()
+        await self._mqtt_coordinator.reconcile()
 
     def get_devices(self) -> list[Device]:
         """Snapshot of the currently-loaded devices."""
@@ -499,21 +500,6 @@ class DevicesController:
     def _get_devices(self) -> list[Device]:
         """Bridge for the state monitor (``self._scanner.devices`` is a property)."""
         return self._scanner.devices
-
-    async def _reconcile_mqtt_monitor(self) -> None:
-        """
-        Start or stop the MQTT monitor based on current device YAML.
-
-        The watcher only runs while at least one configured device
-        declares an ``mqtt:`` block; otherwise the broker connection is
-        closed entirely.
-        """
-        wants_mqtt = any(d.uses_mqtt for d in self._scanner.devices)
-        if wants_mqtt and not self._mqtt_monitor.running:
-            await self._mqtt_monitor.start()
-        elif not wants_mqtt and self._mqtt_monitor.running:
-            _LOGGER.info("No devices use MQTT — stopping MQTT discovery monitor")
-            await self._mqtt_monitor.stop()
 
     def _resolve_board_id(self, config_dir: Path, filename: str) -> str:
         """Resolve a device's board_id from metadata, falling back to YAML.

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -34,6 +34,7 @@ from ..models import (
     UpdateDeviceResponse,
     WizardResponse,
 )
+from ._device_mqtt_monitor import DeviceMqttMonitor
 from ._device_scanner import DeviceScanner, ScanChange
 from ._device_state_monitor import DeviceStateMonitor
 from .config import (
@@ -70,13 +71,20 @@ class DevicesController:
             on_state_change=self._on_state_change,
             on_ip_change=self._on_ip_change,
         )
+        # MQTT routes its observations through the same state monitor so
+        # source-priority is enforced in one place.
+        self._mqtt_monitor = DeviceMqttMonitor(
+            get_devices=self._get_devices,
+            on_state_change=lambda n, s: self._state_monitor.apply(n, s, "mqtt"),
+            on_ip_change=self._state_monitor.apply_ip,
+        )
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
-        """Initialise — load state, scan files, start mDNS + ping discovery."""
+        """Initialise — load state, scan files, start mDNS + ping + MQTT discovery."""
         from .firmware import _find_esphome_cmd
 
         self._esphome_cmd = _find_esphome_cmd()
@@ -85,10 +93,17 @@ class DevicesController:
         await self._scanner.scan()
         _LOGGER.info("Devices controller started — %d devices loaded", len(self._scanner.devices))
         await self._state_monitor.start()
+        await self._reconcile_mqtt_monitor()
+
+    async def stop(self) -> None:
+        """Stop background monitors so the process exits cleanly."""
+        await self._mqtt_monitor.stop()
+        await self._state_monitor.stop()
 
     async def poll(self) -> None:
         """Poll for file changes."""
         await self._scanner.scan()
+        await self._reconcile_mqtt_monitor()
 
     def get_devices(self) -> list[Device]:
         """Snapshot of the currently-loaded devices."""
@@ -484,6 +499,21 @@ class DevicesController:
     def _get_devices(self) -> list[Device]:
         """Bridge for the state monitor (``self._scanner.devices`` is a property)."""
         return self._scanner.devices
+
+    async def _reconcile_mqtt_monitor(self) -> None:
+        """
+        Start or stop the MQTT monitor based on current device YAML.
+
+        The watcher only runs while at least one configured device
+        declares an ``mqtt:`` block; otherwise the broker connection is
+        closed entirely.
+        """
+        wants_mqtt = any(d.uses_mqtt for d in self._scanner.devices)
+        if wants_mqtt and not self._mqtt_monitor.running:
+            await self._mqtt_monitor.start()
+        elif not wants_mqtt and self._mqtt_monitor.running:
+            _LOGGER.info("No devices use MQTT — stopping MQTT discovery monitor")
+            await self._mqtt_monitor.stop()
 
     def _resolve_board_id(self, config_dir: Path, filename: str) -> str:
         """Resolve a device's board_id from metadata, falling back to YAML.

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -123,6 +123,8 @@ class DeviceBuilder:
             task.cancel()
         if self._background_tasks:
             await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        if self.devices is not None:
+            await self.devices.stop()
         if self.editor is not None:
             await self.editor.stop()
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -166,6 +166,24 @@ def detect_platform_from_yaml(path: Path) -> str:
         return ""
 
 
+def device_uses_mqtt(yaml_content: str) -> bool:
+    """
+    Return True when the device YAML declares a top-level ``mqtt:`` block.
+
+    The check is line-based so it handles invalid drafts and partially
+    edited configs gracefully — no full YAML parse required.
+    """
+    for line in yaml_content.splitlines():
+        if not line or line[0].isspace():
+            continue
+        stripped = line.strip()
+        if stripped.startswith("#") or ":" not in stripped:
+            continue
+        if stripped.split(":", 1)[0].strip() == "mqtt":
+            return True
+    return False
+
+
 def parse_esphome_meta(
     yaml_content: str,
 ) -> tuple[str | None, str | None, str | None]:
@@ -267,6 +285,7 @@ def load_device_from_storage(path: Path, board_id: str = "") -> Device:
         loaded_integrations=sorted(storage.loaded_integrations) if storage else [],
         has_pending_changes=has_pending,
         update_available=update_available,
+        uses_mqtt=device_uses_mqtt(yaml_content),
     )
 
 

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -37,6 +37,7 @@ class Device(DataClassORJSONMixin):
     state: DeviceState = DeviceState.UNKNOWN
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     update_available: bool = False  # True if compiled with older ESPHome version
+    uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.9.0",
+  "aiomqtt>=2.4.0",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
   "pyyaml>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.9.0",
-  "aiomqtt>=2.4.0",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
   "pyyaml>=6.0",

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -1,19 +1,28 @@
 """
-Tests for MQTT detection and the async MQTT status monitor.
+Tests for MQTT detection, broker config parsing, and the multi-broker coordinator.
 
 Covers the parts that don't require a live broker:
 * YAML parsing for the ``mqtt:`` opt-in (helpers.device_yaml)
-* Lifecycle gating in ``DeviceMqttMonitor`` (env / aiomqtt / running flag)
+* ``parse_mqtt_block`` — broker extraction with ``!secret`` resolution
+* ``DeviceMqttCoordinator`` — start/stop one monitor per unique broker
 * Source-priority logic in ``DeviceStateMonitor`` (mdns > mqtt > ping)
 """
 
 from __future__ import annotations
 
-import asyncio
+from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
-from esphome_device_builder.controllers._device_mqtt_monitor import DeviceMqttMonitor
+from esphome_device_builder.controllers._device_mqtt_coordinator import (
+    DeviceMqttCoordinator,
+    parse_mqtt_block,
+)
+from esphome_device_builder.controllers._device_mqtt_monitor import (
+    DeviceMqttMonitor,
+    MqttBrokerConfig,
+)
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.helpers.device_yaml import device_uses_mqtt
 from esphome_device_builder.models import Device, DeviceState
@@ -50,55 +59,260 @@ def test_device_uses_mqtt_handles_empty_input() -> None:
 
 
 # ---------------------------------------------------------------------------
-# DeviceMqttMonitor — gating
+# parse_mqtt_block — broker extraction
 # ---------------------------------------------------------------------------
 
 
-def _noop_state(_name: str, _state: DeviceState) -> None:
-    return None
-
-
-def _noop_ip(_name: str, _ip: str) -> None:
-    return None
-
-
-def _make_monitor(devices: list[Device] | None = None) -> DeviceMqttMonitor:
-    devices = devices or []
-    return DeviceMqttMonitor(
-        get_devices=lambda: devices,
-        on_state_change=_noop_state,
-        on_ip_change=_noop_ip,
+def test_parse_mqtt_block_simple() -> None:
+    yaml = "mqtt:\n  broker: 192.168.1.10\n  username: user\n  password: pass\n"
+    config = parse_mqtt_block(yaml)
+    assert config == MqttBrokerConfig(
+        host="192.168.1.10",
+        port=1883,
+        username="user",
+        password="pass",  # noqa: S106 — fixture credential
     )
 
 
-async def test_monitor_skips_start_when_broker_unconfigured(
-    monkeypatch: pytest.MonkeyPatch,
+def test_parse_mqtt_block_custom_port() -> None:
+    yaml = "mqtt:\n  broker: broker.example\n  port: 8883\n"
+    config = parse_mqtt_block(yaml)
+    assert config is not None
+    assert config.port == 8883
+
+
+def test_parse_mqtt_block_resolves_secrets() -> None:
+    yaml = "mqtt:\n  broker: !secret broker_host\n  password: !secret pw\n"
+    secrets = {"broker_host": "192.168.1.5", "pw": "topsecret"}
+    config = parse_mqtt_block(yaml, secrets)
+    assert config is not None
+    assert config.host == "192.168.1.5"
+    assert config.password == "topsecret"  # noqa: S105 — fixture credential
+
+
+def test_parse_mqtt_block_missing_secret_returns_none() -> None:
+    # broker is required; if its secret can't be resolved, the whole
+    # block is unusable.
+    yaml = "mqtt:\n  broker: !secret missing\n"
+    assert parse_mqtt_block(yaml, {}) is None
+
+
+def test_parse_mqtt_block_no_block() -> None:
+    yaml = "esphome:\n  name: foo\n"
+    assert parse_mqtt_block(yaml) is None
+
+
+def test_parse_mqtt_block_ignores_unknown_tags() -> None:
+    # Devices can use ESPHome custom tags (!lambda, !include) that pyyaml
+    # doesn't know about — parsing must not raise.
+    yaml = (
+        "esphome:\n  name: foo\n"
+        "sensor:\n  - platform: template\n    lambda: !lambda 'return 1;'\n"
+        "mqtt:\n  broker: broker.local\n"
+    )
+    config = parse_mqtt_block(yaml)
+    assert config is not None
+    assert config.host == "broker.local"
+
+
+def test_parse_mqtt_block_invalid_yaml_returns_none() -> None:
+    assert parse_mqtt_block("not: valid: yaml: at all") is None
+
+
+def test_mqtt_broker_config_key_groups_by_host_port() -> None:
+    a = MqttBrokerConfig(host="broker", port=1883, username="alice")
+    b = MqttBrokerConfig(host="broker", port=1883, username="bob")
+    c = MqttBrokerConfig(host="broker", port=8883, username="alice")
+    assert a.key == b.key
+    assert a.key != c.key
+
+
+# ---------------------------------------------------------------------------
+# DeviceMqttCoordinator — broker session lifecycle
+# ---------------------------------------------------------------------------
+
+
+class _RecordingMonitor:
+    """Stand-in for ``DeviceMqttMonitor`` that records lifecycle calls."""
+
+    instances: ClassVar[list[_RecordingMonitor]] = []
+
+    def __init__(self, broker: MqttBrokerConfig, *_args: object, **_kwargs: object) -> None:
+        self.broker = broker
+        self.started = False
+        self.stopped = False
+        self.__class__.instances.append(self)
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+    @property
+    def running(self) -> bool:
+        return self.started and not self.stopped
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture
+def stub_monitor(monkeypatch: pytest.MonkeyPatch) -> type[_RecordingMonitor]:
+    _RecordingMonitor.instances = []
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers._device_mqtt_coordinator.DeviceMqttMonitor",
+        _RecordingMonitor,
+    )
+    return _RecordingMonitor
+
+
+def _write_device(config_dir: Path, name: str, mqtt_yaml: str | None) -> Device:
+    yaml = f"esphome:\n  name: {name}\n"
+    if mqtt_yaml is not None:
+        yaml += f"\n{mqtt_yaml}"
+    (config_dir / f"{name}.yaml").write_text(yaml)
+    return Device(
+        name=name,
+        friendly_name=name,
+        configuration=f"{name}.yaml",
+        uses_mqtt=mqtt_yaml is not None,
+    )
+
+
+def _make_coordinator(config_dir: Path, devices: list[Device]) -> DeviceMqttCoordinator:
+    return DeviceMqttCoordinator(
+        config_dir=config_dir,
+        get_devices=lambda: devices,
+        on_state_change=lambda *_args: None,
+        on_ip_change=lambda *_args: None,
+    )
+
+
+async def test_coordinator_no_mqtt_devices_runs_no_monitors(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
 ) -> None:
-    monkeypatch.delenv("ESPHOME_DASHBOARD_MQTT_BROKER", raising=False)
-    monitor = _make_monitor()
-    await monitor.start()
+    devices = [_write_device(tmp_path, "plain", None)]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    assert coord.active_brokers == 0
+    assert stub_monitor.instances == []
+
+
+async def test_coordinator_groups_devices_with_same_broker(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    devices = [
+        _write_device(tmp_path, "alpha", "mqtt:\n  broker: 192.168.1.10\n"),
+        _write_device(tmp_path, "beta", "mqtt:\n  broker: 192.168.1.10\n"),
+    ]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    assert coord.active_brokers == 1
+    assert len(stub_monitor.instances) == 1
+    assert stub_monitor.instances[0].broker.host == "192.168.1.10"
+
+
+async def test_coordinator_starts_one_monitor_per_unique_broker(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    devices = [
+        _write_device(tmp_path, "alpha", "mqtt:\n  broker: broker-a.local\n"),
+        _write_device(tmp_path, "beta", "mqtt:\n  broker: broker-b.local\n  port: 8883\n"),
+    ]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    assert coord.active_brokers == 2
+    hosts = sorted(m.broker.host for m in stub_monitor.instances)
+    assert hosts == ["broker-a.local", "broker-b.local"]
+
+
+async def test_coordinator_stops_monitors_when_devices_drop_mqtt(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    devices = [_write_device(tmp_path, "alpha", "mqtt:\n  broker: broker.local\n")]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    assert coord.active_brokers == 1
+
+    # Simulate the user editing the YAML to remove the mqtt: block.
+    devices[0].uses_mqtt = False
+    await coord.reconcile()
+    assert coord.active_brokers == 0
+    assert stub_monitor.instances[0].stopped is True
+
+
+async def test_coordinator_stop_cleans_up_all_monitors(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    devices = [
+        _write_device(tmp_path, "alpha", "mqtt:\n  broker: broker-a.local\n"),
+        _write_device(tmp_path, "beta", "mqtt:\n  broker: broker-b.local\n"),
+    ]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    await coord.stop()
+    assert coord.active_brokers == 0
+    assert all(m.stopped for m in stub_monitor.instances)
+
+
+async def test_coordinator_skips_devices_with_unresolvable_secrets(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    devices = [_write_device(tmp_path, "alpha", "mqtt:\n  broker: !secret missing\n")]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    assert coord.active_brokers == 0
+
+
+async def test_coordinator_resolves_secrets_from_secrets_yaml(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    (tmp_path / "secrets.yaml").write_text("mqtt_broker: 10.0.0.5\nmqtt_pw: shh\n")
+    devices = [
+        _write_device(
+            tmp_path,
+            "alpha",
+            "mqtt:\n  broker: !secret mqtt_broker\n  password: !secret mqtt_pw\n",
+        )
+    ]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    assert coord.active_brokers == 1
+    assert stub_monitor.instances[0].broker.host == "10.0.0.5"
+    assert stub_monitor.instances[0].broker.password == "shh"  # noqa: S105 — fixture credential
+
+
+# ---------------------------------------------------------------------------
+# DeviceMqttMonitor — solo lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_running_flag_is_false_before_start() -> None:
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda *_args: None,
+        on_ip_change=lambda *_args: None,
+    )
     assert monitor.running is False
-
-
-async def test_monitor_idempotent_start(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("ESPHOME_DASHBOARD_MQTT_BROKER", raising=False)
-    monitor = _make_monitor()
-    await monitor.start()
-    await monitor.start()  # second call must not raise
-    await monitor.stop()
 
 
 async def test_monitor_stop_without_start_is_noop() -> None:
-    monitor = _make_monitor()
-    await monitor.stop()  # must not raise even though never started
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda *_args: None,
+        on_ip_change=lambda *_args: None,
+    )
+    await monitor.stop()
     assert monitor.running is False
-
-
-def test_monitor_is_configured_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ESPHOME_DASHBOARD_MQTT_BROKER", "broker.example")
-    assert DeviceMqttMonitor.is_configured() is True
-    monkeypatch.setenv("ESPHOME_DASHBOARD_MQTT_BROKER", "   ")
-    assert DeviceMqttMonitor.is_configured() is False
 
 
 # ---------------------------------------------------------------------------
@@ -173,70 +387,3 @@ def test_ping_can_rescue_after_mdns_offline() -> None:
     monitor._state_source.pop("alpha", None)
     assert monitor.apply("alpha", DeviceState.ONLINE, "ping") is True
     assert transitions[-1] == ("alpha", DeviceState.ONLINE, "ping")
-
-
-# ---------------------------------------------------------------------------
-# Lifecycle smoke — verify ``stop()`` cancels a running task even when the
-# broker is wedged. Uses an aiomqtt.Client stub to avoid network IO.
-# ---------------------------------------------------------------------------
-
-
-class _StubMessages:
-    def __init__(self, gate: asyncio.Event) -> None:
-        self._gate = gate
-
-    def __aiter__(self) -> _StubMessages:
-        return self
-
-    async def __anext__(self) -> object:
-        await self._gate.wait()
-        raise StopAsyncIteration
-
-
-class _StubClient:
-    """Minimal aiomqtt.Client lookalike that blocks until cancelled."""
-
-    def __init__(self, *_args: object, **_kwargs: object) -> None:
-        self._block = asyncio.Event()
-
-    async def __aenter__(self) -> _StubClient:
-        return self
-
-    async def __aexit__(self, *_args: object) -> None:
-        return None
-
-    async def subscribe(self, *_args: object, **_kwargs: object) -> None:
-        return None
-
-    async def publish(self, *_args: object, **_kwargs: object) -> None:
-        return None
-
-    @property
-    def messages(self) -> _StubMessages:
-        return _StubMessages(self._block)
-
-
-class _FakeAiomqtt:
-    """Stand-in for the aiomqtt module."""
-
-    Client = _StubClient
-
-    class MqttError(Exception):
-        pass
-
-
-async def test_monitor_stop_cancels_running_task(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ESPHOME_DASHBOARD_MQTT_BROKER", "broker.example")
-    monitor = _make_monitor()
-
-    import esphome_device_builder.controllers._device_mqtt_monitor as mod
-
-    monkeypatch.setattr(mod, "aiomqtt", _FakeAiomqtt(), raising=True)
-
-    await monitor.start()
-    assert monitor.running is True
-    # Yield twice so the connect task reaches the listen loop before stop().
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
-    await monitor.stop()
-    assert monitor.running is False

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -1,0 +1,242 @@
+"""
+Tests for MQTT detection and the async MQTT status monitor.
+
+Covers the parts that don't require a live broker:
+* YAML parsing for the ``mqtt:`` opt-in (helpers.device_yaml)
+* Lifecycle gating in ``DeviceMqttMonitor`` (env / aiomqtt / running flag)
+* Source-priority logic in ``DeviceStateMonitor`` (mdns > mqtt > ping)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from esphome_device_builder.controllers._device_mqtt_monitor import DeviceMqttMonitor
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.helpers.device_yaml import device_uses_mqtt
+from esphome_device_builder.models import Device, DeviceState
+
+# ---------------------------------------------------------------------------
+# YAML detection
+# ---------------------------------------------------------------------------
+
+
+def test_device_uses_mqtt_top_level_block() -> None:
+    yaml = "esphome:\n  name: foo\n\nmqtt:\n  broker: 192.168.1.10\n"
+    assert device_uses_mqtt(yaml) is True
+
+
+def test_device_uses_mqtt_with_comment_above() -> None:
+    yaml = "# notes\n\nmqtt:\n  broker: x\n"
+    assert device_uses_mqtt(yaml) is True
+
+
+def test_device_uses_mqtt_inline_token_does_not_count() -> None:
+    yaml = "esphome:\n  name: foo\n  comment: 'uses mqtt for telemetry'\n"
+    assert device_uses_mqtt(yaml) is False
+
+
+def test_device_uses_mqtt_only_indented_block() -> None:
+    # Indented ``mqtt:`` is part of another block (e.g. a sensor config),
+    # not an opt-in to dashboard MQTT discovery.
+    yaml = "esphome:\n  name: foo\n\nsensor:\n  - mqtt:\n      topic: foo\n"
+    assert device_uses_mqtt(yaml) is False
+
+
+def test_device_uses_mqtt_handles_empty_input() -> None:
+    assert device_uses_mqtt("") is False
+
+
+# ---------------------------------------------------------------------------
+# DeviceMqttMonitor — gating
+# ---------------------------------------------------------------------------
+
+
+def _noop_state(_name: str, _state: DeviceState) -> None:
+    return None
+
+
+def _noop_ip(_name: str, _ip: str) -> None:
+    return None
+
+
+def _make_monitor(devices: list[Device] | None = None) -> DeviceMqttMonitor:
+    devices = devices or []
+    return DeviceMqttMonitor(
+        get_devices=lambda: devices,
+        on_state_change=_noop_state,
+        on_ip_change=_noop_ip,
+    )
+
+
+async def test_monitor_skips_start_when_broker_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ESPHOME_DASHBOARD_MQTT_BROKER", raising=False)
+    monitor = _make_monitor()
+    await monitor.start()
+    assert monitor.running is False
+
+
+async def test_monitor_idempotent_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ESPHOME_DASHBOARD_MQTT_BROKER", raising=False)
+    monitor = _make_monitor()
+    await monitor.start()
+    await monitor.start()  # second call must not raise
+    await monitor.stop()
+
+
+async def test_monitor_stop_without_start_is_noop() -> None:
+    monitor = _make_monitor()
+    await monitor.stop()  # must not raise even though never started
+    assert monitor.running is False
+
+
+def test_monitor_is_configured_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ESPHOME_DASHBOARD_MQTT_BROKER", "broker.example")
+    assert DeviceMqttMonitor.is_configured() is True
+    monkeypatch.setenv("ESPHOME_DASHBOARD_MQTT_BROKER", "   ")
+    assert DeviceMqttMonitor.is_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# DeviceStateMonitor — source priority
+# ---------------------------------------------------------------------------
+
+
+def _build_state_monitor() -> tuple[
+    DeviceStateMonitor, list[Device], list[tuple[str, DeviceState, str]]
+]:
+    devices = [Device(name="alpha", friendly_name="Alpha", configuration="alpha.yaml")]
+    transitions: list[tuple[str, DeviceState, str]] = []
+
+    def record(name: str, state: DeviceState, source: str) -> None:
+        transitions.append((name, state, source))
+        for device in devices:
+            if device.name == name:
+                device.state = state
+
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=record,
+        on_ip_change=lambda _n, _ip: None,
+    )
+    return monitor, devices, transitions
+
+
+def test_priority_mdns_blocks_lower_sources() -> None:
+    monitor, _, transitions = _build_state_monitor()
+
+    assert monitor.apply("alpha", DeviceState.ONLINE, "mdns") is True
+    assert monitor.apply("alpha", DeviceState.OFFLINE, "mqtt") is False
+    assert monitor.apply("alpha", DeviceState.OFFLINE, "ping") is False
+    assert transitions == [("alpha", DeviceState.ONLINE, "mdns")]
+
+
+def test_priority_mqtt_overrides_ping() -> None:
+    monitor, _, transitions = _build_state_monitor()
+
+    assert monitor.apply("alpha", DeviceState.ONLINE, "ping") is True
+    assert monitor.apply("alpha", DeviceState.OFFLINE, "mqtt") is True
+    assert transitions[-1] == ("alpha", DeviceState.OFFLINE, "mqtt")
+
+
+def test_priority_same_source_replays_are_noop_for_identical_state() -> None:
+    monitor, _, transitions = _build_state_monitor()
+
+    assert monitor.apply("alpha", DeviceState.ONLINE, "mqtt") is True
+    assert monitor.apply("alpha", DeviceState.ONLINE, "mqtt") is False
+    assert len(transitions) == 1
+
+
+def test_priority_unknown_source_stamped_after_first_observation() -> None:
+    monitor, _, _ = _build_state_monitor()
+
+    assert monitor.apply("alpha", DeviceState.ONLINE, "ping") is True
+    assert monitor.priority_for("alpha") == "ping"
+
+
+def test_unknown_device_observation_is_ignored() -> None:
+    monitor, _, transitions = _build_state_monitor()
+    assert monitor.apply("missing", DeviceState.ONLINE, "mqtt") is False
+    assert transitions == []
+
+
+def test_ping_can_rescue_after_mdns_offline() -> None:
+    """After mDNS pops its source, ping must be allowed to re-mark ONLINE."""
+    monitor, _, transitions = _build_state_monitor()
+    monitor.apply("alpha", DeviceState.ONLINE, "mdns")
+    monitor.apply("alpha", DeviceState.OFFLINE, "mdns")
+    # The mDNS Removed handler clears the source so a different source can take over.
+    monitor._state_source.pop("alpha", None)
+    assert monitor.apply("alpha", DeviceState.ONLINE, "ping") is True
+    assert transitions[-1] == ("alpha", DeviceState.ONLINE, "ping")
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle smoke — verify ``stop()`` cancels a running task even when the
+# broker is wedged. Uses an aiomqtt.Client stub to avoid network IO.
+# ---------------------------------------------------------------------------
+
+
+class _StubMessages:
+    def __init__(self, gate: asyncio.Event) -> None:
+        self._gate = gate
+
+    def __aiter__(self) -> _StubMessages:
+        return self
+
+    async def __anext__(self) -> object:
+        await self._gate.wait()
+        raise StopAsyncIteration
+
+
+class _StubClient:
+    """Minimal aiomqtt.Client lookalike that blocks until cancelled."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        self._block = asyncio.Event()
+
+    async def __aenter__(self) -> _StubClient:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def subscribe(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def publish(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    @property
+    def messages(self) -> _StubMessages:
+        return _StubMessages(self._block)
+
+
+class _FakeAiomqtt:
+    """Stand-in for the aiomqtt module."""
+
+    Client = _StubClient
+
+    class MqttError(Exception):
+        pass
+
+
+async def test_monitor_stop_cancels_running_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ESPHOME_DASHBOARD_MQTT_BROKER", "broker.example")
+    monitor = _make_monitor()
+
+    import esphome_device_builder.controllers._device_mqtt_monitor as mod
+
+    monkeypatch.setattr(mod, "aiomqtt", _FakeAiomqtt(), raising=True)
+
+    await monitor.start()
+    assert monitor.running is True
+    # Yield twice so the connect task reaches the listen loop before stop().
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await monitor.stop()
+    assert monitor.running is False


### PR DESCRIPTION
## Problem

The new dashboard had no MQTT status support — devices configured with an `mqtt:` block could not be tracked for online/offline state, leaving a gap relative to the legacy dashboard ([#5](https://github.com/esphome/device-builder/issues/5)).

## Changes

- New async `DeviceMqttMonitor` (controllers/_device_mqtt_monitor.py) using `aiomqtt`. Subscribes to `esphome/discover/#`, prods devices every 2s, marks them offline if silent for 10s. Auto-reconnects on broker errors.
- Detection helper `device_uses_mqtt()` plus `Device.uses_mqtt` flag — set during the YAML scan.
- `DevicesController` reconciles the MQTT monitor on every scan: starts the watcher only while at least one device declares an `mqtt:` block, stops it when none do.
- `DeviceStateMonitor` switched from an ad-hoc `mdns > ping` check to a shared `_SOURCE_PRIORITY` table (`mdns > mqtt > ping`); ping sweep skips anything outranking it.
- Reads the same env vars the existing dashboard already documents: `ESPHOME_DASHBOARD_MQTT_{BROKER,PORT,USERNAME,PASSWORD}`.
- Added `aiomqtt>=2.4.0` dependency.
- Test coverage for YAML detection, lifecycle gating, and source priority.

Closes #5