### PR TITLE
Treat unreachable ping as OFFLINE, not UNKNOWN

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -44,7 +44,14 @@ _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
 # a full minute to see UNKNOWN devices flip OFFLINE on first load.
 _PING_INTERVAL = 60  # seconds between ping sweeps
 _PING_BOOTSTRAP_DELAY = 10  # seconds before the first ping sweep
-_PING_BATCH_SIZE = 10
+# Batch size matches the upstream esphome dashboard's
+# ``GROUP_SIZE = MAX_EXECUTOR_WORKERS / 2 = 24``. Each batch's pings
+# run in parallel via ``asyncio.gather``; the cap exists because
+# icmplib gets unreliable past a few dozen concurrent probes. With a
+# small fleet (≤24 ping candidates) one batch covers everything and
+# the sweep finishes in a single ICMP timeout window instead of
+# stacking N timeouts back-to-back.
+_PING_BATCH_SIZE = 24
 _MDNS_RESOLVE_TIMEOUT_MS = 2000
 
 # Source priority for state observations. A new observation can only

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -471,11 +471,21 @@ class DeviceStateMonitor:
         return _SOURCE_PRIORITY.get(source, 0) <= _SOURCE_PRIORITY["ping"]
 
     async def _ping_device(self, device: Device, target: str) -> None:
+        # Treat any failure mode as "not reachable" → OFFLINE, not as
+        # "still unknown". An exception here means resolution failed
+        # (NameLookupError), the network refused us (NoRouteToHost,
+        # PermissionError, OSError), or icmplib couldn't open a socket.
+        # In every case the user wants the dot to flip red, not stay
+        # grey forever — once mDNS / MQTT / ping have all tried, the
+        # signal is "we couldn't reach this device". A subsequent
+        # successful ping will flip it right back to ONLINE.
         try:
             result = await icmp_ping(target, count=1, timeout=3, privileged=False)
+            is_alive = result.is_alive
         except Exception:
-            return
-        new_state = DeviceState.ONLINE if result.is_alive else DeviceState.OFFLINE
+            _LOGGER.debug("Ping of %s (%s) failed", device.name, target, exc_info=True)
+            is_alive = False
+        new_state = DeviceState.ONLINE if is_alive else DeviceState.OFFLINE
         self.apply(device.name, new_state, "ping")
 
 

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -35,7 +35,15 @@ from ._dns_cache import DNSCache
 
 _LOGGER = logging.getLogger(__name__)
 _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
+# Ping fallback runs every 60s after a short bootstrap window.
+# ``_PING_BOOTSTRAP_DELAY`` gives the mDNS browser a head start so the
+# common case (everything announces) doesn't fire a ping sweep that
+# the browser would have answered for free a few seconds later. 10s
+# tracks the upstream esphome dashboard's ``MDNS_BOOTSTRAP_TIME``
+# (~7.5s) closely enough to stay correct without making the user wait
+# a full minute to see UNKNOWN devices flip OFFLINE on first load.
 _PING_INTERVAL = 60  # seconds between ping sweeps
+_PING_BOOTSTRAP_DELAY = 10  # seconds before the first ping sweep
 _PING_BATCH_SIZE = 10
 _MDNS_RESOLVE_TIMEOUT_MS = 2000
 
@@ -379,7 +387,14 @@ class DeviceStateMonitor:
             self.apply_config_hash(device_name, config_hash)
 
     async def _ping_loop(self) -> None:
+        # First sweep after the short bootstrap window — gives mDNS a
+        # head start so we don't redundantly ping devices the browser
+        # is about to flip ONLINE for free, but still gets the UNKNOWN
+        # → OFFLINE transition in front of the user within ~10s of
+        # startup instead of after a full minute.
         try:
+            await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
+            await self._ping_sweep()
             while True:
                 await asyncio.sleep(_PING_INTERVAL)
                 await self._ping_sweep()
@@ -482,8 +497,11 @@ class DeviceStateMonitor:
         try:
             result = await icmp_ping(target, count=1, timeout=3, privileged=False)
             is_alive = result.is_alive
-        except Exception:
-            _LOGGER.debug("Ping of %s (%s) failed", device.name, target, exc_info=True)
+        except Exception as exc:
+            # ``.local`` hosts on systems without Avahi / mdnsd hit
+            # this every sweep; the traceback adds nothing and floods
+            # the logs. One-line debug is plenty.
+            _LOGGER.debug("Ping of %s (%s) failed: %s", device.name, target, exc)
             is_alive = False
         new_state = DeviceState.ONLINE if is_alive else DeviceState.OFFLINE
         self.apply(device.name, new_state, "ping")

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -447,16 +447,16 @@ class DeviceStateMonitor:
         for i in range(0, len(devices_to_ping), _PING_BATCH_SIZE):
             batch = devices_to_ping[i : i + _PING_BATCH_SIZE]
             # Pre-resolve every batch via the DNS cache. icmplib would
-            # otherwise re-resolve internally on every ping, and the
-            # OTA cache args would have nothing to draw on for non-mDNS
-            # hostnames.
+            # otherwise re-resolve internally on every ping (going to
+            # the system resolver each time and ignoring our cache),
+            # and the OTA cache args would have nothing to draw on for
+            # non-mDNS hostnames.
             resolved = await asyncio.gather(
                 *(self._dns_cache.async_resolve(d.address) for d in batch),
                 return_exceptions=True,
             )
             ping_targets: list[tuple[Device, str]] = []
             for device, addresses in zip(batch, resolved, strict=True):
-                target = device.address
                 if isinstance(addresses, list) and addresses:
                     target = addresses[0]
                     # mDNS owns IP tracking for ``.local`` hosts; only
@@ -464,11 +464,22 @@ class DeviceStateMonitor:
                     # DNS result can't clobber the live mDNS value.
                     if not is_local_hostname(device.address):
                         self.apply_ip(device.name, target)
-                ping_targets.append((device, target))
-            await asyncio.gather(
-                *(self._ping_device(device, target) for device, target in ping_targets),
-                return_exceptions=True,
-            )
+                    ping_targets.append((device, target))
+                else:
+                    # DNS cache says we can't resolve this hostname
+                    # (the entry is cached as a failure for the cache
+                    # TTL). Don't hand the bare hostname to icmplib —
+                    # it would re-resolve via the system resolver every
+                    # sweep, hammering DNS for nothing. Treat the cache
+                    # miss as the "we tried, can't reach" signal and
+                    # apply OFFLINE via the same source ``_ping_device``
+                    # would have used.
+                    self.apply(device.name, DeviceState.OFFLINE, "ping")
+            if ping_targets:
+                await asyncio.gather(
+                    *(self._ping_device(device, target) for device, target in ping_targets),
+                    return_exceptions=True,
+                )
 
     def _should_ping(self, device: Device) -> bool:
         """

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -415,6 +415,62 @@ class DevicesController:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, path.write_text, content, "utf-8")
         await self._scanner.scan()
+        # Refresh ``StorageJSON`` so address / loaded_integrations /
+        # config_hash etc. reflect the new YAML without waiting for a
+        # full compile. Mirrors the upstream dashboard's
+        # ``async_schedule_storage_json_update`` (called from its
+        # ``EditRequestHandler`` after writing the YAML).
+        self._schedule_storage_regenerate(configuration)
+
+    def _schedule_storage_regenerate(self, configuration: str) -> None:
+        """
+        Run ``esphome compile --only-generate <yaml>`` in the background.
+
+        ``--only-generate`` walks ESPHome's full config validation
+        pipeline (resolving ``!secret`` / ``!include`` / packages /
+        ``dashboard_import``) and writes the resulting StorageJSON
+        without doing a real build. That populates ``address``,
+        ``loaded_integrations``, ``target_platform``, etc. for devices
+        that have never been compiled (the typical "wr2-test was just
+        added and shows UNKNOWN forever" path) and refreshes them
+        whenever the YAML changes.
+
+        Fire-and-forget: a follow-up ``_scanner.reload(configuration)``
+        on completion picks up the new storage and re-emits a
+        ``DEVICE_UPDATED`` event so the frontend reflects the new
+        address / integrations.
+        """
+        if not self._esphome_cmd:
+            return  # ``start()`` hasn't run yet — skip the regenerate.
+
+        async def _run() -> None:
+            config_path = str(self._db.settings.rel_path(configuration))
+            cmd = [*self._esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
+            try:
+                proc = await create_subprocess_exec(
+                    *cmd,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                _, stderr = await proc.communicate()
+            except Exception:
+                _LOGGER.debug(
+                    "Storage regenerate spawn failed for %s",
+                    configuration,
+                    exc_info=True,
+                )
+                return
+            if proc.returncode != 0:
+                _LOGGER.debug(
+                    "Storage regenerate for %s exited %s: %s",
+                    configuration,
+                    proc.returncode,
+                    stderr.decode(errors="replace").strip()[:500],
+                )
+                return
+            await self._scanner.reload(configuration)
+
+        self._db.create_background_task(_run())
 
     @api_command("devices/get_api_key")
     async def get_api_key(self, *, configuration: str, **kwargs: Any) -> dict[str, str]:
@@ -653,6 +709,15 @@ class DevicesController:
             ScanChange.REMOVED: EventType.DEVICE_REMOVED,
         }[kind]
         self._db.bus.fire(event, {"device": device})
+        # First-sight devices that have no compile output yet end up
+        # carrying the ``<filename>.local`` address fallback and an
+        # empty ``loaded_integrations`` list. Schedule a background
+        # ``--only-generate`` so the next scan picks up the real
+        # ``StorageJSON``-derived values without making the user wait
+        # for a real compile. Same upstream pattern used in
+        # ``async_schedule_storage_json_update``.
+        if kind is ScanChange.ADDED and not device.loaded_integrations:
+            self._schedule_storage_regenerate(device.configuration)
 
     def _on_state_change(self, name: str, state: DeviceState, source: str) -> None:
         """Forward state monitor updates onto the event bus."""

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -73,6 +73,22 @@ class DevicesController:
         self.import_result: dict[str, Any] = {}
         self.ignored_devices: set[str] = set()
 
+        # Background ``--only-generate`` bookkeeping. ``--only-generate``
+        # validates a YAML and writes its ``StorageJSON`` without doing
+        # a real build; we trigger it whenever a YAML is saved or
+        # first-seen with no compile output. Three guards stop us from
+        # spinning:
+        #   * ``_regenerate_pending`` — configurations already in flight
+        #     (scheduled but not yet finished). Skip duplicate schedules.
+        #   * ``_regenerate_failed`` — YAMLs whose last attempt failed.
+        #     Don't retry until the file changes (cleared on
+        #     ``ScanChange.UPDATED``).
+        #   * ``_regenerate_lock`` — serialises the actual subprocess
+        #     so we don't spawn N esphome compiles in parallel.
+        self._regenerate_pending: set[str] = set()
+        self._regenerate_failed: set[str] = set()
+        self._regenerate_lock = asyncio.Lock()
+
         self._scanner = DeviceScanner(
             config_dir=self._db.settings.config_dir,
             get_metadata=self._resolve_device_metadata,
@@ -435,40 +451,69 @@ class DevicesController:
         added and shows UNKNOWN forever" path) and refreshes them
         whenever the YAML changes.
 
+        Three guards keep this from running away:
+        * ``_regenerate_pending`` skips duplicate schedules for a
+          configuration that's already in flight.
+        * ``_regenerate_failed`` skips YAMLs whose last attempt
+          failed; entries are cleared in ``_on_scan_change`` when the
+          file's cache key changes (i.e. the user actually edited it).
+        * ``_regenerate_lock`` serialises the subprocess itself so we
+          never spawn more than one esphome compile at a time.
+
         Fire-and-forget: a follow-up ``_scanner.reload(configuration)``
-        on completion picks up the new storage and re-emits a
+        on success picks up the new storage and re-emits a
         ``DEVICE_UPDATED`` event so the frontend reflects the new
         address / integrations.
         """
         if not self._esphome_cmd:
             return  # ``start()`` hasn't run yet — skip the regenerate.
+        if configuration in self._regenerate_pending:
+            return  # already scheduled, don't queue a duplicate.
+        if configuration in self._regenerate_failed:
+            # Last attempt failed and the YAML hasn't changed since;
+            # rerunning would just produce the same error and burn a
+            # subprocess. Wait for an UPDATED scan to clear the marker.
+            return
 
         async def _run() -> None:
-            config_path = str(self._db.settings.rel_path(configuration))
-            cmd = [*self._esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
+            self._regenerate_pending.add(configuration)
             try:
-                proc = await create_subprocess_exec(
-                    *cmd,
-                    stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                _, stderr = await proc.communicate()
-            except Exception:
-                _LOGGER.debug(
-                    "Storage regenerate spawn failed for %s",
-                    configuration,
-                    exc_info=True,
-                )
-                return
-            if proc.returncode != 0:
-                _LOGGER.debug(
-                    "Storage regenerate for %s exited %s: %s",
-                    configuration,
-                    proc.returncode,
-                    stderr.decode(errors="replace").strip()[:500],
-                )
-                return
-            await self._scanner.reload(configuration)
+                async with self._regenerate_lock:
+                    config_path = str(self._db.settings.rel_path(configuration))
+                    cmd = [
+                        *self._esphome_cmd,
+                        "--dashboard",
+                        "compile",
+                        "--only-generate",
+                        config_path,
+                    ]
+                    try:
+                        proc = await create_subprocess_exec(
+                            *cmd,
+                            stdout=asyncio.subprocess.DEVNULL,
+                            stderr=asyncio.subprocess.PIPE,
+                        )
+                        _, stderr = await proc.communicate()
+                    except Exception:
+                        _LOGGER.debug(
+                            "Storage regenerate spawn failed for %s",
+                            configuration,
+                            exc_info=True,
+                        )
+                        self._regenerate_failed.add(configuration)
+                        return
+                    if proc.returncode != 0:
+                        _LOGGER.debug(
+                            "Storage regenerate for %s exited %s: %s",
+                            configuration,
+                            proc.returncode,
+                            stderr.decode(errors="replace").strip()[:500],
+                        )
+                        self._regenerate_failed.add(configuration)
+                        return
+                    await self._scanner.reload(configuration)
+            finally:
+                self._regenerate_pending.discard(configuration)
 
         self._db.create_background_task(_run())
 
@@ -709,6 +754,12 @@ class DevicesController:
             ScanChange.REMOVED: EventType.DEVICE_REMOVED,
         }[kind]
         self._db.bus.fire(event, {"device": device})
+        # The YAML cache key changed (mtime / size / inode) — clear
+        # any prior failure marker so an edit gets a fresh chance at
+        # ``--only-generate``. Same for REMOVED so re-creating the
+        # file later doesn't inherit the old failure.
+        if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
+            self._regenerate_failed.discard(device.configuration)
         # First-sight devices that have no compile output yet end up
         # carrying the ``<filename>.local`` address fallback and an
         # empty ``loaded_integrations`` list. Schedule a background

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -414,11 +414,16 @@ def load_device_from_storage(
         # StorageJSON only exists after a successful compile, so a
         # freshly-added (or never-built) device would otherwise carry
         # an empty ``address`` and fall out of the ping sweep — stuck
-        # in UNKNOWN forever. Fall back to ``<name>.local``, which
-        # matches what every ESPHome device's mDNS layer announces as
-        # by default. The scanner refreshes this on the next compile
-        # if the user picks a different ``esphome.address``.
-        address=(storage.address if storage and storage.address else f"{name}.local"),
+        # in UNKNOWN forever. Fall back to ``<filename-stem>.local``
+        # (NOT ``<name>.local``): the filename is canonical and
+        # matches what the user types, while ``name`` is parsed from
+        # YAML and can come back as a friendly_name or a package
+        # import URL when the YAML doesn't carry a slug-shaped
+        # ``esphome.name`` (e.g. configs that get the name from a
+        # remote ``dashboard_import`` package). The scanner refreshes
+        # this on the next compile if the device picks a different
+        # ``esphome.address``.
+        address=(storage.address if storage and storage.address else f"{fallback_name}.local"),
         ip=ip,
         web_port=storage.web_port if storage else None,
         current_version=const.__version__,

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -411,7 +411,14 @@ def load_device_from_storage(
         comment=comment,
         board_id=board_id,
         target_platform=target_platform,
-        address=storage.address or "" if storage else "",
+        # StorageJSON only exists after a successful compile, so a
+        # freshly-added (or never-built) device would otherwise carry
+        # an empty ``address`` and fall out of the ping sweep — stuck
+        # in UNKNOWN forever. Fall back to ``<name>.local``, which
+        # matches what every ESPHome device's mDNS layer announces as
+        # by default. The scanner refreshes this on the next compile
+        # if the user picks a different ``esphome.address``.
+        address=(storage.address if storage and storage.address else f"{name}.local"),
         ip=ip,
         web_port=storage.web_port if storage else None,
         current_version=const.__version__,

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -29,6 +29,19 @@ _PLATFORM_KEYS = frozenset({"esp32", "esp8266", "rp2040", "bk72xx", "rtl87xx", "
 # matches ``$name`` or ``${name}`` where name is alphanumeric + underscore.
 _SUBSTITUTION_RE = re.compile(r"\$(\{[a-zA-Z0-9_]*\}|[a-zA-Z0-9_]+)")
 
+# ESPHome's ``esphome.name`` accepts lowercase ASCII letters, digits,
+# and hyphens — the same character class an mDNS hostname / API
+# endpoint can carry. A parsed value with anything else (dots, spaces,
+# uppercase, ...) means we picked up the wrong field (a package id, a
+# friendly_name leaked through, etc.) and should be rejected so it
+# doesn't end up as the catalog key.
+_VALID_ESPHOME_NAME_RE = re.compile(r"\A[a-z0-9-]+\Z")
+
+
+def _is_valid_esphome_name(value: str) -> bool:
+    """Return True when *value* matches ESPHome's ``esphome.name`` shape."""
+    return bool(_VALID_ESPHOME_NAME_RE.match(value))
+
 
 # ---------------------------------------------------------------------------
 # YAML generation
@@ -351,7 +364,20 @@ def load_device_from_storage(
 
     fallback_name = filename.removesuffix(".yml").removesuffix(".yaml")
     storage_name = storage.name if storage else None
-    name = yaml_name or storage_name or fallback_name
+    # Pick the first valid ESPHome slug from (yaml_name, storage_name).
+    # Real ESPHome ``esphome.name`` values are ``[a-z0-9-]+`` — a parsed
+    # value with dots / spaces / uppercase is something else (a package
+    # id like ``ratgdo.esphome``, a friendly_name leaked through, etc.).
+    # ``device.name`` is the key the state monitor uses to match mDNS
+    # announcements, so duplicates across multiple YAMLs (which is what
+    # happens when several configs share the same ``dashboard_import``
+    # package) collapse all those devices onto a single Device row.
+    # Falling back to the filename when the parsed name is invalid
+    # keeps the catalog key unique.
+    name = next(
+        (n for n in (yaml_name, storage_name) if n and _is_valid_esphome_name(n)),
+        fallback_name,
+    )
 
     storage_friendly = storage.friendly_name if storage else None
     friendly_name = yaml_friendly if yaml_friendly is not None else (storage_friendly or name)

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Awaitable, Callable
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -438,10 +439,10 @@ def test_load_device_from_storage_threads_ip_through(monkeypatch, tmp_path) -> N
     assert device.board_id == "esp32-devkit"
 
 
-def test_load_device_from_storage_address_falls_back_to_name_local(  # type: ignore[no-untyped-def]
+def test_load_device_from_storage_address_falls_back_to_filename_local(  # type: ignore[no-untyped-def]
     monkeypatch, tmp_path
 ) -> None:
-    """Never-compiled devices get ``<name>.local`` so the ping sweep includes them.
+    """Never-compiled devices get ``<filename-stem>.local`` so the ping sweep includes them.
 
     Without this fallback, ``Device.address`` was empty for any
     device that hadn't been built yet, so the sweep filter
@@ -465,6 +466,39 @@ def test_load_device_from_storage_address_falls_back_to_name_local(  # type: ign
     assert device.address == "wr2-test.local"
 
 
+def test_load_device_from_storage_address_uses_filename_not_parsed_name(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """Address fallback uses the filename, not the YAML-parsed ``name``.
+
+    Configs that pull the device name from a remote ``dashboard_import``
+    package can leave ``parse_esphome_meta`` returning a stem-shaped
+    package id (like ``ratgdo.esphome``) instead of the actual device
+    name. Using ``<name>.local`` as the fallback would then claim
+    ``ratgdo.esphome.local`` for a device whose YAML is
+    ``largegarage.yaml`` — exactly the bug the user reported. The
+    filename stem is canonical and matches what the user types.
+    """
+    from esphome_device_builder.helpers import device_yaml
+
+    monkeypatch.setattr(
+        device_yaml,
+        "ext_storage_path",
+        lambda config: tmp_path / f"{config}.json",
+    )
+    monkeypatch.setattr(device_yaml.StorageJSON, "load", staticmethod(lambda _p: None))
+
+    # YAML where parse_esphome_meta will resolve the name to whatever
+    # the package provides (here we simulate that by writing the
+    # offending value directly under ``esphome.name``).
+    yaml_path = tmp_path / "largegarage.yaml"
+    yaml_path.write_text("esphome:\n  name: ratgdo.esphome\n")
+
+    device = device_yaml.load_device_from_storage(yaml_path)
+    # Address must come from the filename, not the parsed name.
+    assert device.address == "largegarage.local"
+
+
 def test_load_device_from_storage_address_uses_storage_when_set(  # type: ignore[no-untyped-def]
     monkeypatch, tmp_path
 ) -> None:
@@ -476,8 +510,6 @@ def test_load_device_from_storage_address_uses_storage_when_set(  # type: ignore
         "ext_storage_path",
         lambda config: tmp_path / f"{config}.json",
     )
-
-    from typing import ClassVar
 
     class _FakeStorage:
         # Only the fields ``load_device_from_storage`` reads — keeps

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -438,6 +438,69 @@ def test_load_device_from_storage_threads_ip_through(monkeypatch, tmp_path) -> N
     assert device.board_id == "esp32-devkit"
 
 
+def test_load_device_from_storage_address_falls_back_to_name_local(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """Never-compiled devices get ``<name>.local`` so the ping sweep includes them.
+
+    Without this fallback, ``Device.address`` was empty for any
+    device that hadn't been built yet, so the sweep filter
+    (``if not device.address: continue``) excluded them and they
+    stayed UNKNOWN forever — that's what the user reported with
+    ``wr2-test`` and friends.
+    """
+    from esphome_device_builder.helpers import device_yaml
+
+    monkeypatch.setattr(
+        device_yaml,
+        "ext_storage_path",
+        lambda config: tmp_path / f"{config}.json",
+    )
+    monkeypatch.setattr(device_yaml.StorageJSON, "load", staticmethod(lambda _p: None))
+
+    yaml_path = tmp_path / "wr2-test.yaml"
+    yaml_path.write_text("esphome:\n  name: wr2-test\n")
+
+    device = device_yaml.load_device_from_storage(yaml_path)
+    assert device.address == "wr2-test.local"
+
+
+def test_load_device_from_storage_address_uses_storage_when_set(  # type: ignore[no-untyped-def]
+    monkeypatch, tmp_path
+) -> None:
+    """A real ``StorageJSON.address`` wins over the ``<name>.local`` fallback."""
+    from esphome_device_builder.helpers import device_yaml
+
+    monkeypatch.setattr(
+        device_yaml,
+        "ext_storage_path",
+        lambda config: tmp_path / f"{config}.json",
+    )
+
+    from typing import ClassVar
+
+    class _FakeStorage:
+        # Only the fields ``load_device_from_storage`` reads — keeps
+        # the test honest about what it's exercising.
+        name = "kitchen"
+        friendly_name = None
+        comment = None
+        address = "kitchen.lan"
+        web_port = None
+        target_platform = ""
+        firmware_bin_path = None
+        esphome_version = ""
+        loaded_integrations: ClassVar[list[str]] = []
+
+    monkeypatch.setattr(device_yaml.StorageJSON, "load", staticmethod(lambda _p: _FakeStorage()))
+
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n")
+
+    device = device_yaml.load_device_from_storage(yaml_path)
+    assert device.address == "kitchen.lan"
+
+
 def test_on_ip_change_persists_non_empty_value(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """``_on_ip_change`` schedules a metadata write for non-empty IPs."""
     from unittest.mock import MagicMock

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -285,12 +285,22 @@ async def test_ping_sweep_rescues_local_device_from_zeroconf_cache() -> None:
     assert monitor.priority_for("winefridge") == "mdns"
 
 
-async def test_ping_sweep_pings_hostname_when_resolution_fails(fake_resolver) -> None:
-    """DNS resolution failure → fall back to pinging the hostname."""
+async def test_ping_sweep_marks_offline_directly_on_dns_failure(fake_resolver) -> None:
+    """DNS resolution failure → OFFLINE without calling icmp_ping.
+
+    Handing the bare hostname to ``icmp_ping`` would re-resolve via
+    icmplib's own resolver every sweep — bypassing our DNS cache and
+    hammering the system resolver for nothing. Instead, treat a
+    cache-confirmed lookup failure as the "we tried, can't reach"
+    signal and apply OFFLINE directly.
+    """
+    from esphome_device_builder.models import DeviceState
+
     devices = [_device()]
+    state_changes: list[tuple[str, DeviceState, str]] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
-        on_state_change=lambda *_: None,
+        on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
         on_ip_change=lambda *_: None,
     )
 
@@ -311,7 +321,10 @@ async def test_ping_sweep_pings_hostname_when_resolution_fails(fake_resolver) ->
     ):
         await monitor._ping_sweep()
 
-    assert pinged == ["esp.example.com"]
+    # Crucially: ``icmp_ping`` was NOT called. The resolution failure
+    # was enough to declare the device offline.
+    assert pinged == []
+    assert state_changes == [("kitchen", DeviceState.OFFLINE, "ping")]
 
 
 async def test_ping_marks_offline_when_icmp_raises(fake_resolver) -> None:

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -314,6 +314,42 @@ async def test_ping_sweep_pings_hostname_when_resolution_fails(fake_resolver) ->
     assert pinged == ["esp.example.com"]
 
 
+async def test_ping_marks_offline_when_icmp_raises(fake_resolver) -> None:
+    """A ping that raises (NameLookupError, NoRouteToHost, …) flips the device OFFLINE.
+
+    Previously these exceptions short-circuited ``_ping_device`` and
+    left the device stuck in UNKNOWN forever — even after mDNS / MQTT
+    had also failed to find it. The dashboard's red dot was
+    unreachable. Now the failure mode is treated as "we tried, we
+    couldn't reach it" and the state flips to OFFLINE; a subsequent
+    successful ping flips it right back to ONLINE.
+    """
+    from esphome_device_builder.controllers import _device_state_monitor as sm
+    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+    from esphome_device_builder.models import DeviceState
+
+    devices = [_device()]
+    state_changes: list[tuple[str, DeviceState, str]] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
+        on_ip_change=lambda *_: None,
+    )
+
+    resolver = fake_resolver(dns_cache_mod.NameLookupError)
+
+    async def raising_ping(_target, **_kwargs):  # type: ignore[no-untyped-def]
+        raise dns_cache_mod.NameLookupError("not resolvable")
+
+    with (
+        patch.object(dns_cache_mod, "async_resolve", resolver),
+        patch.object(sm, "icmp_ping", raising_ping),
+    ):
+        await monitor._ping_sweep()
+
+    assert state_changes == [("kitchen", DeviceState.OFFLINE, "ping")]
+
+
 # ----------------------------------------------------------------------
 # IP persistence
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Five related fixes to the device-state pipeline so devices actually transition between states instead of getting stuck in UNKNOWN forever.

* **Unreachable ping → OFFLINE.** ``_ping_device``'s exception handler was a bare ``return`` — when ``icmp_ping`` raised (NameLookupError, NoRouteToHost, PermissionError on a privileged socket) we left the device in whatever state it was in, typically UNKNOWN forever. Treat any failure mode as "we tried, can't reach" → OFFLINE. A subsequent successful ping flips it back to ONLINE.
* **Skip ``icmp_ping`` when DNS-cache reports a resolution failure.** The ``DNSCache`` already caches both successes and failures (TTL 120s) so consecutive lookups of an unresolvable host don't hit the system resolver each sweep — but the ping sweep was undoing that on the next line by handing the bare hostname to ``icmp_ping``, which re-resolves through icmplib's own resolver and bypasses our cache. Now a cache-confirmed lookup failure shorts to OFFLINE without re-resolving.
* **Bootstrap delay 60s → 10s.** First sweep now fires ~10s after start (matching upstream ESPHome dashboard's ``MDNS_BOOTSTRAP_TIME``) so UNKNOWN dots flip OFFLINE / ONLINE within the first ~13s of load instead of waiting a full minute. Steady-state cadence between sweeps is unchanged.
* **Quiet ping-failure logs.** Dropped ``exc_info=True`` from the ping-failure debug line — every ``.local`` host on a system without Avahi was producing a screen-sized stack trace per sweep. One-line debug with the exception's short repr is plenty.
* **Bigger batch (10 → 24).** Each batch's pings already ran in parallel via ``asyncio.gather``, but ``_PING_BATCH_SIZE = 10`` meant 12 candidates split into 10+2 sequential batches and stacked two ICMP-timeout windows back-to-back (~6s). Match the upstream dashboard's ``GROUP_SIZE = MAX_EXECUTOR_WORKERS / 2 = 24`` so small fleets finish in one timeout window.

Plus two scanner fixes for never-compiled devices that were silently dropped from the sweep:

* **Address fallback to ``<filename-stem>.local``.** Devices with no ``StorageJSON`` had ``Device.address == ""`` and the sweep filter ``if not device.address: continue`` excluded them. The fallback uses the YAML's filename (canonical, matches what the user sees) — not the parsed ``name``, which for ``dashboard_import``-style configs can come back as the package id (e.g. ``ratgdo.esphome``) and would have claimed ``ratgdo.esphome.local`` for an unrelated device.
* **Auto-regenerate StorageJSON via ``esphome compile --only-generate``.** Mirrors the upstream dashboard's ``async_schedule_storage_json_update`` (called from ``EditRequestHandler`` after writing YAML). Triggered on ``devices/update_config`` (every YAML save) and on first-sight ``ScanChange.ADDED`` for devices with no compile output. Walks ESPHome's full config validation pipeline (resolves ``!secret`` / ``!include`` / packages / ``dashboard_import``) and writes ``StorageJSON`` without doing a real build, so the address / loaded_integrations / target_platform / api_enabled values populate within seconds. Three guards prevent spinning:
  * ``_regenerate_pending`` — duplicate schedules skip.
  * ``_regenerate_failed`` — failed configs don't retry until the YAML changes (cleared on ``ScanChange.UPDATED`` / ``REMOVED``).
  * ``_regenerate_lock`` — only one ``esphome --only-generate`` subprocess runs at a time.

## Test plan

- [x] ``pytest tests/`` — 237 passing, including new regressions in ``tests/test_dns_cache.py`` covering: ping-raises → OFFLINE, DNS-failure → OFFLINE without ``icmp_ping``, address fallback for never-compiled devices, address fallback uses filename-not-parsed-name (the ``ratgdo.esphome`` → ``largegarage.local`` case), and the storage-comes-from-StorageJSON-when-present case.
- [x] ``ruff check`` clean
- [x] Verified manually on a 99-device LAN:
  - 15-device sweep timestamps now cluster at ``+3s`` after the "Pinging N devices" debug line (one ICMP timeout window) instead of stacking two
  - First sweep fires within 10-15s of start instead of 60s
  - Stale ``.local`` hosts: dot flips grey → red within first sweep
  - ``wr2-test`` and other never-compiled devices are now in the ping list and get a real address from StorageJSON within seconds
  - Failing-to-parse YAML doesn't get re-run forever; subsequent saves trigger a fresh attempt