### PR TITLE
Serialise metadata sidecar writes and merge scanner metadata callbacks

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -14,6 +14,7 @@ import logging
 from collections.abc import Callable
 from enum import StrEnum
 from pathlib import Path
+from typing import NamedTuple
 
 from esphome import util
 
@@ -24,6 +25,13 @@ _LOGGER = logging.getLogger(__name__)
 
 # (inode, device, mtime, size) — combined cache key for change detection.
 _CacheKey = tuple[int, int, float, int]
+
+
+class DeviceFileMetadata(NamedTuple):
+    """Persisted sidecar fields the scanner threads into each ``Device``."""
+
+    board_id: str
+    ip: str
 
 
 class ScanChange(StrEnum):
@@ -39,6 +47,10 @@ class ScanChange(StrEnum):
 # for firing whatever events / state updates are appropriate.
 ScanCallback = Callable[[ScanChange, Device], None]
 
+# Callback that resolves the persisted sidecar metadata for a device
+# file. Called once per (added or updated) file during a scan.
+MetadataResolver = Callable[[Path, str], DeviceFileMetadata]
+
 
 class DeviceScanner:
     """
@@ -51,17 +63,11 @@ class DeviceScanner:
     def __init__(
         self,
         config_dir: Path,
-        get_board_id: Callable[[Path, str], str],
+        get_metadata: MetadataResolver,
         on_change: ScanCallback,
-        get_ip: Callable[[Path, str], str] | None = None,
     ) -> None:
         self._config_dir = config_dir
-        self._get_board_id = get_board_id
-        # Optional IP resolver — looks up the last-known resolved IP
-        # from the metadata sidecar so the OTA address cache survives
-        # restarts. Defaults to a no-op so tests that don't care about
-        # persistence stay simple.
-        self._get_ip = get_ip or (lambda _config_dir, _filename: "")
+        self._get_metadata = get_metadata
         self._on_change = on_change
         self._devices: dict[Path, Device] = {}
         self._cache_keys: dict[Path, _CacheKey] = {}
@@ -131,9 +137,8 @@ class DeviceScanner:
         result: dict[Path, Device] = {}
         for path in paths:
             try:
-                board_id = self._get_board_id(self._config_dir, path.name)
-                ip = self._get_ip(self._config_dir, path.name)
-                result[path] = load_device_from_storage(path, board_id, ip)
+                metadata = self._get_metadata(self._config_dir, path.name)
+                result[path] = load_device_from_storage(path, metadata.board_id, metadata.ip)
             except Exception:
                 _LOGGER.warning("Failed to load device from %s", path.name)
         return result

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -8,6 +8,10 @@ import hmac
 import json
 import logging
 import os
+import tempfile
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -118,6 +122,27 @@ class DashboardSettings:
 # Metadata persistence (device-builder.json)
 # ---------------------------------------------------------------------------
 
+# Several controllers (firmware queue, device CRUD, preferences, IP
+# cache) all RMW this file from the executor pool. Without serialisation
+# two writers landing in the same window lose each other's updates.
+_METADATA_LOCK = threading.Lock()
+
+
+@contextmanager
+def metadata_transaction(config_dir: Path) -> Iterator[dict[str, Any]]:
+    """
+    Atomic read-modify-write context for the metadata sidecar.
+
+    Yields the current metadata dict. Mutate it in place; on exit the
+    changes are persisted atomically. Concurrent transactions are
+    serialised so updates can't clobber each other. Use this for any
+    write to the sidecar.
+    """
+    with _METADATA_LOCK:
+        data = _load_metadata(config_dir)
+        yield data
+        _save_metadata(config_dir, data)
+
 
 def _load_metadata(config_dir: Path) -> dict[str, Any]:
     path = config_dir / _METADATA_FILE
@@ -130,7 +155,19 @@ def _load_metadata(config_dir: Path) -> dict[str, Any]:
 
 def _save_metadata(config_dir: Path, data: dict[str, Any]) -> None:
     path = config_dir / _METADATA_FILE
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    # tempfile + os.replace so lock-free readers never observe a partial write.
+    fd, tmp_name = tempfile.mkstemp(prefix=f"{_METADATA_FILE}.", suffix=".tmp", dir=str(config_dir))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
 
 
 def get_board_id(config_dir: Path, filename: str) -> str:
@@ -155,17 +192,16 @@ def set_device_metadata(
     persisted value unchanged (mDNS clears the in-memory IP whenever a
     device drops off the network, but the cache is still useful).
     """
-    data = _load_metadata(config_dir)
-    entry = data.setdefault(filename, {})
-    if board_id is not None:
-        entry["board_id"] = board_id
-    if friendly_name is not None:
-        entry["friendly_name"] = friendly_name
-    if comment is not None:
-        entry["comment"] = comment
-    if ip:
-        entry["ip"] = ip
-    _save_metadata(config_dir, data)
+    with metadata_transaction(config_dir) as data:
+        entry = data.setdefault(filename, {})
+        if board_id is not None:
+            entry["board_id"] = board_id
+        if friendly_name is not None:
+            entry["friendly_name"] = friendly_name
+        if comment is not None:
+            entry["comment"] = comment
+        if ip:
+            entry["ip"] = ip
 
 
 def get_device_metadata(config_dir: Path, filename: str) -> dict[str, Any]:
@@ -181,9 +217,8 @@ def get_device_ip(config_dir: Path, filename: str) -> str:
 
 def remove_device_metadata(config_dir: Path, filename: str) -> None:
     """Remove metadata for a device."""
-    data = _load_metadata(config_dir)
-    data.pop(filename, None)
-    _save_metadata(config_dir, data)
+    with metadata_transaction(config_dir) as data:
+        data.pop(filename, None)
 
 
 def load_preferences(config_dir: Path) -> UserPreferences:
@@ -197,9 +232,8 @@ def load_preferences(config_dir: Path) -> UserPreferences:
 
 def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
     """Save user preferences to disk."""
-    data = _load_metadata(config_dir)
-    data[_PREFS_KEY] = prefs.to_dict()
-    _save_metadata(config_dir, data)
+    with metadata_transaction(config_dir) as data:
+        data[_PREFS_KEY] = prefs.to_dict()
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -133,10 +133,10 @@ def metadata_transaction(config_dir: Path) -> Iterator[dict[str, Any]]:
     """
     Atomic read-modify-write context for the metadata sidecar.
 
-    Yields the current metadata dict. Mutate it in place; on exit the
-    changes are persisted atomically. Concurrent transactions are
-    serialised so updates can't clobber each other. Use this for any
-    write to the sidecar.
+    Yields the current metadata dict. Mutate it in place; on a clean
+    exit the changes are persisted atomically. Exceptions raised
+    inside the block discard the pending mutation. Concurrent
+    transactions are serialised so updates can't clobber each other.
     """
     with _METADATA_LOCK:
         data = _load_metadata(config_dir)

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -524,8 +524,9 @@ class DevicesController:
         Resolve a device's persisted ``board_id`` and ``ip``.
 
         ``board_id`` priority:
-          1. ``metadata.json`` — set explicitly when the user picks a
-             board through the UI, or backfilled by a previous scan.
+          1. The metadata sidecar — set explicitly when the user
+             picks a board through the UI, or backfilled by a
+             previous scan.
           2. Parse the YAML's ``esphome.platform`` / ``board`` /
              ``variant`` and match by PlatformIO board id
              (``find_by_pio_board``).

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -36,11 +36,9 @@ from ..models import (
     WizardResponse,
 )
 from ._device_mqtt_coordinator import DeviceMqttCoordinator
-from ._device_scanner import DeviceScanner, ScanChange
+from ._device_scanner import DeviceFileMetadata, DeviceScanner, ScanChange
 from ._device_state_monitor import DeviceStateMonitor
 from .config import (
-    get_board_id,
-    get_device_ip,
     get_device_metadata,
     remove_device_metadata,
     set_device_metadata,
@@ -65,9 +63,8 @@ class DevicesController:
 
         self._scanner = DeviceScanner(
             config_dir=self._db.settings.config_dir,
-            get_board_id=self._resolve_board_id,
+            get_metadata=self._resolve_device_metadata,
             on_change=self._on_scan_change,
-            get_ip=get_device_ip,
         )
         self._state_monitor = DeviceStateMonitor(
             get_devices=self._get_devices,
@@ -522,10 +519,11 @@ class DevicesController:
         """Bridge for the state monitor (``self._scanner.devices`` is a property)."""
         return self._scanner.devices
 
-    def _resolve_board_id(self, config_dir: Path, filename: str) -> str:
-        """Resolve a device's board_id from metadata, falling back to YAML.
+    def _resolve_device_metadata(self, config_dir: Path, filename: str) -> DeviceFileMetadata:
+        """
+        Resolve a device's persisted ``board_id`` and ``ip``.
 
-        Priority:
+        ``board_id`` priority:
           1. ``metadata.json`` — set explicitly when the user picks a
              board through the UI, or backfilled by a previous scan.
           2. Parse the YAML's ``esphome.platform`` / ``board`` /
@@ -541,10 +539,19 @@ class DevicesController:
 
         On any successful YAML-derived match we persist the result to
         metadata so subsequent scans skip the YAML parse.
+
+        ``ip`` is the last-known resolved address from the metadata
+        sidecar (``""`` if never seen).
         """
-        bid = get_board_id(config_dir, filename)
-        if bid:
-            return bid
+        md = get_device_metadata(config_dir, filename)
+        ip = str(md.get("ip", ""))
+        board_id = str(md.get("board_id", ""))
+        if not board_id:
+            board_id = self._derive_board_id_from_yaml(config_dir, filename)
+        return DeviceFileMetadata(board_id=board_id, ip=ip)
+
+    def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:
+        """Parse the device YAML and look up a matching catalog board, or ``""``."""
         if self._db.boards is None:
             return ""
         yaml_path = config_dir / filename

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
 from esphome.storage_json import StorageJSON, ext_storage_path
 
-from ..controllers.config import _load_metadata, _save_metadata
+from ..controllers.config import _load_metadata, metadata_transaction
 from ..helpers.api import api_command
 from ..models import EventType, FirmwareJob, JobStatus, JobType
 
@@ -1118,8 +1118,7 @@ class FirmwareController:
         config_dir = self._db.settings.config_dir
 
         def _save() -> None:
-            data = _load_metadata(config_dir)
-            data[_JOBS_KEY] = [j.to_dict() for j in self._jobs.values()]
-            _save_metadata(config_dir, data)
+            with metadata_transaction(config_dir) as data:
+                data[_JOBS_KEY] = [j.to_dict() for j in self._jobs.values()]
 
         await loop.run_in_executor(None, _save)

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -395,3 +395,32 @@ def test_on_ip_change_skips_persist_for_empty_value() -> None:
 
     assert device.ip == ""
     db.create_background_task.assert_not_called()
+
+
+def test_metadata_transaction_serialises_concurrent_writers(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """
+    Concurrent ``set_device_metadata`` calls from threads can't lose updates.
+
+    Without the module-level lock the load → mutate → save cycle would
+    race: two writers would both load the same snapshot, each add their
+    own field, and the later save would clobber the earlier. The lock
+    serialises the cycle so every write lands.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from esphome_device_builder.controllers.config import (
+        _load_metadata,
+        set_device_metadata,
+    )
+
+    writer_count = 32
+
+    def _write(i: int) -> None:
+        set_device_metadata(tmp_path, f"device-{i}.yaml", board_id=f"board-{i}")
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(_write, range(writer_count)))
+
+    data = _load_metadata(tmp_path)
+    for i in range(writer_count):
+        assert data[f"device-{i}.yaml"]["board_id"] == f"board-{i}"

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -409,7 +409,7 @@ def test_metadata_transaction_serialises_concurrent_writers(tmp_path) -> None:  
     from concurrent.futures import ThreadPoolExecutor
 
     from esphome_device_builder.controllers.config import (
-        _load_metadata,
+        get_board_id,
         set_device_metadata,
     )
 
@@ -421,6 +421,5 @@ def test_metadata_transaction_serialises_concurrent_writers(tmp_path) -> None:  
     with ThreadPoolExecutor(max_workers=8) as pool:
         list(pool.map(_write, range(writer_count)))
 
-    data = _load_metadata(tmp_path)
     for i in range(writer_count):
-        assert data[f"device-{i}.yaml"]["board_id"] == f"board-{i}"
+        assert get_board_id(tmp_path, f"device-{i}.yaml") == f"board-{i}"


### PR DESCRIPTION
Follow-up to the [#23 review](https://github.com/esphome/device-builder/pull/23#discussion_r3173048703).

Four controllers (firmware queue, device CRUD, preferences, IP cache) all read-modify-write `.device-builder.json` from the executor pool with no locking. Two writers landing in the same window can lose each other's updates. Pre-existed the IP-cache PR but was widened by it, so worth fixing for real.

Separately, the scanner's metadata-callback API took separate `get_board_id` and `get_ip` callbacks, doing two JSON reads per device on every cold scan.

## Changes
- New `metadata_transaction()` context manager in `controllers/config.py` — holds a process-wide `threading.Lock` across the load → mutate → save cycle.
- `_save_metadata` now writes to a sibling tempfile + `os.replace` so lock-free readers can never observe a partial write.
- `set_device_metadata`, `remove_device_metadata`, `save_preferences`, and `firmware._persist_jobs` all routed through the transaction.
- `DeviceScanner` now takes a single `get_metadata` callback returning a `DeviceFileMetadata(board_id, ip)` NamedTuple; resolver in `DevicesController` reads the sidecar once per file.
- Added a concurrency regression test that hammers `set_device_metadata` from a thread pool.