### PR TITLE
Stop dropping mDNS state on Device rebuilds; speed up apply_* lookups

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -10,6 +10,7 @@ mtime, size) are used to avoid re-parsing files that haven't changed.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Callable
 from enum import StrEnum
@@ -97,8 +98,16 @@ class DeviceScanner:
         return self._devices
 
     def get_by_name(self, name: str) -> list[Device]:
-        """Every configured device whose ``esphome.name`` equals *name*."""
-        return self._devices_by_name.get(name, [])
+        """Every configured device whose ``esphome.name`` equals *name*.
+
+        Returns a fresh list (snapshot) — same shape as the
+        ``devices`` property. Callers can iterate / mutate the
+        return value without corrupting the scanner's internal
+        index, and the bucket order is the lexicographic
+        configuration-filename order maintained by ``_set_device``.
+        """
+        bucket = self._devices_by_name.get(name)
+        return list(bucket) if bucket else []
 
     async def scan(self) -> None:
         """Refresh the device cache from disk, emitting per-file change events."""
@@ -188,18 +197,34 @@ class DeviceScanner:
             }
 
     def _set_device(self, path: Path, device: Device) -> None:
-        """Insert / update *device* and keep ``_devices_by_name`` in lockstep."""
+        """Insert / update *device* and keep ``_devices_by_name`` in lockstep.
+
+        Buckets are sorted by ``configuration`` filename so
+        ``get_by_name`` (and downstream ``bucket[0]`` consumers like
+        ``_find_device_by_name``) see a deterministic order. Without
+        this, the order depends on ``paths_to_load`` set iteration
+        and can flip between scans, leaking spurious "first match"
+        flips through the apply / dedupe path.
+        """
         previous = self._devices.get(path)
         if previous is not None and previous.name != device.name:
             # Renamed in YAML: drop from old name's bucket before
-            # appending under the new one.
+            # re-inserting under the new one.
             self._unindex_name(previous)
         self._devices[path] = device
         bucket = self._devices_by_name.setdefault(device.name, [])
-        if previous is not None and previous in bucket:
-            bucket[bucket.index(previous)] = device
-        elif device not in bucket:
-            bucket.append(device)
+        if previous is not None:
+            with contextlib.suppress(ValueError):
+                bucket.remove(previous)
+        # Insert at the position that keeps the bucket sorted by
+        # configuration filename.
+        insert_at = 0
+        while insert_at < len(bucket) and bucket[insert_at].configuration < device.configuration:
+            insert_at += 1
+        if insert_at < len(bucket) and bucket[insert_at].configuration == device.configuration:
+            bucket[insert_at] = device  # same path, refreshed Device
+        else:
+            bucket.insert(insert_at, device)
 
     def _pop_device(self, path: Path) -> Device | None:
         """Drop the *path* entry, mirroring the removal in ``_devices_by_name``."""

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -71,6 +71,14 @@ class DeviceScanner:
         self._get_metadata = get_metadata
         self._on_change = on_change
         self._devices: dict[Path, Device] = {}
+        # Name-keyed shadow index; mDNS / ping / MQTT observations
+        # arrive keyed by the device's ``esphome.name`` and need an
+        # O(1) lookup instead of an O(N) linear scan of every
+        # configured YAML on every announcement. The list is by
+        # design — two YAMLs can share a ``name:`` (a config plus a
+        # ``foo (1).yaml`` copy, dashboard_import siblings, etc.)
+        # and a single broadcast must fan out to all of them.
+        self._devices_by_name: dict[str, list[Device]] = {}
         self._cache_keys: dict[Path, _CacheKey] = {}
         self._lock = asyncio.Lock()
 
@@ -87,6 +95,10 @@ class DeviceScanner:
     def by_path(self) -> dict[Path, Device]:
         """Live mapping ``path → Device``. Treat as read-only."""
         return self._devices
+
+    def get_by_name(self, name: str) -> list[Device]:
+        """Every configured device whose ``esphome.name`` equals *name*."""
+        return self._devices_by_name.get(name, [])
 
     async def scan(self) -> None:
         """Refresh the device cache from disk, emitting per-file change events."""
@@ -117,7 +129,7 @@ class DeviceScanner:
             device = loaded.get(path)
             if device is None:
                 return False
-            self._devices[path] = device
+            self._set_device(path, device)
             try:
                 stat = await loop.run_in_executor(None, path.stat)
                 self._cache_keys[path] = (stat.st_ino, stat.st_dev, stat.st_mtime, stat.st_size)
@@ -148,13 +160,13 @@ class DeviceScanner:
         if paths_to_load:
             loaded = await loop.run_in_executor(None, self._load_devices, paths_to_load)
             for path, device in loaded.items():
-                self._devices[path] = device
+                self._set_device(path, device)
                 self._cache_keys[path] = path_to_cache_key[path]
                 kind = ScanChange.ADDED if path in added_paths else ScanChange.UPDATED
                 self._on_change(kind, device)
 
         for path in removed_paths:
-            removed_device: Device | None = self._devices.pop(path, None)  # type: ignore[arg-type]
+            removed_device = self._pop_device(path)
             self._cache_keys.pop(path, None)  # type: ignore[arg-type]
             if removed_device is not None:
                 self._on_change(ScanChange.REMOVED, removed_device)
@@ -166,12 +178,46 @@ class DeviceScanner:
         # comprehension), keeps the ``devices`` property O(n). Filter
         # to paths actually present so a YAML that failed to load
         # (caught + skipped in ``_load_devices``) doesn't trigger a
-        # ``KeyError`` here.
+        # ``KeyError`` here. ``_devices_by_name`` doesn't need a
+        # parallel re-sort — its values are name-keyed lists whose
+        # iteration order isn't user-visible.
         if added_paths or removed_paths:
             self._devices = {p: self._devices[p] for p in path_to_cache_key if p in self._devices}
             self._cache_keys = {
                 p: self._cache_keys[p] for p in path_to_cache_key if p in self._cache_keys
             }
+
+    def _set_device(self, path: Path, device: Device) -> None:
+        """Insert / update *device* and keep ``_devices_by_name`` in lockstep."""
+        previous = self._devices.get(path)
+        if previous is not None and previous.name != device.name:
+            # Renamed in YAML: drop from old name's bucket before
+            # appending under the new one.
+            self._unindex_name(previous)
+        self._devices[path] = device
+        bucket = self._devices_by_name.setdefault(device.name, [])
+        if previous is not None and previous in bucket:
+            bucket[bucket.index(previous)] = device
+        elif device not in bucket:
+            bucket.append(device)
+
+    def _pop_device(self, path: Path) -> Device | None:
+        """Drop the *path* entry, mirroring the removal in ``_devices_by_name``."""
+        device = self._devices.pop(path, None)
+        if device is not None:
+            self._unindex_name(device)
+        return device
+
+    def _unindex_name(self, device: Device) -> None:
+        bucket = self._devices_by_name.get(device.name)
+        if bucket is None:
+            return
+        try:
+            bucket.remove(device)
+        except ValueError:
+            return
+        if not bucket:
+            del self._devices_by_name[device.name]
 
     def _build_cache_keys(self) -> dict[Path, _CacheKey]:
         """Build ``path → cache_key`` for every YAML file currently on disk."""

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -176,13 +176,6 @@ class DeviceStateMonitor:
         self._on_importable_removed = on_importable_removed
         self._is_ignored = is_ignored or (lambda _name: False)
         self._state_source: dict[str, str] = {}  # device name → "mdns" | "ping"
-        self._device_ips: dict[str, str] = {}  # device name → last known IP
-        self._device_versions: dict[str, str] = {}  # device name → last reported version
-        self._device_config_hashes: dict[str, str] = {}  # device name → last reported config hash
-        # Tri-state-able dedupe map: missing key = never seen mDNS for
-        # this device (callback never fires); empty string = seen
-        # plaintext; non-empty = seen encryption with that algorithm.
-        self._device_api_encryption: dict[str, str] = {}
         # ``DashboardImportDiscovery`` is the upstream esphome class
         # that watches the same ``_esphomelib._tcp.local.`` browser for
         # ``package_import_url`` TXT records and turns them into
@@ -289,17 +282,18 @@ class DeviceStateMonitor:
         Record an IP observation. Empty string clears the stored IP.
 
         Returns True when the IP actually changed and the change was
-        forwarded to the callback.
+        forwarded to the callback. Dedupe is done against the
+        configured devices' current ``ip`` field rather than a
+        separate monitor cache so a Device that's been rebuilt with
+        ``previous=None`` (e.g. an atomic save's brief
+        REMOVE+re-ADD scan churn) still gets repopulated by the
+        next mDNS announcement.
         """
-        if self._find_device_by_name(name) is None:
+        devices = [d for d in self._get_devices() if d.name == name]
+        if not devices:
             return False
-        prev = self._device_ips.get(name, "")
-        if prev == ip:
+        if all(d.ip == ip for d in devices):
             return False
-        if ip:
-            self._device_ips[name] = ip
-        else:
-            self._device_ips.pop(name, None)
         self._on_ip_change(name, ip)
         return True
 
@@ -312,11 +306,11 @@ class DeviceStateMonitor:
         """
         if not version or self._on_version_change is None:
             return False
-        if self._find_device_by_name(name) is None:
+        devices = [d for d in self._get_devices() if d.name == name]
+        if not devices:
             return False
-        if self._device_versions.get(name) == version:
+        if all(d.deployed_version == version for d in devices):
             return False
-        self._device_versions[name] = version
         self._on_version_change(name, version)
         return True
 
@@ -328,24 +322,20 @@ class DeviceStateMonitor:
         ``api_encryption`` TXT was absent — i.e. the device is
         running plaintext API. A non-empty value (e.g.
         ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) confirms encryption
-        is active. The "never seen" case is represented by simply not
-        calling this method at all; the device controller treats
-        absence as "trust the YAML".
+        is active. The "never seen" case is represented by the
+        device's ``api_encryption_active`` staying ``None``; the
+        device controller treats that as "trust the YAML".
 
         Returns True when the value actually changed and the change
         was forwarded to the callback.
         """
         if self._on_api_encryption_change is None:
             return False
-        if self._find_device_by_name(name) is None:
+        devices = [d for d in self._get_devices() if d.name == name]
+        if not devices:
             return False
-        # ``""`` is a meaningful state ("seen plaintext") so we have to
-        # distinguish "no entry" from "entry == empty"; ``in`` does
-        # that without confusing it with the truthy-check guard
-        # apply_config_hash uses for its empty-string drop.
-        if name in self._device_api_encryption and self._device_api_encryption[name] == encryption:
+        if all(d.api_encryption_active == encryption for d in devices):
             return False
-        self._device_api_encryption[name] = encryption
         self._on_api_encryption_change(name, encryption)
         return True
 
@@ -360,11 +350,11 @@ class DeviceStateMonitor:
         """
         if not config_hash or self._on_config_hash_change is None:
             return False
-        if self._find_device_by_name(name) is None:
+        devices = [d for d in self._get_devices() if d.name == name]
+        if not devices:
             return False
-        if self._device_config_hashes.get(name) == config_hash:
+        if all(d.deployed_config_hash == config_hash for d in devices):
             return False
-        self._device_config_hashes[name] = config_hash
         self._on_config_hash_change(name, config_hash)
         return True
 

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -165,8 +165,21 @@ class DeviceStateMonitor:
         on_importable_added: ImportableAddedCallback | None = None,
         on_importable_removed: ImportableRemovedCallback | None = None,
         is_ignored: Callable[[str], bool] | None = None,
+        get_devices_by_name: Callable[[str], list[Device]] | None = None,
     ) -> None:
         self._get_devices = get_devices
+        # ``get_devices_by_name`` is the O(1) name-keyed lookup that
+        # the scanner exposes; mDNS / ping / MQTT observations key on
+        # the device's ``esphome.name`` and call the apply-* methods
+        # several times per broadcast, so a linear scan of every
+        # configured YAML on every announcement is the obvious thing
+        # not to do at fleet scale. Falls back to a linear scan when
+        # the caller hasn't wired the index yet (kept so the existing
+        # tests that build a monitor with just ``get_devices`` keep
+        # working without a parallel rewrite).
+        self._get_devices_by_name = get_devices_by_name or (
+            lambda name: [d for d in get_devices() if d.name == name]
+        )
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
         self._on_version_change = on_version_change
@@ -349,16 +362,14 @@ class DeviceStateMonitor:
     def _any_matching_device_differs(self, name: str, attr: str, value: Any) -> bool:
         """Return True iff some configured device named *name* has ``attr != value``.
 
-        Single-pass scan with an early break: short-circuits the
-        moment a stale value is found, so large fleets don't pay
-        for the dedupe check on every mDNS broadcast. Returns False
-        when no device matches *name* (stray announcement) or when
-        every match already carries *value* (steady-state dedupe).
+        Uses the scanner's ``get_devices_by_name`` index for an O(1)
+        name lookup so a 1000-device fleet doesn't pay an O(N) scan
+        on every mDNS broadcast. Short-circuits the moment a stale
+        match is found; returns False when no device matches *name*
+        (stray announcement) or when every match already carries
+        *value* (steady-state dedupe).
         """
-        for device in self._get_devices():
-            if device.name == name and getattr(device, attr) != value:
-                return True
-        return False
+        return any(getattr(device, attr) != value for device in self._get_devices_by_name(name))
 
     def get_cached_addresses(self, host_name: str) -> list[str] | None:
         """
@@ -496,10 +507,8 @@ class DeviceStateMonitor:
     # ------------------------------------------------------------------
 
     def _find_device_by_name(self, name: str) -> Device | None:
-        for device in self._get_devices():
-            if device.name == name:
-                return device
-        return None
+        bucket = self._get_devices_by_name(name)
+        return bucket[0] if bucket else None
 
     async def _start_mdns_browser(self) -> None:
         try:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -258,10 +258,11 @@ class DeviceStateMonitor:
         """
         Record a state observation from *source*.
 
-        Returns True when the observation actually changed the device's
-        state and the change was forwarded to the callback. Sources
-        below the current source's priority are ignored; same-state
-        observations are no-ops.
+        Returns True when the observation actually changed at least
+        one matching device's state and the change was forwarded to
+        the callback. Sources below the current source's priority
+        are ignored; observations where every matching device
+        already carries *state* are no-ops.
 
         ``claim=True`` lets *source* take ownership of the device's
         state slot even when the state is unchanged, so that a
@@ -271,8 +272,8 @@ class DeviceStateMonitor:
         priority check still applies — ``claim`` doesn't let a lower-
         priority source override a higher-priority owner.
         """
-        device = self._find_device_by_name(name)
-        if device is None:
+        devices = self._get_devices_by_name(name)
+        if not devices:
             _LOGGER.debug(
                 "Device %s not in catalog — ignoring %s state from %s", name, state, source
             )
@@ -281,7 +282,13 @@ class DeviceStateMonitor:
         current_source = self._state_source.get(name, "unknown")
         if _SOURCE_PRIORITY.get(source, 0) < _SOURCE_PRIORITY.get(current_source, 0):
             return False
-        if device.state == state:
+        # Dedupe must look at *every* matching device, not just the
+        # first. With duplicate ``esphome.name`` entries (a config
+        # plus a ``foo (1).yaml`` copy, dashboard_import siblings)
+        # one sibling can be in-sync while another was rebuilt with
+        # state=UNKNOWN — the old "first device matches → bail" path
+        # left the stale sibling stuck.
+        if all(d.state == state for d in devices):
             if claim:
                 self._state_source[name] = source
             return False

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -289,10 +289,7 @@ class DeviceStateMonitor:
         REMOVE+re-ADD scan churn) still gets repopulated by the
         next mDNS announcement.
         """
-        devices = [d for d in self._get_devices() if d.name == name]
-        if not devices:
-            return False
-        if all(d.ip == ip for d in devices):
+        if not self._any_matching_device_differs(name, "ip", ip):
             return False
         self._on_ip_change(name, ip)
         return True
@@ -306,10 +303,7 @@ class DeviceStateMonitor:
         """
         if not version or self._on_version_change is None:
             return False
-        devices = [d for d in self._get_devices() if d.name == name]
-        if not devices:
-            return False
-        if all(d.deployed_version == version for d in devices):
+        if not self._any_matching_device_differs(name, "deployed_version", version):
             return False
         self._on_version_change(name, version)
         return True
@@ -331,10 +325,7 @@ class DeviceStateMonitor:
         """
         if self._on_api_encryption_change is None:
             return False
-        devices = [d for d in self._get_devices() if d.name == name]
-        if not devices:
-            return False
-        if all(d.api_encryption_active == encryption for d in devices):
+        if not self._any_matching_device_differs(name, "api_encryption_active", encryption):
             return False
         self._on_api_encryption_change(name, encryption)
         return True
@@ -350,13 +341,24 @@ class DeviceStateMonitor:
         """
         if not config_hash or self._on_config_hash_change is None:
             return False
-        devices = [d for d in self._get_devices() if d.name == name]
-        if not devices:
-            return False
-        if all(d.deployed_config_hash == config_hash for d in devices):
+        if not self._any_matching_device_differs(name, "deployed_config_hash", config_hash):
             return False
         self._on_config_hash_change(name, config_hash)
         return True
+
+    def _any_matching_device_differs(self, name: str, attr: str, value: Any) -> bool:
+        """Return True iff some configured device named *name* has ``attr != value``.
+
+        Single-pass scan with an early break: short-circuits the
+        moment a stale value is found, so large fleets don't pay
+        for the dedupe check on every mDNS broadcast. Returns False
+        when no device matches *name* (stray announcement) or when
+        every match already carries *value* (steady-state dedupe).
+        """
+        for device in self._get_devices():
+            if device.name == name and getattr(device, attr) != value:
+                return True
+        return False
 
     def get_cached_addresses(self, host_name: str) -> list[str] | None:
         """

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -96,6 +96,7 @@ class DevicesController:
         )
         self._state_monitor = DeviceStateMonitor(
             get_devices=self._get_devices,
+            get_devices_by_name=self._scanner.get_by_name,
             on_state_change=self._on_state_change,
             on_ip_change=self._on_ip_change,
             on_version_change=self._on_version_change,
@@ -967,9 +968,10 @@ class DevicesController:
         so any state / IP / version / config-hash / api-encryption
         observation needs to fan out to every matching device or the
         non-canonical copy stays stuck at "Unknown" while its sibling
-        shows online.
+        shows online. Reads the scanner's name-keyed index for an
+        O(1) lookup.
         """
-        return [d for d in self._scanner.devices if d.name == name]
+        return self._scanner.get_by_name(name)
 
     def _on_state_change(self, name: str, state: DeviceState, source: str) -> None:
         """Forward state monitor updates onto the event bus."""

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -486,9 +486,7 @@ def compute_has_pending_changes(
 
     Decision order, first match wins:
 
-    1. No firmware binary on disk yet → pending. Nothing has been
-       compiled, so we definitionally have unflushed edits.
-    2. Both ``expected_config_hash`` and ``deployed_config_hash``
+    1. Both ``expected_config_hash`` and ``deployed_config_hash``
        known → pending iff they differ. The deployed hash comes from
        mDNS (esphome/esphome#16145), the expected hash is read from
        ``build_info.json`` (firmware-canonical, post-codegen). The
@@ -497,9 +495,13 @@ def compute_has_pending_changes(
        firmware is built from the same logical config the YAML now
        resolves to, even if the YAML's mtime ticked forward
        (whitespace-only / comment-only edits, ``--only-generate``
-       rewriting StorageJSON, etc.). If they differ, the device is
-       running older firmware than the latest compile — failed OTA,
-       flashed elsewhere, etc.
+       rewriting StorageJSON, etc.) or the local ``firmware.bin``
+       was wiped (``clean`` job, fresh checkout, ``--only-generate``
+       only). If they differ, the device is running older firmware
+       than the latest compile — failed OTA, flashed elsewhere, etc.
+    2. No firmware binary on disk yet → pending. Nothing has been
+       compiled and the device hasn't broadcast its hash either, so
+       we definitionally have unflushed edits.
     3. YAML edited after the last compile → pending. Mtime is the
        fallback for devices that pre-date the ``config_hash`` TXT
        broadcast or for the brief window between an edit and the
@@ -508,10 +510,10 @@ def compute_has_pending_changes(
     4. Otherwise → not pending. Devices on firmware that predates
        the broadcast and haven't been edited stay quiet.
     """
-    if bin_mtime is None:
-        return True
     if expected_config_hash and deployed_config_hash:
         return expected_config_hash != deployed_config_hash
+    if bin_mtime is None:
+        return True
     return yaml_mtime is not None and yaml_mtime > bin_mtime
 
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -499,9 +499,12 @@ def compute_has_pending_changes(
        was wiped (``clean`` job, fresh checkout, ``--only-generate``
        only). If they differ, the device is running older firmware
        than the latest compile — failed OTA, flashed elsewhere, etc.
-    2. No firmware binary on disk yet → pending. Nothing has been
-       compiled and the device hasn't broadcast its hash either, so
-       we definitionally have unflushed edits.
+    2. Hashes aren't both known and there's no firmware binary on
+       disk yet → pending. We don't have a comparable pair of
+       hashes (either the YAML's never been compiled or the device
+       isn't broadcasting), and we don't even have a local artefact
+       to mtime-check against, so we definitionally have unflushed
+       edits.
     3. YAML edited after the last compile → pending. Mtime is the
        fallback for devices that pre-date the ``config_hash`` TXT
        broadcast or for the brief window between an edit and the

--- a/tests/test_device_scanner_order.py
+++ b/tests/test_device_scanner_order.py
@@ -171,3 +171,167 @@ async def test_failed_load_does_not_break_rebuild(tmp_path: Path, _stub_load_dev
 
     names = [d.name for d in scanner.devices]
     assert names == ["another_good", "good_one"]  # broken silently skipped, rest sorted
+
+
+# ----------------------------------------------------------------------
+# Name-keyed index — used by ``DeviceStateMonitor.apply_*`` for O(1)
+# lookups when an mDNS / ping / MQTT observation arrives. The index
+# has to stay in lockstep with ``_devices`` across add / update /
+# rename / remove or the monitor's dedupe will silently miss devices
+# (or fan out to deleted ones).
+# ----------------------------------------------------------------------
+
+
+async def test_index_returns_added_device(tmp_path: Path) -> None:
+    """A freshly-scanned device is queryable via ``get_by_name``."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    scanner = _make_scanner(cfg)
+    await scanner.scan()
+
+    bucket = scanner.get_by_name("kitchen")
+    assert len(bucket) == 1
+    assert bucket[0].configuration == "kitchen.yaml"
+
+
+async def test_index_drops_removed_device(tmp_path: Path) -> None:
+    """A removed YAML clears its bucket — no zombie entries."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    scanner = _make_scanner(cfg)
+    await scanner.scan()
+    assert scanner.get_by_name("kitchen")
+
+    (cfg / "kitchen.yaml").unlink()
+    await scanner.scan()
+    assert scanner.get_by_name("kitchen") == []
+
+
+async def test_index_handles_yaml_rename(tmp_path: Path, _stub_load_device: Any) -> None:
+    """Editing a YAML's ``esphome.name`` re-buckets it under the new name.
+
+    Without this, mDNS lookups under the new name would miss while
+    the old name's bucket would fan out to a stale Device — the
+    "non-canonical copy stays Unknown" symptom that motivated the
+    fan-out work in the first place.
+    """
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    yaml_path = _write_yaml(cfg, "device_a")
+
+    # First scan: bucket keyed by the YAML's name.
+    name_box = {"current": "kitchen"}
+
+    def _load(path: Path, *_args: object, **_kwargs: object) -> Device:
+        return Device(
+            name=name_box["current"],
+            friendly_name=name_box["current"],
+            configuration=path.name,
+        )
+
+    _stub_load_device.side_effect = _load
+    scanner = _make_scanner(cfg)
+    await scanner.scan()
+    assert [d.configuration for d in scanner.get_by_name("kitchen")] == ["device_a.yaml"]
+
+    # Simulate the user renaming the device's ``esphome.name`` and
+    # touching the file (cache-key change → UPDATED scan).
+    name_box["current"] = "lounge"
+    yaml_path.write_text(yaml_path.read_text() + "# touch\n", encoding="utf-8")
+    await scanner.scan()
+
+    assert scanner.get_by_name("kitchen") == []
+    assert [d.configuration for d in scanner.get_by_name("lounge")] == ["device_a.yaml"]
+
+
+async def test_index_fans_out_to_duplicate_names(tmp_path: Path, _stub_load_device: Any) -> None:
+    """Two YAMLs sharing an ``esphome.name`` end up in the same bucket.
+
+    ``foo (1).yaml`` copies and ``dashboard_import`` siblings can
+    both broadcast under the same name. mDNS broadcasts must fan
+    out to every match, so the bucket has to carry both Devices.
+    """
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    _write_yaml(cfg, "kitchen_copy")
+
+    def _load(path: Path, *_args: object, **_kwargs: object) -> Device:
+        # Force both YAMLs to claim the same ``esphome.name``.
+        return Device(name="kitchen", friendly_name="kitchen", configuration=path.name)
+
+    _stub_load_device.side_effect = _load
+    scanner = _make_scanner(cfg)
+    await scanner.scan()
+
+    bucket = scanner.get_by_name("kitchen")
+    assert sorted(d.configuration for d in bucket) == ["kitchen.yaml", "kitchen_copy.yaml"]
+
+    # Removing one YAML must leave the sibling.
+    (cfg / "kitchen.yaml").unlink()
+    await scanner.scan()
+    bucket = scanner.get_by_name("kitchen")
+    assert [d.configuration for d in bucket] == ["kitchen_copy.yaml"]
+
+
+async def test_get_by_name_returns_a_snapshot(tmp_path: Path, _stub_load_device: Any) -> None:
+    """Mutations to the returned list must not corrupt the scanner's index.
+
+    ``devices`` already returns a fresh list per call; ``get_by_name``
+    matches that semantic so a careless caller (a misguided
+    ``.append()`` or ``.sort()``) can't poison the name index and
+    silently break dedupe / fan-out for the next mDNS announcement.
+    """
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    _stub_load_device.side_effect = lambda path, *_a, **_kw: Device(
+        name="kitchen", friendly_name="kitchen", configuration=path.name
+    )
+    scanner = _make_scanner(cfg)
+    await scanner.scan()
+
+    bucket = scanner.get_by_name("kitchen")
+    bucket.clear()  # caller misbehaves
+    bucket.append(Device(name="kitchen", friendly_name="kitchen", configuration="ghost.yaml"))
+
+    fresh = scanner.get_by_name("kitchen")
+    assert [d.configuration for d in fresh] == ["kitchen.yaml"]
+
+
+async def test_index_bucket_order_is_deterministic(tmp_path: Path, _stub_load_device: Any) -> None:
+    """Buckets with duplicate names must keep a stable ordering across scans.
+
+    ``_find_device_by_name`` returns ``bucket[0]`` and ``apply()``
+    dedupes state against that single device — if the load loop's
+    iteration order is set-derived, "first match" is non-
+    deterministic and dedupe can flip flop between Devices on every
+    scan, leaking spurious state events. Sort by the configuration
+    filename so the bucket order is reproducible.
+    """
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    # Three siblings, intentionally written in non-alphabetical
+    # creation order so any set-iteration shuffling shows up.
+    for name in ("zebra", "alpha", "mike"):
+        _write_yaml(cfg, name)
+    _stub_load_device.side_effect = lambda path, *_a, **_kw: Device(
+        name="duplicate", friendly_name="duplicate", configuration=path.name
+    )
+
+    scanner = _make_scanner(cfg)
+    await scanner.scan()
+    first = [d.configuration for d in scanner.get_by_name("duplicate")]
+
+    # Touch each YAML in a different order — re-runs of ``_load_devices``
+    # must produce the same bucket order regardless.
+    for name in ("alpha", "zebra", "mike"):
+        path = cfg / f"{name}.yaml"
+        path.write_text(path.read_text() + "# touch\n", encoding="utf-8")
+    await scanner.scan()
+
+    second = [d.configuration for d in scanner.get_by_name("duplicate")]
+    assert first == second
+    assert first == sorted(first)  # specifically: lexicographic by configuration

--- a/tests/test_device_state_event.py
+++ b/tests/test_device_state_event.py
@@ -24,6 +24,7 @@ def _make_controller(devices: list[Device]) -> tuple[DevicesController, MagicMoc
     ctrl._db = db  # type: ignore[attr-defined]
     ctrl._scanner = MagicMock()
     ctrl._scanner.devices = devices
+    ctrl._scanner.get_by_name = lambda name, _d=devices: [d for d in _d if d.name == name]
     return ctrl, db
 
 

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -100,7 +100,29 @@ esphome:
 
 
 def test_pending_when_no_binary_yet() -> None:
-    """Never-compiled device → always pending, regardless of mtime/hash inputs."""
+    """No binary AND no broadcast data → pending (definitionally unflushed)."""
+    assert (
+        compute_has_pending_changes(
+            yaml_mtime=100.0,
+            bin_mtime=None,
+            expected_config_hash="",
+            deployed_config_hash="",
+        )
+        is True
+    )
+
+
+def test_in_sync_when_hashes_match_even_without_local_binary() -> None:
+    """Hash match beats missing ``firmware.bin``.
+
+    ``--only-generate`` writes ``build_info.json`` (so
+    ``expected_config_hash`` is set) without producing
+    ``firmware.bin``; same for a build directory that's been wiped
+    by ``clean`` after a flash. If the device is broadcasting the
+    same hash via mDNS, the running firmware was built from this
+    YAML — that's authoritative, regardless of whether we still
+    have the local artefact.
+    """
     assert (
         compute_has_pending_changes(
             yaml_mtime=100.0,
@@ -108,7 +130,7 @@ def test_pending_when_no_binary_yet() -> None:
             expected_config_hash="abc",
             deployed_config_hash="abc",
         )
-        is True
+        is False
     )
 
 

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -630,6 +630,7 @@ def test_on_ip_change_persists_non_empty_value(monkeypatch) -> None:  # type: ig
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_ip_change("kitchen", "10.0.0.1")
 
@@ -653,6 +654,7 @@ def test_on_ip_change_skips_persist_for_empty_value() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_ip_change("kitchen", "")
 

--- a/tests/test_firmware_refresh.py
+++ b/tests/test_firmware_refresh.py
@@ -366,6 +366,7 @@ def _flush_controller(device: Device) -> tuple[Any, list[Any]]:
 
     scanner = MagicMock()
     scanner.devices = [device]
+    scanner.get_by_name = lambda name: [device] if device.name == name else []
 
     state_monitor = MagicMock()
     # Drive the same de-dup behaviour real ``apply_config_hash`` has —

--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -40,7 +40,17 @@ def _device(**overrides: Any) -> Device:
 
 
 def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
-    on_enc = MagicMock()
+    # Mirror production: the controller's callback writes the value
+    # back onto the device. The monitor's dedupe is keyed off the
+    # device's ``api_encryption_active`` so without the side-effect
+    # every repeat call would re-fire (and the empty-string
+    # plaintext state in particular would never settle).
+    def _flip(name: str, encryption: str) -> None:
+        for d in devices:
+            if d.name == name:
+                d.api_encryption_active = encryption
+
+    on_enc = MagicMock(side_effect=_flip)
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
         on_state_change=MagicMock(),

--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -134,6 +134,7 @@ async def test_on_api_encryption_change_updates_device_and_fires_event() -> None
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
 
@@ -158,6 +159,7 @@ async def test_on_api_encryption_change_records_empty_string() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_api_encryption_change("kitchen", "")
 
@@ -175,6 +177,7 @@ async def test_on_api_encryption_change_skips_when_same() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
 
@@ -189,6 +192,7 @@ async def test_on_api_encryption_change_unknown_device_is_noop() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = []
+    controller._scanner.get_by_name = lambda name, _d=[]: [d for d in _d if d.name == name]
 
     controller._on_api_encryption_change("ghost", "anything")
 

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -35,7 +35,16 @@ def _device(**overrides: Any) -> Device:
 
 
 def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
-    on_config_hash = MagicMock()
+    # Mirror production: the controller's callback writes the value
+    # back onto the device. The monitor's dedupe is keyed off the
+    # device's ``deployed_config_hash`` so without the side-effect
+    # every repeat call would re-fire.
+    def _flip(name: str, config_hash: str) -> None:
+        for d in devices:
+            if d.name == name:
+                d.deployed_config_hash = config_hash
+
+    on_config_hash = MagicMock(side_effect=_flip)
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
         on_state_change=MagicMock(),
@@ -86,6 +95,40 @@ def test_apply_config_hash_ignores_empty_string() -> None:
     monitor, cb = _monitor([_device()])
     assert monitor.apply_config_hash("kitchen", "") is False
     cb.assert_not_called()
+
+
+def test_apply_config_hash_refires_after_device_rebuild() -> None:
+    """A rebuilt Device with empty hash gets repopulated by the next mDNS event.
+
+    Atomic-write editors (vscode-on-macOS et al.) can briefly remove
+    the YAML file mid-save, causing the scanner to fire REMOVED then
+    re-ADD with ``previous=None`` — the new Device has
+    ``deployed_config_hash=""`` even though zeroconf still has the
+    same TXT cached. With the old monitor-side dedupe dict, the next
+    mDNS announcement short-circuited because the cache still held
+    the value, leaving the drawer's "Deployed" hash stuck on an
+    em-dash forever (until either a re-flash or a hash change).
+    Deduping against the device's actual field instead means the
+    rebuild's empty value is observable, the next announcement fires
+    again, and the device repopulates.
+    """
+    devices = [_device()]
+    monitor, cb = _monitor(devices)
+
+    # First observation: device populated.
+    monitor.apply_config_hash("kitchen", "1a2b3c4d")
+    assert devices[0].deployed_config_hash == "1a2b3c4d"
+
+    # Simulate a scanner rebuild with previous=None: the new Device
+    # carries no monitor-derived state.
+    devices[0] = _device()
+    assert devices[0].deployed_config_hash == ""
+
+    # Same hash arrives again. The monitor must NOT short-circuit on
+    # the prior observation; the rebuilt device needs the value back.
+    monitor.apply_config_hash("kitchen", "1a2b3c4d")
+    assert devices[0].deployed_config_hash == "1a2b3c4d"
+    assert cb.call_count == 2
 
 
 def test_apply_config_hash_ignores_unknown_device() -> None:

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -171,6 +171,7 @@ async def test_on_config_hash_change_updates_device_and_fires_event() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_config_hash_change("kitchen", "1a2b3c4d")
 
@@ -190,6 +191,7 @@ async def test_on_config_hash_change_skips_when_same() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_config_hash_change("kitchen", "1a2b3c4d")
 
@@ -206,6 +208,7 @@ async def test_on_config_hash_change_unknown_device_is_noop() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = []
+    controller._scanner.get_by_name = lambda name, _d=[]: [d for d in _d if d.name == name]
 
     controller._on_config_hash_change("ghost", "1a2b3c4d")
 
@@ -228,6 +231,7 @@ async def test_on_config_hash_change_flips_pending_when_hashes_diverge() -> None
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_config_hash_change("kitchen", "deadbeef")
 
@@ -251,6 +255,7 @@ async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_config_hash_change("kitchen", "abc12345")
 
@@ -274,6 +279,7 @@ async def test_on_config_hash_change_leaves_pending_alone_without_expected_hash(
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_config_hash_change("kitchen", "deadbeef")
 

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -35,7 +35,17 @@ def _device(**overrides: Any) -> Device:
 
 
 def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
-    on_version = MagicMock()
+    # Mirror production: the controller's callback writes the value
+    # back onto the device. The monitor's dedupe is keyed off the
+    # device's ``deployed_version`` so without the side-effect every
+    # repeat call would re-fire (the dedupe would never observe the
+    # post-callback state).
+    def _flip(name: str, version: str) -> None:
+        for d in devices:
+            if d.name == name:
+                d.deployed_version = version
+
+    on_version = MagicMock(side_effect=_flip)
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
         on_state_change=MagicMock(),

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -209,6 +209,7 @@ async def test_on_version_change_updates_device_and_fires_event(monkeypatch: Any
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
     monkeypatch.setattr(controller, "_persist_storage_version_async", _fake_persist, raising=False)
 
     controller._on_version_change("kitchen", "2026.5.0")
@@ -232,6 +233,7 @@ async def test_on_version_change_skips_when_same(monkeypatch: Any) -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     controller._on_version_change("kitchen", "2026.5.0")
 
@@ -253,6 +255,7 @@ async def test_on_version_change_marks_update_available_when_behind() -> None:
     controller._db = db
     controller._scanner = MagicMock()
     controller._scanner.devices = [device]
+    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
 
     # Simulate mDNS reporting an even older version than the previous
     # deployed_version — the dashboard's installed esphome is newer

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -143,10 +143,6 @@ async def test_apply_service_info_claims_online() -> None:
     monitor._on_config_hash_change = MagicMock()
     monitor._on_api_encryption_change = MagicMock()
     monitor._state_source = {}
-    monitor._device_ips = {}
-    monitor._device_versions = {}
-    monitor._device_config_hashes = {}
-    monitor._device_api_encryption = {}
     # ``apply()`` validates against the configured-devices catalog.
     from esphome_device_builder.models import Device, DeviceState
 

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -154,6 +154,7 @@ async def test_apply_service_info_claims_online() -> None:
         state=DeviceState.UNKNOWN,
     )
     monitor._get_devices = lambda: [device]
+    monitor._get_devices_by_name = lambda name: [device] if device.name == name else []
 
     fake_info = MagicMock()
     fake_info.parsed_scoped_addresses.return_value = []

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -167,3 +167,43 @@ def test_unrelated_devices_are_not_touched() -> None:
     fired = _fired_events(controller)
     assert len(fired) == 1
     assert fired[0][1]["configuration"] == "kitchen.yaml"
+
+
+def test_apply_state_repairs_stale_sibling_when_first_match_is_in_sync() -> None:
+    """``apply()`` must fan out even when ``bucket[0]``'s state already matches.
+
+    With duplicate ``esphome.name`` entries, ``_find_device_by_name``
+    returns whichever device the scanner happens to have first in
+    its bucket. If that one is already ONLINE (e.g. mDNS already
+    flipped it) and a sibling was rebuilt with state=UNKNOWN
+    (atomic-save churn etc.), the old "first device matches → bail"
+    path skipped the fan-out and left the sibling stuck. Verify
+    that ``apply()`` looks at *every* matching device's state and
+    fires the callback when any one of them is stale.
+    """
+    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+
+    primary = _device("kitchen.yaml")
+    primary.state = DeviceState.ONLINE  # already in-sync
+    sibling = _device("kitchen (1).yaml")  # state=UNKNOWN — was rebuilt
+
+    on_state = MagicMock()
+
+    def _flip(name: str, state: DeviceState, _source: str) -> None:
+        for d in (primary, sibling):
+            if d.name == name:
+                d.state = state
+
+    on_state.side_effect = _flip
+
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [primary, sibling],
+        get_devices_by_name=lambda name: [d for d in (primary, sibling) if d.name == name],
+        on_state_change=on_state,
+        on_ip_change=MagicMock(),
+    )
+
+    assert monitor.apply("kitchen", DeviceState.ONLINE, "mdns", claim=True) is True
+    assert primary.state == DeviceState.ONLINE
+    assert sibling.state == DeviceState.ONLINE
+    on_state.assert_called_once_with("kitchen", DeviceState.ONLINE, "mdns")

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -52,6 +52,12 @@ def _make_controller(devices: list[Device]) -> DevicesController:
     controller._db.bus = MagicMock()
     controller._scanner = MagicMock()
     controller._scanner.devices = devices
+    # ``_devices_by_name`` now reads the scanner's name index. Mirror
+    # the same name-keyed grouping the real scanner maintains.
+    by_name: dict[str, list[Device]] = {}
+    for device in devices:
+        by_name.setdefault(device.name, []).append(device)
+    controller._scanner.get_by_name = lambda name: by_name.get(name, [])
     return controller
 
 


### PR DESCRIPTION
## Summary
Three connected fixes for the mDNS state-tracking layer, all surfaced by the same dashboard symptom: *"I saved the YAML, hashes match, but the device still shows Modified / Deployed=—."*

### 1. Dedupe ``apply_*`` against device state, not a separate cache
Atomic-write editors (vscode-on-macOS, etc.) can briefly remove a YAML mid-save; the scanner sees the file disappear, fires ``REMOVED``, then re-``ADDED`` with ``previous=None``. The rebuilt ``Device`` starts fresh (``deployed_config_hash=""``, ``api_encryption_active=None``, …) even though zeroconf still has the same TXT cached. The bug was that ``apply_ip`` / ``apply_version`` / ``apply_config_hash`` / ``apply_api_encryption`` deduped against monitor-side dicts. Those dicts persisted across the rebuild while the ``Device``'s fields had been wiped, so the next mDNS announcement matched the cache and short-circuited — leaving the drawer's "Deployed" hash stuck on an em-dash.

Drop the dicts; compare against the configured devices' actual fields (the same shape ``apply()`` already uses for state). When any matching device's field differs from the broadcast value, fire — the per-device callback already filters no-op devices on its way through. Single-pass scan with an early break in ``_any_matching_device_differs``.

### 2. Hash match beats missing ``firmware.bin`` in ``has_pending_changes``
Even after #1, the dashboard still showed "Modified" when both hashes matched. ``compute_has_pending_changes`` was checking "no binary on disk → pending" *before* the hash comparison, so a device whose deployed and expected hashes both matched still came back pending whenever the local ``firmware.bin`` was absent. That combination is normal:
- ``--only-generate`` writes ``build_info.json`` (giving an ``expected_config_hash``) but doesn't produce ``firmware.bin``.
- A ``clean`` job wipes the build directory after a flash; the device keeps broadcasting its hash but the local artefact is gone.
- A fresh checkout of the user's config_dir from version control has no compile output yet.

When both hashes are known, the comparison is authoritative — the running firmware was built from a config logically equivalent to what the YAML resolves to today, regardless of whether we still have the local artefact. The bin / mtime fallback only matters when one or both hashes are missing.

### 3. Name-keyed scanner index for O(1) ``apply_*`` lookups
Every mDNS broadcast triggers up to four ``apply_*`` calls; each was walking ``self._scanner.devices`` linearly. At fleet scale (~1000 devices, several broadcasts per second across the LAN) that's measurable churn for what is fundamentally a name-keyed lookup. The scanner now maintains ``_devices_by_name: dict[str, list[Device]]`` alongside ``_devices``, exposed via ``get_by_name(name)``. The list values are by design — two YAMLs can share the same ``esphome.name`` (a config plus a ``foo (1).yaml`` copy, ``dashboard_import`` siblings, etc.) and a single broadcast must fan out to every match. Index maintenance is centralised in ``_set_device`` / ``_pop_device`` / ``_unindex_name`` so renames-in-YAML don't leave stale buckets.

## Reproduction (pre-fix)
1. Configure a device whose firmware broadcasts ``config_hash`` (esphome/esphome#16145).
2. Wait for the dashboard to apply the broadcast — drawer's "Deployed" populates.
3. Edit the YAML in vscode (or any editor doing atomic-rename saves) and save.
4. Drawer's "Deployed" config hash flips back to ``—`` and the card stays "Modified" forever.

After this PR: the next mDNS announcement re-populates the rebuilt device, and the "Modified" pill clears as soon as the hashes match.

## Test plan
- [x] ``uv run pytest tests/`` — 360 passed, 3 skipped
- [x] New regression test ``test_apply_config_hash_refires_after_device_rebuild`` exercises the rebuild scenario
- [x] New regression test ``test_in_sync_when_hashes_match_even_without_local_binary`` locks down the priority change
- [x] Test side-effects updated to mirror production (controller callbacks now write the value back onto the device, since the new dedupe relies on that write to settle)