### PR TITLE
Add Codecov coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,4 +87,14 @@ jobs:
         run: |
           # ``--maxfail=5`` keeps CI snappy when something fundamental
           # is broken; ``-q`` keeps the log readable without ``-vv``.
-          pytest -q --maxfail=5 --durations=10
+          pytest -q --maxfail=5 --durations=10 \
+            --cov=esphome_device_builder \
+            --cov-report=xml \
+            --cov-report=term
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          files: ./coverage.xml
+          flags: py${{ matrix.python-version }}
+          fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,13 +97,11 @@ jobs:
           pip install -e '.[test]'
 
       - name: Run pytest
-        run: |
-          # ``--maxfail=5`` keeps CI snappy when something fundamental
-          # is broken; ``-q`` keeps the log readable without ``-vv``.
-          pytest -q --maxfail=5 --durations=10 \
-            --cov=esphome_device_builder \
-            --cov-report=xml \
-            --cov-report=term
+        # Single-line command — Windows runners default to PowerShell,
+        # which doesn't accept bash-style ``\`` line continuation.
+        # ``--maxfail=5`` keeps CI snappy when something fundamental
+        # is broken; ``-q`` keeps the log readable without ``-vv``.
+        run: pytest -q --maxfail=5 --durations=10 --cov=esphome_device_builder --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ESPHome Device Builder Dashboard
 
+[![codecov](https://codecov.io/gh/esphome/device-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/esphome/device-builder)
+
 > **Status:** in active development. Roughly alpha, closing on beta. Issues
 > and feedback welcome — please check existing issues / the
 > [project board](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder-dashboard%22)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+# Codecov config — see https://docs.codecov.com/docs/codecovyml-reference.
+#
+# The test workflow uploads from each Python matrix entry with a
+# ``py<version>`` flag. ``after_n_builds`` makes Codecov wait until
+# all three uploads have arrived before posting a PR status, so the
+# status reflects merged coverage rather than whichever job finished
+# first.
+
+codecov:
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 3
+    wait_for_ci: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary
- Run pytest with coverage in CI and upload XML reports to Codecov from each Python matrix entry (3.12 / 3.13 / 3.14), tagged with a `py<version>` flag.
- Add `codecov.yml` so Codecov waits for all three uploads (`after_n_builds: 3`) before posting the PR status — that way the status reflects merged coverage rather than whichever job finished first.
- Add a Codecov badge to the README.

Tokenless upload via the org's Codecov integration, so no `CODECOV_TOKEN` secret needed. `codecov-action` is SHA-pinned to v6.0.0 per the repo's action-pinning convention.

## Test plan
- [x] CI's `Pytest` jobs each produce `coverage.xml` and the upload step succeeds for all three Python versions.
- [x] Codecov receives merged coverage and posts a single PR status (not three).
- [x] Badge in `README.md` renders coverage % once the first upload from `main` lands.