### PR TITLE
Forward no_states to esphome logs --no-states

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -641,15 +641,26 @@ class DevicesController:
         *,
         configuration: str,
         port: str = "",
+        no_states: bool = False,
         client: Any = None,
         message_id: str = "",
         **kwargs: Any,
     ) -> None:
-        """Stream live device logs. Per-connection, not queued."""
+        """
+        Stream live device logs. Per-connection, not queued.
+
+        ``no_states`` passes ``--no-states`` through to ``esphome logs``
+        so component state-publish lines (sensor / binary_sensor /
+        switch / cover / climate ...) are suppressed at the source.
+        Mirrors the legacy dashboard's "Show entity state changes"
+        toggle.
+        """
         config_path = str(self._db.settings.rel_path(configuration))
         cmd = [*self._esphome_cmd, "--dashboard", "logs", config_path]
         if port:
             cmd.extend(["--device", port])
+        if no_states:
+            cmd.append("--no-states")
         await self._stream_subprocess(cmd, client, message_id)
 
     @api_command("devices/stop_stream")

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -205,6 +205,69 @@ async def test_stream_logs_command_without_port_omits_device_arg() -> None:
     assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml"]]
 
 
+async def test_stream_logs_command_appends_no_states_when_requested() -> None:
+    """``no_states=True`` → ``--no-states`` is appended after the device arg."""
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(
+        configuration="kitchen.yaml",
+        port="OTA",
+        no_states=True,
+        client=MagicMock(),
+        message_id="m1-ns",
+    )
+
+    assert captured == [
+        ["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA", "--no-states"]
+    ]
+
+
+async def test_stream_logs_command_no_states_without_port() -> None:
+    """``no_states=True`` and no ``port`` → ``--no-states`` lands without ``--device``."""
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(
+        configuration="kitchen.yaml",
+        no_states=True,
+        client=MagicMock(),
+        message_id="m2-ns",
+    )
+
+    assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--no-states"]]
+
+
+async def test_stream_logs_command_omits_no_states_by_default() -> None:
+    """Default ``no_states=False`` → no ``--no-states`` in argv (regression guard)."""
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(
+        configuration="kitchen.yaml",
+        port="OTA",
+        client=MagicMock(),
+        message_id="m3-ns",
+    )
+
+    assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA"]]
+
+
 async def test_validate_config_command_includes_dashboard_flag() -> None:
     """``devices/validate`` invokes ``esphome --dashboard config <yaml>``."""
     ctrl = _make_controller_with_settings(["esphome"])


### PR DESCRIPTION
## Summary

- `devices/logs` now accepts a `no_states: bool = False` parameter and appends `--no-states` to the `esphome logs` invocation when set.
- Mirrors the legacy ESPHome dashboard's "Show entity state changes" toggle — suppresses high-volume sensor/binary_sensor/switch state-publish lines at the source so the user can see lifecycle / boot / API messages without noise.
- Frontend counterpart in [device-builder-frontend#54](https://github.com/esphome/device-builder-frontend/pull/54).

## Test plan

- [x] Existing log streaming continues to work without the new param (default false).
- [x] When the dashboard sends `no_states: true`, the spawned process gets `--no-states` and entity state lines are suppressed.
- [x] Toggling the frontend control restarts the stream cleanly (existing stop_stream path).