### PR TITLE
Stop matching PIO unpack / memory-usage % as build progress

### DIFF
--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -43,13 +43,30 @@ _ERROR_PATTERNS = [
     "command not found",
 ]
 
-# Progress markers in PlatformIO / esptool output. Both phases emit
-# integer percentages we can latch onto:
-#   - PIO compile:  ``[ 17%] Compiling ...``
-#   - esptool:      ``Writing at 0x... (45 %)\r``
-# We accept either form (with or without the space before ``%``) and
-# pull the first match per line.
-_PROGRESS_PATTERN = re.compile(r"\[?\s*(\d{1,3})\s*%\]?")
+# Progress markers we actually want to surface as job.progress. The
+# original wide-open ``\d{1,3}%`` regex matched anything carrying a
+# percent sign — including PlatformIO's startup "Unpacking [###] 100%"
+# package-extract bar and the post-compile "RAM: 19.3%" / "Flash:
+# 80.0%" memory-usage report. Both pinned the bar to non-monotonic
+# garbage long before the build's actual progress signal arrived.
+# Tightened to a whitelist of three known-real progress shapes:
+#
+#   * PlatformIO Arduino compile:    ``[ 17%] Compiling foo.cpp.o``
+#     The percentage MUST start the line and live inside square
+#     brackets so PIO's ESP-IDF builds (which don't emit a per-file
+#     percent at all) and the package-extract bar (no ``[NN%]`` shape)
+#     never trip it.
+#   * esptool serial flash:          ``Writing at 0x10000... (45 %)``
+#     The percentage lives in parens after a Writing/Erasing prefix.
+#     ``(\s*\d{1,3}\s*%\s*\)`` is enough — no other PIO output uses
+#     parens around a bare percentage.
+#   * ESPHome OTA upload:            ``Uploading: [====] 100% Done...``
+#     Anchored to the ``Uploading:`` prefix.
+_PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*\[\s*(\d{1,3})\s*%\s*\]"),
+    re.compile(r"\(\s*(\d{1,3})\s*%\s*\)"),
+    re.compile(r"^\s*Uploading:.*?\b(\d{1,3})\s*%"),
+)
 
 # How long to wait for a SIGTERM'd subprocess to exit before we
 # escalate to SIGKILL. ESPHome / PlatformIO usually clean up promptly;
@@ -145,16 +162,18 @@ def _find_esphome_cmd() -> list[str]:
 def _parse_progress(line: str) -> int | None:
     """Extract a 0-100 progress percentage from a build/flash output line.
 
-    Returns ``None`` when the line carries no recognisable percentage.
-    Out-of-range values (a stray "999%" in a log message) are
-    discarded so the field stays a clean 0-100.
+    Returns ``None`` when the line doesn't match one of the known
+    progress shapes (see ``_PROGRESS_PATTERNS``). Stray ``%`` signs
+    elsewhere in the build output (Unpacking bars, memory-usage
+    reports) are intentionally ignored.
     """
-    match = _PROGRESS_PATTERN.search(line)
-    if match is None:
-        return None
-    value = int(match.group(1))
-    if 0 <= value <= 100:
-        return value
+    for pattern in _PROGRESS_PATTERNS:
+        match = pattern.search(line)
+        if match is None:
+            continue
+        value = int(match.group(1))
+        if 0 <= value <= 100:
+            return value
     return None
 
 

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -57,9 +57,10 @@ _ERROR_PATTERNS = [
 #     percent at all) and the package-extract bar (no ``[NN%]`` shape)
 #     never trip it.
 #   * esptool serial flash:          ``Writing at 0x10000... (45 %)``
-#     The percentage lives in parens after a Writing/Erasing prefix.
-#     ``(\s*\d{1,3}\s*%\s*\)`` is enough — no other PIO output uses
-#     parens around a bare percentage.
+#     We match a bare parenthesized percentage anywhere in the line:
+#     ``(\s*\d{1,3}\s*%\s*\)``. In practice that is enough for esptool
+#     progress, and no other expected PIO/ESPHome output uses parens
+#     around a bare percentage.
 #   * ESPHome OTA upload:            ``Uploading: [====] 100% Done...``
 #     Anchored to the ``Uploading:`` prefix.
 _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (

--- a/tests/test_firmware_progress.py
+++ b/tests/test_firmware_progress.py
@@ -1,0 +1,137 @@
+r"""Progress regex covers real markers, ignores noisy ``%`` lines.
+
+The shipped install / compile pipeline mixes a handful of unrelated
+percent-bearing log lines with the few that actually represent build
+progress. The ``_parse_progress`` whitelist has to pick out the
+real ones (PlatformIO ``[ NN%]`` per-file markers, esptool
+``(NN %)``, ESPHome OTA ``Uploading: 100%``) and skip everything
+else (PIO platform-extract bars, memory-usage reports, stray
+percentages in narrative log text).
+
+The regression these tests guard against: a wide-open
+``\d{1,3}%`` regex pinned ``job.progress`` to 100 the moment
+``Unpacking [###] 100%`` flew by during a fresh PlatformIO
+package install — long before the compile had actually started
+real work.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.controllers.firmware import _parse_progress
+
+
+class TestRealProgressLines:
+    """Lines that should resolve to a percentage."""
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            ("[  1%] Compiling .pio/foo.cpp.o", 1),
+            ("[ 17%] Compiling .pio/bar.cpp.o", 17),
+            ("[100%] Linking .pioenvs/firmware.elf", 100),
+            # leading whitespace is fine, ESPHome's --dashboard mode
+            # sometimes prefixes lines with indent.
+            ("    [ 42%] Compiling baz.cpp.o", 42),
+        ],
+    )
+    def test_pio_arduino_compile_marker(self, line: str, expected: int) -> None:
+        assert _parse_progress(line) == expected
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            ("Writing at 0x00010000... (5 %)", 5),
+            ("Writing at 0x00050000... (45 %)", 45),
+            ("Writing at 0x00100000... (100 %)", 100),
+            # esptool sometimes drops the space before %.
+            ("Writing at 0x00050000... (45%)", 45),
+        ],
+    )
+    def test_esptool_writing_marker(self, line: str, expected: int) -> None:
+        assert _parse_progress(line) == expected
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            ("Uploading: [====================] 100% Done...", 100),
+            ("Uploading: [====      ] 35% ...", 35),
+            ("    Uploading: [===========] 50%", 50),
+        ],
+    )
+    def test_esphome_ota_marker(self, line: str, expected: int) -> None:
+        assert _parse_progress(line) == expected
+
+
+class TestNoisyLinesIgnored:
+    """Lines that look percent-y but aren't real progress signals."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # The original bug report: PIO platform-package extract bar
+            # pinned the dashboard to 100% before the compile had
+            # actually started any meaningful work.
+            "Unpacking [####################################] 100%",
+            "Unpacking  [##                                  ] 5%",
+        ],
+    )
+    def test_unpacking_bar_ignored(self, line: str) -> None:
+        assert _parse_progress(line) is None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # PIO emits a memory-usage report at the end of the link
+            # step. The percentages there describe how full each
+            # memory region is, not build progress.
+            "RAM:   [==        ]  19.3% (used 63276 bytes from 327680 bytes)",
+            "Flash: [========  ]  80.0% (used 1467116 bytes from 1835008 bytes)",
+        ],
+    )
+    def test_memory_usage_report_ignored(self, line: str) -> None:
+        assert _parse_progress(line) is None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Narrative log text that happens to mention a percentage
+            # — should never be treated as progress.
+            "Saved 75% of build artifacts to cache.",
+            "Coverage report: lines 87% / branches 65%",
+            "INFO Flash erased — 100% complete in 0.5s",
+        ],
+    )
+    def test_stray_percentages_ignored(self, line: str) -> None:
+        assert _parse_progress(line) is None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # No percentage at all.
+            "INFO Successfully compiled program.",
+            "Compiling .pio/foo.cpp.o",
+            "",
+        ],
+    )
+    def test_lines_without_percent_ignored(self, line: str) -> None:
+        assert _parse_progress(line) is None
+
+
+class TestOutOfRange:
+    """Sanity-check the bounds.
+
+    A percentage > 100 is data corruption, not progress; we drop it
+    to keep ``job.progress`` clean.
+    """
+
+    def test_over_one_hundred_is_dropped(self) -> None:
+        # Hypothetical malformed esptool output. ``101`` would fall
+        # outside our 0..100 contract and pollute the UI.
+        assert _parse_progress("Writing at 0x00010000... (101 %)") is None
+
+    def test_three_digit_within_range(self) -> None:
+        # 100 is allowed; the regex accepts up to three digits to
+        # cover this exact value.
+        assert _parse_progress("[100%] Linking firmware.elf") == 100


### PR DESCRIPTION
## Symptom

User report: dashboard's compile progress bar pinned to 100% almost immediately on a fresh PlatformIO install. The actual compile then ran for ~2 minutes underneath while the bar said "done."

## Cause

Old regex was `\[?\s*(\d{1,3})\s*%\]?` — open enough to match anything carrying a percent sign. Three sources tripped it during a normal compile:

1. **`Unpacking [####] 100%`** — PlatformIO's package-extract bar that runs *before* the compile starts. Pins the bar to 100 immediately on a cold cache.
2. **`RAM: 19.3%`, `Flash: 80.0%`** — post-link memory-usage report. After a real-progress 100, the monotonic guard hides these; on a warm cache where Unpacking didn't run, they pin the bar to ~80%.
3. **Narrative log text** carrying a percent sign would also match.

## Fix

Replace the wide-open regex with a whitelist of three patterns, each anchored to where the percentage actually appears:

| Source | Pattern | Anchor |
| --- | --- | --- |
| PIO Arduino compile | `^\s*\[\s*(\d{1,3})\s*%\s*\]` | leading `[NN%]` |
| esptool serial flash | `\(\s*(\d{1,3})\s*%\s*\)` | parens around the % |
| ESPHome OTA upload | `^\s*Uploading:.*?\b(\d{1,3})\s*%` | `Uploading:` prefix |

ESP-IDF PIO builds (the case in the user's report) emit no per-file percent — they'll just leave `job.progress` at 0 through compile and update once `Uploading: …%` lines flow during upload. That's accurate; the previous 100-then-actual-work was misleading.

## Tests

`tests/test_firmware_progress.py` — 23 cases, parametrised:

- Real markers: 3 each for PIO compile / esptool / OTA (including leading-whitespace and "no space before %" variants).
- Noise that should NOT register: `Unpacking [#] 100%` (the regression input), memory-usage report, narrative log lines with stray percentages, empty / no-percent lines.
- Sanity: `>100%` is dropped, `100%` is kept.

## Test plan

- [x] Lint clean.
- [x] All 307 backend tests pass.
- [ ] Live: install on a fresh PlatformIO cache. Bar should stay at 0 through compile, jump to 100% during the OTA upload, and stop there. No spurious 100% on Unpacking.