### PR TITLE
Refuse to start when frontend wheel is missing required entries

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -312,6 +312,9 @@ class DeviceBuilder:
     def _register_frontend(app: web.Application, frontend_dir: Path) -> None:
         """Register routes for the built frontend.
 
+        Refuses to start if the installed wheel is missing
+        ``index.html`` or the ``assets/`` tree.
+
         ``add_static("/assets")`` serves images via aiohttp's vetted
         static handler (sendfile + traversal protection). Top-level
         bundles and the SPA fallback share a single catch-all GET
@@ -323,6 +326,19 @@ class DeviceBuilder:
         """
         index_html = frontend_dir / "index.html"
         assets_dir = frontend_dir / "assets"
+        missing: list[str] = []
+        if not index_html.is_file():
+            missing.append("index.html")
+        if not assets_dir.is_dir():
+            missing.append("assets/")
+        if missing:
+            raise RuntimeError(
+                f"Frontend at {frontend_dir} is missing required entries: "
+                f"{', '.join(missing)}. The installed "
+                "esphome-device-builder-frontend wheel looks broken — "
+                "rebuild it (`npm run build` in the frontend repo) and "
+                "reinstall, or uninstall it to run in API-only mode."
+            )
 
         async def handle_index(request: web.Request) -> web.FileResponse:
             return web.FileResponse(index_html)

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from aiohttp import web
 
 from esphome_device_builder.device_builder import DeviceBuilder
@@ -208,3 +209,36 @@ async def test_register_frontend_url_encoded_slash_is_blocked(
         resp = await client.get(url)
         body = await resp.text()
         assert "DO-NOT-LEAK" not in body, url
+
+
+
+def test_register_frontend_raises_when_assets_missing(tmp_path: Path) -> None:
+    """A wheel without assets/ should fail loudly, not 404 silently."""
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "index.html").write_text("<!doctype html>")
+
+    app = web.Application()
+    with pytest.raises(RuntimeError, match="assets/"):
+        DeviceBuilder._register_frontend(app, frontend)
+
+
+def test_register_frontend_raises_when_index_missing(tmp_path: Path) -> None:
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "assets").mkdir()
+
+    app = web.Application()
+    with pytest.raises(RuntimeError, match=r"index\.html"):
+        DeviceBuilder._register_frontend(app, frontend)
+
+
+def test_register_frontend_lists_all_missing_entries(tmp_path: Path) -> None:
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+
+    app = web.Application()
+    with pytest.raises(RuntimeError) as exc:
+        DeviceBuilder._register_frontend(app, frontend)
+    assert "index.html" in str(exc.value)
+    assert "assets/" in str(exc.value)


### PR DESCRIPTION
## Summary
Stacked on #31 (which is stacked on #29).

A frontend wheel installed without `index.html` or the `assets/` tree would, prior to this change, silently 404 every static asset request the SPA makes — with no startup signal that anything was wrong. This is the exact symptom of a wheel built without copying `public/assets/` in rspack (see the matching frontend PR linked below).

`_register_frontend` now validates both required entries up front and raises a clear `RuntimeError` pointing at the likely cause (rebuild the frontend) and the escape hatch (uninstall it to run in API-only mode).

Pairs with [device-builder-frontend#42](https://github.com/esphome/device-builder-frontend/pull/42) which fixes the rspack pattern that produced these broken wheels in the first place.

## Test plan
- [x] `tests/test_frontend_routes.py` covers: missing `assets/` raises, missing `index.html` raises, both missing produces a single error listing both.
- [x] Full suite: `pytest` (179 passed)
- [x] `pre-commit run` clean