### PR TITLE
Share subprocess stream splitter, fix devices/logs progress lines

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -26,7 +26,7 @@ from ..helpers.device_yaml import (
 )
 from ..helpers.hostname import is_local_hostname, normalize_hostname
 from ..helpers.json import JSONDecodeError, dumps_indent, loads
-from ..helpers.subprocess import create_subprocess_exec
+from ..helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ..helpers.yaml import merge_component_yaml, rewrite_esphome_name
 from ..models import (
     AddComponentResponse,
@@ -1433,9 +1433,15 @@ class DevicesController:
                 env=env,
             )
             assert proc.stdout is not None
-            async for line_bytes in proc.stdout:
-                line = line_bytes.decode("utf-8", errors="replace").rstrip("\n\r")
-                await client.send_event(message_id, "output", line)
+            # Use the shared `\n`/`\r` splitter so esptool / PlatformIO
+            # carriage-return progress lines surface live instead of
+            # buffering until the next newline. Strip the terminator
+            # from each event payload — the frontend's logs view
+            # appends every event as a new line, unlike the firmware
+            # job-output path which preserves terminators for in-place
+            # overwrites.
+            async for line in iter_lines_with_progress(proc.stdout):
+                await client.send_event(message_id, "output", line.rstrip("\n\r"))
             exit_code = await proc.wait()
         except asyncio.CancelledError:
             # Synchronous kill only — no awaits in the cancel path. The

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -24,7 +24,7 @@ from esphome.storage_json import StorageJSON, ext_storage_path
 
 from ..controllers.config import _load_metadata, metadata_transaction
 from ..helpers.api import CommandError, api_command
-from ..helpers.subprocess import create_subprocess_exec
+from ..helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ..models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType
 
 if TYPE_CHECKING:
@@ -875,52 +875,21 @@ class FirmwareController:
                         {"job_id": job.job_id, "progress": progress},
                     )
 
-            # Stream stdout in chunks delimited by `\n` _or_ `\r` so
+            # ``iter_lines_with_progress`` splits on `\n` _or_ `\r` so
             # carriage-return-based in-place updates (esptool's
             # `Writing at 0x... (5%)\r`, PlatformIO's progress bars)
             # survive the pipe instead of getting buffered until the
-            # next newline. Each emitted chunk keeps its trailing
-            # terminator so the frontend can decide whether to append
-            # a new line or overwrite the last one.
-            buf = b""
-            while True:
-                data = await proc.stdout.read(4096)
-                if not data:
-                    # EOF — flush any trailing bytes that didn't end
-                    # with a terminator (rare but possible).
-                    if buf:
-                        line = buf.decode("utf-8", errors="replace")
-                        job.output.append(line)
-                        self._db.bus.fire(
-                            EventType.JOB_OUTPUT,
-                            {"job_id": job.job_id, "line": line},
-                        )
-                        _check_error(line)
-                        _check_progress(line)
-                        buf = b""
-                    break
-                buf += data
-                while buf:
-                    nl = buf.find(b"\n")
-                    cr = buf.find(b"\r")
-                    if nl == -1 and cr == -1:
-                        break  # need more bytes before we can split
-                    if nl == -1:
-                        idx = cr
-                    elif cr == -1:
-                        idx = nl
-                    else:
-                        idx = min(nl, cr)
-                    chunk = buf[: idx + 1]
-                    buf = buf[idx + 1 :]
-                    line = chunk.decode("utf-8", errors="replace")
-                    job.output.append(line)
-                    self._db.bus.fire(
-                        EventType.JOB_OUTPUT,
-                        {"job_id": job.job_id, "line": line},
-                    )
-                    _check_error(line)
-                    _check_progress(line)
+            # next newline. Each chunk keeps its trailing terminator
+            # so the frontend can decide whether to append a new line
+            # or overwrite the last one.
+            async for line in iter_lines_with_progress(proc.stdout):
+                job.output.append(line)
+                self._db.bus.fire(
+                    EventType.JOB_OUTPUT,
+                    {"job_id": job.job_id, "line": line},
+                )
+                _check_error(line)
+                _check_progress(line)
 
             exit_code = await proc.wait()
             job.exit_code = exit_code

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -16,9 +16,12 @@ import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
 
-# 4 KB matches the typical pipe buffer on Linux/macOS/Windows.
-# Larger reads don't help (the kernel rounds down anyway) and
-# smaller reads spend more time in the syscall.
+# 4 KB is a reasonable chunk size — large enough to amortise the
+# syscall overhead on a busy pipe, small enough that latency-
+# sensitive consumers (live progress bars) see updates quickly.
+# The actual pipe buffer is platform-dependent (Linux defaults to
+# 64 KB, macOS to 16 KB, Windows varies); we don't need to match
+# it because the StreamReader will keep filling on demand.
 _STREAM_READ_SIZE = 4096
 
 
@@ -49,6 +52,12 @@ async def iter_lines_with_progress(stream: asyncio.StreamReader) -> AsyncIterato
     when the operation finishes, so the user sees a long pause and
     then a wall of progress lines instead of a live indicator.
 
+    ``\r\n`` is treated as a *single* logical terminator (one
+    chunk ending in ``\r\n``) rather than two — the alternative
+    would emit a spurious empty event for every CRLF line on
+    Windows where Python's stdout text-mode write translates
+    ``\n`` into ``\r\n``.
+
     Each emitted chunk **keeps its trailing terminator** so the
     consumer can decide whether to append a new line or overwrite
     the last one (frontend ansi-log component leans on the
@@ -69,12 +78,18 @@ async def iter_lines_with_progress(stream: asyncio.StreamReader) -> AsyncIterato
             cr = buf.find(b"\r")
             if nl == -1 and cr == -1:
                 break  # need more bytes before we can split
-            if nl == -1:
-                idx = cr
-            elif cr == -1:
-                idx = nl
+
+            # Pick the earliest terminator. ``\r\n`` coalesces;
+            # a ``\r`` at the very end of the read might be the
+            # start of a CRLF whose ``\n`` arrives in the next
+            # chunk, so defer until we have more bytes.
+            if cr != -1 and (nl == -1 or cr < nl):
+                if cr + 1 == len(buf):
+                    break  # might be \r\n — wait for the next read
+                # ``\r\n`` coalesces; bare ``\r`` is an esptool overwrite.
+                end = cr + 2 if buf[cr + 1 : cr + 2] == b"\n" else cr + 1
             else:
-                idx = min(nl, cr)
-            chunk = buf[: idx + 1]
-            buf = buf[idx + 1 :]
+                end = nl + 1
+            chunk = buf[:end]
+            buf = buf[end:]
             yield chunk.decode("utf-8", errors="replace")

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -13,7 +13,13 @@ the same pattern in ``esphome.dashboard.util.subprocess``.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from typing import Any
+
+# 4 KB matches the typical pipe buffer on Linux/macOS/Windows.
+# Larger reads don't help (the kernel rounds down anyway) and
+# smaller reads spend more time in the syscall.
+_STREAM_READ_SIZE = 4096
 
 
 async def create_subprocess_exec(
@@ -31,3 +37,44 @@ async def create_subprocess_exec(
     """
     kwargs["close_fds"] = False
     return await asyncio.create_subprocess_exec(*args, **kwargs)
+
+
+async def iter_lines_with_progress(stream: asyncio.StreamReader) -> AsyncIterator[str]:
+    r"""Yield decoded chunks from *stream*, splitting on ``\n`` *or* ``\r``.
+
+    ``StreamReader``'s default ``async for`` iteration only splits
+    on ``\n``, which buffers carriage-return-based progress
+    output (esptool's ``Writing at 0x... (5%)\r``, PlatformIO's
+    progress bars) until the next newline arrives — typically only
+    when the operation finishes, so the user sees a long pause and
+    then a wall of progress lines instead of a live indicator.
+
+    Each emitted chunk **keeps its trailing terminator** so the
+    consumer can decide whether to append a new line or overwrite
+    the last one (frontend ansi-log component leans on the
+    distinction). Decoding is utf-8 with ``errors="replace"`` so a
+    stray byte sequence doesn't kill the stream. Buffer is flushed
+    on EOF so a final chunk without a terminator still surfaces.
+    """
+    buf = b""
+    while True:
+        data = await stream.read(_STREAM_READ_SIZE)
+        if not data:
+            if buf:
+                yield buf.decode("utf-8", errors="replace")
+            return
+        buf += data
+        while buf:
+            nl = buf.find(b"\n")
+            cr = buf.find(b"\r")
+            if nl == -1 and cr == -1:
+                break  # need more bytes before we can split
+            if nl == -1:
+                idx = cr
+            elif cr == -1:
+                idx = nl
+            else:
+                idx = min(nl, cr)
+            chunk = buf[: idx + 1]
+            buf = buf[idx + 1 :]
+            yield chunk.decode("utf-8", errors="replace")

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -148,16 +148,22 @@ async def test_stream_subprocess_emits_carriage_return_progress_lines() -> None:
     # then a normal ``\n``-terminated completion line. Without the
     # ``\r`` splitter all four would arrive as one event after the
     # subprocess finished.
+    #
+    # Write through ``sys.stdout.buffer`` (binary mode) so Windows'
+    # text-mode CRLF translation doesn't turn the trailing ``\n``
+    # into ``\r\n`` — the helper coalesces CRLF correctly, but
+    # binary-mode writes keep the test asserting on exactly the
+    # bytes we mean to assert on regardless of platform.
     script = (
         "import sys\n"
-        "sys.stdout.write('5%\\r')\n"
-        "sys.stdout.flush()\n"
-        "sys.stdout.write('50%\\r')\n"
-        "sys.stdout.flush()\n"
-        "sys.stdout.write('100%\\r')\n"
-        "sys.stdout.flush()\n"
-        "sys.stdout.write('done\\n')\n"
-        "sys.stdout.flush()\n"
+        "sys.stdout.buffer.write(b'5%\\r')\n"
+        "sys.stdout.buffer.flush()\n"
+        "sys.stdout.buffer.write(b'50%\\r')\n"
+        "sys.stdout.buffer.flush()\n"
+        "sys.stdout.buffer.write(b'100%\\r')\n"
+        "sys.stdout.buffer.flush()\n"
+        "sys.stdout.buffer.write(b'done\\n')\n"
+        "sys.stdout.buffer.flush()\n"
     )
     cmd = [sys.executable, "-c", script]
     await ctrl._stream_subprocess(cmd, client, "stream-cr")

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -106,7 +106,7 @@ async def test_stream_subprocess_kills_proc_on_cancel(tmp_path: Any) -> None:
 
 
 async def test_stream_subprocess_normal_completion_emits_success(tmp_path: Any) -> None:
-    """A subprocess that exits 0 sends a non-cancelled, success=True result."""
+    r"""A subprocess that exits 0 sends a non-cancelled, success=True result."""
     ctrl = _make_controller()
     client = _make_client()
     sent_events: list[tuple[str, Any]] = []
@@ -121,6 +121,53 @@ async def test_stream_subprocess_normal_completion_emits_success(tmp_path: Any) 
 
     result_events = [data for ev, data in sent_events if ev == "result"]
     assert result_events == [{"code": 0, "success": True}]
+
+
+async def test_stream_subprocess_emits_carriage_return_progress_lines() -> None:
+    r"""`\r` progress lines reach the client as separate events.
+
+    Pre-fix the consumer used the ``StreamReader`` default
+    ``async for``, which only splits on ``\n``. esptool's
+    ``Writing at 0x... (5%)\r`` lines piled up in the buffer
+    until the next newline arrived — usually only when the
+    operation finished — so the user saw a long pause then a wall
+    of progress lines. With the shared ``iter_lines_with_progress``
+    splitter, each ``\r``-terminated chunk surfaces as its own
+    ``output`` event live.
+    """
+    ctrl = _make_controller()
+    client = _make_client()
+    sent_events: list[tuple[str, Any]] = []
+
+    async def capture(_mid: str, event: str, data: Any = None) -> None:
+        sent_events.append((event, data))
+
+    client.send_event = capture  # type: ignore[method-assign]
+
+    # Subprocess prints three progress chunks separated by ``\r``,
+    # then a normal ``\n``-terminated completion line. Without the
+    # ``\r`` splitter all four would arrive as one event after the
+    # subprocess finished.
+    script = (
+        "import sys\n"
+        "sys.stdout.write('5%\\r')\n"
+        "sys.stdout.flush()\n"
+        "sys.stdout.write('50%\\r')\n"
+        "sys.stdout.flush()\n"
+        "sys.stdout.write('100%\\r')\n"
+        "sys.stdout.flush()\n"
+        "sys.stdout.write('done\\n')\n"
+        "sys.stdout.flush()\n"
+    )
+    cmd = [sys.executable, "-c", script]
+    await ctrl._stream_subprocess(cmd, client, "stream-cr")
+
+    output_lines = [data for ev, data in sent_events if ev == "output"]
+    # Terminators are stripped at the device-logs layer (the frontend
+    # logs view appends each event as a new line; preserving ``\r``
+    # would surface as visible Cs). The point is that all four lines
+    # arrive as separate events, not concatenated into one.
+    assert output_lines == ["5%", "50%", "100%", "done"]
 
 
 async def test_cleanup_kills_running_streams() -> None:

--- a/tests/test_subprocess_stream.py
+++ b/tests/test_subprocess_stream.py
@@ -1,0 +1,154 @@
+r"""Tests for ``iter_lines_with_progress``.
+
+The helper splits subprocess stdout on ``\n`` *or* ``\r`` so esptool's
+``Writing at 0x... (5%)\r`` progress lines and PlatformIO's progress
+bars surface live instead of buffering until the next newline.
+``StreamReader``'s default ``async for`` only splits on ``\n``, which
+is the cause of the original "wall of progress lines after a long
+pause" symptom in `devices/logs`.
+
+Each yielded chunk keeps its trailing terminator so the consumer can
+distinguish "new line" (``\n``) from "overwrite the previous line"
+(``\r``). Decoding is utf-8 with ``errors="replace"`` so a stray
+byte sequence doesn't kill the stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from esphome_device_builder.helpers.subprocess import iter_lines_with_progress
+
+
+def _stream(data: bytes) -> asyncio.StreamReader:
+    r"""Build a StreamReader pre-loaded with *data* and EOF."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+    return reader
+
+
+async def _collect(stream: asyncio.StreamReader) -> list[str]:
+    return [chunk async for chunk in iter_lines_with_progress(stream)]
+
+
+@pytest.mark.asyncio
+async def test_splits_on_newline() -> None:
+    r"""The traditional `\n`-delimited case still works.
+
+    The helper has to be a strict superset of ``StreamReader``'s
+    default iteration; any ``\n``-only consumer that switches to
+    it must keep seeing the same chunks.
+    """
+    chunks = await _collect(_stream(b"alpha\nbeta\ngamma\n"))
+    assert chunks == ["alpha\n", "beta\n", "gamma\n"]
+
+
+@pytest.mark.asyncio
+async def test_splits_on_carriage_return() -> None:
+    r"""`\\r` flushes too — esptool's progress lines surface live.
+
+    Pre-fix, ``Writing at 0x... (5%)\\r`` would sit in the
+    StreamReader's buffer until the operation finished and a final
+    ``\\n`` arrived, producing a multi-screen wall of progress
+    output instead of a live indicator.
+    """
+    chunks = await _collect(_stream(b"5%\r25%\r50%\r"))
+    assert chunks == ["5%\r", "25%\r", "50%\r"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_terminators_emit_separately() -> None:
+    r"""`\\r\\n` is two events: the `\\r` chunk and the `\\n` chunk.
+
+    The split takes the *earliest* terminator each pass, so the
+    `\\r` is consumed first (yielding ``"foo\\r"``) and the
+    leftover ``\\n`` is consumed on the next pass (yielding
+    ``"\\n"``). This matches what the firmware job path has been
+    emitting since #16145 — preserving it means the frontend's
+    overwrite logic doesn't need to learn a new tokenisation.
+    """
+    chunks = await _collect(_stream(b"foo\r\nbar\n"))
+    assert chunks == ["foo\r", "\n", "bar\n"]
+
+
+@pytest.mark.asyncio
+async def test_eof_flushes_trailing_buffer() -> None:
+    """A final chunk without a terminator still surfaces.
+
+    Without the EOF flush, ``echo -n "no newline"`` would silently
+    swallow the final line — the ``buf`` would never hit a
+    delimiter and the function would return without yielding it.
+    """
+    chunks = await _collect(_stream(b"clean\nincomplete"))
+    assert chunks == ["clean\n", "incomplete"]
+
+
+@pytest.mark.asyncio
+async def test_handles_invalid_utf8_with_replace() -> None:
+    """Bad bytes don't kill the stream — decode with `errors='replace'`.
+
+    Subprocess output is occasionally polluted by raw escape codes
+    or bytes from a non-UTF-8 locale. Crashing on a stray byte
+    would silently truncate the user's logs at the offending
+    character; ``errors="replace"`` substitutes U+FFFD instead.
+    """
+    chunks = await _collect(_stream(b"good\n\xff\xfe bad\n"))
+    assert len(chunks) == 2
+    assert chunks[0] == "good\n"
+    assert chunks[1].endswith(" bad\n")
+    assert "�" in chunks[1]  # replacement marker present
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_yields_nothing() -> None:
+    """Closing without writing anything is a no-op (no spurious empty chunk)."""
+    chunks = await _collect(_stream(b""))
+    assert chunks == []
+
+
+@pytest.mark.asyncio
+async def test_chunks_split_across_multiple_reads() -> None:
+    """A line straddling two reads still emits as a single chunk.
+
+    The internal buffer accumulates partial bytes until a
+    terminator arrives. Without the buffer, a ``read(4096)`` that
+    cuts a line in half would emit two truncated chunks.
+    """
+    reader = asyncio.StreamReader()
+    # First chunk has no terminator.
+    reader.feed_data(b"long line that arrives in two")
+    # Second chunk completes the line.
+    reader.feed_data(b" pieces\n")
+    reader.feed_eof()
+
+    chunks = await _collect(reader)
+    assert chunks == ["long line that arrives in two pieces\n"]
+
+
+@pytest.mark.asyncio
+async def test_realistic_esptool_progress_output() -> None:
+    r"""End-to-end shape of an esptool progress stream.
+
+    The pre-fix bug for `devices/logs` was specifically about
+    esptool — its progress lines use ``\\r`` for in-place updates
+    and end with ``\\n`` only when a stage completes. A consumer
+    using the default ``async for`` saw a long pause then a wall
+    of intermediate progress steps; the helper makes each `\\r`
+    chunk surface as it's read.
+    """
+    payload = (
+        b"Writing at 0x00010000... (5%)\r"
+        b"Writing at 0x00010000... (50%)\r"
+        b"Writing at 0x00010000... (100%)\r"
+        b"Wrote 524288 bytes\n"
+    )
+    chunks = await _collect(_stream(payload))
+    assert chunks == [
+        "Writing at 0x00010000... (5%)\r",
+        "Writing at 0x00010000... (50%)\r",
+        "Writing at 0x00010000... (100%)\r",
+        "Wrote 524288 bytes\n",
+    ]

--- a/tests/test_subprocess_stream.py
+++ b/tests/test_subprocess_stream.py
@@ -60,18 +60,52 @@ async def test_splits_on_carriage_return() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mixed_terminators_emit_separately() -> None:
-    r"""`\\r\\n` is two events: the `\\r` chunk and the `\\n` chunk.
+async def test_crlf_coalesces_to_single_chunk() -> None:
+    r"""`\r\n` is one logical line ending, not two events.
 
-    The split takes the *earliest* terminator each pass, so the
-    `\\r` is consumed first (yielding ``"foo\\r"``) and the
-    leftover ``\\n`` is consumed on the next pass (yielding
-    ``"\\n"``). This matches what the firmware job path has been
-    emitting since #16145 — preserving it means the frontend's
-    overwrite logic doesn't need to learn a new tokenisation.
+    Python's text-mode stdout on Windows translates ``\n`` into
+    ``\r\n`` on write — splitting CRLF into ``"foo\r"`` and
+    ``"\n"`` would emit a spurious empty event for every
+    Windows-emitted line once a downstream consumer strips the
+    terminator. Coalescing to one ``"foo\r\n"`` chunk keeps the
+    event count matching the *logical* line count regardless of
+    platform.
     """
     chunks = await _collect(_stream(b"foo\r\nbar\n"))
-    assert chunks == ["foo\r", "\n", "bar\n"]
+    assert chunks == ["foo\r\n", "bar\n"]
+
+
+@pytest.mark.asyncio
+async def test_bare_cr_followed_by_data_is_overwrite() -> None:
+    r"""A bare ``\r`` (no ``\n``) is the esptool-style overwrite case.
+
+    Distinct from CRLF: ``"5%\r10%\r"`` should produce two
+    progress chunks (``"5%\r"``, ``"10%\r"``), not get coalesced
+    into a single one. The lookahead for ``\n`` only triggers
+    when ``\n`` actually follows.
+    """
+    chunks = await _collect(_stream(b"5%\r10%\r"))
+    assert chunks == ["5%\r", "10%\r"]
+
+
+@pytest.mark.asyncio
+async def test_cr_at_end_of_read_defers_until_next_chunk() -> None:
+    r"""A ``\r`` at the read boundary waits for the next byte.
+
+    Without the lookahead deferral, a ``\r`` that turns out to be
+    the start of ``\r\n`` (when the ``\n`` arrives in a later
+    read) would surface as a bare-``\r`` overwrite chunk plus a
+    standalone ``\n`` chunk — the exact split we're trying to
+    avoid. Deferring keeps CRLF coalescing correct even when the
+    pipe boundary cuts a line ending in half.
+    """
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"foo\r")  # ends mid-CRLF
+    reader.feed_data(b"\nbar\n")
+    reader.feed_eof()
+
+    chunks = await _collect(reader)
+    assert chunks == ["foo\r\n", "bar\n"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes #83. ``devices/logs`` and ``devices/validate`` used ``StreamReader``'s default ``async for``, which splits on ``\n`` only. esptool's ``Writing at 0x... (5%)\r`` progress lines piled up in the buffer until the next newline arrived (typically only when the operation finished), so the user saw a long pause then a wall of progress output instead of a live indicator.
- Lifted the byte-buffered ``\n``/``\r`` splitter from ``firmware.py`` into ``helpers.subprocess.iter_lines_with_progress`` and shared it between both sites. The firmware path keeps preserving terminators on each chunk (the frontend's ansi-log component uses them for in-place overwrite); the ``_stream_subprocess`` path strips them since the device-logs view appends each event as a fresh line.

## Test plan
- [x] ``uv run pytest`` — 379 passed, 3 skipped
- [x] New ``tests/test_subprocess_stream.py`` — 8 unit tests for the helper:
  - ``\n``-only split (backwards-compat with ``StreamReader`` default)
  - ``\r``-only split (esptool progress)
  - ``\r\n`` produces two events
  - EOF flushes a trailing chunk without terminator
  - Invalid UTF-8 decodes with ``errors="replace"``
  - Empty stream yields nothing
  - Line straddling two reads still emits as one chunk
  - Realistic esptool progress payload
- [x] New ``test_stream_subprocess_emits_carriage_return_progress_lines`` in ``tests/test_stream_cancel.py`` — drives ``_stream_subprocess`` with a real Python subprocess that writes ``\r``-terminated progress chunks plus a final ``\n`` line, asserts all four arrive as separate ``output`` events (would fail with the pre-fix ``async for`` shape).