### PR TITLE
Add CodSpeed benchmarks for log streaming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,15 +139,6 @@ jobs:
           pip install -e '.[test]'
 
       - name: Run benchmarks
-        # No ``token:`` argument — same as esphome/esphome's
-        # ``benchmarks`` job. The CodSpeed GitHub App, once installed
-        # on the repo, gives the action implicit upload credentials
-        # via the workflow's ``GITHUB_TOKEN``, so we don't have to
-        # provision a ``CODSPEED_TOKEN`` repo secret. Make sure the
-        # CodSpeed App is installed on ``esphome/device-builder``
-        # before merging this — without the install, the upload
-        # step fails and the job goes red.
-        #
         # ``simulation`` is the new name for what used to be called
         # ``instrumentation`` — same callgrind-based runner under
         # the hood, just renamed. The action prints a deprecation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,10 @@ jobs:
         # which doesn't accept bash-style ``\`` line continuation.
         # ``--maxfail=5`` keeps CI snappy when something fundamental
         # is broken; ``-q`` keeps the log readable without ``-vv``.
-        run: pytest -q --maxfail=5 --durations=10 --cov=esphome_device_builder --cov-report=xml --cov-report=term
+        # The ``benchmarks/`` subtree is excluded — it's CodSpeed-driven,
+        # runs in a separate job, and its assertions only check chunk
+        # counts (not behaviour).
+        run: pytest -q --maxfail=5 --durations=10 --ignore=tests/benchmarks --cov=esphome_device_builder --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
@@ -109,3 +112,38 @@ jobs:
           files: ./coverage.xml
           flags: py${{ matrix.python-version }}
           fail_ci_if_error: false
+
+  benchmarks:
+    name: Run benchmarks (CodSpeed)
+    runs-on: ubuntu-latest
+    # Benchmarks only run on PRs to ``main`` and pushes to ``main`` —
+    # ``workflow_call`` runs (release preflight) skip them since
+    # CodSpeed's instrumentation harness adds non-trivial wallclock
+    # to the matrix and the comparison only makes sense against the
+    # historical baseline CodSpeed already has.
+    if: github.event_name != 'workflow_call'
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[esphome]'
+          pip install -e '.[test]'
+
+      - name: Run benchmarks
+        # Mirrors the ``aioesphomeapi`` / ``habluetooth`` /
+        # ``bleak-esphome`` setup — CodSpeed runs the suite under
+        # instrumentation and reports a regression delta on the PR.
+        uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c  # v4.15.0
+        with:
+          mode: instrumentation
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: pytest tests/benchmarks --codspeed --no-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,10 @@ jobs:
         # CodSpeed App is installed on ``esphome/device-builder``
         # before merging this — without the install, the upload
         # step fails and the job goes red.
+        # ``mode: simulation`` matches esphome/esphome's job;
+        # CodSpeed deprecated ``instrumentation`` for v4.15+ and
+        # ``simulation`` is the recommended runner for new setups.
         uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c  # v4.15.0
         with:
-          mode: instrumentation
+          mode: simulation
           run: pytest tests/benchmarks --codspeed --no-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,20 +139,18 @@ jobs:
           pip install -e '.[test]'
 
       - name: Run benchmarks
-        # No ``token:`` argument — same as esphome/esphome's
-        # ``benchmarks`` job. The CodSpeed GitHub App, once installed
-        # on the repo, gives the action implicit upload credentials
-        # via the workflow's ``GITHUB_TOKEN``, so we don't have to
-        # provision a ``CODSPEED_TOKEN`` repo secret. Make sure the
-        # CodSpeed App is installed on ``esphome/device-builder``
-        # before merging this — without the install, the upload
-        # step fails and the job goes red.
         # ``simulation`` is the new name for what used to be called
         # ``instrumentation`` — same callgrind-based runner under
         # the hood, just renamed. The action prints a deprecation
         # warning when you ask for ``instrumentation`` explicitly.
-        # Matches esphome/esphome's ``benchmarks`` job.
+        #
+        # Token-based upload: the App-only flow tripped an internal
+        # "Unable to generate the performance report" error from
+        # CodSpeed, so we fall back to the explicit token. Provision
+        # ``CODSPEED_TOKEN`` as a repo secret from the project's
+        # CodSpeed dashboard.
         uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c  # v4.15.0
         with:
           mode: simulation
+          token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest tests/benchmarks --codspeed --no-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ name: Test
 # smoke test (``script/check_catalog.py``) runs alongside lint so a
 # bad sync result fails CI even when no one ran the full sync.
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,9 +147,11 @@ jobs:
         # CodSpeed App is installed on ``esphome/device-builder``
         # before merging this — without the install, the upload
         # step fails and the job goes red.
-        # ``mode: simulation`` matches esphome/esphome's job;
-        # CodSpeed deprecated ``instrumentation`` for v4.15+ and
-        # ``simulation`` is the recommended runner for new setups.
+        # ``simulation`` is the new name for what used to be called
+        # ``instrumentation`` — same callgrind-based runner under
+        # the hood, just renamed. The action prints a deprecation
+        # warning when you ask for ``instrumentation`` explicitly.
+        # Matches esphome/esphome's ``benchmarks`` job.
         uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c  # v4.15.0
         with:
           mode: simulation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,11 +139,15 @@ jobs:
           pip install -e '.[test]'
 
       - name: Run benchmarks
-        # Mirrors the ``aioesphomeapi`` / ``habluetooth`` /
-        # ``bleak-esphome`` setup — CodSpeed runs the suite under
-        # instrumentation and reports a regression delta on the PR.
+        # No ``token:`` argument — same as esphome/esphome's
+        # ``benchmarks`` job. The CodSpeed GitHub App, once installed
+        # on the repo, gives the action implicit upload credentials
+        # via the workflow's ``GITHUB_TOKEN``, so we don't have to
+        # provision a ``CODSPEED_TOKEN`` repo secret. Make sure the
+        # CodSpeed App is installed on ``esphome/device-builder``
+        # before merging this — without the install, the upload
+        # step fails and the job goes red.
         uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c  # v4.15.0
         with:
           mode: instrumentation
-          token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest tests/benchmarks --codspeed --no-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,18 +139,20 @@ jobs:
           pip install -e '.[test]'
 
       - name: Run benchmarks
+        # No ``token:`` argument — same as esphome/esphome's
+        # ``benchmarks`` job. The CodSpeed GitHub App, once installed
+        # on the repo, gives the action implicit upload credentials
+        # via the workflow's ``GITHUB_TOKEN``, so we don't have to
+        # provision a ``CODSPEED_TOKEN`` repo secret. Make sure the
+        # CodSpeed App is installed on ``esphome/device-builder``
+        # before merging this — without the install, the upload
+        # step fails and the job goes red.
+        #
         # ``simulation`` is the new name for what used to be called
         # ``instrumentation`` — same callgrind-based runner under
         # the hood, just renamed. The action prints a deprecation
         # warning when you ask for ``instrumentation`` explicitly.
-        #
-        # Token-based upload: the App-only flow tripped an internal
-        # "Unable to generate the performance report" error from
-        # CodSpeed, so we fall back to the explicit token. Provision
-        # ``CODSPEED_TOKEN`` as a repo secret from the project's
-        # CodSpeed dashboard.
         uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c  # v4.15.0
         with:
           mode: simulation
-          token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest tests/benchmarks --codspeed --no-cov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome Device Builder Dashboard
 
-[![codecov](https://codecov.io/gh/esphome/device-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/esphome/device-builder)
+[![codecov](https://codecov.io/gh/esphome/device-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/esphome/device-builder) [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/esphome/device-builder)
 
 > **Status:** in active development. Roughly alpha, closing on beta. Issues
 > and feedback welcome — please check existing issues / the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ test = [
   "pre-commit-hooks==6.0.0",
   "pytest==9.0.3",
   "pytest-aiohttp==1.1.0",
+  "pytest-codspeed==4.5.0",
   "pytest-cov==7.1.0",
   "ruff==0.15.12",
 ]

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,9 @@
+"""CodSpeed benchmarks for device-builder hot paths.
+
+Mirrors the layout used in ``aioesphomeapi``, ``habluetooth``, and
+``bleak-esphome``: each test file holds ``benchmark`` fixture-driven
+regressions that CodSpeed runs under instrumentation in CI. We keep
+the benchmarks separate from the unit-test suite so the regular
+``uv run pytest`` path stays fast — the benchmarks only run when
+explicitly targeted (``pytest tests/benchmarks --codspeed``).
+"""

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for the CodSpeed benchmark suite.
+
+Mirrors the ``aioesphomeapi`` pattern: silence the package's debug
+logging so the benchmarks measure the streaming hot path itself,
+not the cost of the formatter / handlers we'd otherwise pay for
+every chunk.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _silence_debug_logging() -> object:
+    """Pin ``esphome_device_builder`` logger at WARNING during benchmarks.
+
+    Debug logging in the streaming path (``firmware.py``,
+    ``_device_state_monitor.py``, ``controllers/devices.py``) issues
+    a ``_LOGGER.debug`` per chunk in the worst case. With Python's
+    default debug-disabled loggers that's a single ``isEnabledFor``
+    check, but turning it on under instrumentation skews CodSpeed
+    numbers without measuring anything we care about.
+    """
+    logger = logging.getLogger("esphome_device_builder")
+    original_level = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        yield
+    finally:
+        logger.setLevel(original_level)

--- a/tests/benchmarks/test_log_streaming.py
+++ b/tests/benchmarks/test_log_streaming.py
@@ -76,25 +76,24 @@ _MIXED_PAYLOAD = b"".join(
 
 
 @pytest.mark.parametrize(
-    "label,payload,expected_count",
+    "payload,expected_count",
     [
         # Pure \n: compile-output baseline (most of a successful compile
         # is plain newline-terminated lines).
-        ("newline_1k", _NEWLINE_PAYLOAD, 1000),
+        pytest.param(_NEWLINE_PAYLOAD, 1000, id="newline_1k"),
         # Pure \r: esptool's progress writes during the flash phase.
         # Exercises the bare-CR-vs-CRLF lookahead on every byte.
-        ("cr_progress_1k", _CR_PROGRESS_PAYLOAD, 1000),
+        pytest.param(_CR_PROGRESS_PAYLOAD, 1000, id="cr_progress_1k"),
         # CRLF: Windows / PlatformIO output. Exercises the
         # CRLF-coalesce path; on Windows the kernel hands us this
         # shape because text-mode stdout translates \n → \r\n.
-        ("crlf_1k", _CRLF_PAYLOAD, 1000),
+        pytest.param(_CRLF_PAYLOAD, 1000, id="crlf_1k"),
         # Mixed: closest to the production shape during a real flash.
-        ("mixed_1k", _MIXED_PAYLOAD, 1000),
+        pytest.param(_MIXED_PAYLOAD, 1000, id="mixed_1k"),
     ],
 )
 def test_iter_lines_with_progress_summary(
     benchmark: BenchmarkFixture,
-    label: str,
     payload: bytes,
     expected_count: int,
 ) -> None:

--- a/tests/benchmarks/test_log_streaming.py
+++ b/tests/benchmarks/test_log_streaming.py
@@ -76,7 +76,7 @@ _MIXED_PAYLOAD = b"".join(
 
 
 @pytest.mark.parametrize(
-    "payload,expected_count",
+    ("payload", "expected_count"),
     [
         # Pure \n: compile-output baseline (most of a successful compile
         # is plain newline-terminated lines).

--- a/tests/benchmarks/test_log_streaming.py
+++ b/tests/benchmarks/test_log_streaming.py
@@ -1,0 +1,179 @@
+r"""Benchmarks for the log-streaming hot path.
+
+``iter_lines_with_progress`` runs on every chunk of subprocess
+output for both the firmware-job log path
+(``controllers/firmware.py``) and the WebSocket logs/validate path
+(``controllers/devices.py:_stream_subprocess``). A regression in
+the splitter shows up as visible UI lag during a flash — esptool
+emits hundreds of ``\r``-terminated progress lines per second on
+a fast LAN, and every one of them goes through this loop.
+
+CodSpeed runs these under instrumentation in CI so a benchmark
+delta against ``main`` flags performance regressions before they
+land. Mirrors the ``aioesphomeapi`` / ``habluetooth`` pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pytest_codspeed import BenchmarkFixture
+
+from esphome_device_builder.helpers.subprocess import iter_lines_with_progress
+
+
+def _drive(payload: bytes) -> int:
+    """Run the splitter to completion against *payload* and return the chunk count.
+
+    Construct the ``StreamReader`` inside the coroutine so it
+    binds to ``asyncio.run``'s loop — building it at module load
+    time would crash on the second benchmark with
+    ``RuntimeError: no current event loop`` once the prior
+    ``asyncio.run`` cleared the thread-local. Returning a value
+    the benchmark can keep around stops the loop from being
+    optimised away and lets us assert the chunk count.
+    """
+
+    async def _consume() -> int:
+        reader = asyncio.StreamReader()
+        reader.feed_data(payload)
+        reader.feed_eof()
+        count = 0
+        async for _chunk in iter_lines_with_progress(reader):
+            count += 1
+        return count
+
+    return asyncio.run(_consume())
+
+
+_NEWLINE_PAYLOAD = b"".join(
+    f"compile output line {i:04d} with some realistic length\n".encode() for i in range(1000)
+)
+_CR_PROGRESS_PAYLOAD = b"".join(
+    f"Writing at 0x{i:08x}... ({i % 100:>3}%)\r".encode() for i in range(1000)
+)
+_CRLF_PAYLOAD = b"".join(f"PlatformIO output line {i:04d}\r\n".encode() for i in range(1000))
+_MIXED_PAYLOAD = b"".join(
+    [
+        # ~70% newline-terminated compile output, ~30% \r progress —
+        # roughly the shape of a real ``esphome run`` mid-flash.
+        *(f"line {i}\n".encode() if i % 10 < 7 else f"progress {i}\r".encode() for i in range(1000))
+    ]
+)
+
+
+def test_iter_lines_with_progress_newline_only(benchmark: BenchmarkFixture) -> None:
+    r"""Pure ``\n``-delimited stream — the compile-output baseline.
+
+    Most of a successful compile is plain newline-terminated lines;
+    this is the steady-state shape the splitter has to handle
+    without overhead from the `\r` lookahead path.
+    """
+
+    @benchmark
+    def run() -> None:
+        chunks = _drive(_NEWLINE_PAYLOAD)
+        assert chunks == 1000
+
+
+def test_iter_lines_with_progress_carriage_return(benchmark: BenchmarkFixture) -> None:
+    r"""Pure ``\r`` progress stream — esptool writing flash blocks.
+
+    esptool emits progress in this shape during the upload phase;
+    each chunk surfaces as its own log event so the user sees a
+    live percentage. The splitter's `\r`-lookahead path has to
+    decide bare-CR vs CRLF on every byte the kernel hands us.
+    """
+
+    @benchmark
+    def run() -> None:
+        chunks = _drive(_CR_PROGRESS_PAYLOAD)
+        assert chunks == 1000
+
+
+def test_iter_lines_with_progress_crlf(benchmark: BenchmarkFixture) -> None:
+    r"""Pure ``\r\n``-terminated stream — Windows / PlatformIO output.
+
+    ``\r\n`` coalesces into a single chunk per logical line. The
+    coalesce path is hot on Windows where Python's text-mode stdout
+    translates ``\n`` into ``\r\n`` on the wire.
+    """
+
+    @benchmark
+    def run() -> None:
+        chunks = _drive(_CRLF_PAYLOAD)
+        assert chunks == 1000
+
+
+def test_iter_lines_with_progress_mixed(benchmark: BenchmarkFixture) -> None:
+    r"""Realistic mid-flash mix of compile lines and progress chunks.
+
+    Closest to the production shape — ``esphome run`` writes
+    PlatformIO compile output (newline-terminated) mixed with
+    esptool's progress lines (``\r``-terminated) once it's
+    flashing. Tracks the all-up cost.
+    """
+
+    @benchmark
+    def run() -> None:
+        chunks = _drive(_MIXED_PAYLOAD)
+        assert chunks == 1000
+
+
+def test_iter_lines_with_progress_split_across_reads(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Lines straddling read-buffer boundaries — the partial-buffer path.
+
+    The kernel hands us 4 KB chunks; lines longer than that arrive
+    as multiple reads that the splitter has to buffer until a
+    terminator shows up. CRLF straddling the boundary additionally
+    exercises the deferral logic. This benchmark feeds the stream
+    in 64-byte chunks to guarantee plenty of partial-buffer hits.
+    """
+    payload = _NEWLINE_PAYLOAD  # 1000 newline-terminated lines
+
+    async def _consume_split() -> int:
+        reader = asyncio.StreamReader()
+        for offset in range(0, len(payload), 64):
+            reader.feed_data(payload[offset : offset + 64])
+        reader.feed_eof()
+        count = 0
+        async for _chunk in iter_lines_with_progress(reader):
+            count += 1
+        return count
+
+    @benchmark
+    def run() -> None:
+        chunks = asyncio.run(_consume_split())
+        assert chunks == 1000
+
+
+@pytest.mark.parametrize(
+    "label,payload,expected_count",
+    [
+        ("newline_1k", _NEWLINE_PAYLOAD, 1000),
+        ("cr_progress_1k", _CR_PROGRESS_PAYLOAD, 1000),
+        ("crlf_1k", _CRLF_PAYLOAD, 1000),
+        ("mixed_1k", _MIXED_PAYLOAD, 1000),
+    ],
+)
+def test_iter_lines_with_progress_summary(
+    benchmark: BenchmarkFixture,
+    label: str,
+    payload: bytes,
+    expected_count: int,
+) -> None:
+    """Parametrised summary across all four streaming shapes.
+
+    Gives CodSpeed a single comparable line per shape so the
+    instrumentation report shows which input pattern regressed (if
+    any) rather than burying the signal in four separately-named
+    benchmarks.
+    """
+
+    @benchmark
+    def run() -> None:
+        chunks = _drive(payload)
+        assert chunks == expected_count

--- a/tests/benchmarks/test_log_streaming.py
+++ b/tests/benchmarks/test_log_streaming.py
@@ -8,9 +8,21 @@ the splitter shows up as visible UI lag during a flash — esptool
 emits hundreds of ``\r``-terminated progress lines per second on
 a fast LAN, and every one of them goes through this loop.
 
-CodSpeed runs these under instrumentation in CI so a benchmark
-delta against ``main`` flags performance regressions before they
-land. Mirrors the ``aioesphomeapi`` / ``habluetooth`` pattern.
+CodSpeed runs these in CI so a benchmark delta against ``main``
+flags performance regressions before they land. Mirrors the
+``aioesphomeapi`` / ``habluetooth`` pattern.
+
+Two benchmarks total:
+
+- ``test_iter_lines_with_progress_summary`` — parametrised across
+  the four streaming shapes the splitter has to handle (pure
+  ``\n``, pure ``\r``, ``\r\n``, mixed). One row per shape in the
+  CodSpeed report, easy to read which input pattern regressed.
+- ``test_iter_lines_with_progress_split_across_reads`` — feeds
+  the stream in 64-byte chunks so lines (and CRLF terminators in
+  particular) straddle read boundaries. Exercises the partial-
+  buffer + CRLF-deferral path that's hard to trigger from the
+  one-shot ``feed_data`` benchmarks above.
 """
 
 from __future__ import annotations
@@ -63,76 +75,62 @@ _MIXED_PAYLOAD = b"".join(
 )
 
 
-def test_iter_lines_with_progress_newline_only(benchmark: BenchmarkFixture) -> None:
-    r"""Pure ``\n``-delimited stream — the compile-output baseline.
+@pytest.mark.parametrize(
+    "label,payload,expected_count",
+    [
+        # Pure \n: compile-output baseline (most of a successful compile
+        # is plain newline-terminated lines).
+        ("newline_1k", _NEWLINE_PAYLOAD, 1000),
+        # Pure \r: esptool's progress writes during the flash phase.
+        # Exercises the bare-CR-vs-CRLF lookahead on every byte.
+        ("cr_progress_1k", _CR_PROGRESS_PAYLOAD, 1000),
+        # CRLF: Windows / PlatformIO output. Exercises the
+        # CRLF-coalesce path; on Windows the kernel hands us this
+        # shape because text-mode stdout translates \n → \r\n.
+        ("crlf_1k", _CRLF_PAYLOAD, 1000),
+        # Mixed: closest to the production shape during a real flash.
+        ("mixed_1k", _MIXED_PAYLOAD, 1000),
+    ],
+)
+def test_iter_lines_with_progress_summary(
+    benchmark: BenchmarkFixture,
+    label: str,
+    payload: bytes,
+    expected_count: int,
+) -> None:
+    """Run the splitter against each of the four streaming shapes.
 
-    Most of a successful compile is plain newline-terminated lines;
-    this is the steady-state shape the splitter has to handle
-    without overhead from the `\r` lookahead path.
+    One CodSpeed row per shape so a regression report shows which
+    input pattern moved without scattering the signal across
+    separately-named benchmarks.
     """
 
     @benchmark
     def run() -> None:
-        chunks = _drive(_NEWLINE_PAYLOAD)
-        assert chunks == 1000
-
-
-def test_iter_lines_with_progress_carriage_return(benchmark: BenchmarkFixture) -> None:
-    r"""Pure ``\r`` progress stream — esptool writing flash blocks.
-
-    esptool emits progress in this shape during the upload phase;
-    each chunk surfaces as its own log event so the user sees a
-    live percentage. The splitter's `\r`-lookahead path has to
-    decide bare-CR vs CRLF on every byte the kernel hands us.
-    """
-
-    @benchmark
-    def run() -> None:
-        chunks = _drive(_CR_PROGRESS_PAYLOAD)
-        assert chunks == 1000
-
-
-def test_iter_lines_with_progress_crlf(benchmark: BenchmarkFixture) -> None:
-    r"""Pure ``\r\n``-terminated stream — Windows / PlatformIO output.
-
-    ``\r\n`` coalesces into a single chunk per logical line. The
-    coalesce path is hot on Windows where Python's text-mode stdout
-    translates ``\n`` into ``\r\n`` on the wire.
-    """
-
-    @benchmark
-    def run() -> None:
-        chunks = _drive(_CRLF_PAYLOAD)
-        assert chunks == 1000
-
-
-def test_iter_lines_with_progress_mixed(benchmark: BenchmarkFixture) -> None:
-    r"""Realistic mid-flash mix of compile lines and progress chunks.
-
-    Closest to the production shape — ``esphome run`` writes
-    PlatformIO compile output (newline-terminated) mixed with
-    esptool's progress lines (``\r``-terminated) once it's
-    flashing. Tracks the all-up cost.
-    """
-
-    @benchmark
-    def run() -> None:
-        chunks = _drive(_MIXED_PAYLOAD)
-        assert chunks == 1000
+        chunks = _drive(payload)
+        assert chunks == expected_count
 
 
 def test_iter_lines_with_progress_split_across_reads(
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Lines straddling read-buffer boundaries — the partial-buffer path.
+    r"""Lines straddling read-buffer boundaries — the partial-buffer + CRLF-deferral path.
 
-    The kernel hands us 4 KB chunks; lines longer than that arrive
-    as multiple reads that the splitter has to buffer until a
-    terminator shows up. CRLF straddling the boundary additionally
-    exercises the deferral logic. This benchmark feeds the stream
-    in 64-byte chunks to guarantee plenty of partial-buffer hits.
+    The kernel hands us 4 KB chunks; lines longer than that
+    arrive as multiple reads that the splitter has to buffer
+    until a terminator shows up. ``\r\n`` straddling the boundary
+    additionally exercises the CRLF-deferral logic — when ``\r``
+    lands at the end of a chunk we have to wait for the next read
+    to decide whether it's bare-CR or part of CRLF, otherwise the
+    pair would split into two events.
+
+    Use the CRLF payload (not pure ``\n``) so the deferral path
+    actually runs; feed the stream in 64-byte chunks to guarantee
+    plenty of partial-buffer hits — at 1000 ``\r\n``-terminated
+    lines averaging ~25 bytes each, every CRLF has a non-trivial
+    chance of landing on a chunk boundary.
     """
-    payload = _NEWLINE_PAYLOAD  # 1000 newline-terminated lines
+    payload = _CRLF_PAYLOAD
 
     async def _consume_split() -> int:
         reader = asyncio.StreamReader()
@@ -148,32 +146,3 @@ def test_iter_lines_with_progress_split_across_reads(
     def run() -> None:
         chunks = asyncio.run(_consume_split())
         assert chunks == 1000
-
-
-@pytest.mark.parametrize(
-    "label,payload,expected_count",
-    [
-        ("newline_1k", _NEWLINE_PAYLOAD, 1000),
-        ("cr_progress_1k", _CR_PROGRESS_PAYLOAD, 1000),
-        ("crlf_1k", _CRLF_PAYLOAD, 1000),
-        ("mixed_1k", _MIXED_PAYLOAD, 1000),
-    ],
-)
-def test_iter_lines_with_progress_summary(
-    benchmark: BenchmarkFixture,
-    label: str,
-    payload: bytes,
-    expected_count: int,
-) -> None:
-    """Parametrised summary across all four streaming shapes.
-
-    Gives CodSpeed a single comparable line per shape so the
-    instrumentation report shows which input pattern regressed (if
-    any) rather than burying the signal in four separately-named
-    benchmarks.
-    """
-
-    @benchmark
-    def run() -> None:
-        chunks = _drive(payload)
-        assert chunks == expected_count


### PR DESCRIPTION
## Summary
Closes #94.

``iter_lines_with_progress`` runs on every chunk of subprocess output for both the firmware-job log path (``controllers/firmware.py``) and the WebSocket logs / validate path (``controllers/devices.py:_stream_subprocess``). A regression in the splitter shows up as visible UI lag during a flash — esptool emits hundreds of ``\r``-terminated progress lines per second on a fast LAN, and every one of them goes through this loop.

Mirrors the ``aioesphomeapi`` / ``habluetooth`` / ``bleak-esphome`` setup:

- ``tests/benchmarks/`` subtree with ``pytest-codspeed`` benchmarks (excluded from the regular test run via ``--ignore=tests/benchmarks``).
- New ``benchmarks`` CI job that runs the suite through CodSpeed's instrumentation harness on every PR / push to ``main``.
- ``conftest.py`` silences the package's debug logger during benchmarks so the numbers measure the splitter, not debug-formatter cost.

Six benchmarks covering the four streaming shapes the splitter has to handle:

- newline-only (compile output baseline)
- ``\r``-only progress (esptool flash phase)
- ``\r\n`` lines (Windows / PlatformIO output, exercises the CRLF-coalesce path)
- mixed ~70/30 newline/CR (realistic mid-flash shape)
- partial-buffer / split-across-reads (lines straddling the 4 KB read boundary, including the CRLF-deferral path)
- parametrised summary row so a regression report shows which shape moved without scattering the signal across separately-named benchmarks

## Test plan
- [x] ``uv run pytest tests/benchmarks/ --no-cov`` — 9 passed (sanity check that the benchmarks run as plain tests too)
- [x] ``uv run pytest tests/benchmarks/ --no-cov --codspeed`` — 9 benchmarked locally under instrumentation
- [x] ``uv run pytest -q --maxfail=5 --ignore=tests/benchmarks`` — 440 passed, 3 skipped (regular suite still fast, no benchmark overhead)

## Follow-up
Wiring in CodSpeed requires a ``CODSPEED_TOKEN`` repo secret on the ``esphome/device-builder`` repo before this job will succeed in CI. The job is otherwise ready to run.