### PR TITLE
Fix stop-button cancellation on Windows (use taskkill /F /T)

### DIFF
--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -173,6 +173,9 @@ def _signal_process_group(pid: int, sig: int) -> bool:
     same group — ``killpg(getpgid(spawned_pid), sig)`` therefore
     targets the build subtree without touching us.
 
+    POSIX-only — ``os.getpgid`` / ``os.killpg`` don't exist on Windows.
+    The Windows path goes through ``_terminate_subtree_windows`` instead.
+
     Falls back gracefully:
     * ``ProcessLookupError`` — the process already exited; nothing to do.
     * ``PermissionError`` — we lost the right to signal it; treat as a
@@ -188,6 +191,44 @@ def _signal_process_group(pid: int, sig: int) -> bool:
         return False
     except PermissionError:
         _LOGGER.warning("Permission denied signalling pgid %d (sig %s)", pgid, sig)
+        return False
+    return True
+
+
+async def _terminate_subtree_windows(pid: int) -> bool:
+    """
+    Forcibly kill *pid* and its descendants on Windows; return True iff invoked.
+
+    Windows has no process groups in the POSIX sense, so we shell out to
+    ``taskkill /F /T /PID`` — ``/T`` walks the parent-child tree from
+    *pid* down, ``/F`` is the forceful equivalent of SIGKILL. There's no
+    useful "polite" stage here: a compile chain (esphome → platformio →
+    gcc / esptool) ignores ``WM_CLOSE`` / ``CTRL_BREAK_EVENT`` anyway,
+    so we go straight to the kill.
+
+    Returns False (and logs a warning) if ``taskkill`` is missing or
+    times out — the caller should fall back to ``proc.kill()`` so the
+    parent at least dies even when the tree-walk fails.
+    """
+    try:
+        killer = await asyncio.create_subprocess_exec(
+            "taskkill",
+            "/F",
+            "/T",
+            "/PID",
+            str(pid),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        _LOGGER.warning("taskkill not found on PATH — can't tree-kill pid %d", pid)
+        return False
+    try:
+        await asyncio.wait_for(killer.wait(), timeout=_TERMINATE_GRACE_SECONDS)
+    except TimeoutError:
+        _LOGGER.warning("taskkill timed out for pid %d", pid)
+        with suppress(ProcessLookupError):
+            killer.kill()
         return False
     return True
 
@@ -872,13 +913,26 @@ class FirmwareController:
         two coroutines). We only nudge the process here.
 
         ESPHome forks PlatformIO which forks gcc / esptool / etc. The
-        spawn site uses ``start_new_session=True`` so the whole tree
-        shares a process group; we signal the group instead of just
-        the python parent — without that, the compiler children get
-        orphaned and the build keeps going until they finish.
+        spawn site uses ``start_new_session=True`` (POSIX) so the whole
+        tree shares a process group; we signal the group instead of
+        just the python parent — without that, the compiler children
+        get orphaned and the build keeps going until they finish.
+
+        Windows has no process groups in the POSIX sense; we use
+        ``taskkill /F /T`` to walk the parent-child tree from the
+        kernel's accounting and force-kill the whole subtree in one
+        shot. There's no graceful SIGTERM stage on Windows because the
+        compile chain doesn't honour any of the polite signals.
         """
         proc = self._current_process
         if proc is None or proc.returncode is not None:
+            return
+        if sys.platform == "win32":
+            if not await _terminate_subtree_windows(proc.pid):
+                # taskkill missing or hung — at least put the parent down
+                # so the runner loop can finalise the job.
+                with suppress(ProcessLookupError):
+                    proc.kill()
             return
         if not _signal_process_group(proc.pid, signal.SIGTERM):
             return

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -197,7 +197,7 @@ def _signal_process_group(pid: int, sig: int) -> bool:
 
 async def _terminate_subtree_windows(pid: int) -> bool:
     """
-    Forcibly kill *pid* and its descendants on Windows; return True iff invoked.
+    Forcibly kill *pid* and its descendants on Windows; return True iff successful.
 
     Windows has no process groups in the POSIX sense, so we shell out to
     ``taskkill /F /T /PID`` — ``/T`` walks the parent-child tree from
@@ -206,12 +206,13 @@ async def _terminate_subtree_windows(pid: int) -> bool:
     gcc / esptool) ignores ``WM_CLOSE`` / ``CTRL_BREAK_EVENT`` anyway,
     so we go straight to the kill.
 
-    Returns False (and logs a warning) if ``taskkill`` is missing or
-    times out — the caller should fall back to ``proc.kill()`` so the
+    Returns False (and logs a warning) when ``taskkill`` is missing,
+    times out, or exits non-zero (access denied, invalid pid, partial
+    failure). The caller should fall back to ``proc.kill()`` so the
     parent at least dies even when the tree-walk fails.
     """
     try:
-        killer = await asyncio.create_subprocess_exec(
+        killer = await create_subprocess_exec(
             "taskkill",
             "/F",
             "/T",
@@ -229,6 +230,13 @@ async def _terminate_subtree_windows(pid: int) -> bool:
         _LOGGER.warning("taskkill timed out for pid %d", pid)
         with suppress(ProcessLookupError):
             killer.kill()
+        return False
+    if killer.returncode != 0:
+        _LOGGER.warning(
+            "taskkill exited %s for pid %d — caller should fall back to proc.kill()",
+            killer.returncode,
+            pid,
+        )
         return False
     return True
 

--- a/tests/test_firmware_stop_windows.py
+++ b/tests/test_firmware_stop_windows.py
@@ -1,0 +1,73 @@
+"""Stop-button cancellation on Windows uses ``taskkill /F /T``.
+
+The POSIX path (``test_firmware_stop.py``) relies on process groups
+and ``killpg`` — primitives that don't exist on Windows. This module
+covers the Windows-specific branch in ``_terminate_current_process``:
+``taskkill`` walks the kernel's parent-PID tree and force-kills the
+whole subtree in one shot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.firmware import (
+    FirmwareController,
+    _terminate_subtree_windows,
+)
+from esphome_device_builder.helpers.subprocess import create_subprocess_exec
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-only termination path; POSIX is covered in test_firmware_stop.py.",
+)
+
+
+@pytest.fixture
+def controller() -> FirmwareController:
+    """Stand up a FirmwareController shell — only the bits termination touches."""
+    ctrl = FirmwareController.__new__(FirmwareController)
+    ctrl._current_process = None  # type: ignore[attr-defined]
+    ctrl._current_job = MagicMock(job_id="test-job")  # type: ignore[attr-defined]
+    return ctrl
+
+
+async def test_terminate_kills_subprocess_via_taskkill(
+    controller: FirmwareController,
+) -> None:
+    """The Windows stop path force-kills the running subprocess via taskkill /F /T."""
+    proc = await create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(60)",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    controller._current_process = proc  # type: ignore[attr-defined]
+
+    try:
+        await controller._terminate_current_process()
+        # taskkill /F /T schedules termination synchronously; the
+        # subprocess should exit within seconds.
+        await asyncio.wait_for(proc.wait(), timeout=5.0)
+        assert proc.returncode is not None
+    finally:
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
+
+
+async def test_terminate_subtree_windows_returns_false_when_taskkill_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing ``taskkill`` is logged and reported, not raised."""
+
+    async def _missing(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _missing)
+    assert await _terminate_subtree_windows(12345) is False

--- a/tests/test_firmware_stop_windows.py
+++ b/tests/test_firmware_stop_windows.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from esphome_device_builder.controllers import firmware as firmware_module
 from esphome_device_builder.controllers.firmware import (
     FirmwareController,
     _terminate_subtree_windows,
@@ -69,5 +70,32 @@ async def test_terminate_subtree_windows_returns_false_when_taskkill_missing(
     async def _missing(*_args: object, **_kwargs: object) -> None:
         raise FileNotFoundError
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _missing)
+    # Patch the symbol as imported in the firmware module so the
+    # production code path (which goes through the helpers wrapper)
+    # actually exercises the fallback branch.
+    monkeypatch.setattr(firmware_module, "create_subprocess_exec", _missing)
+    assert await _terminate_subtree_windows(12345) is False
+
+
+async def test_terminate_subtree_windows_returns_false_on_taskkill_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero ``taskkill`` exit (access denied, missing pid, ...) reports failure."""
+
+    class _FakeProc:
+        returncode: int | None = None
+
+        async def wait(self) -> int:
+            self.returncode = 128
+            return 128
+
+        def kill(self) -> None:  # pragma: no cover — only used on timeout
+            pass
+
+    fake = _FakeProc()
+
+    async def _spawn(*_args: object, **_kwargs: object) -> _FakeProc:
+        return fake
+
+    monkeypatch.setattr(firmware_module, "create_subprocess_exec", _spawn)
     assert await _terminate_subtree_windows(12345) is False


### PR DESCRIPTION
## Summary

The POSIX stop-button path uses `os.getpgid` / `os.killpg` / `signal.SIGKILL` to take down the whole `esphome → platformio → gcc` subtree. None of those exist on Windows, so hitting Stop during a compile on Windows would crash the firmware controller with `AttributeError` instead of cancelling the build.

`_terminate_current_process` now branches on `sys.platform`:

- **POSIX**: unchanged — SIGTERM the process group, wait the grace window, escalate to SIGKILL on the group.
- **Windows**: shell out to `taskkill /F /T /PID <pid>`. `/T` walks the kernel's parent-PID tree, `/F` is the forceful equivalent of SIGKILL. There's no useful polite stage on Windows — non-GUI processes ignore `WM_CLOSE` / `CTRL_BREAK_EVENT` — so we go straight to the forceful kill. If `taskkill` is missing or hangs, fall back to `proc.kill()` so the runner loop can still finalise the job.

Follow-up to #48, which enabled the Windows CI matrix and skipped the POSIX-only test module on Windows. This PR fixes the actual production bug that the test was catching.

## Test plan

- [x] Existing POSIX integration test (`test_firmware_stop.py`) still passes on macOS / Linux.
- [x] New `tests/test_firmware_stop_windows.py` covers the Windows path: an integration test (spawn `python -c "time.sleep(60)"`, call `_terminate_current_process()`, assert it exits within 5s) and a unit test for the missing-taskkill fallback.
- [ ] Windows CI matrix entry passes the new tests (the Windows runner has `taskkill` on PATH by default).