### PR TITLE
Read config_hash from build_info.json instead of recomputing in-process

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -893,7 +893,21 @@ class DevicesController:
         # ``StorageJSON``-derived values without making the user wait
         # for a real compile. Same upstream pattern used in
         # ``async_schedule_storage_json_update``.
-        if kind is ScanChange.ADDED and not device.loaded_integrations:
+        #
+        # Also fire when ``expected_config_hash`` is empty even
+        # though ``loaded_integrations`` is populated. That happens
+        # for devices configured before build_info.json existed (or
+        # imported from an older dashboard) — they have a working
+        # ``StorageJSON`` so the integrations / address / version
+        # all come through, but the build directory either pre-dates
+        # the build_info.json era or was wiped. Without this nudge
+        # the drawer's "Local config hash" shows a permanent em-dash
+        # for those devices because nothing else triggers a
+        # ``--only-generate`` until the user edits the YAML.
+        needs_storage_regen = kind is ScanChange.ADDED and (
+            not device.loaded_integrations or not device.expected_config_hash
+        )
+        if needs_storage_regen:
             self._schedule_storage_regenerate(device.configuration)
         # When a configured device is deleted, re-emit cached
         # discoveries. Upstream's ``DashboardImportDiscovery`` only

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -1155,14 +1155,28 @@ class DevicesController:
         Verified against ``acfloatmonitor32.yaml``: pre-codegen yields
         ``f3e21d5a`` while the firmware bakes in ``5a94a12d``.
 
-        Silently no-op when the hash can't be read — the previously
-        stored sidecar value (if any) stays as the most-recent
-        firmware-canonical value, and the mtime side of
-        ``compute_has_pending_changes`` keeps the dot honest.
+        No-op when the hash can't be read. The caller is on the
+        post-build / post-only-generate path, so a missing or
+        malformed ``build_info.json`` here is unexpected — log a
+        warning so an upstream ESPHome shape change doesn't
+        silently leave the sidecar out of date.
+        ``compute_has_pending_changes`` will lean on the bin mtime
+        in that gap, which catches the "user just edited the YAML"
+        case but won't notice firmware that's drifted from the
+        compile (e.g. flashed elsewhere) — the dot can read
+        in-sync when it shouldn't until the next real flash
+        rewrites the sidecar.
         """
         yaml_path = self._db.settings.rel_path(configuration)
         new_hash = await compute_yaml_config_hash(yaml_path)
         if not new_hash:
+            _LOGGER.warning(
+                "Could not read config_hash from build_info.json for %s — "
+                "the drawer's Local hash may stay stale until the next flash. "
+                "If this persists across compiles, check that ESPHome's "
+                "build_info.json schema hasn't changed.",
+                configuration,
+            )
             return
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -17,7 +17,7 @@ from esphome.helpers import sort_ip_addresses
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 
 from ..helpers.api import CommandError, api_command
-from ..helpers.config_hash import compute_yaml_config_hash
+from ..helpers.config_hash import compute_yaml_config_hash, read_build_info_hash
 from ..helpers.device_yaml import (
     generate_device_yaml,
     get_api_encryption_key,
@@ -822,14 +822,23 @@ class DevicesController:
         ``ip`` is the last-known resolved address from the metadata
         sidecar (``""`` if never seen).
 
-        ``expected_config_hash`` is the YAML's last-compiled
-        ``CORE.config_hash``, written by the firmware controller after
-        each successful compile; ``""`` when the device has never been
-        compiled or the compile predates expected-hash tracking.
+        ``expected_config_hash`` is read from
+        ``<build_path>/build_info.json`` — ESPHome's authoritative
+        post-codegen value. The metadata sidecar is consulted *only*
+        as a fallback for devices whose build directory was wiped
+        (clean) but where we'd previously cached a value. Reading
+        from ``build_info.json`` first keeps the dashboard from
+        getting stuck on a stale sidecar value if a previous run
+        wrote a wrong hash (e.g. the pre-codegen subprocess hash
+        the dashboard used to compute) — the next scan after this
+        change picks up the canonical value automatically.
         """
         md = get_device_metadata(config_dir, filename)
         ip = str(md.get("ip", ""))
-        expected_config_hash = str(md.get("expected_config_hash", ""))
+        # build_info.json wins; sidecar is the post-clean fallback.
+        expected_config_hash = read_build_info_hash(config_dir / filename) or str(
+            md.get("expected_config_hash", "")
+        )
         board_id = str(md.get("board_id", ""))
         if not board_id:
             board_id = self._derive_board_id_from_yaml(config_dir, filename)

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -561,6 +561,12 @@ class DevicesController:
                         )
                         self._regenerate_failed.add(configuration)
                         return
+                    # ``--only-generate`` writes build_info.json with
+                    # the canonical config_hash before exiting, same as
+                    # a real compile. Persist it to the metadata
+                    # sidecar so the drawer can show "Local: <hash>"
+                    # before the first real flash.
+                    await self._persist_expected_config_hash(configuration)
                     await self._scanner.reload(configuration)
             finally:
                 self._regenerate_pending.discard(configuration)
@@ -1107,21 +1113,41 @@ class DevicesController:
         push the real value back in.
         """
         if recompute_hash:
-            yaml_path = self._db.settings.rel_path(configuration)
-            new_hash = await compute_yaml_config_hash(yaml_path)
-            if new_hash:
-                loop = asyncio.get_running_loop()
-                config_dir = self._db.settings.config_dir
-                await loop.run_in_executor(
-                    None,
-                    lambda: set_device_metadata(
-                        config_dir, configuration, expected_config_hash=new_hash
-                    ),
-                )
-                _LOGGER.debug("Stored expected_config_hash for %s: %s", configuration, new_hash)
+            await self._persist_expected_config_hash(configuration)
         await self._scanner.reload(configuration)
         if flashed:
             self._sync_deployed_hash_after_flash(configuration)
+
+    async def _persist_expected_config_hash(self, configuration: str) -> None:
+        """
+        Read the canonical config_hash from build_info.json and persist it.
+
+        ESPHome's build (and ``--only-generate``) writes the
+        ``config_hash`` to ``build_info.json`` after running the full
+        validate + codegen pipeline. We read that value back rather
+        than recompute it, because reproducing the build's hash
+        in-process is fragile — ``CORE.config_hash`` is sensitive to
+        post-codegen state (id-pinning, default backfill,
+        normalisation) that ``read_config`` alone doesn't apply.
+        Verified against ``acfloatmonitor32.yaml``: pre-codegen yields
+        ``f3e21d5a`` while the firmware bakes in ``5a94a12d``.
+
+        Silently no-op when the hash can't be read — the previously
+        stored sidecar value (if any) stays as the most-recent
+        firmware-canonical value, and the mtime side of
+        ``compute_has_pending_changes`` keeps the dot honest.
+        """
+        yaml_path = self._db.settings.rel_path(configuration)
+        new_hash = await compute_yaml_config_hash(yaml_path)
+        if not new_hash:
+            return
+        loop = asyncio.get_running_loop()
+        config_dir = self._db.settings.config_dir
+        await loop.run_in_executor(
+            None,
+            lambda: set_device_metadata(config_dir, configuration, expected_config_hash=new_hash),
+        )
+        _LOGGER.debug("Stored expected_config_hash for %s: %s", configuration, new_hash)
 
     def _sync_deployed_hash_after_flash(self, configuration: str) -> None:
         """

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -1,5 +1,5 @@
 """
-Compute the ``config_hash`` of a device YAML.
+Read the ``config_hash`` of a freshly-built device.
 
 ESPHome internally hashes a fully-resolved-and-sorted dump of the
 config (FNV-1a 32-bit) and exposes it as ``CORE.config_hash``. The
@@ -7,115 +7,83 @@ running firmware exposes the same value via ``App.get_config_hash()``,
 which esphome/esphome#16145 also publishes on the
 ``_esphomelib._tcp`` mDNS service as the ``config_hash`` TXT record.
 
-Computing the hash on the dashboard side requires running ESPHome's
-``read_config()`` — that resolves substitutions / packages, validates
-component schemas, and populates ``CORE.config``. It also mutates
-process-global state (``CORE``), which is why we run it in a
-subprocess instead of in-process.
+The hash is sensitive to *post-codegen* state — each component's
+``to_code`` runs after validation and can mutate the config
+(id-pinning, default backfill, normalisation), and ``CORE.config_hash``
+is read in ``writer.get_build_info`` after that pass has run. So a
+naive "rerun ``read_config`` and read the property" produces a value
+that disagrees with the firmware's broadcast — verified empirically
+on real Apollo float-monitor configs (pre-codegen ``f3e21d5a`` vs
+firmware's ``5a94a12d``).
 
-The hash is the 8-char lowercase hex format used by the mDNS TXT
-record. Returns ``None`` when the YAML doesn't validate or the
-subprocess fails for any reason — ``has_pending_changes`` then falls
-back to its mtime check.
+Rather than reproduce the codegen pipeline ourselves (heavyweight,
+fragile across ESPHome upgrades), we read the authoritative value
+out of ``<build_path>/build_info.json``. ESPHome writes that file
+after every successful build with the canonical hash. The
+device-builder sidecar persists the value across cleans, so a wiped
+build directory still has a recent value to fall back to until the
+next compile rewrites it.
+
+Returns the hash as an 8-char lowercase hex string — matching the
+mDNS TXT record shape. ``None`` on miss / parse failure;
+``compute_has_pending_changes`` then falls back to the mtime check.
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-import re
-import sys
 from pathlib import Path
 
-from .subprocess import create_subprocess_exec
+from esphome.storage_json import StorageJSON, ext_storage_path
+
+from .json import JSONDecodeError, loads
 
 _LOGGER = logging.getLogger(__name__)
 
-# Inline script run as ``python -c <SCRIPT> <yaml_path>``. Run in a
-# subprocess because ``read_config()`` mutates the process-global
-# ``CORE`` and importing it in our event-loop process would leak that
-# state into every later compile.
-_HASH_SCRIPT = (
-    "import sys\n"
-    "from pathlib import Path\n"
-    "from esphome.__main__ import read_config\n"
-    "from esphome.core import CORE\n"
-    # ESPHome's loader uses ``CORE.config_path`` via ``Path`` ops, so a
-    # bare string raises ``AttributeError`` deep inside ``yaml_util``.
-    "CORE.config_path = Path(sys.argv[1])\n"
-    # ``read_config`` returns the resolved config dict and *sets*
-    # ``CORE.raw_config`` — but it does NOT assign ``CORE.config``.
-    # The CLI's ``run_esphome`` does that step manually after the
-    # call, and the ``config_hash`` property hashes ``CORE.config``
-    # specifically (a ``None`` here yields a meaningless-but-stable
-    # hash for every config). Mirror the CLI's assignment.
-    "config = read_config({})\n"
-    "if config is None:\n"
-    "    sys.exit(1)\n"
-    "CORE.config = config\n"
-    "print(f'{CORE.config_hash:08x}')\n"
-)
-
-# 8 lowercase hex chars — same shape the firmware broadcasts.
-_HASH_RE = re.compile(r"\b([0-9a-f]{8})\b")
-
-# Computing a hash for a "normal" device runs in well under a second on
-# warm caches; the 60s ceiling protects against pathological YAMLs that
-# pull a slow external component or a remote package on a cold cache.
-_HASH_TIMEOUT_SECONDS = 60.0
+_BUILD_INFO_FILENAME = "build_info.json"
 
 
 async def compute_yaml_config_hash(yaml_path: Path) -> str | None:
     """
     Return the 8-char lowercase hex ``config_hash`` for *yaml_path*.
 
-    Returns ``None`` when the YAML can't be validated or the hash
-    can't be computed for any other reason. Callers should treat
-    ``None`` as "fall back to mtime-based change detection" rather
-    than as an error to propagate.
+    Resolves the device's build directory via the ESPHome
+    ``StorageJSON`` sidecar and reads ``build_info.json`` from
+    there. Returns ``None`` when the device has never been built,
+    the build directory was wiped, or the file is corrupt — callers
+    should treat ``None`` as "keep the previously-stored hash"
+    (typically already in our metadata sidecar) rather than an
+    error to propagate.
     """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _read_build_info_hash, yaml_path)
+
+
+def _read_build_info_hash(yaml_path: Path) -> str | None:
+    """Read the canonical hash off disk; runs in the default executor."""
+    storage = StorageJSON.load(ext_storage_path(yaml_path.name))
+    if storage is None or storage.build_path is None:
+        return None
+    build_info_path = Path(storage.build_path) / _BUILD_INFO_FILENAME
     try:
-        proc = await create_subprocess_exec(
-            sys.executable,
-            "-c",
-            _HASH_SCRIPT,
-            str(yaml_path),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
+        raw = build_info_path.read_bytes()
+    except FileNotFoundError:
+        # Fresh device or post-clean — nothing to read.
+        return None
     except OSError:
-        _LOGGER.exception("Could not start config_hash subprocess for %s", yaml_path)
+        _LOGGER.warning("Could not read %s", build_info_path, exc_info=True)
         return None
-
     try:
-        stdout_bytes, _ = await asyncio.wait_for(proc.communicate(), timeout=_HASH_TIMEOUT_SECONDS)
-    except TimeoutError:
-        _LOGGER.warning(
-            "config_hash computation timed out after %.0fs for %s",
-            _HASH_TIMEOUT_SECONDS,
-            yaml_path,
-        )
-        # Race: the subprocess may have exited between the timeout
-        # firing and ``kill()`` being called — swallow the lookup
-        # error so a recoverable timeout doesn't bubble up.
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        await proc.wait()
+        data = loads(raw)
+    except JSONDecodeError:
+        _LOGGER.warning("build_info.json at %s is corrupt — ignoring", build_info_path)
         return None
-
-    if proc.returncode != 0:
-        _LOGGER.debug(
-            "config_hash subprocess for %s exited %s — falling back to mtime check",
-            yaml_path,
-            proc.returncode,
-        )
+    config_hash = data.get("config_hash") if isinstance(data, dict) else None
+    if not isinstance(config_hash, int):
         return None
-
-    # ``read_config`` itself prints validation warnings to stdout, so we
-    # scan rather than assume the hash is the only line. The script's
-    # final ``print(f'{...:08x}')`` always emits exactly 8 hex chars on
-    # its own line, so the *last* match wins if multiple show up.
-    text = stdout_bytes.decode("utf-8", errors="replace")
-    matches = _HASH_RE.findall(text)
-    return matches[-1] if matches else None
+    # ESPHome stores the hash as a 32-bit unsigned int. Format to the
+    # 8-char lowercase hex shape the mDNS TXT record carries so the
+    # comparison against ``deployed_config_hash`` is a straight
+    # string equality.
+    return f"{config_hash & 0xFFFFFFFF:08x}"

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -57,11 +57,19 @@ async def compute_yaml_config_hash(yaml_path: Path) -> str | None:
     error to propagate.
     """
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, _read_build_info_hash, yaml_path)
+    return await loop.run_in_executor(None, read_build_info_hash, yaml_path)
 
 
-def _read_build_info_hash(yaml_path: Path) -> str | None:
-    """Read the canonical hash off disk; runs in the default executor."""
+def read_build_info_hash(yaml_path: Path) -> str | None:
+    """Read the canonical hash off disk synchronously.
+
+    Public-by-convention so the device-scanner metadata resolver —
+    which runs in a thread executor and needs the hash inline with
+    the per-file board_id / ip lookups — can call it directly without
+    re-entering the asyncio loop just to dispatch back to the same
+    executor. Returns the same value ``compute_yaml_config_hash``
+    awaits to.
+    """
     storage = StorageJSON.load(ext_storage_path(yaml_path.name))
     if storage is None or storage.build_path is None:
         return None

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -35,7 +35,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-from esphome.storage_json import StorageJSON, ext_storage_path
+from esphome.storage_json import StorageJSON
 
 from .json import JSONDecodeError, loads
 
@@ -69,8 +69,18 @@ def read_build_info_hash(yaml_path: Path) -> str | None:
     re-entering the asyncio loop just to dispatch back to the same
     executor. Returns the same value ``compute_yaml_config_hash``
     awaits to.
+
+    Resolves ``StorageJSON`` from ``<yaml_dir>/.esphome/storage/<name>.json``
+    instead of ``ext_storage_path``. ``ext_storage_path`` is a thin
+    wrapper around ``CORE.data_dir`` that crashes when CORE hasn't
+    been initialised — fine in production (the dashboard sets
+    ``CORE.config_path`` on startup) but a footgun in tests, where
+    leaving the helper coupled to global CORE state would force
+    every test fixture to spin up a CORE just to read a JSON file.
     """
-    storage = StorageJSON.load(ext_storage_path(yaml_path.name))
+    config_dir = yaml_path.parent
+    storage_path = config_dir / ".esphome" / "storage" / f"{yaml_path.name}.json"
+    storage = StorageJSON.load(storage_path)
     if storage is None or storage.build_path is None:
         return None
     build_info_path = Path(storage.build_path) / _BUILD_INFO_FILENAME

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -486,27 +486,33 @@ def compute_has_pending_changes(
 
     Decision order, first match wins:
 
-    1. No firmware binary on disk yet → pending.
-    2. YAML edited after the last compile → pending. The mtime gate
-       runs before any hash comparison so a stale ``expected`` from
-       the prior compile can't accidentally match a deployed hash.
-    3. Both ``expected_config_hash`` and ``deployed_config_hash``
+    1. No firmware binary on disk yet → pending. Nothing has been
+       compiled, so we definitionally have unflushed edits.
+    2. Both ``expected_config_hash`` and ``deployed_config_hash``
        known → pending iff they differ. The deployed hash comes from
-       mDNS (esphome/esphome#16145), the expected hash from the YAML's
-       last compile; differing means the device is running older
-       firmware than the latest compile (e.g. failed OTA, flashed
-       elsewhere).
-    4. Either hash missing → not pending. Devices on firmware that
-       predates the ``config_hash`` TXT broadcast fall through here
-       and stay quiet.
+       mDNS (esphome/esphome#16145), the expected hash is read from
+       ``build_info.json`` (firmware-canonical, post-codegen). The
+       hash comparison is authoritative for any device on
+       broadcast-capable firmware: if they match, the running
+       firmware is built from the same logical config the YAML now
+       resolves to, even if the YAML's mtime ticked forward
+       (whitespace-only / comment-only edits, ``--only-generate``
+       rewriting StorageJSON, etc.). If they differ, the device is
+       running older firmware than the latest compile — failed OTA,
+       flashed elsewhere, etc.
+    3. YAML edited after the last compile → pending. Mtime is the
+       fallback for devices that pre-date the ``config_hash`` TXT
+       broadcast or for the brief window between an edit and the
+       background ``--only-generate`` updating
+       ``expected_config_hash``.
+    4. Otherwise → not pending. Devices on firmware that predates
+       the broadcast and haven't been edited stay quiet.
     """
     if bin_mtime is None:
         return True
-    if yaml_mtime is not None and yaml_mtime > bin_mtime:
-        return True
     if expected_config_hash and deployed_config_hash:
         return expected_config_hash != deployed_config_hash
-    return False
+    return yaml_mtime is not None and yaml_mtime > bin_mtime
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_hash.py
+++ b/tests/test_config_hash.py
@@ -1,13 +1,13 @@
-"""Tests for ``helpers/config_hash.compute_yaml_config_hash``.
+"""Tests for ``helpers/config_hash``.
 
 The hash comes out of ``<build_path>/build_info.json``, which
 ESPHome writes during every successful build (including
 ``--only-generate``). The dashboard already runs ``--only-generate``
 on YAML add / edit, so by the time we'd read the hash the file is
-in place. These tests stub ``StorageJSON.load`` to point at a
-``build_path`` we control, write a representative ``build_info.json``
-there, and verify the helper round-trips the value into the
-mDNS-canonical 8-char lowercase hex format.
+in place. These tests write a representative ``StorageJSON``
+sidecar pointing at a tmp build directory and assert each branch
+of ``read_build_info_hash`` (the sync entry point) and
+``compute_yaml_config_hash`` (the async wrapper).
 """
 
 from __future__ import annotations
@@ -15,32 +15,48 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.helpers.config_hash import compute_yaml_config_hash
+from esphome_device_builder.helpers.config_hash import (
+    compute_yaml_config_hash,
+    read_build_info_hash,
+)
 
 
-def _stub_storage(monkeypatch: Any, build_path: Path | None) -> None:
-    """Make ``StorageJSON.load`` return a stub pointing at *build_path*.
+def _write_storage_pointer(yaml_path: Path, build_path: Path | None) -> None:
+    """Write the ESPHome ``StorageJSON`` sidecar next to *yaml_path*.
 
-    ``None`` simulates "device has never been compiled" — the
-    ``StorageJSON.load`` itself returns None for missing sidecars.
+    ``build_path=None`` simulates "device has never been compiled" —
+    we just don't write the sidecar at all so ``StorageJSON.load``
+    returns None.
     """
     if build_path is None:
-        load_mock = MagicMock(return_value=None)
-    else:
-        storage = MagicMock()
-        storage.build_path = build_path
-        load_mock = MagicMock(return_value=storage)
-    monkeypatch.setattr(
-        "esphome_device_builder.helpers.config_hash.StorageJSON.load",
-        load_mock,
-    )
-    monkeypatch.setattr(
-        "esphome_device_builder.helpers.config_hash.ext_storage_path",
-        lambda _filename: Path("/unused/by/the/stub.json"),
+        return
+    storage_dir = yaml_path.parent / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / f"{yaml_path.name}.json").write_text(
+        json.dumps(
+            {
+                "storage_version": 1,
+                "name": yaml_path.stem,
+                "comment": None,
+                "esphome_version": "2026.5.0-dev",
+                "src_version": 1,
+                "address": "",
+                "web_port": None,
+                "esp_platform": "esp32",
+                "board": "esp32-c3-devkitm-1",
+                "build_path": str(build_path),
+                "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
+                "loaded_integrations": [],
+                "loaded_platforms": [],
+                "no_mdns": False,
+                "framework": "esp-idf",
+                "core_platform": "esp32",
+            }
+        ),
+        encoding="utf-8",
     )
 
 
@@ -63,86 +79,96 @@ def _write_build_info(build_path: Path, **fields: Any) -> None:
     (build_path / "build_info.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
-@pytest.mark.asyncio
-async def test_returns_canonical_hex_from_build_info(tmp_path: Path, monkeypatch: Any) -> None:
-    """``build_info.json`` round-trips into the 8-char hex shape."""
+def _setup(tmp_path: Path, *, hash_value: int | None = 0xDEADBEEF) -> Path:
+    """Write a YAML, sidecar, and build_info.json with *hash_value* under tmp_path.
+
+    Returns the YAML path so each test can pass it to the helper.
+    ``hash_value=None`` skips writing build_info.json (simulates
+    post-clean / never-compiled).
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     build_path = tmp_path / ".esphome" / "build" / "kitchen"
-    # 0x5a94a12d is the value the firmware actually broadcasts via
-    # mDNS for a representative Apollo float-monitor YAML — the
-    # original bug report. Locking in this exact shape protects
-    # against accidentally returning the decimal or hex-with-0x
-    # forms.
-    _write_build_info(build_path, config_hash=0x5A94A12D)
-    _stub_storage(monkeypatch, build_path)
-
-    result = await compute_yaml_config_hash(tmp_path / "kitchen.yaml")
-
-    assert result == "5a94a12d"
+    _write_storage_pointer(yaml_path, build_path)
+    if hash_value is not None:
+        _write_build_info(build_path, config_hash=hash_value)
+    return yaml_path
 
 
-@pytest.mark.asyncio
-async def test_returns_zero_padded_low_value(tmp_path: Path, monkeypatch: Any) -> None:
+def test_returns_canonical_hex_from_build_info(tmp_path: Path) -> None:
+    """``build_info.json`` round-trips into the 8-char hex shape.
+
+    0x5a94a12d is the value the firmware actually broadcasts via
+    mDNS for a representative Apollo float-monitor YAML — the
+    original bug report. Locking in this exact shape protects
+    against accidentally returning the decimal or hex-with-0x
+    forms.
+    """
+    yaml_path = _setup(tmp_path, hash_value=0x5A94A12D)
+
+    assert read_build_info_hash(yaml_path) == "5a94a12d"
+
+
+def test_returns_zero_padded_low_value(tmp_path: Path) -> None:
     """Small ints get padded to 8 chars so the comparison is straight strcmp."""
-    build_path = tmp_path / "build"
-    _write_build_info(build_path, config_hash=0x42)
-    _stub_storage(monkeypatch, build_path)
+    yaml_path = _setup(tmp_path, hash_value=0x42)
 
-    result = await compute_yaml_config_hash(tmp_path / "kitchen.yaml")
-
-    assert result == "00000042"
+    assert read_build_info_hash(yaml_path) == "00000042"
 
 
-@pytest.mark.asyncio
-async def test_returns_none_when_storage_missing(tmp_path: Path, monkeypatch: Any) -> None:
+def test_returns_none_when_storage_missing(tmp_path: Path) -> None:
     """No sidecar → no build path → no hash. Caller falls back to mtime."""
-    _stub_storage(monkeypatch, None)
+    yaml_path = tmp_path / "ghost.yaml"
+    yaml_path.write_text("esphome:\n  name: ghost\n", encoding="utf-8")
+    # Intentionally NOT calling _write_storage_pointer.
 
-    result = await compute_yaml_config_hash(tmp_path / "ghost.yaml")
-
-    assert result is None
+    assert read_build_info_hash(yaml_path) is None
 
 
-@pytest.mark.asyncio
-async def test_returns_none_when_build_info_missing(tmp_path: Path, monkeypatch: Any) -> None:
+def test_returns_none_when_build_info_missing(tmp_path: Path) -> None:
     """Sidecar points at a build dir but ``--only-generate`` hasn't run yet."""
-    build_path = tmp_path / "build"
-    build_path.mkdir(parents=True)
-    _stub_storage(monkeypatch, build_path)
+    yaml_path = _setup(tmp_path, hash_value=None)
 
-    result = await compute_yaml_config_hash(tmp_path / "kitchen.yaml")
-
-    assert result is None
+    assert read_build_info_hash(yaml_path) is None
 
 
-@pytest.mark.asyncio
-async def test_returns_none_for_corrupt_json(tmp_path: Path, monkeypatch: Any) -> None:
+def test_returns_none_for_corrupt_json(tmp_path: Path) -> None:
     """Corrupt build_info.json → None, no exception bubbles up."""
-    build_path = tmp_path / "build"
-    build_path.mkdir(parents=True)
+    yaml_path = _setup(tmp_path, hash_value=None)
+    build_path = tmp_path / ".esphome" / "build" / "kitchen"
+    build_path.mkdir(parents=True, exist_ok=True)
     (build_path / "build_info.json").write_text("{this is not json", encoding="utf-8")
-    _stub_storage(monkeypatch, build_path)
 
-    result = await compute_yaml_config_hash(tmp_path / "kitchen.yaml")
-
-    assert result is None
+    assert read_build_info_hash(yaml_path) is None
 
 
-@pytest.mark.asyncio
-async def test_returns_none_when_hash_missing_or_wrong_type(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_returns_none_when_hash_missing_or_wrong_type(tmp_path: Path) -> None:
     """Defensive: build_info.json shape changes shouldn't crash us."""
-    build_path = tmp_path / "build"
-    build_path.mkdir(parents=True)
+    yaml_path = _setup(tmp_path, hash_value=None)
+    build_path = tmp_path / ".esphome" / "build" / "kitchen"
+    build_path.mkdir(parents=True, exist_ok=True)
+
     (build_path / "build_info.json").write_text(
         json.dumps({"build_time": 0}),  # no config_hash key at all
         encoding="utf-8",
     )
-    _stub_storage(monkeypatch, build_path)
-    assert await compute_yaml_config_hash(tmp_path / "kitchen.yaml") is None
+    assert read_build_info_hash(yaml_path) is None
 
     (build_path / "build_info.json").write_text(
         json.dumps({"config_hash": "not-an-int"}),
         encoding="utf-8",
     )
-    assert await compute_yaml_config_hash(tmp_path / "kitchen.yaml") is None
+    assert read_build_info_hash(yaml_path) is None
+
+
+@pytest.mark.asyncio
+async def test_async_wrapper_dispatches_to_sync_reader(tmp_path: Path) -> None:
+    """``compute_yaml_config_hash`` returns the same value as ``read_build_info_hash``.
+
+    The async path exists so ``_persist_expected_config_hash`` (which
+    runs in an event loop) doesn't block the loop on file IO. Lock
+    the contract: same yaml + same disk state → same hex string.
+    """
+    yaml_path = _setup(tmp_path, hash_value=0x12345678)
+
+    assert await compute_yaml_config_hash(yaml_path) == "12345678"

--- a/tests/test_config_hash.py
+++ b/tests/test_config_hash.py
@@ -1,86 +1,148 @@
 """Tests for ``helpers/config_hash.compute_yaml_config_hash``.
 
-Computing the hash needs the real ESPHome ``read_config()`` toolchain
-on the path, so these run an end-to-end subprocess against a minimal
-valid YAML in ``tmp_path``. They double as a smoke test that our
-inline subprocess script imports cleanly under the dashboard's
-interpreter.
+The hash comes out of ``<build_path>/build_info.json``, which
+ESPHome writes during every successful build (including
+``--only-generate``). The dashboard already runs ``--only-generate``
+on YAML add / edit, so by the time we'd read the hash the file is
+in place. These tests stub ``StorageJSON.load`` to point at a
+``build_path`` we control, write a representative ``build_info.json``
+there, and verify the helper round-trips the value into the
+mDNS-canonical 8-char lowercase hex format.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from esphome_device_builder.helpers.config_hash import compute_yaml_config_hash
 
-_MINIMAL_VALID_YAML = """
-esphome:
-  name: kitchen
-esp32:
-  variant: esp32c3
-  framework:
-    type: esp-idf
-"""
+
+def _stub_storage(monkeypatch: Any, build_path: Path | None) -> None:
+    """Make ``StorageJSON.load`` return a stub pointing at *build_path*.
+
+    ``None`` simulates "device has never been compiled" — the
+    ``StorageJSON.load`` itself returns None for missing sidecars.
+    """
+    if build_path is None:
+        load_mock = MagicMock(return_value=None)
+    else:
+        storage = MagicMock()
+        storage.build_path = build_path
+        load_mock = MagicMock(return_value=storage)
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.config_hash.StorageJSON.load",
+        load_mock,
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.config_hash.ext_storage_path",
+        lambda _filename: Path("/unused/by/the/stub.json"),
+    )
+
+
+def _write_build_info(build_path: Path, **fields: Any) -> None:
+    """Write a ``build_info.json`` with the given fields.
+
+    Defaults match what ESPHome's writer emits (see
+    ``esphome.writer.copy_src_tree``): a 32-bit unsigned int
+    ``config_hash``, a unix ``build_time`` etc. Tests override the
+    one or two fields they care about.
+    """
+    build_path.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "config_hash": 0xDEADBEEF,
+        "build_time": 1700000000,
+        "build_time_str": "2025-11-14 12:00:00 -0500",
+        "esphome_version": "2026.5.0-dev",
+    }
+    payload.update(fields)
+    (build_path / "build_info.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
 @pytest.mark.asyncio
-async def test_compute_returns_eight_char_hex_for_valid_config(tmp_path: Path) -> None:
-    """A valid config produces a deterministic 8-char lowercase hex hash."""
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text(_MINIMAL_VALID_YAML)
+async def test_returns_canonical_hex_from_build_info(tmp_path: Path, monkeypatch: Any) -> None:
+    """``build_info.json`` round-trips into the 8-char hex shape."""
+    build_path = tmp_path / ".esphome" / "build" / "kitchen"
+    # 0x5a94a12d is the value the firmware actually broadcasts via
+    # mDNS for a representative Apollo float-monitor YAML — the
+    # original bug report. Locking in this exact shape protects
+    # against accidentally returning the decimal or hex-with-0x
+    # forms.
+    _write_build_info(build_path, config_hash=0x5A94A12D)
+    _stub_storage(monkeypatch, build_path)
 
-    result = await compute_yaml_config_hash(yaml_path)
+    result = await compute_yaml_config_hash(tmp_path / "kitchen.yaml")
 
-    assert result is not None
-    assert len(result) == 8
-    assert all(c in "0123456789abcdef" for c in result)
-
-
-@pytest.mark.asyncio
-async def test_compute_is_deterministic(tmp_path: Path) -> None:
-    """Same YAML → same hash on subsequent runs (depends on FNV-1a determinism)."""
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text(_MINIMAL_VALID_YAML)
-
-    first = await compute_yaml_config_hash(yaml_path)
-    second = await compute_yaml_config_hash(yaml_path)
-
-    assert first is not None
-    assert first == second
+    assert result == "5a94a12d"
 
 
 @pytest.mark.asyncio
-async def test_compute_hash_changes_with_content(tmp_path: Path) -> None:
-    """Edits that change the resolved config produce a different hash."""
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text(_MINIMAL_VALID_YAML)
-    before = await compute_yaml_config_hash(yaml_path)
+async def test_returns_zero_padded_low_value(tmp_path: Path, monkeypatch: Any) -> None:
+    """Small ints get padded to 8 chars so the comparison is straight strcmp."""
+    build_path = tmp_path / "build"
+    _write_build_info(build_path, config_hash=0x42)
+    _stub_storage(monkeypatch, build_path)
 
-    # Tweak a meaningful field — name change cascades through the
-    # resolved config and so changes the hash.
-    yaml_path.write_text(_MINIMAL_VALID_YAML.replace("name: kitchen", "name: bedroom"))
-    after = await compute_yaml_config_hash(yaml_path)
+    result = await compute_yaml_config_hash(tmp_path / "kitchen.yaml")
 
-    assert before is not None
-    assert after is not None
-    assert before != after
+    assert result == "00000042"
 
 
 @pytest.mark.asyncio
-async def test_compute_returns_none_for_invalid_yaml(tmp_path: Path) -> None:
-    """Subprocess exits non-zero on validation failure → None (fall back to mtime)."""
-    yaml_path = tmp_path / "broken.yaml"
-    yaml_path.write_text("esphome:\n  name: !!! not valid\n")
+async def test_returns_none_when_storage_missing(tmp_path: Path, monkeypatch: Any) -> None:
+    """No sidecar → no build path → no hash. Caller falls back to mtime."""
+    _stub_storage(monkeypatch, None)
 
-    result = await compute_yaml_config_hash(yaml_path)
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_compute_returns_none_for_missing_file(tmp_path: Path) -> None:
-    """Nonexistent path → None, no exception bubbled to the caller."""
     result = await compute_yaml_config_hash(tmp_path / "ghost.yaml")
+
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_build_info_missing(tmp_path: Path, monkeypatch: Any) -> None:
+    """Sidecar points at a build dir but ``--only-generate`` hasn't run yet."""
+    build_path = tmp_path / "build"
+    build_path.mkdir(parents=True)
+    _stub_storage(monkeypatch, build_path)
+
+    result = await compute_yaml_config_hash(tmp_path / "kitchen.yaml")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_for_corrupt_json(tmp_path: Path, monkeypatch: Any) -> None:
+    """Corrupt build_info.json → None, no exception bubbles up."""
+    build_path = tmp_path / "build"
+    build_path.mkdir(parents=True)
+    (build_path / "build_info.json").write_text("{this is not json", encoding="utf-8")
+    _stub_storage(monkeypatch, build_path)
+
+    result = await compute_yaml_config_hash(tmp_path / "kitchen.yaml")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_hash_missing_or_wrong_type(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Defensive: build_info.json shape changes shouldn't crash us."""
+    build_path = tmp_path / "build"
+    build_path.mkdir(parents=True)
+    (build_path / "build_info.json").write_text(
+        json.dumps({"build_time": 0}),  # no config_hash key at all
+        encoding="utf-8",
+    )
+    _stub_storage(monkeypatch, build_path)
+    assert await compute_yaml_config_hash(tmp_path / "kitchen.yaml") is None
+
+    (build_path / "build_info.json").write_text(
+        json.dumps({"config_hash": "not-an-int"}),
+        encoding="utf-8",
+    )
+    assert await compute_yaml_config_hash(tmp_path / "kitchen.yaml") is None

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -112,16 +112,62 @@ def test_pending_when_no_binary_yet() -> None:
     )
 
 
-def test_pending_when_yaml_edited_after_compile() -> None:
-    """YAML newer than binary → pending, even if hashes happen to match."""
+def test_pending_when_yaml_edited_after_compile_and_hashes_unknown() -> None:
+    """YAML newer than binary with no hash signal → pending via mtime fallback.
+
+    Pre-#16145 firmware path: the device doesn't broadcast a config
+    hash, so we have nothing to compare against and the mtime
+    "YAML edited since the last compile" check is the only signal
+    we have.
+    """
     assert (
         compute_has_pending_changes(
             yaml_mtime=200.0,
             bin_mtime=100.0,
-            # Stale expected hash that happens to equal the deployed
-            # — without the mtime gate this would falsely report "in sync".
-            expected_config_hash="abc",
-            deployed_config_hash="abc",
+            expected_config_hash="",
+            deployed_config_hash="",
+        )
+        is True
+    )
+
+
+def test_in_sync_when_hashes_match_even_if_yaml_edited() -> None:
+    """Matching hashes win over newer YAML mtime.
+
+    Real-world case from the field (Apollo R_PRO-1): the user edits
+    the YAML in a way that doesn't change the resolved config —
+    whitespace, comment changes, ``--only-generate`` rewriting
+    ``StorageJSON`` and bumping the YAML stat — and the
+    firmware-canonical hashes still match. The device is genuinely
+    in sync; the previous mtime-first ordering reported "Modified"
+    in the drawer even with hashes equal, which the user reasonably
+    flagged as wrong.
+    """
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=200.0,
+            bin_mtime=100.0,
+            expected_config_hash="039818dc",
+            deployed_config_hash="039818dc",
+        )
+        is False
+    )
+
+
+def test_pending_when_hashes_diverge_even_if_yaml_unchanged() -> None:
+    """Diverging hashes win over an unchanged YAML mtime.
+
+    Mirror image of the case above: ``--only-generate`` updated
+    ``expected_config_hash`` after a YAML edit but the device still
+    runs the old firmware, so deployed != expected. Hashes are
+    authoritative, the mtime side is irrelevant.
+    """
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=100.0,
+            bin_mtime=200.0,
+            expected_config_hash="aaaa1111",
+            deployed_config_hash="bbbb2222",
         )
         is True
     )

--- a/tests/test_metadata_resolver.py
+++ b/tests/test_metadata_resolver.py
@@ -1,0 +1,284 @@
+"""Tests for ``DevicesController._resolve_device_metadata``.
+
+The metadata resolver is what threads ``board_id`` / ``ip`` /
+``expected_config_hash`` through to every reload of a device's
+in-memory state. The hash side specifically has to read
+``build_info.json`` first (firmware-canonical) and only fall back to
+the sidecar's persisted value when the build directory is wiped —
+otherwise a stale sidecar (e.g. left over from a previous bug) would
+keep mis-rendering the drawer's "Local config hash" until the user
+re-flashed every device.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from esphome_device_builder.controllers.devices import DevicesController
+
+
+def _make_controller(monkeypatch: Any, board_id: str = "esp32-c3-devkitm-1") -> Any:
+    """Build a controller with the YAML-parsing path stubbed out.
+
+    The board-id derivation reads StorageJSON / parses YAML — neither
+    relevant to the hash-priority tests, and both heavy to set up. A
+    single stub keeps the resolver focused on the metadata + hash
+    sources we actually want to assert against.
+    """
+    controller = DevicesController.__new__(DevicesController)
+    monkeypatch.setattr(
+        controller,
+        "_derive_board_id_from_yaml",
+        lambda _config_dir, _filename: board_id,
+        raising=False,
+    )
+    return controller
+
+
+def _stub_get_metadata(monkeypatch: Any, payload: dict[str, Any]) -> None:
+    """Make ``get_device_metadata`` return *payload* — no JSON IO."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.get_device_metadata",
+        lambda _config_dir, _filename: payload,
+    )
+
+
+def _write_storage_pointer(config_dir: Path, filename: str, build_path: Path) -> None:
+    """Write the ESPHome ``StorageJSON`` sidecar pointing at *build_path*.
+
+    ``read_build_info_hash`` resolves the build directory by loading
+    ``StorageJSON`` and reading ``storage.build_path`` — these tests
+    write a real sidecar (instead of mocking) so the resolver
+    exercises the same disk path it does in production.
+    """
+    storage_dir = config_dir / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / f"{filename}.json").write_text(
+        json.dumps(
+            {
+                "storage_version": 1,
+                "name": filename.removesuffix(".yaml"),
+                "comment": None,
+                "esphome_version": "2026.5.0-dev",
+                "src_version": 1,
+                "address": "",
+                "web_port": None,
+                "esp_platform": "esp32",
+                "board": "esp32-c3-devkitm-1",
+                "build_path": str(build_path),
+                "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
+                "loaded_integrations": [],
+                "loaded_platforms": [],
+                "no_mdns": False,
+                "framework": "esp-idf",
+                "core_platform": "esp32",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_build_info(build_path: Path, config_hash: int) -> None:
+    """Drop a ``build_info.json`` carrying *config_hash* under *build_path*."""
+    build_path.mkdir(parents=True, exist_ok=True)
+    (build_path / "build_info.json").write_text(
+        json.dumps(
+            {
+                "config_hash": config_hash,
+                "build_time": 1700000000,
+                "build_time_str": "2025-11-14 12:00:00 -0500",
+                "esphome_version": "2026.5.0-dev",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_build_info_hash_wins_over_stale_sidecar(tmp_path: Path, monkeypatch: Any) -> None:
+    """``build_info.json`` is authoritative; sidecar's stale value is ignored."""
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    # Sidecar carries a wrong value left over from the pre-codegen
+    # subprocess bug (the user-visible regression on
+    # ``acfloatmonitor32.yaml``: ``f3e21d5a``).
+    _stub_get_metadata(
+        monkeypatch,
+        {"board_id": "", "ip": "192.168.1.42", "expected_config_hash": "f3e21d5a"},
+    )
+
+    # build_info.json carries the firmware-canonical value.
+    build_path = config_dir / ".esphome" / "build" / "kitchen"
+    _write_storage_pointer(config_dir, filename, build_path)
+    _write_build_info(build_path, config_hash=0x5A94A12D)
+
+    controller = _make_controller(monkeypatch)
+    metadata = controller._resolve_device_metadata(config_dir, filename)
+
+    assert metadata.expected_config_hash == "5a94a12d"
+    assert metadata.ip == "192.168.1.42"  # untouched
+
+
+def test_falls_back_to_sidecar_when_build_dir_wiped(tmp_path: Path, monkeypatch: Any) -> None:
+    """No build_info.json (e.g. after ``clean``) → use the sidecar's hash."""
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    _stub_get_metadata(
+        monkeypatch,
+        {"board_id": "", "ip": "", "expected_config_hash": "abcd1234"},
+    )
+
+    # StorageJSON points at a build dir that no longer exists — clean
+    # job wipes ``.esphome/build/<name>``, and the sidecar is the
+    # only remaining trace of the previous compile's hash.
+    build_path = config_dir / ".esphome" / "build" / "kitchen"
+    _write_storage_pointer(config_dir, filename, build_path)
+    # Intentionally NOT calling _write_build_info — directory empty.
+
+    controller = _make_controller(monkeypatch)
+    metadata = controller._resolve_device_metadata(config_dir, filename)
+
+    assert metadata.expected_config_hash == "abcd1234"
+
+
+def test_no_hash_anywhere_returns_empty_string(tmp_path: Path, monkeypatch: Any) -> None:
+    """Brand-new device, never compiled, no sidecar entry → empty string.
+
+    Empty rather than ``None`` keeps the dataclass shape stable and
+    lets ``compute_has_pending_changes`` fall through to the mtime
+    check without a special-case branch.
+    """
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    _stub_get_metadata(monkeypatch, {})  # nothing in the sidecar
+    # No StorageJSON sidecar either → no build_path → no
+    # build_info.json read.
+
+    controller = _make_controller(monkeypatch)
+    metadata = controller._resolve_device_metadata(config_dir, filename)
+
+    assert metadata.expected_config_hash == ""
+
+
+def test_build_info_hash_used_even_when_sidecar_empty(tmp_path: Path, monkeypatch: Any) -> None:
+    """First sight of a regenerated device: only build_info.json has the hash.
+
+    Mirrors what the dashboard sees right after
+    ``_schedule_storage_regenerate`` runs ``--only-generate`` for a
+    newly-added YAML — the sidecar's ``expected_config_hash`` is
+    only written on success of that regenerate, but the resolver
+    runs on every scan, so the build_info.json read has to carry
+    the value through until the persist completes.
+    """
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    _stub_get_metadata(monkeypatch, {})  # sidecar not yet written
+
+    build_path = config_dir / ".esphome" / "build" / "kitchen"
+    _write_storage_pointer(config_dir, filename, build_path)
+    _write_build_info(build_path, config_hash=0x12345678)
+
+    controller = _make_controller(monkeypatch)
+    metadata = controller._resolve_device_metadata(config_dir, filename)
+
+    assert metadata.expected_config_hash == "12345678"
+
+
+def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None:
+    """An imported device with integrations but no hash gets its hash backfilled.
+
+    Symptom from the field: an Apollo R_PRO-1 added before
+    build_info.json existed in the dashboard had ``loaded_integrations``
+    populated (so the original "first-sight" trigger didn't fire) but
+    no ``expected_config_hash`` — the drawer then showed an em-dash
+    forever, because nothing else nudges ``--only-generate`` until
+    the YAML is edited. Extending the trigger condition to
+    ``not loaded_integrations or not expected_config_hash`` schedules
+    the regenerate so the next scan picks up the canonical hash.
+    """
+    from esphome_device_builder.controllers._device_scanner import ScanChange
+    from esphome_device_builder.models import Device, EventType
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    controller._regenerate_failed = set()
+    schedule = MagicMock()
+    monkeypatch.setattr(controller, "_schedule_storage_regenerate", schedule, raising=False)
+
+    device = Device(
+        name="apollo",
+        friendly_name="Apollo R_PRO-1",
+        configuration="apollo-r-pro-1.yaml",
+        loaded_integrations=["api", "wifi"],  # populated, *not* the empty case
+        expected_config_hash="",  # but no hash yet
+    )
+    controller._on_scan_change(ScanChange.ADDED, device)
+
+    schedule.assert_called_once_with("apollo-r-pro-1.yaml")
+    # Sanity: the bus fire still happens — the trigger is additive,
+    # not a replacement.
+    controller._db.bus.fire.assert_called_with(EventType.DEVICE_ADDED, {"device": device})
+
+
+def test_added_device_fully_populated_does_not_regenerate(
+    monkeypatch: Any,
+) -> None:
+    """A device that already carries integrations + hash skips the regenerate.
+
+    Without this guard, every dashboard restart would needlessly
+    spawn an ``--only-generate`` per device on a fully-warmed
+    config_dir.
+    """
+    from esphome_device_builder.controllers._device_scanner import ScanChange
+    from esphome_device_builder.models import Device
+
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    controller._regenerate_failed = set()
+    schedule = MagicMock()
+    monkeypatch.setattr(controller, "_schedule_storage_regenerate", schedule, raising=False)
+
+    device = Device(
+        name="apollo",
+        friendly_name="Apollo R_PRO-1",
+        configuration="apollo-r-pro-1.yaml",
+        loaded_integrations=["api", "wifi"],
+        expected_config_hash="039818dc",
+    )
+    controller._on_scan_change(ScanChange.ADDED, device)
+
+    schedule.assert_not_called()
+
+
+def test_board_id_from_sidecar_takes_priority_over_yaml(tmp_path: Path, monkeypatch: Any) -> None:
+    """A pinned board_id from the sidecar isn't clobbered by YAML re-derivation.
+
+    Locks down the existing precedence even though the diff under
+    test is about the hash side — board_id and the hash are
+    resolved together, so a refactor that broke the precedence in
+    one direction would likely break the other.
+    """
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    _stub_get_metadata(monkeypatch, {"board_id": "esp32-poe"})
+
+    derive = MagicMock(return_value="should-not-be-called")
+    controller = DevicesController.__new__(DevicesController)
+    monkeypatch.setattr(controller, "_derive_board_id_from_yaml", derive, raising=False)
+
+    metadata = controller._resolve_device_metadata(config_dir, filename)
+
+    assert metadata.board_id == "esp32-poe"
+    derive.assert_not_called()


### PR DESCRIPTION
## Summary

- ``compute_yaml_config_hash`` now reads ``<build_path>/build_info.json`` directly. ESPHome writes that file with the canonical hash at the end of every successful build *and* every ``--only-generate`` run, so we use the firmware's own value instead of trying to reproduce it.
- The previous subprocess approach (``read_config`` + ``CORE.config_hash``) returned a *pre-codegen* hash that disagreed with the post-codegen hash the firmware bakes in. Verified on ``acfloatmonitor32.yaml``: subprocess produced ``f3e21d5a`` while the firmware broadcast ``5a94a12d``.
- Wires ``--only-generate`` success (``_schedule_storage_regenerate``) into ``_persist_expected_config_hash``, so the drawer's "Local config hash" carries the canonical value from the very first regenerate onwards — no flash required.

## Why

The drawer was showing wildly wrong values for any config touched by post-validation codegen mutations (id-pinning, default backfill, normalisation). The user-visible symptom: "Local: f3e21d5a / Deployed: 5a94a12d → out of sync" on a YAML that *was* in sync, plus the optimistic post-flash sync from #68 happily pinning the deployed side to that wrong value.

Reading ``build_info.json`` is exact, free, and matches what's broadcast over mDNS.

## Test plan

- [ ] ``uv run pytest tests/test_config_hash.py`` — 6/6 (round-trip lock-in for the user's reported ``0x5a94a12d`` value, plus all the missing-file / corrupt-JSON / wrong-shape paths)
- [ ] Full suite: ``uv run pytest`` (337 passed, 3 skipped)
- [ ] Manual: open the drawer on ``acfloatmonitor32.yaml`` after a regenerate — Local hash matches the value the firmware reports in its build log (``Build Info: config_hash=0x...``), no longer drifts.