### PR TITLE
Add DNS address cache with ping pre-resolve and IP persistence

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -53,9 +53,15 @@ class DeviceScanner:
         config_dir: Path,
         get_board_id: Callable[[Path, str], str],
         on_change: ScanCallback,
+        get_ip: Callable[[Path, str], str] | None = None,
     ) -> None:
         self._config_dir = config_dir
         self._get_board_id = get_board_id
+        # Optional IP resolver — looks up the last-known resolved IP
+        # from the metadata sidecar so the OTA address cache survives
+        # restarts. Defaults to a no-op so tests that don't care about
+        # persistence stay simple.
+        self._get_ip = get_ip or (lambda _config_dir, _filename: "")
         self._on_change = on_change
         self._devices: dict[Path, Device] = {}
         self._cache_keys: dict[Path, _CacheKey] = {}
@@ -126,7 +132,8 @@ class DeviceScanner:
         for path in paths:
             try:
                 board_id = self._get_board_id(self._config_dir, path.name)
-                result[path] = load_device_from_storage(path, board_id)
+                ip = self._get_ip(self._config_dir, path.name)
+                result[path] = load_device_from_storage(path, board_id, ip)
             except Exception:
                 _LOGGER.warning("Failed to load device from %s", path.name)
         return result

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -28,6 +28,7 @@ except ImportError:  # pragma: no cover — icmplib is optional
     icmp_ping = None  # type: ignore[assignment]
 
 from ..models import Device, DeviceState
+from ._dns_cache import DNSCache
 
 _LOGGER = logging.getLogger(__name__)
 _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
@@ -86,6 +87,11 @@ class DeviceStateMonitor:
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         self._mdns_browser: Any = None
         self._ping_task: asyncio.Task | None = None
+        # DNS resolutions for non-mDNS hostnames are cached here so the
+        # ping sweep, OTA cache args, and device.ip tracking all share
+        # the same TTL'd lookup result instead of re-resolving every
+        # cycle.
+        self._dns_cache = DNSCache()
 
     async def start(self) -> None:
         """Start the mDNS browser and the periodic ping sweep."""
@@ -181,7 +187,8 @@ class DeviceStateMonitor:
         Return zeroconf-cached IPs for *host_name* without issuing a query.
 
         Returns ``None`` when zeroconf isn't running, the cache misses,
-        or the entry has expired.
+        or the entry has expired. mDNS-only — see
+        :meth:`get_cached_dns_addresses` for non-``.local`` hostnames.
         """
         if self._zeroconf is None:
             return None
@@ -198,6 +205,15 @@ class DeviceStateMonitor:
             return None
         addresses = info.parsed_scoped_addresses(IPVersion.All)
         return addresses or None
+
+    def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
+        """
+        Return DNS-cached IPs for *host_name* without issuing a lookup.
+
+        Populated by the ping sweep's pre-resolution pass. Returns
+        ``None`` on cache miss or when the entry has expired.
+        """
+        return self._dns_cache.get_cached_addresses(host_name)
 
     # ------------------------------------------------------------------
     # Internals
@@ -325,12 +341,33 @@ class DeviceStateMonitor:
 
         for i in range(0, len(devices_to_ping), _PING_BATCH_SIZE):
             batch = devices_to_ping[i : i + _PING_BATCH_SIZE]
-            tasks = [self._ping_device(d) for d in batch]
-            await asyncio.gather(*tasks, return_exceptions=True)
+            # Pre-resolve every batch via the DNS cache. icmplib would
+            # otherwise re-resolve internally on every ping, and the
+            # OTA cache args would have nothing to draw on for non-mDNS
+            # hostnames.
+            resolved = await asyncio.gather(
+                *(self._dns_cache.async_resolve(d.address) for d in batch),
+                return_exceptions=True,
+            )
+            ping_targets: list[tuple[Device, str]] = []
+            for device, addresses in zip(batch, resolved, strict=True):
+                target = device.address
+                if isinstance(addresses, list) and addresses:
+                    target = addresses[0]
+                    # mDNS owns IP tracking for ``.local`` hosts; only
+                    # backfill from DNS for non-mDNS hosts so a stale
+                    # DNS result can't clobber the live mDNS value.
+                    if not device.address.rstrip(".").lower().endswith(".local"):
+                        self.apply_ip(device.name, target)
+                ping_targets.append((device, target))
+            await asyncio.gather(
+                *(self._ping_device(device, target) for device, target in ping_targets),
+                return_exceptions=True,
+            )
 
-    async def _ping_device(self, device: Device) -> None:
+    async def _ping_device(self, device: Device, target: str) -> None:
         try:
-            result = await icmp_ping(device.address, count=1, timeout=3, privileged=False)
+            result = await icmp_ping(target, count=1, timeout=3, privileged=False)
         except Exception:
             return
         new_state = DeviceState.ONLINE if result.is_alive else DeviceState.OFFLINE

--- a/esphome_device_builder/controllers/_dns_cache.py
+++ b/esphome_device_builder/controllers/_dns_cache.py
@@ -1,0 +1,133 @@
+"""
+TTL'd async A/AAAA resolver.
+
+Caches DNS lookups so repeated pings and OTA operations against the
+same hostname don't hammer the system resolver. Successful and failed
+resolutions are both cached for the configured TTL — caching failures
+keeps a transient outage from triggering a thundering herd of retries
+across every ping cycle. Failed entries are hidden from
+:meth:`get_cached_addresses` so callers fall through to their own
+fallbacks.
+
+This is intentionally separate from the zeroconf-backed mDNS cache
+exposed by :class:`DeviceStateMonitor`: that one is event-driven and
+mDNS-only, this one is a pull-based DNS resolver useful for non-mDNS
+hostnames.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from contextlib import suppress
+from ipaddress import ip_address
+
+try:
+    from icmplib import NameLookupError, async_resolve
+except ImportError:  # pragma: no cover — icmplib is optional
+    NameLookupError = Exception  # type: ignore[assignment, misc]
+    async_resolve = None  # type: ignore[assignment]
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_TTL_SECONDS = 120
+_RESOLVE_TIMEOUT_SECONDS = 3.0
+# icmplib raises NameLookupError on resolution failure; UnicodeError
+# fires for malformed hostnames; TimeoutError covers the asyncio
+# timeout we wrap the call in.
+_RESOLVE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    TimeoutError,
+    NameLookupError,
+    UnicodeError,
+)
+
+
+class DNSCache:
+    """
+    TTL'd async A/AAAA resolver.
+
+    Use :meth:`async_resolve` to look up a hostname, caching the result
+    for *ttl* seconds. :meth:`get_cached_addresses` returns the cached
+    IPs without triggering resolution — useful when building OTA cache
+    args from data we already have on hand.
+
+    Literal IPv4/IPv6 addresses short-circuit the cache entirely.
+    """
+
+    def __init__(self, ttl: int = _DEFAULT_TTL_SECONDS) -> None:
+        self._ttl = ttl
+        # hostname → (expires_at_monotonic, addresses-or-None-on-failure)
+        self._cache: dict[str, tuple[float, list[str] | None]] = {}
+
+    def get_cached_addresses(self, hostname: str) -> list[str] | None:
+        """
+        Return cached IPs for *hostname* without triggering a lookup.
+
+        ``None`` when the cache misses, the entry has expired, or the
+        last resolution failed.
+        """
+        normalized = self._normalize(hostname)
+        with suppress(ValueError):
+            return [str(ip_address(normalized))]
+
+        entry = self._cache.get(normalized)
+        if entry is None:
+            return None
+        expires_at, addresses = entry
+        if expires_at <= time.monotonic() or not addresses:
+            return None
+        return list(addresses)
+
+    async def async_resolve(self, hostname: str) -> list[str] | None:
+        """
+        Resolve *hostname* to a list of IPs, caching the result.
+
+        Returns ``None`` when resolution fails (the failure is also
+        cached so retries don't hammer the resolver during an outage).
+        Literal IPs are returned immediately without a lookup. When
+        ``.local`` resolution fails, the bare hostname is tried as a
+        fallback in case the network has unicast DNS for it.
+        """
+        normalized = self._normalize(hostname)
+        with suppress(ValueError):
+            return [str(ip_address(normalized))]
+
+        if async_resolve is None:
+            return None
+
+        now = time.monotonic()
+        entry = self._cache.get(normalized)
+        if entry is not None and entry[0] > now:
+            return list(entry[1]) if entry[1] else None
+
+        addresses = await self._resolve(normalized)
+        self._cache[normalized] = (now + self._ttl, addresses)
+        return list(addresses) if addresses else None
+
+    @staticmethod
+    def _normalize(hostname: str) -> str:
+        return hostname.rstrip(".").lower()
+
+    async def _resolve(self, hostname: str) -> list[str] | None:
+        """Resolve *hostname* with a ``.local`` → bare-hostname fallback."""
+        addresses = await self._try_resolve(hostname)
+        if addresses is not None:
+            return addresses
+        # Some networks resolve the bare hostname via unicast DNS even
+        # when ``.local`` mDNS resolution fails — fall back to that
+        # rather than giving up immediately.
+        if hostname.endswith(".local"):
+            bare = hostname.removesuffix(".local")
+            addresses = await self._try_resolve(bare)
+            if addresses is not None:
+                _LOGGER.debug("Resolved %s via bare-hostname fallback (%s)", hostname, bare)
+        return addresses
+
+    @staticmethod
+    async def _try_resolve(hostname: str) -> list[str] | None:
+        try:
+            async with asyncio.timeout(_RESOLVE_TIMEOUT_SECONDS):
+                return await async_resolve(hostname)
+        except _RESOLVE_EXCEPTIONS:
+            return None

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -145,8 +145,16 @@ def set_device_metadata(
     board_id: str | None = None,
     friendly_name: str | None = None,
     comment: str | None = None,
+    ip: str | None = None,
 ) -> None:
-    """Set metadata fields for a device."""
+    """
+    Set metadata fields for a device.
+
+    ``ip`` is the last-known resolved IP — persisted so the address
+    cache survives backend restarts. Pass an empty string to leave the
+    persisted value unchanged (mDNS clears the in-memory IP whenever a
+    device drops off the network, but the cache is still useful).
+    """
     data = _load_metadata(config_dir)
     entry = data.setdefault(filename, {})
     if board_id is not None:
@@ -155,6 +163,8 @@ def set_device_metadata(
         entry["friendly_name"] = friendly_name
     if comment is not None:
         entry["comment"] = comment
+    if ip:
+        entry["ip"] = ip
     _save_metadata(config_dir, data)
 
 
@@ -162,6 +172,11 @@ def get_device_metadata(config_dir: Path, filename: str) -> dict[str, Any]:
     """Get all metadata for a device."""
     result = _load_metadata(config_dir).get(filename, {})
     return result if isinstance(result, dict) else {}
+
+
+def get_device_ip(config_dir: Path, filename: str) -> str:
+    """Return the last-known resolved IP for a device, or ``""`` if unknown."""
+    return str(_load_metadata(config_dir).get(filename, {}).get("ip", ""))
 
 
 def remove_device_metadata(config_dir: Path, filename: str) -> None:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -40,6 +40,7 @@ from ._device_scanner import DeviceScanner, ScanChange
 from ._device_state_monitor import DeviceStateMonitor
 from .config import (
     get_board_id,
+    get_device_ip,
     get_device_metadata,
     remove_device_metadata,
     set_device_metadata,
@@ -66,6 +67,7 @@ class DevicesController:
             config_dir=self._db.settings.config_dir,
             get_board_id=self._resolve_board_id,
             on_change=self._on_scan_change,
+            get_ip=get_device_ip,
         )
         self._state_monitor = DeviceStateMonitor(
             get_devices=self._get_devices,
@@ -587,7 +589,14 @@ class DevicesController:
         self._db.bus.fire(EventType.DEVICE_STATE_CHANGED, {"device": device})
 
     def _on_ip_change(self, name: str, ip: str) -> None:
-        """Forward mDNS-resolved IP updates onto the event bus."""
+        """
+        Forward IP updates onto the event bus and persist non-empty values.
+
+        ``ip=""`` means the device dropped off mDNS — we keep the
+        last-known IP on disk so the OTA address cache stays warm
+        across the device's offline window. The DNS pre-resolve and
+        next mDNS resolve will overwrite it on reconnect.
+        """
         device = next((d for d in self._scanner.devices if d.name == name), None)
         if device is None:
             return
@@ -595,7 +604,17 @@ class DevicesController:
             return
         device.ip = ip
         _LOGGER.debug("Device %s IP: %s", name, ip or "(cleared)")
+        if ip:
+            self._db.create_background_task(self._persist_device_ip_async(device.configuration, ip))
         self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+
+    async def _persist_device_ip_async(self, configuration: str, ip: str) -> None:
+        """Save *ip* to the device-builder metadata sidecar."""
+        loop = asyncio.get_running_loop()
+        config_dir = self._db.settings.config_dir
+        await loop.run_in_executor(
+            None, lambda: set_device_metadata(config_dir, configuration, ip=ip)
+        )
 
     def _on_version_change(self, name: str, version: str) -> None:
         """Apply a fresh ESPHome version observed via mDNS."""
@@ -702,6 +721,7 @@ class DevicesController:
                     board_id=old_meta.get("board_id"),
                     friendly_name=(new_name if meta_friendly == old_name else meta_friendly),
                     comment=old_meta.get("comment"),
+                    ip=old_meta.get("ip"),
                 )
                 remove_device_metadata(config_dir, configuration)
         except Exception:
@@ -764,14 +784,21 @@ def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None
     normalized = address.rstrip(".").lower()
     is_local = normalized.endswith(".local")
 
+    # Preferred source per host type:
+    #   .local  → zeroconf cache (mDNS-only, freshest while the browser is alive)
+    #   non-.local → DNS cache populated by the ping sweep's pre-resolve pass
+    # Either falls back to ``device.ip`` (the last-known resolved IP) so
+    # an expired cache entry doesn't strip the cache args entirely.
     addresses: list[str] = []
-    if is_local and monitor is not None:
-        cached = monitor.get_cached_addresses(address)
+    if monitor is not None:
+        cached = (
+            monitor.get_cached_addresses(address)
+            if is_local
+            else monitor.get_cached_dns_addresses(address)
+        )
         if cached:
             addresses = list(cached)
 
-    # Fall back to the single IP we tracked via mDNS resolution — covers
-    # the case where the zeroconf cache entry expired between resolves.
     if not addresses and device.ip:
         addresses = [device.ip]
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -257,13 +257,17 @@ def parse_esphome_meta(
 # ---------------------------------------------------------------------------
 
 
-def load_device_from_storage(path: Path, board_id: str = "") -> Device:
+def load_device_from_storage(path: Path, board_id: str = "", ip: str = "") -> Device:
     """
     Build a Device model from a YAML config file and its StorageJSON.
 
     User-editable fields (name / friendly_name / comment) come from the
     YAML when present so the dashboard reflects edits immediately,
     without having to wait for the next compile to refresh StorageJSON.
+
+    *ip* is the last-known resolved address from the device-builder
+    metadata sidecar. Loading it back on startup lets the OTA address
+    cache hand the CLI a usable IP before the first ping/mDNS sweep.
     """
     filename = path.name
     storage = StorageJSON.load(ext_storage_path(filename))
@@ -307,6 +311,7 @@ def load_device_from_storage(path: Path, board_id: str = "") -> Device:
         board_id=board_id,
         target_platform=target_platform,
         address=storage.address or "" if storage else "",
+        ip=ip,
         web_port=storage.web_port if storage else None,
         current_version=const.__version__,
         deployed_version=deployed,

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -27,9 +27,10 @@ class Device(DataClassORJSONMixin):
     board_id: str = ""
     target_platform: str = ""
     address: str = ""  # mDNS hostname from StorageJSON (e.g. "my_device.local")
-    ip: str = (
-        ""  # Resolved IPv4 address from mDNS discovery — empty until the device is seen online
-    )
+    # Last-known resolved IP. Populated by mDNS resolution and DNS
+    # pre-resolve in the ping sweep, persisted through the device-builder
+    # metadata sidecar so the OTA address cache survives a restart.
+    ip: str = ""
     web_port: int | None = None
     current_version: str = ""
     deployed_version: str = ""

--- a/tests/test_address_cache.py
+++ b/tests/test_address_cache.py
@@ -30,9 +30,13 @@ def _device(**overrides: Any) -> Device:
     return Device(**base)
 
 
-def _monitor(addresses: list[str] | None) -> Any:
+def _monitor(
+    addresses: list[str] | None = None,
+    dns_addresses: list[str] | None = None,
+) -> Any:
     monitor = MagicMock()
     monitor.get_cached_addresses.return_value = addresses
+    monitor.get_cached_dns_addresses.return_value = dns_addresses
     return monitor
 
 
@@ -70,19 +74,43 @@ def test_local_address_no_cache_no_ip_returns_empty() -> None:
 
 
 def test_non_local_address_uses_dns_cache() -> None:
-    """Non-``.local`` host with tracked IP → ``--dns-address-cache``."""
+    """Non-``.local`` host with DNS-cache hit → ``--dns-address-cache``."""
     args = _build_address_cache_args(
-        _device(address="esp.example.com", ip="10.0.0.1"), _monitor(None)
+        _device(address="esp.example.com"),
+        _monitor(dns_addresses=["10.0.0.1"]),
     )
+    assert args == ["--dns-address-cache", "esp.example.com=10.0.0.1"]
+
+
+def test_non_local_dns_cache_preferred_over_device_ip() -> None:
+    """A fresh DNS-cache hit wins over the stale ``device.ip`` fallback."""
+    args = _build_address_cache_args(
+        _device(address="esp.example.com", ip="10.0.0.99"),
+        _monitor(dns_addresses=["10.0.0.1"]),
+    )
+    assert args == ["--dns-address-cache", "esp.example.com=10.0.0.1"]
+
+
+def test_non_local_falls_back_to_device_ip() -> None:
+    """DNS cache miss + tracked IP → still emit a cache entry."""
+    args = _build_address_cache_args(_device(address="esp.example.com", ip="10.0.0.1"), _monitor())
     assert args == ["--dns-address-cache", "esp.example.com=10.0.0.1"]
 
 
 def test_non_local_skips_zeroconf_lookup() -> None:
     """Non-``.local`` addresses don't hit zeroconf — that cache is mDNS-only."""
-    monitor = _monitor(["1.1.1.1"])
-    args = _build_address_cache_args(_device(address="esp.example.com", ip="10.0.0.1"), monitor)
+    monitor = _monitor(addresses=["1.1.1.1"], dns_addresses=["10.0.0.1"])
+    args = _build_address_cache_args(_device(address="esp.example.com"), monitor)
     assert args == ["--dns-address-cache", "esp.example.com=10.0.0.1"]
     monitor.get_cached_addresses.assert_not_called()
+
+
+def test_local_skips_dns_cache_lookup() -> None:
+    """``.local`` addresses don't hit the DNS cache — zeroconf is the source of truth."""
+    monitor = _monitor(addresses=["192.168.1.50"], dns_addresses=["10.0.0.1"])
+    args = _build_address_cache_args(_device(), monitor)
+    assert args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+    monitor.get_cached_dns_addresses.assert_not_called()
 
 
 def test_no_address_returns_empty() -> None:

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -1,0 +1,397 @@
+"""Tests for the TTL'd DNS cache used by ping pre-resolution + OTA cache args."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder.controllers import _dns_cache as dns_cache_mod
+from esphome_device_builder.controllers._dns_cache import DNSCache
+
+
+@pytest.fixture
+def fake_resolver() -> Callable[..., Callable[[str], Awaitable[list[str]]]]:
+    """Build a stub for ``icmplib.async_resolve``.
+
+    The factory captures call counts and returns successive results
+    from *responses* — a list whose entries are either a list of IPs
+    or an exception class to raise.
+    """
+
+    def factory(
+        *responses: list[str] | type[BaseException],
+    ) -> Callable[[str], Awaitable[list[str]]]:
+        calls: list[str] = []
+        queue = list(responses)
+
+        async def stub(name: str, family: int | None = None) -> list[str]:
+            calls.append(name)
+            if not queue:
+                msg = "no more queued responses"
+                raise RuntimeError(msg)
+            response = queue.pop(0)
+            if isinstance(response, list):
+                return response
+            raise response(name)
+
+        stub.calls = calls  # type: ignore[attr-defined]
+        return stub
+
+    return factory
+
+
+# ----------------------------------------------------------------------
+# get_cached_addresses
+# ----------------------------------------------------------------------
+
+
+def test_literal_ip_returns_self_without_cache() -> None:
+    """Literal IPv4/IPv6 addresses short-circuit and skip the cache."""
+    cache = DNSCache()
+    assert cache.get_cached_addresses("10.0.0.1") == ["10.0.0.1"]
+    assert cache.get_cached_addresses("fe80::1") == ["fe80::1"]
+    assert cache._cache == {}
+
+
+def test_get_cached_returns_none_on_miss() -> None:
+    assert DNSCache().get_cached_addresses("esp.example.com") is None
+
+
+def test_get_cached_returns_none_after_ttl_expiry() -> None:
+    cache = DNSCache(ttl=60)
+    cache._cache["esp.example.com"] = (time.monotonic() - 1, ["10.0.0.1"])
+    assert cache.get_cached_addresses("esp.example.com") is None
+
+
+def test_get_cached_normalises_hostname() -> None:
+    """Trailing dot + uppercase resolve to the same cache key."""
+    cache = DNSCache(ttl=60)
+    cache._cache["esp.example.com"] = (time.monotonic() + 60, ["10.0.0.1"])
+    assert cache.get_cached_addresses("ESP.example.com.") == ["10.0.0.1"]
+
+
+def test_get_cached_hides_failed_resolutions() -> None:
+    """A cached failure is treated as a miss so callers can fall back."""
+    cache = DNSCache(ttl=60)
+    cache._cache["esp.example.com"] = (time.monotonic() + 60, None)
+    assert cache.get_cached_addresses("esp.example.com") is None
+
+
+# ----------------------------------------------------------------------
+# async_resolve
+# ----------------------------------------------------------------------
+
+
+async def test_async_resolve_caches_first_call(fake_resolver) -> None:
+    stub = fake_resolver(["10.0.0.1"])
+    cache = DNSCache(ttl=60)
+    with patch.object(dns_cache_mod, "async_resolve", stub):
+        first = await cache.async_resolve("esp.example.com")
+        second = await cache.async_resolve("esp.example.com")
+    assert first == ["10.0.0.1"]
+    assert second == ["10.0.0.1"]
+    assert stub.calls == ["esp.example.com"]
+
+
+async def test_async_resolve_re_resolves_after_ttl(fake_resolver) -> None:
+    stub = fake_resolver(["10.0.0.1"], ["10.0.0.2"])
+    cache = DNSCache(ttl=60)
+    with patch.object(dns_cache_mod, "async_resolve", stub):
+        first = await cache.async_resolve("esp.example.com")
+        # Manually expire the entry instead of sleeping.
+        expires_at, addresses = cache._cache["esp.example.com"]
+        cache._cache["esp.example.com"] = (expires_at - 9999, addresses)
+        second = await cache.async_resolve("esp.example.com")
+    assert first == ["10.0.0.1"]
+    assert second == ["10.0.0.2"]
+    assert stub.calls == ["esp.example.com", "esp.example.com"]
+
+
+async def test_async_resolve_caches_failures(fake_resolver) -> None:
+    """
+    A failed lookup is cached for the TTL.
+
+    A single transient error must not turn into a re-resolution storm
+    next cycle.
+    """
+    stub = fake_resolver(dns_cache_mod.NameLookupError)
+    cache = DNSCache(ttl=60)
+    with patch.object(dns_cache_mod, "async_resolve", stub):
+        result = await cache.async_resolve("esp.example.com")
+        # Second call should hit the cached failure and NOT re-resolve.
+        result2 = await cache.async_resolve("esp.example.com")
+    assert result is None
+    assert result2 is None
+    assert stub.calls == ["esp.example.com"]
+    assert cache.get_cached_addresses("esp.example.com") is None
+
+
+async def test_async_resolve_falls_back_to_bare_hostname(fake_resolver) -> None:
+    """When ``foo.local`` resolution fails, retry the bare hostname."""
+    stub = fake_resolver(dns_cache_mod.NameLookupError, ["10.0.0.1"])
+    cache = DNSCache(ttl=60)
+    with patch.object(dns_cache_mod, "async_resolve", stub):
+        result = await cache.async_resolve("foo.local")
+    assert result == ["10.0.0.1"]
+    assert stub.calls == ["foo.local", "foo"]
+
+
+async def test_async_resolve_returns_literal_ip_without_lookup(fake_resolver) -> None:
+    stub = fake_resolver(["1.2.3.4"])
+    cache = DNSCache(ttl=60)
+    with patch.object(dns_cache_mod, "async_resolve", stub):
+        result = await cache.async_resolve("10.0.0.1")
+    assert result == ["10.0.0.1"]
+    assert stub.calls == []
+
+
+async def test_async_resolve_handles_timeout(fake_resolver) -> None:
+    """A timeout during resolution is treated as a failure (None)."""
+    stub = fake_resolver(TimeoutError)
+    cache = DNSCache(ttl=60)
+    with patch.object(dns_cache_mod, "async_resolve", stub):
+        result = await cache.async_resolve("esp.example.com")
+    assert result is None
+
+
+# ----------------------------------------------------------------------
+# DeviceStateMonitor — ping pre-resolution
+# ----------------------------------------------------------------------
+
+
+def _device(**overrides):  # type: ignore[no-untyped-def]
+    from esphome_device_builder.models import Device, DeviceState
+
+    base = {
+        "name": "kitchen",
+        "friendly_name": "Kitchen",
+        "configuration": "kitchen.yaml",
+        "address": "esp.example.com",
+        "state": DeviceState.UNKNOWN,
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
+    """A ping sweep populates the DNS cache and pings the resolved IP."""
+    from esphome_device_builder.controllers import _device_state_monitor as sm
+    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+
+    devices = [_device()]
+    state_changes: list[tuple[str, object, str]] = []
+    ip_changes: list[tuple[str, str]] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
+        on_ip_change=lambda n, ip: ip_changes.append((n, ip)),
+    )
+
+    resolver = fake_resolver(["10.0.0.1"])
+    pinged: list[str] = []
+
+    async def fake_ping(target, **_kwargs):  # type: ignore[no-untyped-def]
+        pinged.append(target)
+
+        class _R:
+            is_alive = True
+
+        return _R()
+
+    with (
+        patch.object(dns_cache_mod, "async_resolve", resolver),
+        patch.object(sm, "icmp_ping", fake_ping),
+    ):
+        await monitor._ping_sweep()
+
+    assert pinged == ["10.0.0.1"]
+    assert ip_changes == [("kitchen", "10.0.0.1")]
+    # DNS cache is now warm — ``get_cached_dns_addresses`` should hit
+    # without triggering another resolver call.
+    assert monitor.get_cached_dns_addresses("esp.example.com") == ["10.0.0.1"]
+
+
+async def test_ping_sweep_does_not_apply_ip_for_local_hosts(fake_resolver) -> None:
+    """``.local`` devices keep their mDNS-owned IP — DNS doesn't write."""
+    from esphome_device_builder.controllers import _device_state_monitor as sm
+    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+
+    devices = [_device(address="kitchen.local")]
+    ip_changes: list[tuple[str, str]] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda n, ip: ip_changes.append((n, ip)),
+    )
+
+    resolver = fake_resolver(["192.168.1.50"])
+
+    async def fake_ping(_target, **_kwargs):  # type: ignore[no-untyped-def]
+        class _R:
+            is_alive = True
+
+        return _R()
+
+    with (
+        patch.object(dns_cache_mod, "async_resolve", resolver),
+        patch.object(sm, "icmp_ping", fake_ping),
+    ):
+        await monitor._ping_sweep()
+
+    assert ip_changes == []
+
+
+async def test_ping_sweep_pings_hostname_when_resolution_fails(fake_resolver) -> None:
+    """DNS resolution failure → fall back to pinging the hostname."""
+    from esphome_device_builder.controllers import _device_state_monitor as sm
+    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+
+    devices = [_device()]
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    resolver = fake_resolver(dns_cache_mod.NameLookupError)
+    pinged: list[str] = []
+
+    async def fake_ping(target, **_kwargs):  # type: ignore[no-untyped-def]
+        pinged.append(target)
+
+        class _R:
+            is_alive = False
+
+        return _R()
+
+    with (
+        patch.object(dns_cache_mod, "async_resolve", resolver),
+        patch.object(sm, "icmp_ping", fake_ping),
+    ):
+        await monitor._ping_sweep()
+
+    assert pinged == ["esp.example.com"]
+
+
+# ----------------------------------------------------------------------
+# IP persistence
+# ----------------------------------------------------------------------
+
+
+def test_set_device_ip_writes_to_metadata(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """``set_device_metadata(ip=...)`` round-trips through ``get_device_ip``."""
+    from esphome_device_builder.controllers.config import (
+        get_device_ip,
+        set_device_metadata,
+    )
+
+    set_device_metadata(tmp_path, "kitchen.yaml", ip="10.0.0.1")
+    assert get_device_ip(tmp_path, "kitchen.yaml") == "10.0.0.1"
+
+
+def test_set_device_ip_preserves_existing_when_empty(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """
+    Empty/None ip leaves the persisted value alone.
+
+    Protects the OTA cache during offline windows — mDNS clears the
+    in-memory IP whenever a device drops off, but we still want the
+    cache to be warm next time we OTA.
+    """
+    from esphome_device_builder.controllers.config import (
+        get_device_ip,
+        set_device_metadata,
+    )
+
+    set_device_metadata(tmp_path, "kitchen.yaml", ip="10.0.0.1")
+    set_device_metadata(tmp_path, "kitchen.yaml", ip="")
+    set_device_metadata(tmp_path, "kitchen.yaml", ip=None)
+    assert get_device_ip(tmp_path, "kitchen.yaml") == "10.0.0.1"
+
+
+def test_set_device_ip_unrelated_field_does_not_clobber_ip(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Setting ``board_id`` later doesn't drop the persisted ``ip`` field."""
+    from esphome_device_builder.controllers.config import (
+        get_device_ip,
+        set_device_metadata,
+    )
+
+    set_device_metadata(tmp_path, "kitchen.yaml", ip="10.0.0.1")
+    set_device_metadata(tmp_path, "kitchen.yaml", board_id="esp32-devkit")
+    assert get_device_ip(tmp_path, "kitchen.yaml") == "10.0.0.1"
+
+
+def test_get_device_ip_returns_empty_for_unknown_device(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    from esphome_device_builder.controllers.config import get_device_ip
+
+    assert get_device_ip(tmp_path, "kitchen.yaml") == ""
+
+
+def test_load_device_from_storage_threads_ip_through(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Scanner-loaded devices carry the persisted IP into the model."""
+    from esphome_device_builder.helpers import device_yaml
+
+    # ``ext_storage_path`` walks ``CORE.config_path`` which isn't set
+    # in this test; redirect it to ``tmp_path`` and short-circuit
+    # ``StorageJSON.load`` so we exercise just the YAML + ip plumbing.
+    monkeypatch.setattr(
+        device_yaml,
+        "ext_storage_path",
+        lambda config: tmp_path / f"{config}.json",
+    )
+    monkeypatch.setattr(device_yaml.StorageJSON, "load", staticmethod(lambda _path: None))
+
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n  friendly_name: Kitchen\n")
+
+    device = device_yaml.load_device_from_storage(yaml_path, board_id="esp32-devkit", ip="10.0.0.1")
+    assert device.ip == "10.0.0.1"
+    assert device.board_id == "esp32-devkit"
+
+
+def test_on_ip_change_persists_non_empty_value(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """``_on_ip_change`` schedules a metadata write for non-empty IPs."""
+    from unittest.mock import MagicMock
+
+    from esphome_device_builder.controllers.devices import DevicesController
+    from esphome_device_builder.models import Device
+
+    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    db = MagicMock()
+    scheduled: list[object] = []
+    db.create_background_task.side_effect = lambda coro: scheduled.append(coro) or coro.close()
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    controller._on_ip_change("kitchen", "10.0.0.1")
+
+    assert device.ip == "10.0.0.1"
+    assert len(scheduled) == 1
+
+
+def test_on_ip_change_skips_persist_for_empty_value() -> None:
+    """Empty IP (device went offline) doesn't schedule a write — keeps the cache warm."""
+    from unittest.mock import MagicMock
+
+    from esphome_device_builder.controllers.devices import DevicesController
+    from esphome_device_builder.models import Device
+
+    device = Device(
+        name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml", ip="10.0.0.1"
+    )
+    db = MagicMock()
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    controller._on_ip_change("kitchen", "")
+
+    assert device.ip == ""
+    db.create_background_task.assert_not_called()


### PR DESCRIPTION
## Problem

Devices addressed by a non-`.local` hostname re-resolved through the system resolver on every ping cycle and OTA, and `--dns-address-cache` carried no entry for them. The dashboard tracked the latest mDNS-resolved IP only in memory, so a backend restart wiped the cache and the first OTA after restart paid full DNS latency.

## Changes

- New `DNSCache` (`controllers/_dns_cache.py`) — TTL'd async A/AAAA resolver with `.local` → bare-hostname fallback; caches successes and failures.
- `DeviceStateMonitor._ping_sweep` pre-resolves each batch through the cache, pings the resolved IP, and backfills `device.ip` for non-`.local` hosts (mDNS still owns `.local`).
- `_build_address_cache_args` now picks the right source per host type: zeroconf for `.local`, DNS cache for everything else, with `device.ip` as the fallback for both.
- `Device.ip` is persisted to the metadata sidecar on resolve and re-loaded by the scanner so the OTA cache stays warm across restarts. Empty values (mDNS drop) don't clobber the persisted IP.