### PR TITLE
Skip ping for hostnames with cached DNS failure

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -412,35 +412,7 @@ class DeviceStateMonitor:
         if icmp_ping is None:
             return
 
-        # Match the upstream dashboard: only ping devices that aren't
-        # already ONLINE from a higher-priority source. ``OFFLINE`` and
-        # ``UNKNOWN`` devices still get pinged so off-network hosts (no
-        # mDNS reachability) can transition online via DNS + ICMP.
-        devices_to_ping: list[Device] = []
-        for device in self._get_devices():
-            if not device.address or not self._should_ping(device):
-                continue
-            # Zeroconf's cache is authoritative for ``.local`` — if it
-            # has an entry, the device announced via mDNS even when the
-            # ``AsyncServiceBrowser`` ``Added`` callback didn't fire for
-            # us (multicast packet drops, startup race). Claim it as
-            # mDNS-online and skip ping; otherwise the bare-hostname DNS
-            # fallback can resolve to an unreachable IP on a different
-            # subnet and we'd report a phantom OFFLINE for a device
-            # that's actually right there.
-            if is_local_hostname(device.address) and (
-                cached := self.get_cached_addresses(device.address)
-            ):
-                self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-                # ``apply_ip`` only carries one IP; prefer V4 so the
-                # device-list display and any ad-hoc ICMP probe both get
-                # the cross-subnet-friendly entry. The CLI cache args
-                # built in ``_build_address_cache_args`` consume every
-                # cached IP separately, so we don't lose V6 reachability
-                # by picking V4 here.
-                self.apply_ip(device.name, _pick_ipv4(cached))
-                continue
-            devices_to_ping.append(device)
+        devices_to_ping = self._select_ping_targets()
         if not devices_to_ping:
             return
 
@@ -487,6 +459,50 @@ class DeviceStateMonitor:
                     *(self._ping_device(device, target) for device, target in ping_targets),
                     return_exceptions=True,
                 )
+
+    def _select_ping_targets(self) -> list[Device]:
+        """
+        Filter the device list down to actual ping candidates.
+
+        Devices already known to be ONLINE via a higher-priority source
+        are skipped. ``.local`` hosts that show up in zeroconf's cache
+        are claimed for mDNS so the bare-hostname DNS fallback can't
+        resolve them to an unreachable IP on a different subnet.
+        Hostnames with a fresh DNS-failure cache entry are flipped
+        OFFLINE without a ping attempt — there's nothing to resolve, so
+        re-trying every minute would just hammer the resolver.
+        """
+        devices_to_ping: list[Device] = []
+        dns_skipped: list[Device] = []
+        for device in self._get_devices():
+            if not device.address or not self._should_ping(device):
+                continue
+            if is_local_hostname(device.address) and (
+                cached := self.get_cached_addresses(device.address)
+            ):
+                self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
+                # Prefer IPv4 for ``apply_ip`` (the per-device single
+                # IP) so the device-list display and any ad-hoc ICMP
+                # probe both pick the cross-subnet-friendly entry. The
+                # OTA cache args built in
+                # ``_build_address_cache_args`` consume every cached
+                # IP separately, so we don't lose V6 reachability by
+                # picking V4 here.
+                self.apply_ip(device.name, _pick_ipv4(cached))
+                continue
+            if self._dns_cache.has_cached_failure(device.address):
+                dns_skipped.append(device)
+                self.apply(device.name, DeviceState.OFFLINE, "ping")
+                continue
+            devices_to_ping.append(device)
+
+        if dns_skipped and _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "Skipping ping for %d device(s) with cached DNS failure: %s",
+                len(dns_skipped),
+                ", ".join(f"{d.name} ({d.address})" for d in dns_skipped),
+            )
+        return devices_to_ping
 
     def _should_ping(self, device: Device) -> bool:
         """

--- a/esphome_device_builder/controllers/_dns_cache.py
+++ b/esphome_device_builder/controllers/_dns_cache.py
@@ -81,6 +81,26 @@ class DNSCache:
             return None
         return list(addresses)
 
+    def has_cached_failure(self, hostname: str) -> bool:
+        """
+        Return ``True`` when *hostname* has a fresh cached failure entry.
+
+        Lets callers (the ping sweep) skip a hostname entirely without
+        even logging an attempt when we already know — within the cache
+        TTL — that resolution will fail. Literal IP addresses always
+        return ``False`` because they don't go through resolution.
+        """
+        normalized = self._normalize(hostname)
+        with suppress(ValueError):
+            ip_address(normalized)
+            return False
+
+        entry = self._cache.get(normalized)
+        if entry is None:
+            return False
+        expires_at, addresses = entry
+        return expires_at > time.monotonic() and not addresses
+
     async def async_resolve(self, hostname: str) -> list[str] | None:
         """
         Resolve *hostname* to a list of IPs, caching the result.

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -89,6 +89,44 @@ def test_get_cached_hides_failed_resolutions() -> None:
 
 
 # ----------------------------------------------------------------------
+# has_cached_failure
+# ----------------------------------------------------------------------
+
+
+def test_has_cached_failure_false_on_miss() -> None:
+    assert DNSCache().has_cached_failure("esp.example.com") is False
+
+
+def test_has_cached_failure_true_for_fresh_failure() -> None:
+    cache = DNSCache(ttl=60)
+    cache._cache["esp.example.com"] = (time.monotonic() + 60, None)
+    assert cache.has_cached_failure("esp.example.com") is True
+
+
+def test_has_cached_failure_false_after_ttl_expiry() -> None:
+    cache = DNSCache(ttl=60)
+    cache._cache["esp.example.com"] = (time.monotonic() - 1, None)
+    assert cache.has_cached_failure("esp.example.com") is False
+
+
+def test_has_cached_failure_false_for_successful_entry() -> None:
+    cache = DNSCache(ttl=60)
+    cache._cache["esp.example.com"] = (time.monotonic() + 60, ["10.0.0.1"])
+    assert cache.has_cached_failure("esp.example.com") is False
+
+
+def test_has_cached_failure_false_for_literal_ip() -> None:
+    assert DNSCache().has_cached_failure("10.0.0.1") is False
+    assert DNSCache().has_cached_failure("fe80::1") is False
+
+
+def test_has_cached_failure_normalises_hostname() -> None:
+    cache = DNSCache(ttl=60)
+    cache._cache["esp.example.com"] = (time.monotonic() + 60, None)
+    assert cache.has_cached_failure("ESP.example.com.") is True
+
+
+# ----------------------------------------------------------------------
 # async_resolve
 # ----------------------------------------------------------------------
 
@@ -325,6 +363,49 @@ async def test_ping_sweep_marks_offline_directly_on_dns_failure(fake_resolver) -
     # Crucially: ``icmp_ping`` was NOT called. The resolution failure
     # was enough to declare the device offline.
     assert pinged == []
+    assert state_changes == [("kitchen", DeviceState.OFFLINE, "ping")]
+
+
+async def test_ping_sweep_skips_devices_with_cached_dns_failure(fake_resolver) -> None:
+    """Pre-cached DNS failure → no resolver call, no icmp_ping, OFFLINE applied.
+
+    Once a hostname has a cached failure entry from a previous sweep,
+    subsequent sweeps must short-circuit before logging "Pinging N
+    devices" — otherwise the log lists devices we already know we
+    won't reach. The resolver call must also be skipped so we don't
+    re-attempt a known-bad lookup every minute.
+    """
+    from esphome_device_builder.models import DeviceState
+
+    devices = [_device()]
+    state_changes: list[tuple[str, DeviceState, str]] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
+        on_ip_change=lambda *_: None,
+    )
+    # Prime the cache with a fresh failure so the sweep should skip.
+    monitor._dns_cache._cache["esp.example.com"] = (time.monotonic() + 60, None)
+
+    resolver = fake_resolver(["10.0.0.1"])
+    pinged: list[str] = []
+
+    async def fake_ping(target, **_kwargs):  # type: ignore[no-untyped-def]
+        pinged.append(target)
+
+        class _R:
+            is_alive = True
+
+        return _R()
+
+    with (
+        patch.object(dns_cache_mod, "async_resolve", resolver),
+        patch.object(sm, "icmp_ping", fake_ping),
+    ):
+        await monitor._ping_sweep()
+
+    assert pinged == []
+    assert resolver.calls == []
     assert state_changes == [("kitchen", DeviceState.OFFLINE, "ping")]
 
 


### PR DESCRIPTION
## Summary

- Adds `DNSCache.has_cached_failure(hostname)` — synchronous check for a fresh failure entry without triggering a lookup.
- Ping sweep now partitions candidates **before** the "Pinging N devices" log line: devices whose hostnames have a cached DNS failure are flipped `OFFLINE` up front and excluded from the log.
- Without this, the debug log listed every candidate (including the ones we'd skip during resolve) so it was unclear from the log whether the cache was actually being honored. The `async_resolve` cache hit was already short-circuiting the actual icmp call — this just surfaces it in the logs and avoids the redundant resolver round-trip on every sweep.
- A separate "Skipping ping for N device(s) with cached DNS failure: …" debug line appears when entries are skipped so the behaviour is visible.
- Extracted the partition step out of `_ping_sweep` into `_select_ping_targets` to satisfy ruff PLR0912.

## Test plan

- [ ] Unit tests for `has_cached_failure`: miss, fresh failure, expired, success, literal IPs, hostname normalisation.
- [ ] Sweep-level test: pre-cached failure → no resolver call, no `icmp_ping`, OFFLINE applied.
- [ ] Existing sweep tests still pass.