### PR TITLE
Address Copilot review on PR #86 (CLAUDE.md / compare_legacy.md fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,6 @@ toggle in the official ESPHome container and Home Assistant add-on.
   comment (`uses: actions/checkout@<sha>  # v4`) so dependabot can
   bump them while preserving traceability. Org policy.
 - Release flow lives in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#ci--release-pipeline).
-- **Run tests with `uv run pytest`,** not bare `python -m pytest`
-  — the project is `uv`-managed and `uv.lock` is checked in.
 - **CI runs the test matrix on Windows too.** PowerShell is the
   default shell on `windows-latest` and **does not accept
   bash-style `\` line continuations** — multi-line `run:` steps

--- a/compare_legacy.md
+++ b/compare_legacy.md
@@ -17,7 +17,9 @@ legacy code accreted that the rewrite has yet to fully reabsorb.
   visible to users today: `delete` doesn't wipe the per-device build
   directory, the WebSocket has no server-side heartbeat or trusted-
   domain origin allowlist, and there's no equivalent to the legacy
-  `streamer_mode` (logs/validate always show secrets).
+  `streamer_mode` toggle — `devices/validate` unconditionally
+  redacts `!secret` values to `<removed>` with no opt-in to reveal
+  them.
 - mDNS coverage in the new dashboard is broader (HTTP service browser,
   TXT-driven config_hash and api_encryption signals) but the legacy
   dashboard's `no_mdns`/HTTP-only-poll path for `web_server`-only
@@ -29,9 +31,14 @@ legacy code accreted that the rewrite has yet to fully reabsorb.
   porting question — the new dashboard stops pretty bluntly on
   Windows-only edge cases.
 - Auth/session handling is far more thorough than legacy
-  cookie+Basic. The two surviving gaps: legacy supports HA Supervisor
-  password authentication via `/auth` POST (still used by some HA
-  add-on flows); the new backend only delegates auth to ingress.
+  cookie+Basic — the new backend ships a session store, rate
+  limiter, atomic JSON persistence, and Bearer/Basic on the public
+  site. The surviving gap: legacy supports HA Supervisor password
+  authentication via a `/auth` POST (still used by some HA add-on
+  flows for the password-gated public port); the new backend's
+  HA add-on path is ingress-only and has no Supervisor-backed
+  fallback for the public-port + password combination. (See
+  issue #85 — likely a deliberate decline.)
 
 ---
 


### PR DESCRIPTION
## Summary
Three factual corrections from Copilot's post-merge review of #86:

- **`compare_legacy.md` exec summary, secrets line:** said "logs/validate always show secrets" — backwards. The new backend always *redacts* (``<removed>``); the gap is the missing opt-in to reveal them.
- **`compare_legacy.md` exec summary, auth line:** "the new backend only delegates auth to ingress" was wrong — the new backend ships password gate, session store, rate limiter, Bearer/Basic on the public site. The actual gap is the Supervisor-backed fallback for the public-port + password combination on HA add-ons (issue #85, which is a likely deliberate decline).
- **`CLAUDE.md` workflow note:** "Run tests with ``uv run pytest`` … the project is ``uv``-managed and ``uv.lock`` is checked in" — incorrect. ``uv.lock`` isn't tracked and CI installs via ``pip install -e``. Local ``uv`` use is a personal preference, not a project convention; removing the note keeps CLAUDE.md aligned with what new contributors see in CI.

The fourth Copilot comment (absolute paths in the header) was already addressed during PR #86's review cycle.

## Test plan
- [x] ``uv run pytest`` — 367 passed, 3 skipped (no code changes — pure docs)