### PR TITLE
Pass --dashboard to esphome CLI so log colours render in the dashboard

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -508,7 +508,7 @@ class DevicesController:
     ) -> None:
         """Validate a device YAML config. Streams output per-connection."""
         config_path = str(self._db.settings.rel_path(configuration))
-        cmd = [*self._esphome_cmd, "config", config_path]
+        cmd = [*self._esphome_cmd, "--dashboard", "config", config_path]
         await self._stream_subprocess(cmd, client, message_id)
 
     @api_command("devices/logs")
@@ -523,7 +523,7 @@ class DevicesController:
     ) -> None:
         """Stream live device logs. Per-connection, not queued."""
         config_path = str(self._db.settings.rel_path(configuration))
-        cmd = [*self._esphome_cmd, "logs", config_path]
+        cmd = [*self._esphome_cmd, "--dashboard", "logs", config_path]
         if port:
             cmd.extend(["--device", port])
         await self._stream_subprocess(cmd, client, message_id)

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -160,15 +160,21 @@ def _parse_progress(line: str) -> int | None:
 def _verify_esphome_importable(cmd: list[str]) -> tuple[bool, str]:
     """Sanity-check that ``cmd`` can actually import esphome.
 
-    Runs ``cmd --version`` synchronously with a short timeout. Used at
-    backend startup so misconfigured environments (venv missing
-    esphome, wrong sys.executable, broken shim script) surface as a
-    clear log line rather than a cryptic "No module named esphome"
-    output captured during the user's first compile attempt.
+    Runs ``cmd --dashboard --version`` synchronously with a short
+    timeout. Used at backend startup so misconfigured environments
+    (venv missing esphome, wrong sys.executable, broken shim script)
+    surface as a clear log line rather than a cryptic "No module named
+    esphome" output captured during the user's first compile attempt.
+
+    ``--dashboard`` is included in the probe so we also fail fast on
+    an installed ESPHome that doesn't recognise the flag (very old
+    builds): every real job command now passes ``--dashboard``, so a
+    sanity check without it would let a broken pairing slip through to
+    the user's first compile.
     """
     try:
         proc = subprocess.run(  # noqa: S603 — cmd is built from sys.executable, not user input
-            [*cmd, "--version"],
+            [*cmd, "--dashboard", "--version"],
             capture_output=True,
             text=True,
             timeout=15,

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -976,7 +976,17 @@ class FirmwareController:
         }
         # cache_args go before the subcommand — esphome's argparse parses
         # them on the top-level parser, not the per-subcommand one.
-        cmd = [*self._esphome_cmd, *(cache_args or []), cmd_map[job_type], config_path]
+        # ``--dashboard`` flips ESPHome's log formatter into "escape ANSI
+        # as literal text" mode, which survives the colorama strip when
+        # stdout is piped to us; the frontend's ansi-log component then
+        # un-escapes and renders the colours.
+        cmd = [
+            *self._esphome_cmd,
+            "--dashboard",
+            *(cache_args or []),
+            cmd_map[job_type],
+            config_path,
+        ]
         if job_type == JobType.INSTALL:
             # Without --no-logs the CLI tails logs forever after the
             # upload, never returning — the job would never complete.

--- a/tests/test_address_cache.py
+++ b/tests/test_address_cache.py
@@ -209,8 +209,13 @@ def test_command_places_cache_args_before_subcommand() -> None:
     ]
 
 
-def test_command_without_cache_args_unchanged() -> None:
-    """When there are no cache args, the command keeps the dashboard flag."""
+def test_command_includes_dashboard_flag_with_no_cache_args() -> None:
+    """Even without cache args every job command carries ``--dashboard``.
+
+    The flag flips ESPHome's ``CORE.dashboard`` log-formatter mode so
+    ANSI colour codes survive the colorama strip when stdout is piped
+    to us — without it the dashboard log view renders monochrome.
+    """
     controller = _firmware_controller_with(None)
     cmd = controller._build_command(JobType.COMPILE, "kitchen.yaml", "")
     assert cmd == ["esphome", "--dashboard", "compile", "kitchen.yaml"]

--- a/tests/test_address_cache.py
+++ b/tests/test_address_cache.py
@@ -198,6 +198,7 @@ def test_command_places_cache_args_before_subcommand() -> None:
 
     assert cmd == [
         "esphome",
+        "--dashboard",
         "--mdns-address-cache",
         "kitchen.local=192.168.1.50",
         "run",
@@ -209,7 +210,7 @@ def test_command_places_cache_args_before_subcommand() -> None:
 
 
 def test_command_without_cache_args_unchanged() -> None:
-    """When there are no cache args, the command is identical to before."""
+    """When there are no cache args, the command keeps the dashboard flag."""
     controller = _firmware_controller_with(None)
     cmd = controller._build_command(JobType.COMPILE, "kitchen.yaml", "")
-    assert cmd == ["esphome", "compile", "kitchen.yaml"]
+    assert cmd == ["esphome", "--dashboard", "compile", "kitchen.yaml"]

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -147,3 +148,73 @@ async def test_cleanup_kills_running_streams() -> None:
 
     await client.cleanup()
     assert task.cancelled() or task.done()
+
+
+# ---------------------------------------------------------------------------
+# Stream-command construction (the WS handlers route into _stream_subprocess)
+# ---------------------------------------------------------------------------
+
+
+def _make_controller_with_settings(esphome_cmd: list[str]) -> DevicesController:
+    """Stand up a controller far enough to exercise ``stream_logs`` / ``validate_config``."""
+    ctrl = DevicesController.__new__(DevicesController)
+    ctrl._esphome_cmd = esphome_cmd
+    ctrl._db = MagicMock()
+    ctrl._db.settings.rel_path = Path
+    return ctrl
+
+
+async def test_stream_logs_command_includes_dashboard_flag() -> None:
+    """``devices/logs`` invokes esphome with ``--dashboard`` before the subcommand.
+
+    Without the flag ESPHome's ``ESPHomeLogFormatter`` lets ``colorama``
+    strip the ANSI codes when stdout is piped to us — the dashboard log
+    view ends up monochrome. The flag has to land before ``logs``
+    because esphome's argparse only accepts it on the top-level parser.
+    """
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(
+        configuration="kitchen.yaml",
+        port="OTA",
+        client=MagicMock(),
+        message_id="m1",
+    )
+
+    assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA"]]
+
+
+async def test_stream_logs_command_without_port_omits_device_arg() -> None:
+    """No port given → no ``--device`` arg, ``--dashboard`` still present."""
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(configuration="kitchen.yaml", client=MagicMock(), message_id="m2")
+
+    assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml"]]
+
+
+async def test_validate_config_command_includes_dashboard_flag() -> None:
+    """``devices/validate`` invokes ``esphome --dashboard config <yaml>``."""
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.validate_config(configuration="kitchen.yaml", client=MagicMock(), message_id="m3")
+
+    assert captured == [["esphome", "--dashboard", "config", "kitchen.yaml"]]


### PR DESCRIPTION
## Summary

ESPHome's ``ESPHomeLogFormatter`` always emits ANSI SGR codes for log levels, but ``setup_log()`` calls ``colorama.init()`` which strips them when ``stdout.isatty()`` is False — exactly the case when we capture the subprocess output through a pipe. Result: every log line in the dashboard renders as plain monochrome text.

The upstream ESPHome dashboard solves this with the hidden ``--dashboard`` CLI flag: setting ``CORE.dashboard = True`` makes the formatter rewrite every ``\x1b`` to the literal four-char text ``\033`` so colorama can't see them as escapes. The literal form survives the pipe and the frontend recognises both forms.

This PR adds ``--dashboard`` to every invocation:
* compile / upload / install / clean (``firmware._build_command``)
* ``devices/config``
* ``devices/logs``

Plus the startup sanity probe in ``_verify_esphome_importable`` so an old/misconfigured ESPHome that doesn't recognise the flag fails fast at backend startup rather than on the user's first compile.

Paired with frontend PR https://github.com/esphome/device-builder-frontend/pull/47, which extends the ``ansi-log`` regex to match the literal ``\033`` introducer alongside the real ``\x1b``, preserves indent on continuation lines, and carries SGR state across lines so multi-line WARNINGs stay coloured.

## Test plan

- [x] ``pytest tests/`` — 215 passing, including:
  - the renamed address-cache test (``test_command_includes_dashboard_flag_with_no_cache_args``)
  - new stream-command tests covering ``devices/logs`` (with/without port) and ``devices/validate``
- [x] ``ruff check`` clean
- [x] Verified manually: ``INFO`` / ``WARNING`` / ``CONFIG`` lines from a live ``logs`` stream now render with their colours in the dashboard