### PR TITLE
Serve index.html as SPA fallback for unknown frontend routes

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -310,18 +310,59 @@ class DeviceBuilder:
 
     @staticmethod
     def _register_frontend(app: web.Application, frontend_dir: Path) -> None:
-        """Register static file routes for the built frontend."""
+        """Register routes for the built frontend.
+
+        Refuses to start if the installed wheel is missing
+        ``index.html`` or the ``assets/`` tree.
+
+        ``add_static("/assets")`` serves images via aiohttp's vetted
+        static handler (sendfile + traversal protection). Top-level
+        bundles and the SPA fallback share a single catch-all GET
+        registered last, so aiohttp's FIFO route lookup matches every
+        explicit server route first; only paths nothing else claimed
+        reach this handler. Multi-segment paths never touch the
+        filesystem here, which keeps traversal impossible by
+        construction.
+        """
         index_html = frontend_dir / "index.html"
+        assets_dir = frontend_dir / "assets"
+        missing: list[str] = []
+        if not index_html.is_file():
+            missing.append("index.html")
+        if not assets_dir.is_dir():
+            missing.append("assets/")
+        if missing:
+            raise RuntimeError(
+                f"Frontend at {frontend_dir} is missing required entries: "
+                f"{', '.join(missing)}. The installed "
+                "esphome-device-builder-frontend wheel looks broken — "
+                "rebuild it (`npm run build` in the frontend repo) and "
+                "reinstall, or uninstall it to run in API-only mode."
+            )
 
         async def handle_index(request: web.Request) -> web.FileResponse:
             return web.FileResponse(index_html)
 
-        # FIFO route lookup means the explicit "/" handler wins for the
-        # bare root, and the catch-all add_static under "/" picks up
-        # everything else (hashed JS bundles, rspack license sidecars,
-        # the assets/ tree). API routes are registered before this so
-        # they continue to match first.
+        frontend_root = frontend_dir.resolve()
+
+        async def handle_spa(request: web.Request) -> web.FileResponse:
+            tail = request.match_info["tail"]
+            # Only flat names (hashed bundles, license sidecars) get
+            # served from disk. Anything with a path separator is an
+            # SPA deep link that the client router will resolve.
+            if tail and "/" not in tail:
+                candidate = frontend_dir / tail
+                # Refuse to follow symlinks pointing outside the
+                # frontend dir — matches add_static's default.
+                try:
+                    if candidate.is_file() and candidate.resolve().is_relative_to(frontend_root):
+                        return web.FileResponse(candidate)
+                except OSError:
+                    pass
+            return web.FileResponse(index_html)
+
+        app.router.add_static("/assets", assets_dir)
         app.router.add_get("/", handle_index)
-        app.router.add_static("/", frontend_dir)
+        app.router.add_get("/{tail:.*}", handle_spa)
 
         _LOGGER.info("Serving frontend from %s", frontend_dir)

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
@@ -15,7 +16,8 @@ def _make_frontend(tmp_path: Path) -> Path:
 
     Includes index.html, an assets/ subtree, top-level hashed JS
     bundles, and an rspack license sidecar — the latter is the file
-    that historically tripped add_static (which only takes dirs).
+    that historically tripped the original code, which passed it to
+    add_static (which only takes directories).
     """
     frontend = tmp_path / "frontend"
     frontend.mkdir()
@@ -30,14 +32,16 @@ def _make_frontend(tmp_path: Path) -> Path:
     return frontend
 
 
+def _make_app(frontend: Path) -> web.Application:
+    app = web.Application()
+    DeviceBuilder._register_frontend(app, frontend)
+    return app
+
+
 async def test_register_frontend_serves_index_at_root(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    frontend = _make_frontend(tmp_path)
-    app = web.Application()
-    DeviceBuilder._register_frontend(app, frontend)
-
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
     resp = await client.get("/")
     assert resp.status == 200
     assert "<!doctype html>" in (await resp.text())
@@ -47,11 +51,7 @@ async def test_register_frontend_serves_top_level_bundles(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
     """Hashed JS bundles next to index.html are reachable."""
-    frontend = _make_frontend(tmp_path)
-    app = web.Application()
-    DeviceBuilder._register_frontend(app, frontend)
-
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
     app_resp = await client.get("/app.abc123.js")
     vendors_resp = await client.get("/vendors.def456.js")
     assert (await app_resp.text()) == "// bundle"
@@ -67,11 +67,7 @@ async def test_register_frontend_serves_top_level_license_sidecar(
     aiohttp's add_static, which only accepts directories and raised
     "is not a directory" on this exact filename.
     """
-    frontend = _make_frontend(tmp_path)
-    app = web.Application()
-    DeviceBuilder._register_frontend(app, frontend)
-
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
     resp = await client.get("/vendors.def456.js.LICENSE.txt")
     assert resp.status == 200
     assert "license" in (await resp.text())
@@ -80,35 +76,169 @@ async def test_register_frontend_serves_top_level_license_sidecar(
 async def test_register_frontend_serves_assets_subtree(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    frontend = _make_frontend(tmp_path)
-    app = web.Application()
-    DeviceBuilder._register_frontend(app, frontend)
-
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
     resp = await client.get("/assets/logo/esphome.svg")
     assert resp.status == 200
     assert (await resp.text()) == "<svg/>"
 
 
-async def test_register_frontend_does_not_shadow_api_routes(
+async def test_register_frontend_serves_index_for_spa_deep_links(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """API routes registered before the frontend catch-all still win.
+    """Hard reload of a SPA route returns index.html.
 
-    The frontend catch-all is intentionally an "/" prefix add_static,
-    so we rely on aiohttp's FIFO route lookup to keep API endpoints
-    reachable. Lock that ordering down.
+    Without an SPA fallback the dashboard 404s on every refresh that
+    isn't on the bare root, since the client-side router never gets a
+    chance to handle the URL.
     """
-    frontend = _make_frontend(tmp_path)
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    for url in (
+        "/device/apollo-r-pro-1-eth-5938e0.yaml",
+        "/devices",
+        "/settings/network",
+    ):
+        resp = await client.get(url)
+        assert resp.status == 200, url
+        assert "<!doctype html>" in (await resp.text()), url
+
+
+async def test_register_frontend_does_not_shadow_specific_routes(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """Routes registered before the frontend catch-all still match first.
+
+    aiohttp's FIFO matching is what keeps `/api/...`, `/ws`,
+    `/boards/...` etc. from being shadowed by the frontend SPA
+    fallback — no per-prefix exclusion list needed in our handler.
+    """
     app = web.Application()
 
     async def api_handler(request: web.Request) -> web.Response:
         return web.json_response({"ok": True})
 
     app.router.add_get("/api/ping", api_handler)
-    DeviceBuilder._register_frontend(app, frontend)
+    DeviceBuilder._register_frontend(app, _make_frontend(tmp_path))
 
     client = await aiohttp_client(app)
     resp = await client.get("/api/ping")
     assert resp.status == 200
     assert (await resp.json()) == {"ok": True}
+
+
+async def test_register_frontend_multi_segment_paths_do_not_hit_disk(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """Path-traversal probes can't read files anywhere.
+
+    The catch-all handler only resolves single-segment names against
+    the frontend dir; multi-segment paths (everything containing a
+    ``/``) are treated as SPA routes and return ``index.html``.
+    Plant a sentinel both inside and outside the frontend dir to
+    catch any regression that lets a multi-segment path through.
+    """
+    sentinel_outside = tmp_path / "secret.txt"
+    sentinel_outside.write_text("DO-NOT-LEAK")
+
+    frontend = _make_frontend(tmp_path)
+    nested = frontend / "nested" / "leak.txt"
+    nested.parent.mkdir()
+    nested.write_text("ALSO-DO-NOT-LEAK")
+
+    client = await aiohttp_client(_make_app(frontend))
+    for url in (
+        "/../secret.txt",
+        "/foo/../../secret.txt",
+        "/%2E%2E/secret.txt",
+        "/" + "/".join([".."] * 8) + "/secret.txt",
+        "/nested/leak.txt",
+    ):
+        resp = await client.get(url)
+        body = await resp.text()
+        assert "DO-NOT-LEAK" not in body, url
+        assert "ALSO-DO-NOT-LEAK" not in body, url
+
+
+async def test_register_frontend_does_not_follow_symlinks_outside(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """A symlink inside the frontend dir pointing outside is not served.
+
+    Matches the default behaviour of aiohttp's ``add_static``: the
+    ``resolve().is_relative_to`` check after ``is_file()`` rejects
+    any symlink whose target lies outside ``frontend_dir``.
+    """
+    sentinel = tmp_path / "secret.txt"
+    sentinel.write_text("DO-NOT-LEAK")
+    frontend = _make_frontend(tmp_path)
+    (frontend / "leak").symlink_to(sentinel)
+
+    client = await aiohttp_client(_make_app(frontend))
+    resp = await client.get("/leak")
+    body = await resp.text()
+    assert "DO-NOT-LEAK" not in body
+    # Symlink rejected → caller gets the SPA shell, not the secret.
+    assert "<!doctype html>" in body
+
+
+async def test_register_frontend_follows_symlinks_inside_frontend_dir(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """Symlinks targeting other files within the frontend dir are fine.
+
+    Locks down that we don't accidentally over-broadly reject every
+    symlink — only ones that would escape the frontend root.
+    """
+    frontend = _make_frontend(tmp_path)
+    (frontend / "alias.js").symlink_to(frontend / "app.abc123.js")
+
+    client = await aiohttp_client(_make_app(frontend))
+    resp = await client.get("/alias.js")
+    assert resp.status == 200
+    assert (await resp.text()) == "// bundle"
+
+
+async def test_register_frontend_url_encoded_slash_is_blocked(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """An attacker can't sneak a path separator past the guard via URL encoding."""
+    sentinel = tmp_path / "secret.txt"
+    sentinel.write_text("DO-NOT-LEAK")
+    frontend = _make_frontend(tmp_path)
+
+    client = await aiohttp_client(_make_app(frontend))
+    for url in ("/..%2Fsecret.txt", "/foo%2F..%2F..%2Fsecret.txt"):
+        resp = await client.get(url)
+        body = await resp.text()
+        assert "DO-NOT-LEAK" not in body, url
+
+
+def test_register_frontend_raises_when_assets_missing(tmp_path: Path) -> None:
+    """A wheel without assets/ should fail loudly, not 404 silently."""
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "index.html").write_text("<!doctype html>")
+
+    app = web.Application()
+    with pytest.raises(RuntimeError, match="assets/"):
+        DeviceBuilder._register_frontend(app, frontend)
+
+
+def test_register_frontend_raises_when_index_missing(tmp_path: Path) -> None:
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "assets").mkdir()
+
+    app = web.Application()
+    with pytest.raises(RuntimeError, match=r"index\.html"):
+        DeviceBuilder._register_frontend(app, frontend)
+
+
+def test_register_frontend_lists_all_missing_entries(tmp_path: Path) -> None:
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+
+    app = web.Application()
+    with pytest.raises(RuntimeError) as exc:
+        DeviceBuilder._register_frontend(app, frontend)
+    assert "index.html" in str(exc.value)
+    assert "assets/" in str(exc.value)


### PR DESCRIPTION
## Summary
Now that #29 and #30 have merged, this PR is rebased onto main as a single clean commit covering the SPA fallback + symlink hardening (the validation block from #30 is folded in).

Hard-reloading a SPA deep link like `/device/apollo-r-pro-1-eth-5938e0.yaml` previously 404'd: `add_static("/", frontend_dir)` matched the URL prefix, found no file on disk, and refused to fall through. The client-side router never got a chance to handle the URL.

`_register_frontend` now:

* **Validates** at startup that `index.html` and `assets/` exist on the wheel, raising a clear `RuntimeError` otherwise.
* `add_static("/assets", assets_dir)` — vetted aiohttp static handler for images (sendfile + traversal protection).
* `/` → `index.html`.
* `/{tail:.*}` catch-all registered **last**, so aiohttp's FIFO route matching gives `/api/*`, `/ws`, `/boards/*`, `/assets/*` first crack — no per-prefix exclusion list needed inside the handler.

The catch-all serves a single-segment name from disk only if it's a regular file *and* its resolved path stays under the frontend root (rejects symlinks pointing outside, matching aiohttp's `add_static(follow_symlinks=False)` default). Anything else falls back to `index.html`. **Multi-segment paths never touch the filesystem**, so traversal is impossible by construction.

## Threat model + tested invariants
| Concern | Defense | Test |
|---|---|---|
| `..`/encoded traversal in URL | `"/" not in tail` guard | `test_register_frontend_multi_segment_paths_do_not_hit_disk` |
| URL-encoded slash (`%2F`) | aiohttp decodes pre-routing, then guard fires | `test_register_frontend_url_encoded_slash_is_blocked` |
| Symlink inside frontend pointing out | `resolve().is_relative_to(frontend_root)` | `test_register_frontend_does_not_follow_symlinks_outside` |
| Symlink inside frontend pointing in | allowed | `test_register_frontend_follows_symlinks_inside_frontend_dir` |
| API/server prefix shadowed | aiohttp FIFO ordering | `test_register_frontend_does_not_shadow_specific_routes` |
| SPA deep link returns `index.html` | catch-all fallback | `test_register_frontend_serves_index_for_spa_deep_links` |
| Wheel missing `index.html` / `assets/` | startup `RuntimeError` | `test_register_frontend_raises_when_*` |

Threat model: `frontend_dir` is a Python wheel install location (trusted). An attacker with write access there has already won; this matches the assumption aiohttp's own `add_static` makes.

## Test plan
- [x] Full suite: `pytest` (179 passed, 13 directly on this handler)
- [x] `mypy tests/test_frontend_routes.py` clean (no `# type: ignore`)
- [x] `pre-commit run` clean