### PR TITLE
Stop ghost-offline / ghost-online state transitions in mDNS, ping, and MQTT

### DIFF
--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -197,6 +197,13 @@ class DeviceMqttMonitor:
         loop = asyncio.get_running_loop()
         while True:
             message = await queue.get()
+            # Retained discover/<name> messages are stale broker cache —
+            # they get delivered immediately on subscribe and would
+            # falsely flip a dead device online until the offline timeout
+            # catches it. Wait for a fresh response to our next discover
+            # publish instead.
+            if getattr(message, "retain", False):
+                continue
             payload = _decode_payload(message.payload)
             if not payload:
                 continue

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -422,11 +422,12 @@ class DeviceStateMonitor:
         if not devices_to_ping:
             return
 
-        _LOGGER.debug(
-            "Pinging %d devices: %s",
-            len(devices_to_ping),
-            ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
-        )
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "Pinging %d devices: %s",
+                len(devices_to_ping),
+                ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
+            )
 
         for i in range(0, len(devices_to_ping), _PING_BATCH_SIZE):
             batch = devices_to_ping[i : i + _PING_BATCH_SIZE]

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -21,8 +21,8 @@ from collections.abc import Callable
 from typing import Any
 
 from esphome.zeroconf import AsyncEsphomeZeroconf
-from zeroconf import IPVersion
-from zeroconf.asyncio import AsyncServiceInfo
+from zeroconf import AddressResolver, IPVersion, ServiceStateChange
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
 try:
     from icmplib import async_ping as icmp_ping
@@ -265,10 +265,6 @@ class DeviceStateMonitor:
         """
         if self._zeroconf is None:
             return None
-        try:
-            from zeroconf import AddressResolver
-        except ImportError:
-            return None
 
         normalized = normalize_hostname(host_name)
         base_name = normalized.partition(".")[0]
@@ -301,13 +297,6 @@ class DeviceStateMonitor:
         return None
 
     async def _start_mdns_browser(self) -> None:
-        try:
-            from zeroconf import ServiceStateChange
-            from zeroconf.asyncio import AsyncServiceBrowser
-        except ImportError:
-            _LOGGER.warning("zeroconf not available — mDNS device discovery disabled")
-            return
-
         try:
             self._zeroconf = AsyncEsphomeZeroconf()
         except Exception:
@@ -420,12 +409,12 @@ class DeviceStateMonitor:
             # fallback can resolve to an unreachable IP on a different
             # subnet and we'd report a phantom OFFLINE for a device
             # that's actually right there.
-            if is_local_hostname(device.address):
-                cached = self.get_cached_addresses(device.address)
-                if cached:
-                    self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-                    self.apply_ip(device.name, cached[0])
-                    continue
+            if is_local_hostname(device.address) and (
+                cached := self.get_cached_addresses(device.address)
+            ):
+                self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
+                self.apply_ip(device.name, cached[0])
+                continue
             devices_to_ping.append(device)
         if not devices_to_ping:
             return

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -256,11 +256,17 @@ class DeviceStateMonitor:
         Returns ``None`` when zeroconf isn't running, the cache misses,
         or the entry has expired. mDNS-only — see
         :meth:`get_cached_dns_addresses` for non-``.local`` hostnames.
+
+        IPv4 addresses come first; IPv6 only fills in when no V4 entry
+        exists. This mirrors ``_apply_service_info`` so callers picking
+        ``addresses[0]`` get the same preference everywhere — IPv4 is
+        better for ping (no scope-ID gymnastics, fewer cross-subnet
+        firewall surprises).
         """
         if self._zeroconf is None:
             return None
         try:
-            from zeroconf import AddressResolver, IPVersion
+            from zeroconf import AddressResolver
         except ImportError:
             return None
 
@@ -270,7 +276,9 @@ class DeviceStateMonitor:
         info = AddressResolver(resolver_name)
         if not info.load_from_cache(self._zeroconf.zeroconf):
             return None
-        addresses = info.parsed_scoped_addresses(IPVersion.All)
+        addresses = info.parsed_scoped_addresses(IPVersion.V4Only) or info.parsed_scoped_addresses(
+            IPVersion.V6Only
+        )
         return addresses or None
 
     def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
@@ -425,7 +433,7 @@ class DeviceStateMonitor:
         _LOGGER.debug(
             "Pinging %d devices: %s",
             len(devices_to_ping),
-            ", ".join(d.name for d in devices_to_ping),
+            ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
         )
 
         for i in range(0, len(devices_to_ping), _PING_BATCH_SIZE):

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -251,17 +251,16 @@ class DeviceStateMonitor:
 
     def get_cached_addresses(self, host_name: str) -> list[str] | None:
         """
-        Return zeroconf-cached IPs for *host_name* without issuing a query.
+        Return all zeroconf-cached IPs for *host_name* without issuing a query.
+
+        Both IPv4 and IPv6 (scoped) entries are included — the OTA
+        address-cache CLI args need every IP we know so the runtime
+        can try them in turn. Callers that want a single best target
+        for, say, ICMP should pick IPv4 first themselves.
 
         Returns ``None`` when zeroconf isn't running, the cache misses,
         or the entry has expired. mDNS-only — see
         :meth:`get_cached_dns_addresses` for non-``.local`` hostnames.
-
-        IPv4 addresses come first; IPv6 only fills in when no V4 entry
-        exists. This mirrors ``_apply_service_info`` so callers picking
-        ``addresses[0]`` get the same preference everywhere — IPv4 is
-        better for ping (no scope-ID gymnastics, fewer cross-subnet
-        firewall surprises).
         """
         if self._zeroconf is None:
             return None
@@ -272,9 +271,7 @@ class DeviceStateMonitor:
         info = AddressResolver(resolver_name)
         if not info.load_from_cache(self._zeroconf.zeroconf):
             return None
-        addresses = info.parsed_scoped_addresses(IPVersion.V4Only) or info.parsed_scoped_addresses(
-            IPVersion.V6Only
-        )
+        addresses = info.parsed_scoped_addresses(IPVersion.All)
         return addresses or None
 
     def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
@@ -413,7 +410,13 @@ class DeviceStateMonitor:
                 cached := self.get_cached_addresses(device.address)
             ):
                 self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-                self.apply_ip(device.name, cached[0])
+                # ``apply_ip`` only carries one IP; prefer V4 so the
+                # device-list display and any ad-hoc ICMP probe both get
+                # the cross-subnet-friendly entry. The CLI cache args
+                # built in ``_build_address_cache_args`` consume every
+                # cached IP separately, so we don't lose V6 reachability
+                # by picking V4 here.
+                self.apply_ip(device.name, _pick_ipv4(cached))
                 continue
             devices_to_ping.append(device)
         if not devices_to_ping:
@@ -473,3 +476,19 @@ class DeviceStateMonitor:
             return
         new_state = DeviceState.ONLINE if result.is_alive else DeviceState.OFFLINE
         self.apply(device.name, new_state, "ping")
+
+
+def _pick_ipv4(addresses: list[str]) -> str:
+    """
+    Return the first IPv4 address in *addresses*, or the first entry overall.
+
+    ``Device.ip`` only carries one IP, so when a host has both V4 and V6
+    we lock onto the V4 entry — it's friendlier for ICMP across subnets
+    and avoids the IPv6 scope-ID gymnastics that ``apply_ip`` consumers
+    aren't prepared for. Callers that need every address (CLI cache args)
+    should iterate the list themselves rather than going through this.
+    """
+    for address in addresses:
+        if "." in address and ":" not in address:
+            return address
+    return addresses[0]

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -29,6 +29,7 @@ try:
 except ImportError:  # pragma: no cover — icmplib is optional
     icmp_ping = None  # type: ignore[assignment]
 
+from ..helpers.hostname import is_local_hostname, normalize_hostname
 from ..models import Device, DeviceState
 from ._dns_cache import DNSCache
 
@@ -263,7 +264,7 @@ class DeviceStateMonitor:
         except ImportError:
             return None
 
-        normalized = host_name.rstrip(".").lower()
+        normalized = normalize_hostname(host_name)
         base_name = normalized.partition(".")[0]
         resolver_name = f"{base_name}.local."
         info = AddressResolver(resolver_name)
@@ -395,20 +396,37 @@ class DeviceStateMonitor:
         if icmp_ping is None:
             return
 
-        # Skip devices already owned by a higher-priority source — pinging
-        # them just to confirm what we already know wastes work and would
-        # be ignored by ``apply()`` anyway.
-        ping_priority = _SOURCE_PRIORITY["ping"]
-        devices_to_ping = [
-            d
-            for d in self._get_devices()
-            if d.address
-            and _SOURCE_PRIORITY.get(self._state_source.get(d.name, "unknown"), 0) <= ping_priority
-        ]
+        # Match the upstream dashboard: only ping devices that aren't
+        # already ONLINE from a higher-priority source. ``OFFLINE`` and
+        # ``UNKNOWN`` devices still get pinged so off-network hosts (no
+        # mDNS reachability) can transition online via DNS + ICMP.
+        devices_to_ping: list[Device] = []
+        for device in self._get_devices():
+            if not device.address or not self._should_ping(device):
+                continue
+            # Zeroconf's cache is authoritative for ``.local`` — if it
+            # has an entry, the device announced via mDNS even when the
+            # ``AsyncServiceBrowser`` ``Added`` callback didn't fire for
+            # us (multicast packet drops, startup race). Claim it as
+            # mDNS-online and skip ping; otherwise the bare-hostname DNS
+            # fallback can resolve to an unreachable IP on a different
+            # subnet and we'd report a phantom OFFLINE for a device
+            # that's actually right there.
+            if is_local_hostname(device.address):
+                cached = self.get_cached_addresses(device.address)
+                if cached:
+                    self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
+                    self.apply_ip(device.name, cached[0])
+                    continue
+            devices_to_ping.append(device)
         if not devices_to_ping:
             return
 
-        _LOGGER.debug("Pinging %d devices", len(devices_to_ping))
+        _LOGGER.debug(
+            "Pinging %d devices: %s",
+            len(devices_to_ping),
+            ", ".join(d.name for d in devices_to_ping),
+        )
 
         for i in range(0, len(devices_to_ping), _PING_BATCH_SIZE):
             batch = devices_to_ping[i : i + _PING_BATCH_SIZE]
@@ -428,13 +446,28 @@ class DeviceStateMonitor:
                     # mDNS owns IP tracking for ``.local`` hosts; only
                     # backfill from DNS for non-mDNS hosts so a stale
                     # DNS result can't clobber the live mDNS value.
-                    if not device.address.rstrip(".").lower().endswith(".local"):
+                    if not is_local_hostname(device.address):
                         self.apply_ip(device.name, target)
                 ping_targets.append((device, target))
             await asyncio.gather(
                 *(self._ping_device(device, target) for device, target in ping_targets),
                 return_exceptions=True,
             )
+
+    def _should_ping(self, device: Device) -> bool:
+        """
+        Decide whether *device* needs an ICMP probe this sweep.
+
+        Mirrors the upstream dashboard's rule: skip the device only when
+        it's already ONLINE *and* a higher-priority source (mDNS / MQTT)
+        owns it. We still ping devices that are OFFLINE or UNKNOWN so an
+        off-network host — one mDNS can't reach because it's on a
+        different subnet — has a path to come online via DNS + ping.
+        """
+        if device.state != DeviceState.ONLINE:
+            return True
+        source = self._state_source.get(device.name, "unknown")
+        return _SOURCE_PRIORITY.get(source, 0) <= _SOURCE_PRIORITY["ping"]
 
     async def _ping_device(self, device: Device, target: str) -> None:
         try:

--- a/esphome_device_builder/controllers/_dns_cache.py
+++ b/esphome_device_builder/controllers/_dns_cache.py
@@ -29,6 +29,8 @@ except ImportError:  # pragma: no cover — icmplib is optional
     NameLookupError = Exception  # type: ignore[assignment, misc]
     async_resolve = None  # type: ignore[assignment]
 
+from ..helpers.hostname import normalize_hostname
+
 _LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_TTL_SECONDS = 120
@@ -105,9 +107,7 @@ class DNSCache:
         self._cache[normalized] = (now + self._ttl, addresses)
         return list(addresses) if addresses else None
 
-    @staticmethod
-    def _normalize(hostname: str) -> str:
-        return hostname.rstrip(".").lower()
+    _normalize = staticmethod(normalize_hostname)
 
     async def _resolve(self, hostname: str) -> list[str] | None:
         """Resolve *hostname* with a ``.local`` → bare-hostname fallback."""

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -27,6 +27,7 @@ from ..helpers.device_yaml import (
     generate_device_yaml,
     parse_platform_from_yaml,
 )
+from ..helpers.hostname import is_local_hostname, normalize_hostname
 from ..helpers.subprocess import create_subprocess_exec
 from ..helpers.yaml import merge_component_yaml, rewrite_esphome_name
 from ..models import (
@@ -952,8 +953,8 @@ def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None
 
     # mDNS hostnames are case-insensitive and may carry a trailing dot;
     # normalise once so the CLI cache key matches what it'll look up.
-    normalized = address.rstrip(".").lower()
-    is_local = normalized.endswith(".local")
+    normalized = normalize_hostname(address)
+    is_local = is_local_hostname(address)
 
     # Preferred source per host type:
     #   .local  → zeroconf cache (mDNS-only, freshest while the browser is alive)

--- a/esphome_device_builder/helpers/hostname.py
+++ b/esphome_device_builder/helpers/hostname.py
@@ -1,0 +1,20 @@
+"""Hostname helpers shared between the DNS cache, ping sweep, and OTA cache args."""
+
+from __future__ import annotations
+
+
+def normalize_hostname(hostname: str) -> str:
+    """
+    Lower-case *hostname* and strip the trailing FQDN dot.
+
+    mDNS / DNS hostnames are case-insensitive and zeroconf often hands
+    us names with a trailing ``.`` ; normalising once means cache keys
+    and ``.local`` checks compare equal regardless of which form the
+    caller passed in.
+    """
+    return hostname.rstrip(".").lower()
+
+
+def is_local_hostname(hostname: str) -> bool:
+    """Return True when *hostname* is an mDNS ``.local`` name (case/dot insensitive)."""
+    return normalize_hostname(hostname).endswith(".local")

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -243,7 +243,7 @@ async def test_ping_sweep_does_not_apply_ip_for_local_hosts(fake_resolver) -> No
     assert ip_changes == []
 
 
-async def test_ping_sweep_rescues_local_device_from_zeroconf_cache(fake_resolver) -> None:
+async def test_ping_sweep_rescues_local_device_from_zeroconf_cache() -> None:
     """A ``.local`` device in zeroconf's cache short-circuits before ping.
 
     Catches the case where the ``AsyncServiceBrowser`` ``Added``

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -8,8 +8,15 @@ from unittest.mock import patch
 
 import pytest
 
-from esphome_device_builder.controllers import _dns_cache as dns_cache_mod
+from esphome_device_builder.controllers import (
+    _device_state_monitor as sm,
+)
+from esphome_device_builder.controllers import (
+    _dns_cache as dns_cache_mod,
+)
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.controllers._dns_cache import DNSCache
+from esphome_device_builder.models import Device, DeviceState
 
 
 @pytest.fixture
@@ -163,8 +170,6 @@ async def test_async_resolve_handles_timeout(fake_resolver) -> None:
 
 
 def _device(**overrides):  # type: ignore[no-untyped-def]
-    from esphome_device_builder.models import Device, DeviceState
-
     base = {
         "name": "kitchen",
         "friendly_name": "Kitchen",
@@ -178,9 +183,6 @@ def _device(**overrides):  # type: ignore[no-untyped-def]
 
 async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
     """A ping sweep populates the DNS cache and pings the resolved IP."""
-    from esphome_device_builder.controllers import _device_state_monitor as sm
-    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-
     devices = [_device()]
     state_changes: list[tuple[str, object, str]] = []
     ip_changes: list[tuple[str, str]] = []
@@ -216,9 +218,6 @@ async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
 
 async def test_ping_sweep_does_not_apply_ip_for_local_hosts(fake_resolver) -> None:
     """``.local`` devices keep their mDNS-owned IP — DNS doesn't write."""
-    from esphome_device_builder.controllers import _device_state_monitor as sm
-    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-
     devices = [_device(address="kitchen.local")]
     ip_changes: list[tuple[str, str]] = []
     monitor = DeviceStateMonitor(
@@ -244,11 +243,50 @@ async def test_ping_sweep_does_not_apply_ip_for_local_hosts(fake_resolver) -> No
     assert ip_changes == []
 
 
+async def test_ping_sweep_rescues_local_device_from_zeroconf_cache(fake_resolver) -> None:
+    """A ``.local`` device in zeroconf's cache short-circuits before ping.
+
+    Catches the case where the ``AsyncServiceBrowser`` ``Added``
+    callback didn't fire for us (multicast packet drop or startup race)
+    but zeroconf's underlying cache has the entry from the periodic
+    PTR queries. Without this rescue the ping sweep falls through to
+    the bare-hostname DNS fallback, which can resolve to an
+    unreachable IP on a different subnet and report a phantom OFFLINE
+    for a device that's actually right there.
+    """
+    devices = [_device(address="winefridge.local", name="winefridge")]
+    state_changes: list[tuple[str, object, str]] = []
+    ip_changes: list[tuple[str, str]] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
+        on_ip_change=lambda n, ip: ip_changes.append((n, ip)),
+    )
+
+    pinged: list[str] = []
+
+    async def fake_ping(target, **_kwargs):  # type: ignore[no-untyped-def]
+        pinged.append(target)
+
+        class _R:
+            is_alive = False
+
+        return _R()
+
+    with (
+        patch.object(monitor, "get_cached_addresses", lambda host: ["192.168.213.11"]),
+        patch.object(sm, "icmp_ping", fake_ping),
+    ):
+        await monitor._ping_sweep()
+
+    assert pinged == []
+    assert state_changes == [("winefridge", DeviceState.ONLINE, "mdns")]
+    assert ip_changes == [("winefridge", "192.168.213.11")]
+    assert monitor.priority_for("winefridge") == "mdns"
+
+
 async def test_ping_sweep_pings_hostname_when_resolution_fails(fake_resolver) -> None:
     """DNS resolution failure → fall back to pinging the hostname."""
-    from esphome_device_builder.controllers import _device_state_monitor as sm
-    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-
     devices = [_device()]
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -97,7 +97,7 @@ async def _capture_handler(monitor: DeviceStateMonitor, monkeypatch: pytest.Monk
     fake_zc = MagicMock()
     monkeypatch.setattr(monitor_module, "AsyncEsphomeZeroconf", lambda: fake_zc)
     monkeypatch.setattr(monitor_module, "AsyncServiceInfo", _FakeServiceInfo)
-    monkeypatch.setattr("zeroconf.asyncio.AsyncServiceBrowser", _FakeBrowser)
+    monkeypatch.setattr(monitor_module, "AsyncServiceBrowser", _FakeBrowser)
 
     await monitor._start_mdns_browser()
     return captured["handler"]

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -387,3 +387,77 @@ def test_ping_can_rescue_after_mdns_offline() -> None:
     monitor._state_source.pop("alpha", None)
     assert monitor.apply("alpha", DeviceState.ONLINE, "ping") is True
     assert transitions[-1] == ("alpha", DeviceState.ONLINE, "ping")
+
+
+# ---------------------------------------------------------------------------
+# DeviceMqttMonitor._listen — retained-message filtering
+# ---------------------------------------------------------------------------
+
+
+async def test_listen_drops_retained_discover_messages() -> None:
+    """A retained ``esphome/discover/<name>`` must not flip the device online.
+
+    Retained messages get delivered the moment we subscribe — they're a
+    snapshot of the device's *last* publish, not proof that it's reachable
+    now. Treating one as an online observation ghost-onlines a dead
+    device until the offline timeout catches up.
+    """
+    import asyncio
+    import contextlib
+    import json
+
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda *_: pytest.fail("retained message should be ignored"),
+        on_ip_change=lambda *_: None,
+    )
+
+    class _RetainedMessage:
+        topic = "esphome/discover/stress-esp32"
+        payload = json.dumps({"name": "stress-esp32", "ip": "10.0.0.1"}).encode()
+        retain = True
+
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(_RetainedMessage())
+
+    listen_task = asyncio.create_task(monitor._listen(queue))
+    # Yield control twice: once for ``queue.get()`` to surface the
+    # message, once for the ``continue`` to loop back to the next get().
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    listen_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await listen_task
+
+
+async def test_listen_processes_fresh_discover_messages() -> None:
+    """A fresh (non-retained) discover message updates state and IP."""
+    import asyncio
+    import contextlib
+    import json
+
+    state_calls: list[tuple[str, DeviceState]] = []
+    ip_calls: list[tuple[str, str]] = []
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda n, s: state_calls.append((n, s)),
+        on_ip_change=lambda n, ip: ip_calls.append((n, ip)),
+    )
+
+    class _FreshMessage:
+        topic = "esphome/discover/kitchen"
+        payload = json.dumps({"name": "kitchen", "ip": "10.0.0.5"}).encode()
+        retain = False
+
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(_FreshMessage())
+
+    listen_task = asyncio.create_task(monitor._listen(queue))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    listen_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await listen_task
+
+    assert state_calls == [("kitchen", DeviceState.ONLINE)]
+    assert ip_calls == [("kitchen", "10.0.0.5")]

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -10,6 +10,9 @@ Covers the parts that don't require a live broker:
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
 from pathlib import Path
 from typing import ClassVar
 
@@ -401,14 +404,22 @@ async def test_listen_drops_retained_discover_messages() -> None:
     snapshot of the device's *last* publish, not proof that it's reachable
     now. Treating one as an online observation ghost-onlines a dead
     device until the offline timeout catches up.
+
+    Synchronisation: queue a retained message followed by a fresh one
+    and only assert after the fresh message's callback fires. That
+    proves ``_listen`` actually drained the queue past the retained
+    entry rather than racing the cancel — no ``sleep(0)`` heuristics.
     """
-    import asyncio
-    import contextlib
-    import json
+    state_calls: list[tuple[str, DeviceState]] = []
+    fresh_seen = asyncio.Event()
+
+    def on_state(name: str, state: DeviceState) -> None:
+        state_calls.append((name, state))
+        fresh_seen.set()
 
     monitor = DeviceMqttMonitor(
         broker=MqttBrokerConfig(host="x"),
-        on_state_change=lambda *_: pytest.fail("retained message should be ignored"),
+        on_state_change=on_state,
         on_ip_change=lambda *_: None,
     )
 
@@ -417,30 +428,40 @@ async def test_listen_drops_retained_discover_messages() -> None:
         payload = json.dumps({"name": "stress-esp32", "ip": "10.0.0.1"}).encode()
         retain = True
 
+    class _FreshMessage:
+        topic = "esphome/discover/kitchen"
+        payload = json.dumps({"name": "kitchen", "ip": "10.0.0.2"}).encode()
+        retain = False
+
     queue: asyncio.Queue = asyncio.Queue()
     await queue.put(_RetainedMessage())
+    await queue.put(_FreshMessage())
 
     listen_task = asyncio.create_task(monitor._listen(queue))
-    # Yield control twice: once for ``queue.get()`` to surface the
-    # message, once for the ``continue`` to loop back to the next get().
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
-    listen_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await listen_task
+    try:
+        await asyncio.wait_for(fresh_seen.wait(), timeout=1.0)
+    finally:
+        listen_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await listen_task
+
+    # Only the fresh message produced a callback — the retained one was dropped.
+    assert state_calls == [("kitchen", DeviceState.ONLINE)]
 
 
 async def test_listen_processes_fresh_discover_messages() -> None:
     """A fresh (non-retained) discover message updates state and IP."""
-    import asyncio
-    import contextlib
-    import json
-
     state_calls: list[tuple[str, DeviceState]] = []
     ip_calls: list[tuple[str, str]] = []
+    seen = asyncio.Event()
+
+    def on_state(name: str, state: DeviceState) -> None:
+        state_calls.append((name, state))
+        seen.set()
+
     monitor = DeviceMqttMonitor(
         broker=MqttBrokerConfig(host="x"),
-        on_state_change=lambda n, s: state_calls.append((n, s)),
+        on_state_change=on_state,
         on_ip_change=lambda n, ip: ip_calls.append((n, ip)),
     )
 
@@ -453,11 +474,12 @@ async def test_listen_processes_fresh_discover_messages() -> None:
     await queue.put(_FreshMessage())
 
     listen_task = asyncio.create_task(monitor._listen(queue))
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
-    listen_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await listen_task
+    try:
+        await asyncio.wait_for(seen.wait(), timeout=1.0)
+    finally:
+        listen_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await listen_task
 
     assert state_calls == [("kitchen", DeviceState.ONLINE)]
     assert ip_calls == [("kitchen", "10.0.0.5")]


### PR DESCRIPTION
## Summary

Three fixes for phantom device state transitions, plus a small refactor.

* **mDNS-reachable devices marked OFFLINE via ping.** When the `AsyncServiceBrowser` `Added` callback misses an announcement (multicast drop, startup race) but zeroconf's underlying cache *does* have the entry, the ping sweep falls through to the bare-hostname DNS fallback, which can resolve to an unreachable IP on a different subnet — reporting a phantom OFFLINE for a device that's right there. `aioesphomeapi-discover` finds these devices instantly because it reads the same cache; we now do the same: consult `get_cached_addresses` for `.local` devices before ping, and if it hits, claim them as mDNS-online and skip the ping.
* **`_should_ping` aligned with upstream.** Only skip pinging when already ONLINE from a higher-priority source. OFFLINE / UNKNOWN devices still get pinged so off-network hosts (different subnet, mDNS unreachable) can come online via DNS + ICMP.
* **Retained MQTT discover messages ghost-onlined dead devices.** A retained `esphome/discover/<name>` from a prior session was delivered immediately on subscribe and flipped a now-dead device to ONLINE for ~10s until the offline timeout caught up. `_listen` now drops `msg.retain=True` messages and waits for a fresh response to our next `esphome/discover` publish.
* **`helpers/hostname` helper.** `address.rstrip(".").lower()` / `.endswith(".local")` was duplicated across `_dns_cache`, `_device_state_monitor`, and `devices`. Centralised into `normalize_hostname` and `is_local_hostname`.

## Test plan

- [x] `pytest tests/` — 212 passing (added 3 new regressions: zeroconf-cache rescue, retained-message drop, fresh-message processing)
- [x] `ruff check` clean
- [x] Verified against a 99-device LAN: ping sweep no longer flips `winefridge`/`athom-tem-hum-sensor-6093f8` to OFFLINE when zeroconf's cache has them
- [x] Verified retained `esphome/discover/<name>` no longer ghost-onlines a powered-off `stress-esp32`