### PR TITLE
Add components/get_integration_docs WS command

### DIFF
--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -49,7 +49,12 @@ class ComponentCatalog:
             )
             return
 
-        data = json.loads(_COMPONENTS_JSON.read_text())
+        # ``encoding="utf-8"`` is explicit because the catalog carries
+        # non-ASCII characters (em-dashes, mu, etc.) and Path.read_text
+        # defaults to the platform's locale encoding — Windows' cp1252
+        # then dies on the first multi-byte sequence (UnicodeDecodeError
+        # at the catalog load).
+        data = json.loads(_COMPONENTS_JSON.read_text(encoding="utf-8"))
         self._components = [_load_component(c) for c in data.get("components", [])]
         self._by_id = {c.id: c for c in self._components}
         _LOGGER.info("Component catalog loaded: %d components", len(self._components))

--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -78,6 +78,73 @@ class ComponentCatalog:
         """Get all component categories with counts."""
         return self.categories
 
+    @api_command("components/get_integration_docs")
+    async def get_integration_docs(self, **kwargs: Any) -> dict[str, str]:
+        """Return ``{integration_name: docs_url}`` for resolvable integrations.
+
+        Returns a map covering every loaded-integration identifier we can
+        resolve to an esphome.io docs page.
+
+        ``loaded_integrations`` on a Device is a flat list of bare names
+        (``api``, ``ledc``, ``ltr390``, ``sensor``) — the storage_json
+        captures whatever ESPHome registered, with no category prefix.
+        The catalog's ids are ``<category>.<stem>`` for category-scoped
+        components and bare names for top-level ones, so we resolve by:
+
+        1. Exact id match (``api`` → catalog id ``api``).
+        2. Stem match (``ltr390`` → catalog id ``sensor.ltr390``); first
+           hit wins when multiple categories share a stem.
+        3. Category match (``sensor`` → ``https://esphome.io/components/sensor``,
+           the parent path of any ``sensor.*`` component's docs URL).
+           Only fills a slot a top-level component hasn't already claimed.
+
+        Names with no catalog hit are simply omitted — the frontend
+        renders them as plain text. The catalog's ``docs_url`` is sourced
+        from the live esphome.io docs index, so a present URL is also a
+        guarantee that the page exists.
+        """
+        # Three sources, applied in priority order:
+        #   1. Top-level component (id without ``.``) — wins outright.
+        #   2. Category landing — synthesised from any ``<cat>.<stem>``
+        #      docs URL's parent path. ``switch`` in loaded_integrations
+        #      means the switch *platform*, not the ``binary_sensor.switch``
+        #      driver, so the category landing must beat the stem.
+        #   3. Stem alias — picks up specific drivers like ``ltr390``
+        #      (catalog id ``sensor.ltr390``) that aren't named anywhere
+        #      else. First-hit wins when stems collide.
+        top_level: dict[str, str] = {}
+        category_urls: dict[str, str] = {}
+        stems: dict[str, str] = {}
+        for comp in self._components:
+            comp_id = comp.id
+            docs = comp.docs_url
+            if not comp_id or not docs:
+                continue
+            if "." not in comp_id:
+                top_level[comp_id] = docs
+                continue
+            category, stem = comp_id.split(".", 1)
+            # ESPHome's docs site serves a real index page at
+            # ``/components/<category>/`` for every category that has
+            # subcomponents. Derive it from the docs URL only when the
+            # URL is genuinely under that path — some multi-platform
+            # components (``switch.at581x`` → ``/components/at581x``)
+            # are catalogued under a category for filtering but
+            # documented at a top-level URL outside any category.
+            marker = f"/components/{category}/"
+            idx = docs.find(marker)
+            if idx != -1:
+                category_urls.setdefault(category, docs[: idx + len(marker) - 1])
+            stems.setdefault(stem, docs)
+
+        result: dict[str, str] = {}
+        # Layer in reverse priority order so later writes don't overrule
+        # higher-priority earlier ones.
+        result.update(stems)
+        result.update(category_urls)
+        result.update(top_level)
+        return result
+
     @api_command("components/get_component")
     async def get_component(
         self,

--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -111,10 +111,16 @@ class ComponentCatalog:
         #      driver, so the category landing must beat the stem.
         #   3. Stem alias — picks up specific drivers like ``ltr390``
         #      (catalog id ``sensor.ltr390``) that aren't named anywhere
-        #      else. First-hit wins when stems collide.
+        #      else. Only used when every category in which the stem
+        #      appears agrees on the docs URL — otherwise we'd silently
+        #      pick one arbitrary page out of several conflicting ones
+        #      (e.g. ``binary_sensor.gpio`` vs ``switch.gpio``), so the
+        #      stem is dropped and the frontend renders it as plain
+        #      text. "If we have a docs page for it" demands one
+        #      unambiguous answer, not the first one we happen to see.
         top_level: dict[str, str] = {}
         category_urls: dict[str, str] = {}
-        stems: dict[str, str] = {}
+        stem_candidates: dict[str, set[str]] = {}
         for comp in self._components:
             comp_id = comp.id
             docs = comp.docs_url
@@ -135,11 +141,21 @@ class ComponentCatalog:
             idx = docs.find(marker)
             if idx != -1:
                 category_urls.setdefault(category, docs[: idx + len(marker) - 1])
-            stems.setdefault(stem, docs)
+            stem_candidates.setdefault(stem, set()).add(docs)
 
+        # Stems are unambiguous only when every category that owns the
+        # stem agrees on the same docs URL. Multi-platform components
+        # (``at581x``, ``rotary_encoder``) hit this path because they
+        # share a single docs page across categories.
+        stems: dict[str, str] = {
+            stem: next(iter(urls)) for stem, urls in stem_candidates.items() if len(urls) == 1
+        }
+
+        # ``dict.update()`` overwrites existing keys, so later writes
+        # win. Apply lowest priority first (stems), then category, then
+        # top-level — that way a colliding key is overridden by the
+        # more-specific page.
         result: dict[str, str] = {}
-        # Layer in reverse priority order so later writes don't overrule
-        # higher-priority earlier ones.
         result.update(stems)
         result.update(category_urls)
         result.update(top_level)

--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -182,7 +182,7 @@ def load_board_catalog() -> BoardCatalogResponse:
 
     for manifest in sorted(_BOARDS_DIR.glob("*/manifest.yaml")):
         try:
-            data = yaml.safe_load(manifest.read_text())
+            data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
             board_dir = manifest.parent
             board_id = board_dir.name
 

--- a/tests/test_components_integration_docs.py
+++ b/tests/test_components_integration_docs.py
@@ -46,21 +46,46 @@ async def test_stem_match_for_category_scoped_components(
     """A bare ``ltr390`` resolves to the sensor.ltr390 docs page."""
     docs = await catalog.get_integration_docs()
     assert "ltr390" in docs
-    assert "sensor/ltr390" in docs["ltr390"] or "ltr390" in docs["ltr390"]
+    # Pin the exact path so a regression that silently picks a
+    # different category for the stem fails this assertion instead of
+    # trivially passing on a substring.
+    assert docs["ltr390"].rstrip("/").endswith("/components/sensor/ltr390")
 
 
 async def test_top_level_wins_over_stem(catalog: ComponentCatalog) -> None:
     """When a top-level id and a stem collide, top-level claims the key.
 
-    ``api``, ``light``, ``switch`` exist as both top-level component pages
-    and as category-scoped components (e.g. ``light.binary``). The
-    top-level docs URL is the one users mean when they write ``api`` in
-    YAML, so it must win.
+    ``api`` exists as a top-level component page; the ``api`` key in the
+    map must point at the top-level docs URL, not at any nested page
+    that happens to share the stem.
     """
     docs = await catalog.get_integration_docs()
-    # api top-level page lives at /components/api (no nested category).
-    if "api" in docs:
-        assert docs["api"].rstrip("/").endswith("/components/api")
+    assert "api" in docs, "api top-level component must always resolve"
+    assert docs["api"].rstrip("/").endswith("/components/api")
+
+
+async def test_ambiguous_stems_omitted(catalog: ComponentCatalog) -> None:
+    """Stems that resolve to multiple distinct docs URLs are dropped.
+
+    ``gpio`` is the canonical case — ``binary_sensor.gpio``,
+    ``switch.gpio``, ``output.gpio`` etc. each have their own page. We
+    can't pick one without misleading the user, so the bare ``gpio``
+    name must NOT be in the map (frontend then renders it as plain
+    text). The category landing for any of those parent categories
+    still works — this only guards the stem-alias slot.
+    """
+    docs = await catalog.get_integration_docs()
+    # If a future catalog change consolidates gpio docs we may need to
+    # revisit this; today they're distinct URLs across categories.
+    if "gpio" in docs:
+        # Only acceptable when every collision converges on the same URL.
+        # Surface the URL for the failure message so it's easy to
+        # diagnose without re-running locally.
+        msg = (
+            f"gpio resolved to {docs['gpio']!r} — expected omission because "
+            "binary_sensor/switch/output gpio variants have distinct docs URLs"
+        )
+        raise AssertionError(msg)
 
 
 async def test_unknown_integration_omitted(catalog: ComponentCatalog) -> None:

--- a/tests/test_components_integration_docs.py
+++ b/tests/test_components_integration_docs.py
@@ -1,0 +1,71 @@
+"""Smoke test for ``components/get_integration_docs``.
+
+Loads the real shipped catalog so the keys we expect users to see
+linked actually round-trip — this is the same data that drives the
+frontend's loaded-integration tags. A regression in the lookup logic
+(stem stripping, top-level priority) would silently turn a user's
+``api`` chip into plain text, so spot-check the common cases here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.controllers.components import ComponentCatalog
+
+
+@pytest.fixture
+def catalog() -> ComponentCatalog:
+    cat = ComponentCatalog()
+    cat.load()
+    return cat
+
+
+async def test_top_level_components_resolved(catalog: ComponentCatalog) -> None:
+    """Top-level catalog ids land on esphome.io/components/<id>."""
+    docs = await catalog.get_integration_docs()
+    for name in ("api", "wifi", "ethernet", "mdns", "logger", "web_server"):
+        assert name in docs, f"missing top-level docs for {name}"
+        assert docs[name].startswith("https://esphome.io/components/")
+
+
+async def test_category_landing_pages_resolved(catalog: ComponentCatalog) -> None:
+    """Category names like ``sensor`` / ``ota`` / ``light`` resolve too.
+
+    The URL is synthesized from any subcomponent's docs URL parent path.
+    """
+    docs = await catalog.get_integration_docs()
+    for category in ("sensor", "binary_sensor", "ota", "light", "switch"):
+        assert category in docs, f"missing category landing for {category}"
+        assert docs[category].rstrip("/").endswith(f"/components/{category}")
+
+
+async def test_stem_match_for_category_scoped_components(
+    catalog: ComponentCatalog,
+) -> None:
+    """A bare ``ltr390`` resolves to the sensor.ltr390 docs page."""
+    docs = await catalog.get_integration_docs()
+    assert "ltr390" in docs
+    assert "sensor/ltr390" in docs["ltr390"] or "ltr390" in docs["ltr390"]
+
+
+async def test_top_level_wins_over_stem(catalog: ComponentCatalog) -> None:
+    """When a top-level id and a stem collide, top-level claims the key.
+
+    ``api``, ``light``, ``switch`` exist as both top-level component pages
+    and as category-scoped components (e.g. ``light.binary``). The
+    top-level docs URL is the one users mean when they write ``api`` in
+    YAML, so it must win.
+    """
+    docs = await catalog.get_integration_docs()
+    # api top-level page lives at /components/api (no nested category).
+    if "api" in docs:
+        assert docs["api"].rstrip("/").endswith("/components/api")
+
+
+async def test_unknown_integration_omitted(catalog: ComponentCatalog) -> None:
+    """Names without a catalog hit are simply absent from the map."""
+    docs = await catalog.get_integration_docs()
+    # ``runtime_stats``-style helpers don't have a docs page; verify
+    # the contract by picking one that definitely won't exist.
+    assert "definitely_not_a_component_xyzzy" not in docs


### PR DESCRIPTION
## Summary

New WS command that returns `{integration_name: docs_url}` for every loaded-integration identifier we can resolve to a real esphome.io page. Frontend (separate PR) uses this to turn the device drawer's loaded-integration tags into clickable links.

The data comes from the existing component catalog (`components.json`), which `script/sync_components.py` already builds from the schema bundle's "See also" links plus the docs MDX repo. This command just re-shapes the catalog into a name → URL projection so the frontend doesn't have to ship the full catalog when it only needs the lookup.

### Three lookup layers, priority-ordered

The most-specific page wins:

1. **Top-level component** — catalog id without `.` (`api` → `/components/api`, `wifi` → `/components/wifi`).
2. **Category landing** — `sensor` → `/components/sensor`, synthesised from any `<cat>.<stem>` doc URL only when the URL is genuinely under `/components/<cat>/`. Skips multi-platform components like `switch.at581x` (docs at `/components/at581x`) that would otherwise produce a wrong category URL.
3. **Stem alias** — picks up specific drivers like `ltr390` whose catalog id is `sensor.ltr390`.

Names with no catalog hit are simply omitted; the frontend renders those as plain text. The catalog's `docs_url` is sourced from the live esphome.io docs index, so a present URL is also a guarantee that the page exists.

## Test plan

- [x] New `tests/test_components_integration_docs.py` covers all three layers against the shipped catalog (top-level / category landing / stem alias) plus a guard for unknown names being absent.
- [x] Full backend test suite passes: 273 passed, 3 skipped.
- [x] Lint clean.
- [ ] Frontend PR (separate) consumes the endpoint.