### PR TITLE
Probe mDNS eagerly when a new device appears

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -393,27 +393,36 @@ class DeviceStateMonitor:
         addresses = info.parsed_scoped_addresses(IPVersion.All)
         return addresses or None
 
-    def probe_device(self, device_name: str) -> None:
+    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
         """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
 
         Adoption / import / wizard-created devices land in the
         configured catalog the moment we write their YAML, but the
-        regular browser path only updates IP / version / config_hash
-        / api_encryption when the *next* mDNS announcement arrives —
-        which can be minutes for a quiet device. This method short-
-        circuits the wait by either reading the existing zeroconf
-        cache (sync hit, common case for a device that was just on
-        the discovery banner) or kicking off an ``async_request``
-        in a fire-and-forget task. Either way the apply path is the
-        same one the browser uses, so the device's card flips from
-        "Unknown" to a fully-populated card immediately instead of
-        on the next periodic sweep.
+        regular browser path only updates ONLINE / IP / version /
+        config_hash / api_encryption when the *next* mDNS announcement
+        arrives — which can be minutes for a quiet device. This method
+        short-circuits the wait by either reading the existing
+        zeroconf cache (sync hit, common case for a device that was
+        just on the discovery banner) or kicking off an
+        ``async_request`` in a fire-and-forget task. Either way the
+        apply path is the same one the browser uses, so the device's
+        card flips from "Unknown" to a fully-populated card
+        immediately instead of on the next periodic sweep.
+
+        ``service_name`` defaults to ``device_name`` and is the
+        broadcast name to look up in mDNS. Adoption surfaces a
+        device whose mDNS-advertised name (the original factory
+        firmware's hostname) differs from the user-chosen YAML name;
+        passing it explicitly lets the lookup hit the cached service
+        info while the apply still keys to the configured device's
+        name.
         """
         if self._zeroconf is None:
             return
         zeroconf = self._zeroconf.zeroconf
-        service_name = f"{device_name}.{_ESPHOME_SERVICE_TYPE}"
-        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, service_name)
+        broadcast = service_name or device_name
+        full_service = f"{broadcast}.{_ESPHOME_SERVICE_TYPE}"
+        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, full_service)
         if info.load_from_cache(zeroconf):
             self._apply_service_info(device_name, info)
             return
@@ -747,7 +756,20 @@ class DeviceStateMonitor:
         )
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
-        """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``."""
+        """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``.
+
+        A successful apply is itself proof the device is reachable —
+        we have its broadcast TXT records and address from zeroconf —
+        so claim ONLINE under the mDNS source. The browser callback
+        already calls ``apply(...ONLINE..., claim=True)`` itself, so
+        for that path this is a no-op dedupe; the eager
+        ``probe_device`` path needs it because it skips the
+        browser-callback prelude.
+        """
+        # ``claim=True`` so mDNS owns the slot even when ping/MQTT
+        # had already labelled the device — same shape the browser
+        # callback uses on its way into this method.
+        self.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
         # Prefer V4; fall back to scoped V6 (link-local needs the
         # ``%scope`` suffix to connect at all). Matches the upstream
         # esphome dashboard's ``parsed_scoped_addresses`` usage.

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -393,6 +393,34 @@ class DeviceStateMonitor:
         addresses = info.parsed_scoped_addresses(IPVersion.All)
         return addresses or None
 
+    def probe_device(self, device_name: str) -> None:
+        """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
+
+        Adoption / import / wizard-created devices land in the
+        configured catalog the moment we write their YAML, but the
+        regular browser path only updates IP / version / config_hash
+        / api_encryption when the *next* mDNS announcement arrives —
+        which can be minutes for a quiet device. This method short-
+        circuits the wait by either reading the existing zeroconf
+        cache (sync hit, common case for a device that was just on
+        the discovery banner) or kicking off an ``async_request``
+        in a fire-and-forget task. Either way the apply path is the
+        same one the browser uses, so the device's card flips from
+        "Unknown" to a fully-populated card immediately instead of
+        on the next periodic sweep.
+        """
+        if self._zeroconf is None:
+            return
+        zeroconf = self._zeroconf.zeroconf
+        service_name = f"{device_name}.{_ESPHOME_SERVICE_TYPE}"
+        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, service_name)
+        if info.load_from_cache(zeroconf):
+            self._apply_service_info(device_name, info)
+            return
+        task = asyncio.create_task(self._resolve_and_apply(zeroconf, info, device_name))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
     def revisit_importable(self, device_name: str) -> None:
         """
         Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached.

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -292,6 +292,13 @@ class DevicesController:
 
         await loop.run_in_executor(None, _init_storage)
         await self._scanner.scan()
+        # The freshly-created config might be for a device that's
+        # already on the network (e.g. the wizard ran against a
+        # device the user just plugged in). Probe mDNS so the new
+        # card lands online with version / config_hash /
+        # api_encryption populated instead of waiting on the next
+        # ping sweep or mDNS announcement.
+        self._state_monitor.probe_device(name)
         return WizardResponse(configuration=filename)
 
     @api_command("devices/update")
@@ -703,6 +710,12 @@ class DevicesController:
         cached = self._state_monitor.get_cached_addresses(f"{mdns_name}.local")
         if cached:
             self._state_monitor.apply_ip(name, cached[0])
+        # Eagerly probe the esphomelib service so the new card lands
+        # with version / config_hash / api_encryption populated, not
+        # just IP. Cache hit returns synchronously; otherwise the
+        # probe runs as a fire-and-forget task whose results land
+        # via the same browser-callback path.
+        self._state_monitor.probe_device(name)
         return {"configuration": configuration}
 
     @api_command("devices/ignore")
@@ -880,6 +893,18 @@ class DevicesController:
             ScanChange.REMOVED: EventType.DEVICE_REMOVED,
         }[kind]
         self._db.bus.fire(event, {"device": device})
+        # Eagerly probe mDNS for newly-added devices. Catches the
+        # YAML-dropped-on-disk case the API entrypoints
+        # (``devices/import``, ``devices/create``) can't see — e.g.
+        # the user copies a config into ``config_dir`` from another
+        # dashboard or git clones their setup. Without this the new
+        # card sits at "Unknown" until the next periodic ping sweep
+        # or mDNS announcement, even when the device is already on
+        # the network. ``probe_device`` short-circuits to the
+        # zeroconf cache when present; otherwise it spawns a
+        # fire-and-forget resolve task.
+        if kind is ScanChange.ADDED:
+            self._state_monitor.probe_device(device.name)
         # The YAML cache key changed (mtime / size / inode) — clear
         # any prior failure marker so an edit gets a fresh chance at
         # ``--only-generate``. Same for REMOVED so re-creating the

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -291,14 +291,14 @@ class DevicesController:
                 set_device_metadata(self._db.settings.config_dir, filename, board_id=board_id)
 
         await loop.run_in_executor(None, _init_storage)
+        # ``_scanner.scan`` fires ``_on_scan_change(ADDED)`` for the
+        # new YAML, and that callback already runs ``probe_device`` —
+        # don't double-probe here. ``file_content`` may carry an
+        # ``esphome.name`` that differs from the URL ``name``, in
+        # which case the scan-change handler probes the YAML's name
+        # (the right one) and an explicit second probe here would
+        # target the wrong service.
         await self._scanner.scan()
-        # The freshly-created config might be for a device that's
-        # already on the network (e.g. the wizard ran against a
-        # device the user just plugged in). Probe mDNS so the new
-        # card lands online with version / config_hash /
-        # api_encryption populated instead of waiting on the next
-        # ping sweep or mDNS announcement.
-        self._state_monitor.probe_device(name)
         return WizardResponse(configuration=filename)
 
     @api_command("devices/update")
@@ -712,10 +712,19 @@ class DevicesController:
             self._state_monitor.apply_ip(name, cached[0])
         # Eagerly probe the esphomelib service so the new card lands
         # with version / config_hash / api_encryption populated, not
-        # just IP. Cache hit returns synchronously; otherwise the
-        # probe runs as a fire-and-forget task whose results land
-        # via the same browser-callback path.
-        self._state_monitor.probe_device(name)
+        # just IP. The device on the network is still broadcasting
+        # under its factory-firmware ``mdns_name`` (the user may have
+        # picked a different YAML name during adoption), so look up
+        # the service under that name but apply the result against
+        # the configured device's chosen name. Cache hit returns
+        # synchronously; otherwise the probe runs as a fire-and-
+        # forget task whose results land via the same
+        # browser-callback path. The ``_on_scan_change`` handler
+        # also probes when the scan picked up the new YAML, but it
+        # uses the YAML name only — for adoption that name has no
+        # mDNS broadcast yet, so this explicit call covers the
+        # rename-during-adopt case.
+        self._state_monitor.probe_device(name, service_name=mdns_name)
         return {"configuration": configuration}
 
     @api_command("devices/ignore")

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -152,7 +152,19 @@ async def test_handler_does_not_substitute_hyphens(monkeypatch: pytest.MonkeyPat
     into ``my_device`` before lookup.
     """
     devices = [_device("my-device")]
-    on_state = MagicMock()
+
+    # Mirror production: the real ``on_state_change`` callback flips
+    # ``device.state`` so the eager ``apply(ONLINE)`` in the browser
+    # callback and the redundant claim in ``_apply_service_info``
+    # short-circuit on the second call. Without this side-effect the
+    # MagicMock leaves ``device.state`` at UNKNOWN forever and we'd
+    # see a misleading double-fire.
+    def _flip_state(name: str, state: DeviceState, _source: str) -> None:
+        for device in devices:
+            if device.name == name:
+                device.state = state
+
+    on_state = MagicMock(side_effect=_flip_state)
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
         on_state_change=on_state,

--- a/tests/test_metadata_resolver.py
+++ b/tests/test_metadata_resolver.py
@@ -212,6 +212,7 @@ def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller._regenerate_failed = set()
+    controller._state_monitor = MagicMock()
     schedule = MagicMock()
     monkeypatch.setattr(controller, "_schedule_storage_regenerate", schedule, raising=False)
 
@@ -228,6 +229,9 @@ def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None
     # Sanity: the bus fire still happens — the trigger is additive,
     # not a replacement.
     controller._db.bus.fire.assert_called_with(EventType.DEVICE_ADDED, {"device": device})
+    # Probe fires too — the eager mDNS probe on ADDED is what catches
+    # YAMLs dropped on disk outside the API path.
+    controller._state_monitor.probe_device.assert_called_once_with("apollo")
 
 
 def test_added_device_fully_populated_does_not_regenerate(
@@ -245,6 +249,7 @@ def test_added_device_fully_populated_does_not_regenerate(
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller._regenerate_failed = set()
+    controller._state_monitor = MagicMock()
     schedule = MagicMock()
     monkeypatch.setattr(controller, "_schedule_storage_regenerate", schedule, raising=False)
 

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -1,0 +1,88 @@
+"""
+Tests for ``DeviceStateMonitor.probe_device``.
+
+Adoption / wizard / on-disk YAML drops all need an eager mDNS
+probe so the new device card lands fully populated (IP, version,
+config_hash, api_encryption) instead of waiting on the next
+periodic announcement. The probe takes the cache fast-path when
+zeroconf already has the service, otherwise it spawns a fire-
+and-forget resolve task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers._device_state_monitor import (
+    DeviceStateMonitor,
+)
+
+
+def _make_monitor() -> DeviceStateMonitor:
+    monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+    monitor._zeroconf = MagicMock()
+    monitor._zeroconf.zeroconf = MagicMock()
+    monitor._tasks = set()
+    return monitor
+
+
+@pytest.mark.asyncio
+async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None:
+    """A cached service info applies inline; no task is spawned."""
+    monitor = _make_monitor()
+    apply = MagicMock()
+    monkeypatch.setattr(monitor, "_apply_service_info", apply)
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers._device_state_monitor.AsyncServiceInfo",
+        lambda *_args, **_kw: fake_info,
+    )
+
+    monitor.probe_device("kitchen")
+
+    apply.assert_called_once_with("kitchen", fake_info)
+    assert not monitor._tasks
+
+
+@pytest.mark.asyncio
+async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
+    """Cache miss → fire-and-forget resolve task tracked in ``_tasks``."""
+    monitor = _make_monitor()
+    apply = MagicMock()
+    monkeypatch.setattr(monitor, "_apply_service_info", apply)
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = False
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers._device_state_monitor.AsyncServiceInfo",
+        lambda *_args, **_kw: fake_info,
+    )
+
+    async def fake_resolve(*_args, **_kw) -> None:
+        return None
+
+    monkeypatch.setattr(monitor, "_resolve_and_apply", fake_resolve)
+
+    monitor.probe_device("kitchen")
+
+    apply.assert_not_called()
+    # One task was registered for tracking. Wait it out so the
+    # done-callback can run and prune the set; otherwise pending
+    # tasks would leak into the next test's event loop.
+    assert len(monitor._tasks) == 1
+    await asyncio.gather(*monitor._tasks)
+
+
+def test_probe_device_no_zeroconf_is_a_noop() -> None:
+    """Pre-start (or zeroconf-failed) probe must not raise."""
+    monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+    monitor._zeroconf = None
+    monitor._tasks = set()
+
+    monitor.probe_device("kitchen")  # no exception, no tasks
+    assert not monitor._tasks

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -12,6 +12,7 @@ and-forget resolve task.
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -47,6 +48,43 @@ async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None
 
     apply.assert_called_once_with("kitchen", fake_info)
     assert not monitor._tasks
+
+
+@pytest.mark.asyncio
+async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None:
+    """``service_name`` overrides the lookup but apply still keys by ``device_name``.
+
+    Adoption surfaces a device whose mDNS-advertised name (the
+    factory firmware's hostname) differs from the user-chosen YAML
+    name. The probe needs to look up the broadcast under the OLD
+    name (which is what zeroconf has cached) but apply the data to
+    the configured device under its NEW name.
+    """
+    monitor = _make_monitor()
+    apply = MagicMock()
+    monkeypatch.setattr(monitor, "_apply_service_info", apply)
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    constructor_args: list[tuple[Any, ...]] = []
+
+    def _info_ctor(service_type: Any, full_service: Any) -> Any:
+        constructor_args.append((service_type, full_service))
+        return fake_info
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers._device_state_monitor.AsyncServiceInfo",
+        _info_ctor,
+    )
+
+    monitor.probe_device("my-living-room", service_name="apollo-r-pro-1-eth-5938e0")
+
+    # Looked up under the OLD broadcast name…
+    assert constructor_args == [
+        ("_esphomelib._tcp.local.", "apollo-r-pro-1-eth-5938e0._esphomelib._tcp.local.")
+    ]
+    # …but applied under the NEW configured name.
+    apply.assert_called_once_with("my-living-room", fake_info)
 
 
 @pytest.mark.asyncio
@@ -86,3 +124,46 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
 
     monitor.probe_device("kitchen")  # no exception, no tasks
     assert not monitor._tasks
+
+
+@pytest.mark.asyncio
+async def test_apply_service_info_claims_online() -> None:
+    """``_apply_service_info`` flips the device ONLINE under the mDNS source.
+
+    A successful apply means we have the device's broadcast address
+    + TXT records from zeroconf, which is itself proof it's
+    reachable. Without this claim the eager probe path could write
+    fully-populated TXT data while leaving the card at "Unknown"
+    until the next ping sweep.
+    """
+    monitor = _make_monitor()
+    monitor._on_state_change = MagicMock()
+    monitor._on_ip_change = MagicMock()
+    monitor._on_version_change = MagicMock()
+    monitor._on_config_hash_change = MagicMock()
+    monitor._on_api_encryption_change = MagicMock()
+    monitor._state_source = {}
+    monitor._device_ips = {}
+    monitor._device_versions = {}
+    monitor._device_config_hashes = {}
+    monitor._device_api_encryption = {}
+    # ``apply()`` validates against the configured-devices catalog.
+    from esphome_device_builder.models import Device, DeviceState
+
+    device = Device(
+        name="kitchen",
+        friendly_name="Kitchen",
+        configuration="kitchen.yaml",
+        address="kitchen.local",
+        state=DeviceState.UNKNOWN,
+    )
+    monitor._get_devices = lambda: [device]
+
+    fake_info = MagicMock()
+    fake_info.parsed_scoped_addresses.return_value = []
+    fake_info.decoded_properties = {}
+    monitor._apply_service_info("kitchen", fake_info)
+
+    # ``_on_state_change`` is the bridge our owner registered for
+    # state transitions; the call carries (name, state, source).
+    monitor._on_state_change.assert_called_once_with("kitchen", DeviceState.ONLINE, "mdns")


### PR DESCRIPTION
## Summary

When a new device is added (adopt / wizard create / dropped on disk), the dashboard's card sits at "Unknown" until the next mDNS announcement or ping sweep wanders past — typically tens of seconds, sometimes more for a quiet device. The IP-cache seed in `devices/import` already covers IP, but `version`, `config_hash`, and `api_encryption` come from the `_esphomelib._tcp.local.` TXT records and only land via the browser callback's announcement-driven path.

This adds `DeviceStateMonitor.probe_device(name)`:

- Cache hit (zeroconf already has the service info, common when the device was on the discovery banner moments ago) → applies inline via the same `_apply_service_info` the browser uses. No race, no task.
- Cache miss → fire-and-forget `async_request` task, also feeding `_apply_service_info` once it lands.

Hooked into three entrypoints to cover every "new device on the dashboard" path:

- `devices/import` — after the existing IP-cache seed
- `devices/create` — wizard against a device already on the network
- `_on_scan_change(ADDED)` — catches YAML drops the API path can't see (git clones, copies from another dashboard, manual edits)

## Test plan

- [x] All 356 tests pass (existing + 3 new in `test_probe_device.py` covering cache-hit / cache-miss / no-zeroconf)
- [x] Existing metadata-resolver tests updated to stub `_state_monitor` for the now-required `probe_device` call
- [ ] Adopt a discovered device on a live network → new card lands online with the correct ESPHome version + In-sync config-hash + green lock badge immediately, no "Unknown" intermediate
- [ ] Wizard-create a config matching an already-online device → same
- [ ] `cp` a YAML into the config_dir → next scan picks it up; card lands fully populated within a couple of seconds