### PR TITLE
Enable FLY/FURB/PERF/PL/RET/SIM ruff rule groups

### DIFF
--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -6,6 +6,7 @@ Single /ws endpoint. Dispatches commands to handlers registered on DeviceBuilder
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -75,10 +76,8 @@ class WebSocketClient:
 
     async def send(self, data: dict[str, Any]) -> None:
         """Send a JSON message."""
-        try:
+        with contextlib.suppress(ConnectionResetError):
             await self._ws.send_str(orjson.dumps(data).decode())
-        except ConnectionResetError:
-            pass
         if self._close_after_send:
             await self._ws.close()
 

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -26,6 +26,8 @@ try:
 except ImportError:  # pragma: no cover — paho-mqtt arrives via the [esphome] extra
     paho_mqtt = None  # type: ignore[assignment]
 
+import contextlib
+
 from ..models import DeviceState
 
 _LOGGER = logging.getLogger(__name__)
@@ -114,10 +116,8 @@ class DeviceMqttMonitor:
         if self._task is None:
             return
         self._task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await self._task
-        except asyncio.CancelledError:
-            pass
         self._task = None
         self._last_seen.clear()
 

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -278,7 +278,7 @@ class DeviceStateMonitor:
             # mDNS reports "<my-device>._esphomelib._tcp.local." — strip
             # the service suffix and convert hyphens (mDNS) back to
             # underscores (YAML config naming).
-            device_name = name.split(".")[0].replace("-", "_")
+            device_name = name.split(".", maxsplit=1)[0].replace("-", "_")
             _LOGGER.debug("mDNS: %s %s (raw: %s)", state_change, device_name, name)
 
             # zeroconf callbacks fire on a different thread — bounce work

--- a/esphome_device_builder/controllers/automations.py
+++ b/esphome_device_builder/controllers/automations.py
@@ -242,9 +242,11 @@ class AutomationsController:
         triggers = list(_DEVICE_TRIGGERS)
 
         # Add component-level triggers matching present platform types
-        for trigger in _COMPONENT_TRIGGERS:
-            if any(pt in present_types for pt in trigger.platform_types):
-                triggers.append(trigger)
+        triggers.extend(
+            trigger
+            for trigger in _COMPONENT_TRIGGERS
+            if any(pt in present_types for pt in trigger.platform_types)
+        )
 
         return {
             "triggers": [t.to_dict() for t in triggers],

--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -249,9 +249,8 @@ def _materialise_entry(entry: ConfigEntry, target_platform: str | None) -> Confi
     so the resolution applies at every depth.
     """
     default = entry.default_value
-    if target_platform and entry.platform_defaults:
-        if target_platform in entry.platform_defaults:
-            default = entry.platform_defaults[target_platform]
+    if target_platform and entry.platform_defaults and target_platform in entry.platform_defaults:
+        default = entry.platform_defaults[target_platform]
     nested = (
         [_materialise_entry(e, target_platform) for e in entry.config_entries]
         if entry.config_entries

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -10,7 +10,7 @@ import os
 import tempfile
 import threading
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -167,10 +167,8 @@ def _save_metadata(config_dir: Path, data: dict[str, Any]) -> None:
             json.dump(data, fh, indent=2)
         os.replace(tmp_path, path)
     except Exception:
-        try:
+        with suppress(OSError):
             tmp_path.unlink()
-        except OSError:
-            pass
         raise
 
 

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     import_config = None  # type: ignore[assignment]
 
+import contextlib
+
 from ..helpers.api import api_command
 from ..helpers.config_hash import compute_yaml_config_hash
 from ..helpers.device_yaml import (
@@ -933,10 +935,8 @@ class DevicesController:
             if proc is not None and proc.returncode is None:
                 # Reap so the transport closes cleanly; shielded so an
                 # additional cancellation doesn't strand the subprocess.
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await asyncio.shield(proc.wait())
-                except asyncio.CancelledError:
-                    pass
 
         await client.send_event(
             message_id, "result", {"success": exit_code == 0, "code": exit_code}

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -622,7 +622,7 @@ class FirmwareController:
         except asyncio.CancelledError:
             pass
 
-    async def _execute_job(self, job: FirmwareJob) -> None:
+    async def _execute_job(self, job: FirmwareJob) -> None:  # noqa: PLR0912, PLR0915
         """Execute a single firmware job."""
         job.status = JobStatus.RUNNING
         job.started_at = datetime.now(UTC).isoformat()
@@ -836,10 +836,8 @@ class FirmwareController:
                 self._current_job.job_id if self._current_job else "?",
                 _TERMINATE_GRACE_SECONDS,
             )
-            try:
+            with suppress(ProcessLookupError):
                 proc.kill()
-            except ProcessLookupError:
-                pass
 
     async def _reset_build_env(self, job: FirmwareJob) -> None:
         """

--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -94,9 +94,11 @@ def _resolve_images(board_dir: Path, manifest_images: list[str] | None) -> list[
     images_dir = board_dir / "images"
     if images_dir.is_dir():
         known = {p.rsplit("/", 1)[-1] for p in images}
-        for img in sorted(images_dir.iterdir()):
-            if img.suffix.lower() in _IMAGE_EXTENSIONS and img.name not in known:
-                images.append(_local_to_url(img))
+        images.extend(
+            _local_to_url(img)
+            for img in sorted(images_dir.iterdir())
+            if img.suffix.lower() in _IMAGE_EXTENSIONS and img.name not in known
+        )
 
     return images
 

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -8,6 +8,7 @@ the DevicesController, not here.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -126,10 +127,8 @@ class DeviceBuilder:
         """Shut down the application."""
         if self._bg_task:
             self._bg_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await self._bg_task
-            except asyncio.CancelledError:
-                pass
         for task in self._background_tasks:
             task.cancel()
         if self._background_tasks:

--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -314,7 +314,7 @@ _PUBLIC_PREFIXES = ("/assets/", "/boards/images/")
 
 
 @web.middleware
-async def auth_middleware(request: web.Request, handler: Any) -> web.StreamResponse:
+async def auth_middleware(request: web.Request, handler: Any) -> web.StreamResponse:  # noqa: PLR0911
     """
     Gate REST endpoints by ``Authorization`` header.
 

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -22,6 +22,7 @@ back to its mtime check.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 import sys
@@ -96,10 +97,8 @@ async def compute_yaml_config_hash(yaml_path: Path) -> str | None:
         # Race: the subprocess may have exited between the timeout
         # firing and ``kill()`` being called — swallow the lookup
         # error so a recoverable timeout doesn't bubble up.
-        try:
+        with contextlib.suppress(ProcessLookupError):
             proc.kill()
-        except ProcessLookupError:
-            pass
         await proc.wait()
         return None
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -189,7 +189,7 @@ def device_uses_mqtt(yaml_content: str) -> bool:
     return False
 
 
-def parse_esphome_meta(
+def parse_esphome_meta(  # noqa: PLR0912
     yaml_content: str,
 ) -> tuple[str | None, str | None, str | None]:
     """

--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -13,10 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def json_response(data: Any, status: int = 200) -> web.Response:
     """Return a JSON response, serialising dataclasses via mashumaro."""
-    if hasattr(data, "to_dict"):
-        body = data.to_dict()
-    else:
-        body = data
+    body = data.to_dict() if hasattr(data, "to_dict") else data
     return web.Response(
         status=status,
         content_type="application/json",

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -219,9 +219,10 @@ def generate_component_yaml(
         indent = "  "
 
     for key, value in fields.items():
-        if key == "id" and not value:
-            value = _generate_id(unqualified, fields.get("name"))
-        lines.extend(_emit_field(key, value, indent))
+        emit_value = (
+            _generate_id(unqualified, fields.get("name")) if key == "id" and not value else value
+        )
+        lines.extend(_emit_field(key, emit_value, indent))
 
     return "\n".join(lines)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ ignore = [
   "D203", # conflicts with D211
   "D213", # conflicts with D212
   "D417", # false positives
+  "PLC0415", # late imports are deliberate (avoid circular deps, lazy esphome load)
+  "PLR0913", # too many arguments — not a useful constraint here
+  "PLR2004", # magic value comparison — too noisy for status codes / structural checks
   "S101", # assert used for type checking
   "S104", # binding to all interfaces
 ]
@@ -95,10 +98,16 @@ select = [
   "D", # pydocstyle
   "E", # pycodestyle errors
   "F", # pyflakes
+  "FLY", # flynt: convert string formatting to f-strings
+  "FURB", # refurb
   "I", # isort
   "N", # pep8-naming
+  "PERF", # performance
+  "PL", # pylint
+  "RET", # flake8-return
   "RUF", # ruff-specific
   "S", # flake8-bandit
+  "SIM", # flake8-simplify
   "T20", # flake8-print
   "UP", # pyupgrade
   "W", # pycodestyle warnings

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1140,10 +1140,7 @@ def load_image_map() -> dict[str, str]:
         parts = [p for p in path.strip("/").split("/")[1:] if p]
         if not parts:
             continue
-        if len(parts) >= 2:
-            component_id = f"{parts[0]}.{parts[1]}"
-        else:
-            component_id = parts[0]
+        component_id = f"{parts[0]}.{parts[1]}" if len(parts) >= 2 else parts[0]
         out.setdefault(component_id, _IMAGE_BASE_URL + image)
         # Also store under the bare stem when only one platform exists,
         # so lookups by either id work.
@@ -1373,7 +1370,7 @@ def _resolve_extends(ref: str, schema_dir: Path) -> dict[str, dict]:
     return inner
 
 
-def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:
+def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noqa: PLR0912, PLR0915
     """Build a single ConfigEntry dict from a schema's config_var entry."""
     if not isinstance(raw, dict):
         # Some schemas use bare ``{}``-shaped placeholders for fields
@@ -1439,9 +1436,8 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:
 
     # Key-name fallback — ``icon`` / ``mac_address`` are usually
     # untyped strings in the schema.
-    if entry_type is None:
-        if key == "icon":
-            entry_type = "icon"
+    if entry_type is None and key == "icon":
+        entry_type = "icon"
 
     if entry_type is None and inner_schema and inner_schema.get("config_vars"):
         entry_type = "nested"
@@ -1592,7 +1588,7 @@ def _build_options(raw: dict) -> list[dict] | None:
         return None
     options: list[dict] = []
     for value, info in values.items():
-        label = value if value else "(none)"
+        label = value or "(none)"
         if isinstance(info, dict) and info.get("docs"):
             label = info["docs"]
         options.append({"label": label, "value": value})
@@ -1638,24 +1634,18 @@ def _is_own_id_field(raw: dict) -> bool:
     """
     if raw.get("key") == "GeneratedID":
         return True
-    if isinstance(raw.get("id_type"), dict) and "use_id_type" not in raw:
-        return True
-    return False
+    return bool(isinstance(raw.get("id_type"), dict) and "use_id_type" not in raw)
 
 
 def _resolve_pin_features(raw: dict) -> list[str]:
     """Translate the schema's ``modes`` list into our PinFeature enum keys."""
     modes = raw.get("modes") or []
-    out: list[str] = []
-    for m in modes:
-        # Schema uses ``input``/``output``/``pullup``/``pulldown`` etc.
-        # Our PinFeature enum tracks more capability tags (i2c_sda,
-        # spi_clk, ...) but those don't appear here — only directional
-        # / pull modes do. Pass them through; downstream code can drop
-        # unknown values via _safe_enum.
-        if isinstance(m, str):
-            out.append(m)
-    return out
+    # Schema uses ``input``/``output``/``pullup``/``pulldown`` etc.
+    # Our PinFeature enum tracks more capability tags (i2c_sda,
+    # spi_clk, ...) but those don't appear here — only directional
+    # / pull modes do. Pass them through; downstream code can drop
+    # unknown values via _safe_enum.
+    return [m for m in modes if isinstance(m, str)]
 
 
 def _detect_platform_type(inner_schema: dict) -> str | None:
@@ -1779,7 +1769,7 @@ def _looks_like_boolean_enum(raw: dict) -> bool:
     if not isinstance(values, dict):
         return False
     keys = {str(k).lower() for k in values}
-    return keys == {"true", "false"} or keys == {"true", "false", "yes", "no"}
+    return keys in ({"true", "false"}, {"true", "false", "yes", "no"})
 
 
 def _looks_like_time_period_default(value: Any) -> bool:
@@ -2034,7 +2024,7 @@ def _get_esphome_loader() -> Any:
         return _ESPHOME_LOADER_CACHE["module"]
     _ESPHOME_LOADER_CACHE["resolved"] = True
     try:
-        import esphome.loader as loader
+        from esphome import loader
 
         _ESPHOME_LOADER_CACHE["module"] = loader
         _LOGGER.info("esphome introspection enabled (esphome.loader importable)")
@@ -2200,7 +2190,7 @@ def _collect_platform_defaults(manifest: Any) -> dict[tuple[str, ...], dict[str,
     return out
 
 
-def _collect_refined_types(manifest: Any) -> dict[tuple[str, ...], str]:
+def _collect_refined_types(manifest: Any) -> dict[tuple[str, ...], str]:  # noqa: PLR0915
     """Walk the live ``CONFIG_SCHEMA`` to recover types the schema lost.
 
     The pre-built schema collapses many ``cv.boolean`` / ``cv.float_`` /
@@ -2377,7 +2367,7 @@ def _load_unit_of_measurement_options() -> list[dict[str, str]]:
     Empty list when esphome isn't importable.
     """
     try:
-        import esphome.const as const
+        from esphome import const
     except Exception:
         return []
     raw = sorted(

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -35,8 +35,7 @@ def _make_client() -> WebSocketClient:
 
 def _make_controller() -> DevicesController:
     """Return a DevicesController shell that ``_stream_subprocess`` can use."""
-    ctrl = DevicesController.__new__(DevicesController)
-    return ctrl
+    return DevicesController.__new__(DevicesController)
 
 
 async def test_register_and_cancel_stream_runs_task_to_cancellation() -> None:


### PR DESCRIPTION
## Summary
Brings the ruff selection closer to `esphome/esphome`'s — adds `FLY`, `FURB`, `PERF`, `PL`, `RET`, `SIM`. Auto-fixes plus a few manual conversions (list.extend, contextlib.suppress, combined ifs); 187 tests pass.

Rule groups left disabled with reasons in `pyproject.toml`:
- `PLC0415` — late imports are intentional (circular-dep avoidance, lazy esphome load)
- `PLR0913` — too-many-args isn't a useful cap here
- `PLR2004` — noisy on structural checks (`len(parts) == 2`, status codes, etc.)

A handful of genuinely complex functions (`_execute_job`, `parse_esphome_meta`, `auth_middleware`, `_convert_field`, `_collect_refined_types`) carry per-line `PLR0911/0912/0915` noqa instead of being refactored.

## Test plan
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `pytest -q` 187 passed