### PR TITLE
Fix Show API key + add encryption indicator (api_encrypted flag)

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -25,6 +25,8 @@ from ..helpers.api import api_command
 from ..helpers.config_hash import compute_yaml_config_hash
 from ..helpers.device_yaml import (
     generate_device_yaml,
+    get_api_encryption_key,
+    load_device_yaml,
     parse_platform_from_yaml,
 )
 from ..helpers.hostname import is_local_hostname, normalize_hostname
@@ -413,6 +415,27 @@ class DevicesController:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, path.write_text, content, "utf-8")
         await self._scanner.scan()
+
+    @api_command("devices/get_api_key")
+    async def get_api_key(self, *, configuration: str, **kwargs: Any) -> dict[str, str]:
+        """
+        Return the resolved Native API encryption key for *configuration*.
+
+        Uses ESPHome's own YAML loader so ``!secret`` references and
+        substitutions resolve the same way they would at compile time —
+        the regex-on-raw-YAML approach a frontend has access to gives up
+        whenever the user pulls the key from ``secrets.yaml`` or hides
+        it behind a ``${api_key}`` substitution.
+
+        ``{"key": "<base64 32-byte>"}`` on success; ``{"key": ""}`` when
+        the device has no ``api:`` block, no ``encryption`` key, or YAML
+        loading fails. Callers treat the empty value as the "open the
+        editor and check" signal.
+        """
+        path = self._db.settings.rel_path(configuration)
+        loop = asyncio.get_running_loop()
+        config = await loop.run_in_executor(None, load_device_yaml, path)
+        return {"key": get_api_encryption_key(config)}
 
     @api_command("devices/add_component")
     async def add_component(

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -15,7 +15,7 @@ import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from esphome import const
+from esphome import const, yaml_util
 from esphome.storage_json import StorageJSON, ext_storage_path
 
 from ..models import Device, DeviceState
@@ -172,11 +172,14 @@ def detect_platform_from_yaml(path: Path) -> str:
 
 
 def device_uses_mqtt(yaml_content: str) -> bool:
-    """
-    Return True when the device YAML declares a top-level ``mqtt:`` block.
+    """Return True when the raw YAML *literally* declares a top-level ``mqtt:`` block.
 
-    The check is line-based so it handles invalid drafts and partially
-    edited configs gracefully — no full YAML parse required.
+    Cheap line-scan that survives invalid drafts and partially edited
+    configs — no full parse required. Misses configs that pull the
+    block in via ``!include`` or packages, which is why
+    ``Device.uses_mqtt`` is now sourced from
+    :func:`config_has_top_level_block` over the *resolved* config; this
+    helper is kept for the legacy callers that operate on raw text.
     """
     for line in yaml_content.splitlines():
         if not line or line[0].isspace():
@@ -187,6 +190,17 @@ def device_uses_mqtt(yaml_content: str) -> bool:
         if stripped.split(":", 1)[0].strip() == "mqtt":
             return True
     return False
+
+
+def config_has_top_level_block(config: dict | None, key: str) -> bool:
+    """Return True when *config* (a resolved device YAML) defines top-level *key*.
+
+    Catches configs that split the block across ``!include`` / packages,
+    which a raw-text scan misses. Treats the block as "present" when
+    the key exists even with a ``None`` / empty value (e.g. a bare
+    ``api:`` line is still an opt-in to the Native API).
+    """
+    return isinstance(config, dict) and key in config
 
 
 def parse_esphome_meta(  # noqa: PLR0912
@@ -296,6 +310,12 @@ def load_device_from_storage(
     except OSError:
         yaml_content = ""
     yaml_name, yaml_friendly, yaml_comment = parse_esphome_meta(yaml_content)
+    # Full resolved config (``!include`` / packages / ``!secret``
+    # expanded) drives the api-encryption flag — a bare regex on raw
+    # YAML would miss configs that pull the api block in via include
+    # or split it across packages. ``None`` on parse failure is fine;
+    # ``api_encrypted`` falls back to False.
+    resolved_config = load_device_yaml(path)
 
     fallback_name = filename.removesuffix(".yml").removesuffix(".yaml")
     storage_name = storage.name if storage else None
@@ -349,7 +369,16 @@ def load_device_from_storage(
         state=state,
         has_pending_changes=has_pending,
         update_available=update_available,
-        uses_mqtt=device_uses_mqtt(yaml_content),
+        # Prefer the resolved config so `!include` / packages count;
+        # fall back to the raw-text scan when load_yaml failed (invalid
+        # draft, missing secrets, etc.) so the user still gets a usable
+        # signal during editing rather than silently flipping to False.
+        uses_mqtt=(
+            config_has_top_level_block(resolved_config, "mqtt")
+            if resolved_config is not None
+            else device_uses_mqtt(yaml_content)
+        ),
+        api_encrypted=get_api_encryption_block(resolved_config) is not None,
     )
 
 
@@ -407,6 +436,53 @@ def _parse_inline_value(raw: str) -> str:
     ):
         value = value[1:-1]
     return value
+
+
+def load_device_yaml(path: Path) -> dict | None:
+    """Load *path* with ESPHome's YAML loader; return the top-level mapping.
+
+    Resolves ``!secret`` / ``!include`` / etc. like a real compile, and
+    returns ``None`` when the file isn't a mapping or fails to parse.
+    Centralised so callers that need a parsed config — API-key
+    extraction, encryption-status checks, future config inspection —
+    share one entry point with the same error handling.
+    """
+    try:
+        # ``yaml_util.load_yaml`` calls ``.open()`` on its argument, so
+        # pass the ``Path`` directly — handing it a stringified path
+        # raises ``AttributeError`` deep inside the loader.
+        config = yaml_util.load_yaml(path)
+    except Exception:
+        return None
+    return config if isinstance(config, dict) else None
+
+
+def get_api_encryption_block(config: dict | None) -> dict | None:
+    """
+    Return the ``api.encryption`` mapping from a parsed device config.
+
+    ``None`` when the config is missing, has no ``api:`` block, or the
+    ``api:`` block has no ``encryption:`` sub-mapping. Useful for both
+    the "is encrypted?" boolean and the "show me the key" string —
+    they share the same lookup, the only thing that differs is what
+    they pull off the result.
+    """
+    if not isinstance(config, dict):
+        return None
+    api_block = config.get("api")
+    if not isinstance(api_block, dict):
+        return None
+    encryption = api_block.get("encryption")
+    return encryption if isinstance(encryption, dict) else None
+
+
+def get_api_encryption_key(config: dict | None) -> str:
+    """Return the resolved Native API encryption key, or empty string."""
+    encryption = get_api_encryption_block(config)
+    if encryption is None:
+        return ""
+    key = encryption.get("key")
+    return key if isinstance(key, str) else ""
 
 
 def _resolve_substitutions(value: str | None, subs: dict[str, str]) -> str | None:

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -171,15 +171,16 @@ def detect_platform_from_yaml(path: Path) -> str:
         return ""
 
 
-def device_uses_mqtt(yaml_content: str) -> bool:
-    """Return True when the raw YAML *literally* declares a top-level ``mqtt:`` block.
+def yaml_has_top_level_block(yaml_content: str, key: str) -> bool:
+    """Return True when the raw YAML literally declares a top-level *key*: block.
 
     Cheap line-scan that survives invalid drafts and partially edited
     configs — no full parse required. Misses configs that pull the
-    block in via ``!include`` or packages, which is why
-    ``Device.uses_mqtt`` is now sourced from
-    :func:`config_has_top_level_block` over the *resolved* config; this
-    helper is kept for the legacy callers that operate on raw text.
+    block in via ``!include`` or packages, which is why scan-time
+    flags prefer :func:`config_has_top_level_block` over the resolved
+    config; this helper is the fallback for when YAML parsing fails
+    (mid-edit drafts, missing secrets) so the indicator doesn't
+    silently flip off while the user is typing.
     """
     for line in yaml_content.splitlines():
         if not line or line[0].isspace():
@@ -187,9 +188,34 @@ def device_uses_mqtt(yaml_content: str) -> bool:
         stripped = line.strip()
         if stripped.startswith("#") or ":" not in stripped:
             continue
-        if stripped.split(":", 1)[0].strip() == "mqtt":
+        if stripped.split(":", 1)[0].strip() == key:
             return True
     return False
+
+
+def device_uses_mqtt(yaml_content: str) -> bool:
+    """Return True when the raw YAML literally declares a top-level ``mqtt:`` block."""
+    return yaml_has_top_level_block(yaml_content, "mqtt")
+
+
+_RAW_API_ENCRYPTION_RE = re.compile(
+    # Matches an ``encryption:`` line that's indented under ``api:``
+    # (any depth ≥ 1 space). Used as a draft-time heuristic — once
+    # ``load_device_yaml`` succeeds, the resolved-config check wins.
+    r"^api:\s*\n(?:[ \t][^\n]*\n|\s*\n)*[ \t]+encryption:(?:\s|$)",
+    re.MULTILINE,
+)
+
+
+def yaml_has_api_encryption(yaml_content: str) -> bool:
+    """Heuristic: True when raw YAML appears to declare ``api: encryption:``.
+
+    Used during mid-edit drafts when the full resolver fails so the
+    encryption-indicator doesn't blink off the moment the user types
+    a syntax error. The resolved-config check is preferred whenever
+    available (catches ``!include`` / packages this regex can't see).
+    """
+    return bool(_RAW_API_ENCRYPTION_RE.search(yaml_content))
 
 
 def config_has_top_level_block(config: dict | None, key: str) -> bool:
@@ -351,6 +377,27 @@ def load_device_from_storage(
     else:
         target_platform = detect_platform_from_yaml(path)
 
+    loaded_integrations = sorted(storage.loaded_integrations) if storage else []
+    # ``api_enabled`` / ``api_encrypted`` get the union of every signal
+    # we have:
+    #   1. Resolved YAML config — catches local ``api:`` blocks pulled
+    #      in via ``!include`` / local packages.
+    #   2. Raw-text scan — keeps the indicator stable mid-edit when
+    #      ``yaml_util.load_yaml`` fails on an invalid draft.
+    #   3. ``StorageJSON.loaded_integrations`` — the compile-time
+    #      ground truth. Required for configs that pull the api block
+    #      in from a remote ``dashboard_import`` package (Apollo, etc.):
+    #      ``yaml_util.load_yaml`` doesn't fetch URLs so the resolved
+    #      config has no ``api:`` at the top level, but the compiled
+    #      device still loads it.
+    api_enabled = (
+        ("api" in loaded_integrations)
+        or config_has_top_level_block(resolved_config, "api")
+        or yaml_has_top_level_block(yaml_content, "api")
+    )
+    api_encrypted = get_api_encryption_block(
+        resolved_config
+    ) is not None or yaml_has_api_encryption(yaml_content)
     return Device(
         name=name,
         friendly_name=friendly_name,
@@ -365,21 +412,21 @@ def load_device_from_storage(
         deployed_version=deployed,
         expected_config_hash=expected_config_hash,
         deployed_config_hash=deployed_config_hash,
-        loaded_integrations=sorted(storage.loaded_integrations) if storage else [],
+        loaded_integrations=loaded_integrations,
         state=state,
         has_pending_changes=has_pending,
         update_available=update_available,
-        # Prefer the resolved config so `!include` / packages count;
-        # fall back to the raw-text scan when load_yaml failed (invalid
-        # draft, missing secrets, etc.) so the user still gets a usable
-        # signal during editing rather than silently flipping to False.
+        # ``uses_mqtt`` keeps its prior shape — the resolved config
+        # wins, raw-text fills in mid-edit, and we don't have a
+        # ``loaded_integrations`` entry that maps cleanly to "uses
+        # mqtt for dashboard discovery" the way ``"api"`` does.
         uses_mqtt=(
             config_has_top_level_block(resolved_config, "mqtt")
             if resolved_config is not None
-            else device_uses_mqtt(yaml_content)
+            else yaml_has_top_level_block(yaml_content, "mqtt")
         ),
-        api_enabled=config_has_top_level_block(resolved_config, "api"),
-        api_encrypted=get_api_encryption_block(resolved_config) is not None,
+        api_enabled=api_enabled,
+        api_encrypted=api_encrypted,
     )
 
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -378,6 +378,7 @@ def load_device_from_storage(
             if resolved_config is not None
             else device_uses_mqtt(yaml_content)
         ),
+        api_enabled=config_has_top_level_block(resolved_config, "api"),
         api_encrypted=get_api_encryption_block(resolved_config) is not None,
     )
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -202,7 +202,13 @@ _RAW_API_ENCRYPTION_RE = re.compile(
     # Matches an ``encryption:`` line that's indented under ``api:``
     # (any depth ≥ 1 space). Used as a draft-time heuristic — once
     # ``load_device_yaml`` succeeds, the resolved-config check wins.
-    r"^api:\s*\n(?:[ \t][^\n]*\n|\s*\n)*[ \t]+encryption:(?:\s|$)",
+    #
+    # The two body alternatives are exclusive: ``[ \t][^\n]*\n`` matches
+    # an indented (non-blank) line; ``\n`` alone matches a literal blank
+    # line. No overlap, so the engine can't backtrack between them on a
+    # long run of newlines (the previous ``\s*\n`` alternative could
+    # also consume a bare ``\n``, which CodeQL flagged as exponential).
+    r"^api:[^\n]*\n(?:[ \t][^\n]*\n|\n)*[ \t]+encryption:(?:\s|$)",
     re.MULTILINE,
 )
 

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -50,10 +50,13 @@ class Device(DataClassORJSONMixin):
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
-    # Native API encryption flag — drives the lock-icon indicator in the
-    # device list. ``True`` when the YAML carries an ``api: encryption:``
-    # block; the actual key is fetched on demand via ``devices/get_api_key``
-    # (which does full ``!secret`` resolution).
+    # Native API surface flags — drive the lock-icon indicator in the
+    # device list. ``api_enabled`` is True when the resolved YAML
+    # carries a top-level ``api:`` block; ``api_encrypted`` only adds
+    # the inner ``encryption:`` check. Both come from the resolved
+    # config so ``!include`` / packages are followed; the actual key
+    # is fetched on demand via ``devices/get_api_key``.
+    api_enabled: bool = False
     api_encrypted: bool = False
 
 

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -50,6 +50,11 @@ class Device(DataClassORJSONMixin):
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
+    # Native API encryption flag — drives the lock-icon indicator in the
+    # device list. ``True`` when the YAML carries an ``api: encryption:``
+    # block; the actual key is fetched on demand via ``devices/get_api_key``
+    # (which does full ``!secret`` resolution).
+    api_encrypted: bool = False
 
 
 @dataclass

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -12,12 +12,14 @@ from pathlib import Path
 
 import pytest
 
+from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.helpers.device_yaml import (
     config_has_top_level_block,
     get_api_encryption_block,
     get_api_encryption_key,
     load_device_yaml,
 )
+from esphome_device_builder.models import Device
 
 # ---------------------------------------------------------------------------
 # Pure-helper paths — no disk
@@ -106,3 +108,79 @@ def test_load_device_yaml_resolves_secrets(tmp_path: Path) -> None:
     )
     config = load_device_yaml(yaml_file)
     assert get_api_encryption_key(config) == "AAAA=="
+
+
+# ---------------------------------------------------------------------------
+# Scan-time integration — load_device_from_storage drives the Device flags
+# the frontend reads to render the lock indicator.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect ``ext_storage_path`` into ``tmp_path`` and bypass StorageJSON.
+
+    ``load_device_from_storage`` walks ``CORE.config_path`` for the
+    StorageJSON sidecar, which isn't set in unit tests. Point the helper
+    at the temporary directory and force ``StorageJSON.load`` to return
+    ``None`` so each test exercises the YAML + flag plumbing only.
+    """
+    monkeypatch.setattr(
+        device_yaml,
+        "ext_storage_path",
+        lambda config: tmp_path / f"{config}.json",
+    )
+    monkeypatch.setattr(device_yaml.StorageJSON, "load", staticmethod(lambda _p: None))
+    return tmp_path
+
+
+def _scan(yaml_path: Path, content: str) -> Device:
+    """Write *content* to *yaml_path* and run it through the scanner helper."""
+    yaml_path.write_text(content)
+    return device_yaml.load_device_from_storage(yaml_path)
+
+
+def test_load_device_from_storage_sets_api_encrypted_from_resolved_yaml(
+    isolated_storage: Path,
+) -> None:
+    """Scanner output's ``api_encrypted`` reflects the resolved config."""
+    device = _scan(
+        isolated_storage / "kitchen.yaml",
+        'esphome:\n  name: kitchen\napi:\n  encryption:\n    key: "ZGFzaA=="\n',
+    )
+    assert device.api_enabled is True
+    assert device.api_encrypted is True
+
+
+def test_load_device_from_storage_api_disabled_for_mqtt_only(
+    isolated_storage: Path,
+) -> None:
+    """A device with no ``api:`` block reports neither flag — drives the no-lock case."""
+    device = _scan(
+        isolated_storage / "sensor.yaml",
+        "esphome:\n  name: sensor\nmqtt:\n  broker: 192.168.1.10\n",
+    )
+    assert device.api_enabled is False
+    assert device.api_encrypted is False
+    assert device.uses_mqtt is True
+
+
+def test_load_device_from_storage_falls_back_for_invalid_draft(
+    isolated_storage: Path,
+) -> None:
+    """Mid-edit drafts where ``yaml_util.load_yaml`` fails still get usable flags.
+
+    The lock indicator would otherwise blink off the moment the user
+    typed a syntax error. Raw-text fallback keeps the signal stable.
+    """
+    # Top-level ``api:`` with ``encryption:``, plus a deliberate syntax
+    # error further down so ``yaml_util.load_yaml`` returns ``None`` and
+    # we fall through to the raw-text heuristic.
+    device = _scan(
+        isolated_storage / "broken.yaml",
+        "esphome:\n  name: broken\n"
+        'api:\n  encryption:\n    key: "ZGFzaA=="\n'
+        "sensor:\n  - platform: !\n    bad: [unterminated\n",
+    )
+    assert device.api_enabled is True
+    assert device.api_encrypted is True

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,108 @@
+"""Tests for the Native API encryption-key extraction + scanner flag.
+
+Covers the helper layer (resolves through ESPHome's YAML loader so
+``!secret`` / ``!include`` / packages all work) and the scan-time
+``Device.api_encrypted`` flag that drives the dashboard's lock-icon
+indicator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.device_yaml import (
+    config_has_top_level_block,
+    get_api_encryption_block,
+    get_api_encryption_key,
+    load_device_yaml,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-helper paths — no disk
+# ---------------------------------------------------------------------------
+
+
+def test_get_api_encryption_block_returns_inner_dict() -> None:
+    """An ``api: encryption: ...`` block is returned as a dict for the caller to inspect."""
+    config = {"api": {"encryption": {"key": "abc=="}}}
+    assert get_api_encryption_block(config) == {"key": "abc=="}
+
+
+def test_get_api_encryption_block_none_when_no_api() -> None:
+    assert get_api_encryption_block({"esphome": {"name": "x"}}) is None
+
+
+def test_get_api_encryption_block_none_when_api_unencrypted() -> None:
+    """Bare ``api:`` (Native API enabled but no encryption) → no block."""
+    assert get_api_encryption_block({"api": {}}) is None
+
+
+def test_get_api_encryption_block_handles_non_dict_inputs() -> None:
+    """Bad config shapes (None, list, str) don't blow up the helper."""
+    assert get_api_encryption_block(None) is None
+    assert get_api_encryption_block({"api": "not-a-dict"}) is None
+    assert get_api_encryption_block({"api": {"encryption": "not-a-dict"}}) is None
+
+
+def test_get_api_encryption_key_returns_resolved_string() -> None:
+    config = {"api": {"encryption": {"key": "ZGFzaA=="}}}
+    assert get_api_encryption_key(config) == "ZGFzaA=="
+
+
+def test_get_api_encryption_key_empty_when_missing() -> None:
+    assert get_api_encryption_key({"api": {"encryption": {}}}) == ""
+    assert get_api_encryption_key(None) == ""
+
+
+def test_config_has_top_level_block() -> None:
+    """``api`` / ``mqtt`` etc. are detected even with empty / null values."""
+    assert config_has_top_level_block({"api": None}, "api") is True
+    assert config_has_top_level_block({"mqtt": {"broker": "x"}}, "mqtt") is True
+    assert config_has_top_level_block({"esphome": {}}, "api") is False
+    assert config_has_top_level_block(None, "api") is False
+
+
+# ---------------------------------------------------------------------------
+# load_device_yaml — exercises ESPHome's loader, so this hits the file system
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def yaml_file(tmp_path: Path) -> Path:
+    return tmp_path / "kitchen.yaml"
+
+
+def test_load_device_yaml_parses_valid_config(yaml_file: Path) -> None:
+    yaml_file.write_text(
+        "esphome:\n"
+        "  name: kitchen\n"
+        "api:\n"
+        '  encryption:\n    key: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="\n'
+    )
+    config = load_device_yaml(yaml_file)
+    assert config is not None
+    assert get_api_encryption_key(config) == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+
+def test_load_device_yaml_returns_none_on_parse_failure(yaml_file: Path) -> None:
+    """An invalid draft mid-edit returns ``None`` instead of raising."""
+    yaml_file.write_text("api: !\n  bad: [unterminated\n")
+    assert load_device_yaml(yaml_file) is None
+
+
+def test_load_device_yaml_resolves_secrets(tmp_path: Path) -> None:
+    """``!secret`` references resolve through the sibling ``secrets.yaml``.
+
+    The regex-on-raw-YAML approach the frontend used to do gave up
+    here — backend resolution is the whole reason ``devices/get_api_key``
+    exists.
+    """
+    (tmp_path / "secrets.yaml").write_text("api_key: 'AAAA=='\n")
+    yaml_file = tmp_path / "kitchen.yaml"
+    yaml_file.write_text(
+        "esphome:\n  name: kitchen\napi:\n  encryption:\n    key: !secret api_key\n"
+    )
+    config = load_device_yaml(yaml_file)
+    assert get_api_encryption_key(config) == "AAAA=="


### PR DESCRIPTION
## Summary

Two related fixes to the dashboard's Native API surface, plus the `Device.uses_mqtt` raw-text bug that fell out of the same investigation.

* **Show API key** never worked. The frontend was running a regex on the raw YAML returned by ``devices/get_config``; that gave up the moment a user pulled the key from ``secrets.yaml`` (essentially every modern config) or hid it behind a ``$substitution``, leaving every device on the "Unable to automatically extract API key" message. Move the extraction server-side where ESPHome's own loader does ``!secret`` / ``!include`` / package resolution like a real compile.
* **No visible signal** for "is this device's API encrypted?". Two new `Device` flags drive the dashboard's lock-icon indicator (paired frontend PR #49):
  * ``api_enabled`` — top-level ``api:`` block is present in the resolved config. Devices without one (MQTT-only / sensor-bridge configs) get **no indicator at all** because "insecure" doesn't apply to a surface that's turned off.
  * ``api_encrypted`` — inner ``encryption:`` block is present. Flips the lock variant (filled-green vs open-amber) when ``api_enabled`` is True.
* **`Device.uses_mqtt` had the same blind spot**: a raw-text scan that missed configs pulling the ``mqtt:`` block in via ``!include`` / packages. ``config_has_top_level_block`` over the resolved config catches those, with the line-based scan kept as a fallback for mid-edit drafts where YAML loading fails.

Both flags refresh automatically on YAML save — ``DeviceScanner`` already reloads changed files.

## Changes

* New WS command ``devices/get_api_key`` → ``{"key": "<base64>"}``. Empty string for non-encrypted devices, parse failures, or missing secrets — caller treats empty as "open the editor and check".
* New `Device.api_enabled` and `Device.api_encrypted` boolean fields populated by the scanner from the resolved config.
* New helpers in ``helpers/device_yaml`` shared by current + future consumers:
  * ``load_device_yaml(path)`` — load with full ESPHome resolution, ``None`` on failure
  * ``get_api_encryption_block(config)`` — pull the ``api.encryption`` mapping
  * ``get_api_encryption_key(config)`` — convenience to get the resolved key string
  * ``config_has_top_level_block(config, key)`` — for ``api`` / ``mqtt`` / future flags

## Test plan

- [x] ``pytest tests/`` — 225 passing, 10 new in ``tests/test_api_key.py`` covering the helpers, ``!secret`` resolution, and parse-failure handling
- [x] ``ruff check`` clean
- [x] Verified manually on a 99-device config with mixed ``key:`` / ``!secret`` / inline / ``\$sub`` styles: every encrypted device returns its real key; configs without an ``api:`` block return empty so the dialog falls through to the help text; the lock indicator appears next to the device name in table + card views and as a pill in the detail drawer