### PR TITLE
Split devices/logs on \r so esptool progress lines flush live

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -26,6 +26,7 @@ from ..helpers.device_yaml import (
 )
 from ..helpers.hostname import is_local_hostname, normalize_hostname
 from ..helpers.json import JSONDecodeError, dumps_indent, loads
+from ..helpers.stream import iter_lines
 from ..helpers.subprocess import create_subprocess_exec
 from ..helpers.yaml import merge_component_yaml, rewrite_esphome_name
 from ..models import (
@@ -1452,8 +1453,8 @@ class DevicesController:
                 env=env,
             )
             assert proc.stdout is not None
-            async for line_bytes in proc.stdout:
-                line = line_bytes.decode("utf-8", errors="replace").rstrip("\n\r")
+            async for chunk in iter_lines(proc.stdout):
+                line = chunk.rstrip("\n\r")
                 await client.send_event(message_id, "output", line)
             exit_code = await proc.wait()
         except asyncio.CancelledError:

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -24,6 +24,7 @@ from esphome.storage_json import StorageJSON, ext_storage_path
 
 from ..controllers.config import _load_metadata, metadata_transaction
 from ..helpers.api import CommandError, api_command
+from ..helpers.stream import iter_lines
 from ..helpers.subprocess import create_subprocess_exec
 from ..models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType
 
@@ -875,52 +876,14 @@ class FirmwareController:
                         {"job_id": job.job_id, "progress": progress},
                     )
 
-            # Stream stdout in chunks delimited by `\n` _or_ `\r` so
-            # carriage-return-based in-place updates (esptool's
-            # `Writing at 0x... (5%)\r`, PlatformIO's progress bars)
-            # survive the pipe instead of getting buffered until the
-            # next newline. Each emitted chunk keeps its trailing
-            # terminator so the frontend can decide whether to append
-            # a new line or overwrite the last one.
-            buf = b""
-            while True:
-                data = await proc.stdout.read(4096)
-                if not data:
-                    # EOF — flush any trailing bytes that didn't end
-                    # with a terminator (rare but possible).
-                    if buf:
-                        line = buf.decode("utf-8", errors="replace")
-                        job.output.append(line)
-                        self._db.bus.fire(
-                            EventType.JOB_OUTPUT,
-                            {"job_id": job.job_id, "line": line},
-                        )
-                        _check_error(line)
-                        _check_progress(line)
-                        buf = b""
-                    break
-                buf += data
-                while buf:
-                    nl = buf.find(b"\n")
-                    cr = buf.find(b"\r")
-                    if nl == -1 and cr == -1:
-                        break  # need more bytes before we can split
-                    if nl == -1:
-                        idx = cr
-                    elif cr == -1:
-                        idx = nl
-                    else:
-                        idx = min(nl, cr)
-                    chunk = buf[: idx + 1]
-                    buf = buf[idx + 1 :]
-                    line = chunk.decode("utf-8", errors="replace")
-                    job.output.append(line)
-                    self._db.bus.fire(
-                        EventType.JOB_OUTPUT,
-                        {"job_id": job.job_id, "line": line},
-                    )
-                    _check_error(line)
-                    _check_progress(line)
+            async for line in iter_lines(proc.stdout):
+                job.output.append(line)
+                self._db.bus.fire(
+                    EventType.JOB_OUTPUT,
+                    {"job_id": job.job_id, "line": line},
+                )
+                _check_error(line)
+                _check_progress(line)
 
             exit_code = await proc.wait()
             job.exit_code = exit_code

--- a/esphome_device_builder/helpers/stream.py
+++ b/esphome_device_builder/helpers/stream.py
@@ -22,7 +22,9 @@ async def iter_lines(
     newline; the default ``async for line in reader`` only splits on
     ``\n`` and leaves them piling up. Each emitted chunk keeps its
     trailing terminator so the consumer can decide whether to append a
-    new line or overwrite the last one.
+    new line or overwrite the last one. ``\r\n`` is treated as a
+    single terminator so Windows-style line endings don't produce
+    spurious empty chunks.
 
     Bytes are decoded as UTF-8 with ``errors="replace"``. Trailing
     bytes that arrive without a terminator are flushed at EOF.
@@ -46,6 +48,13 @@ async def iter_lines(
                 idx = nl
             else:
                 idx = min(nl, cr)
-            chunk = buf[: idx + 1]
-            buf = buf[idx + 1 :]
+            # If ``\r`` is the last byte we've seen, defer — the next
+            # read may bring a ``\n`` we want to coalesce with it.
+            if buf[idx] == 0x0D and idx == len(buf) - 1:
+                break
+            end = idx + 1
+            if buf[idx] == 0x0D and idx + 1 < len(buf) and buf[idx + 1] == 0x0A:
+                end = idx + 2
+            chunk = buf[:end]
+            buf = buf[end:]
             yield chunk.decode("utf-8", errors="replace")

--- a/esphome_device_builder/helpers/stream.py
+++ b/esphome_device_builder/helpers/stream.py
@@ -1,0 +1,51 @@
+"""Helpers for consuming subprocess output streams."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+_DEFAULT_CHUNK_SIZE = 4096
+
+
+async def iter_lines(
+    reader: asyncio.StreamReader,
+    *,
+    chunk_size: int = _DEFAULT_CHUNK_SIZE,
+) -> AsyncIterator[str]:
+    r"""
+    Yield decoded chunks from *reader*, split on ``\n`` _or_ ``\r``.
+
+    Carriage-return-based in-place updates (esptool's
+    ``Writing at 0x... (5%)\r``, PlatformIO's progress bars) need to
+    survive the pipe instead of getting buffered until the next
+    newline; the default ``async for line in reader`` only splits on
+    ``\n`` and leaves them piling up. Each emitted chunk keeps its
+    trailing terminator so the consumer can decide whether to append a
+    new line or overwrite the last one.
+
+    Bytes are decoded as UTF-8 with ``errors="replace"``. Trailing
+    bytes that arrive without a terminator are flushed at EOF.
+    """
+    buf = b""
+    while True:
+        data = await reader.read(chunk_size)
+        if not data:
+            if buf:
+                yield buf.decode("utf-8", errors="replace")
+            return
+        buf += data
+        while buf:
+            nl = buf.find(b"\n")
+            cr = buf.find(b"\r")
+            if nl == -1 and cr == -1:
+                break  # need more bytes before we can split
+            if nl == -1:
+                idx = cr
+            elif cr == -1:
+                idx = nl
+            else:
+                idx = min(nl, cr)
+            chunk = buf[: idx + 1]
+            buf = buf[idx + 1 :]
+            yield chunk.decode("utf-8", errors="replace")

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,0 +1,82 @@
+"""Tests for the stream-line helper."""
+
+from __future__ import annotations
+
+import asyncio
+
+from esphome_device_builder.helpers.stream import iter_lines
+
+
+def _reader_from(*chunks: bytes) -> asyncio.StreamReader:
+    """Build a ``StreamReader`` pre-fed with *chunks* and EOF."""
+    reader = asyncio.StreamReader()
+    for chunk in chunks:
+        reader.feed_data(chunk)
+    reader.feed_eof()
+    return reader
+
+
+async def _collect(reader: asyncio.StreamReader) -> list[str]:
+    return [line async for line in iter_lines(reader)]
+
+
+async def test_carriage_return_progress_chunks_flush_separately() -> None:
+    r"""The exact case from issue #83 — three ``\r`` chunks must surface independently."""
+    reader = _reader_from(b"chunk1\rchunk2\rchunk3\n")
+    assert await _collect(reader) == ["chunk1\r", "chunk2\r", "chunk3\n"]
+
+
+async def test_mixed_newline_and_carriage_return() -> None:
+    reader = _reader_from(b"a\nb\rc\n")
+    assert await _collect(reader) == ["a\n", "b\r", "c\n"]
+
+
+async def test_crlf_pair_yields_two_chunks() -> None:
+    r"""``\r\n`` splits on the ``\r`` first, leaving an empty ``\n`` chunk.
+
+    Documents the helper's actual behaviour — coalescing CRLF would
+    require lookahead and isn't needed for the firmware/esptool path
+    (which only emits bare ``\r`` for in-place progress and bare ``\n``
+    for new lines).
+    """
+    reader = _reader_from(b"line\r\n")
+    assert await _collect(reader) == ["line\r", "\n"]
+
+
+async def test_trailing_bytes_without_terminator_are_flushed_at_eof() -> None:
+    reader = _reader_from(b"trailing")
+    assert await _collect(reader) == ["trailing"]
+
+
+async def test_empty_stream_yields_nothing() -> None:
+    reader = _reader_from()
+    assert await _collect(reader) == []
+
+
+async def test_invalid_utf8_is_replaced() -> None:
+    reader = _reader_from(b"x\xe9y\n")
+    chunks = await _collect(reader)
+    assert chunks == ["x�y\n"]
+
+
+async def test_split_across_reads_buffers_correctly() -> None:
+    """Terminator detection still works when a line straddles two reads."""
+    reader = asyncio.StreamReader()
+
+    async def feed() -> None:
+        reader.feed_data(b"par")
+        await asyncio.sleep(0)
+        reader.feed_data(b"tial\nsecond\n")
+        reader.feed_eof()
+
+    feeder = asyncio.create_task(feed())
+    chunks = await _collect(reader)
+    await feeder
+    assert chunks == ["partial\n", "second\n"]
+
+
+async def test_chunk_size_smaller_than_line_still_works() -> None:
+    """Small ``chunk_size`` exercises the cross-read buffer path on every byte."""
+    reader = _reader_from(b"abcdef\nxyz\r")
+    collected = [line async for line in iter_lines(reader, chunk_size=2)]
+    assert collected == ["abcdef\n", "xyz\r"]

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -31,16 +31,42 @@ async def test_mixed_newline_and_carriage_return() -> None:
     assert await _collect(reader) == ["a\n", "b\r", "c\n"]
 
 
-async def test_crlf_pair_yields_two_chunks() -> None:
-    r"""``\r\n`` splits on the ``\r`` first, leaving an empty ``\n`` chunk.
+async def test_crlf_pair_coalesces_into_single_chunk() -> None:
+    r"""``\r\n`` (Windows line endings) must surface as one chunk, not two.
 
-    Documents the helper's actual behaviour — coalescing CRLF would
-    require lookahead and isn't needed for the firmware/esptool path
-    (which only emits bare ``\r`` for in-place progress and bare ``\n``
-    for new lines).
+    Without coalescing, ``rstrip("\n\r")`` callers would emit a spurious
+    empty event for every line on Windows.
     """
     reader = _reader_from(b"line\r\n")
-    assert await _collect(reader) == ["line\r", "\n"]
+    assert await _collect(reader) == ["line\r\n"]
+
+
+async def test_crlf_split_across_reads_still_coalesces() -> None:
+    r"""When ``\r`` and ``\n`` arrive in separate reads, still coalesce them."""
+    reader = asyncio.StreamReader()
+
+    async def feed() -> None:
+        reader.feed_data(b"alpha\r")
+        await asyncio.sleep(0)
+        reader.feed_data(b"\nbeta\r\n")
+        reader.feed_eof()
+
+    feeder = asyncio.create_task(feed())
+    chunks = await _collect(reader)
+    await feeder
+    assert chunks == ["alpha\r\n", "beta\r\n"]
+
+
+async def test_lone_carriage_return_at_eof_is_flushed() -> None:
+    r"""A trailing ``\r`` with no following ``\n`` (and EOF) flushes as-is."""
+    reader = _reader_from(b"progress\r")
+    assert await _collect(reader) == ["progress\r"]
+
+
+async def test_carriage_return_followed_by_non_newline_does_not_coalesce() -> None:
+    r"""``\r`` followed by a regular byte stays a standalone terminator."""
+    reader = _reader_from(b"a\rb\n")
+    assert await _collect(reader) == ["a\r", "b\n"]
 
 
 async def test_trailing_bytes_without_terminator_are_flushed_at_eof() -> None:


### PR DESCRIPTION
`devices/logs` reads subprocess output with `async for line_bytes in proc.stdout`, which only splits on `\n`. esptool emits progress lines terminated by `\r` (`Writing at 0x... (50 %)\r`); they piled up in the pipe buffer until the next newline arrived, so users saw a long pause and then a wall of progress lines instead of a live indicator. The firmware compile/upload path already handled this correctly with a manual byte-scan; the two streamers had diverged.

- New `helpers/stream.py` with an `iter_lines` async generator that splits on `\n` or `\r` (whichever comes first) and preserves the trailing terminator.
- `controllers/firmware.py` uses the helper instead of its own buffer + dual-find loop.
- `controllers/devices.py` `_stream_subprocess` uses the helper too; `rstrip("\n\r")` is kept so the WS payload format stays unchanged.
- `tests/test_stream_helper.py` covers the issue's repro, mixed terminators, CRLF, EOF without terminator, invalid UTF-8, and cross-read buffering.

Closes #83