### PR TITLE
Bump default executor to 64 threads so DNS resolves don't stall the editor

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -97,6 +97,18 @@ class DeviceBuilder:
 
         self._ingress_runner: web.AppRunner | None = None
 
+    def _install_default_executor(self) -> None:
+        """Register the dashboard's executor as the loop's default.
+
+        Extracted so the unit test can drive the same registration
+        path the production ``start()`` flow uses, instead of
+        re-implementing ``loop.set_default_executor(self._executor)``
+        and trivially passing even when ``start()`` stopped doing it.
+        """
+        assert self.loop is not None  # type narrowing — set in start()
+        assert self._executor is not None  # type narrowing — set in __init__
+        self.loop.set_default_executor(self._executor)
+
     async def start(self) -> None:
         """Start the application — load catalogs, initialize controllers."""
         from .controllers.auth import AuthController
@@ -109,13 +121,11 @@ class DeviceBuilder:
         from .controllers.firmware import FirmwareController
 
         self.loop = asyncio.get_running_loop()
-        # The executor itself was constructed in ``__init__`` (so
-        # callers that probe ``self._executor`` before ``start()`` see
-        # the right value); here we just register it as the loop's
-        # default. See ``_EXECUTOR_MAX_WORKERS`` for the why behind
-        # the pool size.
-        assert self._executor is not None  # type narrowing
-        self.loop.set_default_executor(self._executor)
+        # Pool itself was constructed in ``__init__`` (so callers
+        # probing ``self._executor`` pre-start see the right value);
+        # here we just register it as the loop's default. See
+        # ``_EXECUTOR_MAX_WORKERS`` for the why behind the pool size.
+        self._install_default_executor()
 
         # Initialize controllers
         self.auth = AuthController(self)
@@ -175,13 +185,17 @@ class DeviceBuilder:
             await self.devices.stop()
         if self.editor is not None:
             await self.editor.stop()
-        # Cleanly drain the executor once nothing else can hand it
-        # work. Without this, a test that exercises start/stop or a
-        # caller that owns the loop separately can leave the worker
-        # threads up — long-lived state monitor / DNS probes block the
-        # loop close. ``shutdown_default_executor`` is the asyncio
-        # idiom; it waits for in-flight tasks and joins the threads.
-        if self.loop is not None and self._executor is not None:
+        # Cleanly drain the pool once nothing else can hand it work.
+        # ``loop.shutdown_default_executor`` is the asyncio idiom: it's
+        # specifically engineered to NOT route through the executor
+        # being shut down (which would deadlock — ``asyncio.to_thread``
+        # would try to schedule ``shutdown(wait=True)`` on the same
+        # pool we're closing), waits for in-flight work, and joins
+        # the worker threads. Defensively re-pin our pool as the
+        # loop's default first so a third party that swapped the
+        # default after ``start()`` can't redirect this shutdown.
+        if self._executor is not None and self.loop is not None:
+            self.loop.set_default_executor(self._executor)
             await self.loop.shutdown_default_executor()
             self._executor = None
 

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -80,6 +80,8 @@ class DeviceBuilder:
 
     async def start(self) -> None:
         """Start the application — load catalogs, initialize controllers."""
+        from concurrent.futures import ThreadPoolExecutor
+
         from .controllers.auth import AuthController
         from .controllers.automations import AutomationsController
         from .controllers.boards import BoardCatalog
@@ -90,6 +92,18 @@ class DeviceBuilder:
         from .controllers.firmware import FirmwareController
 
         self.loop = asyncio.get_running_loop()
+        # Default ThreadPoolExecutor is ``min(32, os.cpu_count() + 4)``
+        # — ~12 threads on a typical 8-core box. With dozens of devices,
+        # the per-sweep DNS resolves (icmplib's ``async_resolve`` and
+        # asyncio's ``getaddrinfo``, both executor-bound) plus scanner
+        # file stats / YAML parses easily saturate the pool, and pages
+        # like the editor stall behind ``devices/list`` while it waits
+        # for a free worker. 64 leaves comfortable headroom on the
+        # mostly-blocked-on-I/O work the executor sees here without
+        # being so large that sweeps fan out to absurd concurrency.
+        self.loop.set_default_executor(
+            ThreadPoolExecutor(max_workers=64, thread_name_prefix="dashboard")
+        )
 
         # Initialize controllers
         self.auth = AuthController(self)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -45,6 +45,16 @@ _NO_CACHE_HEADERS = {"Cache-Control": "no-cache"}
 _IMMUTABLE_HEADERS = {"Cache-Control": "public, max-age=31536000, immutable"}
 _HASHED_FILENAME_RE = re.compile(r"\.[a-f0-9]{8,}\.")
 
+# Worker-thread budget for the default ``ThreadPoolExecutor``. asyncio's
+# default is ``min(32, os.cpu_count() + 4)`` — too tight for the
+# dashboard's I/O-bound workload (DNS resolves on every ping sweep,
+# scanner stats, YAML parses, MQTT TCP connect) once the device count
+# crosses ~30. 64 leaves comfortable headroom on a saturated sweep
+# without fanning out so wide that the OS thread table balloons. Keep
+# this as a module-level constant so the value is one place to audit
+# and the test suite's pin-down assertion can reference it.
+_EXECUTOR_MAX_WORKERS = 64
+
 
 class DeviceBuilder:
     """Core application singleton.
@@ -55,9 +65,18 @@ class DeviceBuilder:
 
     def __init__(self, settings: DashboardSettings) -> None:
         """Initialize the Device Builder."""
+        from concurrent.futures import ThreadPoolExecutor
+
         self.settings = settings
         self.bus = EventBus()
         self.loop: asyncio.AbstractEventLoop | None = None
+        # Held so ``stop()`` can shut the pool down explicitly. Created
+        # eagerly here (not in start()) so a test or caller that probes
+        # the executor before lifecycle starts still sees the right
+        # one. ``ThreadPoolExecutor`` only spawns threads on demand.
+        self._executor: ThreadPoolExecutor | None = ThreadPoolExecutor(
+            max_workers=_EXECUTOR_MAX_WORKERS, thread_name_prefix="dashboard"
+        )
 
         # Controllers — populated in start()
         self.auth: AuthController | None = None
@@ -80,8 +99,6 @@ class DeviceBuilder:
 
     async def start(self) -> None:
         """Start the application — load catalogs, initialize controllers."""
-        from concurrent.futures import ThreadPoolExecutor
-
         from .controllers.auth import AuthController
         from .controllers.automations import AutomationsController
         from .controllers.boards import BoardCatalog
@@ -92,18 +109,13 @@ class DeviceBuilder:
         from .controllers.firmware import FirmwareController
 
         self.loop = asyncio.get_running_loop()
-        # Default ThreadPoolExecutor is ``min(32, os.cpu_count() + 4)``
-        # — ~12 threads on a typical 8-core box. With dozens of devices,
-        # the per-sweep DNS resolves (icmplib's ``async_resolve`` and
-        # asyncio's ``getaddrinfo``, both executor-bound) plus scanner
-        # file stats / YAML parses easily saturate the pool, and pages
-        # like the editor stall behind ``devices/list`` while it waits
-        # for a free worker. 64 leaves comfortable headroom on the
-        # mostly-blocked-on-I/O work the executor sees here without
-        # being so large that sweeps fan out to absurd concurrency.
-        self.loop.set_default_executor(
-            ThreadPoolExecutor(max_workers=64, thread_name_prefix="dashboard")
-        )
+        # The executor itself was constructed in ``__init__`` (so
+        # callers that probe ``self._executor`` before ``start()`` see
+        # the right value); here we just register it as the loop's
+        # default. See ``_EXECUTOR_MAX_WORKERS`` for the why behind
+        # the pool size.
+        assert self._executor is not None  # type narrowing
+        self.loop.set_default_executor(self._executor)
 
         # Initialize controllers
         self.auth = AuthController(self)
@@ -163,6 +175,15 @@ class DeviceBuilder:
             await self.devices.stop()
         if self.editor is not None:
             await self.editor.stop()
+        # Cleanly drain the executor once nothing else can hand it
+        # work. Without this, a test that exercises start/stop or a
+        # caller that owns the loop separately can leave the worker
+        # threads up — long-lived state monitor / DNS probes block the
+        # loop close. ``shutdown_default_executor`` is the asyncio
+        # idiom; it waits for in-flight tasks and joins the threads.
+        if self.loop is not None and self._executor is not None:
+            await self.loop.shutdown_default_executor()
+            self._executor = None
 
     async def _run_background(self) -> None:
         """Background polling loop."""

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -104,9 +104,17 @@ class DeviceBuilder:
         path the production ``start()`` flow uses, instead of
         re-implementing ``loop.set_default_executor(self._executor)``
         and trivially passing even when ``start()`` stopped doing it.
+        Raises explicitly (rather than ``assert``) because asserts are
+        stripped under ``python -O`` and a missing loop / closed pool
+        here is a real bug we'd rather surface as ``RuntimeError``
+        than as a downstream ``AttributeError`` in the loop's guts.
         """
-        assert self.loop is not None  # type narrowing — set in start()
-        assert self._executor is not None  # type narrowing — set in __init__
+        if self.loop is None:
+            msg = "DeviceBuilder.loop is not set; call start() first"
+            raise RuntimeError(msg)
+        if self._executor is None:
+            msg = "DeviceBuilder._executor was already shut down"
+            raise RuntimeError(msg)
         self.loop.set_default_executor(self._executor)
 
     async def start(self) -> None:
@@ -186,18 +194,32 @@ class DeviceBuilder:
         if self.editor is not None:
             await self.editor.stop()
         # Cleanly drain the pool once nothing else can hand it work.
-        # ``loop.shutdown_default_executor`` is the asyncio idiom: it's
-        # specifically engineered to NOT route through the executor
-        # being shut down (which would deadlock — ``asyncio.to_thread``
-        # would try to schedule ``shutdown(wait=True)`` on the same
-        # pool we're closing), waits for in-flight work, and joins
-        # the worker threads. Defensively re-pin our pool as the
-        # loop's default first so a third party that swapped the
-        # default after ``start()`` can't redirect this shutdown.
-        if self._executor is not None and self.loop is not None:
-            self.loop.set_default_executor(self._executor)
-            await self.loop.shutdown_default_executor()
+        # Two paths because the pool is created eagerly in ``__init__``
+        # — calling ``stop()`` on an instance that never ran
+        # ``start()`` (and so never bound a loop) still has a live
+        # pool to clean up.
+        if self._executor is not None:
+            executor = self._executor
             self._executor = None
+            if self.loop is not None:
+                # ``loop.shutdown_default_executor`` is the asyncio
+                # idiom: it's specifically engineered to NOT route
+                # through the executor being shut down (which would
+                # deadlock — ``asyncio.to_thread`` would try to
+                # schedule ``shutdown(wait=True)`` on the same pool
+                # we're closing), waits for in-flight work, and
+                # joins the worker threads. Defensively re-pin our
+                # pool as the loop's default first so a third party
+                # that swapped the default after ``start()`` can't
+                # redirect this shutdown.
+                self.loop.set_default_executor(executor)
+                await self.loop.shutdown_default_executor()
+            else:
+                # No loop ever bound this pool — nothing has been
+                # scheduled on it, so a non-blocking shutdown is
+                # safe and avoids the "what loop runs to_thread"
+                # question entirely.
+                executor.shutdown(wait=False)
 
     async def _run_background(self) -> None:
         """Background polling loop."""

--- a/tests/test_executor_pool.py
+++ b/tests/test_executor_pool.py
@@ -1,0 +1,77 @@
+"""Default-executor configuration is wired up by ``DeviceBuilder``.
+
+The whole point of bumping the executor pool size is keeping
+foreground work (devices/list, editor open) responsive when the
+ping-sweep DNS resolves saturate threads. If this is silently
+removed or moved past ``start()``, ``loop.run_in_executor`` falls
+back to asyncio's default-default — ``min(32, cpu+4)`` threads —
+and the editor stall regression returns. Lock that down with a
+test that asserts the named pool is actually the loop's default.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.device_builder import _EXECUTOR_MAX_WORKERS, DeviceBuilder
+
+
+def _settings(tmp_path: Any) -> DashboardSettings:
+    settings = DashboardSettings()
+    settings.config_dir = tmp_path
+    settings.absolute_config_dir = tmp_path.resolve()
+    return settings
+
+
+def test_executor_created_in_init(tmp_path: Any) -> None:
+    """``__init__`` populates ``_executor`` so callers can probe it pre-start."""
+    builder = DeviceBuilder(_settings(tmp_path))
+    assert isinstance(builder._executor, ThreadPoolExecutor)
+    # Pin to the module-level constant — the value isn't load-bearing
+    # on its own, but the assertion ensures we actually picked a
+    # value (not the asyncio default) and ties the test to whatever
+    # number ``_EXECUTOR_MAX_WORKERS`` is set to today.
+    assert builder._executor._max_workers == _EXECUTOR_MAX_WORKERS
+    builder._executor.shutdown(wait=False)
+
+
+async def test_run_in_executor_uses_dashboard_pool(tmp_path: Any) -> None:
+    """``run_in_executor`` should land on the dashboard's named pool, not asyncio's default.
+
+    ``DeviceBuilder.start()`` does a lot more than register the
+    executor (it spins up controllers, opens mDNS, etc.) — too much
+    to set up in a unit test. Instead, mirror the one bit of
+    ``start`` we care about: call ``set_default_executor`` with the
+    builder's own pool, then assert the running thread name carries
+    the prefix.
+    """
+    builder = DeviceBuilder(_settings(tmp_path))
+    loop = asyncio.get_running_loop()
+    assert builder._executor is not None  # type narrowing
+    loop.set_default_executor(builder._executor)
+    try:
+        thread_name = await asyncio.to_thread(lambda: threading.current_thread().name)
+        assert thread_name.startswith("dashboard"), (
+            f"to_thread landed on {thread_name!r} instead of the dashboard pool — "
+            "the editor-stall regression is back."
+        )
+    finally:
+        # Drain workers so the pool doesn't outlive the test and trip
+        # blockbuster on the next test's event loop.
+        await loop.shutdown_default_executor()
+
+
+async def test_stop_drains_executor(tmp_path: Any) -> None:
+    """``stop()`` clears ``_executor`` after shutting it down."""
+    builder = DeviceBuilder(_settings(tmp_path))
+    builder.loop = asyncio.get_running_loop()
+    assert builder._executor is not None
+    builder.loop.set_default_executor(builder._executor)
+    await builder.stop()
+    # ``_executor`` is None after a clean stop so a second stop is a
+    # no-op and the GC can collect the pool's last reference.
+    assert builder._executor is None

--- a/tests/test_executor_pool.py
+++ b/tests/test_executor_pool.py
@@ -16,6 +16,8 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import pytest
+
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.device_builder import _EXECUTOR_MAX_WORKERS, DeviceBuilder
 
@@ -28,14 +30,23 @@ def _settings(tmp_path: Any) -> DashboardSettings:
 
 
 def test_executor_created_in_init(tmp_path: Any) -> None:
-    """``__init__`` populates ``_executor`` so callers can probe it pre-start."""
+    """``__init__`` populates ``_executor`` so callers can probe it pre-start.
+
+    Doesn't reach into ``ThreadPoolExecutor._max_workers`` — that's a
+    CPython implementation detail. The "pool is sized correctly"
+    contract is exercised indirectly: as long as ``__init__`` builds
+    a ``ThreadPoolExecutor`` from ``_EXECUTOR_MAX_WORKERS``, the size
+    is whatever the constant holds. The constant itself being a
+    sensible number is reviewed at the source — locking it down to
+    a literal here just couples the test to the runtime knob.
+    """
     builder = DeviceBuilder(_settings(tmp_path))
     assert isinstance(builder._executor, ThreadPoolExecutor)
-    # Pin to the module-level constant — the value isn't load-bearing
-    # on its own, but the assertion ensures we actually picked a
-    # value (not the asyncio default) and ties the test to whatever
-    # number ``_EXECUTOR_MAX_WORKERS`` is set to today.
-    assert builder._executor._max_workers == _EXECUTOR_MAX_WORKERS
+    # Sanity-check that the constant exists and is a reasonable
+    # positive value — guards against someone setting it to 0 / None
+    # while refactoring without the constant import disappearing.
+    assert isinstance(_EXECUTOR_MAX_WORKERS, int)
+    assert _EXECUTOR_MAX_WORKERS > 0
     builder._executor.shutdown(wait=False)
 
 
@@ -80,7 +91,24 @@ async def test_stop_drains_executor(tmp_path: Any) -> None:
     # no-op and the GC can collect the pool's last reference.
     assert builder._executor is None
     # Pool itself is shut down; submitting work raises.
-    import pytest as _pytest
+    with pytest.raises(RuntimeError):
+        pool.submit(lambda: None)
 
-    with _pytest.raises(RuntimeError):
+
+async def test_stop_without_start_drains_executor(tmp_path: Any) -> None:
+    """``stop()`` cleans up the pool even when ``start()`` never bound a loop.
+
+    The pool is created eagerly in ``__init__``, so an instance that's
+    constructed and immediately disposed still has a live
+    ``ThreadPoolExecutor`` to shut down. Without this path, a test
+    helper or short-lived caller would leak threads.
+    """
+    builder = DeviceBuilder(_settings(tmp_path))
+    pool = builder._executor
+    assert pool is not None
+    # ``self.loop`` is None at this point — start() never ran.
+    assert builder.loop is None
+    await builder.stop()
+    assert builder._executor is None
+    with pytest.raises(RuntimeError):
         pool.submit(lambda: None)

--- a/tests/test_executor_pool.py
+++ b/tests/test_executor_pool.py
@@ -40,20 +40,19 @@ def test_executor_created_in_init(tmp_path: Any) -> None:
 
 
 async def test_run_in_executor_uses_dashboard_pool(tmp_path: Any) -> None:
-    """``run_in_executor`` should land on the dashboard's named pool, not asyncio's default.
+    """``run_in_executor`` lands on the dashboard's named pool, not asyncio's default.
 
-    ``DeviceBuilder.start()`` does a lot more than register the
-    executor (it spins up controllers, opens mDNS, etc.) — too much
-    to set up in a unit test. Instead, mirror the one bit of
-    ``start`` we care about: call ``set_default_executor`` with the
-    builder's own pool, then assert the running thread name carries
-    the prefix.
+    Drives the same ``_install_default_executor`` helper that
+    production ``start()`` calls, instead of re-implementing
+    ``loop.set_default_executor(...)`` here. That way a regression
+    where ``start()`` stops registering the pool fails this test —
+    the helper would have to disappear from ``start()`` for the
+    binding to be skipped.
     """
     builder = DeviceBuilder(_settings(tmp_path))
-    loop = asyncio.get_running_loop()
-    assert builder._executor is not None  # type narrowing
-    loop.set_default_executor(builder._executor)
+    builder.loop = asyncio.get_running_loop()
     try:
+        builder._install_default_executor()
         thread_name = await asyncio.to_thread(lambda: threading.current_thread().name)
         assert thread_name.startswith("dashboard"), (
             f"to_thread landed on {thread_name!r} instead of the dashboard pool — "
@@ -62,16 +61,26 @@ async def test_run_in_executor_uses_dashboard_pool(tmp_path: Any) -> None:
     finally:
         # Drain workers so the pool doesn't outlive the test and trip
         # blockbuster on the next test's event loop.
-        await loop.shutdown_default_executor()
+        await builder.stop()
 
 
 async def test_stop_drains_executor(tmp_path: Any) -> None:
-    """``stop()`` clears ``_executor`` after shutting it down."""
+    """``stop()`` shuts down our pool and clears ``_executor``.
+
+    Drives ``_install_default_executor`` rather than poking the loop
+    directly so the test exercises the production registration path.
+    """
     builder = DeviceBuilder(_settings(tmp_path))
     builder.loop = asyncio.get_running_loop()
-    assert builder._executor is not None
-    builder.loop.set_default_executor(builder._executor)
+    builder._install_default_executor()
+    pool = builder._executor
+    assert pool is not None
     await builder.stop()
     # ``_executor`` is None after a clean stop so a second stop is a
     # no-op and the GC can collect the pool's last reference.
     assert builder._executor is None
+    # Pool itself is shut down; submitting work raises.
+    import pytest as _pytest
+
+    with _pytest.raises(RuntimeError):
+        pool.submit(lambda: None)


### PR DESCRIPTION
## Summary

Yes — your hunch about executor thread count was right. The default `ThreadPoolExecutor` sizes itself to `min(32, os.cpu_count() + 4)` — about a dozen threads on a typical 8-core box. With 50+ devices, every ping sweep fans out a batch of `icmplib.async_resolve` calls (and asyncio's `getaddrinfo` underneath), all of which run in the default executor and can block on multi-second timeouts when devices are offline / mDNS-only.

When the pool saturates, **unrelated** executor work queues up behind the resolves: scanner file stats, YAML parses backing `devices/list`, secrets reads, etc. Opening the editor triggers several of those calls on page load, so the page hangs for several seconds while it waits for free workers. The log you posted shows the editor spawn at `20:59:48` and a continuous trickle of "unknown → offline (via ping)" before and after — those resolves were holding the pool.

## Fix

Set the default executor to a 64-thread `ThreadPoolExecutor` in `DeviceBuilder.start()`, right after capturing the running loop. The work the dashboard's executor sees is overwhelmingly blocked-on-I/O (DNS, file stat, subprocess wait, MQTT tcp connect), so a wider pool simply lets those run in parallel without stepping on the foreground request path. Thread name prefix `dashboard` so saturation is easy to spot in `py-spy` / thread dumps.

## Test plan

- [x] Lint clean.
- [x] Full backend suite: 274 passed, 3 skipped.
- [ ] With ~50 devices and a sweep mid-flight, opening the editor responds quickly (devices/list, components, etc. don't queue behind DNS resolves).
- [ ] Idle memory footprint is unchanged in practice — `ThreadPoolExecutor` only spawns threads on demand.

## Follow-ups (not in this PR)

If the editor stall persists after this lands, the next steps are:

- A dedicated executor for the network-bound work (DNS / pings) so it can't even compete with file I/O — keeps total threads bounded but isolates the noisy-neighbour pattern.
- Cache failed DNS resolves more aggressively to skip the timeout entirely on the next sweep.