### PR TITLE
Add mDNS hostname-resolve fallback for non-API devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,25 +159,36 @@ as a working document) and check the open issue list filtered to
   immediately instead of waiting on the rebooted device's mDNS
   announce. If the OTA actually failed silently, the next real
   announce pushes the truth back through the same callback.
-- **Trust mDNS for ONLINE; never claim OFFLINE from a resolve
-  miss.** The non-API resolve fallback
-  (`_resolve_non_api_mdns_targets`) issues an active mDNS
-  A-record query each sweep for devices whose
-  `loaded_integrations` lacks `api`. A hit claims ONLINE under
-  the `mdns` source (priority 3, locks out ICMP) — we want to
-  keep ping / DNS traffic to a minimum on fleets that broadcast,
-  and once mDNS has answered, ICMP is just redundant noise. A
-  miss is **silent on purpose**: it isn't strong enough evidence
-  to flip the indicator red (transient broadcast pauses, slow
-  devices, flaky networks), and claiming OFFLINE under `mdns`
-  would lock out the ICMP fallback forever for any device that
-  ever went quiet. So: hit upgrades, miss does nothing, ICMP
-  decides OFFLINE. The corollary trade-off is that a device
-  which *does* go permanently offline after mDNS first claimed
-  it stays ONLINE in the dashboard until something else
-  contradicts the claim — that's deliberate; the alternative
-  (downgrading on miss) was rejected because quiet-device
-  flapping is far more common than permanent silent disappearance.
+- **Two mDNS paths with different OFFLINE semantics.** The
+  monitor has two distinct mDNS data sources, and they trust
+  the protocol differently:
+
+  - **Browser callback** (`_on_service_state_change`) —
+    passively subscribed to `_esphomelib._tcp.local.`.
+    Trust mDNS in **both directions**: the
+    `AsyncServiceBrowser` delivers a `Removed` event when a
+    cached record's TTL expires without renewal, which is the
+    canonical "device gone" signal. ONLINE → mdns, OFFLINE →
+    mdns, no ICMP needed.
+
+  - **One-off active resolve** (`_resolve_non_api_mdns_targets`,
+    used for non-API devices that don't broadcast on
+    `_esphomelib._tcp.local.`). Trust mDNS for **ONLINE only**.
+    A hit claims ONLINE under `mdns` (priority 3, locks out
+    ICMP) — once mDNS has answered, repeat-pinging is just
+    redundant noise we want to avoid on broadcast-capable
+    fleets. A miss is **deliberately silent**: a single active
+    query that didn't reply in time conflates "device gone",
+    "device slow", and "transient packet loss" — there's no
+    subscription delivering TTL-expiry events here, so we can't
+    tell them apart. Wait for the ICMP sweep that follows in
+    the same loop to decide OFFLINE.
+
+  Don't add an OFFLINE branch to the active-resolve path
+  without re-reading this. The asymmetry isn't an oversight —
+  it's the only way to get aggressive ONLINE detection without
+  flipping the indicator red on every quiet device or dropped
+  reply.
 - **The `Device` is the source of truth, not the monitor.**
   `DeviceStateMonitor.apply_*` (state, ip, version, config_hash,
   api_encryption) all dedupe by comparing the broadcast value

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,25 @@ as a working document) and check the open issue list filtered to
   immediately instead of waiting on the rebooted device's mDNS
   announce. If the OTA actually failed silently, the next real
   announce pushes the truth back through the same callback.
+- **Trust mDNS for ONLINE; never claim OFFLINE from a resolve
+  miss.** The non-API resolve fallback
+  (`_resolve_non_api_mdns_targets`) issues an active mDNS
+  A-record query each sweep for devices whose
+  `loaded_integrations` lacks `api`. A hit claims ONLINE under
+  the `mdns` source (priority 3, locks out ICMP) — we want to
+  keep ping / DNS traffic to a minimum on fleets that broadcast,
+  and once mDNS has answered, ICMP is just redundant noise. A
+  miss is **silent on purpose**: it isn't strong enough evidence
+  to flip the indicator red (transient broadcast pauses, slow
+  devices, flaky networks), and claiming OFFLINE under `mdns`
+  would lock out the ICMP fallback forever for any device that
+  ever went quiet. So: hit upgrades, miss does nothing, ICMP
+  decides OFFLINE. The corollary trade-off is that a device
+  which *does* go permanently offline after mDNS first claimed
+  it stays ONLINE in the dashboard until something else
+  contradicts the claim — that's deliberate; the alternative
+  (downgrading on miss) was rejected because quiet-device
+  flapping is far more common than permanent silent disappearance.
 - **The `Device` is the source of truth, not the monitor.**
   `DeviceStateMonitor.apply_*` (state, ip, version, config_hash,
   api_encryption) all dedupe by comparing the broadcast value

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -64,10 +64,11 @@ _PING_BOOTSTRAP_DELAY = 10  # seconds before the first ping sweep
 _PING_BATCH_SIZE = 24
 _MDNS_RESOLVE_TIMEOUT_MS = 2000
 # Timeout for the per-sweep mDNS hostname resolves we issue for
-# non-API devices. 2s is enough on a working LAN and keeps the
-# whole resolve pass under the ping interval even if every target
-# misses the cache and has to round-trip on the network.
-_MDNS_HOSTNAME_RESOLVE_TIMEOUT = 2.0
+# non-API devices. 3s is enough on a working LAN even when the
+# device is briefly slow to respond, and keeps the whole resolve
+# pass under the ping interval even if every target misses the
+# cache and has to round-trip on the network.
+_MDNS_HOSTNAME_RESOLVE_TIMEOUT = 3.0
 
 # Source priority for state observations. A new observation can only
 # override an existing one when its priority is greater than or equal
@@ -862,18 +863,25 @@ class DeviceStateMonitor:
         )
         for device, addresses in zip(candidates, results, strict=True):
             if isinstance(addresses, list) and addresses:
-                # mDNS owns the slot once we've heard from the
-                # device. ``claim=True`` so a later ping observation
-                # can't downgrade the source if the addresses
-                # subsequently disappear from cache.
+                # Trust mDNS for ONLINE — the active A-record query
+                # answered, so the device is live on this LAN. Claim
+                # under the ``mdns`` source (priority 3) so the
+                # subsequent ICMP sweep skips this device entirely.
+                # Keeping ping / DNS traffic to a minimum for
+                # fleets that broadcast is a deliberate trade-off:
+                # we want mDNS to be the single source of truth for
+                # devices that respond to it.
                 self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
                 self.apply_ip(device.name, _pick_ipv4(addresses))
-            # No OFFLINE branch — let the ICMP sweep below decide.
-            # An mDNS resolve miss in isolation isn't enough signal:
-            # the device might just not be advertising right this
-            # moment. ``apply(OFFLINE, "ping")`` will still fire if
-            # ICMP also fails, and the source-priority guard means
-            # an mDNS hit later in the run can still upgrade it.
+            # No OFFLINE branch — by design. A miss in isolation is
+            # not enough signal to flip the indicator red, and
+            # claiming OFFLINE under ``mdns`` would lock out the
+            # ICMP fallback for devices on networks where mDNS is
+            # flaky. The next sweep's resolve will pick the device
+            # back up if it returns; if mDNS stays silent for an
+            # extended period, ICMP (still allowed by the
+            # source-priority guard until mDNS first claims) is the
+            # path that decides OFFLINE.
 
     async def _ping_sweep(self) -> None:
         if icmp_ping is None:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -873,15 +873,19 @@ class DeviceStateMonitor:
                 # devices that respond to it.
                 self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
                 self.apply_ip(device.name, _pick_ipv4(addresses))
-            # No OFFLINE branch — by design. A miss in isolation is
-            # not enough signal to flip the indicator red, and
-            # claiming OFFLINE under ``mdns`` would lock out the
-            # ICMP fallback for devices on networks where mDNS is
-            # flaky. The next sweep's resolve will pick the device
-            # back up if it returns; if mDNS stays silent for an
-            # extended period, ICMP (still allowed by the
-            # source-priority guard until mDNS first claims) is the
-            # path that decides OFFLINE.
+            # No OFFLINE branch — deliberate. The browser path can
+            # trust mDNS in both directions because the
+            # ServiceBrowser delivers a ``Removed`` event when a
+            # cached record's TTL expires without renewal; that's
+            # the canonical "I'm gone" signal. The one-off active
+            # resolve we run here has no such subscription — a
+            # miss is just "this single query didn't get a reply
+            # in time", which conflates "device gone", "device
+            # slow", and "transient packet loss". Falling back to
+            # ICMP for the OFFLINE decision in this path is the
+            # right shape: an mDNS hit upgrades to mDNS-owned
+            # ONLINE; a miss leaves the source slot at whatever
+            # ping last claimed (or unknown), and ping decides.
 
     async def _ping_sweep(self) -> None:
         if icmp_ping is None:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -63,6 +63,11 @@ _PING_BOOTSTRAP_DELAY = 10  # seconds before the first ping sweep
 # stacking N timeouts back-to-back.
 _PING_BATCH_SIZE = 24
 _MDNS_RESOLVE_TIMEOUT_MS = 2000
+# Timeout for the per-sweep mDNS hostname resolves we issue for
+# non-API devices. 2s is enough on a working LAN and keeps the
+# whole resolve pass under the ping interval even if every target
+# misses the cache and has to round-trip on the network.
+_MDNS_HOSTNAME_RESOLVE_TIMEOUT = 2.0
 
 # Source priority for state observations. A new observation can only
 # override an existing one when its priority is greater than or equal
@@ -806,12 +811,69 @@ class DeviceStateMonitor:
         # startup instead of after a full minute.
         try:
             await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
+            await self._resolve_non_api_mdns_targets()
             await self._ping_sweep()
             while True:
                 await asyncio.sleep(_PING_INTERVAL)
+                await self._resolve_non_api_mdns_targets()
                 await self._ping_sweep()
         except asyncio.CancelledError:
             pass
+
+    async def _resolve_non_api_mdns_targets(self) -> None:
+        """Actively resolve ``.local`` hostnames for non-API devices.
+
+        Devices whose YAML doesn't load the ``api`` integration
+        (web_server-only, MQTT-only, OTA-only configs) never
+        broadcast on ``_esphomelib._tcp.local.`` so the browser
+        callback never fires for them. The cache-based fallback in
+        :meth:`_select_ping_targets` only catches them when the
+        zeroconf A-record cache happens to be primed (e.g. by an
+        unrelated query). On a quiet network where ICMP is also
+        filtered (some corporate / HA setups), those devices stay
+        UNKNOWN forever even though they're reachable.
+
+        Issue an active mDNS A-record resolve for each non-API
+        device every sweep so the indicator flips ONLINE even
+        without an esphomelib service announcement. Mirrors the
+        legacy dashboard's ``async_refresh_hosts`` poll path
+        (``esphome/dashboard/status/mdns.py``). No-op when the
+        zeroconf browser failed to start.
+        """
+        if self._zeroconf is None:
+            return
+        candidates = [
+            d
+            for d in self._get_devices()
+            if d.address
+            and is_local_hostname(d.address)
+            and d.loaded_integrations
+            and "api" not in d.loaded_integrations
+            and self._should_ping(d)
+        ]
+        if not candidates:
+            return
+        results = await asyncio.gather(
+            *(
+                self._zeroconf.async_resolve_host(d.address, _MDNS_HOSTNAME_RESOLVE_TIMEOUT)
+                for d in candidates
+            ),
+            return_exceptions=True,
+        )
+        for device, addresses in zip(candidates, results, strict=True):
+            if isinstance(addresses, list) and addresses:
+                # mDNS owns the slot once we've heard from the
+                # device. ``claim=True`` so a later ping observation
+                # can't downgrade the source if the addresses
+                # subsequently disappear from cache.
+                self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
+                self.apply_ip(device.name, _pick_ipv4(addresses))
+            # No OFFLINE branch — let the ICMP sweep below decide.
+            # An mDNS resolve miss in isolation isn't enough signal:
+            # the device might just not be advertising right this
+            # moment. ``apply(OFFLINE, "ping")`` will still fire if
+            # ICMP also fails, and the source-priority guard means
+            # an mDNS hit later in the run can still upgrade it.
 
     async def _ping_sweep(self) -> None:
         if icmp_ping is None:

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -1,0 +1,330 @@
+"""Tests for the non-API mDNS hostname-resolve fallback.
+
+Devices whose YAML doesn't load the ``api`` integration
+(web_server-only, MQTT-only, OTA-only configs) never broadcast on
+``_esphomelib._tcp.local.``. The state monitor's
+``ServiceBrowser`` callback never fires for them, and on networks
+where ICMP is filtered the ping fallback can't pick them up
+either — the indicator stays UNKNOWN forever even though the
+device is reachable.
+
+``_resolve_non_api_mdns_targets`` issues an active mDNS A-record
+query every sweep for that subset of devices. Mirrors the legacy
+dashboard's ``async_refresh_hosts`` path
+(``esphome/dashboard/status/mdns.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.models import Device, DeviceState
+
+
+def _device(
+    name: str = "kitchen",
+    *,
+    address: str = "kitchen.local",
+    loaded_integrations: list[str] | None = None,
+    state: DeviceState = DeviceState.UNKNOWN,
+) -> Device:
+    return Device(
+        name=name,
+        friendly_name=name,
+        configuration=f"{name}.yaml",
+        address=address,
+        loaded_integrations=loaded_integrations or [],
+        state=state,
+    )
+
+
+def _make_monitor(
+    devices: list[Device], resolved: dict[str, list[str] | None] | None = None
+) -> tuple[DeviceStateMonitor, AsyncMock]:
+    """Build a monitor with a mocked ``AsyncEsphomeZeroconf``.
+
+    ``resolved`` maps a hostname to either a list of IPs (resolve
+    succeeded), an empty list / ``None`` (resolve failed), or a
+    callable returning one of those. The mock's
+    ``async_resolve_host`` is wired to look up the host and return
+    the result, mirroring how the real esphome helper hits the
+    cache and falls through to an active query.
+    """
+    captured_state: list[tuple[str, DeviceState, str]] = []
+    captured_ip: list[tuple[str, str]] = []
+
+    def _flip_state(name: str, state: DeviceState, source: str) -> None:
+        captured_state.append((name, state, source))
+        for d in devices:
+            if d.name == name:
+                d.state = state
+
+    def _flip_ip(name: str, ip: str) -> None:
+        captured_ip.append((name, ip))
+        for d in devices:
+            if d.name == name:
+                d.ip = ip
+
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=_flip_state,
+        on_ip_change=_flip_ip,
+    )
+
+    fake_zc = MagicMock()
+    resolve_map = resolved or {}
+
+    async def _resolve(host: str, _timeout: float = 0) -> list[str] | None:
+        return resolve_map.get(host)
+
+    fake_zc.async_resolve_host = AsyncMock(side_effect=_resolve)
+    monitor._zeroconf = fake_zc
+    return monitor, fake_zc.async_resolve_host
+
+
+@pytest.mark.asyncio
+async def test_non_api_device_marked_online_when_mdns_resolves() -> None:
+    """A web-server-only YAML flips ONLINE when mDNS resolves its hostname.
+
+    The browser path doesn't fire for non-API devices (they never
+    broadcast esphomelib). Without this fallback, on networks
+    where ICMP is filtered the device would stay UNKNOWN forever.
+    """
+    devices = [_device(loaded_integrations=["web_server"])]
+    monitor, resolver = _make_monitor(devices, resolved={"kitchen.local": ["192.168.1.42"]})
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    assert devices[0].state == DeviceState.ONLINE
+    assert devices[0].ip == "192.168.1.42"
+    resolver.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_api_device_skipped() -> None:
+    """API-loaded devices go through the browser path, not the resolve fallback.
+
+    Without this filter we'd issue a redundant A-record query for
+    every esphomelib-broadcasting device on every sweep — wasted
+    work that scales linearly with fleet size.
+    """
+    devices = [_device(loaded_integrations=["api", "web_server"])]
+    monitor, resolver = _make_monitor(devices)
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    resolver.assert_not_called()
+    assert devices[0].state == DeviceState.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_uncompiled_device_skipped() -> None:
+    """Devices with empty ``loaded_integrations`` skip the resolve.
+
+    A YAML that's been added but never compiled has no
+    ``loaded_integrations`` populated yet (StorageJSON hasn't been
+    written). We can't tell whether it'll end up with ``api`` or
+    not, so don't preemptively resolve — wait until
+    ``--only-generate`` finishes and StorageJSON tells us.
+    """
+    devices = [_device(loaded_integrations=[])]
+    monitor, resolver = _make_monitor(devices)
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    resolver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_local_hostname_skipped() -> None:
+    """Resolve only kicks in for ``.local`` hostnames — DNS is the right tool elsewhere."""
+    devices = [_device(address="device.example.com", loaded_integrations=["mqtt"])]
+    monitor, resolver = _make_monitor(devices)
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    resolver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_miss_does_not_apply_offline() -> None:
+    """A miss is silent — let the ICMP sweep decide OFFLINE.
+
+    An mDNS resolve miss in isolation isn't conclusive (the device
+    might not be advertising right this moment, or there's been a
+    transient zeroconf hiccup). Applying OFFLINE eagerly here would
+    flip the indicator red on every brief mDNS pause, even when
+    the device is still pingable.
+    """
+    devices = [_device(loaded_integrations=["web_server"])]
+    monitor, _resolver = _make_monitor(devices, resolved={"kitchen.local": None})
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    assert devices[0].state == DeviceState.UNKNOWN  # not OFFLINE
+    assert devices[0].ip == ""
+
+
+@pytest.mark.asyncio
+async def test_resolve_exception_does_not_propagate() -> None:
+    """A zeroconf exception on one host doesn't poison the others.
+
+    Real ``async_resolve_host`` calls can fail with ``OSError`` /
+    network errors mid-sweep. Use ``return_exceptions=True`` so a
+    single bad host doesn't cancel the gather, and skip-quietly on
+    a non-list result so the next sweep retries normally.
+    """
+    devices = [
+        _device(name="kitchen", loaded_integrations=["web_server"]),
+        _device(name="bedroom", address="bedroom.local", loaded_integrations=["mqtt"]),
+    ]
+    monitor, _ = _make_monitor(devices)
+
+    async def _resolve(host: str, _timeout: float = 0) -> list[str] | None:
+        if host == "kitchen.local":
+            raise OSError("simulated zeroconf failure")
+        return ["192.168.1.50"]
+
+    monitor._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    # bedroom resolves cleanly even though kitchen blew up.
+    bedroom = next(d for d in devices if d.name == "bedroom")
+    assert bedroom.state == DeviceState.ONLINE
+    assert bedroom.ip == "192.168.1.50"
+    # kitchen stayed UNKNOWN — the exception didn't get re-raised
+    # as a state mutation.
+    kitchen = next(d for d in devices if d.name == "kitchen")
+    assert kitchen.state == DeviceState.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_no_zeroconf_is_a_noop() -> None:
+    """Pre-start (or zeroconf-failed) sweep must not raise."""
+    devices = [_device(loaded_integrations=["web_server"])]
+    monitor, _ = _make_monitor(devices)
+    monitor._zeroconf = None  # simulate ``async_setup`` failure
+
+    # No exception, no state change.
+    await monitor._resolve_non_api_mdns_targets()
+    assert devices[0].state == DeviceState.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_already_online_via_higher_priority_skipped() -> None:
+    """A device claimed by mDNS / MQTT already doesn't get re-resolved.
+
+    ``_should_ping`` returns False for ONLINE devices owned by a
+    source whose priority is above ``ping``. We piggyback on the
+    same predicate: if mDNS / MQTT already won, an extra resolve
+    on the next sweep would just spam queries for nothing.
+    """
+    devices = [_device(loaded_integrations=["web_server"], state=DeviceState.ONLINE)]
+    monitor, resolver = _make_monitor(devices)
+    monitor._state_source["kitchen"] = "mdns"  # higher than ping
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    resolver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_offline_via_ping_still_resolved() -> None:
+    """A device flipped OFFLINE by ping is still a resolve candidate.
+
+    Ping is the lower-priority source. If mDNS later reports the
+    device live, we want the resolver pass to upgrade ONLINE on
+    the next sweep. ``_should_ping`` returns True for non-ONLINE
+    devices regardless of source.
+    """
+    devices = [_device(loaded_integrations=["web_server"], state=DeviceState.OFFLINE)]
+    monitor, resolver = _make_monitor(devices, resolved={"kitchen.local": ["192.168.1.42"]})
+    monitor._state_source["kitchen"] = "ping"
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    resolver.assert_awaited_once()
+    assert devices[0].state == DeviceState.ONLINE
+
+
+@pytest.mark.asyncio
+async def test_resolve_picks_ipv4_for_apply_ip() -> None:
+    """``apply_ip`` gets the IPv4 address even when V6 is present.
+
+    ``Device.ip`` only carries one address; cross-subnet ICMP and
+    the device-list display both prefer V4. The address-cache CLI
+    args still consume every IP via a different code path
+    (``_build_address_cache_args``), so we don't lose V6
+    reachability by picking V4 here.
+    """
+    devices = [_device(loaded_integrations=["web_server"])]
+    monitor, _ = _make_monitor(
+        devices,
+        resolved={"kitchen.local": ["fe80::1%en0", "192.168.1.42", "fe80::2%en0"]},
+    )
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    assert devices[0].ip == "192.168.1.42"
+
+
+@pytest.mark.asyncio
+async def test_no_candidates_skips_zeroconf_call() -> None:
+    """All API-loaded fleet → no resolve work.
+
+    Cheap pre-filter: don't even allocate the gather if every
+    matching device is excluded. Verified by asserting the
+    resolver mock was never called (a real call would be O(N)
+    against the live zeroconf instance).
+    """
+    devices = [_device(loaded_integrations=["api"])]
+    monitor, resolver = _make_monitor(devices)
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    resolver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multiple_devices_resolve_in_parallel(monkeypatch: Any) -> None:
+    """All non-API devices resolve in a single ``asyncio.gather`` call.
+
+    Sequential resolution would serialise N devices behind one
+    another; with concurrent resolves the whole sweep finishes
+    inside the timeout window of the slowest single request.
+    Verified by counting concurrent invocations of the mocked
+    ``async_resolve_host`` — it should be called once per device,
+    all dispatched before any awaits return.
+    """
+    devices = [
+        _device(name="kitchen", loaded_integrations=["mqtt"]),
+        _device(name="bedroom", address="bedroom.local", loaded_integrations=["mqtt"]),
+        _device(name="garage", address="garage.local", loaded_integrations=["mqtt"]),
+    ]
+    monitor, _ = _make_monitor(devices)
+
+    pending = 0
+    max_concurrent = 0
+
+    async def _resolve(host: str, _timeout: float = 0) -> list[str] | None:
+        nonlocal pending, max_concurrent
+        pending += 1
+        max_concurrent = max(max_concurrent, pending)
+        try:
+            import asyncio
+
+            await asyncio.sleep(0)  # let other coroutines start
+            return ["10.0.0.1"]
+        finally:
+            pending -= 1
+
+    monitor._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    assert max_concurrent == 3

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -48,11 +48,13 @@ def _make_monitor(
     """Build a monitor with a mocked ``AsyncEsphomeZeroconf``.
 
     ``resolved`` maps a hostname to either a list of IPs (resolve
-    succeeded), an empty list / ``None`` (resolve failed), or a
-    callable returning one of those. The mock's
-    ``async_resolve_host`` is wired to look up the host and return
-    the result, mirroring how the real esphome helper hits the
-    cache and falls through to an active query.
+    succeeded), an empty list / ``None`` (resolve failed). The
+    mock's ``async_resolve_host`` looks up the host in the dict
+    and returns the value verbatim. Tests that need exception
+    behaviour or per-call dynamics replace the mock's
+    ``side_effect`` directly (see
+    ``test_resolve_exception_does_not_propagate`` /
+    ``test_multiple_devices_resolve_in_parallel``).
     """
     captured_state: list[tuple[str, DeviceState, str]] = []
     captured_ip: list[tuple[str, str]] = []
@@ -151,14 +153,18 @@ async def test_non_local_hostname_skipped() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_miss_does_not_apply_offline() -> None:
-    """A miss is silent — let the ICMP sweep decide OFFLINE.
+async def test_resolve_miss_is_silent_no_offline_branch_by_design() -> None:
+    """A miss is silent — ONLY trust mDNS for ONLINE, never for OFFLINE.
 
-    An mDNS resolve miss in isolation isn't conclusive (the device
-    might not be advertising right this moment, or there's been a
-    transient zeroconf hiccup). Applying OFFLINE eagerly here would
-    flip the indicator red on every brief mDNS pause, even when
-    the device is still pingable.
+    Deliberate asymmetry: a successful active mDNS resolve is
+    strong evidence the device is live, but a miss isn't strong
+    evidence it's gone (could be a transient broadcast pause, a
+    flaky network, or just a slow device responding past the
+    timeout). Claiming OFFLINE on miss would lock out the ICMP
+    fallback for the device under ``mdns`` priority and leave
+    devices on flaky networks stuck red. Stay silent and let
+    ICMP — which is unblocked while no source has claimed the
+    slot — decide.
     """
     devices = [_device(loaded_integrations=["web_server"])]
     monitor, _resolver = _make_monitor(devices, resolved={"kitchen.local": None})
@@ -167,6 +173,9 @@ async def test_resolve_miss_does_not_apply_offline() -> None:
 
     assert devices[0].state == DeviceState.UNKNOWN  # not OFFLINE
     assert devices[0].ip == ""
+    # Source slot stays empty so ping (priority 1) can claim
+    # later — the resolve hasn't earned ownership yet.
+    assert monitor.priority_for("kitchen") == "unknown"
 
 
 @pytest.mark.asyncio
@@ -231,6 +240,29 @@ async def test_already_online_via_higher_priority_skipped() -> None:
     await monitor._resolve_non_api_mdns_targets()
 
     resolver.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_hit_locks_out_ping() -> None:
+    """A resolve hit claims ``mdns`` priority and ICMP stops.
+
+    Pings cost network / DNS traffic. Once mDNS has answered, we
+    treat that as the source of truth — locking ICMP out via the
+    ``mdns`` priority claim avoids the redundant probe on every
+    subsequent sweep. The trade-off is that a device going offline
+    after mDNS first claimed it stays ONLINE until either the
+    fleet operator restarts the dashboard or another (higher-
+    priority) source contradicts the claim; that's deliberate
+    given how often quiet devices skip a single mDNS broadcast.
+    """
+    devices = [_device(loaded_integrations=["web_server"])]
+    monitor, _ = _make_monitor(devices, resolved={"kitchen.local": ["192.168.1.42"]})
+
+    await monitor._resolve_non_api_mdns_targets()
+
+    assert devices[0].state == DeviceState.ONLINE
+    assert monitor.priority_for("kitchen") == "mdns"
+    assert monitor._should_ping(devices[0]) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Closes #84.
- Devices whose YAML doesn't load the ``api`` integration (``web_server``-only, MQTT-only, OTA-only configs) never broadcast on ``_esphomelib._tcp.local.``. The state monitor's ``ServiceBrowser`` callback never fires for them, and the cache-based fallback in ``_select_ping_targets`` only catches them when the zeroconf A-record cache happens to be primed by an unrelated query. On networks where ICMP is also filtered, those devices stay UNKNOWN forever even though they're reachable.
- Add ``_resolve_non_api_mdns_targets``: an active mDNS A-record resolve pass that runs at the start of every ping sweep for the subset of devices whose ``loaded_integrations`` is populated and lacks ``api``. A successful resolve flips the device ONLINE under ``mdns`` (with ``claim=True``) and applies the IPv4 address. A miss is silent — the ICMP sweep runs immediately after and decides OFFLINE on its own.

Mirrors the legacy dashboard's poll path (``esphome/dashboard/status/mdns.py:async_refresh_hosts``).

## Test plan
- [x] ``uv run pytest tests/`` — 437 passed, 3 skipped
- [x] New ``tests/test_non_api_mdns_resolve.py`` with 12 tests covering:
  - Non-API device flips ONLINE on resolve hit
  - API-loaded device skipped (browser path covers it)
  - Uncompiled device (empty ``loaded_integrations``) skipped — can't classify yet
  - Non-``.local`` hostname skipped — DNS path handles those
  - Resolve miss is silent (no spurious OFFLINE)
  - One device's exception doesn't poison sibling resolves
  - Pre-start (zeroconf=None) is a no-op
  - Already-ONLINE-via-higher-priority is skipped
  - OFFLINE-via-ping is still resolved (lets mDNS upgrade)
  - IPv4 picked over IPv6 for ``apply_ip``
  - All-API fleet skips zeroconf entirely
  - Multi-device resolves run in parallel (``asyncio.gather``)