### PR TITLE
Publish to PyPI via OIDC trusted publisher

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -89,6 +89,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ needs.check-and-compute.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ on:
         required: false
       ESPHOME_GITHUB_APP_PRIVATE_KEY:
         required: true
-      PYPI_TOKEN:
-        required: false
 
 env:
   PYTHON_VERSION: "3.13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,10 @@ jobs:
     runs-on: ubuntu-latest
     # Drop ``continue-on-error`` after the first successful publish.
     continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write
+    environment: pypi
     steps:
       - name: Download dist artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -237,9 +241,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
-          # Off because we don't grant ``id-token: write``; with it
-          # on the action falls back to OIDC and fails confusingly
-          # when the token is missing.
-          attestations: false
           skip-existing: true


### PR DESCRIPTION
## Summary

Switch the `publish-pypi` job from the long-lived `PYPI_TOKEN` secret to PyPI's OIDC trusted-publisher flow:

- Grant `id-token: write` on the publish job and bind it to the `pypi` environment configured on the PyPI project.
- Drop the `password:` input — the action picks up the OIDC token automatically.
- Remove the `attestations: false` opt-out; with OIDC enabled the action signs and attaches attestations by default.
- Drop `PYPI_TOKEN` from `release.yml`'s `workflow_call` secrets — nothing consumes it anymore.
- Propagate `id-token: write` through `auto-release.yml` so the nightly trigger can call into the publish job (reusable workflows can't elevate permissions on their own).

`continue-on-error: true` stays on for the first release through the new path; once a publish goes green it can come off in a follow-up (existing comment already calls this out).