### PR TITLE
Centralise asyncio.create_subprocess_exec through a close_fds=False helper

### DIFF
--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -23,6 +23,8 @@ import aiohttp
 from aiohttp import web
 from esphome import yaml_util
 
+from ..helpers.subprocess import create_subprocess_exec
+
 _LOGGER = logging.getLogger(__name__)
 
 _ESPHOME_CMD = [sys.executable, "-m", "esphome"]
@@ -50,7 +52,7 @@ async def _handle_legacy_ws_command(
         if extra_args_fn:
             cmd.extend(extra_args_fn(data))
 
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -25,6 +25,7 @@ from ..helpers.device_yaml import (
     generate_device_yaml,
     parse_platform_from_yaml,
 )
+from ..helpers.subprocess import create_subprocess_exec
 from ..helpers.yaml import merge_component_yaml, rewrite_esphome_name
 from ..models import (
     AddComponentResponse,
@@ -333,7 +334,7 @@ class DevicesController:
         config_path = str(self._db.settings.rel_path(configuration))
         cmd = [*self._esphome_cmd, "rename", config_path, new_name]
 
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
@@ -905,7 +906,7 @@ class DevicesController:
         env = {**os.environ, "PLATFORMIO_FORCE_ANSI": "true"}
         proc: asyncio.subprocess.Process | None = None
         try:
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..helpers.api import api_command
+from ..helpers.subprocess import create_subprocess_exec
 from .firmware import _find_esphome_cmd
 
 if TYPE_CHECKING:
@@ -74,7 +75,7 @@ class EditorController:
         config_dir = str(self._db.settings.config_dir)
         cmd = [*self._esphome_cmd, "vscode", config_dir, "--ace"]
         _LOGGER.info("Spawning vscode subprocess: %s", " ".join(cmd))
-        session.proc = await asyncio.create_subprocess_exec(
+        session.proc = await create_subprocess_exec(
             *cmd,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -23,6 +23,7 @@ from esphome.storage_json import StorageJSON, ext_storage_path
 
 from ..controllers.config import _load_metadata, metadata_transaction
 from ..helpers.api import api_command
+from ..helpers.subprocess import create_subprocess_exec
 from ..models import EventType, FirmwareJob, JobStatus, JobType
 
 if TYPE_CHECKING:
@@ -666,7 +667,7 @@ class FirmwareController:
                 "CLICOLOR_FORCE": "1",
                 "PYTHONUNBUFFERED": "1",
             }
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
@@ -922,7 +923,7 @@ class FirmwareController:
         if not expected_platform:
             return  # can't verify without knowing expected platform
 
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_exec(
             sys.executable,
             "-m",
             "esptool",

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -27,6 +27,8 @@ import re
 import sys
 from pathlib import Path
 
+from .subprocess import create_subprocess_exec
+
 _LOGGER = logging.getLogger(__name__)
 
 # Inline script run as ``python -c <SCRIPT> <yaml_path>``. Run in a
@@ -73,7 +75,7 @@ async def compute_yaml_config_hash(yaml_path: Path) -> str | None:
     than as an error to propagate.
     """
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_exec(
             sys.executable,
             "-c",
             _HASH_SCRIPT,

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -1,0 +1,29 @@
+"""Subprocess helpers.
+
+Centralises ``asyncio.create_subprocess_exec`` so every spawn forces
+``close_fds=False``. Python <3.14's default (``close_fds=True``) makes
+the subprocess module ``fork()`` the parent and have the child iterate
+``/proc/self/fd`` to close descriptors before ``exec()``; on
+memory-pressured systems that copies a non-trivial amount of page
+tables for nothing. None of our spawns rely on inherited descriptors
+being closed at the boundary, and the upstream esphome dashboard uses
+the same pattern in ``esphome.dashboard.util.subprocess``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+async def create_subprocess_exec(
+    *args: str,
+    **kwargs: Any,
+) -> asyncio.subprocess.Process:
+    """``asyncio.create_subprocess_exec`` with ``close_fds=False`` forced.
+
+    Accepts the same kwargs as the underlying call. Use everywhere
+    instead of calling ``asyncio.create_subprocess_exec`` directly.
+    """
+    kwargs["close_fds"] = False
+    return await asyncio.create_subprocess_exec(*args, **kwargs)

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -20,10 +20,14 @@ async def create_subprocess_exec(
     *args: str,
     **kwargs: Any,
 ) -> asyncio.subprocess.Process:
-    """``asyncio.create_subprocess_exec`` with ``close_fds=False`` forced.
+    """Spawn a subprocess via ``asyncio.create_subprocess_exec``.
 
-    Accepts the same kwargs as the underlying call. Use everywhere
-    instead of calling ``asyncio.create_subprocess_exec`` directly.
+    Positional and keyword arguments are forwarded to the underlying
+    call, except ``close_fds`` is always overridden to ``False``.
+    Callers must not rely on overriding ``close_fds`` or on kwargs
+    that require ``close_fds=True`` (e.g. ``pass_fds``). Use this
+    helper everywhere instead of calling
+    ``asyncio.create_subprocess_exec`` directly.
     """
     kwargs["close_fds"] = False
     return await asyncio.create_subprocess_exec(*args, **kwargs)

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -35,9 +35,10 @@ async def test_create_subprocess_exec_caller_close_fds_is_overridden() -> None:
         "create_subprocess_exec",
         new_callable=AsyncMock,
     ) as mock:
-        # If a caller passes close_fds=True, our explicit kwarg wins because
-        # it appears later in the call. We document that here so a future
-        # refactor doesn't reverse the precedence.
+        # If a caller passes close_fds=True, the helper still overrides it
+        # by explicitly setting kwargs["close_fds"] = False before delegating
+        # to asyncio. Documented here so a future refactor preserves the
+        # actual mechanism, not the wrong "later kwarg wins" rationale.
         await subprocess_helper.create_subprocess_exec("echo", "hi", close_fds=True)
 
     _, kwargs = mock.call_args

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -1,0 +1,89 @@
+"""Tests for the centralised subprocess spawn helper."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, patch
+
+from esphome_device_builder.helpers import subprocess as subprocess_helper
+
+
+async def test_create_subprocess_exec_forces_close_fds_false() -> None:
+    """The wrapper must always pass ``close_fds=False`` even when the caller doesn't."""
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new_callable=AsyncMock,
+    ) as mock:
+        await subprocess_helper.create_subprocess_exec(
+            "echo",
+            "hi",
+            stdout=asyncio.subprocess.PIPE,
+        )
+
+    args, kwargs = mock.call_args
+    assert args == ("echo", "hi")
+    assert kwargs["close_fds"] is False
+    assert kwargs["stdout"] == asyncio.subprocess.PIPE
+
+
+async def test_create_subprocess_exec_caller_close_fds_is_overridden() -> None:
+    """Callers can't accidentally restore the slow default."""
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new_callable=AsyncMock,
+    ) as mock:
+        # If a caller passes close_fds=True, our explicit kwarg wins because
+        # it appears later in the call. We document that here so a future
+        # refactor doesn't reverse the precedence.
+        await subprocess_helper.create_subprocess_exec("echo", "hi", close_fds=True)
+
+    _, kwargs = mock.call_args
+    assert kwargs["close_fds"] is False
+
+
+async def test_create_subprocess_exec_actually_runs() -> None:
+    """End-to-end smoke: the helper produces a working ``Process``."""
+    proc = await subprocess_helper.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "print('subprocess-helper-ok')",
+        stdout=asyncio.subprocess.PIPE,
+    )
+    stdout, _ = await proc.communicate()
+    assert proc.returncode == 0
+    assert b"subprocess-helper-ok" in stdout
+
+
+async def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> None:
+    """Guard against regressions: no callsite should bypass the helper.
+
+    Catches future commits that re-introduce a direct
+    ``asyncio.create_subprocess_exec`` call (which would skip the
+    ``close_fds=False`` optimisation) anywhere outside the helper itself.
+    """
+    import esphome_device_builder
+
+    pkg_root = (
+        # Resolve the package's filesystem location without depending on
+        # ``__file__`` typing nuances under from __future__ annotations.
+        __import__("pathlib").Path(esphome_device_builder.__file__).parent
+    )
+    helper_path = pkg_root / "helpers" / "subprocess.py"
+
+    offenders: list[str] = []
+    for path in pkg_root.rglob("*.py"):
+        if path == helper_path:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if "asyncio.create_subprocess_exec" in line:
+                offenders.append(f"{path.relative_to(pkg_root)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "Found direct asyncio.create_subprocess_exec calls — use "
+        "esphome_device_builder.helpers.subprocess.create_subprocess_exec "
+        "instead so close_fds=False is applied:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary
Python <3.14's default ``close_fds=True`` for ``asyncio.create_subprocess_exec`` triggers a slow path: the parent process is forked and the child iterates ``/proc/self/fd`` to close descriptors before ``exec()``. On memory-pressured systems that copies a non-trivial amount of page tables for nothing. None of our spawns rely on that descriptor close, and the upstream esphome dashboard uses the same pattern in [`esphome.dashboard.util.subprocess`](https://github.com/esphome/esphome/blob/dev/esphome/dashboard/util/subprocess.py).

This PR introduces a single helper —
`esphome_device_builder.helpers.subprocess.create_subprocess_exec` — that forces `close_fds=False`, and routes every spawn through it. The flag lives in one place; call sites stay readable; and a repo-wide test guards against accidental direct calls to `asyncio.create_subprocess_exec` slipping back in.

### Call sites routed through the helper
| File | Spawn |
|---|---|
| `api/legacy.py` | legacy WS spawn (HA backward compat) |
| `controllers/firmware.py` | compile/upload runner + esptool chip-id |
| `controllers/editor.py` | long-lived `esphome vscode --ace` editor |
| `controllers/devices.py` | rename + `_stream_subprocess` |
| `helpers/config_hash.py` | config-hash sidecar |

## Tests (`tests/test_subprocess_helper.py`)
- Helper forces `close_fds=False` when the caller omits it.
- Caller-supplied `close_fds=True` is overridden — we never silently fall back to the slow path.
- End-to-end smoke: the wrapper produces a working `asyncio.subprocess.Process`.
- **Repo-wide regression guard**: walks every `.py` under `esphome_device_builder/` and fails if any line outside the helper itself contains `asyncio.create_subprocess_exec`. Catches future commits that bypass the helper.

## Test plan
- [x] Full suite: `pytest` (191 passed, 4 new)
- [x] `pre-commit run` clean