### PR TITLE
Return INVALID_ARGS for devices/create user errors

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -227,14 +227,11 @@ class DevicesController:
         filename = f"{name}.yaml"
         config_path = self._db.settings.rel_path(filename)
 
-        # Surface user-correctable failures (name collision, unknown
-        # board) as typed ``INVALID_ARGS`` so the wizard can show a
-        # specific message instead of the WS layer's generic
-        # "Command failed" fallback. Mirrors ``import_device`` below.
-        if config_path.exists():
-            msg = f"Configuration {filename} already exists"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
-
+        # Surface user-correctable failures (unknown board, name
+        # collision) as typed ``INVALID_ARGS`` so the wizard can show
+        # a specific message instead of the WS layer's generic
+        # "Command failed" fallback. The collision check happens at
+        # write time below via exclusive-create — see there for why.
         board = None
         if board_id:
             if self._db.boards:
@@ -268,7 +265,19 @@ class DevicesController:
                 board_id = matched.id
 
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, config_path.write_text, yaml_content, "utf-8")
+
+        def _write_exclusive() -> None:
+            # Exclusive-create so a concurrent ``devices/create`` (or
+            # any other writer) can't slip between a preflight check
+            # and the write and silently clobber an in-flight config.
+            with open(config_path, "x", encoding="utf-8") as f:
+                f.write(yaml_content)
+
+        try:
+            await loop.run_in_executor(None, _write_exclusive)
+        except FileExistsError as exc:
+            msg = f"Configuration {filename} already exists"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
 
         def _init_storage() -> None:
             platform = str(board.esphome.platform) if board else parsed_platform

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -222,15 +222,18 @@ class DevicesController:
         """
         name = name.strip()
         if not name:
-            msg = "name is required"
-            raise ValueError(msg)
+            raise CommandError(ErrorCode.INVALID_ARGS, "name is required")
 
         filename = f"{name}.yaml"
         config_path = self._db.settings.rel_path(filename)
 
+        # Surface user-correctable failures (name collision, unknown
+        # board) as typed ``INVALID_ARGS`` so the wizard can show a
+        # specific message instead of the WS layer's generic
+        # "Command failed" fallback. Mirrors ``import_device`` below.
         if config_path.exists():
-            msg = "File already exists"
-            raise FileExistsError(msg)
+            msg = f"Configuration {filename} already exists"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         board = None
         if board_id:
@@ -238,7 +241,7 @@ class DevicesController:
                 board = await self._db.boards.get_board(board_id=board_id)
             if board is None:
                 msg = f"Unknown board: {board_id}"
-                raise ValueError(msg)
+                raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         friendly = friendly_name_slugify(name)
         if file_content:

--- a/tests/test_create_device.py
+++ b/tests/test_create_device.py
@@ -1,0 +1,80 @@
+"""Tests for the ``devices/create`` command path.
+
+Regression coverage for #81: the three user-correctable failures in
+``create_device`` (name collision, empty name, unknown board_id) must
+arrive at the WS dispatcher as ``CommandError(INVALID_ARGS, …)`` so
+the wizard can show a specific message instead of the generic
+``Command failed`` fallback the WS layer emits for any other
+exception.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
+
+
+def _make_controller(tmp_path: Any) -> DevicesController:
+    """Stand up a controller without booting the full DeviceBuilder."""
+    ctrl = DevicesController.__new__(DevicesController)
+    ctrl._db = MagicMock()
+    ctrl._db.settings.rel_path = lambda name: tmp_path / name
+    # ``_db.boards`` is truthy in production; tests that exercise the
+    # board lookup override ``get_board`` with an ``AsyncMock``.
+    ctrl._db.boards = MagicMock()
+    ctrl._scanner = MagicMock()
+    ctrl._scanner.scan = AsyncMock()
+    ctrl._state_monitor = MagicMock()
+    return ctrl
+
+
+async def test_create_device_translates_file_exists_to_command_error(
+    tmp_path: Any,
+) -> None:
+    """Re-creating an existing config raises ``INVALID_ARGS``, not ``INTERNAL_ERROR``.
+
+    Without the typed error, the WS dispatcher falls back to a generic
+    "Command failed" and the wizard can't tell the user the name is
+    already taken — they just see a 500-equivalent.
+    """
+    ctrl = _make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", "utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "kitchen.yaml already exists" in excinfo.value.message
+    # Nothing should hit the scanner when the pre-flight check fails.
+    ctrl._scanner.scan.assert_not_called()
+
+
+async def test_create_device_rejects_empty_name(tmp_path: Any) -> None:
+    """Whitespace-only names produce ``INVALID_ARGS`` instead of a bare ``ValueError``."""
+    ctrl = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="   ")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "name is required" in excinfo.value.message
+    ctrl._scanner.scan.assert_not_called()
+
+
+async def test_create_device_rejects_unknown_board_id(tmp_path: Any) -> None:
+    """An unknown ``board_id`` produces ``INVALID_ARGS`` and names the bad id."""
+    ctrl = _make_controller(tmp_path)
+    ctrl._db.boards.get_board = AsyncMock(return_value=None)
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen", board_id="bogus-board")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "bogus-board" in excinfo.value.message
+    ctrl._scanner.scan.assert_not_called()

--- a/tests/test_create_device.py
+++ b/tests/test_create_device.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from esphome_device_builder.controllers import devices as devices_module
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
@@ -78,3 +79,26 @@ async def test_create_device_rejects_unknown_board_id(tmp_path: Any) -> None:
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "bogus-board" in excinfo.value.message
     ctrl._scanner.scan.assert_not_called()
+
+
+async def test_create_device_writes_stub_yaml_and_scans(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path with no board / no file_content: stub YAML lands on disk and scan fires."""
+    storage_path = tmp_path / "storage.json"
+    monkeypatch.setattr(devices_module, "ext_storage_path", lambda _filename: storage_path)
+    monkeypatch.setattr(devices_module, "set_device_metadata", lambda *args, **kwargs: None)
+    ctrl = _make_controller(tmp_path)
+    # Catalog lookups must return ``None`` so the derive-from-yaml
+    # branch leaves ``board`` unset; otherwise ``StorageJSON``'s
+    # ``target_platform`` would receive a ``MagicMock``.
+    ctrl._db.boards.find_by_pio_board = MagicMock(return_value=None)
+    ctrl._db.boards.find_by_platform_variant = MagicMock(return_value=None)
+
+    result = await ctrl.create_device(name="kitchen")
+
+    assert result.configuration == "kitchen.yaml"
+    yaml_path = tmp_path / "kitchen.yaml"
+    assert yaml_path.read_text("utf-8").startswith("esphome:\n  name: kitchen\n")
+    assert storage_path.exists()
+    ctrl._scanner.scan.assert_awaited_once()


### PR DESCRIPTION
## Problem

`devices/create` raised bare `FileExistsError` / `ValueError` for the three user-correctable failures (name collision, empty name, unknown `board_id`). The WS dispatcher in `api/ws.py` only forwards `CommandError` as a typed code — anything else becomes a generic `INTERNAL_ERROR`, so the wizard can't tell the user *why* it failed and just shows "Command failed".

`import_device` already gets this right; mirror that pattern.

## Changes

- `controllers/devices.py` — wrap the three raises in `create_device` with `CommandError(ErrorCode.INVALID_ARGS, …)`; reuse the `"Configuration <file> already exists"` phrasing from `import_device` for consistency.
- `tests/test_create_device.py` — new file, three regression tests (name collision, empty name, unknown `board_id`) modelled on `test_import_device.py`.

Closes #81