### PR TITLE
Fix mDNS device discovery: literal name lookup + cache-first handler

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -64,11 +64,6 @@ VersionChangeCallback = Callable[[str, str], None]
 # older devices simply never fire this callback.
 ConfigHashChangeCallback = Callable[[str, str], None]
 
-# zeroconf hands us raw bytes for TXT keys; declared once so the
-# call site can decode without re-typing the key.
-_TXT_RECORD_VERSION = b"version"
-_TXT_RECORD_CONFIG_HASH = b"config_hash"
-
 
 def device_name_from_service(service_name: str) -> str:
     """Extract the device name from an mDNS service-instance name.
@@ -344,35 +339,16 @@ class DeviceStateMonitor:
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``."""
         # ``parsed_addresses`` returns scope-stripped strings
-        # (internally ``str_without_scope_id``) — no manual ``%``-stripping
-        # like ``parsed_scoped_addresses + .split("%", 1)[0]``.
+        # (internally ``str_without_scope_id``) — no manual ``%``-stripping.
         if addresses := info.parsed_addresses(IPVersion.All):
             self.apply_ip(device_name, addresses[0])
-        properties = info.properties or {}
-        self._apply_txt(device_name, properties, _TXT_RECORD_VERSION, "version", self.apply_version)
-        self._apply_txt(
-            device_name,
-            properties,
-            _TXT_RECORD_CONFIG_HASH,
-            "config_hash",
-            self.apply_config_hash,
-        )
-
-    def _apply_txt(
-        self,
-        device_name: str,
-        properties: dict[bytes, bytes | None],
-        key: bytes,
-        label: str,
-        setter: Callable[[str, str], bool],
-    ) -> None:
-        """Decode a TXT record and forward it to *setter*; log + skip on bad UTF-8."""
-        if not (value := properties.get(key)):
-            return
-        try:
-            setter(device_name, value.decode())
-        except UnicodeDecodeError:
-            _LOGGER.debug("Could not decode mDNS %s TXT for %s: %r", label, device_name, value)
+        # ``decoded_properties`` is a ``dict[str, str | None]`` — zeroconf
+        # already handles the UTF-8 decode and None-on-bad-bytes for us.
+        props = info.decoded_properties
+        if version := props.get("version"):
+            self.apply_version(device_name, version)
+        if config_hash := props.get("config_hash"):
+            self.apply_config_hash(device_name, config_hash)
 
     async def _ping_loop(self) -> None:
         try:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -129,6 +129,15 @@ class DeviceStateMonitor:
         if self._ping_task is not None:
             self._ping_task.cancel()
             self._ping_task = None
+        # Cancel any in-flight mDNS resolve tasks before tearing down
+        # zeroconf so they don't fire ``apply_*`` callbacks against an
+        # already-closed instance and don't leave warnings about
+        # pending tasks at shutdown.
+        for task in self._tasks:
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+            self._tasks.clear()
         if self._mdns_browser is not None:
             try:
                 await self._mdns_browser.async_cancel()
@@ -146,7 +155,7 @@ class DeviceStateMonitor:
         """Return the source currently authoritative for *name* (or "unknown")."""
         return self._state_source.get(name, "unknown")
 
-    def apply(self, name: str, state: DeviceState, source: str) -> bool:
+    def apply(self, name: str, state: DeviceState, source: str, *, claim: bool = False) -> bool:
         """
         Record a state observation from *source*.
 
@@ -154,6 +163,14 @@ class DeviceStateMonitor:
         state and the change was forwarded to the callback. Sources
         below the current source's priority are ignored; same-state
         observations are no-ops.
+
+        ``claim=True`` lets *source* take ownership of the device's
+        state slot even when the state is unchanged, so that a
+        higher-priority observation arriving after a lower-priority
+        one already pinned the same state can still prevent the
+        lower-priority source from later flipping it back. The
+        priority check still applies — ``claim`` doesn't let a lower-
+        priority source override a higher-priority owner.
         """
         device = self._find_device_by_name(name)
         if device is None:
@@ -166,6 +183,8 @@ class DeviceStateMonitor:
         if _SOURCE_PRIORITY.get(source, 0) < _SOURCE_PRIORITY.get(current_source, 0):
             return False
         if device.state == state:
+            if claim:
+                self._state_source[name] = source
             return False
 
         self._state_source[name] = source
@@ -291,11 +310,15 @@ class DeviceStateMonitor:
             # ``AsyncServiceBrowser`` dispatches handlers on the asyncio
             # loop, so call apply methods directly. For Added/Updated,
             # try the zeroconf cache first (sync) — only fall back to a
-            # network query (async task) when the cache misses, matching
-            # the pattern used in the upstream esphome dashboard and
-            # aiohomekit.
+            # network query (async task) when the cache misses.
             device_name = device_name_from_service(name)
             _LOGGER.debug("mDNS: %s %s (raw: %s)", state_change, device_name, name)
+
+            # Short-circuit unconfigured devices so we don't spawn
+            # ServiceInfo lookups / resolve tasks for unrelated ESPHome
+            # nodes on the LAN.
+            if self._find_device_by_name(device_name) is None:
+                return
 
             if state_change == ServiceStateChange.Removed:
                 self.apply(device_name, DeviceState.OFFLINE, "mdns")
@@ -303,7 +326,11 @@ class DeviceStateMonitor:
                 self._state_source.pop(device_name, None)
                 return
 
-            self.apply(device_name, DeviceState.ONLINE, "mdns")
+            # ``claim=True`` so mDNS takes ownership even when the
+            # device is already ONLINE via a lower-priority source
+            # (ping / MQTT), preventing later ping observations from
+            # clobbering the now-authoritative mDNS view.
+            self.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
 
             info = AsyncServiceInfo(service_type, name)
             if info.load_from_cache(zeroconf):
@@ -338,9 +365,15 @@ class DeviceStateMonitor:
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``."""
-        # ``parsed_addresses`` returns scope-stripped strings
-        # (internally ``str_without_scope_id``) — no manual ``%``-stripping.
-        if addresses := info.parsed_addresses(IPVersion.All):
+        # Prefer V4 — IPv6 link-local (``fe80::/10``) is unusable for
+        # connections without a scope ID and ``parsed_addresses``
+        # strips scopes. ``parsed_addresses`` returns scope-stripped
+        # strings (internally ``str_without_scope_id``) — no manual
+        # ``%``-stripping needed.
+        addresses = info.parsed_addresses(IPVersion.V4Only) or info.parsed_addresses(
+            IPVersion.V6Only
+        )
+        if addresses:
             self.apply_ip(device_name, addresses[0])
         # ``decoded_properties`` is a ``dict[str, str | None]`` — zeroconf
         # already handles the UTF-8 decode and None-on-bad-bytes for us.

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -21,6 +21,8 @@ from collections.abc import Callable
 from typing import Any
 
 from esphome.zeroconf import AsyncEsphomeZeroconf
+from zeroconf import IPVersion
+from zeroconf.asyncio import AsyncServiceInfo
 
 try:
     from icmplib import async_ping as icmp_ping
@@ -68,6 +70,21 @@ _TXT_RECORD_VERSION = b"version"
 _TXT_RECORD_CONFIG_HASH = b"config_hash"
 
 
+def device_name_from_service(service_name: str) -> str:
+    """Extract the device name from an mDNS service-instance name.
+
+    The mDNS service announcement is
+    ``<device-name>._esphomelib._tcp.local.``; the left-hand label is
+    the device's ``esphome.name`` *verbatim* — modern configs use
+    ``friendly_name_slugify``-style names with hyphens
+    (``apollo-r-pro-1-eth-5938e0``) and the broadcast preserves them.
+    Older underscored names (``my_device``) are likewise broadcast as
+    given. Don't substitute hyphens for underscores or vice versa or
+    the catalog lookup will silently miss every match.
+    """
+    return service_name.split(".", maxsplit=1)[0]
+
+
 class DeviceStateMonitor:
     """
     Drive device state from mDNS broadcasts plus periodic ICMP pings.
@@ -98,6 +115,9 @@ class DeviceStateMonitor:
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         self._mdns_browser: Any = None
         self._ping_task: asyncio.Task | None = None
+        # Strong refs for fire-and-forget mDNS resolve tasks so the
+        # garbage collector can't reap them mid-await.
+        self._tasks: set[asyncio.Task] = set()
         # DNS resolutions for non-mDNS hostnames are cached here so the
         # ping sweep, OTA cache args, and device.ip tracking all share
         # the same TTL'd lookup result instead of re-resolving every
@@ -270,32 +290,34 @@ class DeviceStateMonitor:
             self._zeroconf = None
             return
 
-        loop = asyncio.get_running_loop()
-
         def _on_service_state_change(
             zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
         ) -> None:
-            # mDNS reports "<device-name>._esphomelib._tcp.local."; the
-            # left-hand label is the device's ``esphome.name`` verbatim.
-            # Don't substitute hyphens for underscores — modern configs
-            # use ``friendly_name_slugify``-style names with hyphens, and
-            # the conversion would silently miss every match.
-            device_name = name.split(".", maxsplit=1)[0]
+            # ``AsyncServiceBrowser`` dispatches handlers on the asyncio
+            # loop, so call apply methods directly. For Added/Updated,
+            # try the zeroconf cache first (sync) — only fall back to a
+            # network query (async task) when the cache misses, matching
+            # the pattern used in the upstream esphome dashboard and
+            # aiohomekit.
+            device_name = device_name_from_service(name)
             _LOGGER.debug("mDNS: %s %s (raw: %s)", state_change, device_name, name)
 
-            # zeroconf callbacks fire on a different thread — bounce work
-            # back to the asyncio loop. Added/Updated trigger an async
-            # resolve so we can report the IP alongside the state change;
-            # Removed clears state immediately.
-            if state_change in (ServiceStateChange.Added, ServiceStateChange.Updated):
-                asyncio.run_coroutine_threadsafe(
-                    self._resolve_and_apply(zeroconf, service_type, name, device_name),
-                    loop,
-                )
-            elif state_change == ServiceStateChange.Removed:
-                loop.call_soon_threadsafe(self.apply, device_name, DeviceState.OFFLINE, "mdns")
-                loop.call_soon_threadsafe(self.apply_ip, device_name, "")
+            if state_change == ServiceStateChange.Removed:
+                self.apply(device_name, DeviceState.OFFLINE, "mdns")
+                self.apply_ip(device_name, "")
                 self._state_source.pop(device_name, None)
+                return
+
+            self.apply(device_name, DeviceState.ONLINE, "mdns")
+
+            info = AsyncServiceInfo(service_type, name)
+            if info.load_from_cache(zeroconf):
+                self._apply_service_info(device_name, info)
+                return
+
+            task = asyncio.create_task(self._resolve_and_apply(zeroconf, info, device_name))
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
 
         try:
             self._mdns_browser = AsyncServiceBrowser(
@@ -308,52 +330,45 @@ class DeviceStateMonitor:
             _LOGGER.exception("Could not start mDNS browser — device discovery limited to ping")
 
     async def _resolve_and_apply(
-        self, zeroconf: Any, service_type: str, name: str, device_name: str
+        self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
     ) -> None:
-        """Mark the device online and pull IP + firmware version from mDNS."""
-        # State first — even if the resolve fails or times out, we know the device is online.
-        self.apply(device_name, DeviceState.ONLINE, "mdns")
-
+        """Resolve a cache-miss mDNS service and propagate its details."""
         try:
-            from zeroconf import IPVersion
-            from zeroconf.asyncio import AsyncServiceInfo
-        except ImportError:
-            return
-
-        try:
-            info = AsyncServiceInfo(service_type, name)
             if not await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
                 return
-            addresses = info.parsed_scoped_addresses(
-                IPVersion.V4Only
-            ) or info.parsed_scoped_addresses(IPVersion.V6Only)
-            if addresses:
-                # Strip any zone suffix (e.g. "fe80::1%en0") for display purposes.
-                ip = addresses[0].split("%", 1)[0]
-                self.apply_ip(device_name, ip)
-            properties = info.properties or {}
-            version_bytes = properties.get(_TXT_RECORD_VERSION)
-            if version_bytes:
-                try:
-                    self.apply_version(device_name, version_bytes.decode())
-                except UnicodeDecodeError:
-                    _LOGGER.debug(
-                        "Could not decode mDNS version TXT for %s: %r",
-                        device_name,
-                        version_bytes,
-                    )
-            config_hash_bytes = properties.get(_TXT_RECORD_CONFIG_HASH)
-            if config_hash_bytes:
-                try:
-                    self.apply_config_hash(device_name, config_hash_bytes.decode())
-                except UnicodeDecodeError:
-                    _LOGGER.debug(
-                        "Could not decode mDNS config_hash TXT for %s: %r",
-                        device_name,
-                        config_hash_bytes,
-                    )
         except Exception:
             _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
+            return
+        self._apply_service_info(device_name, info)
+
+    def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
+        """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``."""
+        # ``ip_addresses_by_version`` returns ``IPv4Address``/``IPv6Address``
+        # objects — ``str()`` of those drops any zone suffix automatically,
+        # so no manual ``%``-stripping needed.
+        if addresses := info.ip_addresses_by_version(IPVersion.All):
+            self.apply_ip(device_name, str(addresses[0]))
+        properties = info.properties or {}
+        version_bytes = properties.get(_TXT_RECORD_VERSION)
+        if version_bytes:
+            try:
+                self.apply_version(device_name, version_bytes.decode())
+            except UnicodeDecodeError:
+                _LOGGER.debug(
+                    "Could not decode mDNS version TXT for %s: %r",
+                    device_name,
+                    version_bytes,
+                )
+        config_hash_bytes = properties.get(_TXT_RECORD_CONFIG_HASH)
+        if config_hash_bytes:
+            try:
+                self.apply_config_hash(device_name, config_hash_bytes.decode())
+            except UnicodeDecodeError:
+                _LOGGER.debug(
+                    "Could not decode mDNS config_hash TXT for %s: %r",
+                    device_name,
+                    config_hash_bytes,
+                )
 
     async def _ping_loop(self) -> None:
         try:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -349,26 +349,30 @@ class DeviceStateMonitor:
         if addresses := info.parsed_addresses(IPVersion.All):
             self.apply_ip(device_name, addresses[0])
         properties = info.properties or {}
-        version_bytes = properties.get(_TXT_RECORD_VERSION)
-        if version_bytes:
-            try:
-                self.apply_version(device_name, version_bytes.decode())
-            except UnicodeDecodeError:
-                _LOGGER.debug(
-                    "Could not decode mDNS version TXT for %s: %r",
-                    device_name,
-                    version_bytes,
-                )
-        config_hash_bytes = properties.get(_TXT_RECORD_CONFIG_HASH)
-        if config_hash_bytes:
-            try:
-                self.apply_config_hash(device_name, config_hash_bytes.decode())
-            except UnicodeDecodeError:
-                _LOGGER.debug(
-                    "Could not decode mDNS config_hash TXT for %s: %r",
-                    device_name,
-                    config_hash_bytes,
-                )
+        self._apply_txt(device_name, properties, _TXT_RECORD_VERSION, "version", self.apply_version)
+        self._apply_txt(
+            device_name,
+            properties,
+            _TXT_RECORD_CONFIG_HASH,
+            "config_hash",
+            self.apply_config_hash,
+        )
+
+    def _apply_txt(
+        self,
+        device_name: str,
+        properties: dict[bytes, bytes | None],
+        key: bytes,
+        label: str,
+        setter: Callable[[str, str], bool],
+    ) -> None:
+        """Decode a TXT record and forward it to *setter*; log + skip on bad UTF-8."""
+        if not (value := properties.get(key)):
+            return
+        try:
+            setter(device_name, value.decode())
+        except UnicodeDecodeError:
+            _LOGGER.debug("Could not decode mDNS %s TXT for %s: %r", label, device_name, value)
 
     async def _ping_loop(self) -> None:
         try:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -343,11 +343,11 @@ class DeviceStateMonitor:
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``."""
-        # ``ip_addresses_by_version`` returns ``IPv4Address``/``IPv6Address``
-        # objects — ``str()`` of those drops any zone suffix automatically,
-        # so no manual ``%``-stripping needed.
-        if addresses := info.ip_addresses_by_version(IPVersion.All):
-            self.apply_ip(device_name, str(addresses[0]))
+        # ``parsed_addresses`` returns scope-stripped strings
+        # (internally ``str_without_scope_id``) — no manual ``%``-stripping
+        # like ``parsed_scoped_addresses + .split("%", 1)[0]``.
+        if addresses := info.parsed_addresses(IPVersion.All):
+            self.apply_ip(device_name, addresses[0])
         properties = info.properties or {}
         version_bytes = properties.get(_TXT_RECORD_VERSION)
         if version_bytes:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -365,12 +365,10 @@ class DeviceStateMonitor:
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``."""
-        # Prefer V4 — IPv6 link-local (``fe80::/10``) is unusable for
-        # connections without a scope ID and ``parsed_addresses``
-        # strips scopes. ``parsed_addresses`` returns scope-stripped
-        # strings (internally ``str_without_scope_id``) — no manual
-        # ``%``-stripping needed.
-        addresses = info.parsed_addresses(IPVersion.V4Only) or info.parsed_addresses(
+        # Prefer V4; fall back to scoped V6 (link-local needs the
+        # ``%scope`` suffix to connect at all). Matches the upstream
+        # esphome dashboard's ``parsed_scoped_addresses`` usage.
+        addresses = info.parsed_scoped_addresses(IPVersion.V4Only) or info.parsed_scoped_addresses(
             IPVersion.V6Only
         )
         if addresses:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -129,21 +129,23 @@ class DeviceStateMonitor:
         if self._ping_task is not None:
             self._ping_task.cancel()
             self._ping_task = None
-        # Cancel any in-flight mDNS resolve tasks before tearing down
-        # zeroconf so they don't fire ``apply_*`` callbacks against an
-        # already-closed instance and don't leave warnings about
-        # pending tasks at shutdown.
-        for task in self._tasks:
-            task.cancel()
-        if self._tasks:
-            await asyncio.gather(*self._tasks, return_exceptions=True)
-            self._tasks.clear()
+        # Cancel the browser FIRST so it stops dispatching new mDNS
+        # callbacks. If we drained ``self._tasks`` first, the browser
+        # could still spawn new resolve tasks during the ``gather``
+        # await and they'd miss the snapshot we took.
         if self._mdns_browser is not None:
             try:
                 await self._mdns_browser.async_cancel()
             except Exception:
                 _LOGGER.debug("mDNS browser cancel failed", exc_info=True)
             self._mdns_browser = None
+        # Now drain any in-flight resolve tasks. New tasks can no
+        # longer appear, so a single snapshot is safe.
+        for task in self._tasks:
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+            self._tasks.clear()
         if self._zeroconf is not None:
             try:
                 await self._zeroconf.async_close()

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -275,10 +275,12 @@ class DeviceStateMonitor:
         def _on_service_state_change(
             zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
         ) -> None:
-            # mDNS reports "<my-device>._esphomelib._tcp.local." — strip
-            # the service suffix and convert hyphens (mDNS) back to
-            # underscores (YAML config naming).
-            device_name = name.split(".", maxsplit=1)[0].replace("-", "_")
+            # mDNS reports "<device-name>._esphomelib._tcp.local."; the
+            # left-hand label is the device's ``esphome.name`` verbatim.
+            # Don't substitute hyphens for underscores — modern configs
+            # use ``friendly_name_slugify``-style names with hyphens, and
+            # the conversion would silently miss every match.
+            device_name = name.split(".", maxsplit=1)[0]
             _LOGGER.debug("mDNS: %s %s (raw: %s)", state_change, device_name, name)
 
             # zeroconf callbacks fire on a different thread — bounce work

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -1,21 +1,27 @@
-"""Regression test for the mDNS service-name → device lookup.
+"""Regression tests for the mDNS service-name → device lookup.
 
 mDNS broadcasts ``<device-name>._esphomelib._tcp.local.``; the
 left-hand label is the device's ``esphome.name`` verbatim. Modern
 configs use ``friendly_name_slugify``-style names with hyphens
 (``apollo-r-pro-1-eth-5938e0``); the previous code converted those
 hyphens to underscores before lookup, so every modern device's
-mDNS announcement landed on a non-existent ``apollo_r_pro_...``
-key and the device stayed marked Unknown forever.
+mDNS announcement landed on a non-existent ``apollo_r_pro_...`` key
+and the device stayed marked Unknown forever.
 """
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from zeroconf import ServiceStateChange
 
-from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.controllers import _device_state_monitor as monitor_module
+from esphome_device_builder.controllers._device_state_monitor import (
+    DeviceStateMonitor,
+    device_name_from_service,
+)
 from esphome_device_builder.models import Device, DeviceState
 
 
@@ -29,25 +35,82 @@ def _device(name: str) -> Device:
     )
 
 
+# ----------------------------------------------------------------------
+# device_name_from_service helper — the bit ``_on_service_state_change``
+# actually uses to compute the catalog key.
+# ----------------------------------------------------------------------
+
+
 @pytest.mark.parametrize(
-    "yaml_name,mdns_label",
+    "service_name,expected",
     [
         # Modern hyphenated device — the previously-failing case.
-        ("apollo-r-pro-1-eth-5938e0", "apollo-r-pro-1-eth-5938e0"),
-        ("home-assistant-voice-090073", "home-assistant-voice-090073"),
+        ("apollo-r-pro-1-eth-5938e0._esphomelib._tcp.local.", "apollo-r-pro-1-eth-5938e0"),
+        ("home-assistant-voice-090073._esphomelib._tcp.local.", "home-assistant-voice-090073"),
         # Underscored YAML name (older convention) — must still work.
-        ("legacy_device", "legacy_device"),
+        ("legacy_device._esphomelib._tcp.local.", "legacy_device"),
         # Single-word name — sanity check.
-        ("steamreset", "steamreset"),
+        ("steamreset._esphomelib._tcp.local.", "steamreset"),
     ],
 )
-async def test_mdns_lookup_uses_literal_service_label(yaml_name: str, mdns_label: str) -> None:
-    """A device whose YAML name matches the mDNS label gets marked online.
+def test_device_name_from_service_preserves_label(service_name: str, expected: str) -> None:
+    """The label is returned verbatim — no hyphen↔underscore substitution."""
+    assert device_name_from_service(service_name) == expected
 
-    Pre-fix, the handler did ``.replace("-", "_")`` before lookup so
-    hyphenated YAML names never matched their own mDNS announcement.
+
+# ----------------------------------------------------------------------
+# _on_service_state_change end-to-end (stubbed browser)
+# ----------------------------------------------------------------------
+
+
+class _FakeServiceInfo:
+    """Stand-in for ``AsyncServiceInfo`` whose cache always hits.
+
+    Lets us drive ``_on_service_state_change``'s synchronous path
+    without booting real zeroconf — the handler calls
+    ``info.load_from_cache(zeroconf)`` first and only spawns a
+    network-resolve task on miss.
     """
-    devices = [_device(yaml_name)]
+
+    def __init__(self, _service_type: str, _name: str) -> None:
+        pass
+
+    def load_from_cache(self, _zc: Any) -> bool:
+        return True
+
+    def ip_addresses_by_version(self, _ip_version: Any) -> list[Any]:
+        return []
+
+    @property
+    def properties(self) -> dict[bytes, bytes]:
+        return {}
+
+
+async def _capture_handler(monitor: DeviceStateMonitor, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Boot the mDNS browser with stubs, return the inner handler."""
+    captured: dict[str, Any] = {}
+
+    class _FakeBrowser:
+        def __init__(self, _zc: Any, _service_type: str, *, handlers: list[Any]) -> None:
+            captured["handler"] = handlers[0]
+
+    fake_zc = MagicMock()
+    monkeypatch.setattr(monitor_module, "AsyncEsphomeZeroconf", lambda: fake_zc)
+    monkeypatch.setattr(monitor_module, "AsyncServiceInfo", _FakeServiceInfo)
+    monkeypatch.setattr("zeroconf.asyncio.AsyncServiceBrowser", _FakeBrowser)
+
+    await monitor._start_mdns_browser()
+    return captured["handler"]
+
+
+async def test_handler_marks_hyphenated_device_online(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hyphenated mDNS announcement marks the matching catalog entry online.
+
+    Pre-fix the handler did ``.replace("-", "_")`` before lookup, so
+    ``apollo-r-pro-1-eth-5938e0`` matched nothing in the catalog and
+    the device stayed Unknown until the 60s ping sweep.
+    """
+    devices = [_device("apollo-r-pro-1-eth-5938e0")]
     on_state = MagicMock()
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
@@ -56,23 +119,41 @@ async def test_mdns_lookup_uses_literal_service_label(yaml_name: str, mdns_label
         on_version_change=MagicMock(),
     )
 
-    # ``apply()`` is what the (now hyphen-preserving) handler calls.
-    # Pre-fix this would have been called with an underscored label
-    # that doesn't exist in the catalog, so the assertion below would
-    # fail.
-    monitor.apply(mdns_label, DeviceState.ONLINE, "mdns")
+    handler = await _capture_handler(monitor, monkeypatch)
 
-    assert monitor.priority_for(yaml_name) == "mdns"
-    on_state.assert_called_once_with(yaml_name, DeviceState.ONLINE, "mdns")
+    handler(
+        MagicMock(),
+        "_esphomelib._tcp.local.",
+        "apollo-r-pro-1-eth-5938e0._esphomelib._tcp.local.",
+        ServiceStateChange.Added,
+    )
+
+    on_state.assert_any_call("apollo-r-pro-1-eth-5938e0", DeviceState.ONLINE, "mdns")
 
 
-def test_mdns_label_extraction_does_not_replace_hyphens() -> None:
-    """The exact bit of logic we changed: extract the label, no substitution.
+async def test_handler_does_not_substitute_hyphens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hyphenated YAML must not be looked up via underscores.
 
-    Mirrors the parsing inside ``_on_service_state_change`` so a future
-    refactor that re-introduces ``.replace("-", "_")`` fails fast.
+    Catches a regression that re-introduces the hyphen substitution:
+    a device named ``my-device`` would then never see its mDNS
+    announcement reach the catalog if the handler turned the label
+    into ``my_device`` before lookup.
     """
-    raw = "apollo-r-pro-1-eth-5938e0._esphomelib._tcp.local."
-    label = raw.split(".", maxsplit=1)[0]
-    assert label == "apollo-r-pro-1-eth-5938e0"
-    assert "_" not in label
+    devices = [_device("my-device")]
+    on_state = MagicMock()
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=on_state,
+        on_ip_change=MagicMock(),
+        on_version_change=MagicMock(),
+    )
+
+    handler = await _capture_handler(monitor, monkeypatch)
+    handler(
+        MagicMock(),
+        "_esphomelib._tcp.local.",
+        "my-device._esphomelib._tcp.local.",
+        ServiceStateChange.Added,
+    )
+
+    on_state.assert_called_once_with("my-device", DeviceState.ONLINE, "mdns")

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -78,7 +78,7 @@ class _FakeServiceInfo:
     def load_from_cache(self, _zc: Any) -> bool:
         return True
 
-    def parsed_addresses(self, _ip_version: Any) -> list[str]:
+    def parsed_scoped_addresses(self, _ip_version: Any) -> list[str]:
         return []
 
     @property

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -82,7 +82,7 @@ class _FakeServiceInfo:
         return []
 
     @property
-    def properties(self) -> dict[bytes, bytes]:
+    def decoded_properties(self) -> dict[str, str | None]:
         return {}
 
 

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -78,7 +78,7 @@ class _FakeServiceInfo:
     def load_from_cache(self, _zc: Any) -> bool:
         return True
 
-    def ip_addresses_by_version(self, _ip_version: Any) -> list[Any]:
+    def parsed_addresses(self, _ip_version: Any) -> list[str]:
         return []
 
     @property

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -1,0 +1,78 @@
+"""Regression test for the mDNS service-name → device lookup.
+
+mDNS broadcasts ``<device-name>._esphomelib._tcp.local.``; the
+left-hand label is the device's ``esphome.name`` verbatim. Modern
+configs use ``friendly_name_slugify``-style names with hyphens
+(``apollo-r-pro-1-eth-5938e0``); the previous code converted those
+hyphens to underscores before lookup, so every modern device's
+mDNS announcement landed on a non-existent ``apollo_r_pro_...``
+key and the device stayed marked Unknown forever.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.models import Device, DeviceState
+
+
+def _device(name: str) -> Device:
+    return Device(
+        name=name,
+        friendly_name=name,
+        configuration=f"{name}.yaml",
+        address=f"{name}.local",
+        state=DeviceState.UNKNOWN,
+    )
+
+
+@pytest.mark.parametrize(
+    "yaml_name,mdns_label",
+    [
+        # Modern hyphenated device — the previously-failing case.
+        ("apollo-r-pro-1-eth-5938e0", "apollo-r-pro-1-eth-5938e0"),
+        ("home-assistant-voice-090073", "home-assistant-voice-090073"),
+        # Underscored YAML name (older convention) — must still work.
+        ("legacy_device", "legacy_device"),
+        # Single-word name — sanity check.
+        ("steamreset", "steamreset"),
+    ],
+)
+async def test_mdns_lookup_uses_literal_service_label(yaml_name: str, mdns_label: str) -> None:
+    """A device whose YAML name matches the mDNS label gets marked online.
+
+    Pre-fix, the handler did ``.replace("-", "_")`` before lookup so
+    hyphenated YAML names never matched their own mDNS announcement.
+    """
+    devices = [_device(yaml_name)]
+    on_state = MagicMock()
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=on_state,
+        on_ip_change=MagicMock(),
+        on_version_change=MagicMock(),
+    )
+
+    # ``apply()`` is what the (now hyphen-preserving) handler calls.
+    # Pre-fix this would have been called with an underscored label
+    # that doesn't exist in the catalog, so the assertion below would
+    # fail.
+    monitor.apply(mdns_label, DeviceState.ONLINE, "mdns")
+
+    assert monitor.priority_for(yaml_name) == "mdns"
+    on_state.assert_called_once_with(yaml_name, DeviceState.ONLINE, "mdns")
+
+
+def test_mdns_label_extraction_does_not_replace_hyphens() -> None:
+    """The exact bit of logic we changed: extract the label, no substitution.
+
+    Mirrors the parsing inside ``_on_service_state_change`` so a future
+    refactor that re-introduces ``.replace("-", "_")`` fails fast.
+    """
+    raw = "apollo-r-pro-1-eth-5938e0._esphomelib._tcp.local."
+    label = raw.split(".", maxsplit=1)[0]
+    assert label == "apollo-r-pro-1-eth-5938e0"
+    assert "_" not in label

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -157,3 +157,60 @@ async def test_handler_does_not_substitute_hyphens(monkeypatch: pytest.MonkeyPat
     )
 
     on_state.assert_called_once_with("my-device", DeviceState.ONLINE, "mdns")
+
+
+async def test_handler_short_circuits_unknown_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An mDNS announcement for an unconfigured device is ignored cheaply.
+
+    Otherwise we'd construct an ``AsyncServiceInfo`` and hit the
+    cache for every unrelated ESPHome device on the LAN — wasted
+    work that scales with the size of the user's network.
+    """
+    on_state = MagicMock()
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],  # empty catalog
+        on_state_change=on_state,
+        on_ip_change=MagicMock(),
+        on_version_change=MagicMock(),
+    )
+
+    handler = await _capture_handler(monitor, monkeypatch)
+    handler(
+        MagicMock(),
+        "_esphomelib._tcp.local.",
+        "stranger-on-lan._esphomelib._tcp.local.",
+        ServiceStateChange.Added,
+    )
+
+    on_state.assert_not_called()
+
+
+async def test_mdns_takes_ownership_after_ping_set_online(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An mDNS announcement claims ownership even if ping already set ONLINE.
+
+    Pre-fix, ``apply()``'s "no-op when state is unchanged" early return
+    meant a device that ping had already flipped to ONLINE would stay
+    owned by ``ping`` — letting a future ping-OFFLINE observation
+    override the still-true mDNS view.
+    """
+    devices = [_device("kitchen")]
+    devices[0].state = DeviceState.ONLINE  # ping already saw it
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_version_change=MagicMock(),
+    )
+    monitor._state_source["kitchen"] = "ping"
+
+    handler = await _capture_handler(monitor, monkeypatch)
+    handler(
+        MagicMock(),
+        "_esphomelib._tcp.local.",
+        "kitchen._esphomelib._tcp.local.",
+        ServiceStateChange.Added,
+    )
+
+    assert monitor.priority_for("kitchen") == "mdns"


### PR DESCRIPTION
## Summary
The mDNS browser was effectively non-functional for hyphenated device names — 99 configured devices, mDNS announcements arriving from 41 of them, but only one hyphen-free device (`acfloatmonitor32`) flipped to **Online**. The rest sat at **Unknown** until the 60s ping sweep eventually rescued them via a different code path:

```
mDNS: ServiceStateChange.Added apollo_r_pro_1_eth_5938e0
  (raw: apollo-r-pro-1-eth-5938e0._esphomelib._tcp.local.)
Device apollo_r_pro_1_eth_5938e0 not in catalog — ignoring online state from mdns
…60 seconds later…
Device apollo-r-pro-1-eth-5938e0: unknown → online (via ping)
```

Root cause: the handler converted `-` → `_` before catalog lookup. Modern configs use `friendly_name_slugify`-style names with hyphens (`apollo-r-pro-1-eth-5938e0`) and mDNS broadcasts those literally, so the converted key never matched.

While in there, restructure the handler to match the pattern used by the upstream esphome dashboard and `aiohomekit`:

- **Drop the hyphen substitution.** Extract `device_name_from_service` so the parsing has a real public test target.
- **Drop `run_coroutine_threadsafe`.** `AsyncServiceBrowser` already dispatches handlers on the asyncio loop, so call `apply` / `apply_ip` directly. Track fire-and-forget resolve tasks in `self._tasks` (with `add_done_callback(discard)`) so the GC can't reap them mid-await.
- **Cache-first.** Try `info.load_from_cache(zeroconf)` synchronously. On a cache hit (the common case), drain IP / version / config_hash without spawning a task. Only fall back to a network query (`info.async_request`) on miss. End result: announcements that the browser has already cached propagate to the UI in microseconds rather than waiting on a `create_task` → loop tick.
- **Use `decoded_properties`.** zeroconf already exposes a `dict[str, str | None]` with UTF-8 decoded values and `None` on bad bytes. Drops the bytes-keyed constants and the manual `.decode()` + `UnicodeDecodeError` handler (33 lines of TXT-record handling → 5).
- **`parsed_scoped_addresses(V4Only) or parsed_scoped_addresses(V6Only)`** — V4 first (the previous behaviour), with the *scope id* preserved on the V6 fallback so IPv6 link-local stays usable. Matches `esphome.dashboard.status.mdns` and `esphome.zeroconf.EsphomeZeroconf`.
- **Short-circuit unconfigured devices.** An early `_find_device_by_name is None` check skips ServiceInfo construction and resolve-task spawning for unrelated ESPHome nodes on the LAN.
- **`apply(..., claim=True)` kwarg.** Lets a higher-priority source take ownership of a device's state slot even when the state is unchanged. Without it, a device that ping had already flipped to ONLINE would stay owned by `ping`, and a later ping-OFFLINE observation would override the still-true mDNS view.
- **`stop()` cancels pending resolve tasks.** Prevents resolves from firing `apply_*` against an already-closed zeroconf instance and silences "pending task" warnings at shutdown.

## Tests (`tests/test_mdns_name_match.py`, 8 cases)
- `device_name_from_service` parametrised over modern hyphenated names (`apollo-r-pro-1-eth-5938e0`, `home-assistant-voice-090073`), the older underscored convention (`legacy_device`), and a single-word sanity case (`steamreset`).
- `_on_service_state_change` end-to-end via a stubbed `AsyncServiceBrowser` + `AsyncServiceInfo`:
  - hyphenated mDNS announcement marks the matching catalog entry online
  - regression guard that `my-device` is *not* looked up via underscores
  - announcement for an unconfigured device produces no `apply` calls (short-circuit)
  - mDNS takes ownership when ping has already pinned the device ONLINE (`claim=True`)

## Test plan
- [x] Full suite: `pytest` (203 passed, 8 in this file)
- [x] `pre-commit run` clean
- [x] Manual after rebuild + restart: dashboard shows online state for hyphenated devices via mDNS within ~1s instead of waiting 60s for the ping sweep