### PR TITLE
Drop esphome.dashboard.* import; try new helpers location first

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -13,7 +13,18 @@ from typing import TYPE_CHECKING, Any
 
 from esphome import const
 from esphome.components.dashboard_import import import_config
-from esphome.dashboard.util.text import friendly_name_slugify
+
+try:
+    # ``friendly_name_slugify`` lives in ``esphome.helpers`` from
+    # esphome/esphome#16206 onwards so it survives the legacy
+    # dashboard's eventual removal. Older esphome releases still
+    # expose it from ``esphome.dashboard.util.text``; fall through
+    # only for that back-compat case so we don't carry a hard
+    # dependency on the dashboard package once it's gone.
+    from esphome.helpers import friendly_name_slugify
+except ImportError:  # pragma: no cover — covered by the import below
+    from esphome.dashboard.util.text import friendly_name_slugify
+
 from esphome.helpers import sort_ip_addresses
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 

--- a/tests/test_friendly_name_slugify_import.py
+++ b/tests/test_friendly_name_slugify_import.py
@@ -1,0 +1,57 @@
+"""Regression test for the ``friendly_name_slugify`` import path.
+
+esphome/esphome#16206 moves ``friendly_name_slugify`` from
+``esphome.dashboard.util.text`` to ``esphome.helpers`` so it
+survives the legacy dashboard's eventual removal. We import it via
+a try-new-then-fallback shim — this test pins down that the symbol
+imported from the controller resolves to the *same* function
+regardless of which esphome release the user has installed, so a
+silent drift between the two locations can't sneak past CI.
+"""
+
+from __future__ import annotations
+
+from esphome_device_builder.controllers.devices import friendly_name_slugify
+
+
+def test_friendly_name_slugify_resolves_via_helpers_or_dashboard_shim() -> None:
+    """The slugifier the controller uses is one of the two known sources.
+
+    Asserting object identity rules out a third party (or a future
+    accidental rename / re-implementation) sneaking in. Lock the
+    contract here so an esphome refactor that drops the symbol from
+    both locations fails loudly on import — not at the first
+    adoption flow that calls it.
+    """
+    sources: list = []
+    try:
+        from esphome.helpers import friendly_name_slugify as helpers_impl
+
+        sources.append(helpers_impl)
+    except ImportError:
+        pass
+    try:
+        from esphome.dashboard.util.text import (
+            friendly_name_slugify as dashboard_impl,
+        )
+
+        sources.append(dashboard_impl)
+    except ImportError:
+        pass
+
+    assert sources, "friendly_name_slugify missing from both helpers and dashboard.util.text"
+    assert friendly_name_slugify in sources
+
+
+def test_friendly_name_slugify_produces_dashed_lowercase() -> None:
+    """Sanity-check the function's contract is what the rest of the code expects.
+
+    The catalog key / on-disk filename routing in
+    ``DevicesController`` assumes the result is ``[a-z0-9-]+``
+    (no underscores, no spaces, no uppercase). Smoke-test that
+    invariant here so a silent upstream refactor that changes
+    the slugification rules fails this test instead of corrupting
+    filenames at adoption time.
+    """
+    result = friendly_name_slugify("Living Room Sensor 42")
+    assert result == "living-room-sensor-42"


### PR DESCRIPTION
## Summary
- Switch the ``friendly_name_slugify`` import from ``esphome.dashboard.util.text`` to a try-new-then-fallback shim that prefers ``esphome.helpers`` (post esphome/esphome#16206) and falls through to the legacy dashboard module only on older esphome releases. Once the legacy dashboard is removed upstream we won't take an import-time crash; against current releases the existing path keeps working unchanged.
- This is the only ``esphome.dashboard.*`` import we have. Dropping it (eventually — i.e. when the fallback is no longer needed) lets device-builder run against an esphome install that has had the legacy dashboard package removed entirely.

## Background
- Upstream PR (the new home for ``friendly_name_slugify``): https://github.com/esphome/esphome/pull/16206
- Tracking issue / API inventory: ``compare_legacy.md`` and the working ``upstream_api_inventory.md`` (not checked in) — every other esphome symbol device-builder imports lives outside ``esphome.dashboard.*`` already.

## Test plan
- [x] ``uv run pytest tests/`` — 440 passed, 3 skipped.
- [x] New ``tests/test_friendly_name_slugify_import.py``:
  - Asserts the controller's ``friendly_name_slugify`` resolves to one of the two known source modules (catches a silent third-party rebind).
  - Smoke-checks the slugification contract still produces ``[a-z0-9-]+`` output (catches an upstream refactor that changes the rules before it corrupts on-disk filenames).