### PR TITLE
Reject jobs whose configuration matches an in-flight rename

### DIFF
--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -422,11 +422,20 @@ class FirmwareController:
 
     @api_command("firmware/compile_bulk")
     async def compile_bulk(self, *, configurations: list[str], **kwargs: Any) -> list[FirmwareJob]:
-        """Queue compile for multiple devices."""
-        jobs = []
+        """Queue compile for multiple devices.
+
+        Per-device errors (most commonly the rename lock) skip that
+        device and keep going so a single locked configuration in a
+        bulk request doesn't abort the queue for everyone else.
+        """
+        jobs: list[FirmwareJob] = []
         for config in configurations:
-            job = self._create_job(config, JobType.COMPILE)
-            await self._enqueue(job)
+            try:
+                job = self._create_job(config, JobType.COMPILE)
+                await self._enqueue(job)
+            except CommandError as exc:
+                _LOGGER.info("Skipping %s in compile_bulk: %s", config, exc.message)
+                continue
             jobs.append(job)
         return jobs
 
@@ -434,11 +443,20 @@ class FirmwareController:
     async def install_bulk(
         self, *, configurations: list[str], port: str = "OTA", **kwargs: Any
     ) -> list[FirmwareJob]:
-        """Queue update (compile + upload) for multiple devices. Defaults to OTA."""
-        jobs = []
+        """Queue update (compile + upload) for multiple devices. Defaults to OTA.
+
+        Per-device errors (most commonly the rename lock) skip that
+        device and keep going — a rename-in-flight on one of the
+        selected devices shouldn't abort the install for the rest.
+        """
+        jobs: list[FirmwareJob] = []
         for config in configurations:
-            job = self._create_job(config, JobType.INSTALL, port=port)
-            await self._enqueue(job)
+            try:
+                job = self._create_job(config, JobType.INSTALL, port=port)
+                await self._enqueue(job)
+            except CommandError as exc:
+                _LOGGER.info("Skipping %s in install_bulk: %s", config, exc.message)
+                continue
             jobs.append(job)
         return jobs
 

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -23,9 +23,9 @@ from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
 from esphome.storage_json import StorageJSON, ext_storage_path
 
 from ..controllers.config import _load_metadata, metadata_transaction
-from ..helpers.api import api_command
+from ..helpers.api import CommandError, api_command
 from ..helpers.subprocess import create_subprocess_exec
-from ..models import EventType, FirmwareJob, JobStatus, JobType
+from ..models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
@@ -131,6 +131,23 @@ def _trim_job_output(job: FirmwareJob) -> None:
         f"{_OUTPUT_TRIM_NOTICE_PREFIX} {total_elided} earlier line(s) elided]\n",
         *output[-_MAX_OUTPUT_LINES_RETAINED:],
     ]
+
+
+def _names_touched_by_job(job: FirmwareJob) -> set[str]:
+    """YAML filenames a job will read or write.
+
+    Used by the rename-lock check to spot collisions between an
+    in-flight rename and any other job. A rename has two: the old
+    YAML it's reading from (``configuration``) and the new YAML it
+    will create on install success (``new_name + ".yaml"``). Every
+    other job type touches just one — its ``configuration``.
+    """
+    names: set[str] = set()
+    if job.configuration:
+        names.add(job.configuration)
+    if job.job_type == JobType.RENAME and job.new_name:
+        names.add(f"{job.new_name}.yaml")
+    return names
 
 
 def _find_esphome_cmd() -> list[str]:
@@ -1207,13 +1224,58 @@ class FirmwareController:
         drop the old entry silently rather than parking it in the
         "Recent" history. Reset jobs (empty configuration) skip the
         supersede.
+
+        Rejects with ``CommandError(INVALID_ARGS)`` when an in-flight
+        ``RENAME`` job has the new job's configuration locked. Rename
+        rewrites the YAML mid-flight (old YAML still on disk during
+        compile, new YAML only written on install success), so a
+        compile/install/clean/upload — or another rename targeting the
+        same old or new name — would fight for files the rename is
+        actively reading or about to write. Same-old-config rename
+        retries are allowed through so the supersede path can cancel
+        and replace.
         """
+        self._check_rename_lock(job)
         await self._queue.put(job)
         self._db.bus.fire(EventType.JOB_QUEUED, {"job": job})
         if job.configuration:
             await self._supersede_active_jobs(job.configuration, exclude_job_id=job.job_id)
         await self._persist_jobs()
         return job
+
+    def _check_rename_lock(self, job: FirmwareJob) -> None:
+        """Reject jobs that would clash with an in-flight rename.
+
+        A rename touches two YAML filenames: the old one it's reading
+        from and the new one it'll create on install success. Any
+        other job that touches either name would either fight for the
+        same file or land its work on a half-flashed device. The one
+        exception is a fresh ``RENAME`` on the same old configuration
+        — that's an explicit user retry / target-name change and the
+        supersede path is meant to cancel-and-replace.
+        """
+        new_touches = _names_touched_by_job(job)
+        if not new_touches:
+            return
+        for active in self._jobs.values():
+            if active.job_type != JobType.RENAME:
+                continue
+            if active.status not in (JobStatus.QUEUED, JobStatus.RUNNING):
+                continue
+            # Same-old-config rename retry: let supersede do its thing.
+            if job.job_type == JobType.RENAME and job.configuration == active.configuration:
+                continue
+            clash = new_touches & _names_touched_by_job(active)
+            if not clash:
+                continue
+            old = active.configuration
+            new = f"{active.new_name}.yaml" if active.new_name else "(unknown)"
+            msg = (
+                f"Device {old} is being renamed to {new}; wait for the "
+                f"rename to finish before queueing another firmware "
+                f"task on either name."
+            )
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
     async def _supersede_active_jobs(self, configuration: str, *, exclude_job_id: str) -> None:
         """Cancel queued/running jobs for ``configuration``."""

--- a/tests/test_firmware_rename_lock.py
+++ b/tests/test_firmware_rename_lock.py
@@ -1,0 +1,133 @@
+"""
+Tests for ``FirmwareController._check_rename_lock``.
+
+A rename touches two YAML files at different points in its lifetime:
+- the *old* configuration it's reading from (``configuration``), and
+- the *new* configuration it'll write on install success
+  (``new_name + ".yaml"``).
+
+Any other firmware job that touches either name would either fight
+for the same file or end up flashing a half-renamed device. These
+tests pin down the lock policy:
+
+- Compile / install / upload / clean on either side → rejected.
+- Another rename whose old or new name overlaps → rejected.
+- Fresh rename on the same old config → allowed (supersede path).
+- Independent jobs on unrelated configs → allowed.
+- Once the rename leaves QUEUED/RUNNING, the lock lifts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import (
+    ErrorCode,
+    FirmwareJob,
+    JobStatus,
+    JobType,
+)
+
+
+def _controller(*active: FirmwareJob) -> FirmwareController:
+    """Build a stub controller with just the bits ``_check_rename_lock`` reads."""
+    controller = FirmwareController.__new__(FirmwareController)
+    controller._jobs = {j.job_id: j for j in active}
+    return controller
+
+
+def _job(
+    job_id: str,
+    configuration: str,
+    job_type: JobType,
+    *,
+    new_name: str = "",
+    status: JobStatus = JobStatus.QUEUED,
+) -> FirmwareJob:
+    return FirmwareJob(
+        job_id=job_id,
+        configuration=configuration,
+        job_type=job_type,
+        status=status,
+        new_name=new_name,
+    )
+
+
+def test_install_on_old_name_is_rejected() -> None:
+    rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
+    controller = _controller(rename)
+    new = _job("inst1", "kitchen.yaml", JobType.INSTALL)
+
+    with pytest.raises(CommandError) as excinfo:
+        controller._check_rename_lock(new)
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "kitchen.yaml" in excinfo.value.message
+    assert "livingroom.yaml" in excinfo.value.message
+
+
+def test_install_on_new_name_is_rejected() -> None:
+    rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
+    controller = _controller(rename)
+    new = _job("inst1", "livingroom.yaml", JobType.INSTALL)
+
+    with pytest.raises(CommandError):
+        controller._check_rename_lock(new)
+
+
+def test_compile_on_unrelated_config_is_allowed() -> None:
+    rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
+    controller = _controller(rename)
+
+    controller._check_rename_lock(_job("c1", "garage.yaml", JobType.COMPILE))
+
+
+def test_rename_targeting_same_new_name_is_rejected() -> None:
+    """Two renames pointing at the same target name would fight to write it."""
+    rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
+    controller = _controller(rename)
+    second = _job("rn2", "garage.yaml", JobType.RENAME, new_name="livingroom")
+
+    with pytest.raises(CommandError):
+        controller._check_rename_lock(second)
+
+
+def test_rename_retry_on_same_old_config_is_allowed() -> None:
+    """Fresh rename on the same OLD config goes through so supersede can cancel-and-replace."""
+    rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
+    controller = _controller(rename)
+    retry = _job("rn2", "kitchen.yaml", JobType.RENAME, new_name="bedroom")
+
+    controller._check_rename_lock(retry)
+
+
+def test_lock_lifts_when_rename_terminates() -> None:
+    """Terminal-status rename no longer holds the lock."""
+    rename = _job(
+        "rn1",
+        "kitchen.yaml",
+        JobType.RENAME,
+        new_name="livingroom",
+        status=JobStatus.COMPLETED,
+    )
+    controller = _controller(rename)
+
+    controller._check_rename_lock(_job("inst1", "kitchen.yaml", JobType.INSTALL))
+    controller._check_rename_lock(_job("inst2", "livingroom.yaml", JobType.INSTALL))
+
+
+def test_running_rename_blocks_install() -> None:
+    """RUNNING jobs hold the lock just like QUEUED ones do."""
+    rename = _job(
+        "rn1",
+        "kitchen.yaml",
+        JobType.RENAME,
+        new_name="livingroom",
+        status=JobStatus.RUNNING,
+    )
+    controller = _controller(rename)
+
+    with pytest.raises(CommandError):
+        controller._check_rename_lock(_job("inst1", "kitchen.yaml", JobType.INSTALL))

--- a/tests/test_firmware_rename_lock.py
+++ b/tests/test_firmware_rename_lock.py
@@ -131,3 +131,44 @@ def test_running_rename_blocks_install() -> None:
 
     with pytest.raises(CommandError):
         controller._check_rename_lock(_job("inst1", "kitchen.yaml", JobType.INSTALL))
+
+
+@pytest.mark.asyncio
+async def test_install_bulk_skips_locked_configs_and_queues_the_rest() -> None:
+    """A rename-locked device in a bulk request must not abort the others.
+
+    Bulk install is the user pattern for "update everything that has
+    pending changes" — if a single device is mid-rename, queueing
+    should still go ahead for every other selected device. This is
+    the regression guard for that.
+    """
+    from unittest.mock import AsyncMock
+
+    rename = _job(
+        "rn1",
+        "kitchen.yaml",
+        JobType.RENAME,
+        new_name="livingroom",
+        status=JobStatus.RUNNING,
+    )
+    controller = _controller(rename)
+    controller._queue = AsyncMock()
+    controller._db = type(
+        "DB",
+        (),
+        {
+            "bus": type("Bus", (), {"fire": lambda *a, **kw: None})(),
+        },
+    )()
+    controller._persist_jobs = AsyncMock()
+    controller._supersede_active_jobs = AsyncMock()
+
+    queued = await controller.install_bulk(
+        configurations=["kitchen.yaml", "garage.yaml", "livingroom.yaml", "office.yaml"]
+    )
+
+    # ``kitchen.yaml`` (rename source) and ``livingroom.yaml`` (rename
+    # target) both clash with the in-flight rename and skip; the
+    # other two queue normally.
+    queued_configs = sorted(j.configuration for j in queued)
+    assert queued_configs == ["garage.yaml", "office.yaml"]


### PR DESCRIPTION
## Summary

Adds a rename lock at the firmware queue's `_enqueue` so a casual Install click (or the kebab menu's Install entry, or a bulk install, or a direct API call) can't cancel a rename mid-flight. Followup to [#66](https://github.com/esphome/device-builder/pull/66) — that PR fixed "rename leaves device unreachable on install failure"; this one fixes "rename leaves device half-flashed because someone clicked Install".

A rename touches two YAML files in sequence: the *old* configuration it's reading from, and the *new* configuration it writes on install success. The legacy supersede logic only matched on the old name, so:
- Install on the same device while a rename is running → supersede cancels the rename mid-compile.
- Install on the new device card (which shows up mid-flight when the new YAML is written) → races to flash the device.
- Two renames pointing at the same target name → second silently overwrites the first.

The new `_check_rename_lock` rejects any job whose configuration overlaps with an in-flight rename's old *or* new name. Same-old-config rename retries are still allowed through so the existing supersede path can cancel-and-replace (a user changing their mind on the new name shouldn't have to wait the full 30-60s for the wrong name to land).

## Test plan

- [x] All 331 existing backend tests pass
- [x] 7 new tests in `tests/test_firmware_rename_lock.py` covering install on old/new name, compile on unrelated config, double-rename onto same target, rename retry, lock lift on terminal status, and RUNNING-status lock
- [ ] Click Install on a device whose rename is in progress → API returns `INVALID_ARGS` with "wait for the rename to finish" message; rename keeps running
- [ ] Click Install on the new device card while rename is running → same rejection
- [ ] Bulk install while one of the selected devices is being renamed → that device's job rejects, others queue normally
- [ ] Two renames `a → c` and `b → c` queued back-to-back → second rejects
- [ ] After rename completes (success or failure), all locks lift and normal jobs run again