### PR TITLE
Surface mDNS api_encryption observation on configured devices

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -90,6 +90,16 @@ VersionChangeCallback = Callable[[str, str], None]
 # older devices simply never fire this callback.
 ConfigHashChangeCallback = Callable[[str, str], None]
 
+# Callback fired when the mDNS ``api_encryption`` TXT record reports a
+# different value than last seen. Empty string means the device's
+# service announcement was seen but the TXT was absent — i.e. the
+# device is broadcasting plaintext API. A non-empty value (e.g.
+# ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) confirms encryption is
+# live on the device. The "no mDNS seen yet" case never fires this
+# callback at all, so the device controller can keep that state as
+# ``None`` to mean "trust whatever the YAML says".
+ApiEncryptionChangeCallback = Callable[[str, str], None]
+
 # Callback fired when zeroconf turns up a previously-unseen device that
 # advertises ``package_import_url`` / ``project_name`` /
 # ``project_version`` TXT records — the signal that this is a factory
@@ -151,6 +161,7 @@ class DeviceStateMonitor:
         on_ip_change: IPChangeCallback,
         on_version_change: VersionChangeCallback | None = None,
         on_config_hash_change: ConfigHashChangeCallback | None = None,
+        on_api_encryption_change: ApiEncryptionChangeCallback | None = None,
         on_importable_added: ImportableAddedCallback | None = None,
         on_importable_removed: ImportableRemovedCallback | None = None,
         is_ignored: Callable[[str], bool] | None = None,
@@ -160,6 +171,7 @@ class DeviceStateMonitor:
         self._on_ip_change = on_ip_change
         self._on_version_change = on_version_change
         self._on_config_hash_change = on_config_hash_change
+        self._on_api_encryption_change = on_api_encryption_change
         self._on_importable_added = on_importable_added
         self._on_importable_removed = on_importable_removed
         self._is_ignored = is_ignored or (lambda _name: False)
@@ -167,6 +179,10 @@ class DeviceStateMonitor:
         self._device_ips: dict[str, str] = {}  # device name → last known IP
         self._device_versions: dict[str, str] = {}  # device name → last reported version
         self._device_config_hashes: dict[str, str] = {}  # device name → last reported config hash
+        # Tri-state-able dedupe map: missing key = never seen mDNS for
+        # this device (callback never fires); empty string = seen
+        # plaintext; non-empty = seen encryption with that algorithm.
+        self._device_api_encryption: dict[str, str] = {}
         # ``DashboardImportDiscovery`` is the upstream esphome class
         # that watches the same ``_esphomelib._tcp.local.`` browser for
         # ``package_import_url`` TXT records and turns them into
@@ -302,6 +318,35 @@ class DeviceStateMonitor:
             return False
         self._device_versions[name] = version
         self._on_version_change(name, version)
+        return True
+
+    def apply_api_encryption(self, name: str, encryption: str) -> bool:
+        """
+        Record the device's broadcast API encryption status.
+
+        Empty string means the mDNS service was seen but the
+        ``api_encryption`` TXT was absent — i.e. the device is
+        running plaintext API. A non-empty value (e.g.
+        ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) confirms encryption
+        is active. The "never seen" case is represented by simply not
+        calling this method at all; the device controller treats
+        absence as "trust the YAML".
+
+        Returns True when the value actually changed and the change
+        was forwarded to the callback.
+        """
+        if self._on_api_encryption_change is None:
+            return False
+        if self._find_device_by_name(name) is None:
+            return False
+        # ``""`` is a meaningful state ("seen plaintext") so we have to
+        # distinguish "no entry" from "entry == empty"; ``in`` does
+        # that without confusing it with the truthy-check guard
+        # apply_config_hash uses for its empty-string drop.
+        if name in self._device_api_encryption and self._device_api_encryption[name] == encryption:
+            return False
+        self._device_api_encryption[name] = encryption
+        self._on_api_encryption_change(name, encryption)
         return True
 
     def apply_config_hash(self, name: str, config_hash: str) -> bool:
@@ -690,6 +735,10 @@ class DeviceStateMonitor:
             self.apply_version(device_name, version)
         if config_hash := props.get("config_hash"):
             self.apply_config_hash(device_name, config_hash)
+        # Always apply api_encryption — empty / missing TXT is itself
+        # a meaningful signal (device is broadcasting plaintext) and
+        # apply_api_encryption distinguishes it from "never seen".
+        self.apply_api_encryption(device_name, props.get("api_encryption") or "")
 
     async def _ping_loop(self) -> None:
         # First sweep after the short bootstrap window — gives mDNS a

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -100,6 +100,7 @@ class DevicesController:
             on_ip_change=self._on_ip_change,
             on_version_change=self._on_version_change,
             on_config_hash_change=self._on_config_hash_change,
+            on_api_encryption_change=self._on_api_encryption_change,
             on_importable_added=self._on_importable_added,
             on_importable_removed=self._on_importable_removed,
             is_ignored=self.ignored_devices.__contains__,
@@ -900,6 +901,24 @@ class DevicesController:
         device.deployed_version = version
         device.update_available = bool(device.current_version and version != device.current_version)
         _LOGGER.info("Device %s version: %s → %s (via mdns)", name, old_version or "?", version)
+        self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+
+    def _on_api_encryption_change(self, name: str, encryption: str) -> None:
+        """
+        Apply the API-encryption state observed via mDNS.
+
+        Stores the broadcast value (or empty string for "TXT absent —
+        device is plaintext") on the in-memory device. The dashboard's
+        four-state lock indicator reads this together with
+        ``api_encrypted`` to distinguish active / pending-flash /
+        mismatch / plaintext.
+        """
+        device = next((d for d in self._scanner.devices if d.name == name), None)
+        if device is None:
+            return
+        if device.api_encryption_active == encryption:
+            return
+        device.api_encryption_active = encryption
         self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 
     def _on_config_hash_change(self, name: str, config_hash: str) -> None:

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -58,6 +58,18 @@ class Device(DataClassORJSONMixin):
     # is fetched on demand via ``devices/get_api_key``.
     api_enabled: bool = False
     api_encrypted: bool = False
+    # Encryption status as observed from the device's
+    # ``_esphomelib._tcp.local.`` mDNS broadcast.
+    #   None  → mDNS not seen yet. The frontend trusts ``api_encrypted``
+    #           verbatim (assume the YAML matches what's on the device).
+    #   ""    → mDNS seen, ``api_encryption`` TXT absent. The device is
+    #           running plaintext regardless of what the YAML says.
+    #   "..." → mDNS seen, ``api_encryption`` TXT present (e.g.
+    #           ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``). Encryption is
+    #           confirmed live on the device.
+    # Drives the four-state lock indicator on the device card / table:
+    # active, pending-flash, mismatch, plaintext.
+    api_encryption_active: str | None = None
 
 
 @dataclass

--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -1,0 +1,103 @@
+"""Tests for mDNS-driven API encryption observation.
+
+The ``_esphomelib._tcp`` service announcement carries an
+``api_encryption`` TXT record (e.g.
+``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) when the device's API is
+running encryption, and omits it when the device is running plaintext.
+The dashboard reads this through the monitor → controller pipeline so
+the four-state lock indicator can tell active / pending-flash /
+mismatch / plaintext apart.
+
+Three states matter for the apply path:
+- "never seen" — the callback never fires; the controller leaves
+  ``api_encryption_active`` at ``None`` and the UI trusts the YAML.
+- "" — mDNS seen, TXT absent. Device is broadcasting plaintext.
+- non-empty — mDNS seen, TXT present. Encryption confirmed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.models import Device, DeviceState
+
+
+def _device(**overrides: Any) -> Device:
+    base: dict[str, Any] = {
+        "name": "kitchen",
+        "friendly_name": "Kitchen",
+        "configuration": "kitchen.yaml",
+        "address": "kitchen.local",
+        "state": DeviceState.UNKNOWN,
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
+    on_enc = MagicMock()
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=MagicMock(),
+        on_ip_change=MagicMock(),
+        on_api_encryption_change=on_enc,
+    )
+    return monitor, on_enc
+
+
+def test_apply_api_encryption_first_observation_fires_callback() -> None:
+    """A first encryption value reaches the controller."""
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256") is True
+    cb.assert_called_once_with("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+
+
+def test_apply_api_encryption_empty_string_is_a_real_observation() -> None:
+    """Empty string ("TXT absent → plaintext confirmed") fires the callback.
+
+    Distinct from "never observed" — the controller relies on the
+    callback firing at least once to know we have ground truth from
+    mDNS at all.
+    """
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_api_encryption("kitchen", "") is True
+    cb.assert_called_once_with("kitchen", "")
+
+
+def test_apply_api_encryption_dedupes_same_value() -> None:
+    """Repeated identical observations don't churn the controller."""
+    monitor, cb = _monitor([_device()])
+    monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+    monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+    cb.assert_called_once()
+
+
+def test_apply_api_encryption_fires_on_change() -> None:
+    """Encrypted → plaintext (or vice versa) re-fires the callback."""
+    monitor, cb = _monitor([_device()])
+    monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+    monitor.apply_api_encryption("kitchen", "")
+    assert cb.call_count == 2
+    assert cb.call_args_list[1].args == ("kitchen", "")
+
+
+def test_apply_api_encryption_unknown_device_is_ignored() -> None:
+    """A name that doesn't match any configured device drops the call.
+
+    Discovered-but-not-imported devices fire mDNS too; they shouldn't
+    trigger a DEVICE_UPDATED on a configured device that happens to
+    share a similar name slot.
+    """
+    monitor, cb = _monitor([_device()])
+    assert monitor.apply_api_encryption("not-a-device", "anything") is False
+    cb.assert_not_called()
+
+
+def test_apply_api_encryption_dedupes_repeated_empty() -> None:
+    """The empty-string state is dedup'd just like a non-empty one."""
+    monitor, cb = _monitor([_device()])
+    monitor.apply_api_encryption("kitchen", "")
+    monitor.apply_api_encryption("kitchen", "")
+    cb.assert_called_once()

--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -20,8 +20,11 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.models import Device, DeviceState
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.models import Device, DeviceState, EventType
 
 
 def _device(**overrides: Any) -> Device:
@@ -101,3 +104,82 @@ def test_apply_api_encryption_dedupes_repeated_empty() -> None:
     monitor.apply_api_encryption("kitchen", "")
     monitor.apply_api_encryption("kitchen", "")
     cb.assert_called_once()
+
+
+# ----------------------------------------------------------------------
+# DevicesController._on_api_encryption_change
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_api_encryption_change_updates_device_and_fires_event() -> None:
+    """Callback writes the value onto the in-memory device + fires DEVICE_UPDATED."""
+    device = _device(api_encryption_active=None)
+
+    db = MagicMock()
+    fired_events: list[tuple[EventType, dict]] = []
+    db.bus.fire.side_effect = lambda event_type, data: fired_events.append((event_type, data))
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+
+    assert device.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+    assert any(et == EventType.DEVICE_UPDATED for et, _ in fired_events)
+
+
+@pytest.mark.asyncio
+async def test_on_api_encryption_change_records_empty_string() -> None:
+    """Empty string flips ``None`` → ``""`` and fires the event.
+
+    The transition from "never seen" to "seen plaintext" is itself a
+    meaningful state change and the dashboard's lock indicator depends
+    on observing it (None → "" makes the four-state classifier flip
+    from ``active`` to ``mismatch``/``pending`` when paired with a
+    plaintext device).
+    """
+    device = _device(api_encryption_active=None)
+
+    db = MagicMock()
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    controller._on_api_encryption_change("kitchen", "")
+
+    assert device.api_encryption_active == ""
+    db.bus.fire.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_on_api_encryption_change_skips_when_same() -> None:
+    """No-op when the in-memory device already has the announced value."""
+    device = _device(api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+
+    db = MagicMock()
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+
+    controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+
+    db.bus.fire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_api_encryption_change_unknown_device_is_noop() -> None:
+    """A stray callback for a name we don't track must not raise or fire."""
+    db = MagicMock()
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = db
+    controller._scanner = MagicMock()
+    controller._scanner.devices = []
+
+    controller._on_api_encryption_change("ghost", "anything")
+
+    db.bus.fire.assert_not_called()


### PR DESCRIPTION
## Summary

Backend half of a four-state encryption indicator for the dashboard. Today the lock badge reads `api_encrypted` from the resolved YAML, which is wrong whenever a device hasn't been re-flashed yet (the YAML says encrypted, the device is still broadcasting plaintext API).

ESPHome already publishes the live state in the `_esphomelib._tcp.local.` TXT records:
- `api_encryption=Noise_NNpsk0_25519_ChaChaPoly_SHA256` when encryption is on
- TXT absent when running plaintext

This adds:
- `Device.api_encryption_active: str | None` — `None` = mDNS not seen yet, `""` = TXT absent / plaintext confirmed, non-empty = algorithm string
- `apply_api_encryption(name, value)` on `DeviceStateMonitor`, mirroring `apply_config_hash` but tri-state-able (the empty-string case is meaningful)
- `_on_api_encryption_change` callback on the devices controller — stores the value and fires `DEVICE_UPDATED`

The dashboard frontend renders this in a follow-up PR (active / pending-flash / mismatch / plaintext).

## Test plan

- [ ] Backend tests pass (`tests/test_mdns_api_encryption.py` covers first observation, dedupe, "" vs non-empty, change re-fire, and unknown-name drop)
- [ ] After backend deploy, observe `api_encryption_active` in `devices/list` for a device with encryption (Noise string) and one without (empty string once mDNS sees it)