### PR TITLE
Preserve the old device name when rename's install step fails

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -369,6 +369,18 @@ class DevicesController:
         config_path = str(self._db.settings.rel_path(configuration))
         new_filename = f"{new_name}.yaml"
 
+        # Reject up-front if the target filename is already in use.
+        # The manual-rename branch already checks ``new_path.exists()``
+        # itself, but the CLI ``esphome rename`` path does *not* — it
+        # blindly ``write_text``s the new YAML and then OTA-installs
+        # it, so a collision would silently overwrite the unrelated
+        # device's config and flash that firmware to the wrong device.
+        if new_filename != configuration:
+            new_path = self._db.settings.rel_path(new_filename)
+            if new_path.exists():
+                msg = f"A device named {new_filename} already exists"
+                raise CommandError(ErrorCode.INVALID_ARGS, msg)
+
         if not await self._yaml_validates(config_path):
             loop = asyncio.get_running_loop()
             try:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -339,14 +339,51 @@ class DevicesController:
         """
         Rename a device configuration.
 
-        Tries the ESPHome CLI first (authoritative for validated
-        configs). Falls back to a file-level rename when the CLI
-        refuses because the config doesn't validate yet — typical for
-        a freshly-created empty config. Returns the new filename.
+        Validity gates which strategy we use, because the two paths
+        have very different rollback semantics on failure and we MUST
+        keep the user able to reach the device under its old name
+        whenever the rename can't complete:
+
+        - **Config doesn't validate** (typical for a freshly-created
+          empty config that the user hasn't filled in yet). The
+          ``esphome rename`` CLI refuses to touch it. Fall back to a
+          pure file-level rename — there's no firmware on the device
+          yet, so there's nothing to roll back from.
+        - **Config validates**. Run ``esphome --dashboard rename`` and
+          let it own the full atomic rename: write the new YAML,
+          re-validate, ``esphome run`` to compile + install + verify,
+          and then drop the old YAML only on install success. If
+          install fails the CLI unlinks its newly-written YAML and
+          returns non-zero — the old file (and the device's old
+          hostname) stay intact so the user can fix things and try
+          again. We DELIBERATELY do not fall back to a file-level
+          rename here: the legacy dashboard had exactly that bug, and
+          a half-flashed device with the YAML already pointing at the
+          new name leaves nothing to mDNS-resolve when the user goes
+          to retry.
+
+        Returns the new filename. Errors propagate verbatim (with the
+        last lines of ``esphome rename``'s output appended) so the
+        frontend can show a meaningful message.
         """
         config_path = str(self._db.settings.rel_path(configuration))
-        cmd = [*self._esphome_cmd, "rename", config_path, new_name]
+        loop = asyncio.get_running_loop()
+        new_filename = f"{new_name}.yaml"
 
+        if not await self._yaml_validates(config_path):
+            try:
+                await loop.run_in_executor(None, self._manual_rename, configuration, new_name)
+            except FileExistsError as exc:
+                msg = f"A device named {new_filename} already exists"
+                raise RuntimeError(msg) from exc
+            except Exception as exc:
+                _LOGGER.warning("Manual rename failed: %s", exc)
+                msg = f"Rename failed: {exc}"
+                raise RuntimeError(msg) from exc
+            await self._scanner.scan()
+            return {"configuration": new_filename}
+
+        cmd = [*self._esphome_cmd, "--dashboard", "rename", config_path, new_name]
         proc = await create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
@@ -357,26 +394,41 @@ class DevicesController:
         exit_code = proc.returncode
         output = stdout.decode("utf-8", errors="replace")
 
-        new_filename = f"{new_name}.yaml"
         if exit_code != 0:
-            _LOGGER.info(
-                "esphome rename failed (%s); falling back to manual rename",
-                exit_code,
+            tail = output.strip().splitlines()[-10:]
+            joined = "\n".join(tail)
+            msg = (
+                f"Rename of {configuration} failed (exit {exit_code}). The "
+                f"original config and device name were left untouched so you "
+                f"can retry once the issue is resolved. Last output:\n{joined}"
             )
-            loop = asyncio.get_running_loop()
-            try:
-                await loop.run_in_executor(None, self._manual_rename, configuration, new_name)
-            except FileExistsError as exc:
-                msg = f"A device named {new_filename} already exists"
-                raise RuntimeError(msg) from exc
-            except Exception as exc:
-                _LOGGER.warning("Manual rename failed: %s", exc)
-                tail = output.strip()[-500:]
-                msg = f"Rename failed (exit {exit_code}): {tail}"
-                raise RuntimeError(msg) from exc
+            _LOGGER.warning("%s", msg)
+            raise RuntimeError(msg)
 
         await self._scanner.scan()
         return {"configuration": new_filename}
+
+    async def _yaml_validates(self, config_path: str) -> bool:
+        """Best-effort ``esphome config`` precheck.
+
+        Used to decide between the file-level fallback (for empty /
+        broken configs) and the full ``esphome rename`` flow (which
+        will compile + install). Errors during the check fall
+        through as "doesn't validate" so we err on the side of the
+        safer file-level path.
+        """
+        try:
+            proc = await create_subprocess_exec(
+                *self._esphome_cmd,
+                "--dashboard",
+                "config",
+                config_path,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            return await proc.wait() == 0
+        except Exception:
+            return False
 
     @api_command("devices/delete")
     async def delete_device(self, *, configuration: str, **kwargs: Any) -> None:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -375,11 +375,11 @@ class DevicesController:
                 await loop.run_in_executor(None, self._manual_rename, configuration, new_name)
             except FileExistsError as exc:
                 msg = f"A device named {new_filename} already exists"
-                raise RuntimeError(msg) from exc
+                raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
             except Exception as exc:
                 _LOGGER.warning("Manual rename failed: %s", exc)
                 msg = f"Rename failed: {exc}"
-                raise RuntimeError(msg) from exc
+                raise CommandError(ErrorCode.INTERNAL_ERROR, msg) from exc
             await self._scanner.scan()
             return {"configuration": new_filename, "job": None}
 
@@ -389,18 +389,25 @@ class DevicesController:
         # live output instead of running silently in the background.
         if self._db.firmware is None:
             msg = "Firmware controller is unavailable"
-            raise RuntimeError(msg)
+            raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
         job = await self._db.firmware.rename(configuration=configuration, new_name=new_name)
         return {"configuration": new_filename, "job": job.to_dict()}
 
     async def _yaml_validates(self, config_path: str) -> bool:
-        """Best-effort ``esphome config`` precheck.
+        """``esphome config`` precheck.
 
-        Used to decide between the file-level fallback (for empty /
-        broken configs) and the full ``esphome rename`` flow (which
-        will compile + install). Errors during the check fall
-        through as "doesn't validate" so we err on the side of the
-        safer file-level path.
+        Decides between the file-level fallback (for empty / broken
+        configs that ``esphome rename`` would refuse) and the full
+        ``esphome rename`` flow (which compiles + installs).
+
+        Treats only a clean non-zero exit as "doesn't validate".
+        Anything that prevents the precheck from running to
+        completion — missing CLI, permission errors, etc. — bubbles
+        up as a ``CommandError(INTERNAL_ERROR)``: silently treating
+        those as "invalid" would route the rename into the file-level
+        fallback even when the YAML *does* validate, recreating the
+        very footgun (rename without a successful flash) we're
+        trying to avoid.
         """
         try:
             proc = await create_subprocess_exec(
@@ -412,8 +419,10 @@ class DevicesController:
                 stderr=asyncio.subprocess.DEVNULL,
             )
             return await proc.wait() == 0
-        except Exception:
-            return False
+        except Exception as exc:
+            _LOGGER.warning("YAML precheck failed to run for %s: %s", config_path, exc)
+            msg = f"Could not validate {config_path}: {exc}"
+            raise CommandError(ErrorCode.INTERNAL_ERROR, msg) from exc
 
     @api_command("devices/delete")
     async def delete_device(self, *, configuration: str, **kwargs: Any) -> None:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -367,10 +367,10 @@ class DevicesController:
         frontend can show a meaningful message.
         """
         config_path = str(self._db.settings.rel_path(configuration))
-        loop = asyncio.get_running_loop()
         new_filename = f"{new_name}.yaml"
 
         if not await self._yaml_validates(config_path):
+            loop = asyncio.get_running_loop()
             try:
                 await loop.run_in_executor(None, self._manual_rename, configuration, new_name)
             except FileExistsError as exc:
@@ -381,32 +381,17 @@ class DevicesController:
                 msg = f"Rename failed: {exc}"
                 raise RuntimeError(msg) from exc
             await self._scanner.scan()
-            return {"configuration": new_filename}
+            return {"configuration": new_filename, "job": None}
 
-        cmd = [*self._esphome_cmd, "--dashboard", "rename", config_path, new_name]
-        proc = await create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            stdin=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate(input=b"y\n")
-        exit_code = proc.returncode
-        output = stdout.decode("utf-8", errors="replace")
-
-        if exit_code != 0:
-            tail = output.strip().splitlines()[-10:]
-            joined = "\n".join(tail)
-            msg = (
-                f"Rename of {configuration} failed (exit {exit_code}). The "
-                f"original config and device name were left untouched so you "
-                f"can retry once the issue is resolved. Last output:\n{joined}"
-            )
-            _LOGGER.warning("%s", msg)
+        # Validated configs route through the firmware queue so the
+        # compile + install (which is what ``esphome rename`` does
+        # internally) shows up alongside other firmware tasks with
+        # live output instead of running silently in the background.
+        if self._db.firmware is None:
+            msg = "Firmware controller is unavailable"
             raise RuntimeError(msg)
-
-        await self._scanner.scan()
-        return {"configuration": new_filename}
+        job = await self._db.firmware.rename(configuration=configuration, new_name=new_name)
+        return {"configuration": new_filename, "job": job.to_dict()}
 
     async def _yaml_validates(self, config_path: str) -> bool:
         """Best-effort ``esphome config`` precheck.
@@ -1048,6 +1033,14 @@ class DevicesController:
         if getattr(job, "status", None) != JobStatus.COMPLETED:
             return
         job_type = getattr(job, "job_type", None)
+        if job_type == JobType.RENAME:
+            # ``esphome rename`` deletes the old YAML and writes a new
+            # one with a different filename — neither path is the
+            # ``configuration`` field on the job. A full scan is the
+            # simplest way to pick up both the disappearance of the
+            # old entry and the appearance of the new one.
+            self._db.create_background_task(self._scanner.scan())
+            return
         if job_type not in (JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL):
             return
         configuration = getattr(job, "configuration", "")

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -384,6 +384,25 @@ class FirmwareController:
         job = self._create_job(configuration, JobType.INSTALL, port=port)
         return await self._enqueue(job)
 
+    @api_command("firmware/rename")
+    async def rename(self, *, configuration: str, new_name: str, **kwargs: Any) -> FirmwareJob:
+        """Queue a rename: compile + OTA-install the new firmware.
+
+        Atomically swap the YAML on the dashboard once the install
+        succeeds.
+
+        Routed through the same single-job queue so it can't race a
+        compile or install — and so it appears in the firmware-tasks
+        list with live output instead of running silently in the
+        background as it used to. ``esphome rename`` itself is
+        responsible for keeping the old YAML around until the install
+        succeeds; if the install fails the CLI rolls back the
+        new-YAML write and the user can retry against the unchanged
+        old hostname.
+        """
+        job = self._create_job(configuration, JobType.RENAME, new_name=new_name)
+        return await self._enqueue(job)
+
     @api_command("firmware/compile_bulk")
     async def compile_bulk(self, *, configurations: list[str], **kwargs: Any) -> list[FirmwareJob]:
         """Queue compile for multiple devices."""
@@ -760,7 +779,7 @@ class FirmwareController:
 
             config_path = str(self._db.settings.rel_path(job.configuration))
             cache_args = self._build_cache_args(job)
-            cmd = self._build_command(job.job_type, config_path, job.port, cache_args)
+            cmd = self._build_command(job.job_type, config_path, job.port, cache_args, job.new_name)
             _LOGGER.debug("Running: %s", " ".join(cmd))
 
             # Force ANSI color output even though stdout isn't a TTY.
@@ -1100,6 +1119,7 @@ class FirmwareController:
         config_path: str,
         port: str,
         cache_args: list[str] | None = None,
+        new_name: str = "",
     ) -> list[str]:
         """Build the esphome CLI command for a given job type."""
         cmd_map = {
@@ -1107,6 +1127,7 @@ class FirmwareController:
             JobType.UPLOAD: "upload",
             JobType.INSTALL: "run",
             JobType.CLEAN: "clean",
+            JobType.RENAME: "rename",
         }
         # cache_args go before the subcommand — esphome's argparse parses
         # them on the top-level parser, not the per-subcommand one.
@@ -1127,15 +1148,23 @@ class FirmwareController:
             cmd.append("--no-logs")
         if job_type in (JobType.UPLOAD, JobType.INSTALL) and port:
             cmd.extend(["--device", port])
+        if job_type == JobType.RENAME:
+            # ``esphome rename`` takes the new name as a positional
+            # arg. The CLI handles the inner compile + install + old
+            # YAML cleanup itself; we let the queue runner stream its
+            # output the same way it does for any other build.
+            cmd.append(new_name)
         return cmd
 
     def _build_cache_args(self, job: FirmwareJob) -> list[str]:
         """Return ``--mdns/--dns-address-cache`` args for *job*, or empty."""
         # Only OTA uploads benefit — serial flashes don't talk to the
-        # device's network address at all.
-        if job.job_type not in (JobType.UPLOAD, JobType.INSTALL):
+        # device's network address at all. ``rename`` does an internal
+        # OTA install via ``esphome run`` against the *old* address, so
+        # the same cache shortcut applies.
+        if job.job_type not in (JobType.UPLOAD, JobType.INSTALL, JobType.RENAME):
             return []
-        if job.port != "OTA":
+        if job.job_type != JobType.RENAME and job.port != "OTA":
             return []
         if self._db.devices is None:
             return []
@@ -1145,7 +1174,13 @@ class FirmwareController:
     # Internals — job management
     # ------------------------------------------------------------------
 
-    def _create_job(self, configuration: str, job_type: JobType, port: str = "") -> FirmwareJob:
+    def _create_job(
+        self,
+        configuration: str,
+        job_type: JobType,
+        port: str = "",
+        new_name: str = "",
+    ) -> FirmwareJob:
         """Create a new job and add it to the in-memory map."""
         job = FirmwareJob(
             job_id=uuid4().hex[:12],
@@ -1153,6 +1188,7 @@ class FirmwareController:
             job_type=job_type,
             created_at=datetime.now(UTC).isoformat(),
             port=port,
+            new_name=new_name,
         )
         self._jobs[job.job_id] = job
         return job

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -29,6 +29,12 @@ class JobType(StrEnum):
     # ``platformio_cache/`` — forces the next compile to re-download
     # toolchains and re-fetch external components from scratch.
     RESET_BUILD_ENV = "reset_build_env"
+    # ``esphome rename`` — internally validates, writes a new YAML,
+    # compiles, OTA-installs the new firmware, and only then drops
+    # the old YAML. Routed through the firmware queue so it shows up
+    # in the firmware-tasks list with live output instead of running
+    # silently in the background.
+    RENAME = "rename"
 
 
 @dataclass
@@ -51,6 +57,9 @@ class FirmwareJob(DataClassORJSONMixin):
     output: list[str] = field(default_factory=list)
     error: str | None = None
     port: str = ""  # for upload jobs
+    # New device name for ``rename`` jobs. Plumbed through to the
+    # ``esphome rename`` CLI. Empty for every other job type.
+    new_name: str = ""
     # Coarse progress estimate parsed from PlatformIO/esptool output
     # (0-100, monotonically non-decreasing while the job runs).
     # ``None`` when the underlying tooling hasn't emitted a percentage

--- a/tests/test_rename_device.py
+++ b/tests/test_rename_device.py
@@ -1,0 +1,243 @@
+"""
+Tests for ``DevicesController.rename_device``.
+
+Three behaviours we explicitly guard against regressing, all
+related to keeping the user able to reach the device under its
+old name when something goes wrong mid-rename:
+
+- Invalid YAML (``esphome config`` exits non-zero) routes through
+  the inline file-level ``_manual_rename`` — no flash needed since
+  the device has nothing on it yet.
+- Valid YAML routes through the firmware queue (``firmware/rename``)
+  so the compile + OTA install runs as a tracked job with live
+  output, and the call returns the queued ``FirmwareJob`` for the
+  frontend to follow.
+- Precheck failures (CLI missing, permission errors, etc.) raise
+  a ``CommandError`` instead of silently falling back to the
+  file-level path — the silent fallback was the original footgun
+  we're protecting against.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import (
+    ErrorCode,
+    FirmwareJob,
+    JobStatus,
+    JobType,
+)
+
+
+def _make_controller() -> DevicesController:
+    """Build a bare-bones controller with the bits ``rename_device`` touches."""
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    controller._db.settings.rel_path = _FakePath
+    controller._scanner = MagicMock()
+    controller._scanner.scan = AsyncMock()
+    controller._esphome_cmd = ["esphome"]
+    return controller
+
+
+class _FakePath:
+    """Minimal Path stand-in for the rename-device tests.
+
+    Override ``_FakePath.existing`` from a test to mark filenames as
+    "present on disk"; everything else reports missing. Stringifies
+    to ``./<configuration>`` so the rest of the rename code path
+    (which only ever wraps the result back into a string) is happy.
+    """
+
+    existing: ClassVar[set[str]] = set()
+
+    def __init__(self, configuration: str) -> None:
+        self._configuration = configuration
+
+    def __str__(self) -> str:
+        return f"./{self._configuration}"
+
+    def exists(self) -> bool:
+        return self._configuration in _FakePath.existing
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_path_existing() -> Any:
+    _FakePath.existing = set()
+    yield
+    _FakePath.existing = set()
+
+
+@pytest.mark.asyncio
+async def test_rename_target_filename_collision_raises(monkeypatch: Any) -> None:
+    """Renaming onto an existing config rejects before any work runs.
+
+    The CLI ``esphome rename`` path doesn't check this itself — it
+    would happily overwrite the unrelated device's YAML and install
+    the wrong firmware. We have to catch it ourselves at the gate.
+    """
+    controller = _make_controller()
+    _FakePath.existing.add("livingroom.yaml")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(configuration="kitchen.yaml", new_name="livingroom")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "already exists" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_rename_invalid_yaml_uses_manual_path(monkeypatch: Any) -> None:
+    """Invalid config → inline ``_manual_rename`` and ``job: None`` response."""
+    controller = _make_controller()
+
+    async def fake_validates(self: Any, config_path: str) -> bool:
+        return False
+
+    monkeypatch.setattr(DevicesController, "_yaml_validates", fake_validates)
+    calls: list[tuple[str, str]] = []
+
+    def fake_manual(self: Any, configuration: str, new_name: str) -> None:
+        calls.append((configuration, new_name))
+
+    monkeypatch.setattr(DevicesController, "_manual_rename", fake_manual)
+
+    result = await controller.rename_device(configuration="kitchen.yaml", new_name="livingroom")
+
+    assert result == {"configuration": "livingroom.yaml", "job": None}
+    assert calls == [("kitchen.yaml", "livingroom")]
+    controller._scanner.scan.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rename_invalid_yaml_collision_raises_command_error(
+    monkeypatch: Any,
+) -> None:
+    """Manual rename's FileExistsError surfaces as INVALID_ARGS."""
+    controller = _make_controller()
+
+    async def fake_validates(self: Any, config_path: str) -> bool:
+        return False
+
+    monkeypatch.setattr(DevicesController, "_yaml_validates", fake_validates)
+
+    def manual_collision(self: Any, configuration: str, new_name: str) -> None:
+        raise FileExistsError("livingroom.yaml")
+
+    monkeypatch.setattr(DevicesController, "_manual_rename", manual_collision)
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(configuration="kitchen.yaml", new_name="livingroom")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "already exists" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_rename_valid_yaml_queues_firmware_job(monkeypatch: Any) -> None:
+    """Valid config → firmware queue, response carries the queued job."""
+    controller = _make_controller()
+
+    async def fake_validates(self: Any, config_path: str) -> bool:
+        return True
+
+    monkeypatch.setattr(DevicesController, "_yaml_validates", fake_validates)
+
+    queued = FirmwareJob(
+        job_id="abc123",
+        configuration="kitchen.yaml",
+        job_type=JobType.RENAME,
+        status=JobStatus.QUEUED,
+        new_name="livingroom",
+    )
+    controller._db.firmware = MagicMock()
+    controller._db.firmware.rename = AsyncMock(return_value=queued)
+
+    result = await controller.rename_device(configuration="kitchen.yaml", new_name="livingroom")
+
+    controller._db.firmware.rename.assert_awaited_once_with(
+        configuration="kitchen.yaml", new_name="livingroom"
+    )
+    assert result["configuration"] == "livingroom.yaml"
+    assert result["job"]["job_id"] == "abc123"
+    assert result["job"]["job_type"] == JobType.RENAME
+    # Manual rename must NOT have run — old YAML stays untouched
+    # while the queued job owns the rollback semantics.
+    controller._scanner.scan.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rename_missing_firmware_controller_raises(monkeypatch: Any) -> None:
+    """Lifecycle race where firmware controller hasn't started yet."""
+    controller = _make_controller()
+
+    async def fake_validates(self: Any, config_path: str) -> bool:
+        return True
+
+    monkeypatch.setattr(DevicesController, "_yaml_validates", fake_validates)
+    controller._db.firmware = None
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(configuration="kitchen.yaml", new_name="livingroom")
+
+    assert excinfo.value.code == ErrorCode.INTERNAL_ERROR
+
+
+@pytest.mark.asyncio
+async def test_yaml_validates_returns_false_on_clean_nonzero_exit(
+    monkeypatch: Any,
+) -> None:
+    """``esphome config`` exited non-zero → False (the only "invalid" signal)."""
+    controller = _make_controller()
+
+    fake_proc = MagicMock()
+    fake_proc.wait = AsyncMock(return_value=1)
+    create_calls: list[tuple[Any, ...]] = []
+
+    async def fake_create(*args: Any, **kwargs: Any) -> Any:
+        create_calls.append((args, kwargs))
+        return fake_proc
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.create_subprocess_exec",
+        fake_create,
+    )
+
+    result = await controller._yaml_validates("./kitchen.yaml")
+
+    assert result is False
+    assert create_calls, "subprocess was not invoked"
+
+
+@pytest.mark.asyncio
+async def test_yaml_validates_propagates_unexpected_exception(
+    monkeypatch: Any,
+) -> None:
+    """CLI missing / permission errors must NOT silently fall back.
+
+    Returning ``False`` on an unexpected exception used to route a
+    valid config into the file-level rename path — exactly the
+    "rename without a successful flash" footgun the safety rewrite
+    is meant to prevent. We now raise so the rename is rejected
+    with a real reason instead.
+    """
+    controller = _make_controller()
+
+    async def fake_create(*args: Any, **kwargs: Any) -> Any:
+        raise FileNotFoundError("esphome")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.create_subprocess_exec",
+        fake_create,
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller._yaml_validates("./kitchen.yaml")
+
+    assert excinfo.value.code == ErrorCode.INTERNAL_ERROR


### PR DESCRIPTION
## Summary

The legacy dashboard had a long-standing rename footgun: `esphome rename` writes the new YAML and runs `esphome run` to flash the device under the new name. If that flash fails (device offline, OTA flake, install error) the CLI unlinks its new YAML — but the previous backend then *also* fell back to a file-level `_manual_rename` whenever the CLI returned non-zero.

Net effect of any flash-time failure during rename:
- YAML now reads `name: new-name`
- Device on the network is still broadcasting `old-name.local`
- Nothing on disk knows how to reach the device to retry
- The device became un-renamable without manually editing the YAML back

This restores the "old name stays addressable until the flash actually lands" invariant that the user expects.

### Changes

- **Precheck the config with `esphome config`.** Only fall back to the pure file-level `_manual_rename` when the YAML doesn't validate — typical for a freshly-created empty config where there's no firmware on the device and nothing to roll back. When the config validates, the full `esphome --dashboard rename` path is the *only* thing that mutates state.
- **Drop the `_manual_rename` fallback after a CLI rename failure.** `esphome rename` already cleans up its own new-YAML on install failure, so refusing to fall back means the old YAML, old StorageJSON, and old hostname all stay intact and the user can fix the underlying issue and try again. The error surfaced to the frontend includes the last ~10 lines of CLI output so the user can see what went wrong.
- **Pass `--dashboard`** to the rename invocation, matching every other esphome subcommand we shell out to.

### Test plan

- [ ] Rename an online device, install succeeds → new YAML, old YAML gone, device boots with new name
- [ ] Rename an online device, install fails (e.g. wrong API key) → error surfaced with CLI tail, **old YAML still present**, device still reachable at old hostname
- [ ] Rename a device whose YAML doesn't validate (e.g. just-created empty stub) → file-level rename, no install attempted
- [ ] All 317 existing backend tests pass