### PR TITLE
Add authentication with session tokens and rate limiting

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -45,6 +45,8 @@ On connect, the server sends a [`ServerInfoMessage`](../esphome_device_builder/m
 | `invalid_args` | Missing or invalid arguments |
 | `not_found` | Resource not found |
 | `internal_error` | Server error |
+| `not_authenticated` | Connection has not authenticated; only `auth/login` is accepted |
+| `rate_limited` | Too many failed login attempts from this IP |
 
 ### Enums
 
@@ -55,6 +57,35 @@ On connect, the server sends a [`ServerInfoMessage`](../esphome_device_builder/m
 ---
 
 ## Commands
+
+### Authentication
+
+> Controller: [`AuthController`](../esphome_device_builder/controllers/auth.py)
+
+When the dashboard is started with `--username`/`--password` (or `$USERNAME`/`$PASSWORD` env vars), every WebSocket connection on the public port must authenticate before any other command will be accepted.
+
+The handshake:
+
+1. Server sends `ServerInfoMessage` with `requires_auth: true`.
+2. Client sends `auth/login` (or its alias `auth`) with either `{username, password}` or a previously issued `{token}`.
+3. Server replies with `{token, expires_at}`.
+4. Subsequent commands on the same connection are accepted normally.
+
+Tokens are opaque random strings, persisted to `<config>/.device-builder-sessions.json`, and auto-refresh on each use (sliding 30-day window). Frontends should store the token in `localStorage` and reuse it on reconnect — only fall back to the password form on `not_authenticated`.
+
+Connections that arrive on the trusted ingress site (HA add-on supervisor proxy) get `requires_auth: false` and skip the handshake entirely.
+
+| Command | Args | Response | Description |
+|---------|------|----------|-------------|
+| `auth/login` (alias: `auth`) | `{username, password}` *or* `{token}` | `{token, expires_at}` | Authenticate this connection |
+| `auth/logout` | — | `{logged_out: true}` | Revoke the current token; closes the connection |
+| `auth/refresh` | — | `{token, expires_at}` | Slide the expiry forward without making another API call |
+
+**Bearer header (non-browser clients).** Anything that can set HTTP headers — the HA `esphome-dashboard-api` client, CLI tools, scripts — may pass `Authorization: Bearer <token>` on the WS handshake or on a REST request. The server treats that as equivalent to a successful in-band `auth/login {token}` call.
+
+**Basic auth (REST only).** Legacy REST endpoints also accept `Authorization: Basic <base64(user:pass)>`. WebSocket clients can't use this because browsers don't allow setting headers on `new WebSocket(...)`.
+
+**Rate limiting.** After 10 failed login attempts from one IP within a 5-minute window, that IP is locked out for 5 minutes. A successful login clears the failure history immediately. Token-based logins (replays) are exempt — brute-forcing 256 bits of token entropy is infeasible, and rate-limiting valid replays would lock legitimate clients out after a network blip.
 
 ### Devices
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,6 +120,19 @@ PR with a diff summary when the rebuild produces a change.
 All workflow files are commented end-to-end — start there for the source
 of truth.
 
+## Authentication
+
+Auth is opaque server-issued session tokens, gated by the WebSocket handshake. See [API.md](API.md#authentication) for the wire protocol.
+
+When `--ha-addon` is set, the server binds **two** TCP sites on a shared `DeviceBuilder` singleton:
+
+- **Public site** (`--host:--port`, default `0.0.0.0:6052`) — the standard dashboard. The auth middleware enforces password (or bearer token) on REST endpoints, and the WS handler enforces the in-band `auth` handshake. This is what users hit at `http://homeassistant.local:6052`.
+- **Trusted ingress site** (`--ingress-host:--ingress-port`, default `0.0.0.0:8099` inside the addon container) — bound to the supervisor's docker network only, never exposed externally. Skips the auth gate because the supervisor has already authenticated the request upstream. The HA add-on `config.yaml` advertises `ingress_port` to the supervisor so the ingress proxy knows where to forward.
+
+This is the Music Assistant pattern: physically separating the listeners is the security boundary, rather than trusting an `X-Ingress-Path` header. It also means HA app users can keep ingress access (no password) while operators can still secure direct access from outside HA with a username/password.
+
+The legacy `DISABLE_HA_AUTHENTICATION=true` env var skips the ingress site entirely — operators get only the password-gated public port.
+
 ## Deployment
 
 ### Beta (HA add-on)

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 
-from .constants import DEFAULT_HOST, DEFAULT_PORT
+from .constants import DEFAULT_HOST, DEFAULT_INGRESS_PORT, DEFAULT_PORT
 from .controllers.config import DashboardSettings
 from .device_builder import DeviceBuilder
 
@@ -56,9 +57,31 @@ def main() -> None:
     )
     parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="HTTP port to listen on")
     parser.add_argument("--host", default=DEFAULT_HOST, help="Host/IP to bind to")
-    parser.add_argument("--username", default="", help="Dashboard username")
-    parser.add_argument("--password", default="", help="Dashboard password")
+    parser.add_argument(
+        "--username",
+        default="",
+        help="Dashboard username (must be paired with --password; falls back to $USERNAME)",
+    )
+    parser.add_argument(
+        "--password",
+        default="",
+        help="Dashboard password (must be paired with --username; falls back to $PASSWORD)",
+    )
     parser.add_argument("--ha-addon", action="store_true", help="Running as HA add-on")
+    parser.add_argument(
+        "--ingress-port",
+        type=int,
+        default=DEFAULT_INGRESS_PORT,
+        help="Port for the trusted HA Ingress site (only used with --ha-addon)",
+    )
+    parser.add_argument(
+        "--ingress-host",
+        default="",
+        help=(
+            "Bind address for the HA Ingress site (defaults to all interfaces "
+            "inside the addon container)"
+        ),
+    )
     parser.add_argument(
         "--log-level",
         default="info",
@@ -69,13 +92,50 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    _validate_credentials(parser, args)
+
     _setup_logging(args.log_level, args.log_file)
 
     settings = DashboardSettings()
     settings.parse_args(args)
 
+    _warn_if_unprotected(settings)
+
     device_builder = DeviceBuilder(settings)
     device_builder.run()
+
+
+def _validate_credentials(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    """Reject mismatched --username / --password (or env equivalents)."""
+    has_user = bool(args.username or os.getenv("USERNAME"))
+    has_pass = bool(args.password or os.getenv("PASSWORD"))
+    if has_user != has_pass:
+        parser.error(
+            "--username and --password must both be set (or both unset). "
+            "Use $USERNAME / $PASSWORD env vars as alternatives."
+        )
+
+
+def _warn_if_unprotected(settings: DashboardSettings) -> None:
+    """Print a banner when starting without any authentication boundary."""
+    if settings.using_password:
+        return
+    # HA add-on installs are exempt — the supervisor's ingress proxy
+    # authenticates upstream of the trusted site.
+    if settings.create_ingress_site:
+        return
+    banner = "=" * 70
+    logging.getLogger(_LOGGER_NAME).warning(
+        "\n%s\n"
+        " WARNING: Dashboard is running WITHOUT AUTHENTICATION.\n"
+        " Anyone with network access to %s:%d can manage your devices.\n"
+        " Set --username and --password (or $USERNAME / $PASSWORD) to enable.\n"
+        "%s",
+        banner,
+        settings.host,
+        settings.port,
+        banner,
+    )
 
 
 if __name__ == "__main__":

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import orjson
 from aiohttp import WSMsgType, web
@@ -150,14 +151,23 @@ class WebSocketClient:
             )
 
 
-async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
+async def websocket_handler(request: web.Request) -> web.StreamResponse:
     """Multiplexed WebSocket API endpoint."""
-    ws = web.WebSocketResponse()
-    await ws.prepare(request)
-
     device_builder: DeviceBuilder = request.app["device_builder"]
     settings = device_builder.settings
     trusted_site = bool(request.app.get("trusted_site", False))
+
+    # Reject cross-origin browser connections on the password-gated public
+    # site. CORS middleware doesn't apply to WebSockets, so without this a
+    # malicious page could open /ws against a victim's dashboard. Clients
+    # without an Origin header (CLI tools, HA integration) are unaffected.
+    if settings.using_password and not trusted_site:
+        origin = request.headers.get("Origin")
+        if origin and not _origin_matches_host(origin, request.host):
+            return web.Response(status=403, text="Cross-origin connection rejected")
+
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
 
     pre_authenticated = trusted_site or not settings.using_password
     token: str | None = None
@@ -214,7 +224,16 @@ def create_ws_routes() -> web.RouteTableDef:
     routes = web.RouteTableDef()
 
     @routes.get("/ws")
-    async def ws_route(request: web.Request) -> web.WebSocketResponse:
+    async def ws_route(request: web.Request) -> web.StreamResponse:
         return await websocket_handler(request)
 
     return routes
+
+
+def _origin_matches_host(origin: str, request_host: str) -> bool:
+    """Return True when *origin*'s host:port matches the request's Host header."""
+    try:
+        parsed = urlparse(origin)
+    except ValueError:
+        return False
+    return bool(parsed.netloc) and parsed.netloc == request_host

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -14,6 +14,8 @@ from aiohttp import WSMsgType, web
 from esphome.const import __version__ as esphome_version
 
 from ..constants import __version__
+from ..controllers.auth import AuthError
+from ..helpers.auth import extract_bearer_token
 from ..models import (
     CommandMessage,
     ErrorCode,
@@ -28,14 +30,46 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Commands a client may send before the authenticated flag is set.
+_PRE_AUTH_COMMANDS = frozenset({"auth", "auth/login"})
+
 
 class WebSocketClient:
     """A single WebSocket client connection."""
 
-    def __init__(self, ws: web.WebSocketResponse, device_builder: DeviceBuilder) -> None:
+    def __init__(
+        self,
+        ws: web.WebSocketResponse,
+        device_builder: DeviceBuilder,
+        *,
+        remote: str = "",
+        authenticated: bool = False,
+        token: str | None = None,
+    ) -> None:
         self._ws = ws
         self.device_builder = device_builder
+        self.remote = remote
+        self._authenticated = authenticated
+        self._token = token
         self._tasks: set[asyncio.Task] = set()
+        self._close_after_send: bool = False
+
+    @property
+    def authenticated(self) -> bool:
+        return self._authenticated
+
+    @property
+    def token(self) -> str | None:
+        return self._token
+
+    def set_authenticated(self, token: str | None) -> None:
+        """Mark this connection as authenticated and remember its token."""
+        self._authenticated = True
+        self._token = token
+
+    def schedule_close(self) -> None:
+        """Close the WebSocket after the current message is sent."""
+        self._close_after_send = True
 
     async def send(self, data: dict[str, Any]) -> None:
         """Send a JSON message."""
@@ -43,6 +77,8 @@ class WebSocketClient:
             await self._ws.send_str(orjson.dumps(data).decode())
         except ConnectionResetError:
             pass
+        if self._close_after_send:
+            await self._ws.close()
 
     async def send_result(self, message_id: str, result: Any = None) -> None:
         """Send a success result, serializing dataclass results automatically."""
@@ -61,35 +97,6 @@ class WebSocketClient:
         msg = EventMessage(message_id=message_id, event=event, data=data)
         await self.send(msg.to_dict())
 
-    async def _handle_command(self, raw: dict[str, Any]) -> None:
-        """Parse and dispatch a command."""
-        try:
-            cmd = CommandMessage.from_dict(raw)
-        except Exception:
-            await self.send_error("", ErrorCode.INVALID_MESSAGE, "Invalid command format")
-            return
-
-        handler = self.device_builder.command_handlers.get(cmd.command)
-        if handler is None:
-            await self.send_error(
-                cmd.message_id,
-                ErrorCode.UNKNOWN_COMMAND,
-                f"Unknown command: {cmd.command}",
-            )
-            return
-
-        try:
-            result = await handler(client=self, message_id=cmd.message_id, **cmd.args)
-
-            await self.send_result(cmd.message_id, result)
-        except Exception:
-            _LOGGER.exception("Error handling command %s", cmd.command)
-            await self.send_error(
-                cmd.message_id,
-                ErrorCode.INTERNAL_ERROR,
-                f"Command failed: {cmd.command}",
-            )
-
     def create_task(self, coro: Any) -> asyncio.Task:
         """Create a tracked task."""
         task = asyncio.create_task(coro)
@@ -104,6 +111,44 @@ class WebSocketClient:
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
 
+    async def _handle_command(self, raw: dict[str, Any]) -> None:
+        """Parse and dispatch a command."""
+        try:
+            cmd = CommandMessage.from_dict(raw)
+        except Exception:
+            await self.send_error("", ErrorCode.INVALID_MESSAGE, "Invalid command format")
+            return
+
+        if not self._authenticated and cmd.command not in _PRE_AUTH_COMMANDS:
+            await self.send_error(
+                cmd.message_id,
+                ErrorCode.NOT_AUTHENTICATED,
+                "Authentication required",
+            )
+            return
+
+        handler = self.device_builder.command_handlers.get(cmd.command)
+        if handler is None:
+            await self.send_error(
+                cmd.message_id,
+                ErrorCode.UNKNOWN_COMMAND,
+                f"Unknown command: {cmd.command}",
+            )
+            return
+
+        try:
+            result = await handler(client=self, message_id=cmd.message_id, **cmd.args)
+            await self.send_result(cmd.message_id, result)
+        except AuthError as err:
+            await self.send_error(cmd.message_id, err.code, err.message)
+        except Exception:
+            _LOGGER.exception("Error handling command %s", cmd.command)
+            await self.send_error(
+                cmd.message_id,
+                ErrorCode.INTERNAL_ERROR,
+                f"Command failed: {cmd.command}",
+            )
+
 
 async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
     """Multiplexed WebSocket API endpoint."""
@@ -111,16 +156,38 @@ async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
     await ws.prepare(request)
 
     device_builder: DeviceBuilder = request.app["device_builder"]
-    client = WebSocketClient(ws, device_builder)
-
-    # Send server info on connect
     settings = device_builder.settings
+    trusted_site = bool(request.app.get("trusted_site", False))
+
+    pre_authenticated = trusted_site or not settings.using_password
+    token: str | None = None
+
+    if not pre_authenticated:
+        # Non-browser clients (HA integration, CLI tools) can authenticate
+        # via Authorization header instead of the in-band protocol.
+        bearer = extract_bearer_token(request.headers.get("Authorization", ""))
+        if bearer:
+            session = await device_builder.auth.session_store.validate(bearer)
+            if session is not None:
+                pre_authenticated = True
+                token = session.token
+
+    client = WebSocketClient(
+        ws,
+        device_builder,
+        remote=request.remote or "",
+        authenticated=pre_authenticated,
+        token=token,
+    )
+
+    # Per-connection: trusted-site and bearer-pre-auth connections don't need
+    # the in-band auth handshake, so the frontend skips the login prompt.
     info = ServerInfoMessage(
         server_version=__version__,
         esphome_version=esphome_version,
         port=settings.port,
         ha_addon=settings.on_ha_addon,
-        requires_auth=settings.using_auth,
+        requires_auth=(not pre_authenticated),
     )
     await client.send(info.to_dict())
 

--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -4,3 +4,8 @@ __version__ = "0.0.0"
 
 DEFAULT_PORT = 6052
 DEFAULT_HOST = "0.0.0.0"
+
+# Trusted TCP site for HA Ingress. Bound only when ``--ha-addon`` is set,
+# on the supervisor's docker bridge network, and bypasses the password
+# gate (the supervisor has already authenticated the request).
+DEFAULT_INGRESS_PORT = 8099

--- a/esphome_device_builder/controllers/auth.py
+++ b/esphome_device_builder/controllers/auth.py
@@ -1,0 +1,110 @@
+"""Auth controller — login, logout, token refresh."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ..helpers.api import api_command
+from ..helpers.auth import RateLimiter, SessionStore
+from ..models import ErrorCode
+
+if TYPE_CHECKING:
+    from ..api.ws import WebSocketClient
+    from ..device_builder import DeviceBuilder
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AuthError(Exception):
+    """Authentication failure carrying a wire-level ``ErrorCode``."""
+
+    def __init__(self, code: ErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class AuthController:
+    """Manages session tokens and login attempts for the dashboard."""
+
+    def __init__(self, device_builder: DeviceBuilder) -> None:
+        self._db = device_builder
+        self.session_store = SessionStore(device_builder.settings.config_dir)
+        self.rate_limiter = RateLimiter()
+
+    @api_command("auth/login")
+    async def login(
+        self,
+        *,
+        client: WebSocketClient | None = None,
+        username: str = "",
+        password: str = "",
+        token: str = "",
+        **kwargs: Any,
+    ) -> dict:
+        """
+        Authenticate the calling WebSocket connection.
+
+        Accepts either ``{username, password}`` or a previously issued
+        ``{token}``. Returns ``{token, expires_at}`` so the caller can
+        persist the token and reuse it on reconnect.
+
+        Raises ``AuthError`` on bad credentials, expired token, or when
+        the remote IP is currently rate-limited.
+        """
+        if client is None:
+            raise AuthError(ErrorCode.INTERNAL_ERROR, "auth/login requires a connected client")
+
+        if token:
+            # Token replay is exempt from the password rate limiter — see
+            # ``test_auth_controller_token_path_skips_rate_limit`` for rationale.
+            session = await self.session_store.validate(token)
+            if session is None:
+                raise AuthError(ErrorCode.NOT_AUTHENTICATED, "Invalid or expired token")
+            client.set_authenticated(session.token)
+            return {"token": session.token, "expires_at": session.expires_at}
+
+        ip = client.remote or "?"
+        remaining = self.rate_limiter.remaining_lockout(ip)
+        if remaining > 0:
+            raise AuthError(
+                ErrorCode.RATE_LIMITED,
+                f"Too many failed attempts; try again in {int(remaining) + 1}s",
+            )
+
+        if not self._db.settings.check_password(username, password):
+            self.rate_limiter.record_failure(ip)
+            raise AuthError(ErrorCode.NOT_AUTHENTICATED, "Invalid credentials")
+
+        self.rate_limiter.clear(ip)
+        session = await self.session_store.create()
+        client.set_authenticated(session.token)
+        _LOGGER.info("Authenticated WS client from %s", ip)
+        return {"token": session.token, "expires_at": session.expires_at}
+
+    @api_command("auth/logout")
+    async def logout(self, *, client: WebSocketClient | None = None, **kwargs: Any) -> dict:
+        """Revoke the current session token and close the connection."""
+        if client is None:
+            return {"logged_out": True}
+        if client.token:
+            await self.session_store.revoke(client.token)
+        client.schedule_close()
+        return {"logged_out": True}
+
+    @api_command("auth/refresh")
+    async def refresh(self, *, client: WebSocketClient | None = None, **kwargs: Any) -> dict:
+        """
+        Slide the current session's expiry forward and return the new value.
+
+        Tokens auto-refresh on every validated use; this command is for
+        callers that want to extend a session without making another API
+        call.
+        """
+        if client is None or not client.token:
+            raise AuthError(ErrorCode.NOT_AUTHENTICATED, "No active session")
+        session = await self.session_store.validate(client.token)
+        if session is None:
+            raise AuthError(ErrorCode.NOT_AUTHENTICATED, "Session expired")
+        return {"token": session.token, "expires_at": session.expires_at}

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import hmac
 import json
 import logging
@@ -19,8 +18,10 @@ from esphome.helpers import get_bool_env
 from esphome.storage_json import StorageJSON, ext_storage_path
 from esphome.util import get_serial_ports
 
+from ..constants import DEFAULT_INGRESS_PORT
 from ..constants import __version__ as server_version
 from ..helpers.api import api_command
+from ..helpers.auth import hash_password
 from ..models import UserPreferences
 
 if TYPE_CHECKING:
@@ -38,10 +39,6 @@ _PREFS_KEY = "_preferences"
 # ---------------------------------------------------------------------------
 
 
-def _hash_password(password: str) -> bytes:
-    return hashlib.sha256(password.encode("utf-8")).digest()
-
-
 @dataclass
 class DashboardSettings:
     """Application settings parsed from CLI args and environment."""
@@ -52,20 +49,21 @@ class DashboardSettings:
     password_hash: bytes = field(default_factory=bytes)
     using_password: bool = False
     on_ha_addon: bool = False
-    cookie_secret: str | None = None
     log_level: str = "info"
     port: int = 6052
     host: str = "0.0.0.0"
+    ingress_port: int = DEFAULT_INGRESS_PORT
+    ingress_host: str = ""
 
     def parse_args(self, args: Any) -> None:
         """Parse CLI arguments into settings."""
         self.on_ha_addon = getattr(args, "ha_addon", False)
+        username = getattr(args, "username", None) or os.getenv("USERNAME") or ""
         password = getattr(args, "password", None) or os.getenv("PASSWORD") or ""
-        if not self.on_ha_addon:
-            self.username = getattr(args, "username", None) or os.getenv("USERNAME") or ""
-            self.using_password = bool(password)
+        self.username = username
+        self.using_password = bool(username and password)
         if self.using_password:
-            self.password_hash = _hash_password(password)
+            self.password_hash = hash_password(password)
         self.config_dir = Path(args.configuration)
         self.config_dir.mkdir(parents=True, exist_ok=True)
         self.absolute_config_dir = self.config_dir.resolve()
@@ -82,6 +80,8 @@ class DashboardSettings:
         self.log_level = getattr(args, "log_level", "info")
         self.port = getattr(args, "port", 6052)
         self.host = getattr(args, "host", "0.0.0.0")
+        self.ingress_port = getattr(args, "ingress_port", DEFAULT_INGRESS_PORT)
+        self.ingress_host = getattr(args, "ingress_host", "") or ""
         CORE.config_path = self.config_dir / _DASHBOARD_SENTINEL_FILE
 
     def rel_path(self, *parts: str) -> Path:
@@ -96,21 +96,25 @@ class DashboardSettings:
         return bool(get_bool_env("ESPHOME_DASHBOARD_USE_MQTT"))
 
     @property
-    def using_ha_addon_auth(self) -> bool:
+    def create_ingress_site(self) -> bool:
+        """Whether to bind the trusted HA Ingress TCP site alongside the public site."""
         if not self.on_ha_addon:
             return False
+        # DISABLE_HA_AUTHENTICATION lets operators force ingress users
+        # through the password-gated public port too.
         return not get_bool_env("DISABLE_HA_AUTHENTICATION")
 
-    @property
-    def using_auth(self) -> bool:
-        return self.using_password or self.using_ha_addon_auth
-
     def check_password(self, username: str, password: str) -> bool:
-        """Verify username and password."""
-        if not self.using_auth:
-            return True
+        """
+        Verify *username* and *password* in constant time.
+
+        Returns ``False`` when no password is configured — check
+        ``using_password`` separately to know whether the gate is active.
+        """
+        if not self.using_password:
+            return False
         username_ok = hmac.compare_digest(username.encode("utf-8"), self.username.encode("utf-8"))
-        password_ok = hmac.compare_digest(self.password_hash, _hash_password(password))
+        password_ok = hmac.compare_digest(self.password_hash, hash_password(password))
         return username_ok and password_ok
 
 

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -16,10 +16,12 @@ from aiohttp import web
 
 from .controllers.config import DashboardSettings
 from .helpers.api import CommandHandler, collect_api_commands
+from .helpers.auth import auth_middleware
 from .helpers.event_bus import EventBus
 from .helpers.json import cors_middleware
 
 if TYPE_CHECKING:
+    from .controllers.auth import AuthController
     from .controllers.automations import AutomationsController
     from .controllers.boards import BoardCatalog
     from .controllers.components import ComponentCatalog
@@ -45,6 +47,7 @@ class DeviceBuilder:
         self.loop: asyncio.AbstractEventLoop | None = None
 
         # Controllers — populated in start()
+        self.auth: AuthController | None = None
         self.boards: BoardCatalog | None = None
         self.components: ComponentCatalog | None = None
         self.config: ConfigController | None = None
@@ -60,8 +63,11 @@ class DeviceBuilder:
         self._background_tasks: set[asyncio.Task] = set()
         self._bg_task: asyncio.Task | None = None
 
+        self._ingress_runner: web.AppRunner | None = None
+
     async def start(self) -> None:
         """Start the application — load catalogs, initialize controllers."""
+        from .controllers.auth import AuthController
         from .controllers.automations import AutomationsController
         from .controllers.boards import BoardCatalog
         from .controllers.components import ComponentCatalog
@@ -73,6 +79,7 @@ class DeviceBuilder:
         self.loop = asyncio.get_running_loop()
 
         # Initialize controllers
+        self.auth = AuthController(self)
         self.boards = BoardCatalog()
         self.boards.load()
         self.components = ComponentCatalog(self)
@@ -88,6 +95,7 @@ class DeviceBuilder:
 
         # Collect command handlers from all controllers
         for controller in (
+            self.auth,
             self.boards,
             self.components,
             self.config,
@@ -101,6 +109,9 @@ class DeviceBuilder:
         # Register built-in commands
         self.command_handlers["ping"] = self._cmd_ping
         self.command_handlers["subscribe_events"] = self._cmd_subscribe_events
+        # `auth` is an alias for `auth/login` so both forms work on the wire.
+        if "auth/login" in self.command_handlers:
+            self.command_handlers["auth"] = self.command_handlers["auth/login"]
 
         # Start background polling
         self._bg_task = asyncio.create_task(self._run_background())
@@ -203,10 +214,22 @@ class DeviceBuilder:
     # Web application
     # ------------------------------------------------------------------
 
-    def create_app(self) -> web.Application:
-        """Create the aiohttp application."""
-        app = web.Application(middlewares=[cors_middleware])
+    def create_app(self, *, trusted: bool = False, with_lifecycle: bool = True) -> web.Application:
+        """
+        Build the aiohttp application.
+
+        ``trusted`` skips the auth middleware (HA Ingress site).
+        ``with_lifecycle`` toggles startup/cleanup hooks; the ingress
+        app reuses the public app's controller singleton and so passes
+        ``False`` to avoid re-initialising them.
+        """
+        middlewares: list[Any] = [cors_middleware]
+        if not trusted:
+            middlewares.append(auth_middleware)
+
+        app = web.Application(middlewares=middlewares)
         app["device_builder"] = self
+        app["trusted_site"] = trusted
 
         # WebSocket API
         from .api.ws import create_ws_routes
@@ -227,14 +250,19 @@ class DeviceBuilder:
         frontend_dir = self._get_frontend_dir()
         if frontend_dir and frontend_dir.is_dir():
             self._register_frontend(app, frontend_dir)
-        else:
+        elif with_lifecycle:
+            # The ingress app is silent here — the public app already logged.
             _LOGGER.info(
                 "Frontend package not installed — running in API-only mode. "
                 "Install esphome-device-builder-frontend for the web UI."
             )
 
-        app.on_startup.append(self._on_startup)
-        app.on_cleanup.append(self._on_cleanup)
+        if with_lifecycle:
+            app.on_startup.append(self._on_startup)
+            if self.settings.create_ingress_site:
+                app.on_startup.append(self._start_ingress_site)
+                app.on_cleanup.append(self._stop_ingress_site)
+            app.on_cleanup.append(self._on_cleanup)
 
         return app
 
@@ -243,6 +271,26 @@ class DeviceBuilder:
 
     async def _on_cleanup(self, app: web.Application) -> None:
         await self.stop()
+
+    async def _start_ingress_site(self, _: web.Application) -> None:
+        """Start the trusted HA Ingress TCP site alongside the public site."""
+        ingress_app = self.create_app(trusted=True, with_lifecycle=False)
+        runner = web.AppRunner(ingress_app)
+        await runner.setup()
+        host = self.settings.ingress_host or "0.0.0.0"
+        site = web.TCPSite(runner, host, self.settings.ingress_port)
+        await site.start()
+        self._ingress_runner = runner
+        _LOGGER.info(
+            "Ingress site listening on %s:%d (trusted, bypasses auth)",
+            host,
+            self.settings.ingress_port,
+        )
+
+    async def _stop_ingress_site(self, _: web.Application) -> None:
+        if self._ingress_runner is not None:
+            await self._ingress_runner.cleanup()
+            self._ingress_runner = None
 
     def run(self) -> None:
         """Start the HTTP server (blocking)."""

--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -1,0 +1,317 @@
+"""Authentication helpers — session store, rate limiter, REST middleware."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import logging
+import os
+import secrets
+import time
+from collections import deque
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from aiohttp import web
+
+_LOGGER = logging.getLogger(__name__)
+
+_SESSIONS_FILENAME = ".device-builder-sessions.json"
+_TOKEN_TTL_SECONDS = 30 * 24 * 3600  # 30 days, sliding
+_TOKEN_BYTES = 32  # 256 bits of entropy
+
+# 10 failed attempts in 5 minutes locks the IP for 5 minutes.
+_RATE_LIMIT_MAX_ATTEMPTS = 10
+_RATE_LIMIT_WINDOW_SECONDS = 5 * 60
+_RATE_LIMIT_LOCKOUT_SECONDS = 5 * 60
+
+
+# ---------------------------------------------------------------------------
+# Password hashing
+# ---------------------------------------------------------------------------
+
+
+def hash_password(password: str) -> bytes:
+    """Hash a password into a fixed-size digest for constant-time comparison."""
+    # SHA-256 is sufficient because the digest is only compared against a
+    # single in-memory value via hmac.compare_digest — never persisted.
+    return hashlib.sha256(password.encode("utf-8")).digest()
+
+
+# ---------------------------------------------------------------------------
+# Session store
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Session:
+    """A persisted authentication session."""
+
+    token: str
+    created_at: float
+    last_used_at: float
+    expires_at: float
+
+    def is_expired(self, now: float | None = None) -> bool:
+        """Return True if the session has passed its expiry timestamp."""
+        return (now if now is not None else time.time()) >= self.expires_at
+
+
+class SessionStore:
+    """
+    Persistent store of opaque session tokens.
+
+    Tokens auto-expire after ``ttl_seconds`` of inactivity — the
+    expiry is a sliding window refreshed on each ``validate`` call.
+    Persisted to a JSON file in the config directory so sessions
+    survive server restarts.
+    """
+
+    def __init__(self, config_dir: Path, ttl_seconds: int = _TOKEN_TTL_SECONDS) -> None:
+        self._path = config_dir / _SESSIONS_FILENAME
+        self._ttl = ttl_seconds
+        self._sessions: dict[str, Session] = {}
+        self._lock = asyncio.Lock()
+        self._load()
+
+    async def create(self) -> Session:
+        """Mint a new session and return it."""
+        async with self._lock:
+            now = time.time()
+            session = Session(
+                token=secrets.token_urlsafe(_TOKEN_BYTES),
+                created_at=now,
+                last_used_at=now,
+                expires_at=now + self._ttl,
+            )
+            self._sessions[session.token] = session
+            self._persist()
+            return session
+
+    async def validate(self, token: str) -> Session | None:
+        """
+        Look up *token*, refresh its expiry on success, return the session.
+
+        Returns ``None`` if the token is unknown or has expired.
+        """
+        if not token:
+            return None
+        async with self._lock:
+            session = self._sessions.get(token)
+            if session is None:
+                return None
+            now = time.time()
+            if session.is_expired(now):
+                del self._sessions[token]
+                self._persist()
+                return None
+            session.last_used_at = now
+            session.expires_at = now + self._ttl
+            self._persist()
+            return session
+
+    async def revoke(self, token: str) -> None:
+        """Drop *token* from the store; no-op if unknown."""
+        async with self._lock:
+            if self._sessions.pop(token, None) is not None:
+                self._persist()
+
+    async def revoke_all(self) -> None:
+        """Drop every active session, forcing all clients to re-authenticate."""
+        async with self._lock:
+            self._sessions.clear()
+            self._persist()
+
+    @property
+    def active_count(self) -> int:
+        """Number of currently valid sessions in the store."""
+        return len(self._sessions)
+
+    def _load(self) -> None:
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            _LOGGER.warning("Sessions file is corrupt; starting fresh: %s", self._path)
+            return
+        now = time.time()
+        for entry in data.get("sessions", []):
+            try:
+                session = Session(**entry)
+            except TypeError:
+                continue
+            if not session.is_expired(now):
+                self._sessions[session.token] = session
+
+    def _persist(self) -> None:
+        data = {"sessions": [asdict(s) for s in self._sessions.values()]}
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data), encoding="utf-8")
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, self._path)
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+class RateLimiter:
+    """
+    Per-IP sliding-window rate limiter for login attempts.
+
+    Once an IP exceeds ``max_attempts`` failures within
+    ``window_seconds``, it is locked out for ``lockout_seconds``.
+    A successful login should call ``clear`` to drop the IP's
+    history immediately.
+    """
+
+    def __init__(
+        self,
+        max_attempts: int = _RATE_LIMIT_MAX_ATTEMPTS,
+        window_seconds: float = _RATE_LIMIT_WINDOW_SECONDS,
+        lockout_seconds: float = _RATE_LIMIT_LOCKOUT_SECONDS,
+    ) -> None:
+        self._max = max_attempts
+        self._window = window_seconds
+        self._lockout = lockout_seconds
+        # monotonic clock — wall-clock jumps must not extend or shorten lockouts
+        self._attempts: dict[str, deque[float]] = {}
+        self._lockouts: dict[str, float] = {}
+
+    def remaining_lockout(self, ip: str) -> float:
+        """Seconds until *ip* is unlocked, or ``0`` if it isn't locked."""
+        now = time.monotonic()
+        unlock_at = self._lockouts.get(ip)
+        if unlock_at is None:
+            return 0.0
+        remaining = unlock_at - now
+        if remaining <= 0:
+            del self._lockouts[ip]
+            self._attempts.pop(ip, None)
+            return 0.0
+        return remaining
+
+    def record_failure(self, ip: str) -> None:
+        """Record a failed attempt for *ip*, triggering a lockout at the threshold."""
+        now = time.monotonic()
+        cutoff = now - self._window
+        attempts = self._attempts.setdefault(ip, deque())
+        while attempts and attempts[0] < cutoff:
+            attempts.popleft()
+        attempts.append(now)
+        if len(attempts) >= self._max:
+            self._lockouts[ip] = now + self._lockout
+            _LOGGER.warning(
+                "Rate limit triggered for %s (%d failed attempts in %ds); locked for %ds",
+                ip,
+                len(attempts),
+                int(self._window),
+                int(self._lockout),
+            )
+
+    def clear(self, ip: str) -> None:
+        """Drop *ip*'s failure history and any active lockout."""
+        self._attempts.pop(ip, None)
+        self._lockouts.pop(ip, None)
+
+
+# ---------------------------------------------------------------------------
+# Authorization header parsing
+# ---------------------------------------------------------------------------
+
+
+def extract_bearer_token(authorization: str) -> str | None:
+    """Return the token from an ``Authorization: Bearer ...`` header, or None."""
+    if not authorization:
+        return None
+    parts = authorization.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    token = parts[1].strip()
+    return token or None
+
+
+def parse_basic_auth(authorization: str) -> tuple[str, str] | None:
+    """Decode an ``Authorization: Basic ...`` header into ``(username, password)``."""
+    if not authorization:
+        return None
+    parts = authorization.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "basic":
+        return None
+    try:
+        decoded = base64.b64decode(parts[1].strip(), validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if ":" not in decoded:
+        return None
+    username, password = decoded.split(":", 1)
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# REST auth middleware
+# ---------------------------------------------------------------------------
+
+# /ws bypasses the gate because auth happens in-band on the WebSocket —
+# browsers can't set Authorization headers on `new WebSocket(...)`.
+# Frontend assets are public so the login page can load before login.
+_PUBLIC_PATHS = frozenset({"/", "/ws", "/favicon.ico", "/manifest.json"})
+_PUBLIC_PREFIXES = ("/assets/", "/boards/images/")
+
+
+@web.middleware
+async def auth_middleware(request: web.Request, handler: Any) -> web.StreamResponse:
+    """
+    Gate REST endpoints by ``Authorization`` header.
+
+    Accepts ``Bearer <token>`` (preferred) or ``Basic <user:pass>``.
+    Returns ``401`` with a ``WWW-Authenticate`` challenge otherwise.
+    """
+    db = request.app["device_builder"]
+    settings = db.settings
+
+    if not settings.using_password:
+        return await handler(request)
+
+    if request.method == "OPTIONS":
+        return await handler(request)
+
+    path = request.path
+    if path in _PUBLIC_PATHS or any(path.startswith(p) for p in _PUBLIC_PREFIXES):
+        return await handler(request)
+
+    header = request.headers.get("Authorization", "")
+    ip = request.remote or "?"
+
+    token = extract_bearer_token(header)
+    if token and await db.auth.session_store.validate(token) is not None:
+        return await handler(request)
+
+    creds = parse_basic_auth(header)
+    if creds is not None:
+        if db.auth.rate_limiter.remaining_lockout(ip) > 0:
+            return _unauthorized("Too many failed attempts; try again later")
+        username, password = creds
+        if settings.check_password(username, password):
+            db.auth.rate_limiter.clear(ip)
+            return await handler(request)
+        db.auth.rate_limiter.record_failure(ip)
+
+    return _unauthorized()
+
+
+def _unauthorized(message: str = "Authentication required") -> web.Response:
+    return web.Response(
+        status=401,
+        text=message,
+        headers={
+            "WWW-Authenticate": 'Basic realm="ESPHome Device Builder", Bearer',
+        },
+    )

--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -22,11 +22,15 @@ _LOGGER = logging.getLogger(__name__)
 _SESSIONS_FILENAME = ".device-builder-sessions.json"
 _TOKEN_TTL_SECONDS = 30 * 24 * 3600  # 30 days, sliding
 _TOKEN_BYTES = 32  # 256 bits of entropy
+# Re-persist a refreshed session at most once per hour to avoid disk churn
+# (e.g. on SD-card backed Home Assistant installs).
+_PERSIST_DEBOUNCE_SECONDS = 3600
 
 # 10 failed attempts in 5 minutes locks the IP for 5 minutes.
 _RATE_LIMIT_MAX_ATTEMPTS = 10
 _RATE_LIMIT_WINDOW_SECONDS = 5 * 60
 _RATE_LIMIT_LOCKOUT_SECONDS = 5 * 60
+_RATE_LIMIT_PRUNE_INTERVAL = 60
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +78,10 @@ class SessionStore:
         self._path = config_dir / _SESSIONS_FILENAME
         self._ttl = ttl_seconds
         self._sessions: dict[str, Session] = {}
+        # Tracks the ``expires_at`` that was last written to disk per token,
+        # so ``validate`` can debounce re-persists when the sliding window
+        # only nudges the expiry forward by a small amount.
+        self._persisted_expires: dict[str, float] = {}
         self._lock = asyncio.Lock()
         self._load()
 
@@ -88,7 +96,8 @@ class SessionStore:
                 expires_at=now + self._ttl,
             )
             self._sessions[session.token] = session
-            self._persist()
+            self._persisted_expires[session.token] = session.expires_at
+            await self._persist_async()
             return session
 
     async def validate(self, token: str) -> Session | None:
@@ -106,48 +115,68 @@ class SessionStore:
             now = time.time()
             if session.is_expired(now):
                 del self._sessions[token]
-                self._persist()
+                self._persisted_expires.pop(token, None)
+                await self._persist_async()
                 return None
             session.last_used_at = now
             session.expires_at = now + self._ttl
-            self._persist()
+            persisted = self._persisted_expires.get(token, 0.0)
+            if session.expires_at - persisted >= _PERSIST_DEBOUNCE_SECONDS:
+                self._persisted_expires[token] = session.expires_at
+                await self._persist_async()
             return session
 
     async def revoke(self, token: str) -> None:
         """Drop *token* from the store; no-op if unknown."""
         async with self._lock:
             if self._sessions.pop(token, None) is not None:
-                self._persist()
+                self._persisted_expires.pop(token, None)
+                await self._persist_async()
 
     async def revoke_all(self) -> None:
         """Drop every active session, forcing all clients to re-authenticate."""
         async with self._lock:
             self._sessions.clear()
-            self._persist()
+            self._persisted_expires.clear()
+            await self._persist_async()
 
     @property
     def active_count(self) -> int:
         """Number of currently valid sessions in the store."""
         return len(self._sessions)
 
+    async def _persist_async(self) -> None:
+        await asyncio.to_thread(self._persist)
+
     def _load(self) -> None:
         try:
             raw = self._path.read_text(encoding="utf-8")
         except FileNotFoundError:
+            return
+        except OSError as err:
+            _LOGGER.warning("Could not read sessions file (%s); starting fresh", err)
             return
         try:
             data = json.loads(raw)
         except json.JSONDecodeError:
             _LOGGER.warning("Sessions file is corrupt; starting fresh: %s", self._path)
             return
+        if not isinstance(data, dict):
+            return
         now = time.time()
-        for entry in data.get("sessions", []):
+        for entry in data.get("sessions") or []:
+            if not isinstance(entry, dict):
+                continue
             try:
                 session = Session(**entry)
-            except TypeError:
+                if session.is_expired(now):
+                    continue
+            except (TypeError, ValueError):
+                # Skip entries with unexpected fields or non-numeric timestamps
+                # so a corrupt row can't take down the whole store.
                 continue
-            if not session.is_expired(now):
-                self._sessions[session.token] = session
+            self._sessions[session.token] = session
+            self._persisted_expires[session.token] = session.expires_at
 
     def _persist(self) -> None:
         data = {"sessions": [asdict(s) for s in self._sessions.values()]}
@@ -184,6 +213,7 @@ class RateLimiter:
         # monotonic clock — wall-clock jumps must not extend or shorten lockouts
         self._attempts: dict[str, deque[float]] = {}
         self._lockouts: dict[str, float] = {}
+        self._last_prune: float = 0.0
 
     def remaining_lockout(self, ip: str) -> float:
         """Seconds until *ip* is unlocked, or ``0`` if it isn't locked."""
@@ -201,6 +231,7 @@ class RateLimiter:
     def record_failure(self, ip: str) -> None:
         """Record a failed attempt for *ip*, triggering a lockout at the threshold."""
         now = time.monotonic()
+        self._maybe_prune(now)
         cutoff = now - self._window
         attempts = self._attempts.setdefault(ip, deque())
         while attempts and attempts[0] < cutoff:
@@ -220,6 +251,22 @@ class RateLimiter:
         """Drop *ip*'s failure history and any active lockout."""
         self._attempts.pop(ip, None)
         self._lockouts.pop(ip, None)
+
+    def _maybe_prune(self, now: float) -> None:
+        # Drop IPs whose attempts are all outside the window and that aren't
+        # locked out. Without this, distributed probing can grow the dicts
+        # unboundedly even though each individual IP is well below threshold.
+        if now - self._last_prune < _RATE_LIMIT_PRUNE_INTERVAL:
+            return
+        self._last_prune = now
+        cutoff = now - self._window
+        stale = [
+            ip
+            for ip, attempts in self._attempts.items()
+            if (not attempts or attempts[-1] < cutoff) and ip not in self._lockouts
+        ]
+        for ip in stale:
+            self._attempts.pop(ip, None)
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/models/api.py
+++ b/esphome_device_builder/models/api.py
@@ -17,6 +17,8 @@ class ErrorCode(StrEnum):
     INVALID_ARGS = "invalid_args"
     NOT_FOUND = "not_found"
     INTERNAL_ERROR = "internal_error"
+    NOT_AUTHENTICATED = "not_authenticated"
+    RATE_LIMITED = "rate_limited"
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ select = [
 
 [tool.ruff.lint.per-file-ignores]
 "script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501"] # CLI scripts
+"tests/*" = ["S105", "S106"] # hardcoded test credentials
 
 [tool.codespell]
 skip = "*.json,*/definitions/*"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,6 +9,8 @@ the esphome dependency chain, which is out of scope for unit tests.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import time
 from pathlib import Path
 from typing import Any
@@ -141,6 +143,80 @@ async def test_session_store_skips_expired_on_load(tmp_path: Path) -> None:
     assert await store2.validate(stale.token) is None
 
 
+async def test_session_store_load_skips_garbage_entries(tmp_path: Path) -> None:
+    """A corrupt session row can't take down the whole store."""
+    persisted = tmp_path / ".device-builder-sessions.json"
+    persisted.write_text(
+        json.dumps(
+            {
+                "sessions": [
+                    "not-a-dict",
+                    {"token": "missing-fields"},
+                    {
+                        "token": "wrong-types",
+                        "created_at": "yesterday",
+                        "last_used_at": 0,
+                        "expires_at": 0,
+                    },
+                    {
+                        "token": "good",
+                        "created_at": time.time(),
+                        "last_used_at": time.time(),
+                        "expires_at": time.time() + 60,
+                    },
+                ]
+            }
+        )
+    )
+
+    store = SessionStore(tmp_path)
+    assert await store.validate("good") is not None
+    assert await store.validate("missing-fields") is None
+    assert await store.validate("wrong-types") is None
+
+
+async def test_session_store_load_handles_top_level_garbage(tmp_path: Path) -> None:
+    """A non-dict top-level payload is treated as an empty store."""
+    persisted = tmp_path / ".device-builder-sessions.json"
+    persisted.write_text(json.dumps(["not", "a", "dict"]))
+    store = SessionStore(tmp_path)
+    assert store.active_count == 0
+
+
+async def test_session_store_validate_debounces_persist(tmp_path: Path) -> None:
+    """Validate doesn't rewrite the file on every refresh — only when expiry advances enough."""
+    store = SessionStore(tmp_path, ttl_seconds=24 * 3600)
+    session = await store.create()
+
+    persisted = tmp_path / ".device-builder-sessions.json"
+    mtime_before = persisted.stat().st_mtime_ns
+
+    # Validate a few times immediately. Expiry only nudges by microseconds,
+    # well under the 1 hour debounce, so the file should be left alone.
+    await asyncio.sleep(0.01)
+    for _ in range(5):
+        await store.validate(session.token)
+
+    assert persisted.stat().st_mtime_ns == mtime_before
+
+
+async def test_session_store_validate_persists_when_threshold_crossed(tmp_path: Path) -> None:
+    """When the per-session debounce threshold is crossed, validate writes again."""
+    store = SessionStore(tmp_path, ttl_seconds=24 * 3600)
+    session = await store.create()
+
+    persisted = tmp_path / ".device-builder-sessions.json"
+    mtime_before = persisted.stat().st_mtime_ns
+
+    # Simulate enough time having passed for the debounce to trigger by
+    # rolling the persisted-expires marker back further than the threshold.
+    store._persisted_expires[session.token] = session.expires_at - 7200
+    await asyncio.sleep(0.01)
+    await store.validate(session.token)
+
+    assert persisted.stat().st_mtime_ns > mtime_before
+
+
 # ---------------------------------------------------------------------------
 # RateLimiter
 # ---------------------------------------------------------------------------
@@ -198,6 +274,63 @@ def test_rate_limiter_lockout_expires() -> None:
 
     time.sleep(0.06)
     assert rl.remaining_lockout("7.7.7.7") == 0
+
+
+def test_rate_limiter_prunes_stale_entries() -> None:
+    """IPs whose only failures aged out of the window get evicted from the dict."""
+    rl = RateLimiter(max_attempts=10, window_seconds=0.05, lockout_seconds=60)
+    rl.record_failure("8.8.8.1")
+    rl.record_failure("8.8.8.2")
+    assert len(rl._attempts) == 2
+
+    # Force the prune interval to trigger on the next record_failure call.
+    rl._last_prune = 0.0
+    time.sleep(0.06)
+    rl.record_failure("8.8.8.3")
+
+    assert "8.8.8.1" not in rl._attempts
+    assert "8.8.8.2" not in rl._attempts
+    assert "8.8.8.3" in rl._attempts
+
+
+def test_rate_limiter_prune_keeps_locked_out_ips() -> None:
+    """Locked-out IPs must not be pruned even if their attempts aged out."""
+    rl = RateLimiter(max_attempts=2, window_seconds=0.05, lockout_seconds=60)
+    rl.record_failure("9.9.9.1")
+    rl.record_failure("9.9.9.1")  # triggers lockout
+
+    rl._last_prune = 0.0
+    time.sleep(0.06)
+    rl.record_failure("9.9.9.2")
+
+    assert "9.9.9.1" in rl._lockouts
+    assert rl.remaining_lockout("9.9.9.1") > 0
+
+
+# ---------------------------------------------------------------------------
+# WebSocket Origin check
+# ---------------------------------------------------------------------------
+
+
+def test_origin_matches_host_accepts_same_origin() -> None:
+    from esphome_device_builder.api.ws import _origin_matches_host
+
+    assert _origin_matches_host("http://homeassistant.local:6052", "homeassistant.local:6052")
+    assert _origin_matches_host("https://esphome.example.com", "esphome.example.com")
+
+
+def test_origin_matches_host_rejects_cross_origin() -> None:
+    from esphome_device_builder.api.ws import _origin_matches_host
+
+    assert not _origin_matches_host("https://attacker.com", "homeassistant.local:6052")
+    assert not _origin_matches_host("http://homeassistant.local:9999", "homeassistant.local:6052")
+
+
+def test_origin_matches_host_rejects_garbage() -> None:
+    from esphome_device_builder.api.ws import _origin_matches_host
+
+    assert not _origin_matches_host("", "homeassistant.local:6052")
+    assert not _origin_matches_host("not-a-url", "homeassistant.local:6052")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,565 @@
+"""Tests for the authentication subsystem.
+
+Covers the helpers (``SessionStore``, ``RateLimiter``, header parsing),
+the ``AuthController`` login flow including rate-limit interaction, and
+``DashboardSettings.check_password`` semantics. The full WebSocket auth
+gate is exercised indirectly here — instantiating the WS app brings in
+the esphome dependency chain, which is out of scope for unit tests.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.auth import AuthController, AuthError
+from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.helpers.auth import (
+    RateLimiter,
+    Session,
+    SessionStore,
+    extract_bearer_token,
+    hash_password,
+    parse_basic_auth,
+)
+from esphome_device_builder.models import ErrorCode
+
+# ---------------------------------------------------------------------------
+# SessionStore
+# ---------------------------------------------------------------------------
+
+
+async def test_session_store_create_and_validate(tmp_path: Path) -> None:
+    """A freshly created session is recoverable by its token."""
+    store = SessionStore(tmp_path)
+    session = await store.create()
+
+    assert session.token
+    assert len(session.token) >= 32  # token_urlsafe(32) → 43+ chars
+    assert session.expires_at > session.created_at
+
+    fetched = await store.validate(session.token)
+    assert fetched is not None
+    assert fetched.token == session.token
+
+
+async def test_session_store_validate_unknown_token(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path)
+    assert await store.validate("not-a-real-token") is None
+    assert await store.validate("") is None
+
+
+async def test_session_store_validate_refreshes_expiry(tmp_path: Path) -> None:
+    """Each successful validate slides the expiry window forward."""
+    store = SessionStore(tmp_path, ttl_seconds=60)
+    session = await store.create()
+    initial_expiry = session.expires_at
+
+    # Force a measurable time delta — without sleeping, time.time() may
+    # return the same value twice on fast systems.
+    await _advance_clock(0.01)
+    refreshed = await store.validate(session.token)
+    assert refreshed is not None
+    assert refreshed.expires_at >= initial_expiry
+
+
+async def test_session_store_validate_drops_expired(tmp_path: Path) -> None:
+    """Expired sessions are pruned on validate and return None."""
+    store = SessionStore(tmp_path, ttl_seconds=0)  # immediate expiry
+    session = await store.create()
+
+    # Even at ttl=0, monotonic float comparisons may briefly tie; force
+    # the session expiry to the past.
+    store._sessions[session.token].expires_at = time.time() - 1
+
+    assert await store.validate(session.token) is None
+    assert store.active_count == 0
+
+
+async def test_session_store_revoke(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path)
+    session = await store.create()
+
+    await store.revoke(session.token)
+    assert await store.validate(session.token) is None
+
+    # Idempotent — revoking unknown tokens is a no-op.
+    await store.revoke("unknown")
+
+
+async def test_session_store_revoke_all(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path)
+    s1 = await store.create()
+    s2 = await store.create()
+
+    await store.revoke_all()
+    assert await store.validate(s1.token) is None
+    assert await store.validate(s2.token) is None
+
+
+async def test_session_store_persists_across_instances(tmp_path: Path) -> None:
+    """Sessions written by one store are visible to a fresh instance."""
+    store1 = SessionStore(tmp_path)
+    session = await store1.create()
+
+    store2 = SessionStore(tmp_path)
+    fetched = await store2.validate(session.token)
+    assert fetched is not None
+    assert fetched.token == session.token
+
+
+async def test_session_store_persists_with_restrictive_permissions(tmp_path: Path) -> None:
+    """The persisted file is mode 0600 — readable only by the owner."""
+    store = SessionStore(tmp_path)
+    await store.create()
+
+    persisted = tmp_path / ".device-builder-sessions.json"
+    assert persisted.exists()
+    assert persisted.stat().st_mode & 0o777 == 0o600
+
+
+async def test_session_store_skips_expired_on_load(tmp_path: Path) -> None:
+    """Loading a store drops sessions that already expired on disk."""
+    store1 = SessionStore(tmp_path, ttl_seconds=60)
+    fresh = await store1.create()
+    # Inject a stale session directly so we can persist it.
+    stale = Session(
+        token="stale-token",
+        created_at=time.time() - 7200,
+        last_used_at=time.time() - 7200,
+        expires_at=time.time() - 3600,
+    )
+    store1._sessions[stale.token] = stale
+    store1._persist()
+
+    store2 = SessionStore(tmp_path)
+    assert await store2.validate(fresh.token) is not None
+    assert await store2.validate(stale.token) is None
+
+
+# ---------------------------------------------------------------------------
+# RateLimiter
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limiter_allows_under_threshold() -> None:
+    rl = RateLimiter(max_attempts=3, window_seconds=60, lockout_seconds=60)
+    rl.record_failure("1.1.1.1")
+    rl.record_failure("1.1.1.1")
+    assert rl.remaining_lockout("1.1.1.1") == 0
+
+
+def test_rate_limiter_locks_after_threshold() -> None:
+    rl = RateLimiter(max_attempts=3, window_seconds=60, lockout_seconds=60)
+    for _ in range(3):
+        rl.record_failure("2.2.2.2")
+    assert rl.remaining_lockout("2.2.2.2") > 0
+
+
+def test_rate_limiter_clear_releases_lockout() -> None:
+    rl = RateLimiter(max_attempts=2, window_seconds=60, lockout_seconds=60)
+    rl.record_failure("3.3.3.3")
+    rl.record_failure("3.3.3.3")
+    assert rl.remaining_lockout("3.3.3.3") > 0
+
+    rl.clear("3.3.3.3")
+    assert rl.remaining_lockout("3.3.3.3") == 0
+
+
+def test_rate_limiter_per_ip_isolation() -> None:
+    """Failures on one IP don't lock out a different IP."""
+    rl = RateLimiter(max_attempts=2, window_seconds=60, lockout_seconds=60)
+    rl.record_failure("4.4.4.4")
+    rl.record_failure("4.4.4.4")
+    assert rl.remaining_lockout("4.4.4.4") > 0
+    assert rl.remaining_lockout("5.5.5.5") == 0
+
+
+def test_rate_limiter_window_drops_old_failures() -> None:
+    """Failures older than the window don't count toward the threshold."""
+    rl = RateLimiter(max_attempts=3, window_seconds=0.05, lockout_seconds=60)
+    rl.record_failure("6.6.6.6")
+    rl.record_failure("6.6.6.6")
+    time.sleep(0.06)
+    rl.record_failure("6.6.6.6")
+    # Two old failures dropped, only one fresh — well under the threshold.
+    assert rl.remaining_lockout("6.6.6.6") == 0
+
+
+def test_rate_limiter_lockout_expires() -> None:
+    rl = RateLimiter(max_attempts=2, window_seconds=60, lockout_seconds=0.05)
+    rl.record_failure("7.7.7.7")
+    rl.record_failure("7.7.7.7")
+    assert rl.remaining_lockout("7.7.7.7") > 0
+
+    time.sleep(0.06)
+    assert rl.remaining_lockout("7.7.7.7") == 0
+
+
+# ---------------------------------------------------------------------------
+# Authorization header parsing
+# ---------------------------------------------------------------------------
+
+
+def test_extract_bearer_token() -> None:
+    assert extract_bearer_token("Bearer abc123") == "abc123"
+    assert extract_bearer_token("bearer xyz") == "xyz"
+    assert extract_bearer_token("BEARER  with-spaces  ") == "with-spaces"
+
+
+def test_extract_bearer_token_rejects_other_schemes() -> None:
+    assert extract_bearer_token("Basic dXNlcjpwYXNz") is None
+    assert extract_bearer_token("") is None
+    assert extract_bearer_token("Bearer") is None
+    assert extract_bearer_token("Bearer ") is None
+
+
+def test_parse_basic_auth() -> None:
+    # base64("user:pass") = "dXNlcjpwYXNz"
+    assert parse_basic_auth("Basic dXNlcjpwYXNz") == ("user", "pass")
+    assert parse_basic_auth("basic dXNlcjpwYXNz") == ("user", "pass")
+
+
+def test_parse_basic_auth_rejects_bad_input() -> None:
+    assert parse_basic_auth("") is None
+    assert parse_basic_auth("Bearer dXNlcjpwYXNz") is None
+    assert parse_basic_auth("Basic not-base64!") is None
+    # Decodes successfully but missing colon separator.
+    # base64("nocolon") = "bm9jb2xvbg=="
+    assert parse_basic_auth("Basic bm9jb2xvbg==") is None
+
+
+# ---------------------------------------------------------------------------
+# DashboardSettings.check_password
+# ---------------------------------------------------------------------------
+
+
+def test_check_password_matches() -> None:
+    s = DashboardSettings()
+    s.using_password = True
+    s.username = "admin"
+    s.password_hash = hash_password("hunter2")
+    assert s.check_password("admin", "hunter2") is True
+
+
+def test_check_password_rejects_wrong_credentials() -> None:
+    s = DashboardSettings()
+    s.using_password = True
+    s.username = "admin"
+    s.password_hash = hash_password("hunter2")
+    assert s.check_password("admin", "wrong") is False
+    assert s.check_password("not-admin", "hunter2") is False
+
+
+def test_check_password_returns_false_when_unconfigured() -> None:
+    """check_password returns False when no password is configured."""
+    s = DashboardSettings()
+    assert s.using_password is False
+    assert s.check_password("anything", "anything") is False
+
+
+# ---------------------------------------------------------------------------
+# AuthController
+# ---------------------------------------------------------------------------
+
+
+def _make_controller(tmp_path: Path) -> tuple[AuthController, Any]:
+    """Build an AuthController with a stub DeviceBuilder."""
+    settings = DashboardSettings()
+    settings.config_dir = tmp_path
+    settings.using_password = True
+    settings.username = "admin"
+    settings.password_hash = hash_password("hunter2")
+
+    stub_db = MagicMock()
+    stub_db.settings = settings
+    return AuthController(stub_db), stub_db
+
+
+def _make_client(remote: str = "9.9.9.9") -> MagicMock:
+    client = MagicMock()
+    client.remote = remote
+    client.token = None
+    client._authenticated = False
+
+    def _set_authenticated(token: str | None) -> None:
+        client._authenticated = True
+        client.token = token
+
+    client.set_authenticated = _set_authenticated
+    return client
+
+
+async def test_auth_controller_login_password_success(tmp_path: Path) -> None:
+    auth, _ = _make_controller(tmp_path)
+    client = _make_client()
+
+    result = await auth.login(client=client, username="admin", password="hunter2")
+    assert "token" in result
+    assert "expires_at" in result
+    assert client._authenticated is True
+    assert client.token == result["token"]
+
+
+async def test_auth_controller_login_wrong_password(tmp_path: Path) -> None:
+    auth, _ = _make_controller(tmp_path)
+    client = _make_client()
+
+    with pytest.raises(AuthError) as exc:
+        await auth.login(client=client, username="admin", password="wrong")
+    assert exc.value.code == ErrorCode.NOT_AUTHENTICATED
+    assert client._authenticated is False
+
+
+async def test_auth_controller_login_token_reuse(tmp_path: Path) -> None:
+    """A token issued by one login can be replayed on a later login."""
+    auth, _ = _make_controller(tmp_path)
+    client_a = _make_client()
+    client_b = _make_client()
+
+    first = await auth.login(client=client_a, username="admin", password="hunter2")
+
+    second = await auth.login(client=client_b, token=first["token"])
+    assert second["token"] == first["token"]
+    assert client_b._authenticated is True
+
+
+async def test_auth_controller_login_invalid_token(tmp_path: Path) -> None:
+    auth, _ = _make_controller(tmp_path)
+    client = _make_client()
+
+    with pytest.raises(AuthError) as exc:
+        await auth.login(client=client, token="bogus")
+    assert exc.value.code == ErrorCode.NOT_AUTHENTICATED
+
+
+async def test_auth_controller_rate_limits_after_repeated_failures(tmp_path: Path) -> None:
+    """After enough wrong passwords from one IP, further attempts are rate-limited."""
+    auth, _ = _make_controller(tmp_path)
+    auth.rate_limiter = RateLimiter(max_attempts=3, window_seconds=60, lockout_seconds=60)
+    client = _make_client(remote="10.0.0.1")
+
+    for _ in range(3):
+        with pytest.raises(AuthError):
+            await auth.login(client=client, username="admin", password="wrong")
+
+    with pytest.raises(AuthError) as exc:
+        await auth.login(client=client, username="admin", password="hunter2")
+    assert exc.value.code == ErrorCode.RATE_LIMITED
+
+
+async def test_auth_controller_success_clears_rate_limit(tmp_path: Path) -> None:
+    """A successful login wipes the failure history for that IP."""
+    auth, _ = _make_controller(tmp_path)
+    auth.rate_limiter = RateLimiter(max_attempts=3, window_seconds=60, lockout_seconds=60)
+    client = _make_client(remote="10.0.0.2")
+
+    # Two wrong attempts (under the threshold), then a correct one.
+    for _ in range(2):
+        with pytest.raises(AuthError):
+            await auth.login(client=client, username="admin", password="wrong")
+    await auth.login(client=client, username="admin", password="hunter2")
+
+    # The history should be cleared — three more wrong attempts again
+    # land on NOT_AUTHENTICATED, not RATE_LIMITED.
+    fresh_client = _make_client(remote="10.0.0.2")
+    for _ in range(2):
+        with pytest.raises(AuthError) as exc:
+            await auth.login(client=fresh_client, username="admin", password="wrong")
+        assert exc.value.code == ErrorCode.NOT_AUTHENTICATED
+
+
+async def test_auth_controller_rate_limit_per_ip(tmp_path: Path) -> None:
+    """Different IPs accumulate rate-limit counters independently."""
+    auth, _ = _make_controller(tmp_path)
+    auth.rate_limiter = RateLimiter(max_attempts=3, window_seconds=60, lockout_seconds=60)
+
+    attacker = _make_client(remote="11.0.0.1")
+    for _ in range(3):
+        with pytest.raises(AuthError):
+            await auth.login(client=attacker, username="admin", password="wrong")
+
+    # The attacker is locked out, but another IP is fine.
+    other = _make_client(remote="11.0.0.2")
+    result = await auth.login(client=other, username="admin", password="hunter2")
+    assert result["token"]
+
+
+async def test_auth_controller_token_path_skips_rate_limit(tmp_path: Path) -> None:
+    """
+    Token replay is exempt from password rate limits.
+
+    Brute-forcing a 256-bit token is infeasible, and rate-limiting
+    valid token reconnections would lock legitimate clients out
+    after a network blip.
+    """
+    auth, _ = _make_controller(tmp_path)
+    auth.rate_limiter = RateLimiter(max_attempts=3, window_seconds=60, lockout_seconds=60)
+
+    client = _make_client(remote="12.0.0.1")
+    first = await auth.login(client=client, username="admin", password="hunter2")
+
+    # Land the IP in lockout via password failures from a separate client
+    # state — same remote IP though.
+    fail_client = _make_client(remote="12.0.0.1")
+    for _ in range(3):
+        with pytest.raises(AuthError):
+            await auth.login(client=fail_client, username="admin", password="wrong")
+
+    # Token replay from the same IP still succeeds.
+    replay_client = _make_client(remote="12.0.0.1")
+    result = await auth.login(client=replay_client, token=first["token"])
+    assert result["token"] == first["token"]
+
+
+async def test_auth_controller_logout_revokes_token(tmp_path: Path) -> None:
+    auth, _ = _make_controller(tmp_path)
+    client = _make_client()
+    await auth.login(client=client, username="admin", password="hunter2")
+    token = client.token
+
+    await auth.logout(client=client)
+    client.schedule_close.assert_called_once()
+
+    # The token is no longer valid.
+    fresh_client = _make_client()
+    with pytest.raises(AuthError):
+        await auth.login(client=fresh_client, token=token)
+
+
+async def test_auth_controller_refresh_extends_session(tmp_path: Path) -> None:
+    auth, _ = _make_controller(tmp_path)
+    client = _make_client()
+    await auth.login(client=client, username="admin", password="hunter2")
+
+    refreshed = await auth.refresh(client=client)
+    assert refreshed["token"] == client.token
+
+
+async def test_auth_controller_refresh_without_session_raises(tmp_path: Path) -> None:
+    auth, _ = _make_controller(tmp_path)
+    client = _make_client()
+    client.token = None
+
+    with pytest.raises(AuthError) as exc:
+        await auth.refresh(client=client)
+    assert exc.value.code == ErrorCode.NOT_AUTHENTICATED
+
+
+# ---------------------------------------------------------------------------
+# WebSocketClient dispatch gate
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_client(
+    auth_ctrl: AuthController, *, authenticated: bool = False, remote: str = "127.0.0.1"
+) -> Any:
+    """Build a WebSocketClient with a mocked underlying WebSocket."""
+    from esphome_device_builder.api.ws import WebSocketClient
+
+    db = MagicMock()
+    db.settings = auth_ctrl._db.settings
+    db.auth = auth_ctrl
+    db.command_handlers = {
+        "auth/login": auth_ctrl.login,
+        "auth": auth_ctrl.login,
+        "ping": _stub_ping,
+    }
+
+    fake_ws = MagicMock()
+    sent: list[dict] = []
+
+    async def _send_str(payload: str) -> None:
+        import orjson
+
+        sent.append(orjson.loads(payload))
+
+    async def _close(*_: Any, **__: Any) -> None:
+        pass
+
+    fake_ws.send_str = _send_str
+    fake_ws.close = _close
+
+    client = WebSocketClient(fake_ws, db, remote=remote, authenticated=authenticated, token=None)
+    client._sent = sent  # type: ignore[attr-defined]
+    return client
+
+
+async def _stub_ping(**_: Any) -> dict:
+    return {"pong": True}
+
+
+async def test_ws_pre_auth_rejects_non_auth_command(tmp_path: Path) -> None:
+    """An unauthenticated WS connection cannot call arbitrary commands."""
+    auth, _ = _make_controller(tmp_path)
+    client = _make_ws_client(auth, authenticated=False)
+
+    await client._handle_command({"command": "ping", "message_id": "1", "args": {}})
+
+    sent = client._sent
+    assert len(sent) == 1
+    assert sent[0]["error_code"] == ErrorCode.NOT_AUTHENTICATED.value
+
+
+async def test_ws_pre_auth_allows_auth_command(tmp_path: Path) -> None:
+    """The auth command is the one exception during the pre-auth gate."""
+    auth, _ = _make_controller(tmp_path)
+    client = _make_ws_client(auth, authenticated=False)
+
+    await client._handle_command(
+        {
+            "command": "auth/login",
+            "message_id": "2",
+            "args": {"username": "admin", "password": "hunter2"},
+        }
+    )
+
+    sent = client._sent
+    assert len(sent) == 1
+    assert "result" in sent[0]
+    assert "token" in sent[0]["result"]
+    assert client.authenticated is True
+
+
+async def test_ws_authenticated_can_call_normal_commands(tmp_path: Path) -> None:
+    auth, _ = _make_controller(tmp_path)
+    client = _make_ws_client(auth, authenticated=True)
+
+    await client._handle_command({"command": "ping", "message_id": "3", "args": {}})
+
+    sent = client._sent
+    assert sent[0]["result"] == {"pong": True}
+
+
+async def test_ws_auth_alias_command_works(tmp_path: Path) -> None:
+    """The bare `auth` command is registered as an alias for `auth/login`."""
+    auth, _ = _make_controller(tmp_path)
+    client = _make_ws_client(auth, authenticated=False)
+
+    await client._handle_command(
+        {
+            "command": "auth",
+            "message_id": "4",
+            "args": {"username": "admin", "password": "hunter2"},
+        }
+    )
+
+    sent = client._sent
+    assert "result" in sent[0]
+    assert "token" in sent[0]["result"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _advance_clock(seconds: float) -> None:
+    """Block briefly so ``time.time()`` reads a fresh value."""
+    import asyncio
+
+    await asyncio.sleep(seconds)

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -70,7 +70,7 @@ def test_parse_mqtt_block_simple() -> None:
         host="192.168.1.10",
         port=1883,
         username="user",
-        password="pass",  # noqa: S106 — fixture credential
+        password="pass",
     )
 
 
@@ -87,7 +87,7 @@ def test_parse_mqtt_block_resolves_secrets() -> None:
     config = parse_mqtt_block(yaml, secrets)
     assert config is not None
     assert config.host == "192.168.1.5"
-    assert config.password == "topsecret"  # noqa: S105 — fixture credential
+    assert config.password == "topsecret"
 
 
 def test_parse_mqtt_block_missing_secret_returns_none() -> None:
@@ -288,7 +288,7 @@ async def test_coordinator_resolves_secrets_from_secrets_yaml(
     await coord.reconcile()
     assert coord.active_brokers == 1
     assert stub_monitor.instances[0].broker.host == "10.0.0.5"
-    assert stub_monitor.instances[0].broker.password == "shh"  # noqa: S105 — fixture credential
+    assert stub_monitor.instances[0].broker.password == "shh"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes [#22](https://github.com/esphome/device-builder/issues/22).

The dashboard had no auth enforcement — anyone with network access could manage devices. This adds password-gated WebSocket and REST access, with the dual-TCP-site pattern so HA Ingress users still get a transparent (no-password) experience while operators can secure direct access from outside HA.

## Changes

- New `auth/login` (alias `auth`), `auth/logout`, `auth/refresh` WebSocket commands. Until authenticated, the dispatcher rejects every other command with `not_authenticated`.
- Opaque server-issued session tokens, persisted to ``<config>/.device-builder-sessions.json`` (0600) with a sliding 30-day TTL — frontend stores the token and reuses it on reconnect.
- Per-IP rate limiter on failed password attempts: 10 failures within 5 minutes locks the IP for 5 minutes; success clears history; token replays are exempt.
- REST middleware accepts `Authorization: Bearer <token>` (preferred) or `Authorization: Basic <user:pass>`; returns 401 with `WWW-Authenticate` challenge otherwise.
- `--ha-addon` now binds a second trusted TCP site (`--ingress-port`, default 8099) on the supervisor's docker network that bypasses the auth gate. Public site keeps password enforcement.
- CLI: paired `--username`/`--password` validation, big startup banner when running unprotected, new `--ingress-port`/`--ingress-host` flags. Existing `DISABLE_HA_AUTHENTICATION` env var honoured.
- Drops the unused `cookie_secret` field; tightens `check_password` to return `False` when no password is configured (was returning `True`).

Frontend follow-up: it should read `requires_auth` from `ServerInfoMessage`, send `auth` with stored token on reconnect, fall back to login form on `not_authenticated`. Wire format documented in `docs/API.md`.