### PR TITLE
Refresh device state after firmware completes; add config_hash plumbing

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -32,6 +32,7 @@ class DeviceFileMetadata(NamedTuple):
 
     board_id: str
     ip: str
+    expected_config_hash: str = ""
 
 
 class ScanChange(StrEnum):
@@ -88,6 +89,39 @@ class DeviceScanner:
         async with self._lock:
             await self._do_scan()
 
+    async def reload(self, filename: str) -> bool:
+        """
+        Force-reload a single device's state from disk.
+
+        Use when something other than the YAML changed but still
+        affects the device model — most importantly, a successful
+        firmware compile updates the binary's mtime and flips
+        ``has_pending_changes``, but the YAML stat is unchanged so the
+        cache-key check in :meth:`scan` would otherwise skip the
+        reload.
+
+        Returns True when the device exists and was re-read; False if
+        the file isn't tracked. Fires ``ScanChange.UPDATED`` on
+        success.
+        """
+        async with self._lock:
+            path = next((p for p in self._devices if p.name == filename), None)
+            if path is None:
+                return False
+            loop = asyncio.get_running_loop()
+            loaded = await loop.run_in_executor(None, self._load_devices, {path})
+            device = loaded.get(path)
+            if device is None:
+                return False
+            self._devices[path] = device
+            try:
+                stat = path.stat()
+                self._cache_keys[path] = (stat.st_ino, stat.st_dev, stat.st_mtime, stat.st_size)
+            except OSError:
+                pass
+            self._on_change(ScanChange.UPDATED, device)
+            return True
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
@@ -138,7 +172,13 @@ class DeviceScanner:
         for path in paths:
             try:
                 metadata = self._get_metadata(self._config_dir, path.name)
-                result[path] = load_device_from_storage(path, metadata.board_id, metadata.ip)
+                result[path] = load_device_from_storage(
+                    path,
+                    metadata.board_id,
+                    metadata.ip,
+                    metadata.expected_config_hash,
+                    previous=self._devices.get(path),
+                )
             except Exception:
                 _LOGGER.warning("Failed to load device from %s", path.name)
         return result

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -55,9 +55,17 @@ IPChangeCallback = Callable[[str, str], None]
 # different firmware version than last seen for a device.
 VersionChangeCallback = Callable[[str, str], None]
 
+# Callback fired when the mDNS ``config_hash`` TXT record reports a
+# different running-config hash than last seen for a device. The hash
+# is the 8-char lowercase hex of ``App.get_config_hash()`` and is only
+# broadcast by firmware built from esphome/esphome#16145 onwards;
+# older devices simply never fire this callback.
+ConfigHashChangeCallback = Callable[[str, str], None]
+
 # zeroconf hands us raw bytes for TXT keys; declared once so the
 # call site can decode without re-typing the key.
 _TXT_RECORD_VERSION = b"version"
+_TXT_RECORD_CONFIG_HASH = b"config_hash"
 
 
 class DeviceStateMonitor:
@@ -76,14 +84,17 @@ class DeviceStateMonitor:
         on_state_change: StateChangeCallback,
         on_ip_change: IPChangeCallback,
         on_version_change: VersionChangeCallback | None = None,
+        on_config_hash_change: ConfigHashChangeCallback | None = None,
     ) -> None:
         self._get_devices = get_devices
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
         self._on_version_change = on_version_change
+        self._on_config_hash_change = on_config_hash_change
         self._state_source: dict[str, str] = {}  # device name → "mdns" | "ping"
         self._device_ips: dict[str, str] = {}  # device name → last known IP
         self._device_versions: dict[str, str] = {}  # device name → last reported version
+        self._device_config_hashes: dict[str, str] = {}  # device name → last reported config hash
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         self._mdns_browser: Any = None
         self._ping_task: asyncio.Task | None = None
@@ -180,6 +191,25 @@ class DeviceStateMonitor:
             return False
         self._device_versions[name] = version
         self._on_version_change(name, version)
+        return True
+
+    def apply_config_hash(self, name: str, config_hash: str) -> bool:
+        """
+        Record a running-firmware config hash observation.
+
+        Returns True when the hash actually changed and the change was
+        forwarded to the callback. Empty strings are dropped so devices
+        running pre-#16145 firmware (no ``config_hash`` TXT) don't churn
+        the callback.
+        """
+        if not config_hash or self._on_config_hash_change is None:
+            return False
+        if self._find_device_by_name(name) is None:
+            return False
+        if self._device_config_hashes.get(name) == config_hash:
+            return False
+        self._device_config_hashes[name] = config_hash
+        self._on_config_hash_change(name, config_hash)
         return True
 
     def get_cached_addresses(self, host_name: str) -> list[str] | None:
@@ -299,7 +329,8 @@ class DeviceStateMonitor:
                 # Strip any zone suffix (e.g. "fe80::1%en0") for display purposes.
                 ip = addresses[0].split("%", 1)[0]
                 self.apply_ip(device_name, ip)
-            version_bytes = info.properties.get(_TXT_RECORD_VERSION) if info.properties else None
+            properties = info.properties or {}
+            version_bytes = properties.get(_TXT_RECORD_VERSION)
             if version_bytes:
                 try:
                     self.apply_version(device_name, version_bytes.decode())
@@ -308,6 +339,16 @@ class DeviceStateMonitor:
                         "Could not decode mDNS version TXT for %s: %r",
                         device_name,
                         version_bytes,
+                    )
+            config_hash_bytes = properties.get(_TXT_RECORD_CONFIG_HASH)
+            if config_hash_bytes:
+                try:
+                    self.apply_config_hash(device_name, config_hash_bytes.decode())
+                except UnicodeDecodeError:
+                    _LOGGER.debug(
+                        "Could not decode mDNS config_hash TXT for %s: %r",
+                        device_name,
+                        config_hash_bytes,
                     )
         except Exception:
             _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -183,6 +183,7 @@ def set_device_metadata(
     friendly_name: str | None = None,
     comment: str | None = None,
     ip: str | None = None,
+    expected_config_hash: str | None = None,
 ) -> None:
     """
     Set metadata fields for a device.
@@ -191,6 +192,13 @@ def set_device_metadata(
     cache survives backend restarts. Pass an empty string to leave the
     persisted value unchanged (mDNS clears the in-memory IP whenever a
     device drops off the network, but the cache is still useful).
+
+    ``expected_config_hash`` is the 8-char hex FNV-1a-32 hash of the
+    YAML as last successfully compiled — pair it with the mDNS
+    ``config_hash`` TXT record (esphome/esphome#16145) to tell whether
+    the running firmware matches the compiled config. Passing an empty
+    string clears it (e.g. after a YAML edit invalidates the prior
+    compile).
     """
     with metadata_transaction(config_dir) as data:
         entry = data.setdefault(filename, {})
@@ -202,6 +210,11 @@ def set_device_metadata(
             entry["comment"] = comment
         if ip:
             entry["ip"] = ip
+        if expected_config_hash is not None:
+            if expected_config_hash:
+                entry["expected_config_hash"] = expected_config_hash
+            else:
+                entry.pop("expected_config_hash", None)
 
 
 def get_device_metadata(config_dir: Path, filename: str) -> dict[str, Any]:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -22,7 +22,6 @@ except ImportError:
 from ..helpers.api import api_command
 from ..helpers.config_hash import compute_yaml_config_hash
 from ..helpers.device_yaml import (
-    compute_has_pending_changes,
     generate_device_yaml,
     parse_platform_from_yaml,
 )
@@ -670,12 +669,13 @@ class DevicesController:
         """
         Apply a running-firmware config hash observed via mDNS.
 
-        Stores the hash on the in-memory device and re-evaluates
-        ``has_pending_changes`` so the dashboard can tell "device runs
-        the latest compile" apart from "device has older firmware".
-        Devices on firmware that predates the ``config_hash`` TXT
-        broadcast never trigger this callback and stay on the legacy
-        mtime check.
+        Stores the hash on the in-memory device and, when both
+        expected and deployed hashes are known, flips
+        ``has_pending_changes`` to reflect the comparison so the
+        dashboard can tell "device runs the latest compile" apart
+        from "device has older firmware". Devices on firmware that
+        predates the ``config_hash`` TXT broadcast never trigger this
+        callback and stay on the legacy mtime check.
         """
         device = next((d for d in self._scanner.devices if d.name == name), None)
         if device is None:
@@ -684,41 +684,15 @@ class DevicesController:
             return
         old_hash = device.deployed_config_hash
         device.deployed_config_hash = config_hash
-        self._refresh_has_pending_changes(device)
+        # Mtime side stays with the periodic scanner poll so this
+        # callback can stay off-disk and non-blocking. A YAML edit
+        # between polls (~5s window) self-corrects on the next scan.
+        if device.expected_config_hash:
+            device.has_pending_changes = device.expected_config_hash != config_hash
         _LOGGER.info(
             "Device %s config_hash: %s → %s (via mdns)", name, old_hash or "?", config_hash
         )
         self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
-
-    def _refresh_has_pending_changes(self, device: Device) -> None:
-        """
-        Re-evaluate ``device.has_pending_changes`` and update it in place.
-
-        Used when an input has changed without going through the disk
-        scanner — e.g. mDNS reported a new ``deployed_config_hash`` for
-        a device the controller already has loaded.
-        """
-        config_path = self._db.settings.rel_path(device.configuration)
-        try:
-            yaml_mtime: float | None = config_path.stat().st_mtime
-        except OSError:
-            yaml_mtime = None
-        bin_mtime: float | None = None
-        try:
-            storage = StorageJSON.load(ext_storage_path(device.configuration))
-        except Exception:
-            storage = None
-        if storage and storage.firmware_bin_path and storage.firmware_bin_path.exists():
-            try:
-                bin_mtime = storage.firmware_bin_path.stat().st_mtime
-            except OSError:
-                bin_mtime = None
-        device.has_pending_changes = compute_has_pending_changes(
-            yaml_mtime=yaml_mtime,
-            bin_mtime=bin_mtime,
-            expected_config_hash=device.expected_config_hash,
-            deployed_config_hash=device.deployed_config_hash,
-        )
 
     def _on_firmware_job_completed(self, event: Any) -> None:
         """

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -20,7 +20,9 @@ except ImportError:
     import_config = None  # type: ignore[assignment]
 
 from ..helpers.api import api_command
+from ..helpers.config_hash import compute_yaml_config_hash
 from ..helpers.device_yaml import (
+    compute_has_pending_changes,
     generate_device_yaml,
     parse_platform_from_yaml,
 )
@@ -32,6 +34,8 @@ from ..models import (
     DevicesResponse,
     DeviceState,
     EventType,
+    JobStatus,
+    JobType,
     UpdateDeviceResponse,
     WizardResponse,
 )
@@ -56,6 +60,9 @@ class DevicesController:
     def __init__(self, device_builder: DeviceBuilder) -> None:
         self._db = device_builder
         self._esphome_cmd: list[str] = []
+        # Unsubscribe handle for the firmware-job-completion listener
+        # wired up in start(); held so stop() can detach cleanly.
+        self._unsub_job_completed: Any = None
 
         # Discovery / import state
         self.import_result: dict[str, Any] = {}
@@ -71,6 +78,7 @@ class DevicesController:
             on_state_change=self._on_state_change,
             on_ip_change=self._on_ip_change,
             on_version_change=self._on_version_change,
+            on_config_hash_change=self._on_config_hash_change,
         )
         # MQTT routes its observations through the same state monitor so
         # source-priority is enforced in one place.
@@ -96,9 +104,15 @@ class DevicesController:
         _LOGGER.info("Devices controller started — %d devices loaded", len(self._scanner.devices))
         await self._state_monitor.start()
         await self._mqtt_coordinator.reconcile()
+        self._unsub_job_completed = self._db.bus.add_listener(
+            EventType.JOB_COMPLETED, self._on_firmware_job_completed
+        )
 
     async def stop(self) -> None:
         """Stop background monitors so the process exits cleanly."""
+        if self._unsub_job_completed is not None:
+            self._unsub_job_completed()
+            self._unsub_job_completed = None
         await self._mqtt_coordinator.stop()
         await self._state_monitor.stop()
 
@@ -521,7 +535,7 @@ class DevicesController:
 
     def _resolve_device_metadata(self, config_dir: Path, filename: str) -> DeviceFileMetadata:
         """
-        Resolve a device's persisted ``board_id`` and ``ip``.
+        Resolve a device's persisted ``board_id``, ``ip``, and config hash.
 
         ``board_id`` priority:
           1. The metadata sidecar — set explicitly when the user
@@ -543,13 +557,21 @@ class DevicesController:
 
         ``ip`` is the last-known resolved address from the metadata
         sidecar (``""`` if never seen).
+
+        ``expected_config_hash`` is the YAML's last-compiled
+        ``CORE.config_hash``, written by the firmware controller after
+        each successful compile; ``""`` when the device has never been
+        compiled or the compile predates expected-hash tracking.
         """
         md = get_device_metadata(config_dir, filename)
         ip = str(md.get("ip", ""))
+        expected_config_hash = str(md.get("expected_config_hash", ""))
         board_id = str(md.get("board_id", ""))
         if not board_id:
             board_id = self._derive_board_id_from_yaml(config_dir, filename)
-        return DeviceFileMetadata(board_id=board_id, ip=ip)
+        return DeviceFileMetadata(
+            board_id=board_id, ip=ip, expected_config_hash=expected_config_hash
+        )
 
     def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:
         """Parse the device YAML and look up a matching catalog board, or ``""``."""
@@ -643,6 +665,119 @@ class DevicesController:
         device.update_available = bool(device.current_version and version != device.current_version)
         _LOGGER.info("Device %s version: %s → %s (via mdns)", name, old_version or "?", version)
         self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+
+    def _on_config_hash_change(self, name: str, config_hash: str) -> None:
+        """
+        Apply a running-firmware config hash observed via mDNS.
+
+        Stores the hash on the in-memory device and re-evaluates
+        ``has_pending_changes`` so the dashboard can tell "device runs
+        the latest compile" apart from "device has older firmware".
+        Devices on firmware that predates the ``config_hash`` TXT
+        broadcast never trigger this callback and stay on the legacy
+        mtime check.
+        """
+        device = next((d for d in self._scanner.devices if d.name == name), None)
+        if device is None:
+            return
+        if device.deployed_config_hash == config_hash:
+            return
+        old_hash = device.deployed_config_hash
+        device.deployed_config_hash = config_hash
+        self._refresh_has_pending_changes(device)
+        _LOGGER.info(
+            "Device %s config_hash: %s → %s (via mdns)", name, old_hash or "?", config_hash
+        )
+        self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+
+    def _refresh_has_pending_changes(self, device: Device) -> None:
+        """
+        Re-evaluate ``device.has_pending_changes`` and update it in place.
+
+        Used when an input has changed without going through the disk
+        scanner — e.g. mDNS reported a new ``deployed_config_hash`` for
+        a device the controller already has loaded.
+        """
+        config_path = self._db.settings.rel_path(device.configuration)
+        try:
+            yaml_mtime: float | None = config_path.stat().st_mtime
+        except OSError:
+            yaml_mtime = None
+        bin_mtime: float | None = None
+        try:
+            storage = StorageJSON.load(ext_storage_path(device.configuration))
+        except Exception:
+            storage = None
+        if storage and storage.firmware_bin_path and storage.firmware_bin_path.exists():
+            try:
+                bin_mtime = storage.firmware_bin_path.stat().st_mtime
+            except OSError:
+                bin_mtime = None
+        device.has_pending_changes = compute_has_pending_changes(
+            yaml_mtime=yaml_mtime,
+            bin_mtime=bin_mtime,
+            expected_config_hash=device.expected_config_hash,
+            deployed_config_hash=device.deployed_config_hash,
+        )
+
+    def _on_firmware_job_completed(self, event: Any) -> None:
+        """
+        Refresh a device's cached state after a successful firmware job.
+
+        Without this hook, a freshly-flashed device keeps its stale
+        ``has_pending_changes=True`` — the symptom users see as a
+        still-orange "update pending" dot — because the disk scanner
+        only re-evaluates when the YAML file's stat changes.
+
+        COMPILE and INSTALL also recompute the YAML's
+        ``expected_config_hash`` here so the next mDNS resolve can
+        compare against the firmware's broadcast hash; UPLOAD doesn't
+        recompile, so it reuses whatever the previous compile cached.
+        """
+        job = event.data.get("job")
+        if job is None:
+            return
+        if getattr(job, "status", None) != JobStatus.COMPLETED:
+            return
+        job_type = getattr(job, "job_type", None)
+        if job_type not in (JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL):
+            return
+        configuration = getattr(job, "configuration", "")
+        if not configuration:
+            return
+        recompute_hash = job_type in (JobType.COMPILE, JobType.INSTALL)
+        self._db.create_background_task(
+            self._refresh_after_firmware_job(configuration, recompute_hash=recompute_hash)
+        )
+
+    async def _refresh_after_firmware_job(
+        self, configuration: str, *, recompute_hash: bool
+    ) -> None:
+        """
+        Persist the YAML's freshly-compiled hash and reload the device.
+
+        When *recompute_hash* is True, recomputes the YAML's
+        ``CORE.config_hash`` and writes it to the metadata sidecar so
+        the next mDNS resolve can compare against the firmware's
+        broadcast. The device is always reloaded afterwards — even
+        when hash computation is skipped or fails — so the mtime side
+        of ``has_pending_changes`` still flips after a successful
+        compile.
+        """
+        if recompute_hash:
+            yaml_path = self._db.settings.rel_path(configuration)
+            new_hash = await compute_yaml_config_hash(yaml_path)
+            if new_hash:
+                loop = asyncio.get_running_loop()
+                config_dir = self._db.settings.config_dir
+                await loop.run_in_executor(
+                    None,
+                    lambda: set_device_metadata(
+                        config_dir, configuration, expected_config_hash=new_hash
+                    ),
+                )
+                _LOGGER.debug("Stored expected_config_hash for %s: %s", configuration, new_hash)
+        await self._scanner.reload(configuration)
 
     async def _persist_storage_version_async(self, configuration: str, version: str) -> None:
         """Update ``StorageJSON.esphome_version`` on disk if it differs."""

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -93,7 +93,13 @@ async def compute_yaml_config_hash(yaml_path: Path) -> str | None:
             _HASH_TIMEOUT_SECONDS,
             yaml_path,
         )
-        proc.kill()
+        # Race: the subprocess may have exited between the timeout
+        # firing and ``kill()`` being called — swallow the lookup
+        # error so a recoverable timeout doesn't bubble up.
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
         await proc.wait()
         return None
 

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -1,0 +1,114 @@
+"""
+Compute the ``config_hash`` of a device YAML.
+
+ESPHome internally hashes a fully-resolved-and-sorted dump of the
+config (FNV-1a 32-bit) and exposes it as ``CORE.config_hash``. The
+running firmware exposes the same value via ``App.get_config_hash()``,
+which esphome/esphome#16145 also publishes on the
+``_esphomelib._tcp`` mDNS service as the ``config_hash`` TXT record.
+
+Computing the hash on the dashboard side requires running ESPHome's
+``read_config()`` — that resolves substitutions / packages, validates
+component schemas, and populates ``CORE.config``. It also mutates
+process-global state (``CORE``), which is why we run it in a
+subprocess instead of in-process.
+
+The hash is the 8-char lowercase hex format used by the mDNS TXT
+record. Returns ``None`` when the YAML doesn't validate or the
+subprocess fails for any reason — ``has_pending_changes`` then falls
+back to its mtime check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import sys
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+# Inline script run as ``python -c <SCRIPT> <yaml_path>``. Run in a
+# subprocess because ``read_config()`` mutates the process-global
+# ``CORE`` and importing it in our event-loop process would leak that
+# state into every later compile.
+_HASH_SCRIPT = (
+    "import sys\n"
+    "from pathlib import Path\n"
+    "from esphome.__main__ import read_config\n"
+    "from esphome.core import CORE\n"
+    # ESPHome's loader uses ``CORE.config_path`` via ``Path`` ops, so a
+    # bare string raises ``AttributeError`` deep inside ``yaml_util``.
+    "CORE.config_path = Path(sys.argv[1])\n"
+    # ``read_config`` returns the resolved config dict and *sets*
+    # ``CORE.raw_config`` — but it does NOT assign ``CORE.config``.
+    # The CLI's ``run_esphome`` does that step manually after the
+    # call, and the ``config_hash`` property hashes ``CORE.config``
+    # specifically (a ``None`` here yields a meaningless-but-stable
+    # hash for every config). Mirror the CLI's assignment.
+    "config = read_config({})\n"
+    "if config is None:\n"
+    "    sys.exit(1)\n"
+    "CORE.config = config\n"
+    "print(f'{CORE.config_hash:08x}')\n"
+)
+
+# 8 lowercase hex chars — same shape the firmware broadcasts.
+_HASH_RE = re.compile(r"\b([0-9a-f]{8})\b")
+
+# Computing a hash for a "normal" device runs in well under a second on
+# warm caches; the 60s ceiling protects against pathological YAMLs that
+# pull a slow external component or a remote package on a cold cache.
+_HASH_TIMEOUT_SECONDS = 60.0
+
+
+async def compute_yaml_config_hash(yaml_path: Path) -> str | None:
+    """
+    Return the 8-char lowercase hex ``config_hash`` for *yaml_path*.
+
+    Returns ``None`` when the YAML can't be validated or the hash
+    can't be computed for any other reason. Callers should treat
+    ``None`` as "fall back to mtime-based change detection" rather
+    than as an error to propagate.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            _HASH_SCRIPT,
+            str(yaml_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError:
+        _LOGGER.exception("Could not start config_hash subprocess for %s", yaml_path)
+        return None
+
+    try:
+        stdout_bytes, _ = await asyncio.wait_for(proc.communicate(), timeout=_HASH_TIMEOUT_SECONDS)
+    except TimeoutError:
+        _LOGGER.warning(
+            "config_hash computation timed out after %.0fs for %s",
+            _HASH_TIMEOUT_SECONDS,
+            yaml_path,
+        )
+        proc.kill()
+        await proc.wait()
+        return None
+
+    if proc.returncode != 0:
+        _LOGGER.debug(
+            "config_hash subprocess for %s exited %s — falling back to mtime check",
+            yaml_path,
+            proc.returncode,
+        )
+        return None
+
+    # ``read_config`` itself prints validation warnings to stdout, so we
+    # scan rather than assume the hash is the only line. The script's
+    # final ``print(f'{...:08x}')`` always emits exactly 8 hex chars on
+    # its own line, so the *last* match wins if multiple show up.
+    text = stdout_bytes.decode("utf-8", errors="replace")
+    matches = _HASH_RE.findall(text)
+    return matches[-1] if matches else None

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 from esphome import const
 from esphome.storage_json import StorageJSON, ext_storage_path
 
-from ..models import Device
+from ..models import Device, DeviceState
 
 if TYPE_CHECKING:
     from ..models import BoardCatalogEntry
@@ -257,7 +257,14 @@ def parse_esphome_meta(
 # ---------------------------------------------------------------------------
 
 
-def load_device_from_storage(path: Path, board_id: str = "", ip: str = "") -> Device:
+def load_device_from_storage(
+    path: Path,
+    board_id: str = "",
+    ip: str = "",
+    expected_config_hash: str = "",
+    *,
+    previous: Device | None = None,
+) -> Device:
     """
     Build a Device model from a YAML config file and its StorageJSON.
 
@@ -268,6 +275,18 @@ def load_device_from_storage(path: Path, board_id: str = "", ip: str = "") -> De
     *ip* is the last-known resolved address from the device-builder
     metadata sidecar. Loading it back on startup lets the OTA address
     cache hand the CLI a usable IP before the first ping/mDNS sweep.
+
+    *expected_config_hash* is the YAML's last-compiled config hash,
+    typically read back from the metadata sidecar. Pair with the
+    deployed hash from mDNS to tell "device runs the latest compile"
+    apart from "device has older firmware"; empty when the device
+    hasn't been compiled yet, in which case ``has_pending_changes``
+    falls back to the mtime check.
+
+    *previous* is the prior in-memory Device for this path, when one
+    exists. Runtime-only fields populated by monitors (``state``,
+    ``deployed_config_hash``) carry forward from it so a reload
+    doesn't wipe what mDNS / ping has already discovered.
     """
     filename = path.name
     storage = StorageJSON.load(ext_storage_path(filename))
@@ -288,11 +307,20 @@ def load_device_from_storage(path: Path, board_id: str = "", ip: str = "") -> De
     storage_comment = storage.comment if storage else None
     comment = yaml_comment if yaml_comment is not None else storage_comment
 
-    has_pending = True  # default: needs compile until we prove otherwise
+    yaml_mtime = path.stat().st_mtime if path.exists() else None
+    bin_mtime: float | None = None
     if storage and storage.firmware_bin_path and storage.firmware_bin_path.exists():
-        yaml_mtime = path.stat().st_mtime
         bin_mtime = storage.firmware_bin_path.stat().st_mtime
-        has_pending = yaml_mtime > bin_mtime
+
+    deployed_config_hash = previous.deployed_config_hash if previous else ""
+    state = previous.state if previous else DeviceState.UNKNOWN
+
+    has_pending = compute_has_pending_changes(
+        yaml_mtime=yaml_mtime,
+        bin_mtime=bin_mtime,
+        expected_config_hash=expected_config_hash,
+        deployed_config_hash=deployed_config_hash,
+    )
 
     deployed = storage.esphome_version or "" if storage else ""
     update_available = bool(deployed and deployed != const.__version__)
@@ -315,11 +343,49 @@ def load_device_from_storage(path: Path, board_id: str = "", ip: str = "") -> De
         web_port=storage.web_port if storage else None,
         current_version=const.__version__,
         deployed_version=deployed,
+        expected_config_hash=expected_config_hash,
+        deployed_config_hash=deployed_config_hash,
         loaded_integrations=sorted(storage.loaded_integrations) if storage else [],
+        state=state,
         has_pending_changes=has_pending,
         update_available=update_available,
         uses_mqtt=device_uses_mqtt(yaml_content),
     )
+
+
+def compute_has_pending_changes(
+    *,
+    yaml_mtime: float | None,
+    bin_mtime: float | None,
+    expected_config_hash: str,
+    deployed_config_hash: str,
+) -> bool:
+    """
+    Decide whether a device's running firmware is out of sync with its YAML.
+
+    Decision order, first match wins:
+
+    1. No firmware binary on disk yet → pending.
+    2. YAML edited after the last compile → pending. The mtime gate
+       runs before any hash comparison so a stale ``expected`` from
+       the prior compile can't accidentally match a deployed hash.
+    3. Both ``expected_config_hash`` and ``deployed_config_hash``
+       known → pending iff they differ. The deployed hash comes from
+       mDNS (esphome/esphome#16145), the expected hash from the YAML's
+       last compile; differing means the device is running older
+       firmware than the latest compile (e.g. failed OTA, flashed
+       elsewhere).
+    4. Either hash missing → not pending. Devices on firmware that
+       predates the ``config_hash`` TXT broadcast fall through here
+       and stay quiet.
+    """
+    if bin_mtime is None:
+        return True
+    if yaml_mtime is not None and yaml_mtime > bin_mtime:
+        return True
+    if expected_config_hash and deployed_config_hash:
+        return expected_config_hash != deployed_config_hash
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -34,6 +34,17 @@ class Device(DataClassORJSONMixin):
     web_port: int | None = None
     current_version: str = ""
     deployed_version: str = ""
+    # 8-char hex hash of the YAML as last successfully compiled.
+    # Persisted in the metadata sidecar; matches what ESPHome's
+    # runtime publishes via ``App.get_config_hash()``.
+    expected_config_hash: str = ""
+    # 8-char hex hash of the running firmware, read from the mDNS
+    # ``config_hash`` TXT record (esphome/esphome#16145). When this
+    # and ``expected_config_hash`` are both known they drive
+    # ``has_pending_changes`` instead of the mtime fallback — that's
+    # how we tell "flashed with the latest compile" apart from
+    # "compile succeeded but device still runs older firmware".
+    deployed_config_hash: str = ""
     loaded_integrations: list[str] = field(default_factory=list)  # from StorageJSON after compile
     state: DeviceState = DeviceState.UNKNOWN
     has_pending_changes: bool = True  # True until successfully compiled + deployed

--- a/tests/test_config_hash.py
+++ b/tests/test_config_hash.py
@@ -1,0 +1,86 @@
+"""Tests for ``helpers/config_hash.compute_yaml_config_hash``.
+
+Computing the hash needs the real ESPHome ``read_config()`` toolchain
+on the path, so these run an end-to-end subprocess against a minimal
+valid YAML in ``tmp_path``. They double as a smoke test that our
+inline subprocess script imports cleanly under the dashboard's
+interpreter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.config_hash import compute_yaml_config_hash
+
+_MINIMAL_VALID_YAML = """
+esphome:
+  name: kitchen
+esp32:
+  variant: esp32c3
+  framework:
+    type: esp-idf
+"""
+
+
+@pytest.mark.asyncio
+async def test_compute_returns_eight_char_hex_for_valid_config(tmp_path: Path) -> None:
+    """A valid config produces a deterministic 8-char lowercase hex hash."""
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text(_MINIMAL_VALID_YAML)
+
+    result = await compute_yaml_config_hash(yaml_path)
+
+    assert result is not None
+    assert len(result) == 8
+    assert all(c in "0123456789abcdef" for c in result)
+
+
+@pytest.mark.asyncio
+async def test_compute_is_deterministic(tmp_path: Path) -> None:
+    """Same YAML → same hash on subsequent runs (depends on FNV-1a determinism)."""
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text(_MINIMAL_VALID_YAML)
+
+    first = await compute_yaml_config_hash(yaml_path)
+    second = await compute_yaml_config_hash(yaml_path)
+
+    assert first is not None
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_compute_hash_changes_with_content(tmp_path: Path) -> None:
+    """Edits that change the resolved config produce a different hash."""
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text(_MINIMAL_VALID_YAML)
+    before = await compute_yaml_config_hash(yaml_path)
+
+    # Tweak a meaningful field — name change cascades through the
+    # resolved config and so changes the hash.
+    yaml_path.write_text(_MINIMAL_VALID_YAML.replace("name: kitchen", "name: bedroom"))
+    after = await compute_yaml_config_hash(yaml_path)
+
+    assert before is not None
+    assert after is not None
+    assert before != after
+
+
+@pytest.mark.asyncio
+async def test_compute_returns_none_for_invalid_yaml(tmp_path: Path) -> None:
+    """Subprocess exits non-zero on validation failure → None (fall back to mtime)."""
+    yaml_path = tmp_path / "broken.yaml"
+    yaml_path.write_text("esphome:\n  name: !!! not valid\n")
+
+    result = await compute_yaml_config_hash(yaml_path)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_compute_returns_none_for_missing_file(tmp_path: Path) -> None:
+    """Nonexistent path → None, no exception bubbled to the caller."""
+    result = await compute_yaml_config_hash(tmp_path / "ghost.yaml")
+    assert result is None

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -6,7 +6,10 @@ hand-rolled text scanning makes regression risk meaningful.
 
 from __future__ import annotations
 
-from esphome_device_builder.helpers.device_yaml import parse_esphome_meta
+from esphome_device_builder.helpers.device_yaml import (
+    compute_has_pending_changes,
+    parse_esphome_meta,
+)
 
 
 def test_parse_meta_plain_values() -> None:
@@ -89,3 +92,88 @@ esphome:
 """
     _, friendly_name, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "$missing"
+
+
+# ----------------------------------------------------------------------
+# compute_has_pending_changes
+# ----------------------------------------------------------------------
+
+
+def test_pending_when_no_binary_yet() -> None:
+    """Never-compiled device → always pending, regardless of mtime/hash inputs."""
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=100.0,
+            bin_mtime=None,
+            expected_config_hash="abc",
+            deployed_config_hash="abc",
+        )
+        is True
+    )
+
+
+def test_pending_when_yaml_edited_after_compile() -> None:
+    """YAML newer than binary → pending, even if hashes happen to match."""
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=200.0,
+            bin_mtime=100.0,
+            # Stale expected hash that happens to equal the deployed
+            # — without the mtime gate this would falsely report "in sync".
+            expected_config_hash="abc",
+            deployed_config_hash="abc",
+        )
+        is True
+    )
+
+
+def test_in_sync_when_hashes_match_and_yaml_unchanged() -> None:
+    """Both hashes known, YAML unchanged since compile → not pending."""
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=100.0,
+            bin_mtime=200.0,
+            expected_config_hash="abc",
+            deployed_config_hash="abc",
+        )
+        is False
+    )
+
+
+def test_pending_when_hashes_diverge() -> None:
+    """Hashes known and differ → pending (compiled but device runs older firmware)."""
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=100.0,
+            bin_mtime=200.0,
+            expected_config_hash="abc",
+            deployed_config_hash="def",
+        )
+        is True
+    )
+
+
+def test_in_sync_when_hashes_unknown_and_yaml_unchanged() -> None:
+    """Pre-#16145 firmware path: no hashes, YAML <= binary → not pending."""
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=100.0,
+            bin_mtime=200.0,
+            expected_config_hash="",
+            deployed_config_hash="",
+        )
+        is False
+    )
+
+
+def test_in_sync_when_only_one_hash_known() -> None:
+    """Half-known hash isn't usable — fall through to the mtime answer."""
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=100.0,
+            bin_mtime=200.0,
+            expected_config_hash="abc",
+            deployed_config_hash="",
+        )
+        is False
+    )

--- a/tests/test_firmware_refresh.py
+++ b/tests/test_firmware_refresh.py
@@ -1,0 +1,341 @@
+"""Tests for the firmware-job → device-state refresh hook.
+
+After a successful compile/install, two things flip:
+
+1. The firmware binary's mtime moves forward — the legacy mtime check
+   in ``compute_has_pending_changes`` keys off this. Without a refresh
+   the just-flashed device keeps its stale ``has_pending_changes=True``
+   (the symptom users see as a still-orange "update pending" dot).
+2. The YAML's ``CORE.config_hash`` is now baked into the new firmware,
+   so the dashboard persists it as ``expected_config_hash`` so a
+   later mDNS resolve can do a hash comparison against the device's
+   broadcast (esphome/esphome#16145).
+
+Three pieces are covered:
+
+- ``DeviceScanner.reload`` re-reads a single device's state from disk
+  and emits an ``UPDATED`` change, bypassing the cache-key check.
+- ``DevicesController._on_firmware_job_completed`` schedules a refresh
+  task only for successful COMPILE / UPLOAD / INSTALL jobs.
+- ``DevicesController._refresh_after_firmware_job`` writes the freshly
+  computed expected hash for COMPILE / INSTALL (UPLOAD reuses the
+  prior compile's hash, so it skips the recompute), then reloads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers._device_scanner import (
+    DeviceFileMetadata,
+    DeviceScanner,
+    ScanChange,
+)
+from esphome_device_builder.helpers.event_bus import Event
+from esphome_device_builder.models import (
+    Device,
+    DeviceState,
+    EventType,
+    FirmwareJob,
+    JobStatus,
+    JobType,
+)
+
+
+def _device(name: str = "kitchen", **overrides: Any) -> Device:
+    base: dict[str, Any] = {
+        "name": name,
+        "friendly_name": name.title(),
+        "configuration": f"{name}.yaml",
+        "address": f"{name}.local",
+        "current_version": "2026.5.0",
+        "deployed_version": "",
+        "state": DeviceState.UNKNOWN,
+        "has_pending_changes": True,
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+# ----------------------------------------------------------------------
+# DeviceScanner.reload
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reload_rereads_state_and_fires_updated(tmp_path: Path) -> None:
+    """Reload re-runs the loader and fires ``UPDATED`` so listeners refresh."""
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n")
+
+    changes: list[tuple[ScanChange, Device]] = []
+    scanner = DeviceScanner(
+        config_dir=tmp_path,
+        get_metadata=lambda _config_dir, _filename: DeviceFileMetadata(board_id="", ip=""),
+        on_change=lambda kind, device: changes.append((kind, device)),
+    )
+
+    # Seed the scanner with an initial in-memory snapshot — pre-install
+    # state where ``has_pending_changes`` was True.
+    initial = _device(has_pending_changes=True)
+    scanner._devices[yaml_path] = initial
+    scanner._cache_keys[yaml_path] = (0, 0, 0.0, 0)
+
+    refreshed = _device(has_pending_changes=False)
+    scanner._load_devices = MagicMock(return_value={yaml_path: refreshed})  # type: ignore[method-assign]
+
+    assert await scanner.reload("kitchen.yaml") is True
+    assert scanner._devices[yaml_path] is refreshed
+    assert changes == [(ScanChange.UPDATED, refreshed)]
+
+
+@pytest.mark.asyncio
+async def test_reload_unknown_filename_is_noop(tmp_path: Path) -> None:
+    """Reload of an untracked file returns False without touching listeners."""
+    changes: list[tuple[ScanChange, Device]] = []
+    scanner = DeviceScanner(
+        config_dir=tmp_path,
+        get_metadata=lambda _config_dir, _filename: DeviceFileMetadata(board_id="", ip=""),
+        on_change=lambda kind, device: changes.append((kind, device)),
+    )
+
+    assert await scanner.reload("ghost.yaml") is False
+    assert changes == []
+
+
+# ----------------------------------------------------------------------
+# DevicesController._on_firmware_job_completed
+#
+# The handler hands the actual work off to ``_refresh_after_firmware_job``
+# as a background task. Tests capture which configuration / recompute_hash
+# combination was scheduled (or that no task was scheduled at all).
+# ----------------------------------------------------------------------
+
+
+def _make_controller() -> tuple[Any, list[tuple[str, bool]]]:
+    """Build a partially-initialised controller and a capture list.
+
+    ``_refresh_after_firmware_job`` is patched with a sync stub that
+    records ``(configuration, recompute_hash)`` at call time and
+    returns a no-op coroutine. The handler is sync; capturing eagerly
+    sidesteps the question of whether the test runs the coroutine.
+    """
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    captured: list[tuple[str, bool]] = []
+
+    def _capturing_refresh(configuration: str, *, recompute_hash: bool) -> Any:
+        captured.append((configuration, recompute_hash))
+
+        async def _noop() -> None:
+            return None
+
+        return _noop()
+
+    db = MagicMock()
+    db.create_background_task.side_effect = lambda coro: coro.close() or MagicMock()
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._refresh_after_firmware_job = _capturing_refresh  # type: ignore[method-assign]
+    return controller, captured
+
+
+def _job(job_type: JobType, status: JobStatus, configuration: str = "kitchen.yaml") -> FirmwareJob:
+    return FirmwareJob(
+        job_id="abc123",
+        configuration=configuration,
+        job_type=job_type,
+        status=status,
+    )
+
+
+def test_completed_install_recomputes_hash_and_reloads() -> None:
+    """A successful INSTALL recompiles + flashes → hash is fresh, persist it."""
+    controller, captured = _make_controller()
+    job = _job(JobType.INSTALL, JobStatus.COMPLETED)
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
+
+    assert captured == [("kitchen.yaml", True)]
+
+
+def test_completed_compile_recomputes_hash_and_reloads() -> None:
+    """COMPILE produces a new binary tied to a (potentially) new YAML hash."""
+    controller, captured = _make_controller()
+    job = _job(JobType.COMPILE, JobStatus.COMPLETED)
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
+
+    assert captured == [("kitchen.yaml", True)]
+
+
+def test_completed_upload_reloads_without_recomputing_hash() -> None:
+    """UPLOAD doesn't recompile — the persisted hash from prior compile still applies."""
+    controller, captured = _make_controller()
+    job = _job(JobType.UPLOAD, JobStatus.COMPLETED)
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
+
+    assert captured == [("kitchen.yaml", False)]
+
+
+def test_failed_job_does_not_schedule_refresh() -> None:
+    """FAILED jobs leave the device's pending state alone."""
+    controller, captured = _make_controller()
+    job = _job(JobType.INSTALL, JobStatus.FAILED)
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
+
+    assert captured == []
+
+
+def test_clean_job_does_not_schedule_refresh() -> None:
+    """CLEAN doesn't move the binary mtime in a way that affects has_pending."""
+    controller, captured = _make_controller()
+    job = _job(JobType.CLEAN, JobStatus.COMPLETED)
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
+
+    assert captured == []
+
+
+def test_reset_build_env_does_not_schedule_refresh() -> None:
+    """RESET_BUILD_ENV has no per-device configuration to refresh."""
+    controller, captured = _make_controller()
+    job = _job(JobType.RESET_BUILD_ENV, JobStatus.COMPLETED, configuration="")
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
+
+    assert captured == []
+
+
+def test_event_without_job_payload_is_safe() -> None:
+    """Defensive: ``data["job"]`` missing must not raise."""
+    controller, captured = _make_controller()
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {}))
+
+    assert captured == []
+
+
+# ----------------------------------------------------------------------
+# DevicesController._refresh_after_firmware_job
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_compile_persists_hash_and_reloads(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Successful compile → hash computed + persisted, then device reloaded."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n")
+
+    persisted: list[dict[str, Any]] = []
+
+    def _fake_set_metadata(_config_dir: Path, filename: str, **kwargs: Any) -> None:
+        persisted.append({"filename": filename, **kwargs})
+
+    async def _fake_compute(_path: Path) -> str | None:
+        return "1a2b3c4d"
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.set_device_metadata",
+        _fake_set_metadata,
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.compute_yaml_config_hash",
+        _fake_compute,
+    )
+
+    db = MagicMock()
+    db.settings.config_dir = tmp_path
+    db.settings.rel_path = lambda c: tmp_path / c
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.reload = AsyncMock(return_value=True)
+
+    await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=True)
+
+    assert persisted == [{"filename": "kitchen.yaml", "expected_config_hash": "1a2b3c4d"}]
+    controller._scanner.reload.assert_awaited_once_with("kitchen.yaml")
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_compile_skips_persist_on_hash_failure(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """If hash computation fails, fall back to mtime check — don't write empty hash."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    persisted: list[dict[str, Any]] = []
+
+    def _fake_set_metadata(_config_dir: Path, filename: str, **kwargs: Any) -> None:
+        persisted.append({"filename": filename, **kwargs})
+
+    async def _fake_compute(_path: Path) -> str | None:
+        return None  # YAML didn't validate, subprocess failed, etc.
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.set_device_metadata",
+        _fake_set_metadata,
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.compute_yaml_config_hash",
+        _fake_compute,
+    )
+
+    db = MagicMock()
+    db.settings.config_dir = tmp_path
+    db.settings.rel_path = lambda c: tmp_path / c
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.reload = AsyncMock(return_value=True)
+
+    await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=True)
+
+    assert persisted == []  # don't overwrite with garbage
+    controller._scanner.reload.assert_awaited_once_with("kitchen.yaml")  # reload still happens
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypatch: Any) -> None:
+    """UPLOAD-only doesn't recompile — skip the heavy hash subprocess entirely."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    compute_calls: list[Path] = []
+
+    async def _fake_compute(path: Path) -> str | None:
+        compute_calls.append(path)
+        return "deadbeef"
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.compute_yaml_config_hash",
+        _fake_compute,
+    )
+
+    db = MagicMock()
+    db.settings.config_dir = tmp_path
+    db.settings.rel_path = lambda c: tmp_path / c
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.reload = AsyncMock(return_value=True)
+
+    await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=False)
+
+    assert compute_calls == []
+    controller._scanner.reload.assert_awaited_once_with("kitchen.yaml")

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -1,0 +1,237 @@
+"""Tests for mDNS-driven running-config-hash sync.
+
+esphome/esphome#16145 added an 8-char lowercase-hex ``config_hash``
+TXT record to the ``_esphomelib._tcp`` mDNS service so dashboards can
+distinguish "device is running the YAML I just compiled" from "device
+is on stale firmware". Mirrors the ``version`` TXT pipeline already
+covered by ``test_mdns_version.py`` — we plumb the new TXT through
+the same monitor → controller path so the comparison logic that lands
+later only has to read ``device.deployed_config_hash``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.models import Device, DeviceState
+
+
+def _device(**overrides: Any) -> Device:
+    base: dict[str, Any] = {
+        "name": "kitchen",
+        "friendly_name": "Kitchen",
+        "configuration": "kitchen.yaml",
+        "address": "kitchen.local",
+        "current_version": "2026.5.0",
+        "deployed_version": "",
+        "state": DeviceState.UNKNOWN,
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
+    on_config_hash = MagicMock()
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_version_change=MagicMock(),
+        on_config_hash_change=on_config_hash,
+    )
+    return monitor, on_config_hash
+
+
+# ----------------------------------------------------------------------
+# DeviceStateMonitor.apply_config_hash
+# ----------------------------------------------------------------------
+
+
+def test_apply_config_hash_first_observation_fires_callback() -> None:
+    """A hash we haven't seen before reaches the controller."""
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_config_hash("kitchen", "1a2b3c4d") is True
+    cb.assert_called_once_with("kitchen", "1a2b3c4d")
+
+
+def test_apply_config_hash_dedupes_same_value() -> None:
+    """Same hash twice → callback only fires once.
+
+    mDNS announcements are noisy and the hash only changes when the
+    user re-flashes; deduping keeps the DEVICE_UPDATED stream quiet.
+    """
+    monitor, cb = _monitor([_device()])
+    monitor.apply_config_hash("kitchen", "1a2b3c4d")
+    monitor.apply_config_hash("kitchen", "1a2b3c4d")
+    cb.assert_called_once()
+
+
+def test_apply_config_hash_fires_on_change() -> None:
+    """A different hash than the last observation fires the callback again."""
+    monitor, cb = _monitor([_device()])
+    monitor.apply_config_hash("kitchen", "1a2b3c4d")
+    monitor.apply_config_hash("kitchen", "deadbeef")
+    assert cb.call_args_list == [
+        (("kitchen", "1a2b3c4d"),),
+        (("kitchen", "deadbeef"),),
+    ]
+
+
+def test_apply_config_hash_ignores_empty_string() -> None:
+    """Pre-#16145 firmware doesn't broadcast the TXT → empty-string is a no-op."""
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_config_hash("kitchen", "") is False
+    cb.assert_not_called()
+
+
+def test_apply_config_hash_ignores_unknown_device() -> None:
+    """Stray mDNS announcements for devices not in the catalog are dropped."""
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_config_hash("ghost", "1a2b3c4d") is False
+    cb.assert_not_called()
+
+
+def test_apply_config_hash_no_callback_silently_drops() -> None:
+    """Without a wired callback (older test setups) we don't raise."""
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [_device()],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_version_change=None,
+        on_config_hash_change=None,
+    )
+    assert monitor.apply_config_hash("kitchen", "1a2b3c4d") is False
+
+
+# ----------------------------------------------------------------------
+# DevicesController._on_config_hash_change
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_config_hash_change_updates_device_and_fires_event(monkeypatch: Any) -> None:
+    """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
+    from esphome_device_builder.controllers.devices import DevicesController
+    from esphome_device_builder.models import EventType
+
+    device = _device(deployed_config_hash="")
+
+    db = MagicMock()
+    fired_events: list[tuple[EventType, dict]] = []
+    db.bus.fire.side_effect = lambda event_type, data: fired_events.append((event_type, data))
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+    # Skip the heavyweight mtime/StorageJSON probing in the helper —
+    # this test only exercises the deployed-hash mutation + event fan-out.
+    monkeypatch.setattr(controller, "_refresh_has_pending_changes", lambda _device: None)
+
+    controller._on_config_hash_change("kitchen", "1a2b3c4d")
+
+    assert device.deployed_config_hash == "1a2b3c4d"
+    assert any(et == EventType.DEVICE_UPDATED for et, _ in fired_events)
+
+
+@pytest.mark.asyncio
+async def test_on_config_hash_change_skips_when_same() -> None:
+    """No-op when in-memory device already has the announced hash."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    device = _device(deployed_config_hash="1a2b3c4d")
+
+    db = MagicMock()
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    controller._on_config_hash_change("kitchen", "1a2b3c4d")
+
+    db.bus.fire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_config_hash_change_unknown_device_is_noop() -> None:
+    """A stray callback for an unknown device must not raise or fire events."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    db = MagicMock()
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = []
+
+    controller._on_config_hash_change("ghost", "1a2b3c4d")
+
+    db.bus.fire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_config_hash_change_flips_pending_when_hashes_diverge(
+    monkeypatch: Any,
+) -> None:
+    """Hashes don't match → ``has_pending_changes`` flips True via the recompute helper."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    device = _device(
+        expected_config_hash="abc12345",
+        deployed_config_hash="",
+        has_pending_changes=False,
+    )
+
+    db = MagicMock()
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    # Stand in for the mtime/StorageJSON probe by writing the answer
+    # directly off the (now-mutated) device hashes — this isolates the
+    # _on_config_hash_change flow from filesystem state.
+    def _fake_refresh(d: Any) -> None:
+        if d.expected_config_hash and d.deployed_config_hash:
+            d.has_pending_changes = d.expected_config_hash != d.deployed_config_hash
+
+    monkeypatch.setattr(controller, "_refresh_has_pending_changes", _fake_refresh)
+
+    controller._on_config_hash_change("kitchen", "deadbeef")
+
+    assert device.deployed_config_hash == "deadbeef"
+    assert device.has_pending_changes is True
+
+
+@pytest.mark.asyncio
+async def test_on_config_hash_change_marks_in_sync_when_hashes_match(
+    monkeypatch: Any,
+) -> None:
+    """Hashes match → ``has_pending_changes`` flips False even if mtime check disagreed."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    device = _device(
+        expected_config_hash="abc12345",
+        deployed_config_hash="",
+        has_pending_changes=True,
+    )
+
+    db = MagicMock()
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    def _fake_refresh(d: Any) -> None:
+        if d.expected_config_hash and d.deployed_config_hash:
+            d.has_pending_changes = d.expected_config_hash != d.deployed_config_hash
+
+    monkeypatch.setattr(controller, "_refresh_has_pending_changes", _fake_refresh)
+
+    controller._on_config_hash_change("kitchen", "abc12345")
+
+    assert device.deployed_config_hash == "abc12345"
+    assert device.has_pending_changes is False

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -113,7 +113,7 @@ def test_apply_config_hash_no_callback_silently_drops() -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_config_hash_change_updates_device_and_fires_event(monkeypatch: Any) -> None:
+async def test_on_config_hash_change_updates_device_and_fires_event() -> None:
     """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
     from esphome_device_builder.controllers.devices import DevicesController
     from esphome_device_builder.models import EventType
@@ -128,9 +128,6 @@ async def test_on_config_hash_change_updates_device_and_fires_event(monkeypatch:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
-    # Skip the heavyweight mtime/StorageJSON probing in the helper —
-    # this test only exercises the deployed-hash mutation + event fan-out.
-    monkeypatch.setattr(controller, "_refresh_has_pending_changes", lambda _device: None)
 
     controller._on_config_hash_change("kitchen", "1a2b3c4d")
 
@@ -173,10 +170,8 @@ async def test_on_config_hash_change_unknown_device_is_noop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_config_hash_change_flips_pending_when_hashes_diverge(
-    monkeypatch: Any,
-) -> None:
-    """Hashes don't match → ``has_pending_changes`` flips True via the recompute helper."""
+async def test_on_config_hash_change_flips_pending_when_hashes_diverge() -> None:
+    """Hashes don't match → ``has_pending_changes`` flips True."""
     from esphome_device_builder.controllers.devices import DevicesController
 
     device = _device(
@@ -191,15 +186,6 @@ async def test_on_config_hash_change_flips_pending_when_hashes_diverge(
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
 
-    # Stand in for the mtime/StorageJSON probe by writing the answer
-    # directly off the (now-mutated) device hashes — this isolates the
-    # _on_config_hash_change flow from filesystem state.
-    def _fake_refresh(d: Any) -> None:
-        if d.expected_config_hash and d.deployed_config_hash:
-            d.has_pending_changes = d.expected_config_hash != d.deployed_config_hash
-
-    monkeypatch.setattr(controller, "_refresh_has_pending_changes", _fake_refresh)
-
     controller._on_config_hash_change("kitchen", "deadbeef")
 
     assert device.deployed_config_hash == "deadbeef"
@@ -207,10 +193,8 @@ async def test_on_config_hash_change_flips_pending_when_hashes_diverge(
 
 
 @pytest.mark.asyncio
-async def test_on_config_hash_change_marks_in_sync_when_hashes_match(
-    monkeypatch: Any,
-) -> None:
-    """Hashes match → ``has_pending_changes`` flips False even if mtime check disagreed."""
+async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
+    """Hashes match → ``has_pending_changes`` flips False."""
     from esphome_device_builder.controllers.devices import DevicesController
 
     device = _device(
@@ -225,13 +209,32 @@ async def test_on_config_hash_change_marks_in_sync_when_hashes_match(
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
 
-    def _fake_refresh(d: Any) -> None:
-        if d.expected_config_hash and d.deployed_config_hash:
-            d.has_pending_changes = d.expected_config_hash != d.deployed_config_hash
-
-    monkeypatch.setattr(controller, "_refresh_has_pending_changes", _fake_refresh)
-
     controller._on_config_hash_change("kitchen", "abc12345")
 
     assert device.deployed_config_hash == "abc12345"
     assert device.has_pending_changes is False
+
+
+@pytest.mark.asyncio
+async def test_on_config_hash_change_leaves_pending_alone_without_expected_hash() -> None:
+    """No expected hash on file → don't touch has_pending_changes (mtime fallback owns it)."""
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    device = _device(
+        expected_config_hash="",
+        deployed_config_hash="",
+        has_pending_changes=True,
+    )
+
+    db = MagicMock()
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    controller._on_config_hash_change("kitchen", "deadbeef")
+
+    assert device.deployed_config_hash == "deadbeef"
+    # Stays as the scanner's last computation; the callback only takes
+    # over when both hashes are known.
+    assert device.has_pending_changes is True


### PR DESCRIPTION
## Problem

After a successful flash the device kept showing as "update pending" in the dashboard. The cause: ``has_pending_changes`` is computed from a YAML-vs-binary mtime check at scan time, and the disk scanner only re-evaluates a device when the YAML stat changes — so the freshly-bumped binary mtime never reached the in-memory ``Device``.

While here, prepared the dashboard for [esphome/esphome#16145](https://github.com/esphome/esphome/pull/16145), which adds a ``config_hash`` TXT record to the ``_esphomelib._tcp`` mDNS service so the dashboard can tell "running the latest compile" apart from "compile succeeded but device still has older firmware".

## Changes

- Listen for ``JOB_COMPLETED`` in ``DevicesController`` and reload the affected device after a successful COMPILE / UPLOAD / INSTALL — fixes the stale pending indicator.
- New ``DeviceScanner.reload(filename)`` that re-runs the loader for a single path and carries forward runtime-only fields (``state``, ``deployed_config_hash``) so a reload doesn't drop what the monitors have discovered.
- New ``compute_yaml_config_hash`` helper that runs ``read_config()`` in a subprocess and returns the 8-char hex hash; called after each successful compile and persisted to the metadata sidecar as ``expected_config_hash``.
- Parse the new ``config_hash`` mDNS TXT record into ``Device.deployed_config_hash``.
- Unified ``compute_has_pending_changes``: prefers the hash comparison when both expected and deployed hashes are known, falls back to the existing mtime check otherwise (so devices on older firmware behave exactly as before).