### PR TITLE
Fan state monitor callbacks out to every same-named device

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -895,23 +895,41 @@ class DevicesController:
         if kind is ScanChange.REMOVED:
             self._state_monitor.revisit_all_importables()
 
+    def _devices_by_name(self, name: str) -> list[Device]:
+        """Every configured device whose ``name`` field matches ``name``.
+
+        Two YAML files can ship the same ``name:`` value (e.g.
+        ``foo.yaml`` and ``foo (1).yaml`` both pointing at
+        ``foo.local``). They share a single mDNS service announcement,
+        so any state / IP / version / config-hash / api-encryption
+        observation needs to fan out to every matching device or the
+        non-canonical copy stays stuck at "Unknown" while its sibling
+        shows online.
+        """
+        return [d for d in self._scanner.devices if d.name == name]
+
     def _on_state_change(self, name: str, state: DeviceState, source: str) -> None:
         """Forward state monitor updates onto the event bus."""
-        device = next((d for d in self._scanner.devices if d.name == name), None)
-        if device is None:
-            return
-        old_state = device.state
-        device.state = state
-        _LOGGER.info("Device %s: %s → %s (via %s)", name, old_state, state, source)
-        # Frontend's ``DeviceStateChangedEventData`` is the flat
-        # ``{configuration, state}`` shape — sending the full ``device``
-        # object made the destructure resolve both fields to
-        # ``undefined`` and the table never updated. Match the type
-        # exactly so the row's state cell flips on the next event.
-        self._db.bus.fire(
-            EventType.DEVICE_STATE_CHANGED,
-            {"configuration": device.configuration, "state": state.value},
-        )
+        for device in self._devices_by_name(name):
+            old_state = device.state
+            device.state = state
+            _LOGGER.info(
+                "Device %s (%s): %s → %s (via %s)",
+                name,
+                device.configuration,
+                old_state,
+                state,
+                source,
+            )
+            # Frontend's ``DeviceStateChangedEventData`` is the flat
+            # ``{configuration, state}`` shape — sending the full ``device``
+            # object made the destructure resolve both fields to
+            # ``undefined`` and the table never updated. Match the type
+            # exactly so the row's state cell flips on the next event.
+            self._db.bus.fire(
+                EventType.DEVICE_STATE_CHANGED,
+                {"configuration": device.configuration, "state": state.value},
+            )
 
     def _on_ip_change(self, name: str, ip: str) -> None:
         """
@@ -922,16 +940,16 @@ class DevicesController:
         across the device's offline window. The DNS pre-resolve and
         next mDNS resolve will overwrite it on reconnect.
         """
-        device = next((d for d in self._scanner.devices if d.name == name), None)
-        if device is None:
-            return
-        if device.ip == ip:
-            return
-        device.ip = ip
-        _LOGGER.debug("Device %s IP: %s", name, ip or "(cleared)")
-        if ip:
-            self._db.create_background_task(self._persist_device_ip_async(device.configuration, ip))
-        self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+        for device in self._devices_by_name(name):
+            if device.ip == ip:
+                continue
+            device.ip = ip
+            _LOGGER.debug("Device %s (%s) IP: %s", name, device.configuration, ip or "(cleared)")
+            if ip:
+                self._db.create_background_task(
+                    self._persist_device_ip_async(device.configuration, ip)
+                )
+            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 
     async def _persist_device_ip_async(self, configuration: str, ip: str) -> None:
         """Save *ip* to the device-builder metadata sidecar."""
@@ -943,23 +961,29 @@ class DevicesController:
 
     def _on_version_change(self, name: str, version: str) -> None:
         """Apply a fresh ESPHome version observed via mDNS."""
-        device = next((d for d in self._scanner.devices if d.name == name), None)
-        if device is None:
-            return
-        if device.deployed_version == version:
-            return
+        for device in self._devices_by_name(name):
+            if device.deployed_version == version:
+                continue
 
-        # StorageJSON.load/save are blocking — push to a background task
-        # so any error gets surfaced via the loop's exception handler.
-        self._db.create_background_task(
-            self._persist_storage_version_async(device.configuration, version)
-        )
+            # StorageJSON.load/save are blocking — push to a background task
+            # so any error gets surfaced via the loop's exception handler.
+            self._db.create_background_task(
+                self._persist_storage_version_async(device.configuration, version)
+            )
 
-        old_version = device.deployed_version
-        device.deployed_version = version
-        device.update_available = bool(device.current_version and version != device.current_version)
-        _LOGGER.info("Device %s version: %s → %s (via mdns)", name, old_version or "?", version)
-        self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+            old_version = device.deployed_version
+            device.deployed_version = version
+            device.update_available = bool(
+                device.current_version and version != device.current_version
+            )
+            _LOGGER.info(
+                "Device %s (%s) version: %s → %s (via mdns)",
+                name,
+                device.configuration,
+                old_version or "?",
+                version,
+            )
+            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 
     def _on_api_encryption_change(self, name: str, encryption: str) -> None:
         """
@@ -971,13 +995,11 @@ class DevicesController:
         ``api_encrypted`` to distinguish active / pending-flash /
         mismatch / plaintext.
         """
-        device = next((d for d in self._scanner.devices if d.name == name), None)
-        if device is None:
-            return
-        if device.api_encryption_active == encryption:
-            return
-        device.api_encryption_active = encryption
-        self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+        for device in self._devices_by_name(name):
+            if device.api_encryption_active == encryption:
+                continue
+            device.api_encryption_active = encryption
+            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 
     def _on_config_hash_change(self, name: str, config_hash: str) -> None:
         """
@@ -991,22 +1013,24 @@ class DevicesController:
         predates the ``config_hash`` TXT broadcast never trigger this
         callback and stay on the legacy mtime check.
         """
-        device = next((d for d in self._scanner.devices if d.name == name), None)
-        if device is None:
-            return
-        if device.deployed_config_hash == config_hash:
-            return
-        old_hash = device.deployed_config_hash
-        device.deployed_config_hash = config_hash
-        # Mtime side stays with the periodic scanner poll so this
-        # callback can stay off-disk and non-blocking. A YAML edit
-        # between polls (~5s window) self-corrects on the next scan.
-        if device.expected_config_hash:
-            device.has_pending_changes = device.expected_config_hash != config_hash
-        _LOGGER.info(
-            "Device %s config_hash: %s → %s (via mdns)", name, old_hash or "?", config_hash
-        )
-        self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+        for device in self._devices_by_name(name):
+            if device.deployed_config_hash == config_hash:
+                continue
+            old_hash = device.deployed_config_hash
+            device.deployed_config_hash = config_hash
+            # Mtime side stays with the periodic scanner poll so this
+            # callback can stay off-disk and non-blocking. A YAML edit
+            # between polls (~5s window) self-corrects on the next scan.
+            if device.expected_config_hash:
+                device.has_pending_changes = device.expected_config_hash != config_hash
+            _LOGGER.info(
+                "Device %s (%s) config_hash: %s → %s (via mdns)",
+                name,
+                device.configuration,
+                old_hash or "?",
+                config_hash,
+            )
+            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 
     def _on_importable_added(self, device: AdoptableDevice) -> None:
         """Stash a newly-discovered importable device and notify subscribers."""

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -1,0 +1,119 @@
+"""
+Tests for fan-out of state monitor callbacks across duplicate-named devices.
+
+Two YAML files can declare the same ``name:`` value
+(``foo.yaml`` and ``foo (1).yaml`` is the canonical case). They
+share a single mDNS service announcement, so a state / IP /
+version / config-hash / api-encryption observation has to fan
+out to *every* configured device with that name — not just the
+first one. The legacy behaviour returned the first match from
+``next()``, which left the duplicate stuck at ``UNKNOWN`` while
+its sibling tracked the device.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.models import Device, DeviceState
+
+
+def _device(configuration: str, **overrides: Any) -> Device:
+    base: dict[str, Any] = {
+        "name": "kitchen",
+        "friendly_name": "Kitchen",
+        "configuration": configuration,
+        "address": "kitchen.local",
+        "state": DeviceState.UNKNOWN,
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+def _make_controller(devices: list[Device]) -> DevicesController:
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    controller._scanner = MagicMock()
+    controller._scanner.devices = devices
+    return controller
+
+
+def test_state_change_fans_out_to_every_matching_device() -> None:
+    """``_on_state_change`` updates *every* device sharing the name."""
+    a = _device("kitchen.yaml")
+    b = _device("kitchen (1).yaml")
+    controller = _make_controller([a, b])
+
+    controller._on_state_change("kitchen", DeviceState.ONLINE, "mdns")
+
+    assert a.state == DeviceState.ONLINE
+    assert b.state == DeviceState.ONLINE
+
+
+def test_ip_change_fans_out_to_every_matching_device() -> None:
+    a = _device("kitchen.yaml", ip="")
+    b = _device("kitchen (1).yaml", ip="")
+    controller = _make_controller([a, b])
+    # Drop the persist-async side effect; we only care about the
+    # in-memory mutation here.
+    controller._db.create_background_task = MagicMock()
+
+    controller._on_ip_change("kitchen", "10.0.0.5")
+
+    assert a.ip == "10.0.0.5"
+    assert b.ip == "10.0.0.5"
+
+
+def test_version_change_fans_out_to_every_matching_device() -> None:
+    a = _device("kitchen.yaml", current_version="2026.5.0", deployed_version="")
+    b = _device("kitchen (1).yaml", current_version="2026.5.0", deployed_version="")
+    controller = _make_controller([a, b])
+    controller._db.create_background_task = MagicMock()
+
+    controller._on_version_change("kitchen", "2026.5.0")
+
+    assert a.deployed_version == "2026.5.0"
+    assert b.deployed_version == "2026.5.0"
+
+
+def test_config_hash_change_fans_out_to_every_matching_device() -> None:
+    a = _device("kitchen.yaml", expected_config_hash="abcd1234", deployed_config_hash="")
+    b = _device(
+        "kitchen (1).yaml",
+        expected_config_hash="abcd1234",
+        deployed_config_hash="",
+    )
+    controller = _make_controller([a, b])
+
+    controller._on_config_hash_change("kitchen", "abcd1234")
+
+    assert a.deployed_config_hash == "abcd1234"
+    assert b.deployed_config_hash == "abcd1234"
+    # Both devices' has_pending_changes should reflect the match.
+    assert a.has_pending_changes is False
+    assert b.has_pending_changes is False
+
+
+def test_api_encryption_change_fans_out_to_every_matching_device() -> None:
+    a = _device("kitchen.yaml", api_encryption_active=None)
+    b = _device("kitchen (1).yaml", api_encryption_active=None)
+    controller = _make_controller([a, b])
+
+    controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+
+    assert a.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+    assert b.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+
+
+def test_unrelated_devices_are_not_touched() -> None:
+    """Devices with a different ``name`` field stay UNKNOWN."""
+    kitchen = _device("kitchen.yaml")
+    garage = _device("garage.yaml", name="garage", address="garage.local")
+    controller = _make_controller([kitchen, garage])
+
+    controller._on_state_change("kitchen", DeviceState.ONLINE, "mdns")
+
+    assert kitchen.state == DeviceState.ONLINE
+    assert garage.state == DeviceState.UNKNOWN

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -32,16 +32,41 @@ def _device(configuration: str, **overrides: Any) -> Device:
     return Device(**base)
 
 
+def _close_coro(coro: Any) -> Any:
+    """Close any coroutine handed to ``create_background_task``.
+
+    Without this the test stub leaves ``_persist_device_ip_async`` /
+    ``_persist_storage_version_async`` coroutines un-awaited, which
+    triggers ``RuntimeWarning: coroutine was never awaited`` (some
+    pytest configs upgrade that to a failure).
+    """
+    if hasattr(coro, "close"):
+        coro.close()
+    return MagicMock()
+
+
 def _make_controller(devices: list[Device]) -> DevicesController:
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
+    controller._db.create_background_task = MagicMock(side_effect=_close_coro)
+    controller._db.bus = MagicMock()
     controller._scanner = MagicMock()
     controller._scanner.devices = devices
     return controller
 
 
+def _fired_events(controller: DevicesController) -> list[tuple[Any, dict[str, Any]]]:
+    """All ``(event_type, data)`` pairs forwarded to the event bus."""
+    return [call.args for call in controller._db.bus.fire.call_args_list]
+
+
 def test_state_change_fans_out_to_every_matching_device() -> None:
-    """``_on_state_change`` updates *every* device sharing the name."""
+    """Fans the state update + bus event out to every matching device.
+
+    ``_on_state_change`` has to update *every* device sharing the
+    name and fire ``DEVICE_STATE_CHANGED`` once per configuration
+    so each dashboard card redraws independently.
+    """
     a = _device("kitchen.yaml")
     b = _device("kitchen (1).yaml")
     controller = _make_controller([a, b])
@@ -50,32 +75,44 @@ def test_state_change_fans_out_to_every_matching_device() -> None:
 
     assert a.state == DeviceState.ONLINE
     assert b.state == DeviceState.ONLINE
+    fired = _fired_events(controller)
+    assert len(fired) == 2
+    targeted = sorted(data["configuration"] for _et, data in fired)
+    assert targeted == ["kitchen (1).yaml", "kitchen.yaml"]
 
 
 def test_ip_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", ip="")
     b = _device("kitchen (1).yaml", ip="")
     controller = _make_controller([a, b])
-    # Drop the persist-async side effect; we only care about the
-    # in-memory mutation here.
-    controller._db.create_background_task = MagicMock()
 
     controller._on_ip_change("kitchen", "10.0.0.5")
 
     assert a.ip == "10.0.0.5"
     assert b.ip == "10.0.0.5"
+    fired = _fired_events(controller)
+    assert len(fired) == 2
+    assert sorted(data["device"].configuration for _et, data in fired) == [
+        "kitchen (1).yaml",
+        "kitchen.yaml",
+    ]
 
 
 def test_version_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", current_version="2026.5.0", deployed_version="")
     b = _device("kitchen (1).yaml", current_version="2026.5.0", deployed_version="")
     controller = _make_controller([a, b])
-    controller._db.create_background_task = MagicMock()
 
     controller._on_version_change("kitchen", "2026.5.0")
 
     assert a.deployed_version == "2026.5.0"
     assert b.deployed_version == "2026.5.0"
+    fired = _fired_events(controller)
+    assert len(fired) == 2
+    assert sorted(data["device"].configuration for _et, data in fired) == [
+        "kitchen (1).yaml",
+        "kitchen.yaml",
+    ]
 
 
 def test_config_hash_change_fans_out_to_every_matching_device() -> None:
@@ -94,6 +131,8 @@ def test_config_hash_change_fans_out_to_every_matching_device() -> None:
     # Both devices' has_pending_changes should reflect the match.
     assert a.has_pending_changes is False
     assert b.has_pending_changes is False
+    fired = _fired_events(controller)
+    assert len(fired) == 2
 
 
 def test_api_encryption_change_fans_out_to_every_matching_device() -> None:
@@ -105,6 +144,8 @@ def test_api_encryption_change_fans_out_to_every_matching_device() -> None:
 
     assert a.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
     assert b.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+    fired = _fired_events(controller)
+    assert len(fired) == 2
 
 
 def test_unrelated_devices_are_not_touched() -> None:
@@ -117,3 +158,6 @@ def test_unrelated_devices_are_not_touched() -> None:
 
     assert kitchen.state == DeviceState.ONLINE
     assert garage.state == DeviceState.UNKNOWN
+    fired = _fired_events(controller)
+    assert len(fired) == 1
+    assert fired[0][1]["configuration"] == "kitchen.yaml"


### PR DESCRIPTION
## Summary

Two YAML files can declare the same `name:` value — typical when adoption + a re-import lands as `foo.yaml` and `foo (1).yaml`, both pointing at the same device. The dashboard then shows two cards but only one of them ever leaves "Unknown":

> **livingroomalexproxy** — `livingroomalexproxy (1).yaml` — Online
> **livingroomalexproxy** — `livingroomalexproxy.yaml` — Unknown

Cause: every `_on_*_change` callback in `DevicesController` looked up the device with `next((d for d in scanner.devices if d.name == name), None)` — first match wins, the other sibling never gets state / IP / version / config_hash / api_encryption updates.

Fix: a small `_devices_by_name` helper returns every matching device, and each callback loops over them. `DEVICE_UPDATED` / `DEVICE_STATE_CHANGED` events now fire once per matching configuration so the dashboard redraws each card independently.

## Test plan

- [x] All 342 existing tests pass; 6 new tests in `test_state_fanout_duplicate_names.py` cover state / IP / version / config_hash / api_encryption fan-out plus an "unrelated devices stay untouched" regression guard
- [ ] In a config dir with `foo.yaml` + `foo (1).yaml` (both `name: foo`), once the device comes online both cards flip from Unknown to Online together
- [ ] Same for an IP refresh, version refresh, config-hash sync, and the API-encryption indicator