### PR TITLE
Fix frontend serving for top-level files alongside index.html

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -311,21 +311,17 @@ class DeviceBuilder:
     @staticmethod
     def _register_frontend(app: web.Application, frontend_dir: Path) -> None:
         """Register static file routes for the built frontend."""
-        assets_dir = frontend_dir / "assets"
-        if assets_dir.is_dir():
-            app.router.add_static("/assets", assets_dir)
-
         index_html = frontend_dir / "index.html"
 
         async def handle_index(request: web.Request) -> web.FileResponse:
             return web.FileResponse(index_html)
 
-        for path in frontend_dir.iterdir():
-            if path.is_file():
-                rel = path.name
-                if rel == "index.html":
-                    app.router.add_get("/", handle_index)
-                else:
-                    app.router.add_static(f"/{rel}", path)
+        # FIFO route lookup means the explicit "/" handler wins for the
+        # bare root, and the catch-all add_static under "/" picks up
+        # everything else (hashed JS bundles, rspack license sidecars,
+        # the assets/ tree). API routes are registered before this so
+        # they continue to match first.
+        app.router.add_get("/", handle_index)
+        app.router.add_static("/", frontend_dir)
 
         _LOGGER.info("Serving frontend from %s", frontend_dir)

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from aiohttp import web
+from pytest_aiohttp.plugin import AiohttpClient
 
 from esphome_device_builder.device_builder import DeviceBuilder
 
@@ -30,27 +31,27 @@ def _make_frontend(tmp_path: Path) -> Path:
 
 
 async def test_register_frontend_serves_index_at_root(
-    tmp_path: Path, aiohttp_client: object
+    tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
     frontend = _make_frontend(tmp_path)
     app = web.Application()
     DeviceBuilder._register_frontend(app, frontend)
 
-    client = await aiohttp_client(app)  # type: ignore[operator]
+    client = await aiohttp_client(app)
     resp = await client.get("/")
     assert resp.status == 200
     assert "<!doctype html>" in (await resp.text())
 
 
 async def test_register_frontend_serves_top_level_bundles(
-    tmp_path: Path, aiohttp_client: object
+    tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
     """Hashed JS bundles next to index.html are reachable."""
     frontend = _make_frontend(tmp_path)
     app = web.Application()
     DeviceBuilder._register_frontend(app, frontend)
 
-    client = await aiohttp_client(app)  # type: ignore[operator]
+    client = await aiohttp_client(app)
     app_resp = await client.get("/app.abc123.js")
     vendors_resp = await client.get("/vendors.def456.js")
     assert (await app_resp.text()) == "// bundle"
@@ -58,7 +59,7 @@ async def test_register_frontend_serves_top_level_bundles(
 
 
 async def test_register_frontend_serves_top_level_license_sidecar(
-    tmp_path: Path, aiohttp_client: object
+    tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
     """A top-level *.LICENSE.txt no longer crashes startup or 404s.
 
@@ -70,27 +71,27 @@ async def test_register_frontend_serves_top_level_license_sidecar(
     app = web.Application()
     DeviceBuilder._register_frontend(app, frontend)
 
-    client = await aiohttp_client(app)  # type: ignore[operator]
+    client = await aiohttp_client(app)
     resp = await client.get("/vendors.def456.js.LICENSE.txt")
     assert resp.status == 200
     assert "license" in (await resp.text())
 
 
 async def test_register_frontend_serves_assets_subtree(
-    tmp_path: Path, aiohttp_client: object
+    tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
     frontend = _make_frontend(tmp_path)
     app = web.Application()
     DeviceBuilder._register_frontend(app, frontend)
 
-    client = await aiohttp_client(app)  # type: ignore[operator]
+    client = await aiohttp_client(app)
     resp = await client.get("/assets/logo/esphome.svg")
     assert resp.status == 200
     assert (await resp.text()) == "<svg/>"
 
 
 async def test_register_frontend_does_not_shadow_api_routes(
-    tmp_path: Path, aiohttp_client: object
+    tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
     """API routes registered before the frontend catch-all still win.
 
@@ -107,7 +108,7 @@ async def test_register_frontend_does_not_shadow_api_routes(
     app.router.add_get("/api/ping", api_handler)
     DeviceBuilder._register_frontend(app, frontend)
 
-    client = await aiohttp_client(app)  # type: ignore[operator]
+    client = await aiohttp_client(app)
     resp = await client.get("/api/ping")
     assert resp.status == 200
     assert (await resp.json()) == {"ok": True}

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -1,0 +1,113 @@
+"""Tests for frontend static file route registration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aiohttp import web
+
+from esphome_device_builder.device_builder import DeviceBuilder
+
+
+def _make_frontend(tmp_path: Path) -> Path:
+    """Build a frontend directory layout matching the released wheel.
+
+    Includes index.html, an assets/ subtree, top-level hashed JS
+    bundles, and an rspack license sidecar — the latter is the file
+    that historically tripped add_static (which only takes dirs).
+    """
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "index.html").write_text("<!doctype html><body></body>")
+    (frontend / "app.abc123.js").write_text("// bundle")
+    (frontend / "vendors.def456.js").write_text("// vendors")
+    (frontend / "vendors.def456.js.LICENSE.txt").write_text("/* license */")
+
+    assets = frontend / "assets"
+    (assets / "logo").mkdir(parents=True)
+    (assets / "logo" / "esphome.svg").write_text("<svg/>")
+    return frontend
+
+
+async def test_register_frontend_serves_index_at_root(
+    tmp_path: Path, aiohttp_client: object
+) -> None:
+    frontend = _make_frontend(tmp_path)
+    app = web.Application()
+    DeviceBuilder._register_frontend(app, frontend)
+
+    client = await aiohttp_client(app)  # type: ignore[operator]
+    resp = await client.get("/")
+    assert resp.status == 200
+    assert "<!doctype html>" in (await resp.text())
+
+
+async def test_register_frontend_serves_top_level_bundles(
+    tmp_path: Path, aiohttp_client: object
+) -> None:
+    """Hashed JS bundles next to index.html are reachable."""
+    frontend = _make_frontend(tmp_path)
+    app = web.Application()
+    DeviceBuilder._register_frontend(app, frontend)
+
+    client = await aiohttp_client(app)  # type: ignore[operator]
+    app_resp = await client.get("/app.abc123.js")
+    vendors_resp = await client.get("/vendors.def456.js")
+    assert (await app_resp.text()) == "// bundle"
+    assert (await vendors_resp.text()) == "// vendors"
+
+
+async def test_register_frontend_serves_top_level_license_sidecar(
+    tmp_path: Path, aiohttp_client: object
+) -> None:
+    """A top-level *.LICENSE.txt no longer crashes startup or 404s.
+
+    Regression: the previous code passed each top-level file to
+    aiohttp's add_static, which only accepts directories and raised
+    "is not a directory" on this exact filename.
+    """
+    frontend = _make_frontend(tmp_path)
+    app = web.Application()
+    DeviceBuilder._register_frontend(app, frontend)
+
+    client = await aiohttp_client(app)  # type: ignore[operator]
+    resp = await client.get("/vendors.def456.js.LICENSE.txt")
+    assert resp.status == 200
+    assert "license" in (await resp.text())
+
+
+async def test_register_frontend_serves_assets_subtree(
+    tmp_path: Path, aiohttp_client: object
+) -> None:
+    frontend = _make_frontend(tmp_path)
+    app = web.Application()
+    DeviceBuilder._register_frontend(app, frontend)
+
+    client = await aiohttp_client(app)  # type: ignore[operator]
+    resp = await client.get("/assets/logo/esphome.svg")
+    assert resp.status == 200
+    assert (await resp.text()) == "<svg/>"
+
+
+async def test_register_frontend_does_not_shadow_api_routes(
+    tmp_path: Path, aiohttp_client: object
+) -> None:
+    """API routes registered before the frontend catch-all still win.
+
+    The frontend catch-all is intentionally an "/" prefix add_static,
+    so we rely on aiohttp's FIFO route lookup to keep API endpoints
+    reachable. Lock that ordering down.
+    """
+    frontend = _make_frontend(tmp_path)
+    app = web.Application()
+
+    async def api_handler(request: web.Request) -> web.Response:
+        return web.json_response({"ok": True})
+
+    app.router.add_get("/api/ping", api_handler)
+    DeviceBuilder._register_frontend(app, frontend)
+
+    client = await aiohttp_client(app)  # type: ignore[operator]
+    resp = await client.get("/api/ping")
+    assert resp.status == 200
+    assert (await resp.json()) == {"ok": True}


### PR DESCRIPTION
## Summary
The previous code looped over the frontend dir and passed each top-level file to `app.router.add_static`, but aiohttp's `add_static` only accepts directories — so a wheel containing rspack's license sidecar (`vendors.*.js.LICENSE.txt`) raised `ValueError: '...' is not a directory` at startup. Released wheels (0.1.5/0.1.6) ship only `index.html` at the top level so the bug never fired in production.

Replace the per-file dance with a single `add_static` over the whole frontend dir as a catch-all under `/`, plus an explicit `/` → `index.html` GET. aiohttp's FIFO route lookup means the API routes registered before this in `create_app` continue to match first; the catch-all only handles unmatched paths.

## Test plan
- [x] `tests/test_frontend_routes.py` covers: index at `/`, top-level JS bundles, license sidecar (regression case), `assets/` subtree, and a guard test that a pre-registered API route is not shadowed by the frontend catch-all.
- [x] Full suite: `pytest` (174 passed)
- [x] `pre-commit run` clean