### PR TITLE
Wire importable-device discovery via mDNS

### DIFF
--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -80,21 +80,11 @@ def create_legacy_routes() -> web.RouteTableDef:
 
         configured = [d.to_dict() for d in devices_ctrl.get_devices()]
 
-        importable = []
-        for name, imp in devices_ctrl.import_result.items():
-            if name in devices_ctrl.ignored_devices:
-                continue
-            importable.append(
-                {
-                    "name": name,
-                    "friendly_name": getattr(imp, "friendly_name", name),
-                    "package_import_url": getattr(imp, "package_import_url", ""),
-                    "project_name": getattr(imp, "project_name", ""),
-                    "project_version": getattr(imp, "project_version", ""),
-                    "network": getattr(imp, "network", "wifi"),
-                    "ignored": name in devices_ctrl.ignored_devices,
-                }
-            )
+        importable = [
+            imp.to_dict()
+            for name, imp in devices_ctrl.import_result.items()
+            if name not in devices_ctrl.ignored_devices
+        ]
 
         return web.json_response({"configured": configured, "importable": importable})
 

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -17,6 +17,7 @@ from esphome.const import __version__ as esphome_version
 
 from ..constants import __version__
 from ..controllers.auth import AuthError
+from ..helpers.api import CommandError
 from ..helpers.auth import extract_bearer_token
 from ..models import (
     CommandMessage,
@@ -162,6 +163,11 @@ class WebSocketClient:
             result = await handler(client=self, message_id=cmd.message_id, **cmd.args)
             await self.send_result(cmd.message_id, result)
         except AuthError as err:
+            await self.send_error(cmd.message_id, err.code, err.message)
+        except CommandError as err:
+            # Deliberate user-facing failure raised by a handler; pass
+            # the code + message through verbatim so the client can
+            # show something actionable instead of "Command failed".
             await self.send_error(cmd.message_id, err.code, err.message)
         except Exception:
             _LOGGER.exception("Error handling command %s", cmd.command)

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -314,6 +314,30 @@ class DeviceStateMonitor:
         addresses = info.parsed_scoped_addresses(IPVersion.All)
         return addresses or None
 
+    def revisit_importable(self, device_name: str) -> None:
+        """
+        Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached.
+
+        Used after a configured device is deleted: the device's mDNS
+        announcement was being suppressed by the ``configured-name``
+        filter in ``_on_import_update``, but upstream's
+        ``DashboardImportDiscovery.import_state`` already has the
+        ``DiscoveredImport`` entry from the original announcement.
+        Without this nudge the discovery banner stays silent until the
+        device re-announces (which can be minutes for a quiet device).
+
+        Ignored devices are skipped — the user already said "don't
+        show me this", so a deletion shouldn't unilaterally bring it
+        back. They can unignore through the menu if they change their
+        mind, and an unsolicited mDNS re-announce will surface it
+        through the normal callback path either way.
+        """
+        if self._import_discovery is None or self._is_ignored(device_name):
+            return
+        for service_name, discovered in self._import_discovery.import_state.items():
+            if discovered.device_name == device_name:
+                self._on_import_update(service_name, discovered)
+
     def get_importable_devices(self) -> list[AdoptableDevice]:
         """
         Snapshot of devices currently advertising as importable.

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -99,6 +99,19 @@ ImportableAddedCallback = Callable[[AdoptableDevice], None]
 ImportableRemovedCallback = Callable[[str], None]
 
 
+def _http_url_from_service_info(device_name: str, info: AsyncServiceInfo) -> str:
+    """Build ``http://<host>[:port]`` from a populated HTTP service info.
+
+    Single source of truth for the URL shape — ``_apply_http_service_info``
+    (browser callback path) and ``_seed_http_url_from_cache`` (late-binding
+    path when the HTTP service was already cached before the importable
+    arrived) both call this so the format stays consistent.
+    """
+    host = info.server.removesuffix(".") if info.server else f"{device_name}.local"
+    port = info.port or 80
+    return f"http://{host}{'' if port == 80 else f':{port}'}"
+
+
 def device_name_from_service(service_name: str) -> str:
     """Extract the device name from an mDNS service-instance name.
 
@@ -385,18 +398,7 @@ class DeviceStateMonitor:
         for discovered in self._import_discovery.import_state.values():
             if discovered.device_name in configured_names:
                 continue
-            out.append(
-                AdoptableDevice(
-                    name=discovered.device_name,
-                    friendly_name=discovered.friendly_name or "",
-                    package_import_url=discovered.package_import_url,
-                    project_name=discovered.project_name,
-                    project_version=discovered.project_version,
-                    network=discovered.network,
-                    ignored=self._is_ignored(discovered.device_name),
-                    web_url=self._http_urls.get(discovered.device_name, ""),
-                )
-            )
+            out.append(self._build_adoptable(discovered))
         return out
 
     def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
@@ -502,14 +504,30 @@ class DeviceStateMonitor:
     async def _resolve_and_apply(
         self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
     ) -> None:
-        """Resolve a cache-miss mDNS service and propagate its details."""
+        """Resolve a cache-miss esphomelib mDNS service and propagate its details."""
+        await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
+
+    async def _resolve_then(
+        self,
+        zeroconf: Any,
+        info: AsyncServiceInfo,
+        device_name: str,
+        apply: Callable[[str, AsyncServiceInfo], None],
+    ) -> None:
+        """Resolve a cache-miss service and hand the result to *apply*.
+
+        The esphomelib and HTTP browsers share the same fire-and-forget
+        shape: spawn a task on cache miss, ``async_request`` the
+        record, swallow exceptions to a debug log, then dispatch to
+        the per-type applier when resolution succeeds.
+        """
         try:
             if not await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
                 return
         except Exception:
             _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
             return
-        self._apply_service_info(device_name, info)
+        apply(device_name, info)
 
     def _on_http_service_state_change(
         self,
@@ -546,13 +564,7 @@ class DeviceStateMonitor:
         self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
     ) -> None:
         """Resolve a cache-miss HTTP service and store its URL."""
-        try:
-            if not await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
-                return
-        except Exception:
-            _LOGGER.debug("HTTP mDNS resolve failed for %s", device_name, exc_info=True)
-            return
-        self._apply_http_service_info(device_name, info)
+        await self._resolve_then(zeroconf, info, device_name, self._apply_http_service_info)
 
     def _apply_http_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """Build the Visit-web-UI URL from a populated HTTP service info.
@@ -566,9 +578,7 @@ class DeviceStateMonitor:
         """
         if not self._has_importable(device_name):
             return
-        host = info.server.removesuffix(".") if info.server else f"{device_name}.local"
-        port = info.port or 80
-        url = f"http://{host}{'' if port == 80 else f':{port}'}"
+        url = _http_url_from_service_info(device_name, info)
         if self._http_urls.get(device_name) == url:
             return
         self._http_urls[device_name] = url
@@ -606,9 +616,7 @@ class DeviceStateMonitor:
         info = AsyncServiceInfo(_HTTP_SERVICE_TYPE, f"{device_name}.{_HTTP_SERVICE_TYPE}")
         if not info.load_from_cache(self._zeroconf.zeroconf):
             return
-        host = info.server.removesuffix(".") if info.server else f"{device_name}.local"
-        port = info.port or 80
-        self._http_urls[device_name] = f"http://{host}{'' if port == 80 else f':{port}'}"
+        self._http_urls[device_name] = _http_url_from_service_info(device_name, info)
 
     def _on_import_update(self, service_name: str, discovered: DiscoveredImport | None) -> None:
         """Bridge ``DashboardImportDiscovery`` → controller callbacks.
@@ -636,18 +644,27 @@ class DeviceStateMonitor:
         # here carries it without waiting for the next HTTP re-announce.
         self._seed_http_url_from_cache(discovered.device_name)
         if self._on_importable_added is not None:
-            self._on_importable_added(
-                AdoptableDevice(
-                    name=discovered.device_name,
-                    friendly_name=discovered.friendly_name or "",
-                    package_import_url=discovered.package_import_url,
-                    project_name=discovered.project_name,
-                    project_version=discovered.project_version,
-                    network=discovered.network,
-                    ignored=self._is_ignored(discovered.device_name),
-                    web_url=self._http_urls.get(discovered.device_name, ""),
-                )
-            )
+            self._on_importable_added(self._build_adoptable(discovered))
+
+    def _build_adoptable(self, discovered: DiscoveredImport) -> AdoptableDevice:
+        """Translate an upstream ``DiscoveredImport`` into our ``AdoptableDevice``.
+
+        Single construction site for the cross-type mapping plus the
+        two locally-known fields (``ignored`` from the persisted set,
+        ``web_url`` from the HTTP-service cache). Used by both the
+        live ADD path (``_on_import_update``) and the snapshot path
+        (``get_importable_devices``) so the two views stay identical.
+        """
+        return AdoptableDevice(
+            name=discovered.device_name,
+            friendly_name=discovered.friendly_name or "",
+            package_import_url=discovered.package_import_url,
+            project_name=discovered.project_name,
+            project_version=discovered.project_version,
+            network=discovered.network,
+            ignored=self._is_ignored(discovered.device_name),
+            web_url=self._http_urls.get(discovered.device_name, ""),
+        )
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``."""

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -39,6 +39,12 @@ from ._dns_cache import DNSCache
 
 _LOGGER = logging.getLogger(__name__)
 _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
+# A second mDNS browser watches for HTTP services so we can light up
+# a "Visit web UI" link on discovered devices that are running their
+# factory firmware's built-in web server. The browser only feeds the
+# importable-discovery flow; configured devices already get their
+# web_port from the YAML (``web_server:``).
+_HTTP_SERVICE_TYPE = "_http._tcp.local."
 # Ping fallback runs every 60s after a short bootstrap window.
 # ``_PING_BOOTSTRAP_DELAY`` gives the mDNS browser a head start so the
 # common case (everything announces) doesn't fire a ping sweep that
@@ -148,8 +154,16 @@ class DeviceStateMonitor:
         # browser-callback keeps us in lockstep with whatever the
         # upstream considers an importable device.
         self._import_discovery: DashboardImportDiscovery | None = None
+        # Map of device-name → web-UI URL, populated by the
+        # ``_http._tcp.local.`` browser. Lets the discovered-device
+        # card render a Visit-web-UI link without the frontend having
+        # to know which factory firmwares ship a web server.
+        self._http_urls: dict[str, str] = {}
         self._zeroconf: AsyncEsphomeZeroconf | None = None
-        self._mdns_browser: Any = None
+        # Single browser covers both ``_esphomelib._tcp.local.`` and
+        # ``_http._tcp.local.``; the dispatch handler routes events
+        # by ``service_type`` to the right per-type logic.
+        self._mdns_browser: AsyncServiceBrowser | None = None
         self._ping_task: asyncio.Task | None = None
         # Strong refs for fire-and-forget mDNS resolve tasks so the
         # garbage collector can't reap them mid-await.
@@ -364,6 +378,7 @@ class DeviceStateMonitor:
                     project_version=discovered.project_version,
                     network=discovered.network,
                     ignored=self._is_ignored(discovered.device_name),
+                    web_url=self._http_urls.get(discovered.device_name, ""),
                 )
             )
         return out
@@ -395,7 +410,7 @@ class DeviceStateMonitor:
             self._zeroconf = None
             return
 
-        def _on_service_state_change(
+        def _on_esphomelib_service_state_change(
             zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
         ) -> None:
             # ``AsyncServiceBrowser`` dispatches handlers on the asyncio
@@ -433,18 +448,38 @@ class DeviceStateMonitor:
             task.add_done_callback(self._tasks.discard)
 
         # ``DashboardImportDiscovery`` from upstream esphome owns the
-        # TXT-record parsing for adoptable factory firmwares. Adding
-        # its callback as a second handler on the same browser means
-        # we share zeroconf cache reads with the state-change handler
-        # above instead of running a parallel browser.
+        # TXT-record parsing for adoptable factory firmwares — its
+        # ``browser_callback`` only acts on services that carry the
+        # ``package_import_url`` TXT records, so harmlessly receiving
+        # HTTP events is fine.
         self._import_discovery = DashboardImportDiscovery(self._on_import_update)
+
+        def _dispatch(
+            zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
+        ) -> None:
+            # Single ``AsyncServiceBrowser`` covers both service types;
+            # dispatch by ``service_type`` so each inner handler only
+            # sees the events it cares about. Sharing one browser
+            # halves the zeroconf bookkeeping vs running two separate
+            # browsers and lets the upstream ``DashboardImportDiscovery``
+            # callback piggy-back on the same dispatch path.
+            if service_type == _ESPHOME_SERVICE_TYPE:
+                _on_esphomelib_service_state_change(zeroconf, service_type, name, state_change)
+                self._import_discovery.browser_callback(zeroconf, service_type, name, state_change)
+            elif service_type == _HTTP_SERVICE_TYPE:
+                self._on_http_service_state_change(zeroconf, service_type, name, state_change)
+
         try:
             self._mdns_browser = AsyncServiceBrowser(
                 self._zeroconf.zeroconf,
-                _ESPHOME_SERVICE_TYPE,
-                handlers=[_on_service_state_change, self._import_discovery.browser_callback],
+                [_ESPHOME_SERVICE_TYPE, _HTTP_SERVICE_TYPE],
+                handlers=[_dispatch],
             )
-            _LOGGER.info("mDNS browser started for %s", _ESPHOME_SERVICE_TYPE)
+            _LOGGER.info(
+                "mDNS browser started for %s, %s",
+                _ESPHOME_SERVICE_TYPE,
+                _HTTP_SERVICE_TYPE,
+            )
         except Exception:
             _LOGGER.exception("Could not start mDNS browser — device discovery limited to ping")
 
@@ -459,6 +494,68 @@ class DeviceStateMonitor:
             _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
             return
         self._apply_service_info(device_name, info)
+
+    def _on_http_service_state_change(
+        self,
+        zeroconf: Any,
+        service_type: str,
+        name: str,
+        state_change: ServiceStateChange,
+    ) -> None:
+        """Track ``_http._tcp.local.`` services so discovered cards can show a Visit-web-UI link.
+
+        The browser fires for every HTTP service on the LAN — we only
+        care about the ones whose left-hand label matches an importable
+        device, so the matching is name-driven. When an HTTP service
+        appears (or disappears) for an existing importable, re-emit
+        the entry so the card's ``web_url`` field stays in sync
+        without waiting for the next esphomelib announcement.
+        """
+        device_name = device_name_from_service(name)
+        if state_change == ServiceStateChange.Removed:
+            if self._http_urls.pop(device_name, None) is None:
+                return
+            self._refire_importable_for(device_name)
+            return
+
+        info = AsyncServiceInfo(service_type, name)
+        if info.load_from_cache(zeroconf):
+            self._apply_http_service_info(device_name, info)
+            return
+        task = asyncio.create_task(self._resolve_and_apply_http(zeroconf, info, device_name))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _resolve_and_apply_http(
+        self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
+    ) -> None:
+        """Resolve a cache-miss HTTP service and store its URL."""
+        try:
+            if not await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
+                return
+        except Exception:
+            _LOGGER.debug("HTTP mDNS resolve failed for %s", device_name, exc_info=True)
+            return
+        self._apply_http_service_info(device_name, info)
+
+    def _apply_http_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
+        """Build the Visit-web-UI URL from a populated HTTP service info."""
+        host = info.server.removesuffix(".") if info.server else f"{device_name}.local"
+        port = info.port or 80
+        url = f"http://{host}{'' if port == 80 else f':{port}'}"
+        if self._http_urls.get(device_name) == url:
+            return
+        self._http_urls[device_name] = url
+        self._refire_importable_for(device_name)
+
+    def _refire_importable_for(self, device_name: str) -> None:
+        """Re-emit ADDED for *device_name* so frontends pick up a web_url change."""
+        if self._import_discovery is None:
+            return
+        for service_name, discovered in self._import_discovery.import_state.items():
+            if discovered.device_name == device_name:
+                self._on_import_update(service_name, discovered)
+                return
 
     def _on_import_update(self, service_name: str, discovered: DiscoveredImport | None) -> None:
         """Bridge ``DashboardImportDiscovery`` → controller callbacks.
@@ -490,6 +587,7 @@ class DeviceStateMonitor:
                     project_version=discovered.project_version,
                     network=discovered.network,
                     ignored=self._is_ignored(discovered.device_name),
+                    web_url=self._http_urls.get(discovered.device_name, ""),
                 )
             )
 

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -352,6 +352,22 @@ class DeviceStateMonitor:
             if discovered.device_name == device_name:
                 self._on_import_update(service_name, discovered)
 
+    def revisit_all_importables(self) -> None:
+        """
+        Re-fire ``on_importable_added`` for every cached importable.
+
+        Used when a configured YAML is deleted but we don't know what
+        mDNS name it came from (the user may have picked a YAML name
+        that differs from the discovered hostname during adoption).
+        ``_on_import_update`` already filters configured + ignored
+        names so re-emitting the full set is safe; only the entries
+        that should appear in the banner do.
+        """
+        if self._import_discovery is None:
+            return
+        for service_name, discovered in self._import_discovery.import_state.items():
+            self._on_import_update(service_name, discovered)
+
     def get_importable_devices(self) -> list[AdoptableDevice]:
         """
         Snapshot of devices currently advertising as importable.
@@ -539,7 +555,17 @@ class DeviceStateMonitor:
         self._apply_http_service_info(device_name, info)
 
     def _apply_http_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
-        """Build the Visit-web-UI URL from a populated HTTP service info."""
+        """Build the Visit-web-UI URL from a populated HTTP service info.
+
+        Only stored when an importable device with the same name is
+        currently advertising. Without this guard ``_http_urls`` grew
+        unbounded from every HTTP service on the LAN (printers, NAS
+        boxes, routers — none of which we have any use for); this
+        keeps the cache scoped to entries that can actually drive a
+        Visit-web-UI link on the discovered card.
+        """
+        if not self._has_importable(device_name):
+            return
         host = info.server.removesuffix(".") if info.server else f"{device_name}.local"
         port = info.port or 80
         url = f"http://{host}{'' if port == 80 else f':{port}'}"
@@ -547,6 +573,14 @@ class DeviceStateMonitor:
             return
         self._http_urls[device_name] = url
         self._refire_importable_for(device_name)
+
+    def _has_importable(self, device_name: str) -> bool:
+        """Return True when an importable currently exists for *device_name*."""
+        if self._import_discovery is None:
+            return False
+        return any(
+            d.device_name == device_name for d in self._import_discovery.import_state.values()
+        )
 
     def _refire_importable_for(self, device_name: str) -> None:
         """Re-emit ADDED for *device_name* so frontends pick up a web_url change."""
@@ -556,6 +590,25 @@ class DeviceStateMonitor:
             if discovered.device_name == device_name:
                 self._on_import_update(service_name, discovered)
                 return
+
+    def _seed_http_url_from_cache(self, device_name: str) -> None:
+        """Pull ``device_name``'s HTTP service URL out of zeroconf's cache.
+
+        Handles the case where the HTTP service arrived first: the
+        browser callback skipped storing the URL because no importable
+        existed for that name yet. Now that one does, look directly at
+        zeroconf's cache (no network round-trip) and stash the URL so
+        the about-to-fire ``on_importable_added`` carries the right
+        ``web_url``.
+        """
+        if self._zeroconf is None or self._http_urls.get(device_name):
+            return
+        info = AsyncServiceInfo(_HTTP_SERVICE_TYPE, f"{device_name}.{_HTTP_SERVICE_TYPE}")
+        if not info.load_from_cache(self._zeroconf.zeroconf):
+            return
+        host = info.server.removesuffix(".") if info.server else f"{device_name}.local"
+        port = info.port or 80
+        self._http_urls[device_name] = f"http://{host}{'' if port == 80 else f':{port}'}"
 
     def _on_import_update(self, service_name: str, discovered: DiscoveredImport | None) -> None:
         """Bridge ``DashboardImportDiscovery`` → controller callbacks.
@@ -577,6 +630,11 @@ class DeviceStateMonitor:
             # Already configured — surfacing it as importable would
             # confuse the dashboard.
             return
+        # Late-binding: if the HTTP service for this device is already
+        # in zeroconf's cache (it arrived before the esphomelib
+        # service), pull its URL now so the AdoptableDevice we emit
+        # here carries it without waiting for the next HTTP re-announce.
+        self._seed_http_url_from_cache(discovered.device_name)
         if self._on_importable_added is not None:
             self._on_importable_added(
                 AdoptableDevice(

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -20,7 +20,11 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from esphome.zeroconf import AsyncEsphomeZeroconf
+from esphome.zeroconf import (
+    AsyncEsphomeZeroconf,
+    DashboardImportDiscovery,
+    DiscoveredImport,
+)
 from zeroconf import AddressResolver, IPVersion, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
@@ -30,7 +34,7 @@ except ImportError:  # pragma: no cover — icmplib is optional
     icmp_ping = None  # type: ignore[assignment]
 
 from ..helpers.hostname import is_local_hostname, normalize_hostname
-from ..models import Device, DeviceState
+from ..models import AdoptableDevice, Device, DeviceState
 from ._dns_cache import DNSCache
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,6 +84,14 @@ VersionChangeCallback = Callable[[str, str], None]
 # older devices simply never fire this callback.
 ConfigHashChangeCallback = Callable[[str, str], None]
 
+# Callback fired when zeroconf turns up a previously-unseen device that
+# advertises ``package_import_url`` / ``project_name`` /
+# ``project_version`` TXT records — the signal that this is a factory
+# build ready to be adopted into the dashboard. The companion
+# ``ImportableRemovedCallback`` fires when the service goes away.
+ImportableAddedCallback = Callable[[AdoptableDevice], None]
+ImportableRemovedCallback = Callable[[str], None]
+
 
 def device_name_from_service(service_name: str) -> str:
     """Extract the device name from an mDNS service-instance name.
@@ -113,16 +125,29 @@ class DeviceStateMonitor:
         on_ip_change: IPChangeCallback,
         on_version_change: VersionChangeCallback | None = None,
         on_config_hash_change: ConfigHashChangeCallback | None = None,
+        on_importable_added: ImportableAddedCallback | None = None,
+        on_importable_removed: ImportableRemovedCallback | None = None,
+        is_ignored: Callable[[str], bool] | None = None,
     ) -> None:
         self._get_devices = get_devices
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
         self._on_version_change = on_version_change
         self._on_config_hash_change = on_config_hash_change
+        self._on_importable_added = on_importable_added
+        self._on_importable_removed = on_importable_removed
+        self._is_ignored = is_ignored or (lambda _name: False)
         self._state_source: dict[str, str] = {}  # device name → "mdns" | "ping"
         self._device_ips: dict[str, str] = {}  # device name → last known IP
         self._device_versions: dict[str, str] = {}  # device name → last reported version
         self._device_config_hashes: dict[str, str] = {}  # device name → last reported config hash
+        # ``DashboardImportDiscovery`` is the upstream esphome class
+        # that watches the same ``_esphomelib._tcp.local.`` browser for
+        # ``package_import_url`` TXT records and turns them into
+        # ``DiscoveredImport`` entries. Hooking it as a sibling
+        # browser-callback keeps us in lockstep with whatever the
+        # upstream considers an importable device.
+        self._import_discovery: DashboardImportDiscovery | None = None
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         self._mdns_browser: Any = None
         self._ping_task: asyncio.Task | None = None
@@ -289,6 +314,36 @@ class DeviceStateMonitor:
         addresses = info.parsed_scoped_addresses(IPVersion.All)
         return addresses or None
 
+    def get_importable_devices(self) -> list[AdoptableDevice]:
+        """
+        Snapshot of devices currently advertising as importable.
+
+        Built fresh each call from ``DashboardImportDiscovery``'s
+        ``import_state`` so the ``ignored`` flag and the configured-
+        device filter both reflect the live dashboard state. Callers
+        (e.g. the WebSocket ``initial_state`` event) get the same view
+        the per-device ADDED events would have surfaced incrementally.
+        """
+        if self._import_discovery is None:
+            return []
+        configured_names = {d.name for d in self._get_devices()}
+        out: list[AdoptableDevice] = []
+        for discovered in self._import_discovery.import_state.values():
+            if discovered.device_name in configured_names:
+                continue
+            out.append(
+                AdoptableDevice(
+                    name=discovered.device_name,
+                    friendly_name=discovered.friendly_name or "",
+                    package_import_url=discovered.package_import_url,
+                    project_name=discovered.project_name,
+                    project_version=discovered.project_version,
+                    network=discovered.network,
+                    ignored=self._is_ignored(discovered.device_name),
+                )
+            )
+        return out
+
     def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
         """
         Return DNS-cached IPs for *host_name* without issuing a lookup.
@@ -353,11 +408,17 @@ class DeviceStateMonitor:
             self._tasks.add(task)
             task.add_done_callback(self._tasks.discard)
 
+        # ``DashboardImportDiscovery`` from upstream esphome owns the
+        # TXT-record parsing for adoptable factory firmwares. Adding
+        # its callback as a second handler on the same browser means
+        # we share zeroconf cache reads with the state-change handler
+        # above instead of running a parallel browser.
+        self._import_discovery = DashboardImportDiscovery(self._on_import_update)
         try:
             self._mdns_browser = AsyncServiceBrowser(
                 self._zeroconf.zeroconf,
                 _ESPHOME_SERVICE_TYPE,
-                handlers=[_on_service_state_change],
+                handlers=[_on_service_state_change, self._import_discovery.browser_callback],
             )
             _LOGGER.info("mDNS browser started for %s", _ESPHOME_SERVICE_TYPE)
         except Exception:
@@ -374,6 +435,39 @@ class DeviceStateMonitor:
             _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
             return
         self._apply_service_info(device_name, info)
+
+    def _on_import_update(self, service_name: str, discovered: DiscoveredImport | None) -> None:
+        """Bridge ``DashboardImportDiscovery`` → controller callbacks.
+
+        ``service_name`` is the full mDNS service-instance name
+        (``<device>._esphomelib._tcp.local.``); ``discovered`` is None
+        on removal. We re-key by device name so callers don't have to
+        carry the suffix, drop devices that are already configured
+        locally (since the dashboard knows about them already), and
+        translate the upstream ``DiscoveredImport`` shape into our
+        ``AdoptableDevice`` model with the ``ignored`` flag filled in.
+        """
+        device_name = device_name_from_service(service_name)
+        if discovered is None:
+            if self._on_importable_removed is not None:
+                self._on_importable_removed(device_name)
+            return
+        if self._find_device_by_name(device_name) is not None:
+            # Already configured — surfacing it as importable would
+            # confuse the dashboard.
+            return
+        if self._on_importable_added is not None:
+            self._on_importable_added(
+                AdoptableDevice(
+                    name=discovered.device_name,
+                    friendly_name=discovered.friendly_name or "",
+                    package_import_url=discovered.package_import_url,
+                    project_name=discovered.project_name,
+                    project_version=discovered.project_version,
+                    network=discovered.network,
+                    ignored=self._is_ignored(discovered.device_name),
+                )
+            )
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``."""

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -106,8 +106,15 @@ def _http_url_from_service_info(device_name: str, info: AsyncServiceInfo) -> str
     (browser callback path) and ``_seed_http_url_from_cache`` (late-binding
     path when the HTTP service was already cached before the importable
     arrived) both call this so the format stays consistent.
+
+    ``info.server`` is trusted only when it's an ``.local`` hostname.
+    Anything else (a routable hostname, a remote SRV target) gets
+    rewritten to ``<device_name>.local`` so a malicious or
+    misconfigured announcement can't surface a clickable link
+    pointing somewhere off-LAN.
     """
-    host = info.server.removesuffix(".") if info.server else f"{device_name}.local"
+    raw_server = info.server.removesuffix(".") if info.server else ""
+    host = raw_server if is_local_hostname(raw_server) else f"{device_name}.local"
     port = info.port or 80
     return f"http://{host}{'' if port == 80 else f':{port}'}"
 

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -11,21 +12,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from esphome import const
+from esphome.components.dashboard_import import import_config
 from esphome.dashboard.util.text import friendly_name_slugify
 from esphome.helpers import sort_ip_addresses
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
-
-try:
-    # The YAML-generation entrypoint for adopting discovered devices
-    # lives in ``esphome.components.dashboard_import`` — it fetches the
-    # package-import URL, writes a stub YAML, and (when asked) emits a
-    # fresh API encryption key. The previous ``esphome.config_helpers``
-    # path never resolved, so ``devices/import`` always raised.
-    from esphome.components.dashboard_import import import_config
-except ImportError:
-    import_config = None  # type: ignore[assignment]
-
-import contextlib
 
 from ..helpers.api import api_command
 from ..helpers.config_hash import compute_yaml_config_hash
@@ -587,10 +577,6 @@ class DevicesController:
         **kwargs: Any,
     ) -> dict:
         """Import / adopt a discovered device."""
-        if import_config is None:
-            msg = "import_config not available in this ESPHome version"
-            raise RuntimeError(msg)
-
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
             None,

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -933,8 +933,16 @@ class DevicesController:
         self._db.bus.fire(EventType.IMPORTABLE_DEVICE_REMOVED, {"name": name})
 
     def get_importable_devices(self) -> list[AdoptableDevice]:
-        """Snapshot of the current importable list (used for ``initial_state``)."""
-        return list(self.import_result.values())
+        """
+        Snapshot of the current importable list (used for ``initial_state``).
+
+        Filters against the configured-name set on every call so an
+        adoption that landed without an mDNS Removed (the device kept
+        announcing on its old name) doesn't leak through into the
+        seed an a fresh page load gets.
+        """
+        configured_names = {d.name for d in self._scanner.devices}
+        return [d for d in self.import_result.values() if d.name not in configured_names]
 
     def _on_firmware_job_completed(self, event: Any) -> None:
         """

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -952,7 +952,7 @@ class DevicesController:
         Filters against the configured-name set on every call so an
         adoption that landed without an mDNS Removed (the device kept
         announcing on its old name) doesn't leak through into the
-        seed an a fresh page load gets.
+        seed a fresh page load gets.
         """
         configured_names = {d.name for d in self._scanner.devices}
         return [d for d in self.import_result.values() if d.name not in configured_names]

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -610,6 +610,28 @@ class DevicesController:
             await self._scanner.scan()
         except Exception:
             _LOGGER.exception("Scan after import failed; will pick up on next poll")
+
+        # Drop the discovery banner entry: the device is now configured,
+        # so it shouldn't continue to show up under "Discovered". The
+        # importable cache key is the device's mDNS-advertised name,
+        # which usually matches the user-chosen YAML name but may
+        # differ (e.g. they edited the MAC suffix off). Match by
+        # ``package_import_url`` so we always find the right entry.
+        for cached_name in [
+            n for n, d in self.import_result.items() if d.package_import_url == package_import_url
+        ]:
+            self._on_importable_removed(cached_name)
+
+        # Skip-the-wait state seed. We just adopted a device that was
+        # advertising on mDNS milliseconds ago, so the next ping sweep
+        # would only confirm what zeroconf already knew. Pull the
+        # cached IP out of zeroconf and apply both ONLINE and the
+        # address right away so the new card lands online instead of
+        # blinking through OFFLINE for ~10s.
+        self._state_monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
+        cached = self._state_monitor.get_cached_addresses(f"{name}.local")
+        if cached:
+            self._state_monitor.apply_ip(name, cached[0])
         return {"configuration": configuration}
 
     @api_command("devices/ignore")

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -616,20 +616,26 @@ class DevicesController:
         # importable cache key is the device's mDNS-advertised name,
         # which usually matches the user-chosen YAML name but may
         # differ (e.g. they edited the MAC suffix off). Match by
-        # ``package_import_url`` so we always find the right entry.
-        for cached_name in [
+        # ``package_import_url`` so we always find the right entry,
+        # and remember the cached name so we can use it for the
+        # zeroconf-cache lookup below — the device is broadcasting
+        # under that name, not the YAML name.
+        cached_names = [
             n for n, d in self.import_result.items() if d.package_import_url == package_import_url
-        ]:
+        ]
+        for cached_name in cached_names:
             self._on_importable_removed(cached_name)
+        mdns_name = cached_names[0] if cached_names else name
 
         # Skip-the-wait state seed. We just adopted a device that was
         # advertising on mDNS milliseconds ago, so the next ping sweep
         # would only confirm what zeroconf already knew. Pull the
-        # cached IP out of zeroconf and apply both ONLINE and the
-        # address right away so the new card lands online instead of
-        # blinking through OFFLINE for ~10s.
+        # cached IP out of zeroconf — keyed by the mDNS-advertised
+        # name, not the user's chosen YAML name — and apply both
+        # ONLINE and the address right away so the new card lands
+        # online instead of blinking through OFFLINE for ~10s.
         self._state_monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
-        cached = self._state_monitor.get_cached_addresses(f"{name}.local")
+        cached = self._state_monitor.get_cached_addresses(f"{mdns_name}.local")
         if cached:
             self._state_monitor.apply_ip(name, cached[0])
         return {"configuration": configuration}
@@ -815,13 +821,20 @@ class DevicesController:
         # ``async_schedule_storage_json_update``.
         if kind is ScanChange.ADDED and not device.loaded_integrations:
             self._schedule_storage_regenerate(device.configuration)
-        # When a configured device is deleted, re-emit the discovery
-        # entry it was hiding. Upstream's ``DashboardImportDiscovery``
-        # only fires ``on_update`` on first sight (``is_new`` check),
-        # so without this nudge the device stays silent until it
+        # When a configured device is deleted, re-emit cached
+        # discoveries. Upstream's ``DashboardImportDiscovery`` only
+        # fires ``on_update`` on first sight (``is_new`` check), so
+        # without this nudge a device stays silent until it
         # re-announces — which can be many minutes for a quiet device.
+        # Use the "revisit all" variant rather than matching on
+        # ``device.name``: the user may have adopted with a YAML name
+        # that differs from the discovered hostname (e.g. they edited
+        # the MAC suffix off), in which case a name-keyed lookup
+        # would miss. ``_on_import_update`` already filters configured
+        # + ignored entries so re-emitting the full set is cheap and
+        # only surfaces what should actually appear.
         if kind is ScanChange.REMOVED:
-            self._state_monitor.revisit_importable(device.name)
+            self._state_monitor.revisit_all_importables()
 
     def _on_state_change(self, name: str, state: DeviceState, source: str) -> None:
         """Forward state monitor updates onto the event bus."""

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -815,6 +815,13 @@ class DevicesController:
         # ``async_schedule_storage_json_update``.
         if kind is ScanChange.ADDED and not device.loaded_integrations:
             self._schedule_storage_regenerate(device.configuration)
+        # When a configured device is deleted, re-emit the discovery
+        # entry it was hiding. Upstream's ``DashboardImportDiscovery``
+        # only fires ``on_update`` on first sight (``is_new`` check),
+        # so without this nudge the device stays silent until it
+        # re-announces — which can be many minutes for a quiet device.
+        if kind is ScanChange.REMOVED:
+            self._state_monitor.revisit_importable(device.name)
 
     def _on_state_change(self, name: str, state: DeviceState, source: str) -> None:
         """Forward state monitor updates onto the event bus."""

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -16,7 +16,12 @@ from esphome.helpers import sort_ip_addresses
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 
 try:
-    from esphome.config_helpers import import_config
+    # The YAML-generation entrypoint for adopting discovered devices
+    # lives in ``esphome.components.dashboard_import`` — it fetches the
+    # package-import URL, writes a stub YAML, and (when asked) emits a
+    # fresh API encryption key. The previous ``esphome.config_helpers``
+    # path never resolved, so ``devices/import`` always raised.
+    from esphome.components.dashboard_import import import_config
 except ImportError:
     import_config = None  # type: ignore[assignment]
 

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -17,7 +17,7 @@ from esphome.dashboard.util.text import friendly_name_slugify
 from esphome.helpers import sort_ip_addresses
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 
-from ..helpers.api import api_command
+from ..helpers.api import CommandError, api_command
 from ..helpers.config_hash import compute_yaml_config_hash
 from ..helpers.device_yaml import (
     generate_device_yaml,
@@ -34,6 +34,7 @@ from ..models import (
     Device,
     DevicesResponse,
     DeviceState,
+    ErrorCode,
     EventType,
     JobStatus,
     JobType,
@@ -577,21 +578,39 @@ class DevicesController:
         **kwargs: Any,
     ) -> dict:
         """Import / adopt a discovered device."""
+        configuration = f"{name}.yaml"
+        path = self._db.settings.rel_path(configuration)
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None,
-            import_config,
-            self._db.settings.rel_path(f"{name}.yaml"),
-            name,
-            friendly_name,
-            project_name,
-            package_import_url,
-            const.CONF_WIFI,
-            encryption,
-        )
+        try:
+            await loop.run_in_executor(
+                None,
+                import_config,
+                path,
+                name,
+                friendly_name,
+                project_name,
+                package_import_url,
+                const.CONF_WIFI,
+                encryption,
+            )
+        except FileExistsError as exc:
+            # ``import_config`` refuses to overwrite an existing YAML.
+            # Surface this as a user-facing error so the dialog can
+            # show "Configuration <file> already exists" instead of
+            # the WS layer's generic "Command failed".
+            msg = f"Configuration {configuration} already exists"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
 
-        await self._scanner.scan()
-        return {"configuration": f"{name}.yaml"}
+        # Picking up the new YAML is best-effort — if the scanner
+        # hiccups (e.g. a transient stat error on a network mount),
+        # the next periodic scan will catch it. We've already written
+        # the YAML, so failing the whole command here would lie to
+        # the user and trip a follow-up FileExistsError if they retry.
+        try:
+            await self._scanner.scan()
+        except Exception:
+            _LOGGER.exception("Scan after import failed; will pick up on next poll")
+        return {"configuration": configuration}
 
     @api_command("devices/ignore")
     async def toggle_ignore(self, *, name: str, ignore: bool = True, **kwargs: Any) -> None:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -69,8 +70,11 @@ class DevicesController:
         # wired up in start(); held so stop() can detach cleanly.
         self._unsub_job_completed: Any = None
 
-        # Discovery / import state
-        self.import_result: dict[str, Any] = {}
+        # Discovery / import state. Keyed by ``device.name`` so the
+        # WebSocket layer and ``devices/ignore`` can address entries
+        # without juggling full mDNS service-instance names. Filled by
+        # ``DeviceStateMonitor`` callbacks.
+        self.import_result: dict[str, AdoptableDevice] = {}
         self.ignored_devices: set[str] = set()
 
         # Background ``--only-generate`` bookkeeping. ``--only-generate``
@@ -100,6 +104,9 @@ class DevicesController:
             on_ip_change=self._on_ip_change,
             on_version_change=self._on_version_change,
             on_config_hash_change=self._on_config_hash_change,
+            on_importable_added=self._on_importable_added,
+            on_importable_removed=self._on_importable_removed,
+            is_ignored=self.ignored_devices.__contains__,
         )
         # MQTT routes its observations through the same state monitor so
         # source-priority is enforced in one place.
@@ -173,23 +180,11 @@ class DevicesController:
         await self._scanner.scan()
         configured = self._scanner.devices
         configured_names = {d.name for d in configured}
-
-        importable = []
-        for discovered in self.import_result.values():
-            if discovered.device_name in configured_names:
-                continue
-            importable.append(
-                AdoptableDevice(
-                    name=discovered.device_name,
-                    friendly_name=discovered.friendly_name or "",
-                    package_import_url=discovered.package_import_url,
-                    project_name=discovered.project_name,
-                    project_version=discovered.project_version,
-                    network=discovered.network,
-                    ignored=discovered.device_name in self.ignored_devices,
-                )
-            )
-
+        # ``import_result`` is already pre-filtered against configured
+        # devices when the discovery callback fires; this guard catches
+        # the race where a YAML appeared between the callback and this
+        # listing.
+        importable = [d for d in self.import_result.values() if d.name not in configured_names]
         return DevicesResponse(configured=configured, importable=importable)
 
     @api_command("devices/get_states")
@@ -616,6 +611,14 @@ class DevicesController:
             self.ignored_devices.discard(name)
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._save_ignored_devices)
+        # Mirror the new flag onto the cached AdoptableDevice and
+        # re-publish ADDED so subscribed frontends update the badge
+        # without waiting for a full re-discovery cycle.
+        existing = self.import_result.get(name)
+        if existing is not None and existing.ignored != ignore:
+            updated = replace(existing, ignored=ignore)
+            self.import_result[name] = updated
+            self._db.bus.fire(EventType.IMPORTABLE_DEVICE_ADDED, {"device": updated})
 
     # ------------------------------------------------------------------
     # API commands — per-connection streams (validate, logs)
@@ -875,6 +878,24 @@ class DevicesController:
             "Device %s config_hash: %s → %s (via mdns)", name, old_hash or "?", config_hash
         )
         self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+
+    def _on_importable_added(self, device: AdoptableDevice) -> None:
+        """Stash a newly-discovered importable device and notify subscribers."""
+        # Keyed by device name so ``devices/list`` can dedupe against
+        # configured devices and ``devices/ignore`` can flip the flag
+        # by name without juggling the full mdns service-instance.
+        self.import_result[device.name] = device
+        self._db.bus.fire(EventType.IMPORTABLE_DEVICE_ADDED, {"device": device})
+
+    def _on_importable_removed(self, name: str) -> None:
+        """Forget an importable device that disappeared from mDNS."""
+        if self.import_result.pop(name, None) is None:
+            return
+        self._db.bus.fire(EventType.IMPORTABLE_DEVICE_REMOVED, {"name": name})
+
+    def get_importable_devices(self) -> list[AdoptableDevice]:
+        """Snapshot of the current importable list (used for ``initial_state``)."""
+        return list(self.import_result.values())
 
     def _on_firmware_job_completed(self, event: Any) -> None:
         """

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -201,13 +201,21 @@ class DeviceBuilder:
             unsub = self.bus.add_listener(event_type, _on_event)
             unsubscribers.append(unsub)
 
-        # Send initial device list
+        # Send initial device + importable lists. Importable devices
+        # are populated by the mDNS browser and per-device events
+        # fire only on transitions; without seeding the snapshot here
+        # a fresh page load misses every importable device the dashboard
+        # had already seen by then.
         if self.devices:
             devices = self.devices.get_devices()
+            importable = self.devices.get_importable_devices()
             await client.send_event(
                 message_id,
                 "initial_state",
-                {"devices": [d.to_dict() for d in devices]},
+                {
+                    "devices": [d.to_dict() for d in devices],
+                    "importable": [d.to_dict() for d in importable],
+                },
             )
 
         # Confirm subscription

--- a/esphome_device_builder/helpers/api.py
+++ b/esphome_device_builder/helpers/api.py
@@ -5,8 +5,26 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+from ..models import ErrorCode
+
 # Type alias for command handler functions
 CommandHandler = Callable[..., Coroutine[Any, Any, Any]]
+
+
+class CommandError(Exception):
+    """A user-facing error raised by an ``api_command`` handler.
+
+    The WS dispatcher catches these and forwards the carried ``code``
+    + ``message`` verbatim to the client, instead of swallowing them
+    as a generic ``INTERNAL_ERROR``. Use this when the failure has a
+    specific reason the user can act on (file already exists, name
+    invalid, etc.) — not for crashes / bugs.
+    """
+
+    def __init__(self, code: ErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
 
 
 def api_command(command: str) -> Callable[[CommandHandler], CommandHandler]:

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -71,6 +71,11 @@ class AdoptableDevice(DataClassORJSONMixin):
     project_version: str
     network: str
     ignored: bool
+    # Pre-built URL to the device's web UI when it advertises a
+    # ``_http._tcp.local.`` mDNS service. Empty string when no web
+    # server was found — the discovered card then hides the
+    # Visit-web-UI affordance.
+    web_url: str = ""
 
 
 @dataclass

--- a/tests/test_import_device.py
+++ b/tests/test_import_device.py
@@ -32,6 +32,15 @@ def _make_controller(tmp_path: Any) -> DevicesController:
     ctrl._db.settings.rel_path = lambda name: tmp_path / name
     ctrl._scanner = MagicMock()
     ctrl._scanner.scan = AsyncMock()
+    # The fast-online seed pulls the cached IP out of the state
+    # monitor and forces ONLINE on success; tests use a Mock so they
+    # can assert the calls without standing up a real zeroconf.
+    ctrl._state_monitor = MagicMock()
+    ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=None)
+    # ``import_result`` must be a real dict so the iteration in
+    # ``import_device`` works; the discovery callback path is
+    # exercised separately in ``test_importable_discovery``.
+    ctrl.import_result = {}
     return ctrl
 
 
@@ -135,3 +144,99 @@ async def test_import_device_returns_even_when_post_scan_fails(
     )
 
     assert result == {"configuration": "kitchen.yaml"}
+
+
+async def test_import_device_seeds_online_state_from_zeroconf_cache(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A freshly-adopted device should land ONLINE without waiting for ping.
+
+    The device was advertising on mDNS milliseconds ago — that's how
+    it ended up on the discovery banner — so we already know it's
+    reachable. ``import_device`` claims ONLINE via the state monitor
+    (``mdns`` priority + ``claim=True`` so a later ping observation
+    can't clobber it) and pulls the cached IP out of zeroconf so the
+    new card has an address right away.
+    """
+    from esphome_device_builder.models import DeviceState
+
+    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
+    ctrl = _make_controller(tmp_path)
+    ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=["192.168.1.42"])
+
+    await ctrl.import_device(
+        name="kitchen",
+        project_name="x",
+        package_import_url="github://x",
+    )
+
+    ctrl._state_monitor.apply.assert_called_once_with(
+        "kitchen", DeviceState.ONLINE, "mdns", claim=True
+    )
+    ctrl._state_monitor.get_cached_addresses.assert_called_once_with("kitchen.local")
+    ctrl._state_monitor.apply_ip.assert_called_once_with("kitchen", "192.168.1.42")
+
+
+async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No cached IP → state still flips ONLINE, just no apply_ip call."""
+    from esphome_device_builder.models import DeviceState
+
+    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
+    ctrl = _make_controller(tmp_path)
+    ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=None)
+
+    await ctrl.import_device(
+        name="kitchen",
+        project_name="x",
+        package_import_url="github://x",
+    )
+
+    ctrl._state_monitor.apply.assert_called_once_with(
+        "kitchen", DeviceState.ONLINE, "mdns", claim=True
+    )
+    ctrl._state_monitor.apply_ip.assert_not_called()
+
+
+async def test_import_device_drops_matching_import_result_entry(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The discovery banner entry disappears the moment adoption finishes.
+
+    Before this fix, the discovered card stuck around until the next
+    discovery cycle filtered it out by name. Match the cache entry by
+    ``package_import_url`` (which uniquely identifies the firmware)
+    so we drop the right entry even when the user typed a different
+    YAML name in the dialog.
+    """
+    from esphome_device_builder.models import AdoptableDevice, EventType
+
+    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
+    ctrl = _make_controller(tmp_path)
+    discovered = AdoptableDevice(
+        name="apollo-plt-1-983300",
+        friendly_name="Apollo PLT-1",
+        package_import_url="github://apollo/plt-1.yaml",
+        project_name="apollo.plt-1",
+        project_version="26.3.2.1",
+        network="wifi",
+        ignored=False,
+    )
+    ctrl.import_result["apollo-plt-1-983300"] = discovered
+
+    await ctrl.import_device(
+        # User typed a shorter name (without the MAC suffix).
+        name="apollo-plt-1",
+        project_name="apollo.plt-1",
+        package_import_url="github://apollo/plt-1.yaml",
+    )
+
+    assert "apollo-plt-1-983300" not in ctrl.import_result
+    # Removal is broadcast so subscribed frontends drop the card.
+    fired = list(ctrl._db.bus.fire.mock_calls)
+    removed_events = [
+        c for c in fired if c.args and c.args[0] == EventType.IMPORTABLE_DEVICE_REMOVED
+    ]
+    assert removed_events, "expected IMPORTABLE_DEVICE_REMOVED to fire"
+    assert removed_events[0].args[1] == {"name": "apollo-plt-1-983300"}

--- a/tests/test_import_device.py
+++ b/tests/test_import_device.py
@@ -1,0 +1,137 @@
+"""Tests for the ``devices/import`` command path.
+
+Covers two regressions discovered while wiring up the adoption flow:
+
+* ``import_config`` lives at ``esphome.components.dashboard_import``,
+  not ``esphome.config_helpers``. The previous import path silently
+  became ``None`` and every adoption attempt raised a generic
+  RuntimeError before doing anything.
+* When the target YAML already exists, ``import_config`` raises
+  ``FileExistsError``. We re-surface it as a ``CommandError`` so the
+  dashboard can show a useful message instead of the WS layer's
+  generic ``Command failed`` fallback.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers import devices as devices_module
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
+
+
+def _make_controller(tmp_path: Any) -> DevicesController:
+    """Stand up a controller without booting the full DeviceBuilder."""
+    ctrl = DevicesController.__new__(DevicesController)
+    ctrl._db = MagicMock()
+    ctrl._db.settings.rel_path = lambda name: tmp_path / name
+    ctrl._scanner = MagicMock()
+    ctrl._scanner.scan = AsyncMock()
+    return ctrl
+
+
+def test_import_config_resolves_at_import_time() -> None:
+    """Regression guard for the import path move.
+
+    ``import_config`` used to be imported via ``esphome.config_helpers``
+    behind a try/except, so a wrong path silently became ``None`` and
+    every adoption attempt raised. The current call site imports
+    directly from ``esphome.components.dashboard_import``; if that
+    module ever moves we want the test suite to fail loudly here, not
+    a user's first adoption attempt.
+    """
+    assert devices_module.import_config is not None
+    assert callable(devices_module.import_config)
+
+
+async def test_import_device_invokes_import_config_and_returns_path(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: write the YAML, run a scan, return the configuration name."""
+    captured: dict[str, Any] = {}
+
+    def fake_import_config(*args: Any, **_kwargs: Any) -> None:
+        captured["args"] = args
+
+    monkeypatch.setattr(devices_module, "import_config", fake_import_config)
+    ctrl = _make_controller(tmp_path)
+
+    result = await ctrl.import_device(
+        name="kitchen-1a2b3c",
+        project_name="acme.kitchen",
+        package_import_url="github://acme/firmware.yaml@main",
+        friendly_name="Kitchen",
+        encryption="true",
+    )
+
+    assert result == {"configuration": "kitchen-1a2b3c.yaml"}
+    # Argument order matters — upstream signature is
+    # ``(path, name, friendly_name, project_name, import_url, network, encryption)``.
+    args = captured["args"]
+    assert args[0] == tmp_path / "kitchen-1a2b3c.yaml"
+    assert args[1] == "kitchen-1a2b3c"
+    assert args[2] == "Kitchen"
+    assert args[3] == "acme.kitchen"
+    assert args[4] == "github://acme/firmware.yaml@main"
+    assert args[6] == "true"  # encryption flag forwarded
+    ctrl._scanner.scan.assert_awaited_once()
+
+
+async def test_import_device_translates_file_exists_to_command_error(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``FileExistsError`` becomes a user-facing ``CommandError``.
+
+    The WS layer turns generic exceptions into ``Command failed: …``;
+    the dashboard's adopt dialog can't surface that meaningfully. The
+    handler catches ``FileExistsError`` and re-raises as a
+    ``CommandError`` carrying ``INVALID_ARGS`` and a message that
+    names the offending file.
+    """
+
+    def raises_file_exists(*_args: Any, **_kwargs: Any) -> None:
+        raise FileExistsError
+
+    monkeypatch.setattr(devices_module, "import_config", raises_file_exists)
+    ctrl = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.import_device(
+            name="kitchen",
+            project_name="x",
+            package_import_url="github://x",
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "kitchen.yaml already exists" in excinfo.value.message
+    # Scan must NOT run when the YAML write failed — otherwise we'd
+    # falsely advertise a successful adoption to subscribers.
+    ctrl._scanner.scan.assert_not_called()
+
+
+async def test_import_device_returns_even_when_post_scan_fails(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scan failure after a successful YAML write must not roll back.
+
+    The YAML is on disk; failing the WS command would leave the user
+    in a state where retrying produces ``FileExistsError`` despite
+    nothing being wrong. Best-effort scan; the periodic poll picks up
+    whatever this attempt missed.
+    """
+    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
+    ctrl = _make_controller(tmp_path)
+    ctrl._scanner.scan = AsyncMock(side_effect=RuntimeError("transient"))
+
+    result = await ctrl.import_device(
+        name="kitchen",
+        project_name="x",
+        package_import_url="github://x",
+    )
+
+    assert result == {"configuration": "kitchen.yaml"}

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -222,6 +222,93 @@ def test_revisit_importable_noop_when_browser_not_started() -> None:
     monitor.revisit_importable("kitchen")  # must not raise
 
 
+def test_apply_http_service_info_populates_web_url_and_refires() -> None:
+    """An HTTP service announcement decorates the cached importable.
+
+    Sequence: ``_esphomelib._tcp.local.`` arrives first → AdoptableDevice
+    surfaces with ``web_url=""``. Then ``_http._tcp.local.`` arrives;
+    we store the URL and re-fire ADDED so the frontend updates the
+    card's Visit-web-UI link in place.
+    """
+    from esphome.zeroconf import DashboardImportDiscovery
+    from zeroconf.asyncio import AsyncServiceInfo
+
+    added: list[AdoptableDevice] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+    )
+    monitor._import_discovery = DashboardImportDiscovery()
+    monitor._import_discovery.import_state = {
+        "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
+    }
+
+    info = AsyncServiceInfo("_http._tcp.local.", "kitchen._http._tcp.local.")
+    info.server = "kitchen.local."
+    info.port = 80
+
+    monitor._apply_http_service_info("kitchen", info)
+
+    assert monitor._http_urls == {"kitchen": "http://kitchen.local"}
+    assert len(added) == 1
+    assert added[0].web_url == "http://kitchen.local"
+
+
+def test_apply_http_service_info_includes_non_default_port() -> None:
+    """Non-port-80 services build URLs with the explicit ``:port`` suffix."""
+    from esphome.zeroconf import DashboardImportDiscovery
+    from zeroconf.asyncio import AsyncServiceInfo
+
+    added: list[AdoptableDevice] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+    )
+    monitor._import_discovery = DashboardImportDiscovery()
+    monitor._import_discovery.import_state = {
+        "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
+    }
+
+    info = AsyncServiceInfo("_http._tcp.local.", "kitchen._http._tcp.local.")
+    info.server = "kitchen.local."
+    info.port = 8080
+
+    monitor._apply_http_service_info("kitchen", info)
+    assert added[0].web_url == "http://kitchen.local:8080"
+
+
+def test_apply_http_service_info_skips_when_unchanged() -> None:
+    """Repeat announcements for the same URL don't re-fire ADDED."""
+    from esphome.zeroconf import DashboardImportDiscovery
+    from zeroconf.asyncio import AsyncServiceInfo
+
+    added: list[AdoptableDevice] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+    )
+    monitor._import_discovery = DashboardImportDiscovery()
+    monitor._import_discovery.import_state = {
+        "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
+    }
+
+    info = AsyncServiceInfo("_http._tcp.local.", "kitchen._http._tcp.local.")
+    info.server = "kitchen.local."
+    info.port = 80
+
+    monitor._apply_http_service_info("kitchen", info)
+    monitor._apply_http_service_info("kitchen", info)
+
+    # Single fire — duplicate calls are deduped by URL equality.
+    assert len(added) == 1
+
+
 def test_revisit_importable_skips_ignored_devices() -> None:
     """Ignored devices stay hidden after deletion.
 

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from esphome.zeroconf import DiscoveredImport
+from esphome.zeroconf import DashboardImportDiscovery, DiscoveredImport
+from zeroconf.asyncio import AsyncServiceInfo
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.models import AdoptableDevice, Device, DeviceState
@@ -141,7 +142,6 @@ def test_get_importable_devices_filters_configured() -> None:
     )
     # Stand in for a started DashboardImportDiscovery — populate its
     # ``import_state`` directly so we don't have to spin up zeroconf.
-    from esphome.zeroconf import DashboardImportDiscovery
 
     monitor._import_discovery = DashboardImportDiscovery()
     monitor._import_discovery.import_state = {
@@ -173,8 +173,6 @@ def test_revisit_importable_refires_added_when_cached() -> None:
     was hiding a discovered entry gets removed, no fresh announcement
     fires; we have to nudge the cache ourselves.
     """
-    from esphome.zeroconf import DashboardImportDiscovery
-
     added: list[AdoptableDevice] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: [],  # device just got deleted
@@ -195,8 +193,6 @@ def test_revisit_importable_refires_added_when_cached() -> None:
 
 def test_revisit_importable_noop_for_unknown_name() -> None:
     """No cached entry → no callback fires (and no crash)."""
-    from esphome.zeroconf import DashboardImportDiscovery
-
     added: list[AdoptableDevice] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: [],
@@ -230,9 +226,6 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
     we store the URL and re-fire ADDED so the frontend updates the
     card's Visit-web-UI link in place.
     """
-    from esphome.zeroconf import DashboardImportDiscovery
-    from zeroconf.asyncio import AsyncServiceInfo
-
     added: list[AdoptableDevice] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: [],
@@ -258,9 +251,6 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
 
 def test_apply_http_service_info_includes_non_default_port() -> None:
     """Non-port-80 services build URLs with the explicit ``:port`` suffix."""
-    from esphome.zeroconf import DashboardImportDiscovery
-    from zeroconf.asyncio import AsyncServiceInfo
-
     added: list[AdoptableDevice] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: [],
@@ -283,9 +273,6 @@ def test_apply_http_service_info_includes_non_default_port() -> None:
 
 def test_apply_http_service_info_skips_when_unchanged() -> None:
     """Repeat announcements for the same URL don't re-fire ADDED."""
-    from esphome.zeroconf import DashboardImportDiscovery
-    from zeroconf.asyncio import AsyncServiceInfo
-
     added: list[AdoptableDevice] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: [],
@@ -316,8 +303,6 @@ def test_revisit_importable_skips_ignored_devices() -> None:
     shouldn't unilaterally bring it back into the banner. They can
     unignore through the menu if they change their mind.
     """
-    from esphome.zeroconf import DashboardImportDiscovery
-
     added: list[AdoptableDevice] = []
     ignored = {"kitchen-1a2b3c"}
     monitor = DeviceStateMonitor(

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -163,3 +163,88 @@ def test_get_importable_devices_returns_empty_before_browser_start() -> None:
         on_ip_change=MagicMock(),
     )
     assert monitor.get_importable_devices() == []
+
+
+def test_revisit_importable_refires_added_when_cached() -> None:
+    """``revisit_importable`` re-emits the callback for cached entries.
+
+    Upstream's ``DashboardImportDiscovery`` only calls ``on_update``
+    on first sight (``is_new`` check). When a configured device that
+    was hiding a discovered entry gets removed, no fresh announcement
+    fires; we have to nudge the cache ourselves.
+    """
+    from esphome.zeroconf import DashboardImportDiscovery
+
+    added: list[AdoptableDevice] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],  # device just got deleted
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+    )
+    monitor._import_discovery = DashboardImportDiscovery()
+    monitor._import_discovery.import_state = {
+        "kitchen-1a2b3c._esphomelib._tcp.local.": _discovered("kitchen-1a2b3c"),
+    }
+
+    monitor.revisit_importable("kitchen-1a2b3c")
+
+    assert len(added) == 1
+    assert added[0].name == "kitchen-1a2b3c"
+
+
+def test_revisit_importable_noop_for_unknown_name() -> None:
+    """No cached entry → no callback fires (and no crash)."""
+    from esphome.zeroconf import DashboardImportDiscovery
+
+    added: list[AdoptableDevice] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+    )
+    monitor._import_discovery = DashboardImportDiscovery()
+    monitor._import_discovery.import_state = {}
+
+    monitor.revisit_importable("unknown")
+
+    assert added == []
+
+
+def test_revisit_importable_noop_when_browser_not_started() -> None:
+    """No browser → silent skip (no crash on the optional attr)."""
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+    )
+    monitor.revisit_importable("kitchen")  # must not raise
+
+
+def test_revisit_importable_skips_ignored_devices() -> None:
+    """Ignored devices stay hidden after deletion.
+
+    The user already said "don't show me this"; a YAML deletion
+    shouldn't unilaterally bring it back into the banner. They can
+    unignore through the menu if they change their mind.
+    """
+    from esphome.zeroconf import DashboardImportDiscovery
+
+    added: list[AdoptableDevice] = []
+    ignored = {"kitchen-1a2b3c"}
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+        is_ignored=ignored.__contains__,
+    )
+    monitor._import_discovery = DashboardImportDiscovery()
+    monitor._import_discovery.import_state = {
+        "kitchen-1a2b3c._esphomelib._tcp.local.": _discovered("kitchen-1a2b3c"),
+    }
+
+    monitor.revisit_importable("kitchen-1a2b3c")
+
+    assert added == []

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -1,0 +1,165 @@
+"""Tests for the importable-device discovery plumbing.
+
+Covers the bridge between upstream esphome's ``DashboardImportDiscovery``
+and our dashboard event bus / ``import_result`` cache. The browser
+itself is upstream code — what we own is the translation from
+``DiscoveredImport`` to ``AdoptableDevice``, the configured-device
+filter, and the ignore flag.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from esphome.zeroconf import DiscoveredImport
+
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.models import AdoptableDevice, Device, DeviceState
+
+
+def _device(name: str) -> Device:
+    return Device(
+        name=name,
+        friendly_name=name,
+        configuration=f"{name}.yaml",
+        address=f"{name}.local",
+        state=DeviceState.UNKNOWN,
+    )
+
+
+def _discovered(device_name: str = "kitchen-1a2b3c") -> DiscoveredImport:
+    return DiscoveredImport(
+        friendly_name="Kitchen",
+        device_name=device_name,
+        package_import_url="github://acme/firmware/kitchen.yaml@main",
+        project_name="acme.kitchen",
+        project_version="2026.05.01",
+        network="wifi",
+    )
+
+
+def test_on_import_update_translates_to_adoptable_device() -> None:
+    added: list[AdoptableDevice] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+    )
+
+    monitor._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+
+    assert added == [
+        AdoptableDevice(
+            name="kitchen-1a2b3c",
+            friendly_name="Kitchen",
+            package_import_url="github://acme/firmware/kitchen.yaml@main",
+            project_name="acme.kitchen",
+            project_version="2026.05.01",
+            network="wifi",
+            ignored=False,
+        )
+    ]
+
+
+def test_on_import_update_emits_removed_with_device_name() -> None:
+    removed: list[str] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_removed=removed.append,
+    )
+
+    monitor._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", None)
+
+    # The mDNS service name is sliced down to the device-name label so
+    # the dashboard can index ``import_result`` by ``device.name``.
+    assert removed == ["kitchen-1a2b3c"]
+
+
+def test_on_import_update_skips_already_configured_devices() -> None:
+    """Configured devices never surface as importable."""
+    added: list[AdoptableDevice] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [_device("kitchen-1a2b3c")],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+    )
+
+    monitor._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+    assert added == []
+
+
+def test_on_import_update_threads_ignored_flag() -> None:
+    """The ignored set drives the ``ignored`` flag on the AdoptableDevice."""
+    added: list[AdoptableDevice] = []
+    ignored = {"kitchen-1a2b3c"}
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+        is_ignored=ignored.__contains__,
+    )
+
+    monitor._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+    assert len(added) == 1 and added[0].ignored is True
+
+
+def test_on_import_update_friendly_name_none_becomes_empty_string() -> None:
+    """``DiscoveredImport.friendly_name`` is Optional; AdoptableDevice expects str."""
+    added: list[AdoptableDevice] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_importable_added=added.append,
+    )
+
+    discovered = DiscoveredImport(
+        friendly_name=None,
+        device_name="kitchen",
+        package_import_url="github://x",
+        project_name="x",
+        project_version="1.0",
+        network="wifi",
+    )
+    monitor._on_import_update("kitchen._esphomelib._tcp.local.", discovered)
+
+    assert added[0].friendly_name == ""
+
+
+def test_get_importable_devices_filters_configured() -> None:
+    """``get_importable_devices`` rebuilds the snapshot, dropping configured."""
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [_device("garage")],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        is_ignored=lambda _: False,
+    )
+    # Stand in for a started DashboardImportDiscovery — populate its
+    # ``import_state`` directly so we don't have to spin up zeroconf.
+    from esphome.zeroconf import DashboardImportDiscovery
+
+    monitor._import_discovery = DashboardImportDiscovery()
+    monitor._import_discovery.import_state = {
+        "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
+        "garage._esphomelib._tcp.local.": _discovered("garage"),
+    }
+
+    snapshot = monitor.get_importable_devices()
+
+    names = sorted(d.name for d in snapshot)
+    assert names == ["kitchen"]
+
+
+def test_get_importable_devices_returns_empty_before_browser_start() -> None:
+    """Without a started browser the snapshot is just empty (no crash)."""
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [],
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+    )
+    assert monitor.get_importable_devices() == []

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -15,6 +15,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from esphome import zeroconf as esphome_zc
 from zeroconf import ServiceStateChange
 
 from esphome_device_builder.controllers import _device_state_monitor as monitor_module
@@ -108,8 +109,6 @@ async def _capture_handler(monitor: DeviceStateMonitor, monkeypatch: pytest.Monk
     # module — patch that copy too so the dispatch handler can fan
     # the same event through the upstream callback without touching
     # real zeroconf.
-    import esphome.zeroconf as esphome_zc
-
     monkeypatch.setattr(esphome_zc, "AsyncServiceInfo", _FakeServiceInfo)
 
     await monitor._start_mdns_browser()

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -73,7 +73,12 @@ class _FakeServiceInfo:
     """
 
     def __init__(self, _service_type: str, _name: str) -> None:
-        pass
+        # ``DashboardImportDiscovery.browser_callback`` (also driven
+        # by the dispatch handler) reads ``info.properties`` looking
+        # for ``package_import_url`` TXT records. Empty dict means
+        # "not an importable device" so it bails out cleanly without
+        # touching real zeroconf state.
+        self.properties: dict[bytes, bytes] = {}
 
     def load_from_cache(self, _zc: Any) -> bool:
         return True
@@ -91,13 +96,21 @@ async def _capture_handler(monitor: DeviceStateMonitor, monkeypatch: pytest.Monk
     captured: dict[str, Any] = {}
 
     class _FakeBrowser:
-        def __init__(self, _zc: Any, _service_type: str, *, handlers: list[Any]) -> None:
+        def __init__(self, _zc: Any, _service_types: Any, *, handlers: list[Any]) -> None:
             captured["handler"] = handlers[0]
 
     fake_zc = MagicMock()
     monkeypatch.setattr(monitor_module, "AsyncEsphomeZeroconf", lambda: fake_zc)
     monkeypatch.setattr(monitor_module, "AsyncServiceInfo", _FakeServiceInfo)
     monkeypatch.setattr(monitor_module, "AsyncServiceBrowser", _FakeBrowser)
+    # Upstream ``DashboardImportDiscovery.browser_callback`` builds
+    # its own ``AsyncServiceInfo`` from the ``esphome.zeroconf``
+    # module — patch that copy too so the dispatch handler can fan
+    # the same event through the upstream callback without touching
+    # real zeroconf.
+    import esphome.zeroconf as esphome_zc
+
+    monkeypatch.setattr(esphome_zc, "AsyncServiceInfo", _FakeServiceInfo)
 
     await monitor._start_mdns_browser()
     return captured["handler"]


### PR DESCRIPTION
## Summary

Restores mDNS-driven discovery of importable devices — anything advertising `package_import_url` / `project_name` / `project_version` TXT records on `_esphomelib._tcp.local.` (Apollo / Athom / Open Home Foundation factory firmwares, etc.).

Without this, the frontend's adoption flow ([device-builder-frontend#58](https://github.com/esphome/device-builder-frontend/pull/58)) had nothing to render — `import_result` was an empty dict and the `IMPORTABLE_DEVICE_ADDED` / `_REMOVED` event constants were defined but never published.

> Note: this PR ships alongside the new dashboard frontend, which has not yet been released. We don't carry compatibility with older backends/frontends — the WS event shapes (`IMPORTABLE_DEVICE_REMOVED` payload, `initial_state.importable`) are part of the new contract.

### Plumbing

- **`DeviceStateMonitor` hosts the import discovery.** It already runs the `_esphomelib._tcp.local.` browser; we attach upstream `DashboardImportDiscovery.browser_callback` as a sibling handler so we share the zeroconf cache rather than running a parallel browser.
- A **single `AsyncServiceBrowser`** now watches `_esphomelib._tcp.local.` AND `_http._tcp.local.` (`type_` accepts a list). One dispatch handler routes events to the right inner handler by `service_type`, sharing one set of zeroconf bookkeeping for both flows.
- Two new optional callbacks on the monitor: `on_importable_added(AdoptableDevice)` and `on_importable_removed(name)`. The `_on_import_update` bridge translates `DiscoveredImport` → `AdoptableDevice`, drops devices that already exist in the local catalog, and threads the ignored flag through `is_ignored`.
- New `get_importable_devices()` snapshot accessor on the monitor, used to seed `initial_state`.
- `DevicesController._on_importable_added/removed` keeps `import_result` in sync (now keyed by `device.name`, not the full mDNS service-instance) and fires `EventType.IMPORTABLE_DEVICE_ADDED` / `_REMOVED` on the bus.
- `DevicesController.get_importable_devices()` filters against the configured-name set on every call so an adoption that landed without an mDNS Removed (the device kept announcing on its old name) doesn't leak into the snapshot a fresh page load gets.
- `toggle_ignore` re-fires `IMPORTABLE_DEVICE_ADDED` with the updated `ignored` flag so subscribed frontends update the badge in place.
- `subscribe_events` now sends `{devices, importable}` in `initial_state` so a fresh page load starts with the discovery snapshot the dashboard had built up before subscription.
- `list_devices` (and the legacy `/devices` REST endpoint) simplified to a single comprehension since `import_result` already holds typed `AdoptableDevice`s.

### Adoption flow

- `import_config` imported directly from `esphome.components.dashboard_import` (the previous fallback path silently became `None`).
- `import_device` catches `FileExistsError` and re-raises as `CommandError(INVALID_ARGS, "Configuration <file> already exists")`. New `CommandError` class in `helpers/api.py`; WS layer forwards `code + message` verbatim instead of swallowing as "Command failed".
- `_scanner.scan()` after a successful YAML write is best-effort — if it raises, we log and still return success so the user isn't told the adoption failed when it didn't.
- After a successful adoption: drop the matching `import_result` entry (matched by `package_import_url` so it works even when the user typed a different YAML name) and seed ONLINE state via `_state_monitor.apply(name, ONLINE, "mdns", claim=True)`. Pull the IP from zeroconf cache via `apply_ip` so the new card lands online without waiting for the next ping sweep.
- After a YAML deletion: re-fire discovery via `_state_monitor.revisit_importable(name)` so the device returns to the discovered banner, except when it's been ignored — the user already said "don't show me this".

### HTTP (Visit-web-UI) discovery

- New `_http_urls: dict[str, str]` tracks device-name → URL from `_http._tcp.local.` SRV records.
- `_apply_http_service_info` derives `http://<server>[:port]` from the resolved info, dedupes by URL equality, and re-fires `_on_import_update` so the cached `AdoptableDevice` picks up `web_url` immediately.
- `AdoptableDevice` model gains a `web_url: str` field; `_on_import_update` and `get_importable_devices()` thread it through.

### Tests

- `tests/test_importable_discovery.py` — 14 cases covering translation, configured-device filter, ignored-flag flow, friendly-name None handling, snapshot vs browser state, `revisit_importable` cached-rediscover / unknown-name / no-browser / ignored-skip, and the new `_apply_http_service_info` URL build / non-default port / dedup.
- `tests/test_import_device.py` — 7 cases covering import-path regression guard, happy-path arg forwarding, `FileExistsError` → `CommandError`, scan-failure tolerance, ONLINE state seed, cache-miss skip, and `import_result` drop on adoption.

Total: 268 passed, 3 skipped.

## Test plan

- [x] All 268 backend tests pass.
- [ ] Power up an Apollo / Athom / Open Home Foundation factory device on the LAN: it appears in the discovered banner; Take Control opens the dialog; submit creates the YAML and the device appears in the configured grid.
- [ ] Refresh the page after a device is discovered — still in the discovered banner (initial_state seeds it).
- [ ] Click Ignore — badge flips to IGNORED without a full discovery cycle.
- [ ] Adopt a device — disappears from the discovered banner, shows up under Configured, lands ONLINE without waiting.
- [ ] Delete an adopted device — reappears in the discovered banner unless it's ignored.
- [ ] Discovered devices that also advertise `_http._tcp.local.` carry a Visit-web-UI link.

## Related

Pairs with [device-builder-frontend#58](https://github.com/esphome/device-builder-frontend/pull/58) (the adoption UI + the `initial_state.importable` consumer + the upsert-on-re-fired-ADDED tweak).