### PR TITLE
Set Cache-Control on the SPA shell so re-deploys aren't masked by stale browser cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,15 @@ git clone https://github.com/esphome/device-builder
 cd device-builder
 script/setup
 source .venv/bin/activate
-esphome-device-builder ./configs --log-level debug
+esphome-device-builder ./configs --log-level debug --dev
 ```
+
+`--dev` serves `index.html` with `Cache-Control: no-cache` so a
+re-deployed frontend wheel isn't masked by a browser-cached SPA
+shell pointing at a now-deleted hashed bundle. Hashed bundles
+themselves stay `immutable` regardless. Skip `--dev` in production —
+the browser's default heuristic is fine when you're not rebuilding
+every few minutes.
 
 ## Roadmap
 

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -89,6 +89,16 @@ def main() -> None:
         help="Log level",
     )
     parser.add_argument("--log-file", default=None, help="Log to file (rotated)")
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help=(
+            "Development mode: serve ``index.html`` with ``Cache-Control: "
+            "no-cache`` so the browser always picks up a freshly-rebuilt "
+            "frontend wheel. Disabled by default — the browser's heuristic "
+            "is fine in production."
+        ),
+    )
 
     args = parser.parse_args()
 

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -58,6 +58,12 @@ class DashboardSettings:
     host: str = "0.0.0.0"
     ingress_port: int = DEFAULT_INGRESS_PORT
     ingress_host: str = ""
+    # In dev mode the SPA shell is served with ``Cache-Control: no-cache``
+    # so a re-deployed wheel isn't masked by a browser-cached
+    # ``index.html`` pointing at a now-deleted hashed bundle. In
+    # production we let the browser apply its default heuristic; the
+    # hashed bundles are still served as ``immutable`` regardless.
+    dev_mode: bool = False
 
     def parse_args(self, args: Any) -> None:
         """Parse CLI arguments into settings."""
@@ -86,6 +92,7 @@ class DashboardSettings:
         self.host = getattr(args, "host", "0.0.0.0")
         self.ingress_port = getattr(args, "ingress_port", DEFAULT_INGRESS_PORT)
         self.ingress_host = getattr(args, "ingress_host", "") or ""
+        self.dev_mode = bool(getattr(args, "dev", False))
         CORE.config_path = self.config_dir / _DASHBOARD_SENTINEL_FILE
 
     def rel_path(self, *parts: str) -> Path:

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -260,7 +260,7 @@ class DeviceBuilder:
         # Frontend serving
         frontend_dir = self._get_frontend_dir()
         if frontend_dir and frontend_dir.is_dir():
-            self._register_frontend(app, frontend_dir)
+            self._register_frontend(app, frontend_dir, dev_mode=self.settings.dev_mode)
         elif with_lifecycle:
             # The ingress app is silent here — the public app already logged.
             _LOGGER.info(
@@ -320,7 +320,9 @@ class DeviceBuilder:
             return None
 
     @staticmethod
-    def _register_frontend(app: web.Application, frontend_dir: Path) -> None:
+    def _register_frontend(
+        app: web.Application, frontend_dir: Path, *, dev_mode: bool = False
+    ) -> None:
         """Register routes for the built frontend.
 
         Refuses to start if the installed wheel is missing
@@ -334,6 +336,12 @@ class DeviceBuilder:
         reach this handler. Multi-segment paths never touch the
         filesystem here, which keeps traversal impossible by
         construction.
+
+        ``dev_mode`` flips the SPA shell to ``Cache-Control: no-cache``
+        so a re-deployed wheel isn't masked by a browser-cached
+        ``index.html`` that points at a now-deleted hashed bundle.
+        Hashed bundles are served as ``immutable`` regardless — their
+        filenames are content-addressed by definition.
         """
         index_html = frontend_dir / "index.html"
         assets_dir = frontend_dir / "assets"
@@ -352,9 +360,10 @@ class DeviceBuilder:
             )
 
         frontend_root = frontend_dir.resolve()
+        shell_headers = _NO_CACHE_HEADERS if dev_mode else None
 
         async def handle_index(request: web.Request) -> web.FileResponse:
-            return web.FileResponse(index_html, headers=_NO_CACHE_HEADERS)
+            return web.FileResponse(index_html, headers=shell_headers)
 
         async def handle_spa(request: web.Request) -> web.FileResponse:
             tail = request.match_info["tail"]
@@ -370,15 +379,15 @@ class DeviceBuilder:
                         headers = (
                             _IMMUTABLE_HEADERS
                             if _HASHED_FILENAME_RE.search(tail)
-                            else _NO_CACHE_HEADERS
+                            else shell_headers
                         )
                         return web.FileResponse(candidate, headers=headers)
                 except OSError:
                     pass
-            return web.FileResponse(index_html, headers=_NO_CACHE_HEADERS)
+            return web.FileResponse(index_html, headers=shell_headers)
 
         app.router.add_static("/assets", assets_dir)
         app.router.add_get("/", handle_index)
         app.router.add_get("/{tail:.*}", handle_spa)
 
-        _LOGGER.info("Serving frontend from %s", frontend_dir)
+        _LOGGER.info("Serving frontend from %s (dev_mode=%s)", frontend_dir, dev_mode)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +33,17 @@ if TYPE_CHECKING:
     from .controllers.firmware import FirmwareController
 
 _LOGGER = logging.getLogger(__name__)
+
+# Cache policy for the SPA shell:
+#   - ``index.html`` and any non-hashed top-level file: must always
+#     revalidate so a re-deployed wheel doesn't get masked by a
+#     stale browser cache.
+#   - Hashed bundles (``app.<hash>.js``, ``vendors.<hash>.js``,
+#     license sidecars) are content-addressed — the filename changes
+#     on every rebuild, so they're safe to cache forever.
+_NO_CACHE_HEADERS = {"Cache-Control": "no-cache"}
+_IMMUTABLE_HEADERS = {"Cache-Control": "public, max-age=31536000, immutable"}
+_HASHED_FILENAME_RE = re.compile(r"\.[a-f0-9]{8,}\.")
 
 
 class DeviceBuilder:
@@ -339,10 +351,10 @@ class DeviceBuilder:
                 "reinstall, or uninstall it to run in API-only mode."
             )
 
-        async def handle_index(request: web.Request) -> web.FileResponse:
-            return web.FileResponse(index_html)
-
         frontend_root = frontend_dir.resolve()
+
+        async def handle_index(request: web.Request) -> web.FileResponse:
+            return web.FileResponse(index_html, headers=_NO_CACHE_HEADERS)
 
         async def handle_spa(request: web.Request) -> web.FileResponse:
             tail = request.match_info["tail"]
@@ -355,10 +367,15 @@ class DeviceBuilder:
                 # frontend dir — matches add_static's default.
                 try:
                     if candidate.is_file() and candidate.resolve().is_relative_to(frontend_root):
-                        return web.FileResponse(candidate)
+                        headers = (
+                            _IMMUTABLE_HEADERS
+                            if _HASHED_FILENAME_RE.search(tail)
+                            else _NO_CACHE_HEADERS
+                        )
+                        return web.FileResponse(candidate, headers=headers)
                 except OSError:
                     pass
-            return web.FileResponse(index_html)
+            return web.FileResponse(index_html, headers=_NO_CACHE_HEADERS)
 
         app.router.add_static("/assets", assets_dir)
         app.router.add_get("/", handle_index)

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -22,9 +22,12 @@ def _make_frontend(tmp_path: Path) -> Path:
     frontend = tmp_path / "frontend"
     frontend.mkdir()
     (frontend / "index.html").write_text("<!doctype html><body></body>")
-    (frontend / "app.abc123.js").write_text("// bundle")
-    (frontend / "vendors.def456.js").write_text("// vendors")
-    (frontend / "vendors.def456.js.LICENSE.txt").write_text("/* license */")
+    # Use 16-char hex hashes to match what rspack actually emits (xxhash64)
+    # so the cache-header regex (``\.[a-f0-9]{8,}\.``) classifies them
+    # as immutable.
+    (frontend / "app.abc123def4567890.js").write_text("// bundle")
+    (frontend / "vendors.def4567890abcdef.js").write_text("// vendors")
+    (frontend / "vendors.def4567890abcdef.js.LICENSE.txt").write_text("/* license */")
 
     assets = frontend / "assets"
     (assets / "logo").mkdir(parents=True)
@@ -45,6 +48,42 @@ async def test_register_frontend_serves_index_at_root(
     resp = await client.get("/")
     assert resp.status == 200
     assert "<!doctype html>" in (await resp.text())
+    # index.html must always be revalidated so a re-deployed wheel
+    # doesn't get masked by a stale browser-cached HTML pointing at
+    # a hashed bundle that no longer exists.
+    assert resp.headers["Cache-Control"] == "no-cache"
+
+
+async def test_register_frontend_hashed_bundle_is_immutable(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """Content-addressed bundles get a long ``immutable`` Cache-Control."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/app.abc123def4567890.js")
+    assert resp.status == 200
+    assert resp.headers["Cache-Control"] == "public, max-age=31536000, immutable"
+
+
+async def test_register_frontend_non_hashed_top_level_is_revalidated(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """A top-level file without a content hash falls back to no-cache."""
+    frontend = _make_frontend(tmp_path)
+    (frontend / "robots.txt").write_text("User-agent: *\n")
+    client = await aiohttp_client(_make_app(frontend))
+    resp = await client.get("/robots.txt")
+    assert resp.status == 200
+    assert resp.headers["Cache-Control"] == "no-cache"
+
+
+async def test_register_frontend_spa_fallback_is_no_cache(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """The SPA-fallback ``index.html`` for a deep link is also no-cache."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/device/foo.yaml")
+    assert resp.status == 200
+    assert resp.headers["Cache-Control"] == "no-cache"
 
 
 async def test_register_frontend_serves_top_level_bundles(
@@ -52,8 +91,8 @@ async def test_register_frontend_serves_top_level_bundles(
 ) -> None:
     """Hashed JS bundles next to index.html are reachable."""
     client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
-    app_resp = await client.get("/app.abc123.js")
-    vendors_resp = await client.get("/vendors.def456.js")
+    app_resp = await client.get("/app.abc123def4567890.js")
+    vendors_resp = await client.get("/vendors.def4567890abcdef.js")
     assert (await app_resp.text()) == "// bundle"
     assert (await vendors_resp.text()) == "// vendors"
 
@@ -68,7 +107,7 @@ async def test_register_frontend_serves_top_level_license_sidecar(
     "is not a directory" on this exact filename.
     """
     client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
-    resp = await client.get("/vendors.def456.js.LICENSE.txt")
+    resp = await client.get("/vendors.def4567890abcdef.js.LICENSE.txt")
     assert resp.status == 200
     assert "license" in (await resp.text())
 
@@ -189,7 +228,7 @@ async def test_register_frontend_follows_symlinks_inside_frontend_dir(
     symlink — only ones that would escape the frontend root.
     """
     frontend = _make_frontend(tmp_path)
-    (frontend / "alias.js").symlink_to(frontend / "app.abc123.js")
+    (frontend / "alias.js").symlink_to(frontend / "app.abc123def4567890.js")
 
     client = await aiohttp_client(_make_app(frontend))
     resp = await client.get("/alias.js")

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -35,9 +35,9 @@ def _make_frontend(tmp_path: Path) -> Path:
     return frontend
 
 
-def _make_app(frontend: Path) -> web.Application:
+def _make_app(frontend: Path, *, dev_mode: bool = False) -> web.Application:
     app = web.Application()
-    DeviceBuilder._register_frontend(app, frontend)
+    DeviceBuilder._register_frontend(app, frontend, dev_mode=dev_mode)
     return app
 
 
@@ -48,39 +48,50 @@ async def test_register_frontend_serves_index_at_root(
     resp = await client.get("/")
     assert resp.status == 200
     assert "<!doctype html>" in (await resp.text())
-    # index.html must always be revalidated so a re-deployed wheel
-    # doesn't get masked by a stale browser-cached HTML pointing at
-    # a hashed bundle that no longer exists.
+
+
+async def test_register_frontend_dev_mode_index_is_no_cache(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """``dev_mode=True`` opts in to ``Cache-Control: no-cache`` for the SPA shell.
+
+    Without this, a re-deployed wheel during development would be
+    masked by a browser-cached ``index.html`` pointing at a now-deleted
+    hashed bundle.
+    """
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path), dev_mode=True))
+    resp = await client.get("/")
+    assert resp.status == 200
     assert resp.headers["Cache-Control"] == "no-cache"
 
 
-async def test_register_frontend_hashed_bundle_is_immutable(
+async def test_register_frontend_default_index_omits_cache_control(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """Content-addressed bundles get a long ``immutable`` Cache-Control."""
+    """Production (default) leaves caching up to the browser's default heuristic."""
     client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
-    resp = await client.get("/app.abc123def4567890.js")
+    resp = await client.get("/")
     assert resp.status == 200
-    assert resp.headers["Cache-Control"] == "public, max-age=31536000, immutable"
+    assert "Cache-Control" not in resp.headers
 
 
-async def test_register_frontend_non_hashed_top_level_is_revalidated(
+async def test_register_frontend_hashed_bundle_is_always_immutable(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """A top-level file without a content hash falls back to no-cache."""
+    """Hashed bundles are content-addressed → safe to cache forever in either mode."""
     frontend = _make_frontend(tmp_path)
-    (frontend / "robots.txt").write_text("User-agent: *\n")
-    client = await aiohttp_client(_make_app(frontend))
-    resp = await client.get("/robots.txt")
-    assert resp.status == 200
-    assert resp.headers["Cache-Control"] == "no-cache"
+    for dev_mode in (False, True):
+        client = await aiohttp_client(_make_app(frontend, dev_mode=dev_mode))
+        resp = await client.get("/app.abc123def4567890.js")
+        assert resp.status == 200, dev_mode
+        assert resp.headers["Cache-Control"] == "public, max-age=31536000, immutable", dev_mode
 
 
-async def test_register_frontend_spa_fallback_is_no_cache(
+async def test_register_frontend_dev_mode_spa_fallback_is_no_cache(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """The SPA-fallback ``index.html`` for a deep link is also no-cache."""
-    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    """Dev-mode SPA-fallback ``index.html`` for a deep link is also no-cache."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path), dev_mode=True))
     resp = await client.get("/device/foo.yaml")
     assert resp.status == 200
     assert resp.headers["Cache-Control"] == "no-cache"


### PR DESCRIPTION
## Summary
After redeploying the frontend wheel during development, browsers were happily serving the previously-cached `index.html` (which points at a hashed bundle that's no longer on disk). Without explicit `Cache-Control` directives the heuristic kicks in and re-deploys are masked.

The hot-reload-during-development case is what actually needs the override; in production the browser's default heuristic is fine when re-deploys are infrequent.

* New `--dev` CLI flag → `DashboardSettings.dev_mode`.
* `_register_frontend(..., dev_mode=...)` plumbing.
* When `dev_mode=True`: `index.html` (and the SPA-fallback shell) gets `Cache-Control: no-cache`.
* When `dev_mode=False` (default, production): no `Cache-Control` header on the shell — the browser applies its default heuristic.
* **Hashed bundles always get `Cache-Control: public, max-age=31536000, immutable`** — the filename is content-addressed by definition, so caching them forever is safe in either mode. A filename is treated as hashed when its name contains `.<hex 8+>.` (matches what rspack's `xxhash64` and webpack's md4 emit).

## README
Updated the development invocation to include `--dev` with a short note explaining what it does.

## Tests (`tests/test_frontend_routes.py`)
- `dev_mode=True` index → `Cache-Control: no-cache`
- default-mode index → no `Cache-Control` header at all
- hashed bundle is `immutable` regardless of `dev_mode`
- `dev_mode=True` SPA-fallback `/device/foo.yaml` → `Cache-Control: no-cache`

## Test plan
- [x] Full suite: `pytest` (195 passed, 5 new)
- [x] `pre-commit run` clean