### PR TITLE
Stop compile actually kills the build (signal the whole process group)

### DIFF
--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 from contextlib import suppress
@@ -155,6 +156,36 @@ def _parse_progress(line: str) -> int | None:
     if 0 <= value <= 100:
         return value
     return None
+
+
+def _signal_process_group(pid: int, sig: int) -> bool:
+    """
+    Send *sig* to the process group of *pid*; return True iff delivered.
+
+    Used to take down the whole esphome → platformio → gcc tree when
+    the user hits Stop. ``proc.terminate()`` / ``proc.kill()`` only
+    signal the direct child (the python esphome process), so the
+    compiler grandchildren keep running and the build effectively
+    ignores the cancel. Pair this with ``start_new_session=True`` at
+    the spawn site so the children share a group with the parent.
+
+    Falls back gracefully:
+    * ``ProcessLookupError`` — the process already exited; nothing to do.
+    * ``PermissionError`` — we lost the right to signal it; treat as a
+      no-op rather than crashing the controller.
+    """
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        return False
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        _LOGGER.warning("Permission denied signalling pgid %d (sig %s)", pgid, sig)
+        return False
+    return True
 
 
 def _verify_esphome_importable(cmd: list[str]) -> tuple[bool, str]:
@@ -678,6 +709,14 @@ class FirmwareController:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 env=env,
+                # Put the whole esphome → platformio → gcc tree in its
+                # own process group so ``_terminate_current_process``
+                # can signal the entire chain, not just the python
+                # parent. Without this, killing the parent leaves the
+                # compiler children orphaned and the build keeps
+                # running until they finish on their own — exactly the
+                # "stop compile doesn't work" symptom.
+                start_new_session=True,
             )
             self._current_process = proc
 
@@ -822,18 +861,22 @@ class FirmwareController:
             await self._persist_jobs()
 
     async def _terminate_current_process(self) -> None:
-        """Send SIGTERM to the running subprocess; escalate if it lingers.
+        """Signal the running subprocess (and its children); escalate if it lingers.
 
         The runner loop is the one that actually finalises the
         ``FirmwareJob`` on exit (so we don't double-write status from
         two coroutines). We only nudge the process here.
+
+        ESPHome forks PlatformIO which forks gcc / esptool / etc. The
+        spawn site uses ``start_new_session=True`` so the whole tree
+        shares a process group; we signal the group instead of just
+        the python parent — without that, the compiler children get
+        orphaned and the build keeps going until they finish.
         """
         proc = self._current_process
         if proc is None or proc.returncode is not None:
             return
-        try:
-            proc.terminate()
-        except ProcessLookupError:
+        if not _signal_process_group(proc.pid, signal.SIGTERM):
             return
         try:
             await asyncio.wait_for(proc.wait(), timeout=_TERMINATE_GRACE_SECONDS)
@@ -843,8 +886,7 @@ class FirmwareController:
                 self._current_job.job_id if self._current_job else "?",
                 _TERMINATE_GRACE_SECONDS,
             )
-            with suppress(ProcessLookupError):
-                proc.kill()
+            _signal_process_group(proc.pid, signal.SIGKILL)
 
     async def _reset_build_env(self, job: FirmwareJob) -> None:
         """

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -167,7 +167,11 @@ def _signal_process_group(pid: int, sig: int) -> bool:
     signal the direct child (the python esphome process), so the
     compiler grandchildren keep running and the build effectively
     ignores the cancel. Pair this with ``start_new_session=True`` at
-    the spawn site so the children share a group with the parent.
+    the spawn site: that makes the spawned process the leader of a
+    new session (and a new process group), and its descendants
+    inherit that group. The dashboard process itself is *not* in the
+    same group — ``killpg(getpgid(spawned_pid), sig)`` therefore
+    targets the build subtree without touching us.
 
     Falls back gracefully:
     * ``ProcessLookupError`` — the process already exited; nothing to do.

--- a/tests/test_firmware_stop.py
+++ b/tests/test_firmware_stop.py
@@ -1,0 +1,154 @@
+"""Stop-button cancellation kills the *whole* esphome compile tree.
+
+Without this, ``proc.terminate()`` / ``proc.kill()`` only signals the
+python esphome parent. PlatformIO + gcc grandchildren get orphaned and
+the build keeps running until they finish on their own — exactly the
+"hit Stop, build kept going" symptom from production.
+
+Drives the regression by spawning a tiny shell script that itself
+spawns a long-running grandchild, calling our ``_terminate_current_process``,
+and asserting both pids are gone shortly after.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.firmware import (
+    FirmwareController,
+    _signal_process_group,
+)
+from esphome_device_builder.helpers.subprocess import create_subprocess_exec
+
+
+def _is_alive(pid: int) -> bool:
+    """Return True if *pid* is still running. Survives EPERM on macOS."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we can't signal it — for our test that
+        # only happens if reused as a system pid (negligible odds).
+        return True
+    return True
+
+
+async def _wait_dead(pid: int, timeout: float = 3.0) -> bool:
+    """Poll until *pid* exits or *timeout* elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _is_alive(pid):
+            return True
+        await asyncio.sleep(0.05)
+    return _is_alive(pid) is False
+
+
+# ---------------------------------------------------------------------------
+# _signal_process_group helper
+# ---------------------------------------------------------------------------
+
+
+def test_signal_process_group_returns_false_for_dead_pid() -> None:
+    """A pid that already exited is treated as 'nothing to signal' — no exception."""
+    # Spawn + wait + reap, then try to signal. The pid is now dead so
+    # ``os.getpgid`` raises ``ProcessLookupError`` and our helper has
+    # to return False rather than propagate.
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])  # noqa: S603
+    proc.wait()
+    assert _signal_process_group(proc.pid, signal.SIGTERM) is False
+
+
+# ---------------------------------------------------------------------------
+# _terminate_current_process — full integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def controller() -> FirmwareController:
+    """Stand up a FirmwareController shell — only the bits termination touches."""
+    ctrl = FirmwareController.__new__(FirmwareController)
+    ctrl._current_process = None  # type: ignore[attr-defined]
+    ctrl._current_job = MagicMock(job_id="test-job")  # type: ignore[attr-defined]
+    return ctrl
+
+
+async def test_terminate_kills_grandchild_via_process_group(
+    controller: FirmwareController,
+) -> None:
+    """Cancel-while-compiling must kill platformio/gcc grandchildren too.
+
+    Mirrors the real failure: ``esphome run`` forks ``platformio`` which
+    forks ``gcc``. ``proc.terminate()`` only hits the direct child, so
+    the toolchain runs on regardless. Group-signalling fixes that.
+    """
+    # Parent spawns a grandchild that traps SIGTERM (so a parent-only
+    # signal would not cascade) and prints its pid for the assertion.
+    script = (
+        "import os, signal, sys, time\n"
+        "p = os.fork()\n"
+        "if p == 0:\n"
+        # Grandchild: trap SIGTERM as no-op, then sleep forever.
+        # Without process-group signalling our terminate path can't
+        # reach it.
+        "    signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "    print(f'GRANDCHILD={os.getpid()}', flush=True)\n"
+        "    time.sleep(60)\n"
+        "    sys.exit(0)\n"
+        "else:\n"
+        # Parent: print its own pid then wait. SIGTERM-traps too so it
+        # only exits when SIGKILL escalates — the controller's grace
+        # window is short enough that the test still completes fast.
+        "    signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "    print(f'PARENT={os.getpid()}', flush=True)\n"
+        "    os.waitpid(p, 0)\n"
+    )
+    proc = await create_subprocess_exec(
+        sys.executable,
+        "-c",
+        script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        start_new_session=True,
+    )
+    controller._current_process = proc  # type: ignore[attr-defined]
+
+    # Read the two pid lines from stdout so we know what to verify.
+    parent_pid: int | None = None
+    grandchild_pid: int | None = None
+    deadline = time.monotonic() + 5.0
+    assert proc.stdout is not None
+    while time.monotonic() < deadline and (parent_pid is None or grandchild_pid is None):
+        line = await asyncio.wait_for(proc.stdout.readline(), timeout=2.0)
+        if not line:
+            break
+        text = line.decode().strip()
+        if text.startswith("PARENT="):
+            parent_pid = int(text.split("=", 1)[1])
+        elif text.startswith("GRANDCHILD="):
+            grandchild_pid = int(text.split("=", 1)[1])
+    assert parent_pid is not None, "child never reported its pid"
+    assert grandchild_pid is not None, "grandchild never reported its pid"
+    assert _is_alive(parent_pid)
+    assert _is_alive(grandchild_pid)
+
+    # Hit Stop. Both pids must die — SIGTERM is ignored, so the
+    # controller's grace window expires and SIGKILL escalates to the
+    # whole process group.
+    await controller._terminate_current_process()
+    await proc.wait()
+
+    assert await _wait_dead(parent_pid), f"parent pid {parent_pid} still alive after stop"
+    grandchild_alive = not await _wait_dead(grandchild_pid)
+    assert not grandchild_alive, (
+        f"grandchild pid {grandchild_pid} still alive after stop — "
+        "process-group signal didn't reach it"
+    )

--- a/tests/test_firmware_stop.py
+++ b/tests/test_firmware_stop.py
@@ -18,6 +18,7 @@ import signal
 import subprocess
 import sys
 import time
+from contextlib import suppress
 from unittest.mock import MagicMock
 
 import pytest
@@ -121,34 +122,44 @@ async def test_terminate_kills_grandchild_via_process_group(
     )
     controller._current_process = proc  # type: ignore[attr-defined]
 
-    # Read the two pid lines from stdout so we know what to verify.
-    parent_pid: int | None = None
-    grandchild_pid: int | None = None
-    deadline = time.monotonic() + 5.0
-    assert proc.stdout is not None
-    while time.monotonic() < deadline and (parent_pid is None or grandchild_pid is None):
-        line = await asyncio.wait_for(proc.stdout.readline(), timeout=2.0)
-        if not line:
-            break
-        text = line.decode().strip()
-        if text.startswith("PARENT="):
-            parent_pid = int(text.split("=", 1)[1])
-        elif text.startswith("GRANDCHILD="):
-            grandchild_pid = int(text.split("=", 1)[1])
-    assert parent_pid is not None, "child never reported its pid"
-    assert grandchild_pid is not None, "grandchild never reported its pid"
-    assert _is_alive(parent_pid)
-    assert _is_alive(grandchild_pid)
+    try:
+        # Read the two pid lines from stdout so we know what to verify.
+        parent_pid: int | None = None
+        grandchild_pid: int | None = None
+        deadline = time.monotonic() + 5.0
+        assert proc.stdout is not None
+        while time.monotonic() < deadline and (parent_pid is None or grandchild_pid is None):
+            line = await asyncio.wait_for(proc.stdout.readline(), timeout=2.0)
+            if not line:
+                break
+            text = line.decode().strip()
+            if text.startswith("PARENT="):
+                parent_pid = int(text.split("=", 1)[1])
+            elif text.startswith("GRANDCHILD="):
+                grandchild_pid = int(text.split("=", 1)[1])
+        assert parent_pid is not None, "child never reported its pid"
+        assert grandchild_pid is not None, "grandchild never reported its pid"
+        assert _is_alive(parent_pid)
+        assert _is_alive(grandchild_pid)
 
-    # Hit Stop. Both pids must die — SIGTERM is ignored, so the
-    # controller's grace window expires and SIGKILL escalates to the
-    # whole process group.
-    await controller._terminate_current_process()
-    await proc.wait()
+        # Hit Stop. Both pids must die — SIGTERM is ignored, so the
+        # controller's grace window expires and SIGKILL escalates to
+        # the whole process group.
+        await controller._terminate_current_process()
+        await proc.wait()
 
-    assert await _wait_dead(parent_pid), f"parent pid {parent_pid} still alive after stop"
-    grandchild_alive = not await _wait_dead(grandchild_pid)
-    assert not grandchild_alive, (
-        f"grandchild pid {grandchild_pid} still alive after stop — "
-        "process-group signal didn't reach it"
-    )
+        assert await _wait_dead(parent_pid), f"parent pid {parent_pid} still alive after stop"
+        grandchild_alive = not await _wait_dead(grandchild_pid)
+        assert not grandchild_alive, (
+            f"grandchild pid {grandchild_pid} still alive after stop — "
+            "process-group signal didn't reach it"
+        )
+    finally:
+        # Belt-and-suspenders cleanup: if any assertion above failed
+        # before the SIGKILL chain ran, the SIGTERM-trapped grandchild
+        # would otherwise sleep for 60s and pollute the suite. SIGKILL
+        # the whole group regardless of test outcome;
+        # ``_signal_process_group`` no-ops for already-dead pids.
+        _signal_process_group(proc.pid, signal.SIGKILL)
+        with suppress(asyncio.TimeoutError, ProcessLookupError):
+            await asyncio.wait_for(proc.wait(), timeout=5.0)


### PR DESCRIPTION
## Summary

Hit Stop on a running compile and the build kept going for the full remaining duration. Logs showed ``proc.terminate()`` → SIGTERM after 3s → SIGKILL right after, yet the gcc / platformio output kept streaming.

Root cause: ``proc.terminate()`` / ``proc.kill()`` signal **only the direct child** (the python esphome process). ESPHome forks PlatformIO which forks gcc / esptool / etc.; those grandchildren got orphaned when the parent died and ran to completion on their own.

Two changes fix it:

* Spawn the firmware subprocess with ``start_new_session=True`` so the entire esphome → platformio → gcc tree shares a process group with the python parent.
* New ``_signal_process_group(pid, sig)`` helper used by ``_terminate_current_process`` to send SIGTERM (then SIGKILL after the grace window) to the **whole group** via ``os.killpg``. Falls back gracefully on ``ProcessLookupError`` / ``PermissionError`` so the controller doesn't crash if the parent already exited or we're sandboxed.

## Test plan

- [x] ``pytest tests/`` — 230 passing, 2 new in ``tests/test_firmware_stop.py`` covering:
  - ``_signal_process_group`` returns ``False`` on a dead pid (no exception)
  - End-to-end: spawn a SIGTERM-trapped parent + grandchild via ``start_new_session=True``, call ``_terminate_current_process``, assert both pids are dead. Without the process-group signal the grandchild outlives the parent and the test fails.
- [x] Confirmed manually by the user: "confirmed working now"