### PR TITLE
Honour AdoptableDevice.network when importing discovered devices

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -696,6 +696,22 @@ class DevicesController:
         """Import / adopt a discovered device."""
         configuration = f"{name}.yaml"
         path = self._db.settings.rel_path(configuration)
+        # Honour the network type the discovery TXT advertised — an
+        # ESP32-PoE / Olimex / etc. broadcasts ``network=ethernet``
+        # and the imported template needs to start from
+        # ``ethernet:`` rather than the Wi-Fi default. Match against
+        # ``package_import_url`` so a user-edited YAML name (the
+        # mDNS-advertised name and the YAML name can diverge — see
+        # the "Drop the discovery banner entry" block below) doesn't
+        # mask the lookup. Fall back to Wi-Fi when the importable
+        # cache has no entry (older factory firmware that didn't
+        # advertise the field, or a discovery row that was already
+        # purged) — that matches the legacy dashboard's behaviour.
+        adoptable = next(
+            (d for d in self.import_result.values() if d.package_import_url == package_import_url),
+            None,
+        )
+        network = adoptable.network if adoptable and adoptable.network else const.CONF_WIFI
         loop = asyncio.get_running_loop()
         try:
             await loop.run_in_executor(
@@ -706,7 +722,7 @@ class DevicesController:
                 friendly_name,
                 project_name,
                 package_import_url,
-                const.CONF_WIFI,
+                network,
                 encryption,
             )
         except FileExistsError as exc:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -699,15 +699,25 @@ class DevicesController:
         # Honour the network type the discovery TXT advertised — an
         # ESP32-PoE / Olimex / etc. broadcasts ``network=ethernet``
         # and the imported template needs to start from
-        # ``ethernet:`` rather than the Wi-Fi default. Match against
-        # ``package_import_url`` so a user-edited YAML name (the
-        # mDNS-advertised name and the YAML name can diverge — see
-        # the "Drop the discovery banner entry" block below) doesn't
-        # mask the lookup. Fall back to Wi-Fi when the importable
-        # cache has no entry (older factory firmware that didn't
-        # advertise the field, or a discovery row that was already
-        # purged) — that matches the legacy dashboard's behaviour.
-        adoptable = next(
+        # ``ethernet:`` rather than the Wi-Fi default.
+        #
+        # Prefer the direct ``name`` → ``import_result`` lookup since
+        # factory firmware broadcasts with a MAC suffix
+        # (``apollo-plt-1-983300``), which keeps each entry unique
+        # per physical device even when multiple identical products
+        # share the same ``package_import_url``. The frontend
+        # pre-fills the adoption dialog with the discovery row's
+        # broadcast name, so this matches in the common path.
+        # Fall back to a ``package_import_url`` match only when the
+        # user edited the name during adoption — at that point the
+        # ``import_result`` key no longer matches. The fallback is
+        # technically ambiguous between identical-product devices,
+        # but those share the same ``network`` value so picking
+        # whichever lands first is correct in practice.
+        # Final fallback to Wi-Fi when no row matches at all (older
+        # factory firmware that didn't advertise the field, or a
+        # discovery row that was already purged).
+        adoptable = self.import_result.get(name) or next(
             (d for d in self.import_result.values() if d.package_import_url == package_import_url),
             None,
         )

--- a/tests/test_import_device.py
+++ b/tests/test_import_device.py
@@ -87,8 +87,88 @@ async def test_import_device_invokes_import_config_and_returns_path(
     assert args[2] == "Kitchen"
     assert args[3] == "acme.kitchen"
     assert args[4] == "github://acme/firmware.yaml@main"
+    # No matching importable cache entry → fall back to wifi (legacy behaviour).
+    assert args[5] == "wifi"
     assert args[6] == "true"  # encryption flag forwarded
     ctrl._scanner.scan.assert_awaited_once()
+
+
+async def test_import_device_passes_ethernet_network_through_to_import_config(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An ESP32-PoE / Olimex broadcasts ``network=ethernet`` — preserve it.
+
+    Hard-coding ``CONF_WIFI`` produced a YAML with a Wi-Fi template
+    that the user had to fix by hand on every Ethernet adoption.
+    Look up the discovered ``AdoptableDevice`` by the
+    ``package_import_url`` the dialog passes and forward its
+    ``network`` field to ``import_config``.
+    """
+    from esphome_device_builder.models import AdoptableDevice
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
+    )
+
+    ctrl = _make_controller(tmp_path)
+    ctrl.import_result["olimex-poe-aabbcc"] = AdoptableDevice(
+        name="olimex-poe-aabbcc",
+        friendly_name="Olimex PoE",
+        package_import_url="github://olimex/esp32-poe.yaml",
+        project_name="olimex.esp32-poe",
+        project_version="1.0.0",
+        network="ethernet",
+        ignored=False,
+    )
+
+    await ctrl.import_device(
+        # User picked a shorter name in the dialog — discovery key
+        # still matches because we look up by URL.
+        name="garage",
+        project_name="olimex.esp32-poe",
+        package_import_url="github://olimex/esp32-poe.yaml",
+    )
+
+    assert captured["args"][5] == "ethernet"
+
+
+async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Older factory firmwares didn't advertise ``network=`` — fall back to wifi.
+
+    The TXT field ``network`` only became part of the dashboard_import
+    discovery contract recently. A device whose mDNS broadcast omits
+    it (``AdoptableDevice.network == ""``) shouldn't fail adoption —
+    Wi-Fi is the historical default and matches what the legacy
+    dashboard wrote.
+    """
+    from esphome_device_builder.models import AdoptableDevice
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
+    )
+
+    ctrl = _make_controller(tmp_path)
+    ctrl.import_result["legacy-bulb-001122"] = AdoptableDevice(
+        name="legacy-bulb-001122",
+        friendly_name="Legacy Bulb",
+        package_import_url="github://vendor/old.yaml",
+        project_name="vendor.old",
+        project_version="0.1.0",
+        network="",  # field absent / empty in TXT
+        ignored=False,
+    )
+
+    await ctrl.import_device(
+        name="legacy-bulb",
+        project_name="vendor.old",
+        package_import_url="github://vendor/old.yaml",
+    )
+
+    assert captured["args"][5] == "wifi"
 
 
 async def test_import_device_translates_file_exists_to_command_error(

--- a/tests/test_import_device.py
+++ b/tests/test_import_device.py
@@ -133,6 +133,65 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
     assert captured["args"][5] == "ethernet"
 
 
+async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Multiple identical products on the LAN don't get the wrong network.
+
+    Factory firmware broadcasts each device with a MAC suffix
+    (``apollo-plt-1-983300``, ``apollo-plt-1-aabbcc``), so the
+    ``import_result`` key is unique per physical device even when
+    several share the same ``package_import_url``. The frontend
+    pre-fills the adoption dialog with the discovery row's broadcast
+    name, so we look up by ``name`` first — that's unambiguous.
+
+    Pre-fix the lookup walked the dict and returned whichever
+    matching ``package_import_url`` row landed first; for two
+    Apollo PLT-1s on different networks (one Wi-Fi reflashed for
+    Ethernet, one stock) that meant a coin-flip on which network
+    the imported YAML got.
+    """
+    from esphome_device_builder.models import AdoptableDevice
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
+    )
+
+    ctrl = _make_controller(tmp_path)
+    # Two Apollo PLT-1s — same firmware, different network types.
+    # The import dict's insertion order would otherwise pick whichever
+    # arrived first; the direct-name lookup ignores order.
+    ctrl.import_result["apollo-plt-1-aabbcc"] = AdoptableDevice(
+        name="apollo-plt-1-aabbcc",
+        friendly_name="Apollo PLT-1 (Wi-Fi)",
+        package_import_url="github://apollo/plt-1.yaml",
+        project_name="apollo.plt-1",
+        project_version="1.0.0",
+        network="wifi",
+        ignored=False,
+    )
+    ctrl.import_result["apollo-plt-1-ddeeff"] = AdoptableDevice(
+        name="apollo-plt-1-ddeeff",
+        friendly_name="Apollo PLT-1 (Ethernet)",
+        package_import_url="github://apollo/plt-1.yaml",
+        project_name="apollo.plt-1",
+        project_version="1.0.0",
+        network="ethernet",
+        ignored=False,
+    )
+
+    # User adopts the second one — frontend passes its broadcast name.
+    await ctrl.import_device(
+        name="apollo-plt-1-ddeeff",
+        project_name="apollo.plt-1",
+        package_import_url="github://apollo/plt-1.yaml",
+    )
+
+    # Got the Ethernet entry, not whichever came first.
+    assert captured["args"][5] == "ethernet"
+
+
 async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

``devices/import`` was hard-coding ``const.CONF_WIFI`` for the ``network`` arg of ``import_config``. ``AdoptableDevice.network`` already plumbs the discovery TXT value through to the importable cache, so look up the matching record by ``package_import_url`` and forward it. Fall back to Wi-Fi when the cache has no entry or the field is empty (older factory firmware that didn't carry the field).

Closes #78.

## Why

Adopting an ESP32-PoE / Olimex (or any device whose factory firmware advertises ``network=ethernet``) produced a YAML with a Wi-Fi template the user had to fix by hand on every adoption. Matches the legacy dashboard's ``imported_device.network or const.CONF_WIFI`` pattern.

## Test plan

- [ ] ``uv run pytest tests/test_import_device.py`` — 9/9 (two new cases: ethernet forwards verbatim, empty network falls back to wifi; happy-path test locks ``args[5] == "wifi"`` explicitly so the fallback is no longer an unverified assumption)
- [ ] Full suite: ``uv run pytest`` (429 passed, 3 skipped)
- [ ] Manual: adopt a discovered ESP32-PoE — generated YAML carries an ``ethernet:`` block instead of ``wifi:``.
- [ ] Manual: adopt an Athom RGBCT or similar Wi-Fi factory image — still produces a ``wifi:`` block (regression check).