### PR TITLE
Wire Blockbuster into CI to catch event-loop blocking calls

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -119,7 +119,7 @@ class DeviceScanner:
                 return False
             self._devices[path] = device
             try:
-                stat = path.stat()
+                stat = await loop.run_in_executor(None, path.stat)
                 self._cache_keys[path] = (stat.st_ino, stat.st_dev, stat.st_mtime, stat.st_size)
             except OSError:
                 pass

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -365,6 +365,21 @@ class DeviceBuilder:
         async def handle_index(request: web.Request) -> web.FileResponse:
             return web.FileResponse(index_html, headers=shell_headers)
 
+        def _resolve_static(candidate: Path) -> Path | None:
+            """Return the candidate if it's a real file inside ``frontend_root``.
+
+            Combined into one helper so the per-request stat / resolve
+            chain runs in a single thread hop instead of three. Refuses
+            to follow symlinks pointing outside the frontend directory
+            — matches ``add_static``'s default safety.
+            """
+            try:
+                if candidate.is_file() and candidate.resolve().is_relative_to(frontend_root):
+                    return candidate
+            except OSError:
+                return None
+            return None
+
         async def handle_spa(request: web.Request) -> web.FileResponse:
             tail = request.match_info["tail"]
             # Only flat names (hashed bundles, license sidecars) get
@@ -372,18 +387,12 @@ class DeviceBuilder:
             # SPA deep link that the client router will resolve.
             if tail and "/" not in tail:
                 candidate = frontend_dir / tail
-                # Refuse to follow symlinks pointing outside the
-                # frontend dir — matches add_static's default.
-                try:
-                    if candidate.is_file() and candidate.resolve().is_relative_to(frontend_root):
-                        headers = (
-                            _IMMUTABLE_HEADERS
-                            if _HASHED_FILENAME_RE.search(tail)
-                            else shell_headers
-                        )
-                        return web.FileResponse(candidate, headers=headers)
-                except OSError:
-                    pass
+                resolved = await asyncio.to_thread(_resolve_static, candidate)
+                if resolved is not None:
+                    headers = (
+                        _IMMUTABLE_HEADERS if _HASHED_FILENAME_RE.search(tail) else shell_headers
+                    )
+                    return web.FileResponse(resolved, headers=headers)
             return web.FileResponse(index_html, headers=shell_headers)
 
         app.router.add_static("/assets", assets_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ esphome = [
   "esphome>=2024.1.0",
 ]
 test = [
+  "blockbuster>=1.5.5,<1.6",
   "codespell==2.4.2",
   "jsonschema>=4.20.0",
   "mypy==1.20.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,74 @@
+"""Test fixtures shared across the suite.
+
+Currently just wires Blockbuster (https://github.com/cbornet/blockbuster)
+in as an autouse fixture so any blocking call made from inside an
+asyncio event loop fails the test instead of silently stalling the
+loop. The dashboard is async-first; a stray ``time.sleep`` or sync
+``open().read()`` on the request path would tank latency without
+showing up in the build, so we let CI catch them.
+
+The fixture only activates on Linux — that's what production runs on
+(ESPHome container, HA add-on), so it's the only platform where a
+blocking call would actually hit users. Windows and macOS just skip
+the check; their CI runs are about catching platform-specific
+regressions, not async hygiene.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+from blockbuster import blockbuster_ctx
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from blockbuster import BlockBuster
+
+# Call sites known to do bounded blocking I/O during one-time server
+# startup, where the cost is paid once and not on the request path.
+# Listed here as ``(filename, function_name)`` pairs so blockbuster
+# only exempts that specific frame, not the function globally. Keep
+# this list short — anything genuinely on a hot path should be
+# refactored, not allowlisted.
+_STARTUP_BLOCKING_OK: tuple[tuple[str, str], ...] = (
+    # SessionStore reads the persisted JSON sessions file once at
+    # AuthController construction time. Bounded by the dashboard's
+    # own startup, not request volume.
+    ("helpers/auth.py", "_load"),
+    # Sync sibling of ``_persist_async``. Production callers always
+    # wrap it via ``asyncio.to_thread`` (so blockbuster wouldn't see
+    # it from a worker thread anyway); tests call it directly to seed
+    # state without a round-trip through the executor.
+    ("helpers/auth.py", "_persist"),
+    # ``_register_frontend`` stat-checks ``index.html`` and ``assets/``
+    # at app construction so a broken frontend wheel surfaces a clear
+    # RuntimeError instead of mysterious 404s. Runs once at startup.
+    ("device_builder.py", "_register_frontend"),
+)
+
+
+@pytest.fixture(autouse=True)
+def blockbuster() -> Iterator[BlockBuster | None]:
+    """Fail any test that performs a blocking call from inside the event loop.
+
+    Linux-only: production targets are Linux containers, so other
+    platforms skip the check and just yield ``None`` (the fixture
+    return value isn't consumed by any test today).
+    """
+    if not sys.platform.startswith("linux"):
+        yield None
+        return
+    # Scope the check to our package: a blocking call only fails the
+    # test when the offending frame originates inside
+    # ``esphome_device_builder``. Test-fixture niceties (sync
+    # ``Path.mkdir`` for setup, ``tmp_path.write_text``, etc.) and
+    # third-party library internals are intentionally exempt — we're
+    # auditing the dashboard's request paths, not pytest itself.
+    with blockbuster_ctx("esphome_device_builder") as bb:
+        for fn in bb.functions.values():
+            for filename, func_name in _STARTUP_BLOCKING_OK:
+                fn.can_block_in(filename, func_name)
+        yield bb


### PR DESCRIPTION
## Summary

[Blockbuster](https://github.com/cbornet/blockbuster) wraps common sync I/O primitives (`time.sleep`, `os.stat`, `io.TextIOWrapper.read`, `socket.recv`, ...) and raises `BlockingError` when they're called from inside a running asyncio event loop. The dashboard is async-first, so a stray sync `read_text()` or `path.stat()` on a request handler tanks latency without showing up in the build. This PR makes blocking calls fail tests instead.

### How it's wired

- New `tests/conftest.py` defines a single `autouse=True` `blockbuster` fixture that wraps every test in `blockbuster_ctx("esphome_device_builder")`.
- Scoped to **our package only** — third-party library internals (aiohttp, mashumaro, esphome, pytest itself) are exempt because the offending frame must originate inside `esphome_device_builder/` for blockbuster to fire.
- **Linux-only** — production targets are Linux containers (ESPHome container, HA add-on), so that's the platform where a sync stall would actually hit users. The Windows/macOS matrix entries skip the check (the fixture yields `None`) so they keep running fast and only catch OS-specific regressions.
- Three startup-time call sites are exempted via `BlockBusterFunction.can_block_in` with explanatory comments: `SessionStore._load` / `._persist` (one-shot at AuthController construction) and `_register_frontend` (one-shot stat checks at app build).

### Findings fixed in this PR

Two real hot-path bugs surfaced on the first run:

- `controllers/_device_scanner.py:_DeviceScanner.reload` — `path.stat()` was running synchronously inside the async lock on every config-file reload. Now wrapped in `loop.run_in_executor`.
- `device_builder.py:handle_spa` (SPA-fallback frontend handler) — `candidate.is_file()` + `candidate.resolve()` ran synchronously on every deep-link request. Pulled into a `_resolve_static` helper that runs in a single `asyncio.to_thread` hop instead of three.

## Test plan

- [x] Full test suite passes locally (233 passed, 3 skipped) with blockbuster active.
- [x] Verified scoping: third-party `aiofile/version.py` import-time blocking is correctly ignored.
- [ ] Linux CI matrix entries pass with blockbuster live.
- [ ] Windows/macOS CI matrix entries skip the check and stay fast.