### PR TITLE
Add devices/stop_stream WS command + kill subprocess on cancel

### DIFF
--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -53,6 +53,7 @@ class WebSocketClient:
         self._authenticated = authenticated
         self._token = token
         self._tasks: set[asyncio.Task] = set()
+        self._stream_tasks: dict[str, asyncio.Task] = {}
         self._close_after_send: bool = False
 
     @property
@@ -104,6 +105,27 @@ class WebSocketClient:
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
         return task
+
+    def register_stream(self, message_id: str, task: asyncio.Task) -> None:
+        """Register a long-running task so ``cancel_stream`` can stop it.
+
+        Streaming command handlers call this with their own ``asyncio.current_task()``
+        so a later ``stop_stream`` (or any peer with the message id) can cancel them.
+        Pair with ``unregister_stream`` in a ``finally`` block.
+        """
+        self._stream_tasks[message_id] = task
+
+    def unregister_stream(self, message_id: str) -> None:
+        """Drop a previously-registered stream entry. Safe to call twice."""
+        self._stream_tasks.pop(message_id, None)
+
+    def cancel_stream(self, message_id: str) -> bool:
+        """Cancel a registered stream by its id. Returns True if cancelled."""
+        task = self._stream_tasks.pop(message_id, None)
+        if task is None or task.done():
+            return False
+        task.cancel()
+        return True
 
     async def cleanup(self) -> None:
         """Cancel all pending tasks."""

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -915,7 +915,11 @@ class DevicesController:
             # is what tells the frontend the cancel succeeded.
             if proc.returncode is None:
                 proc.kill()
-            raise
+            # Honour the cancellation contract — only swallow if no
+            # outstanding cancel requests remain on this task.
+            if (current := asyncio.current_task()) and current.cancelling():
+                raise
+            return
         finally:
             client.unregister_stream(message_id)
             if proc.returncode is None:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -524,6 +524,24 @@ class DevicesController:
             cmd.extend(["--device", port])
         await self._stream_subprocess(cmd, client, message_id)
 
+    @api_command("devices/stop_stream")
+    async def stop_stream(
+        self,
+        *,
+        stream_id: str,
+        client: Any = None,
+        **kwargs: Any,
+    ) -> dict:
+        """
+        Cancel a streaming command (``devices/logs`` or ``devices/validate``) on this connection.
+
+        ``stream_id`` is the ``message_id`` returned when the streaming
+        command was issued. Returns ``{"cancelled": True}`` if a matching
+        in-flight stream was found; ``{"cancelled": False}`` otherwise
+        (already finished or never registered).
+        """
+        return {"cancelled": client.cancel_stream(stream_id)}
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
@@ -870,7 +888,12 @@ class DevicesController:
         await loop.run_in_executor(None, _delete_all)
 
     async def _stream_subprocess(self, cmd: list[str], client: Any, message_id: str) -> None:
-        """Run a CLI subprocess and stream its merged stdout/stderr to a single client."""
+        """Run a CLI subprocess and stream its merged stdout/stderr to a single client.
+
+        Registers the running task with the client so a peer ``devices/stop_stream``
+        command (or a WS disconnect) can cancel it; cancellation kills the
+        subprocess so it doesn't keep running detached.
+        """
         env = {**os.environ, "PLATFORMIO_FORCE_ANSI": "true"}
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -879,12 +902,30 @@ class DevicesController:
             env=env,
         )
 
-        assert proc.stdout is not None  # type narrowing
-        async for line_bytes in proc.stdout:
-            line = line_bytes.decode("utf-8", errors="replace").rstrip("\n\r")
-            await client.send_event(message_id, "output", line)
+        client.register_stream(message_id, asyncio.current_task())
+        try:
+            assert proc.stdout is not None
+            async for line_bytes in proc.stdout:
+                line = line_bytes.decode("utf-8", errors="replace").rstrip("\n\r")
+                await client.send_event(message_id, "output", line)
+            exit_code = await proc.wait()
+        except asyncio.CancelledError:
+            # Synchronous kill only — no awaits in the cancel path. The
+            # ``finally`` block reaps the process and ``devices/stop_stream``
+            # is what tells the frontend the cancel succeeded.
+            if proc.returncode is None:
+                proc.kill()
+            raise
+        finally:
+            client.unregister_stream(message_id)
+            if proc.returncode is None:
+                # Reap so the transport closes cleanly; shielded so an
+                # additional cancellation doesn't strand the subprocess.
+                try:
+                    await asyncio.shield(proc.wait())
+                except asyncio.CancelledError:
+                    pass
 
-        exit_code = await proc.wait()
         await client.send_event(
             message_id, "result", {"success": exit_code == 0, "code": exit_code}
         )

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -538,8 +538,10 @@ class DevicesController:
         ``stream_id`` is the ``message_id`` returned when the streaming
         command was issued. Returns ``{"cancelled": True}`` if a matching
         in-flight stream was found; ``{"cancelled": False}`` otherwise
-        (already finished or never registered).
+        (already finished, never registered, or no client context).
         """
+        if client is None:
+            return {"cancelled": False}
         return {"cancelled": client.cancel_stream(stream_id)}
 
     # ------------------------------------------------------------------
@@ -894,16 +896,21 @@ class DevicesController:
         command (or a WS disconnect) can cancel it; cancellation kills the
         subprocess so it doesn't keep running detached.
         """
-        env = {**os.environ, "PLATFORMIO_FORCE_ANSI": "true"}
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            env=env,
-        )
+        # Register before the first await so an early ``stop_stream`` (during
+        # subprocess spawn) still finds and cancels this task.
+        task = asyncio.current_task()
+        assert task is not None  # always running inside a Task
+        client.register_stream(message_id, task)
 
-        client.register_stream(message_id, asyncio.current_task())
+        env = {**os.environ, "PLATFORMIO_FORCE_ANSI": "true"}
+        proc: asyncio.subprocess.Process | None = None
         try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=env,
+            )
             assert proc.stdout is not None
             async for line_bytes in proc.stdout:
                 line = line_bytes.decode("utf-8", errors="replace").rstrip("\n\r")
@@ -912,8 +919,9 @@ class DevicesController:
         except asyncio.CancelledError:
             # Synchronous kill only — no awaits in the cancel path. The
             # ``finally`` block reaps the process and ``devices/stop_stream``
-            # is what tells the frontend the cancel succeeded.
-            if proc.returncode is None:
+            # is what tells the frontend the cancel succeeded. ``proc`` may
+            # be ``None`` if cancellation arrived before spawn returned.
+            if proc is not None and proc.returncode is None:
                 proc.kill()
             # Honour the cancellation contract — only swallow if no
             # outstanding cancel requests remain on this task.
@@ -922,7 +930,7 @@ class DevicesController:
             return
         finally:
             client.unregister_stream(message_id)
-            if proc.returncode is None:
+            if proc is not None and proc.returncode is None:
                 # Reap so the transport closes cleanly; shielded so an
                 # additional cancellation doesn't strand the subprocess.
                 try:

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -1,0 +1,150 @@
+"""Tests for streaming-subprocess cancellation via WS ``devices/stop_stream``."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.api.ws import WebSocketClient
+from esphome_device_builder.controllers.devices import DevicesController
+
+
+class _FakeWS:
+    """Minimal WebSocket stand-in capturing sent messages."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def send_str(self, payload: str) -> None:
+        import orjson
+
+        self.sent.append(orjson.loads(payload))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _make_client() -> WebSocketClient:
+    return WebSocketClient(_FakeWS(), MagicMock(), authenticated=True)
+
+
+def _make_controller() -> DevicesController:
+    """Return a DevicesController shell that ``_stream_subprocess`` can use."""
+    ctrl = DevicesController.__new__(DevicesController)
+    return ctrl
+
+
+async def test_register_and_cancel_stream_runs_task_to_cancellation() -> None:
+    """``cancel_stream`` cancels a registered task; uncancelled stays running."""
+    client = _make_client()
+
+    async def long_running() -> None:
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(long_running())
+    client.register_stream("abc", task)
+
+    assert client.cancel_stream("abc") is True
+    assert client.cancel_stream("abc") is False  # already cancelled / unregistered
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_unregister_stream_is_idempotent() -> None:
+    client = _make_client()
+    client.register_stream("xyz", asyncio.create_task(asyncio.sleep(0)))
+    client.unregister_stream("xyz")
+    client.unregister_stream("xyz")  # no error
+
+
+async def test_stream_subprocess_kills_proc_on_cancel(tmp_path: Any) -> None:
+    """Cancellation of the streaming task terminates the subprocess.
+
+    Uses a tiny Python child that writes one line and then sleeps; if our
+    cancel path doesn't kill it, the test would hang on ``proc.wait()``.
+    """
+    ctrl = _make_controller()
+    client = _make_client()
+    sent_events: list[tuple[str, Any]] = []
+
+    async def capture(_mid: str, event: str, data: Any = None) -> None:
+        sent_events.append((event, data))
+
+    # Patch the send_event to record events instead of going over the wire.
+    client.send_event = capture  # type: ignore[method-assign]
+
+    script = "import sys, time\nprint('hello', flush=True)\ntime.sleep(60)\n"
+    cmd = [sys.executable, "-c", script]
+
+    async def run_stream() -> None:
+        await ctrl._stream_subprocess(cmd, client, "stream-1")
+
+    task = asyncio.create_task(run_stream())
+    # Wait for the first output line so we know the proc is up.
+    for _ in range(50):
+        await asyncio.sleep(0.05)
+        if any(ev == "output" for ev, _ in sent_events):
+            break
+    assert any(ev == "output" for ev, _ in sent_events), "child never produced output"
+
+    # Cancel via the public API.
+    assert client.cancel_stream("stream-1") is True
+
+    # The task must complete promptly (proc was killed).
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=5.0)
+
+    # No "result" event on cancel — the stream task ends in CANCELLED state
+    # and the frontend learns it succeeded via ``devices/stop_stream``'s
+    # normal response. We only sent "output" events.
+    assert all(ev == "output" for ev, _ in sent_events)
+
+
+async def test_stream_subprocess_normal_completion_emits_success(tmp_path: Any) -> None:
+    """A subprocess that exits 0 sends a non-cancelled, success=True result."""
+    ctrl = _make_controller()
+    client = _make_client()
+    sent_events: list[tuple[str, Any]] = []
+
+    async def capture(_mid: str, event: str, data: Any = None) -> None:
+        sent_events.append((event, data))
+
+    client.send_event = capture  # type: ignore[method-assign]
+
+    cmd = [sys.executable, "-c", "print('done')"]
+    await ctrl._stream_subprocess(cmd, client, "stream-2")
+
+    result_events = [data for ev, data in sent_events if ev == "result"]
+    assert result_events == [{"code": 0, "success": True}]
+
+
+async def test_cleanup_kills_running_streams() -> None:
+    """A pending stream registered on a client is cancelled when the WS cleans up."""
+    ctrl = _make_controller()
+    client = _make_client()
+
+    async def capture(_mid: str, _event: str, _data: Any = None) -> None: ...
+
+    client.send_event = capture  # type: ignore[method-assign]
+
+    cmd = [sys.executable, "-c", "import time; time.sleep(60)"]
+
+    async def run_stream() -> None:
+        await ctrl._stream_subprocess(cmd, client, "stream-3")
+
+    task = client.create_task(run_stream())
+    # Also register the stream like the real handler would (via current_task
+    # inside _stream_subprocess). Give that a beat to take effect.
+    for _ in range(20):
+        if "stream-3" in client._stream_tasks:
+            break
+        await asyncio.sleep(0.05)
+    assert "stream-3" in client._stream_tasks
+
+    await client.cleanup()
+    assert task.cancelled() or task.done()


### PR DESCRIPTION
## Summary
The frontend's stop button only cleared local UI state — it never told the backend to stop the streaming subprocess. The flagrant case is `esphome logs`: when the device sends a crash trace whose decode requires a local build dir we don't have, upstream's `process_stacktrace` raises `EsphomeError`, the API connection dies, and the CLI auto-reconnects forever, flooding output the dashboard can no longer silence.

This PR fixes the cancel path. Stack-trace decoding itself is a separate problem (will follow up).

* `WebSocketClient.register_stream(message_id, task)` / `cancel_stream(message_id)` — opt-in registry indexed by message id. Streaming commands register themselves; the generic `create_task` path is untouched.
* `_stream_subprocess` registers `asyncio.current_task()`, `proc.kill()`s in the `except CancelledError` handler (synchronous — no awaits in the cancel path), and reaps the process in `finally` under `asyncio.shield` so a second cancellation can't leak the transport.
* New `devices/stop_stream` WS command. Its normal `result` response confirms the cancel to the frontend; the cancelled task ends in CANCELLED state and emits no extra event.

## Test plan
- [x] `tests/test_stream_cancel.py` covers: cancel-by-id, idempotent unregister, subprocess killed on cancel (uses a real Python child that sleeps; the test would hang if we didn't kill it), normal-completion result event, WS-cleanup cancels in-flight streams.
- [x] Full suite: `pytest` (187 passed)
- [x] `pre-commit run` clean