### PR TITLE
Accept show_secrets opt-in on devices/validate

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -6,7 +6,9 @@ import asyncio
 import contextlib
 import logging
 import os
+import re
 import shutil
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -817,9 +819,18 @@ class DevicesController:
         """
         config_path = str(self._db.settings.rel_path(configuration))
         cmd = [*self._esphome_cmd, "--dashboard", "config", config_path]
+        line_transform: Callable[[str], str] | None = None
         if show_secrets:
             cmd.append("--show-secrets")
-        await self._stream_subprocess(cmd, client, message_id)
+        else:
+            # ``esphome config`` without ``--show-secrets`` doesn't
+            # redact — it wraps each ``password|key|psk|ssid`` value
+            # in the ANSI conceal SGR (8/28). Browsers don't honour
+            # that escape, so the resolved secret bytes were leaking
+            # plain into the validate dialog. Strip the wrapped runs
+            # before the line leaves the WS handler.
+            line_transform = _redact_concealed_secrets
+        await self._stream_subprocess(cmd, client, message_id, line_transform=line_transform)
 
     @api_command("devices/logs")
     async def stream_logs(
@@ -1478,12 +1489,26 @@ class DevicesController:
 
         await loop.run_in_executor(None, _delete_all)
 
-    async def _stream_subprocess(self, cmd: list[str], client: Any, message_id: str) -> None:
+    async def _stream_subprocess(
+        self,
+        cmd: list[str],
+        client: Any,
+        message_id: str,
+        *,
+        line_transform: Callable[[str], str] | None = None,
+    ) -> None:
         """Run a CLI subprocess and stream its merged stdout/stderr to a single client.
 
         Registers the running task with the client so a peer ``devices/stop_stream``
         command (or a WS disconnect) can cancel it; cancellation kills the
         subprocess so it doesn't keep running detached.
+
+        ``line_transform``, if given, is applied to every output line
+        before it leaves the WS handler. Used by ``validate_config``
+        to scrub the resolved ``!secret`` values out of the stream
+        when ``show_secrets`` is off (``esphome config`` doesn't
+        actually redact in that mode — it wraps values with the ANSI
+        conceal SGR, which browsers don't honour).
         """
         # Register before the first await so an early ``stop_stream`` (during
         # subprocess spawn) still finds and cancels this task.
@@ -1509,7 +1534,10 @@ class DevicesController:
             # job-output path which preserves terminators for in-place
             # overwrites.
             async for line in iter_lines_with_progress(proc.stdout):
-                await client.send_event(message_id, "output", line.rstrip("\n\r"))
+                payload = line.rstrip("\n\r")
+                if line_transform is not None:
+                    payload = line_transform(payload)
+                await client.send_event(message_id, "output", payload)
             exit_code = await proc.wait()
         except asyncio.CancelledError:
             # Synchronous kill only — no awaits in the cancel path. The
@@ -1534,6 +1562,22 @@ class DevicesController:
         await client.send_event(
             message_id, "result", {"success": exit_code == 0, "code": exit_code}
         )
+
+
+# Match an ANSI conceal-wrapped run: ``\x1b[8m...\x1b[28m``. ESPHome's
+# ``command_config`` emits this for every line containing
+# ``password``, ``key``, ``psk`` or ``ssid`` when ``--show-secrets``
+# is off. The wrapper assumes the terminal will hide the run via the
+# Concealed SGR — but browsers don't, so the resolved secret bytes
+# render plainly. Replace the entire wrapped run (including the
+# escape codes) with the same ``<removed>`` placeholder the legacy
+# dashboard's ``streamer_mode`` produced.
+_CONCEALED_SECRET_RE = re.compile(r"\x1b\[8m.*?\x1b\[28m")
+
+
+def _redact_concealed_secrets(line: str) -> str:
+    """Replace ANSI-conceal-wrapped secret runs with ``<removed>``."""
+    return _CONCEALED_SECRET_RE.sub("<removed>", line)
 
 
 def _apply_featured_presets(

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -1590,15 +1590,30 @@ class DevicesController:
         )
 
 
-# Match an ANSI conceal-wrapped run: ``\x1b[8m...\x1b[28m``. ESPHome's
-# ``command_config`` emits this for every line containing
-# ``password``, ``key``, ``psk`` or ``ssid`` when ``--show-secrets``
-# is off. The wrapper assumes the terminal will hide the run via the
-# Concealed SGR — but browsers don't, so the resolved secret bytes
-# render plainly. Replace the entire wrapped run (including the
-# escape codes) with the same ``<removed>`` placeholder the legacy
-# dashboard's ``streamer_mode`` produced.
-_CONCEALED_SECRET_RE = re.compile(r"\x1b\[8m.*?\x1b\[28m")
+# Match an ANSI conceal-wrapped run. ESPHome's ``command_config``
+# emits this around every ``password|key|psk|ssid`` value when
+# ``--show-secrets`` is off, on the assumption that the terminal
+# will hide it via the Concealed SGR (8) and reveal it again with
+# 28. Browsers don't honour those codes, so the resolved secret
+# bytes render plainly in our HTML ansi-log.
+#
+# Two byte representations to handle:
+#
+# - ``\x1b[8m...\x1b[28m`` — raw ESC byte. What you get reading
+#   ``esphome config`` directly without ``--dashboard``.
+# - ``\033[8m...\033[28m`` — the literal four-character escape
+#   sequence. ``--dashboard`` mode replaces every real ANSI escape
+#   with this so the dashboard can re-decode them on render. We
+#   pass ``--dashboard`` on every validate, so this is the form we
+#   actually see on the wire.
+#
+# Match both so a future ESPHome change to either side stays
+# scrubbed. Replace the whole wrapped run including the escape
+# codes — leaving the literal ``\033[8m`` bytes in the output
+# would still expose the secret to anyone screen-recording the
+# network tab even if a hypothetical conceal-aware renderer hid
+# the visible glyphs.
+_CONCEALED_SECRET_RE = re.compile(r"(?:\x1b|\\033)\[8m.*?(?:\x1b|\\033)\[28m")
 
 
 def _redact_concealed_secrets(line: str) -> str:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -787,13 +787,27 @@ class DevicesController:
         self,
         *,
         configuration: str,
+        show_secrets: bool = False,
         client: Any = None,
         message_id: str = "",
         **kwargs: Any,
     ) -> None:
-        """Validate a device YAML config. Streams output per-connection."""
+        """
+        Validate a device YAML config. Streams output per-connection.
+
+        ``show_secrets`` passes ``--show-secrets`` to ``esphome config``
+        so resolved ``!secret`` values appear in the output instead of
+        the default ``<removed>`` redaction. Default is ``False`` —
+        secrets only appear when the user actively asks for them.
+        Mirrors the legacy dashboard's ``streamer_mode`` semantics
+        but as a per-call opt-in rather than a global setting, so one
+        user wanting to see secrets in a multi-user deployment doesn't
+        change the default for everyone else.
+        """
         config_path = str(self._db.settings.rel_path(configuration))
         cmd = [*self._esphome_cmd, "--dashboard", "config", config_path]
+        if show_secrets:
+            cmd.append("--show-secrets")
         await self._stream_subprocess(cmd, client, message_id)
 
     @api_command("devices/logs")

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -228,7 +228,7 @@ async def test_stream_logs_command_includes_dashboard_flag() -> None:
     ctrl = _make_controller_with_settings(["esphome"])
     captured: list[list[str]] = []
 
-    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
         captured.append(cmd)
 
     ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
@@ -248,7 +248,7 @@ async def test_stream_logs_command_without_port_omits_device_arg() -> None:
     ctrl = _make_controller_with_settings(["esphome"])
     captured: list[list[str]] = []
 
-    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
         captured.append(cmd)
 
     ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
@@ -263,7 +263,7 @@ async def test_stream_logs_command_appends_no_states_when_requested() -> None:
     ctrl = _make_controller_with_settings(["esphome"])
     captured: list[list[str]] = []
 
-    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
         captured.append(cmd)
 
     ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
@@ -286,7 +286,7 @@ async def test_stream_logs_command_no_states_without_port() -> None:
     ctrl = _make_controller_with_settings(["esphome"])
     captured: list[list[str]] = []
 
-    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
         captured.append(cmd)
 
     ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
@@ -306,7 +306,7 @@ async def test_stream_logs_command_omits_no_states_by_default() -> None:
     ctrl = _make_controller_with_settings(["esphome"])
     captured: list[list[str]] = []
 
-    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
         captured.append(cmd)
 
     ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
@@ -326,7 +326,7 @@ async def test_validate_config_command_includes_dashboard_flag() -> None:
     ctrl = _make_controller_with_settings(["esphome"])
     captured: list[list[str]] = []
 
-    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
         captured.append(cmd)
 
     ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
@@ -347,7 +347,7 @@ async def test_validate_config_omits_show_secrets_by_default() -> None:
     ctrl = _make_controller_with_settings(["esphome"])
     captured: list[list[str]] = []
 
-    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
         captured.append(cmd)
 
     ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
@@ -368,7 +368,7 @@ async def test_validate_config_passes_show_secrets_flag_when_enabled() -> None:
     ctrl = _make_controller_with_settings(["esphome"])
     captured: list[list[str]] = []
 
-    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
         captured.append(cmd)
 
     ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
@@ -386,3 +386,96 @@ async def test_validate_config_passes_show_secrets_flag_when_enabled() -> None:
     assert captured == [
         ["esphome", "--dashboard", "config", "kitchen.yaml", "--show-secrets"],
     ]
+
+
+async def test_validate_config_off_attaches_redactor_transform() -> None:
+    r"""``show_secrets=False`` wires the line transform that scrubs concealed runs.
+
+    ``esphome config`` without ``--show-secrets`` doesn't redact —
+    it wraps every ``password|key|psk|ssid`` value in the ANSI
+    Concealed SGR (``\\x1b[8m...\\x1b[28m``). The escape codes pass
+    through to the browser unchanged because ansi-log doesn't honour
+    Concealed, so the resolved secret bytes were rendering plain in
+    the validate dialog. Hand ``_stream_subprocess`` a callable that
+    strips those wrapped runs so the secret never leaves the
+    server.
+    """
+    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: dict[str, Any] = {}
+
+    async def fake_stream(
+        _cmd: list[str], _client: Any, _mid: str, *, line_transform: Any = None
+    ) -> None:
+        captured["line_transform"] = line_transform
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.validate_config(configuration="kitchen.yaml", client=MagicMock(), message_id="m-off")
+
+    assert captured["line_transform"] is _redact_concealed_secrets
+
+
+async def test_validate_config_on_passes_no_line_transform() -> None:
+    """``show_secrets=True`` ships raw output — no redactor wired."""
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: dict[str, Any] = {}
+
+    async def fake_stream(
+        _cmd: list[str], _client: Any, _mid: str, *, line_transform: Any = None
+    ) -> None:
+        captured["line_transform"] = line_transform
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.validate_config(
+        configuration="kitchen.yaml",
+        show_secrets=True,
+        client=MagicMock(),
+        message_id="m-on",
+    )
+
+    assert captured["line_transform"] is None
+
+
+def test_redact_concealed_secrets_replaces_wrapped_runs() -> None:
+    r"""ESPHome's ``\\x1b[8m...\\x1b[28m`` wrapper resolves to ``<removed>``.
+
+    Spec mirrored from ``esphome.__main__.command_config``: every
+    ``(password|key|psk|ssid): VALUE`` line gets the value wrapped
+    with the Concealed and Reveal SGR codes. Strip the entire
+    wrapped run including the escapes — leaving the literal escape
+    bytes in the output would still expose them to anyone screen-
+    recording the network tab, even if the visible glyphs were
+    hidden by a hypothetical conceal-aware renderer.
+    """
+    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+
+    raw = "  password: \x1b[8mhunter2\x1b[28m"
+    assert _redact_concealed_secrets(raw) == "  password: <removed>"
+
+
+def test_redact_concealed_secrets_handles_multiple_runs_per_line() -> None:
+    """Multiple wrapped runs in one line all get redacted (non-greedy)."""
+    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+
+    raw = "ssid: \x1b[8mwifi-name\x1b[28m psk: \x1b[8msuper-secret\x1b[28m"
+    assert _redact_concealed_secrets(raw) == "ssid: <removed> psk: <removed>"
+
+
+def test_redact_concealed_secrets_leaves_unwrapped_lines_alone() -> None:
+    r"""No Concealed wrapper → line is forwarded verbatim.
+
+    Validate output is mostly schema dumps and ANSI colour codes
+    that aren't conceal — a too-aggressive replacer would garble
+    every line. The pattern is anchored on ``\\x1b[8m...\\x1b[28m``
+    so unrelated SGR runs (colours, bold, dim) pass through.
+    """
+    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+
+    raw = "INFO Reading configuration kitchen.yaml..."
+    assert _redact_concealed_secrets(raw) == raw
+
+    coloured = "\x1b[32mINFO\x1b[0m starting up"
+    assert _redact_concealed_secrets(coloured) == coloured

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -334,3 +334,55 @@ async def test_validate_config_command_includes_dashboard_flag() -> None:
     await ctrl.validate_config(configuration="kitchen.yaml", client=MagicMock(), message_id="m3")
 
     assert captured == [["esphome", "--dashboard", "config", "kitchen.yaml"]]
+
+
+async def test_validate_config_omits_show_secrets_by_default() -> None:
+    """``--show-secrets`` is not appended unless the caller explicitly opts in.
+
+    Resolved secrets are sensitive — the legacy dashboard surfaced
+    them in screenshots / live streams when ``streamer_mode`` was
+    off. The new dashboard inverts the default so they only appear
+    when the user actively asks for them.
+    """
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    # show_secrets=False explicitly, mirroring the WS default.
+    await ctrl.validate_config(
+        configuration="kitchen.yaml",
+        show_secrets=False,
+        client=MagicMock(),
+        message_id="m4",
+    )
+
+    assert captured == [["esphome", "--dashboard", "config", "kitchen.yaml"]]
+
+
+async def test_validate_config_passes_show_secrets_flag_when_enabled() -> None:
+    """``show_secrets=True`` appends ``--show-secrets`` to the esphome command."""
+    ctrl = _make_controller_with_settings(["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.validate_config(
+        configuration="kitchen.yaml",
+        show_secrets=True,
+        client=MagicMock(),
+        message_id="m5",
+    )
+
+    # ``--show-secrets`` lands at the end of the argv — esphome's
+    # subcommand parser accepts it on the ``config`` subparser, so
+    # placement after the YAML is correct.
+    assert captured == [
+        ["esphome", "--dashboard", "config", "kitchen.yaml", "--show-secrets"],
+    ]

--- a/tests/test_stream_cancel.py
+++ b/tests/test_stream_cancel.py
@@ -456,6 +456,28 @@ def test_redact_concealed_secrets_replaces_wrapped_runs() -> None:
     assert _redact_concealed_secrets(raw) == "  password: <removed>"
 
 
+def test_redact_concealed_secrets_handles_dashboard_literal_escape() -> None:
+    r"""``--dashboard`` mode emits literal ``\\033`` not the raw ESC byte.
+
+    ESPHome's ``--dashboard`` flag re-encodes every real ANSI
+    escape as the four-character sequence ``\\033`` so the
+    dashboard renderer can re-decode them safely. Validate runs
+    always pass ``--dashboard``, so the bytes that hit our handler
+    are the literal form, not the raw ESC. The first cut of the
+    redactor only matched the raw form and the secret bytes were
+    leaking through verbatim — the user saw
+    ``ssid: \\033[8mrocketiot\\033[28m`` in the dialog instead
+    of ``ssid: <removed>``.
+    """
+    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+
+    # Build the literal four-character form by hand to avoid Python
+    # interpreting ``\033`` as the octal escape for ESC.
+    backslash = "\\"
+    literal = f"    - ssid: {backslash}033[8mrocketiot{backslash}033[28m"
+    assert _redact_concealed_secrets(literal) == "    - ssid: <removed>"
+
+
 def test_redact_concealed_secrets_handles_multiple_runs_per_line() -> None:
     """Multiple wrapped runs in one line all get redacted (non-greedy)."""
     from esphome_device_builder.controllers.devices import _redact_concealed_secrets


### PR DESCRIPTION
## Summary

Adds an optional ``show_secrets`` arg to the ``devices/validate`` WebSocket command. Default off — resolved ``!secret`` values stay redacted as ``<removed>``. When ``True`` the dashboard appends ``--show-secrets`` to the underlying ``esphome --dashboard config`` subprocess so the actual values appear in the streamed output.

Closes #82.

## Why

Mirrors what the legacy dashboard called ``streamer_mode``, but inverted: secrets are off by default and surface only when the user actively asks for them. Per-call rather than a global setting so:

- One user wanting to see secrets in a multi-user HA-add-on deployment doesn't change the default for everyone else.
- The risky direction (revealing secrets) lives at the moment of the click, not as ambient process state.
- Fits the WS-first command shape — no new global settings to plumb.

Frontend companion adds a "Show secrets / Hide secrets" toggle to the validate dialog's toolbar, in the same shape as the logs-dialog "States" toggle.

## Test plan

- [ ] ``uv run pytest tests/test_stream_cancel.py`` — 13/13 (two new cases: default omits the flag, explicit opt-in appends it after the YAML)
- [ ] Full suite: ``uv run pytest`` (369 passed, 3 skipped)
- [ ] Manual with frontend PR: open Validate on a YAML that uses ``!secret`` — initial output redacts, toggling Show secrets re-runs validation and reveals the resolved values, toggling again re-redacts.