### PR TITLE
Add featured components on the board catalog

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -174,6 +174,14 @@ The subscription stays open for the connection's lifetime; closing the WebSocket
 | `boards/get_boards` | `{query?, platform?, variant?, tag?, offset?, limit?}` | `PagedBoardsResponse` | Search/list boards |
 | `boards/get_board` | `{board_id}` | `BoardCatalogEntry` | Get board with pin map |
 
+`BoardCatalogEntry` carries two recommendation lists for the Add Component dialog:
+
+- `featured_components: list[FeaturedComponent]` — components recommended for this board, surfaced in the catalog API as `featured.<board_id>.<local_id>` under category `featured`. Each entry can override the catalog `name`/`description` and pre-fill any subset of the underlying component's `config_entries` via a `fields` map keyed by `ConfigEntry.key`. Three preset modes per field:
+  - **default**: a primitive value the frontend pre-fills; user can change it.
+  - **locked**: `{value, locked: true}` — frontend disables the input and `devices/add_component` rejects deviating user values.
+  - **suggestions**: `{suggestions: [...]}` — frontend renders a picker, user must pick from the list.
+- `featured_bundles: list[FeaturedBundle]` — `{id, name, description, component_ids}` groups of featured components (e.g. "Status LED" = `output.gpio` + `light.binary`). The frontend triggers sequential `devices/add_component` calls for each `component_id` when the user adds a bundle.
+
 ### Components
 
 > Controller: [`ComponentCatalog`](../esphome_device_builder/controllers/components.py)
@@ -182,13 +190,15 @@ The subscription stays open for the connection's lifetime; closing the WebSocket
 
 | Command | Args | Response | Description |
 |---------|------|----------|-------------|
-| `components/get_categories` | — | `[{id, name, count}]` | List categories with counts |
+| `components/get_categories` | `{board_id?}` | `[{id, name, count}]` | List categories with counts |
 | `components/get_components` | `{query?, category?, exclude_category?, platform?, board_id?, offset?, limit?}` | `PagedComponentsResponse` | Search/list components |
 | `components/get_component` | `{component_id, platform?, board_id?}` | `ComponentCatalogEntry` | Get component with config entries |
 
 `platform` filters to components compatible with the given target platform; components with an empty `supported_platforms` list are platform-agnostic and always included. `board_id` is a convenience — the boards catalog resolves it to a platform; `platform` wins when both are passed. The platform is also used to materialise each entry's `platform_defaults` into `default_value`.
 
 `category` / `exclude_category` accept either a single category or a list. Use `exclude_category` for the regular catalog selector to hide entries that belong to the dedicated "Add core configuration" dialog.
+
+**Featured components.** The board catalog's `featured_components` are surfaced through this same API under the synthetic category `featured` and ID prefix `featured.<board_id>.<local_id>`. They are **only** returned when `category` explicitly includes `featured` and `board_id` is supplied — the regular catalog listing never mixes them in. `get_categories` adds a `featured` entry with the board's recommended-count when `board_id` is set. A featured `ComponentCatalogEntry` carries the board overrides baked into its `config_entries`: `default_value` reflects the preset, and the new `locked: bool` and `suggestions: list[ConfigPrimitive] | None` fields tell the frontend to disable the input or render a picker. `devices/add_component` recognises `featured.*` ids — the wire shape doesn't change, but the backend resolves the underlying component, validates user input against the locked/suggestion constraints, and merges presets before delegating to the regular merge logic.
 
 ### Automations
 

--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -96,6 +96,16 @@ class BoardCatalog:
                 return board
         return None
 
+    def iter_boards(self) -> list[BoardCatalogEntry]:
+        """
+        Return every loaded board.
+
+        Returns the internal list directly — callers must treat it as
+        read-only. Used by the components controller to build the
+        featured-component registry at startup.
+        """
+        return self._boards
+
     def find_by_pio_board(self, pio_board: str, pio_variant: str = "") -> BoardCatalogEntry | None:
         """
         Find a board by its PlatformIO board id, preferring a matching variant.

--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -212,7 +212,19 @@ class ComponentCatalog:
             record = self._featured_by_id.get(component_id)
             if record is None:
                 return None
-            target_platform = self._resolve_platform(platform, board_id or record.board_id)
+            # The featured id already encodes the board, so we pin platform
+            # resolution to ``record.board_id``. A caller-supplied ``board_id``
+            # that disagrees is almost certainly a bug — log it but don't
+            # honour it (it'd resolve platform_defaults from the wrong board).
+            if board_id is not None and board_id != record.board_id:
+                _LOGGER.warning(
+                    "Featured component %s requested with mismatched board_id %s; "
+                    "resolving platform from %s",
+                    component_id,
+                    board_id,
+                    record.board_id,
+                )
+            target_platform = self._resolve_platform(platform, record.board_id)
             return _materialise_featured(record, target_platform)
 
         target_platform = self._resolve_platform(platform, board_id)
@@ -258,54 +270,72 @@ class ComponentCatalog:
 
         Featured components are surfaced **only** when ``category``
         explicitly includes ``featured`` and ``board_id`` is set — the
-        regular catalog listing never returns them.
+        regular catalog listing never returns them. Mixed queries
+        (e.g. ``category=["featured", "sensor"]``) return featured
+        entries first followed by the matching regular entries.
         """
         target_platform = self._resolve_platform(platform, board_id)
         include_set = _as_category_set(category) if category else None
         exclude_set = _as_category_set(exclude_category) if exclude_category else None
 
-        # Without a board_id there's no way to pick a subset, so an
-        # explicit ``category=featured`` filter without one returns an
-        # empty page rather than recommendations from unrelated hardware.
-        if include_set is not None and ComponentCategory.FEATURED.value in include_set and board_id:
-            featured_entries = self._featured_components_for_board(board_id, target_platform, query)
-            total = len(featured_entries)
-            page = featured_entries[offset : offset + limit]
-            return PagedComponentsResponse(
-                components=page,
-                total=total,
-                offset=offset,
-                limit=limit,
-                categories=self._categories_for_board(board_id),
+        include_featured = (
+            include_set is not None
+            and ComponentCategory.FEATURED.value in include_set
+            and board_id is not None
+        )
+        featured_entries = (
+            self._featured_components_for_board(board_id, target_platform, query)
+            if include_featured and board_id is not None
+            else []
+        )
+
+        # Featured entries live in their own registry, never in
+        # ``self._components``; strip the synthetic category before applying
+        # the include filter so it doesn't filter out every regular entry.
+        regular_include = (
+            include_set - {ComponentCategory.FEATURED.value} if include_set is not None else None
+        )
+
+        if include_set is not None and not regular_include:
+            results: list[ComponentCatalogEntry] = []
+        else:
+            results = self._components
+            if regular_include:
+                results = [c for c in results if c.category in regular_include]
+            if exclude_set is not None:
+                results = [c for c in results if c.category not in exclude_set]
+            if target_platform:
+                results = [
+                    c
+                    for c in results
+                    if not c.supported_platforms or target_platform in c.supported_platforms
+                ]
+            if query:
+                query_lower = query.lower()
+                results = [
+                    c
+                    for c in results
+                    if query_lower in c.name.lower()
+                    or query_lower in c.description.lower()
+                    or query_lower in c.id.lower()
+                ]
+
+        # Compose the page across both lists. Featured entries (already
+        # materialised) come first; the regular slice is materialised lazily
+        # so a wide query doesn't pay for entries the caller never reads.
+        total_featured = len(featured_entries)
+        total = total_featured + len(results)
+        end = offset + limit
+        page: list[ComponentCatalogEntry] = []
+        if offset < total_featured:
+            page.extend(featured_entries[offset : min(end, total_featured)])
+        regular_start = max(0, offset - total_featured)
+        regular_end = max(0, end - total_featured)
+        if regular_end > regular_start:
+            page.extend(
+                _materialise(c, target_platform) for c in results[regular_start:regular_end]
             )
 
-        results = self._components
-
-        if include_set is not None:
-            results = [c for c in results if c.category in include_set]
-
-        if exclude_set is not None:
-            results = [c for c in results if c.category not in exclude_set]
-
-        if target_platform:
-            results = [
-                c
-                for c in results
-                if not c.supported_platforms or target_platform in c.supported_platforms
-            ]
-
-        if query:
-            query_lower = query.lower()
-            results = [
-                c
-                for c in results
-                if query_lower in c.name.lower()
-                or query_lower in c.description.lower()
-                or query_lower in c.id.lower()
-            ]
-
-        total = len(results)
-        page = [_materialise(c, target_platform) for c in results[offset : offset + limit]]
         return PagedComponentsResponse(
             components=page,
             total=total,

--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,8 @@ from ..models import (
     ConfigEntry,
     ConfigEntryType,
     ConfigValueOption,
+    FeaturedComponent,
+    FieldPreset,
     PagedComponentsResponse,
     PinFeature,
     PinMode,
@@ -21,6 +24,10 @@ from ..models import (
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
+
+# Prefix used to route featured-component IDs to the featured registry.
+# Format: ``featured.<board_id>.<local_id>`` (e.g. ``featured.sonoff-basic.relay``).
+_FEATURED_PREFIX = "featured."
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +41,12 @@ class ComponentCatalog:
         self._db = device_builder
         self._components: list[ComponentCatalogEntry] = []
         self._by_id: dict[str, ComponentCatalogEntry] = {}
+        # Featured-component lookups, populated by ``_build_featured_registry``
+        # after both catalogs have loaded. The ``_by_board`` index is what
+        # lets ``get_components`` scope a ``category=featured`` query to one
+        # board's recommendations rather than the whole catalog.
+        self._featured_by_id: dict[str, _FeaturedRecord] = {}
+        self._featured_by_board: dict[str, list[str]] = {}
 
     def load(self) -> None:
         """
@@ -56,7 +69,12 @@ class ComponentCatalog:
         data = loads(_COMPONENTS_JSON.read_bytes())
         self._components = [_load_component(c) for c in data.get("components", [])]
         self._by_id = {c.id: c for c in self._components}
-        _LOGGER.info("Component catalog loaded: %d components", len(self._components))
+        self._build_featured_registry()
+        _LOGGER.info(
+            "Component catalog loaded: %d components, %d featured",
+            len(self._components),
+            len(self._featured_by_id),
+        )
 
     @property
     def categories(self) -> list[dict[str, str | int]]:
@@ -66,21 +84,23 @@ class ComponentCatalog:
         Each entry is a ``{id, name, count}`` dict suitable for direct
         use in the catalog UI's filter list.
         """
-        counts: dict[str, int] = {}
-        for comp in self._components:
-            counts[comp.category] = counts.get(comp.category, 0) + 1
-        return sorted(
-            [
-                {"id": str(cat), "name": str(cat).replace("_", " ").title(), "count": count}
-                for cat, count in counts.items()
-            ],
-            key=lambda c: (-int(c["count"]), str(c["name"])),
-        )
+        return self._categories_for_board(None)
 
     @api_command("components/get_categories")
-    async def get_categories(self, **kwargs: Any) -> list[dict[str, str | int]]:
-        """Get all component categories with counts."""
-        return self.categories
+    async def get_categories(
+        self,
+        *,
+        board_id: str | None = None,
+        **kwargs: Any,
+    ) -> list[dict[str, str | int]]:
+        """
+        Get all component categories with counts.
+
+        When ``board_id`` is supplied, the response includes a synthetic
+        ``featured`` entry whose count reflects the recommended components
+        for that board (omitted entirely when the board has none).
+        """
+        return self._categories_for_board(board_id)
 
     @api_command("components/get_integration_docs")
     async def get_integration_docs(self, **kwargs: Any) -> dict[str, str]:
@@ -182,12 +202,24 @@ class ComponentCatalog:
         into ``default_value`` for that target platform — frontend
         gets the right default without having to know the
         cv.SplitDefault details.
+
+        ``component_id`` may also be a featured-component id of the form
+        ``featured.<board>.<local>`` — the response then carries the
+        underlying component with the board's ``FieldPreset`` overrides
+        baked into ``default_value`` / ``locked`` / ``suggestions``.
         """
-        platform = self._resolve_platform(platform, board_id)
+        if component_id.startswith(_FEATURED_PREFIX):
+            record = self._featured_by_id.get(component_id)
+            if record is None:
+                return None
+            target_platform = self._resolve_platform(platform, board_id or record.board_id)
+            return _materialise_featured(record, target_platform)
+
+        target_platform = self._resolve_platform(platform, board_id)
         component = self._by_id.get(component_id)
         if component is None:
             return None
-        return _materialise(component, platform)
+        return _materialise(component, target_platform)
 
     @api_command("components/get_components")
     async def get_components(
@@ -223,21 +255,43 @@ class ComponentCatalog:
         plus the platform-domain umbrellas ``ota`` / ``time`` /
         ``update``). Both filters can be combined though that's
         unusual.
+
+        Featured components are surfaced **only** when ``category``
+        explicitly includes ``featured`` and ``board_id`` is set — the
+        regular catalog listing never returns them.
         """
-        platform = self._resolve_platform(platform, board_id)
+        target_platform = self._resolve_platform(platform, board_id)
+        include_set = _as_category_set(category) if category else None
+        exclude_set = _as_category_set(exclude_category) if exclude_category else None
+
+        # Without a board_id there's no way to pick a subset, so an
+        # explicit ``category=featured`` filter without one returns an
+        # empty page rather than recommendations from unrelated hardware.
+        if include_set is not None and ComponentCategory.FEATURED.value in include_set and board_id:
+            featured_entries = self._featured_components_for_board(board_id, target_platform, query)
+            total = len(featured_entries)
+            page = featured_entries[offset : offset + limit]
+            return PagedComponentsResponse(
+                components=page,
+                total=total,
+                offset=offset,
+                limit=limit,
+                categories=self._categories_for_board(board_id),
+            )
+
         results = self._components
 
-        if category:
-            include_set = _as_category_set(category)
+        if include_set is not None:
             results = [c for c in results if c.category in include_set]
 
-        if exclude_category:
-            exclude_set = _as_category_set(exclude_category)
+        if exclude_set is not None:
             results = [c for c in results if c.category not in exclude_set]
 
-        if platform:
+        if target_platform:
             results = [
-                c for c in results if not c.supported_platforms or platform in c.supported_platforms
+                c
+                for c in results
+                if not c.supported_platforms or target_platform in c.supported_platforms
             ]
 
         if query:
@@ -251,14 +305,89 @@ class ComponentCatalog:
             ]
 
         total = len(results)
-        page = [_materialise(c, platform) for c in results[offset : offset + limit]]
+        page = [_materialise(c, target_platform) for c in results[offset : offset + limit]]
         return PagedComponentsResponse(
             components=page,
             total=total,
             offset=offset,
             limit=limit,
-            categories=self.categories,
+            categories=self._categories_for_board(board_id),
         )
+
+    def get_featured_record(self, component_id: str) -> _FeaturedRecord | None:
+        """Return the registry record for a ``featured.*`` id, or ``None``."""
+        return self._featured_by_id.get(component_id)
+
+    def _build_featured_registry(self) -> None:
+        """Walk the board catalog and index every featured component."""
+        self._featured_by_id = {}
+        self._featured_by_board = {}
+        if self._db is None or self._db.boards is None:
+            return
+        for board in self._db.boards.iter_boards():
+            ids: list[str] = []
+            for fc in board.featured_components:
+                full_id = f"{_FEATURED_PREFIX}{board.id}.{fc.id}"
+                underlying = self._by_id.get(fc.component_id)
+                if underlying is None:
+                    _LOGGER.warning(
+                        "Board %s featured.%s references unknown component %s — skipping",
+                        board.id,
+                        fc.id,
+                        fc.component_id,
+                    )
+                    continue
+                self._featured_by_id[full_id] = _FeaturedRecord(
+                    full_id=full_id,
+                    board_id=board.id,
+                    featured=fc,
+                    underlying=underlying,
+                )
+                ids.append(full_id)
+            if ids:
+                self._featured_by_board[board.id] = ids
+
+    def _categories_for_board(self, board_id: str | None) -> list[dict[str, str | int]]:
+        """Build the category list, optionally with a per-board ``featured`` count."""
+        counts: dict[str, int] = {}
+        for comp in self._components:
+            counts[comp.category] = counts.get(comp.category, 0) + 1
+        if board_id:
+            featured_count = len(self._featured_by_board.get(board_id, []))
+            if featured_count:
+                counts[ComponentCategory.FEATURED.value] = featured_count
+        return sorted(
+            [
+                {"id": str(cat), "name": str(cat).replace("_", " ").title(), "count": count}
+                for cat, count in counts.items()
+            ],
+            key=lambda c: (-int(c["count"]), str(c["name"])),
+        )
+
+    def _featured_components_for_board(
+        self,
+        board_id: str,
+        target_platform: str | None,
+        query: str | None,
+    ) -> list[ComponentCatalogEntry]:
+        """Materialise every featured component on *board_id*, optionally filtered by *query*."""
+        ids = self._featured_by_board.get(board_id, [])
+        entries: list[ComponentCatalogEntry] = []
+        for full_id in ids:
+            record = self._featured_by_id.get(full_id)
+            if record is None:
+                continue
+            entries.append(_materialise_featured(record, target_platform))
+        if query:
+            query_lower = query.lower()
+            entries = [
+                e
+                for e in entries
+                if query_lower in e.name.lower()
+                or query_lower in e.description.lower()
+                or query_lower in e.id.lower()
+            ]
+        return entries
 
     def _resolve_platform(
         self,
@@ -280,6 +409,85 @@ class ComponentCatalog:
         if board is None or board.esphome.platform is None:
             return None
         return board.esphome.platform.value.lower()
+
+
+# ---------------------------------------------------------------------------
+# Featured registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FeaturedRecord:
+    """
+    A featured component resolved against the underlying catalog entry.
+
+    ``underlying`` is the regular catalog entry the user is actually
+    adding (``switch.gpio``, ...); ``featured`` carries the manifest's
+    name/description overrides and per-field presets to layer on top.
+    """
+
+    full_id: str
+    board_id: str
+    featured: FeaturedComponent
+    underlying: ComponentCatalogEntry
+
+    @property
+    def underlying_id(self) -> str:
+        return self.underlying.id
+
+
+def _materialise_featured(
+    record: _FeaturedRecord,
+    target_platform: str | None,
+) -> ComponentCatalogEntry:
+    """
+    Return *record* as a ``ComponentCatalogEntry`` ready for the catalog API.
+
+    The result carries the synthetic ``featured.<board>.<local>`` id and
+    category ``featured``, the manifest's name/description overrides, and
+    each ``FieldPreset`` baked into the corresponding ``ConfigEntry`` as
+    ``default_value`` / ``locked`` / ``suggestions``.
+    """
+    underlying = record.underlying
+    fc = record.featured
+    return ComponentCatalogEntry(
+        id=record.full_id,
+        name=fc.name or underlying.name,
+        description=fc.description if fc.description is not None else underlying.description,
+        category=ComponentCategory.FEATURED,
+        docs_url=underlying.docs_url,
+        image_url=underlying.image_url,
+        dependencies=list(underlying.dependencies),
+        multi_conf=underlying.multi_conf,
+        supported_platforms=list(underlying.supported_platforms),
+        config_entries=[
+            _materialise_entry_with_preset(entry, target_platform, fc.fields.get(entry.key))
+            for entry in underlying.config_entries
+        ],
+    )
+
+
+def _materialise_entry_with_preset(
+    entry: ConfigEntry,
+    target_platform: str | None,
+    preset: FieldPreset | None,
+) -> ConfigEntry:
+    """
+    Return *entry* materialised for *target_platform* with *preset* applied.
+
+    ``preset.value`` overrides ``default_value``, ``preset.locked`` and
+    ``preset.suggestions`` ride through to the returned entry. Without a
+    preset this is equivalent to :func:`_materialise_entry`.
+    """
+    base = _materialise_entry(entry, target_platform)
+    if preset is None:
+        return base
+    if preset.value is not None:
+        base.default_value = preset.value  # type: ignore[assignment]
+    base.locked = preset.locked
+    if preset.suggestions is not None:
+        base.suggestions = list(preset.suggestions)
+    return base
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -52,6 +52,7 @@ from .config import (
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
+    from .components import _FeaturedRecord
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -617,14 +618,32 @@ class DevicesController:
         ``fields`` is a flat mapping of config-entry key → value. For
         NESTED config entries the value is itself a dict matching the
         nested entry's structure (recursive).
+
+        Featured-component ids (``featured.<board>.<local>``) are
+        recognised here: the backend resolves them to the underlying
+        catalog component, validates user input against the manifest's
+        ``locked`` / ``suggestions`` constraints, and merges the
+        manifest's preset values into ``fields`` before delegating to
+        the regular merge logic.
         """
         assert self._db.components is not None  # type narrowing
-        component = await self._db.components.get_component(component_id=component_id)
+
+        fields = dict(fields or {})
+        underlying_component_id = component_id
+
+        if component_id.startswith("featured."):
+            record = self._db.components.get_featured_record(component_id)
+            if record is None:
+                msg = f"Unknown featured component: {component_id}"
+                raise ValueError(msg)
+            underlying_component_id = record.underlying_id
+            fields = _apply_featured_presets(record, fields)
+
+        component = await self._db.components.get_component(component_id=underlying_component_id)
         if component is None:
-            msg = f"Unknown component: {component_id}"
+            msg = f"Unknown component: {underlying_component_id}"
             raise ValueError(msg)
 
-        fields = fields or {}
         for entry in component.config_entries:
             if entry.required and entry.key not in fields:
                 msg = f"Missing required field: {entry.key}"
@@ -1460,6 +1479,55 @@ class DevicesController:
         await client.send_event(
             message_id, "result", {"success": exit_code == 0, "code": exit_code}
         )
+
+
+def _apply_featured_presets(
+    record: _FeaturedRecord,
+    user_fields: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Merge a featured component's presets onto *user_fields*.
+
+    Returns a new field map ready for the regular merge logic; raises
+    ``ValueError`` when *user_fields* violates a preset constraint.
+
+    Per-field semantics:
+
+    - Locked: user must omit the key or supply the locked value verbatim.
+    - Suggestions: user-supplied value must be one of the listed values;
+      omission falls back to the preset's ``value`` (when set).
+    - Plain default: filled in only when the user didn't supply one.
+    """
+    merged: dict[str, Any] = dict(user_fields)
+    for key, preset in record.featured.fields.items():
+        user_value = merged.get(key)
+        user_supplied = key in merged
+        if preset.locked:
+            if user_supplied and user_value != preset.value:
+                msg = (
+                    f"Featured component {record.full_id} field '{key}' is "
+                    f"locked to {preset.value!r}; cannot override with "
+                    f"{user_value!r}"
+                )
+                raise ValueError(msg)
+            if preset.value is not None:
+                merged[key] = preset.value
+            continue
+        if preset.suggestions is not None:
+            if user_supplied:
+                if user_value not in preset.suggestions:
+                    msg = (
+                        f"Featured component {record.full_id} field '{key}' "
+                        f"must be one of {preset.suggestions}; got "
+                        f"{user_value!r}"
+                    )
+                    raise ValueError(msg)
+            elif preset.value is not None:
+                merged[key] = preset.value
+            continue
+        if not user_supplied and preset.value is not None:
+            merged[key] = preset.value
+    return merged
 
 
 def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None) -> list[str]:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -1503,6 +1503,15 @@ def _apply_featured_presets(
         user_value = merged.get(key)
         user_supplied = key in merged
         if preset.locked:
+            # Schema validation rejects ``locked: true`` without a value, but
+            # guard the runtime too so a malformed manifest fails fast with a
+            # clear error instead of "locked to None".
+            if preset.value is None:
+                msg = (
+                    f"Featured component {record.full_id} field '{key}' has "
+                    f"locked=true without a value — board manifest is malformed"
+                )
+                raise ValueError(msg)
             if user_supplied and user_value != preset.value:
                 msg = (
                     f"Featured component {record.full_id} field '{key}' is "
@@ -1510,8 +1519,7 @@ def _apply_featured_presets(
                     f"{user_value!r}"
                 )
                 raise ValueError(msg)
-            if preset.value is not None:
-                merged[key] = preset.value
+            merged[key] = preset.value
             continue
         if preset.suggestions is not None:
             if user_supplied:

--- a/esphome_device_builder/definitions/README.md
+++ b/esphome_device_builder/definitions/README.md
@@ -118,6 +118,70 @@ Use `occupied_by` when a GPIO is connected to an onboard component. Examples:
 
 This tells the Device Builder to warn users before assigning these pins.
 
+### Featured Components
+
+A board manifest can recommend specific components for the Add Component
+dialog under a `featured_components:` section. Each entry references an
+existing catalog component by `component_id` (e.g. `switch.gpio`) and
+optionally pre-fills any of its config fields. Three preset modes:
+
+```yaml
+featured_components:
+  # 1) Recommend-only — points users at a component, no config preset.
+  - id: dht
+    component_id: sensor.dht
+    name: Temperature & Humidity (DHT)
+
+  # 2) Locked — fixed value the user cannot change.
+  - id: relay
+    component_id: switch.gpio
+    name: Onboard Relay
+    description: 10 A relay wired to GPIO12.
+    fields:
+      pin: { value: 12, locked: true }
+      name: Relay   # primitive shorthand → value="Relay", locked=false
+
+  # 3) Suggestions — short list of allowed values (frontend renders a picker).
+  - id: pir-motion
+    component_id: binary_sensor.gpio
+    name: PIR Motion Module
+    fields:
+      pin:
+        suggestions: [4, 5]
+        value: 4    # initial pick
+      device_class: motion
+```
+
+Inside `fields:`:
+
+- A bare primitive / list is shorthand for `{ value: <x>, locked: false }`.
+- The full mapping form is `{ value, locked, suggestions }`. `locked: true`
+  and `suggestions: [...]` are mutually exclusive.
+- Pin values can be either a bare integer or the rich ESPHome pin form
+  (`{ number: 0, mode: { input: true, pullup: true }, inverted: true }`)
+  for cases like the Sonoff button that need pull-ups and inversion.
+
+**Bundles** group multiple featured components that go together — typical
+case is a status LED that needs both `output.gpio` and `light.binary`:
+
+```yaml
+featured_bundles:
+  - id: status-led
+    name: Status LED (full setup)
+    description: GPIO output plus a binary light entity.
+    component_ids: [status-led-output, status-led-light]
+```
+
+`component_ids` references the local `id` of entries in
+`featured_components:` on the same board. The frontend adds bundle
+members sequentially via the regular `devices/add_component` flow.
+
+The validator (`script/validate_definitions.py`) cross-checks every
+featured component against `components.json`: the `component_id` must
+exist, every key in `fields:` must match a real `ConfigEntry.key`, and
+pin values / suggestions must reference GPIOs declared in the board's
+`pins:` list.
+
 ## Adding a Component
 
 Create a new subfolder in `components/` with a `manifest.yaml`:

--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -34,6 +34,9 @@ from ..models import (
     BoardTag,
     Connectivity,
     Esp32Variant,
+    FeaturedBundle,
+    FeaturedComponent,
+    FieldPreset,
     PinFeature,
     Platform,
 )
@@ -151,6 +154,51 @@ def _load_pin(data: dict, board_id: str) -> BoardPin:
     )
 
 
+def _coerce_field_preset(raw: object) -> FieldPreset:
+    """
+    Normalise the YAML representation of a field preset.
+
+    Three accepted shapes:
+
+    - primitive (string/number/bool/null) → ``FieldPreset(value=raw)``
+    - list → ``FieldPreset(value=raw)`` (used for fields that take a list)
+    - dict → parsed as the explicit ``{value, locked, suggestions}`` form
+
+    Unknown keys in the dict form are silently dropped — schema validation
+    in ``script/validate_definitions.py`` is the strict gate.
+    """
+    if isinstance(raw, dict):
+        return FieldPreset(
+            value=raw.get("value"),
+            locked=bool(raw.get("locked", False)),
+            suggestions=list(raw["suggestions"]) if "suggestions" in raw else None,
+        )
+    return FieldPreset(value=raw)  # type: ignore[arg-type]
+
+
+def _load_featured_component(data: dict) -> FeaturedComponent:
+    """Load a FeaturedComponent from its YAML dict form."""
+    raw_fields = data.get("fields") or {}
+    fields = {key: _coerce_field_preset(val) for key, val in raw_fields.items()}
+    return FeaturedComponent(
+        id=data["id"],
+        component_id=data["component_id"],
+        name=data.get("name"),
+        description=data.get("description"),
+        fields=fields,
+    )
+
+
+def _load_featured_bundle(data: dict) -> FeaturedBundle:
+    """Load a FeaturedBundle from its YAML dict form."""
+    return FeaturedBundle(
+        id=data["id"],
+        name=data["name"],
+        description=data.get("description", ""),
+        component_ids=list(data.get("component_ids", [])),
+    )
+
+
 def _load_esphome_config(data: dict, board_id: str) -> BoardEsphomeConfig:
     """Load a BoardEsphomeConfig from a dict."""
     platform = Platform(data["platform"])
@@ -213,6 +261,12 @@ def load_board_catalog() -> BoardCatalogResponse:
                     product_url=data.get("product_url", ""),
                     featured=data.get("featured", False),
                     is_generic=data.get("is_generic", False),
+                    featured_components=[
+                        _load_featured_component(fc) for fc in data.get("featured_components", [])
+                    ],
+                    featured_bundles=[
+                        _load_featured_bundle(fb) for fb in data.get("featured_bundles", [])
+                    ],
                 )
             )
         except Exception:

--- a/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
@@ -87,3 +87,75 @@ pins:
   features:
   - uart_tx
   available: true
+featured_components:
+- id: i2c-bus
+  component_id: i2c
+  name: I²C Bus (sensor modules)
+  description: |
+    The two FPC connectors expose the same I²C bus on GPIO0 (SCL) and
+    GPIO1 (SDA). Configure I²C once and any of the swappable sensor
+    modules (AHT20, additional I²C breakouts) will work.
+  fields:
+    scl:
+      value: 0
+      locked: true
+    sda:
+      value: 1
+      locked: true
+- id: aht20
+  component_id: sensor.aht10
+  name: AHT20 Temperature & Humidity
+  description: |
+    Sensor module shipped with the kit. Plug into either FPC connector;
+    it talks I²C so no per-pin config is needed beyond the bus above.
+  fields:
+    variant: AHT20
+- id: pir-motion
+  component_id: binary_sensor.gpio
+  name: PIR Motion Module (MH-SR602)
+  description: |
+    Motion sensor module included with the kit. Pin depends on which
+    FPC connector you plug it into — pick GPIO4 for connector A or
+    GPIO5 for connector B.
+  fields:
+    pin:
+      suggestions: [4, 5]
+      value: 4
+    device_class: motion
+- id: rgb-strip
+  component_id: light.esp32_rmt_led_strip
+  name: RGB LED Strip (addon module)
+  description: |
+    Addressable LED strip from the RGB+buzzer addon. Pin tracks the
+    FPC connector (GPIO4 for A, GPIO5 for B). Defaults to 8 LEDs in
+    GRB order — adjust to match your strip.
+  fields:
+    pin:
+      suggestions: [4, 5]
+      value: 4
+    num_leds: 8
+    rgb_order: GRB
+- id: buzzer-output
+  component_id: output.ledc
+  name: Piezo Buzzer (addon module)
+  description: |
+    PWM output driving the piezo buzzer on the RGB+buzzer addon.
+    Pick the FPC connector pin not used by the strip — GPIO4 or GPIO5.
+  fields:
+    pin:
+      suggestions: [4, 5]
+      value: 5
+- id: rtttl-player
+  component_id: rtttl
+  name: RTTTL Player (addon buzzer)
+  description: |
+    Plays RTTTL ringtones through the piezo buzzer above. Wire the
+    ``output`` field to the buzzer output you just added.
+featured_bundles:
+- id: rgb-buzzer-module
+  name: RGB LED + Buzzer Module
+  description: |
+    Plug-in addon shipped with the starter kit — addressable LED
+    strip plus a piezo buzzer. Adds the strip, the buzzer PWM output,
+    and the RTTTL player as one logical unit.
+  component_ids: [rgb-strip, buzzer-output, rtttl-player]

--- a/esphome_device_builder/definitions/boards/athom-smart-plug-v3/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/athom-smart-plug-v3/manifest.yaml
@@ -1,0 +1,139 @@
+id: athom-smart-plug-v3
+name: Athom Smart Plug v3
+description: >
+  Athom Smart Plug v3 (PG02-V3) with an ESP32-C3 module, 16 A onboard
+  relay, HLW8012 energy metering, push button, and status LED. Sold
+  pre-flashed with ESPHome firmware. Popular drop-in replacement for
+  Sonoff/TP-Link plugs in Home Assistant deployments.
+manufacturer: Athom
+esphome:
+  platform: esp32
+  board: esp32-c3-devkitm-1
+  variant: esp32c3
+  framework: esp-idf
+hardware:
+  flash_size: 4MB
+  cpu_frequency: 160MHz
+  connectivity:
+  - wifi
+  - bluetooth
+tags:
+- relay
+- compact
+docs_url: https://esphome.io/components/sensor/hlw8012.html
+product_url: https://www.athom.tech/blank-1/esphome-smart-plug-v3
+pins:
+- gpio: 3
+  label: HLW_CF
+  features:
+  - pwm
+  available: false
+  occupied_by: HLW8012 CF (active power pulse)
+  notes: Pulse output proportional to active power
+- gpio: 4
+  label: HLW_CF1
+  features:
+  - adc
+  - pwm
+  available: false
+  occupied_by: HLW8012 CF1 (current/voltage pulse)
+  notes: Multiplexed current/voltage pulse output
+- gpio: 5
+  label: HLW_SEL
+  features:
+  - adc
+  - pwm
+  available: false
+  occupied_by: HLW8012 SEL (mux select)
+  notes: Selects whether CF1 reports current or voltage
+- gpio: 6
+  label: RELAY
+  features:
+  - pwm
+  available: false
+  occupied_by: 16 A onboard relay
+  notes: Active high — drives the front-panel relay
+- gpio: 7
+  label: STATUS_LED
+  features:
+  - pwm
+  available: false
+  occupied_by: Front-panel blue LED
+  notes: Active low — must be inverted for "on" = LED on
+- gpio: 9
+  label: BUTTON
+  features:
+  - boot_button
+  available: false
+  occupied_by: Front-panel push button
+  notes: Boot strapping pin — wired to the front-panel button (active low)
+featured_components:
+- id: relay
+  component_id: switch.gpio
+  name: Onboard Relay
+  description: |
+    16 A relay hard-wired to GPIO6. The pin is fixed; the rest of the
+    fields are yours to set.
+  fields:
+    pin:
+      value: 6
+      locked: true
+    name: Relay
+- id: button
+  component_id: binary_sensor.gpio
+  name: Front-Panel Button
+  description: |
+    Front-panel push button on GPIO9 (active low — uses internal pull-up
+    via the rich pin form).
+  fields:
+    pin:
+      value:
+        number: 9
+        mode:
+          input: true
+          pullup: true
+        inverted: true
+      locked: true
+- id: status-led-output
+  component_id: output.gpio
+  name: Status LED Output
+  description: |
+    Low-level GPIO output for the onboard blue LED on GPIO7. Pair with
+    a ``Status LED Light`` so Home Assistant can toggle it as a light.
+  fields:
+    pin:
+      value: 7
+      locked: true
+    inverted: true
+- id: status-led-light
+  component_id: light.binary
+  name: Status LED Light
+  description: |
+    Binary light entity for the onboard status LED. Wire its ``output``
+    to the ``status-led-output`` you added.
+  fields:
+    name: Status LED
+- id: power-monitor
+  component_id: sensor.hlw8012
+  name: HLW8012 Power Monitor
+  description: |
+    Energy-metering chip wired to GPIO3 (CF), GPIO4 (CF1), and GPIO5
+    (SEL). The pins are physically fixed on this board.
+  fields:
+    cf_pin:
+      value: 3
+      locked: true
+    cf1_pin:
+      value: 4
+      locked: true
+    sel_pin:
+      value: 5
+      locked: true
+    model: BL0937
+featured_bundles:
+- id: status-led
+  name: Status LED (full setup)
+  description: |
+    Adds the onboard LED's GPIO output plus a binary light entity so it
+    surfaces as a light in Home Assistant.
+  component_ids: [status-led-output, status-led-light]

--- a/esphome_device_builder/definitions/boards/sonoff-basic/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/sonoff-basic/manifest.yaml
@@ -18,12 +18,13 @@ tags:
 docs_url: https://esphome.io/components/esp8266.html
 pins:
 - gpio: 0
-  label: GPIO0
+  label: BUTTON
   features:
   - pwm
   - strapping
-  available: null
-  notes: Strapping pin (boot mode select) — pulled high for normal boot
+  available: false
+  occupied_by: Front-panel push button
+  notes: Strapping pin — wired to the front-panel button (active low, internal pull-up)
 - gpio: 1
   label: GPIO1
   features:
@@ -90,19 +91,21 @@ pins:
   occupied_by: SPI Flash
   notes: SPI Flash CS — do not use
 - gpio: 12
-  label: GPIO12
+  label: RELAY
   features:
   - pwm
   - spi_miso
-  available: null
-  notes: Default SPI MISO
+  available: false
+  occupied_by: 10 A onboard relay
+  notes: Drives the front-panel relay (active high)
 - gpio: 13
-  label: GPIO13
+  label: STATUS_LED
   features:
   - pwm
   - spi_mosi
-  available: null
-  notes: Default SPI MOSI
+  available: false
+  occupied_by: Front-panel status LED
+  notes: Onboard blue status LED (active low — must be inverted)
 - gpio: 14
   label: GPIO14
   features:
@@ -128,3 +131,56 @@ pins:
   - adc
   available: null
   notes: Analog input (TOUT pin) — 0-1V range, single ADC channel; not a standard GPIO
+featured_components:
+- id: relay
+  component_id: switch.gpio
+  name: Onboard Relay
+  description: |
+    The 10 A AC relay is hard-wired to GPIO12. This recommendation pre-fills
+    the GPIO and gives it a sensible default name.
+  fields:
+    pin:
+      value: 12
+      locked: true
+    name: Relay
+- id: button
+  component_id: binary_sensor.gpio
+  name: Front-Panel Button
+  description: |
+    Front-panel push button on GPIO0 (active low — note ``inverted: true``
+    plus the internal pull-up).
+  fields:
+    pin:
+      value:
+        number: 0
+        mode:
+          input: true
+          pullup: true
+        inverted: true
+      locked: true
+- id: status-led-output
+  component_id: output.gpio
+  name: Status LED Output
+  description: |
+    Low-level GPIO output for the onboard blue LED on GPIO13. Pair with
+    a ``Status LED Light`` so Home Assistant can toggle it as a light.
+  fields:
+    pin:
+      value: 13
+      locked: true
+    inverted: true
+- id: status-led-light
+  component_id: light.binary
+  name: Status LED Light
+  description: |
+    Binary light entity for the onboard status LED. Wire its ``output``
+    to the ``status-led-output`` you added.
+  fields:
+    name: Status LED
+featured_bundles:
+- id: status-led
+  name: Status LED (full setup)
+  description: |
+    Adds the GPIO output for the onboard LED plus a binary light entity
+    so it surfaces as a controllable light in Home Assistant.
+  component_ids: [status-led-output, status-led-light]

--- a/esphome_device_builder/definitions/schemas/board.schema.json
+++ b/esphome_device_builder/definitions/schemas/board.schema.json
@@ -259,7 +259,7 @@
             },
             "locked": {
               "type": "boolean",
-              "description": "When true, frontend disables the input and the backend rejects deviating user input on add.",
+              "description": "When true, frontend disables the input and the backend rejects deviating user input on add. Requires 'value'.",
               "default": false
             },
             "suggestions": {
@@ -269,7 +269,12 @@
               "items": { "type": ["string", "number", "integer", "boolean"] }
             }
           },
-          "not": { "required": ["locked", "suggestions"] }
+          "not": { "required": ["locked", "suggestions"] },
+          "if": {
+            "required": ["locked"],
+            "properties": { "locked": { "const": true } }
+          },
+          "then": { "required": ["value"] }
         }
       ]
     }

--- a/esphome_device_builder/definitions/schemas/board.schema.json
+++ b/esphome_device_builder/definitions/schemas/board.schema.json
@@ -126,6 +126,16 @@
       "type": "boolean",
       "description": "True for generic fallback boards where not all pins may be physically accessible.",
       "default": false
+    },
+    "featured_components": {
+      "type": "array",
+      "description": "Components recommended for this board. Surfaced as a 'Recommended' section in the Add Component dialog.",
+      "items": { "$ref": "#/$defs/featured_component" }
+    },
+    "featured_bundles": {
+      "type": "array",
+      "description": "Logical groups of featured components added together (hardware addon modules, status-LED setups, ...).",
+      "items": { "$ref": "#/$defs/featured_bundle" }
     }
   },
   "$defs": {
@@ -173,6 +183,95 @@
           "description": "Extra guidance for the user."
         }
       }
+    },
+    "featured_component": {
+      "type": "object",
+      "description": "A component recommended for this board, optionally with pre-filled field values.",
+      "required": ["id", "component_id"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Local id, unique within this board (e.g. 'relay', 'pir-motion').",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+        },
+        "component_id": {
+          "type": "string",
+          "description": "Underlying ComponentCatalogEntry id (e.g. 'switch.gpio').",
+          "pattern": "^[a-z0-9_]+(\\.[a-z0-9_]+)?$"
+        },
+        "name": {
+          "type": "string",
+          "description": "Override for the component's display name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Override for the component's description."
+        },
+        "fields": {
+          "type": "object",
+          "description": "Per-config-entry presets, keyed by ConfigEntry.key.",
+          "additionalProperties": { "$ref": "#/$defs/field_preset_or_value" }
+        }
+      }
+    },
+    "featured_bundle": {
+      "type": "object",
+      "description": "A logical group of featured components added together.",
+      "required": ["id", "name", "component_ids"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Local id, unique within this board.",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+        },
+        "name": {
+          "type": "string",
+          "description": "Display name for the bundle."
+        },
+        "description": {
+          "type": "string",
+          "description": "What the bundle represents (e.g. 'Onboard status LED')."
+        },
+        "component_ids": {
+          "type": "array",
+          "description": "Local ids referring to entries in featured_components on this same board.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+          }
+        }
+      }
+    },
+    "field_preset_or_value": {
+      "description": "Either a primitive shorthand (pre-fills a default), a list, or a verbose object form ({value, locked, suggestions}).",
+      "oneOf": [
+        { "type": ["string", "number", "integer", "boolean", "null"] },
+        { "type": "array" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "value": {
+              "description": "Pre-filled value. Optional when only suggestions are set."
+            },
+            "locked": {
+              "type": "boolean",
+              "description": "When true, frontend disables the input and the backend rejects deviating user input on add.",
+              "default": false
+            },
+            "suggestions": {
+              "type": "array",
+              "description": "Limit the user's choice to this list (e.g. allowed GPIOs).",
+              "minItems": 1,
+              "items": { "type": ["string", "number", "integer", "boolean"] }
+            }
+          },
+          "not": { "required": ["locked", "suggestions"] }
+        }
+      ]
     }
   }
 }

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .common import PagedResponse, PinFeature  # PinFeature re-exported
+from .common import FieldPreset, PagedResponse, PinFeature  # PinFeature re-exported
 
 # `PinFeature` lives in .common (it's shared with config-entry pin
 # constraints), but is re-imported here for stability of existing
@@ -126,6 +126,47 @@ class BoardHardware(DataClassORJSONMixin):
 
 
 @dataclass
+class FeaturedComponent(DataClassORJSONMixin):
+    """
+    A component recommended for this board.
+
+    Surfaced in the catalog API under id ``featured.<board_id>.<id>`` and
+    category ``featured``. ``component_id`` points at the underlying
+    catalog entry the user is actually adding (``switch.gpio``,
+    ``binary_sensor.gpio``, ...) — the featured entry contributes
+    name/description overrides plus per-field presets keyed by
+    ``ConfigEntry.key``.
+    """
+
+    # Local id, unique within this board (e.g. "relay", "pir-motion").
+    id: str
+    component_id: str
+    name: str | None = None
+    description: str | None = None
+    fields: dict[str, FieldPreset] = field(default_factory=dict)
+
+
+@dataclass
+class FeaturedBundle(DataClassORJSONMixin):
+    """
+    A logical group of featured components added together.
+
+    Models hardware addons that span multiple ESPHome components — e.g.
+    a status LED that needs both ``output.gpio`` and ``light.binary``,
+    or an RGB+buzzer module. ``component_ids`` references the local id
+    of entries in ``featured_components`` on the same board; the
+    frontend triggers sequential ``devices/add_component`` calls for
+    each.
+    """
+
+    # Local id, unique within this board.
+    id: str
+    name: str
+    description: str = ""
+    component_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
 class BoardCatalogEntry(DataClassORJSONMixin):
     """A board definition in the catalog."""
 
@@ -142,6 +183,12 @@ class BoardCatalogEntry(DataClassORJSONMixin):
     product_url: str = ""
     featured: bool = False
     is_generic: bool = False
+    # Components recommended for this board, surfaced in the Add
+    # Component dialog as a "Recommended" section.
+    featured_components: list[FeaturedComponent] = field(default_factory=list)
+    # Logical groups of featured components that the frontend adds
+    # together (e.g. a status LED = output.gpio + light.binary).
+    featured_bundles: list[FeaturedBundle] = field(default_factory=list)
 
 
 @dataclass

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -260,6 +260,18 @@ class ConfigEntry(DataClassORJSONMixin):
     # Most ESPHome fields are templatable.
     templatable: bool = False
 
+    # === featured-component overlays ===
+    # Populated only on materialised featured components — the regular
+    # catalog never sets these. ``locked=True`` tells the frontend to
+    # disable the input (the value comes from a board-side preset and
+    # the backend rejects deviating user input on add). ``suggestions``,
+    # when non-None, limits the user's choice to this list — most often
+    # used on PIN entries for addon modules whose pin can land on one
+    # of a few GPIOs.
+
+    locked: bool = False
+    suggestions: list[ConfigPrimitive] | None = None
+
     # === conditional visibility ===
     # `depends_on_value` and `depends_on_value_not` are mutually
     # exclusive — set at most one. Frontend hides the entry when the
@@ -338,3 +350,30 @@ class ConfigEntry(DataClassORJSONMixin):
     # device_class, ...) on top of `config_entries` for these. None
     # means a plain structured group.
     platform_type: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Featured-component presets (board-side)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldPreset(DataClassORJSONMixin):
+    """
+    Pre-filled value for a single config-entry on a featured component.
+
+    Three modes, expressed by which fields are populated:
+
+    - ``value`` only: pre-filled default, user can change it.
+    - ``value`` + ``locked=True``: fixed value. Frontend disables the input;
+      backend rejects deviating user input on add.
+    - ``suggestions``: short list of allowed values (frontend renders a
+      picker). ``value`` (if also set) is the initial selection.
+
+    ``locked`` and ``suggestions`` are mutually exclusive. ``value`` can be
+    a primitive, list, or dict — the latter for nested config entries.
+    """
+
+    value: ConfigPrimitive | list[Any] | dict[str, Any] | None = None
+    locked: bool = False
+    suggestions: list[ConfigPrimitive] | None = None

--- a/esphome_device_builder/models/components.py
+++ b/esphome_device_builder/models/components.py
@@ -66,6 +66,12 @@ class ComponentCategory(StrEnum):
     STEPPER = "stepper"
     WATER_HEATER = "water_heater"
     MISC = "misc"
+    # Synthetic category for components surfaced as board recommendations.
+    # Featured entries are materialised on the fly from the board catalog
+    # and only appear in API results when ``category=featured`` is the
+    # explicit filter — they are excluded from the regular catalog
+    # listing the same way ``core`` / ``ota`` / ``time`` / ``update`` are.
+    FEATURED = "featured"
 
 
 @dataclass

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -144,7 +144,7 @@ def _build_components_index() -> dict | None:
             file=sys.stderr,
         )
         return None
-    raw = json.loads(COMPONENTS_JSON.read_text())
+    raw = json.loads(COMPONENTS_JSON.read_text(encoding="utf-8"))
     by_id: dict[str, dict] = {}
     for comp in raw.get("components", []):
         cid = comp.get("id")
@@ -191,12 +191,12 @@ def _validate_featured(
             if b_id in seen_bundle_ids:
                 errors.append(f"{board_id}.featured_bundles[{idx}]: duplicate id '{b_id}'")
             seen_bundle_ids.add(b_id)
-        for cid in bundle.get("component_ids", []) or []:
-            if cid not in seen_fc_ids:
-                errors.append(
-                    f"{board_id}.featured_bundles[{idx}].component_ids: "
-                    f"'{cid}' does not match any featured_components[].id"
-                )
+        errors.extend(
+            f"{board_id}.featured_bundles[{idx}].component_ids: "
+            f"'{cid}' does not match any featured_components[].id"
+            for cid in bundle.get("component_ids", []) or []
+            if cid not in seen_fc_ids
+        )
     return errors
 
 

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -24,6 +24,37 @@ except ImportError:
 
 DEFINITIONS_DIR = Path(__file__).resolve().parent.parent / "esphome_device_builder" / "definitions"
 SCHEMAS_DIR = DEFINITIONS_DIR / "schemas"
+COMPONENTS_JSON = DEFINITIONS_DIR / "components.json"
+
+# Categories excluded from featured-component eligibility — these belong in
+# the dedicated "Add core configuration" dialog, not in board recommendations.
+_FEATURED_EXCLUDED_CATEGORIES = {"core", "ota", "time", "update"}
+
+# Pin features the board manifest can declare (mirrors the JSON Schema enum
+# in board.schema.json). Components.json sometimes carries pin_features
+# values like "input" / "output" that the board side doesn't model — we
+# only enforce intersections with this set during cross-validation.
+_BOARD_PIN_FEATURES = {
+    "adc",
+    "dac",
+    "touch",
+    "pwm",
+    "i2c_sda",
+    "i2c_scl",
+    "spi_mosi",
+    "spi_miso",
+    "spi_clk",
+    "spi_cs",
+    "uart_tx",
+    "uart_rx",
+    "usb_dp",
+    "usb_dm",
+    "rgb_led",
+    "jtag",
+    "strapping",
+    "input_only",
+    "boot_button",
+}
 
 # Load JSON schemas if jsonschema is available
 _BOARD_SCHEMA: dict | None = None
@@ -50,8 +81,14 @@ def _validate_against_schema(data: dict, schema: dict | None, item_id: str) -> l
     return errors
 
 
-def validate_board(manifest: Path) -> list[str]:
-    """Validate a board manifest. Returns list of error messages."""
+def validate_board(manifest: Path, components_index: dict | None = None) -> list[str]:
+    """
+    Validate a board manifest. Returns list of error messages.
+
+    *components_index* is the dict returned by :func:`_build_components_index`;
+    when provided, featured-component cross-references are validated against
+    the live component catalog.
+    """
     errors: list[str] = []
     board_id = manifest.parent.name
 
@@ -75,6 +112,7 @@ def validate_board(manifest: Path) -> list[str]:
 
     # Duplicate GPIO check (schema can't do cross-item uniqueness)
     pins = data.get("pins", [])
+    pins_by_gpio: dict[int, dict] = {}
     if isinstance(pins, list):
         seen_gpios: set[int] = set()
         for pin in pins:
@@ -82,8 +120,214 @@ def validate_board(manifest: Path) -> list[str]:
                 if gpio in seen_gpios:
                     errors.append(f"{board_id}: duplicate gpio {gpio}")
                 seen_gpios.add(gpio)
+                pins_by_gpio[gpio] = pin
+
+    # Featured components & bundles — cross-catalog validation against
+    # the loaded component index when available.
+    errors.extend(_validate_featured(board_id, data, pins_by_gpio, components_index))
 
     return errors
+
+
+def _build_components_index() -> dict | None:
+    """
+    Index ``components.json`` for featured-component cross-checks.
+
+    Returns ``None`` when the file is missing — featured-component
+    cross-validation is skipped (schema-only) and a warning is printed
+    so contributors know to run ``script/sync_components.py`` first.
+    """
+    if not COMPONENTS_JSON.exists():
+        print(
+            f"WARNING: {COMPONENTS_JSON} not found — skipping featured-component "
+            "cross-validation. Run script/sync_components.py first.",
+            file=sys.stderr,
+        )
+        return None
+    raw = json.loads(COMPONENTS_JSON.read_text())
+    by_id: dict[str, dict] = {}
+    for comp in raw.get("components", []):
+        cid = comp.get("id")
+        if cid:
+            by_id[cid] = comp
+    return by_id
+
+
+def _validate_featured(
+    board_id: str,
+    data: dict,
+    pins_by_gpio: dict[int, dict],
+    components_index: dict | None,
+) -> list[str]:
+    """Validate featured_components / featured_bundles cross-references."""
+    errors: list[str] = []
+    featured = data.get("featured_components") or []
+    bundles = data.get("featured_bundles") or []
+    if not featured and not bundles:
+        return errors
+
+    # Local id uniqueness within featured_components and featured_bundles.
+    seen_fc_ids: set[str] = set()
+    fc_index: dict[str, dict] = {}
+    for idx, entry in enumerate(featured):
+        if not isinstance(entry, dict):
+            continue
+        fc_id = entry.get("id")
+        if not isinstance(fc_id, str):
+            continue
+        if fc_id in seen_fc_ids:
+            errors.append(f"{board_id}.featured_components[{idx}]: duplicate id '{fc_id}'")
+        seen_fc_ids.add(fc_id)
+        fc_index[fc_id] = entry
+
+        errors.extend(
+            _validate_featured_component(board_id, idx, entry, pins_by_gpio, components_index)
+        )
+
+    seen_bundle_ids: set[str] = set()
+    for idx, bundle in enumerate(bundles):
+        if not isinstance(bundle, dict):
+            continue
+        b_id = bundle.get("id")
+        if isinstance(b_id, str):
+            if b_id in seen_bundle_ids:
+                errors.append(f"{board_id}.featured_bundles[{idx}]: duplicate id '{b_id}'")
+            seen_bundle_ids.add(b_id)
+        for cid in bundle.get("component_ids", []) or []:
+            if cid not in seen_fc_ids:
+                errors.append(
+                    f"{board_id}.featured_bundles[{idx}].component_ids: "
+                    f"'{cid}' does not match any featured_components[].id"
+                )
+    return errors
+
+
+def _validate_featured_component(
+    board_id: str,
+    idx: int,
+    entry: dict,
+    pins_by_gpio: dict[int, dict],
+    components_index: dict | None,
+) -> list[str]:
+    """Validate a single featured_components[i] entry against the catalog."""
+    errors: list[str] = []
+    fc_id = entry.get("id", f"#{idx}")
+    component_id = entry.get("component_id")
+    path = f"{board_id}.featured_components[{idx}]({fc_id})"
+
+    if components_index is None:
+        # Without a component index we can only sanity-check the local
+        # shape; cross-references stay unverified.
+        return errors
+
+    if component_id not in components_index:
+        errors.append(f"{path}: component_id '{component_id}' not found in components.json")
+        return errors
+
+    component = components_index[component_id]
+    if component.get("category") in _FEATURED_EXCLUDED_CATEGORIES:
+        errors.append(
+            f"{path}: component_id '{component_id}' has excluded category "
+            f"'{component.get('category')}'; featured components must be "
+            "regular catalog entries"
+        )
+
+    # Map config-entry keys → entry for fast lookup of pin_features / type.
+    entries_by_key: dict[str, dict] = {}
+    for ce in component.get("config_entries", []) or []:
+        key = ce.get("key")
+        if isinstance(key, str):
+            entries_by_key[key] = ce
+
+    for fkey, fval in (entry.get("fields") or {}).items():
+        if fkey not in entries_by_key:
+            errors.append(f"{path}.fields.{fkey}: not a config_entry on {component_id}")
+            continue
+        ce = entries_by_key[fkey]
+        errors.extend(_validate_field_preset(path, fkey, fval, ce, pins_by_gpio))
+
+    return errors
+
+
+def _validate_field_preset(
+    path: str,
+    fkey: str,
+    fval: object,
+    ce: dict,
+    pins_by_gpio: dict[int, dict],
+) -> list[str]:
+    """Validate a single field preset against its config-entry constraints."""
+    errors: list[str] = []
+    locked, value, suggestions = _unpack_field_preset(fval)
+
+    if locked and suggestions is not None:
+        errors.append(f"{path}.fields.{fkey}: cannot set both 'locked' and 'suggestions'")
+
+    if ce.get("type") == "pin":
+        # Limit the constraint to features both sides actually model.
+        # Component-side ``pin_features`` like ``input`` / ``output``
+        # don't appear in the board-pin enum — skip them rather than
+        # fail every plain-GPIO recommendation.
+        required_features = {f for f in (ce.get("pin_features") or []) if f in _BOARD_PIN_FEATURES}
+        for raw in _pin_values_to_check(value, suggestions):
+            gpio = _extract_gpio(raw)
+            if gpio is None:
+                # Best-effort: rich pin specs without a recognisable
+                # ``number`` (e.g. lambdas) are skipped rather than failed.
+                continue
+            pin = pins_by_gpio.get(gpio)
+            if pin is None:
+                errors.append(f"{path}.fields.{fkey}: GPIO {gpio} not declared in pins")
+                continue
+            pin_features = set(pin.get("features") or [])
+            missing = required_features - pin_features
+            if missing:
+                errors.append(
+                    f"{path}.fields.{fkey}: GPIO {gpio} is missing required "
+                    f"pin features {sorted(missing)}"
+                )
+    return errors
+
+
+def _extract_gpio(raw: object) -> int | None:
+    """
+    Pull the GPIO number out of a pin reference.
+
+    Pins can be expressed two ways in ESPHome YAML — bare integer
+    (``pin: 12``) or rich mapping (``pin: { number: 0, mode: ..., inverted: ... }``).
+    Returns ``None`` for anything else (lambdas, strings, missing
+    ``number``) so the caller treats it as un-validatable.
+    """
+    if isinstance(raw, bool):  # bool is an int subclass — exclude it
+        return None
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, dict):
+        number = raw.get("number")
+        if isinstance(number, int) and not isinstance(number, bool):
+            return number
+    return None
+
+
+def _unpack_field_preset(raw: object) -> tuple[bool, object, list | None]:
+    """Return ``(locked, value, suggestions)`` from any of the accepted shapes."""
+    if isinstance(raw, dict):
+        return (
+            bool(raw.get("locked", False)),
+            raw.get("value"),
+            list(raw["suggestions"]) if "suggestions" in raw else None,
+        )
+    return False, raw, None
+
+
+def _pin_values_to_check(value: object, suggestions: list | None) -> list[object]:
+    """Collect every concrete pin reference in a preset for GPIO validation."""
+    out: list[object] = []
+    if value is not None:
+        out.append(value)
+    if suggestions:
+        out.extend(suggestions)
+    return out
 
 
 def validate_component(manifest: Path) -> list[str]:
@@ -111,10 +355,12 @@ def main() -> int:
     """Validate all definitions. Returns 0 on success, 1 on errors."""
     all_errors: list[str] = []
 
+    components_index = _build_components_index()
+
     # Validate boards
     boards_dir = DEFINITIONS_DIR / "boards"
     for manifest in sorted(boards_dir.glob("*/manifest.yaml")):
-        all_errors.extend(validate_board(manifest))
+        all_errors.extend(validate_board(manifest, components_index))
 
     # Validate components
     components_dir = DEFINITIONS_DIR / "components"

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -168,7 +168,6 @@ def _validate_featured(
 
     # Local id uniqueness within featured_components and featured_bundles.
     seen_fc_ids: set[str] = set()
-    fc_index: dict[str, dict] = {}
     for idx, entry in enumerate(featured):
         if not isinstance(entry, dict):
             continue
@@ -178,7 +177,6 @@ def _validate_featured(
         if fc_id in seen_fc_ids:
             errors.append(f"{board_id}.featured_components[{idx}]: duplicate id '{fc_id}'")
         seen_fc_ids.add(fc_id)
-        fc_index[fc_id] = entry
 
         errors.extend(
             _validate_featured_component(board_id, idx, entry, pins_by_gpio, components_index)
@@ -312,11 +310,12 @@ def _extract_gpio(raw: object) -> int | None:
 def _unpack_field_preset(raw: object) -> tuple[bool, object, list | None]:
     """Return ``(locked, value, suggestions)`` from any of the accepted shapes."""
     if isinstance(raw, dict):
-        return (
-            bool(raw.get("locked", False)),
-            raw.get("value"),
-            list(raw["suggestions"]) if "suggestions" in raw else None,
-        )
+        # Schema validation already rejects non-list ``suggestions`` with a
+        # readable error; this defensive check keeps the validator from
+        # crashing when run without jsonschema installed.
+        raw_suggestions = raw.get("suggestions")
+        suggestions = list(raw_suggestions) if isinstance(raw_suggestions, list) else None
+        return bool(raw.get("locked", False)), raw.get("value"), suggestions
     return False, raw, None
 
 

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -166,6 +166,39 @@ async def test_get_components_excludes_featured_by_default(
     assert all(not c.id.startswith("featured.") for c in page.components)
 
 
+async def test_get_components_mixed_category_unions(
+    catalog: ComponentCatalog,
+) -> None:
+    """``category=[featured, sensor]`` returns featured first then matching sensors."""
+    page = await catalog.get_components(
+        board_id="sonoff-basic",
+        category=["featured", "sensor"],
+        limit=2000,
+    )
+    categories_seen = {c.category for c in page.components}
+    assert ComponentCategory.FEATURED in categories_seen
+    assert ComponentCategory.SENSOR in categories_seen
+    first_non_featured = next(
+        (i for i, c in enumerate(page.components) if c.category != ComponentCategory.FEATURED),
+        len(page.components),
+    )
+    assert all(
+        c.category == ComponentCategory.FEATURED for c in page.components[:first_non_featured]
+    )
+
+
+async def test_get_component_featured_ignores_mismatched_board_id(
+    catalog: ComponentCatalog,
+) -> None:
+    """Featured ids resolve their platform from ``record.board_id``, not the caller's."""
+    entry = await catalog.get_component(
+        component_id="featured.sonoff-basic.relay",
+        board_id="apollo-esk-1",
+    )
+    assert entry is not None
+    assert entry.id == "featured.sonoff-basic.relay"
+
+
 async def test_get_categories_surfaces_featured_count(
     catalog: ComponentCatalog,
 ) -> None:
@@ -251,3 +284,18 @@ async def test_apply_presets_default_overridable(catalog: ComponentCatalog) -> N
     assert record is not None
     out: dict[str, Any] = _apply_featured_presets(record, {"variant": "AHT10"})
     assert out["variant"] == "AHT10"
+
+
+async def test_apply_presets_locked_without_value_fails_fast(
+    catalog: ComponentCatalog,
+) -> None:
+    """A malformed manifest (locked=True with no value) fails fast at add time."""
+    from copy import deepcopy
+
+    from esphome_device_builder.models import FieldPreset
+
+    record = deepcopy(catalog.get_featured_record("featured.sonoff-basic.relay"))
+    assert record is not None
+    record.featured.fields["pin"] = FieldPreset(value=None, locked=True)
+    with pytest.raises(ValueError, match="locked=true without a value"):
+        _apply_featured_presets(record, {})

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -1,0 +1,253 @@
+"""Tests for the featured-components feature.
+
+Covers four layers:
+
+1. Loader — primitive shorthand, locked, suggestions, dict pin shape, and
+   the in-manifest mutual-exclusion rules.
+2. Featured registry — IDs are minted as ``featured.<board>.<local>``,
+   unknown component_ids are skipped with a warning rather than crashing
+   the load.
+3. Materialisation — ``locked`` and ``suggestions`` ride through to the
+   returned ``ConfigEntry`` and ``default_value`` reflects the preset.
+4. Add-component flow — ``_apply_featured_presets`` enforces the locked
+   and suggestion rules and lets plain defaults fall through.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from esphome_device_builder.controllers.boards import BoardCatalog
+from esphome_device_builder.controllers.components import ComponentCatalog
+from esphome_device_builder.controllers.devices import _apply_featured_presets
+from esphome_device_builder.definitions import (
+    _coerce_field_preset,
+    _load_featured_bundle,
+    _load_featured_component,
+)
+from esphome_device_builder.models import ComponentCategory
+
+# ---------------------------------------------------------------------------
+# Loader-level (pure unit tests, no catalog)
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_primitive_shorthand() -> None:
+    """Bare primitives become FieldPreset(value=x), not locked."""
+    preset = _coerce_field_preset(12)
+    assert preset.value == 12
+    assert preset.locked is False
+    assert preset.suggestions is None
+
+
+def test_coerce_locked_form() -> None:
+    """Verbose dict with locked=True passes locked through."""
+    preset = _coerce_field_preset({"value": 12, "locked": True})
+    assert preset.value == 12
+    assert preset.locked is True
+    assert preset.suggestions is None
+
+
+def test_coerce_suggestions_form() -> None:
+    """``suggestions`` populates the picker; value can come along as initial."""
+    preset = _coerce_field_preset({"suggestions": [4, 5], "value": 4})
+    assert preset.value == 4
+    assert preset.locked is False
+    assert preset.suggestions == [4, 5]
+
+
+def test_coerce_dict_pin_value() -> None:
+    """Rich pin form (mapping) survives as the preset value."""
+    rich = {"number": 0, "mode": {"input": True, "pullup": True}, "inverted": True}
+    preset = _coerce_field_preset({"value": rich, "locked": True})
+    assert preset.value == rich
+    assert preset.locked is True
+
+
+def test_load_featured_component_minimal() -> None:
+    """Only id+component_id required; fields default to empty."""
+    fc = _load_featured_component({"id": "dht", "component_id": "sensor.dht"})
+    assert fc.id == "dht"
+    assert fc.component_id == "sensor.dht"
+    assert fc.fields == {}
+
+
+def test_load_featured_bundle() -> None:
+    """Bundle just stores ids — uniqueness/cross-refs come at validate time."""
+    fb = _load_featured_bundle(
+        {
+            "id": "status-led",
+            "name": "Status LED",
+            "description": "...",
+            "component_ids": ["status-led-output", "status-led-light"],
+        }
+    )
+    assert fb.id == "status-led"
+    assert fb.component_ids == ["status-led-output", "status-led-light"]
+
+
+# ---------------------------------------------------------------------------
+# Registry & materialisation (real catalogs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def catalog() -> ComponentCatalog:
+    """Boot board + component catalogs once per module."""
+
+    class _DB:
+        boards: BoardCatalog | None = None
+        components: ComponentCatalog | None = None
+
+    db = _DB()
+    db.boards = BoardCatalog()
+    db.boards.load()
+    db.components = ComponentCatalog(db)
+    db.components.load()
+    return db.components
+
+
+def test_registry_indexes_known_boards(catalog: ComponentCatalog) -> None:
+    """Tier-1 manifests register their featured components under the right ids."""
+    assert "featured.sonoff-basic.relay" in catalog._featured_by_id
+    assert "featured.apollo-esk-1.pir-motion" in catalog._featured_by_id
+    assert "featured.athom-smart-plug-v3.relay" in catalog._featured_by_id
+
+
+def test_registry_groups_per_board(catalog: ComponentCatalog) -> None:
+    """``_featured_by_board`` lets get_components scope the featured listing."""
+    assert "featured.sonoff-basic.relay" in catalog._featured_by_board["sonoff-basic"]
+    assert all(
+        bid.startswith("featured.apollo-esk-1.")
+        for bid in catalog._featured_by_board["apollo-esk-1"]
+    )
+
+
+async def test_get_component_locked_field(catalog: ComponentCatalog) -> None:
+    """Sonoff relay materialisation pins ``pin`` to GPIO12 and marks it locked."""
+    entry = await catalog.get_component(component_id="featured.sonoff-basic.relay")
+    assert entry is not None
+    assert entry.id == "featured.sonoff-basic.relay"
+    assert entry.category == ComponentCategory.FEATURED
+    assert entry.name == "Onboard Relay"
+    pin = next(ce for ce in entry.config_entries if ce.key == "pin")
+    assert pin.default_value == 12
+    assert pin.locked is True
+    assert pin.suggestions is None
+
+
+async def test_get_component_suggestions(catalog: ComponentCatalog) -> None:
+    """ESK-1 PIR materialisation surfaces the pin suggestions list."""
+    entry = await catalog.get_component(component_id="featured.apollo-esk-1.pir-motion")
+    assert entry is not None
+    pin = next(ce for ce in entry.config_entries if ce.key == "pin")
+    assert pin.default_value == 4
+    assert pin.locked is False
+    assert pin.suggestions == [4, 5]
+
+
+async def test_get_components_featured_only_with_board_id(
+    catalog: ComponentCatalog,
+) -> None:
+    """``category=featured`` returns the per-board recommended list."""
+    page = await catalog.get_components(board_id="sonoff-basic", category="featured")
+    ids = {c.id for c in page.components}
+    assert "featured.sonoff-basic.relay" in ids
+    assert all(c.category == ComponentCategory.FEATURED for c in page.components)
+
+
+async def test_get_components_excludes_featured_by_default(
+    catalog: ComponentCatalog,
+) -> None:
+    """A regular catalog query never includes featured entries."""
+    page = await catalog.get_components(board_id="sonoff-basic", limit=2000)
+    assert all(not c.id.startswith("featured.") for c in page.components)
+
+
+async def test_get_categories_surfaces_featured_count(
+    catalog: ComponentCatalog,
+) -> None:
+    """``board_id`` makes the synthetic ``featured`` category appear."""
+    cats = await catalog.get_categories(board_id="apollo-esk-1")
+    featured = next(c for c in cats if c["id"] == "featured")
+    assert int(featured["count"]) == len(catalog._featured_by_board["apollo-esk-1"])
+
+
+async def test_get_categories_no_featured_without_board(
+    catalog: ComponentCatalog,
+) -> None:
+    """Without ``board_id`` we don't synthesise the ``featured`` row."""
+    cats = await catalog.get_categories()
+    assert all(c["id"] != "featured" for c in cats)
+
+
+# ---------------------------------------------------------------------------
+# Add-path preset application
+# ---------------------------------------------------------------------------
+
+
+async def test_apply_presets_locked_fills_in(catalog: ComponentCatalog) -> None:
+    """Empty user input picks up the locked + default values from the preset."""
+    record = catalog.get_featured_record("featured.sonoff-basic.relay")
+    assert record is not None
+    out = _apply_featured_presets(record, {})
+    assert out["pin"] == 12
+    assert out["name"] == "Relay"
+
+
+async def test_apply_presets_locked_rejects_override(
+    catalog: ComponentCatalog,
+) -> None:
+    """Submitting a different value for a locked field raises ValueError."""
+    record = catalog.get_featured_record("featured.sonoff-basic.relay")
+    assert record is not None
+    with pytest.raises(ValueError, match="locked"):
+        _apply_featured_presets(record, {"pin": 5})
+
+
+async def test_apply_presets_locked_accepts_matching_value(
+    catalog: ComponentCatalog,
+) -> None:
+    """Submitting the exact locked value is allowed (idempotent)."""
+    record = catalog.get_featured_record("featured.sonoff-basic.relay")
+    assert record is not None
+    out = _apply_featured_presets(record, {"pin": 12, "name": "MyRelay"})
+    assert out["pin"] == 12
+    assert out["name"] == "MyRelay"  # plain default is overridable
+
+
+async def test_apply_presets_suggestion_in_set(catalog: ComponentCatalog) -> None:
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    assert record is not None
+    out = _apply_featured_presets(record, {"pin": 5})
+    assert out["pin"] == 5
+    assert out["device_class"] == "motion"
+
+
+async def test_apply_presets_suggestion_rejects_off_list(
+    catalog: ComponentCatalog,
+) -> None:
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    assert record is not None
+    with pytest.raises(ValueError, match="must be one of"):
+        _apply_featured_presets(record, {"pin": 99})
+
+
+async def test_apply_presets_suggestion_falls_back_to_value(
+    catalog: ComponentCatalog,
+) -> None:
+    """Omitting a suggestion field falls back to the preset's initial value."""
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    assert record is not None
+    out = _apply_featured_presets(record, {})
+    assert out["pin"] == 4
+
+
+async def test_apply_presets_default_overridable(catalog: ComponentCatalog) -> None:
+    """Plain defaults (no locked/suggestions) are overridable by user input."""
+    record = catalog.get_featured_record("featured.apollo-esk-1.aht20")
+    assert record is not None
+    out: dict[str, Any] = _apply_featured_presets(record, {"variant": "AHT10"})
+    assert out["variant"] == "AHT10"

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -199,6 +199,27 @@ async def test_get_component_featured_ignores_mismatched_board_id(
     assert entry.id == "featured.sonoff-basic.relay"
 
 
+async def test_get_component_unknown_featured_id(catalog: ComponentCatalog) -> None:
+    """Unknown ``featured.*`` ids return ``None`` instead of raising."""
+    assert await catalog.get_component(component_id="featured.no-such-board.x") is None
+
+
+async def test_get_components_featured_with_query_filter(
+    catalog: ComponentCatalog,
+) -> None:
+    """``query`` narrows the featured listing on name / description / id."""
+    page = await catalog.get_components(
+        board_id="apollo-esk-1",
+        category="featured",
+        query="pir",
+    )
+    assert any("pir" in c.id.lower() for c in page.components)
+    assert all(
+        "pir" in c.name.lower() or "pir" in c.description.lower() or "pir" in c.id.lower()
+        for c in page.components
+    )
+
+
 async def test_get_categories_surfaces_featured_count(
     catalog: ComponentCatalog,
 ) -> None:

--- a/tests/test_validate_featured.py
+++ b/tests/test_validate_featured.py
@@ -1,0 +1,205 @@
+"""Tests for the featured-components cross-catalog validation in ``script/validate_definitions.py``.
+
+These poke the validator's pure helpers directly with synthetic manifest
+fragments rather than spinning up real boards on disk — that way each
+case stays isolated and we don't have to ship deliberately-broken
+manifests in ``definitions/boards/``.
+"""
+
+from __future__ import annotations
+
+from script.validate_definitions import (  # type: ignore[import-not-found]
+    _build_components_index,
+    _validate_featured,
+)
+
+
+def _index() -> dict | None:
+    return _build_components_index()
+
+
+def _board(featured: list[dict] | None = None, bundles: list[dict] | None = None) -> dict:
+    return {
+        "featured_components": featured or [],
+        "featured_bundles": bundles or [],
+    }
+
+
+def _pins(*gpios: int) -> dict[int, dict]:
+    """Build a pins_by_gpio map with every pin marked as having no features."""
+    return {g: {"gpio": g, "features": []} for g in gpios}
+
+
+def test_valid_locked_pin() -> None:
+    """A featured switch.gpio with a locked, declared pin passes."""
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "relay",
+                    "component_id": "switch.gpio",
+                    "fields": {"pin": {"value": 12, "locked": True}},
+                }
+            ]
+        ),
+        _pins(12),
+        _index(),
+    )
+    assert errors == []
+
+
+def test_unknown_component_id() -> None:
+    errors = _validate_featured(
+        "demo",
+        _board([{"id": "foo", "component_id": "definitely.not.real", "fields": {}}]),
+        {},
+        _index(),
+    )
+    assert any("not found in components.json" in e for e in errors)
+
+
+def test_unknown_field_key() -> None:
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "relay",
+                    "component_id": "switch.gpio",
+                    "fields": {"not_a_real_field": 1},
+                }
+            ]
+        ),
+        _pins(12),
+        _index(),
+    )
+    assert any("not a config_entry on switch.gpio" in e for e in errors)
+
+
+def test_pin_not_declared() -> None:
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "relay",
+                    "component_id": "switch.gpio",
+                    "fields": {"pin": {"value": 99, "locked": True}},
+                }
+            ]
+        ),
+        _pins(12),  # GPIO99 is not a declared pin
+        _index(),
+    )
+    assert any("GPIO 99 not declared in pins" in e for e in errors)
+
+
+def test_suggestions_pin_not_declared() -> None:
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "pir",
+                    "component_id": "binary_sensor.gpio",
+                    "fields": {"pin": {"suggestions": [4, 99]}},
+                }
+            ]
+        ),
+        _pins(4),
+        _index(),
+    )
+    assert any("GPIO 99 not declared in pins" in e for e in errors)
+
+
+def test_dict_pin_with_number_validates() -> None:
+    """Rich pin form ({number, mode, inverted}) gets its GPIO checked."""
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "button",
+                    "component_id": "binary_sensor.gpio",
+                    "fields": {
+                        "pin": {
+                            "value": {
+                                "number": 0,
+                                "mode": {"input": True, "pullup": True},
+                                "inverted": True,
+                            },
+                            "locked": True,
+                        }
+                    },
+                }
+            ]
+        ),
+        _pins(0),
+        _index(),
+    )
+    assert errors == []
+
+
+def test_duplicate_featured_id() -> None:
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {"id": "relay", "component_id": "switch.gpio", "fields": {}},
+                {"id": "relay", "component_id": "switch.gpio", "fields": {}},
+            ]
+        ),
+        {},
+        _index(),
+    )
+    assert any("duplicate id 'relay'" in e for e in errors)
+
+
+def test_duplicate_bundle_id() -> None:
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [{"id": "a", "component_id": "switch.gpio", "fields": {}}],
+            [
+                {"id": "led", "name": "LED", "component_ids": ["a"]},
+                {"id": "led", "name": "LED2", "component_ids": ["a"]},
+            ],
+        ),
+        {},
+        _index(),
+    )
+    assert any("duplicate id 'led'" in e for e in errors)
+
+
+def test_bundle_unknown_component_id() -> None:
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [{"id": "a", "component_id": "switch.gpio", "fields": {}}],
+            [
+                {"id": "b", "name": "Bundle", "component_ids": ["a", "ghost"]},
+            ],
+        ),
+        {},
+        _index(),
+    )
+    assert any("'ghost' does not match any" in e for e in errors)
+
+
+def test_locked_and_suggestions_both_set() -> None:
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "x",
+                    "component_id": "binary_sensor.gpio",
+                    "fields": {"pin": {"locked": True, "suggestions": [4, 5]}},
+                }
+            ]
+        ),
+        _pins(4, 5),
+        _index(),
+    )
+    assert any("cannot set both 'locked' and 'suggestions'" in e for e in errors)


### PR DESCRIPTION
## Problem / feature

Boards already have a `featured` flag (sort priority for the ESK-1) and the component catalog has rich field metadata, but there's no way for a board to say "these are the components users will reach for first on this hardware" — let alone pre-fill the GPIO for a sonoff relay or restrict the PIR pin to the two FPC connectors on the ESK-1. Configuring a Sonoff or starter-kit today means scrolling the full ~900-component catalog and looking up GPIO numbers in the docs.

This PR introduces **featured components** on the board catalog: per-board recommendation lists with optional per-field presets, surfaced through the existing component API under the synthetic ``featured`` category and ``featured.<board_id>.<local_id>`` ids. Three preset modes:

- **default** — pre-filled value the user can change
- **locked** — fixed value (sonoff relay = GPIO12), backend rejects deviation
- **suggestions** — short list of allowed values (ESK-1 PIR pin = connector A or B)

Also introduces **bundles** for multi-component addons (e.g. status LED = `output.gpio` + `light.binary`, or the ESK-1 RGB+buzzer module).

## Changes

- New models: `FieldPreset`, `FeaturedComponent`, `FeaturedBundle`; new `ConfigEntry.locked` / `.suggestions` overlays; new `ComponentCategory.FEATURED`.
- Board JSON schema extended with `featured_components` / `featured_bundles` (primitive shorthand + `{value, locked, suggestions}` form).
- Loader parses the new sections; `ComponentCatalog` builds a featured registry at startup, materialises featured ids on demand, scopes ``category=featured`` queries to one board, and excludes featured entries from the regular catalog listing.
- `devices/add_component` recognises `featured.*` ids — looks up the underlying component, enforces locked / suggestion constraints, merges presets, then delegates to the existing merge logic. Wire shape unchanged.
- `script/validate_definitions.py` cross-checks every featured component against `components.json`: component_id exists, field keys match real config_entries, locked/suggested pins are declared on the board with matching features, no duplicate ids, no `locked + suggestions` together.
- Manifests: Apollo ESK-1 (i2c, AHT20, PIR with suggestions, RGB+buzzer bundle), Sonoff Basic (relay, button with rich pin form, status-LED bundle, plus `occupied_by` annotations on GPIO 0/12/13), new Athom Smart Plug v3 board.
- Docs: `docs/API.md` and `definitions/README.md` document the new manifest sections, id format, and three preset modes.
- Tests: 31 new tests covering loader shorthand, registry indexing, materialisation, add-path enforcement, and every validator error class.