### PR TITLE
Accept explicit IP / hostname target for firmware install + upload

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -123,12 +123,12 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | Command | Args | Response | Description |
 |---------|------|----------|-------------|
 | `firmware/compile` | `{configuration}` | `FirmwareJob` | Queue compile job |
-| `firmware/upload` | `{configuration, port?}` | `FirmwareJob` | Queue upload of existing binary. `port` accepts `"OTA"`, a serial path (`/dev/ttyUSB0`, `COM3`), or an explicit IP / hostname for "install to a specific address" — the address-cache shortcut is bypassed when a target is named directly. |
-| `firmware/install` | `{configuration, port?: "OTA"}` | `FirmwareJob` | Queue compile + upload. Same `port` semantics as `firmware/upload`. |
+| `firmware/upload` | `{configuration, port?: ""}` | `FirmwareJob` | Queue upload of existing binary. `port` defaults to `""` (no `--device` arg — CLI auto-detects). Also accepts `"OTA"`, a serial path (`/dev/ttyUSB0`, `COM3`), or an explicit IP / hostname for "install to a specific address" — the address-cache shortcut is bypassed when a target is named directly. |
+| `firmware/install` | `{configuration, port?: "OTA" \| serial \| ip \| hostname}` | `FirmwareJob` | Queue compile + upload. `port` defaults to `"OTA"` (let the CLI resolve the configured host). Same `port` semantics as `firmware/upload` for non-default values. |
 | `firmware/clean` | `{configuration}` | `FirmwareJob` | Queue build clean for one device |
 | `firmware/reset_build_env` | — | `FirmwareJob` | Queue full reset of `.esphome/` build dirs and PIO cache |
 | `firmware/compile_bulk` | `{configurations: string[]}` | `[FirmwareJob]` | Queue multiple compiles |
-| `firmware/install_bulk` | `{configurations: string[], port?: "OTA"}` | `[FirmwareJob]` | Queue multiple installs. `port` is shared across every queued job — almost always callers want the per-device default of `"OTA"` rather than a single explicit target. |
+| `firmware/install_bulk` | `{configurations: string[], port?: "OTA" \| serial \| ip \| hostname}` | `[FirmwareJob]` | Queue multiple installs. `port` defaults to `"OTA"` and is shared across every queued job — almost always callers want that default rather than a single explicit target across the fleet. Same `port` validation as `firmware/install`. |
 | `firmware/get_jobs` | `{status?, configuration?}` | `[FirmwareJob]` | List jobs with filters |
 | `firmware/get_job` | `{job_id}` | `FirmwareJob` | Get job with full output |
 | `firmware/follow_job` | `{job_id}` | Streaming | Historical output + live stream for one job |

--- a/docs/API.md
+++ b/docs/API.md
@@ -123,12 +123,12 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | Command | Args | Response | Description |
 |---------|------|----------|-------------|
 | `firmware/compile` | `{configuration}` | `FirmwareJob` | Queue compile job |
-| `firmware/upload` | `{configuration, port?}` | `FirmwareJob` | Queue upload of existing binary |
-| `firmware/install` | `{configuration, port?: "OTA"}` | `FirmwareJob` | Queue compile + upload |
+| `firmware/upload` | `{configuration, port?}` | `FirmwareJob` | Queue upload of existing binary. `port` accepts `"OTA"`, a serial path (`/dev/ttyUSB0`, `COM3`), or an explicit IP / hostname for "install to a specific address" — the address-cache shortcut is bypassed when a target is named directly. |
+| `firmware/install` | `{configuration, port?: "OTA"}` | `FirmwareJob` | Queue compile + upload. Same `port` semantics as `firmware/upload`. |
 | `firmware/clean` | `{configuration}` | `FirmwareJob` | Queue build clean for one device |
 | `firmware/reset_build_env` | — | `FirmwareJob` | Queue full reset of `.esphome/` build dirs and PIO cache |
 | `firmware/compile_bulk` | `{configurations: string[]}` | `[FirmwareJob]` | Queue multiple compiles |
-| `firmware/install_bulk` | `{configurations: string[], port?: "OTA"}` | `[FirmwareJob]` | Queue multiple installs |
+| `firmware/install_bulk` | `{configurations: string[], port?: "OTA"}` | `[FirmwareJob]` | Queue multiple installs. `port` is shared across every queued job — almost always callers want the per-device default of `"OTA"` rather than a single explicit target. |
 | `firmware/get_jobs` | `{status?, configuration?}` | `[FirmwareJob]` | List jobs with filters |
 | `firmware/get_job` | `{job_id}` | `FirmwareJob` | Get job with full output |
 | `firmware/follow_job` | `{job_id}` | Streaming | Historical output + live stream for one job |

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import gzip
 import importlib
+import ipaddress
 import logging
 import os
 import re
@@ -278,6 +279,72 @@ async def _terminate_subtree_windows(pid: int) -> bool:
     return True
 
 
+def _validate_port(port: str) -> None:
+    """Sanity-check the user-supplied ``--device`` value.
+
+    The esphome CLI accepts arbitrary strings for ``--device`` and
+    treats them as one of: the literal ``"OTA"`` (let the CLI
+    resolve the configured host), a serial path, or a network host
+    (IPv4 / IPv6 / ``.local`` hostname). Without an upfront check
+    a typo'd IP would queue, run a compile, and only fail at the
+    flash step with a CLI error buried in the job output. Validate
+    early so the WS layer can return a clean ``INVALID_ARGS``.
+
+    The check is deliberately permissive — any of these shapes is
+    accepted:
+
+    * Empty string (``upload`` default — CLI auto-detects)
+    * The literal ``"OTA"``
+    * A serial path: starts with ``/``, ``COM`` (Windows), or
+      contains ``ttyUSB`` / ``ttyACM`` / ``cu.``
+    * A valid IPv4 or IPv6 address
+    * A hostname (``[a-z0-9-]+`` per label, optional ``.local``
+      suffix) — covers ``device-name.local`` and bare hostnames
+
+    Anything else (random punctuation, IPv4 with extra dots, etc.)
+    raises ``CommandError(INVALID_ARGS)``. Coordinated frontend
+    forms can pre-filter to the same shape.
+    """
+    if not port or port == "OTA":
+        return
+    # Serial paths.
+    if (
+        port.startswith("/")
+        or port.startswith("COM")
+        or any(marker in port for marker in ("ttyUSB", "ttyACM", "cu.", "tty."))
+    ):
+        return
+    # IP-shaped input must parse as a valid IP. Doing this check
+    # *before* the hostname check rejects truncated / malformed
+    # IPv4 strings (``192.168.1``, ``256.256.256.256``) that would
+    # otherwise pass the permissive hostname rules — RFC 1123
+    # technically allows numeric hostnames, but a user typing
+    # ``192.168.1`` meant an IP and we should fail loudly rather
+    # than route it as ``--device 192.168.1`` to the CLI's DNS path.
+    looks_ip = ":" in port or (port.replace(".", "").isdigit() and "." in port)
+    if looks_ip:
+        try:
+            ipaddress.ip_address(port)
+            return
+        except ValueError as exc:
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                f"Invalid install target {port!r} — looks like an IP but didn't parse: {exc}",
+            ) from exc
+    # Hostnames: a sequence of dot-separated labels, each
+    # ``[a-z0-9](?:[a-z0-9-]*[a-z0-9])?``.
+    if re.fullmatch(
+        r"(?i)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*",
+        port,
+    ):
+        return
+    raise CommandError(
+        ErrorCode.INVALID_ARGS,
+        f"Invalid install target {port!r} — expected ``OTA``, a serial path, "
+        f"an IP address, or a hostname",
+    )
+
+
 def _verify_esphome_importable(cmd: list[str]) -> tuple[bool, str]:
     """Sanity-check that ``cmd`` can actually import esphome.
 
@@ -370,7 +437,22 @@ class FirmwareController:
 
     @api_command("firmware/upload")
     async def upload(self, *, configuration: str, port: str = "", **kwargs: Any) -> FirmwareJob:
-        """Queue an upload job."""
+        """Queue an upload job.
+
+        ``port`` is forwarded to the esphome CLI via ``--device``.
+        Accepts:
+
+        * ``"OTA"`` — let the CLI resolve the configured device's
+          address from the YAML's ``esphome.address``.
+        * A serial path (``/dev/ttyUSB0``, ``COM3``) — wired flash.
+        * An IPv4 / IPv6 address or ``.local`` hostname — explicit
+          OTA target. Useful for "install to a specific address"
+          flows (re-flashing a device whose address has drifted, or
+          flashing a known-good IP when mDNS is broken). The address
+          cache is bypassed since the user has named the target
+          explicitly.
+        """
+        _validate_port(port)
         job = self._create_job(configuration, JobType.UPLOAD, port=port)
         return await self._enqueue(job)
 
@@ -397,7 +479,17 @@ class FirmwareController:
 
     @api_command("firmware/install")
     async def install(self, *, configuration: str, port: str = "OTA", **kwargs: Any) -> FirmwareJob:
-        """Queue a device update (compile + upload). Defaults to OTA."""
+        """Queue a device update (compile + upload).
+
+        ``port`` defaults to ``"OTA"`` — the CLI resolves the
+        configured device's address from the YAML's
+        ``esphome.address``. Accepts the same values as
+        :meth:`upload`: a serial path for wired flashing, or an
+        explicit IP / hostname for "install to a specific address"
+        — the address cache is bypassed when the user names the
+        target directly.
+        """
+        _validate_port(port)
         job = self._create_job(configuration, JobType.INSTALL, port=port)
         return await self._enqueue(job)
 
@@ -445,10 +537,16 @@ class FirmwareController:
     ) -> list[FirmwareJob]:
         """Queue update (compile + upload) for multiple devices. Defaults to OTA.
 
+        ``port`` is shared across every queued job; pass an explicit
+        IP only when you really want every device installed against
+        the same target (rare — almost always callers want the
+        per-device default of ``"OTA"``).
+
         Per-device errors (most commonly the rename lock) skip that
         device and keep going — a rename-in-flight on one of the
         selected devices shouldn't abort the install for the rest.
         """
+        _validate_port(port)
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -299,11 +299,19 @@ def _validate_port(port: str) -> None:
       contains ``ttyUSB`` / ``ttyACM`` / ``cu.``
     * A valid IPv4 or IPv6 address
     * A hostname (``[a-z0-9-]+`` per label, optional ``.local``
-      suffix) — covers ``device-name.local`` and bare hostnames
+      suffix, optional FQDN trailing dot) — covers
+      ``device-name.local``, ``device.example.com.``, and bare
+      hostnames
 
     Anything else (random punctuation, IPv4 with extra dots, etc.)
     raises ``CommandError(INVALID_ARGS)``. Coordinated frontend
     forms can pre-filter to the same shape.
+
+    Error messages use neutral "device target" wording — this
+    helper is shared across ``firmware/upload``, ``firmware/install``,
+    and ``firmware/install_bulk``, and the message is surfaced
+    verbatim over WS, so naming a single command in the error
+    would mislead callers of the others.
     """
     if not port or port == "OTA":
         return
@@ -329,18 +337,24 @@ def _validate_port(port: str) -> None:
         except ValueError as exc:
             raise CommandError(
                 ErrorCode.INVALID_ARGS,
-                f"Invalid install target {port!r} — looks like an IP but didn't parse: {exc}",
+                f"Invalid device target {port!r} — looks like an IP but didn't parse: {exc}",
             ) from exc
     # Hostnames: a sequence of dot-separated labels, each
-    # ``[a-z0-9](?:[a-z0-9-]*[a-z0-9])?``.
+    # ``[a-z0-9](?:[a-z0-9-]*[a-z0-9])?``. Strip a single trailing
+    # FQDN dot before matching — zeroconf and the system resolver
+    # both produce trailing-dot forms (``kitchen.local.``,
+    # ``device.example.com.``), and rejecting those would force
+    # users to manually clean up addresses pasted from the mDNS
+    # browser.
+    canonical = port.removesuffix(".")
     if re.fullmatch(
         r"(?i)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*",
-        port,
+        canonical,
     ):
         return
     raise CommandError(
         ErrorCode.INVALID_ARGS,
-        f"Invalid install target {port!r} — expected ``OTA``, a serial path, "
+        f"Invalid device target {port!r} — expected ``OTA``, a serial path, "
         f"an IP address, or a hostname",
     )
 

--- a/tests/test_install_to_specific_address.py
+++ b/tests/test_install_to_specific_address.py
@@ -66,6 +66,8 @@ def _controller() -> FirmwareController:
         "kitchen",  # bare hostname
         "apollo-plt-1-983300",  # hyphenated mDNS name
         "device.example.com",  # routable DNS hostname
+        "kitchen.local.",  # FQDN trailing-dot from zeroconf
+        "device.example.com.",  # FQDN trailing-dot from system resolver
     ],
 )
 def test_validate_port_accepts_known_shapes(port: str) -> None:
@@ -104,6 +106,12 @@ def test_validate_port_rejects_typos(port: str) -> None:
         _validate_port(port)
     assert exc.value.code == ErrorCode.INVALID_ARGS
     assert port in exc.value.message  # offending value is named
+    # The error wording is shared across firmware/upload, install,
+    # and install_bulk — must use neutral "device target" rather
+    # than naming a single command, since the message is surfaced
+    # verbatim over WS to whichever command the user actually ran.
+    assert "device target" in exc.value.message
+    assert "install target" not in exc.value.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_install_to_specific_address.py
+++ b/tests/test_install_to_specific_address.py
@@ -1,0 +1,219 @@
+"""Tests for the "Install to Specific Address" feature.
+
+The ``port`` parameter on ``firmware/upload``, ``firmware/install``,
+and ``firmware/install_bulk`` accepts:
+
+- ``"OTA"`` (the default) — let the CLI resolve the configured
+  device's address from the YAML.
+- A serial path — wired flash.
+- An IP address or hostname — explicit OTA target. Useful when
+  re-flashing a device whose address has drifted, or flashing a
+  known-good IP when mDNS is broken.
+
+The address-cache shortcut is correctly bypassed when the user
+names the target explicitly — the cache is keyed on the
+configured hostname, so feeding it for an unrelated IP would
+mislead the CLI's resolver.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.firmware import (
+    FirmwareController,
+    _validate_port,
+)
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode, FirmwareJob, JobType
+
+
+def _controller() -> FirmwareController:
+    """Build a controller skeleton with just the surface ``_build_command`` needs.
+
+    ``_build_command`` only reads ``self._esphome_cmd``; the rest of
+    the controller (queue, scanner, bus) isn't relevant for these
+    tests. ``__new__`` skips ``__init__`` so we don't have to seed a
+    full ``DeviceBuilder``.
+    """
+    controller = FirmwareController.__new__(FirmwareController)
+    controller._esphome_cmd = ["esphome"]
+    controller._db = MagicMock()
+    controller._db.devices = None  # cache args become a no-op
+    return controller
+
+
+# ---------------------------------------------------------------------------
+# _validate_port
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        "",  # default (upload, no explicit target)
+        "OTA",  # the CLI's special "configured host" token
+        "/dev/ttyUSB0",  # Linux serial
+        "/dev/cu.usbserial-1410",  # macOS serial
+        "COM3",  # Windows serial
+        "/dev/ttyACM0",  # ESP32-S3 native USB CDC
+        "192.168.1.42",  # explicit IPv4 target
+        "10.0.0.1",  # private range IPv4
+        "fe80::1",  # IPv6 (link-local)
+        "kitchen.local",  # mDNS hostname
+        "kitchen",  # bare hostname
+        "apollo-plt-1-983300",  # hyphenated mDNS name
+        "device.example.com",  # routable DNS hostname
+    ],
+)
+def test_validate_port_accepts_known_shapes(port: str) -> None:
+    """Anything an ESPHome user might reasonably type is accepted.
+
+    The validator's job is to catch typos and bad input *before*
+    the user spends 30 seconds compiling, not to reject things the
+    CLI itself would handle. Any of the documented input shapes
+    should pass without raising.
+    """
+    _validate_port(port)
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        "192.168.1",  # truncated IPv4
+        "256.256.256.256",  # out-of-range octets
+        "192.168.1.1.1",  # too many octets
+        "192.168.1 1",  # space in the middle
+        "device name",  # space (hostname disallows)
+        "kitchen$",  # punctuation
+        "-leading-dash.local",  # hostname label can't start with dash
+        "trailing-dash-.local",  # nor end with one
+    ],
+)
+def test_validate_port_rejects_typos(port: str) -> None:
+    """A typo'd target raises ``INVALID_ARGS`` instead of queueing a doomed job.
+
+    Without the early check the user would compile + queue, and
+    only see the failure at the flash phase ~30 s later when the
+    CLI rejects the value. Surface a clean WS error up front so
+    the dialog can re-prompt.
+    """
+    with pytest.raises(CommandError) as exc:
+        _validate_port(port)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+    assert port in exc.value.message  # offending value is named
+
+
+# ---------------------------------------------------------------------------
+# _build_command — IP-target shape
+# ---------------------------------------------------------------------------
+
+
+def test_install_to_ip_emits_device_arg_with_no_cache_args() -> None:
+    """Explicit IP installs route ``--device <ip>`` with no address-cache args.
+
+    The cache shortcut is keyed on the device's *configured*
+    hostname (from YAML's ``esphome.address``); it's irrelevant
+    when the user has named a different target. Passing the cache
+    args anyway would make the CLI prefer the configured host's
+    cached IP over what the user typed — the opposite of what the
+    user is asking for. ``_build_cache_args`` returns ``[]`` for
+    non-OTA ports, and this test pins that the resulting command
+    line stays clean.
+    """
+    controller = _controller()
+    job = FirmwareJob(
+        job_id="install-1",
+        configuration="kitchen.yaml",
+        job_type=JobType.INSTALL,
+        port="192.168.1.42",
+    )
+
+    cache_args = controller._build_cache_args(job)
+    cmd = controller._build_command(JobType.INSTALL, "kitchen.yaml", "192.168.1.42", cache_args)
+
+    # No ``--mdns-address-cache`` — the user picked their own target.
+    assert "--mdns-address-cache" not in cmd
+    assert "--dns-address-cache" not in cmd
+    # The IP reaches the CLI as ``--device <ip>``.
+    assert cmd == [
+        "esphome",
+        "--dashboard",
+        "run",
+        "kitchen.yaml",
+        "--no-logs",
+        "--device",
+        "192.168.1.42",
+    ]
+
+
+def test_upload_to_ip_emits_device_arg_with_no_cache_args() -> None:
+    """``firmware/upload`` with an IP target gets the same shape as install.
+
+    Both endpoints route through ``_build_command``; the
+    ``UPLOAD`` job type just runs ``upload`` instead of ``run``
+    and skips the ``--no-logs`` suffix the install path adds.
+    """
+    controller = _controller()
+    job = FirmwareJob(
+        job_id="upload-1",
+        configuration="kitchen.yaml",
+        job_type=JobType.UPLOAD,
+        port="192.168.1.42",
+    )
+
+    cache_args = controller._build_cache_args(job)
+    cmd = controller._build_command(JobType.UPLOAD, "kitchen.yaml", "192.168.1.42", cache_args)
+
+    assert "--mdns-address-cache" not in cmd
+    assert cmd == [
+        "esphome",
+        "--dashboard",
+        "upload",
+        "kitchen.yaml",
+        "--device",
+        "192.168.1.42",
+    ]
+
+
+def test_install_to_hostname_routes_through_device_arg() -> None:
+    """A bare or ``.local`` hostname reaches the CLI verbatim.
+
+    The CLI does its own resolution; we shouldn't second-guess it
+    by mDNS-resolving here. Passing the literal hostname keeps the
+    user's intent intact even when the device's mDNS broadcast is
+    flaky or the cached A-record is stale.
+    """
+    controller = _controller()
+    cmd = controller._build_command(JobType.INSTALL, "kitchen.yaml", "kitchen.local", [])
+    assert cmd[-2:] == ["--device", "kitchen.local"]
+
+
+def test_install_ota_default_keeps_cache_args() -> None:
+    """The OTA default still gets the address-cache shortcut.
+
+    Regression guard for the cache path — locking IP-target
+    behaviour shouldn't accidentally make the OTA fast path slow
+    too. Builds a controller whose devices controller surfaces
+    cache args and verifies they pass through to the command.
+    """
+    controller = _controller()
+    controller._db.devices = MagicMock()
+    controller._db.devices.get_address_cache_args.return_value = [
+        "--mdns-address-cache",
+        "kitchen.local=192.168.1.50",
+    ]
+    job = FirmwareJob(
+        job_id="install-2",
+        configuration="kitchen.yaml",
+        job_type=JobType.INSTALL,
+        port="OTA",
+    )
+
+    cache_args = controller._build_cache_args(job)
+    cmd = controller._build_command(JobType.INSTALL, "kitchen.yaml", "OTA", cache_args)
+
+    assert cache_args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+    assert "--mdns-address-cache" in cmd


### PR DESCRIPTION
## Summary
Backend support for "Install to Specific Address" — re-flashing a device whose address has drifted, or flashing a known-good IP when mDNS is broken.

The ``port`` parameter on ``firmware/upload``, ``firmware/install``, and ``firmware/install_bulk`` was already forwarding its value to the esphome CLI as ``--device <port>``, so the CLI natively handles ``"OTA"``, serial paths, IPs, and hostnames. This PR:

- **Documents the contract** explicitly in the API reference and the endpoint docstrings, so the frontend can expose an "install to a specific address" UI on top of the existing endpoints (no new WS commands needed).
- **Adds ``_validate_port``** as a permissive but typo-catching upfront check. Without it, a truncated IP or punctuation typo would queue a job, run a 30-second compile, and only fail at the flash phase with the CLI's error buried in job output. The validator surfaces a clean ``CommandError(INVALID_ARGS)`` so the dialog can re-prompt immediately.
- **Confirms the cache-args path stays correct**: ``_build_cache_args`` already returns ``[]`` for any non-OTA port, so explicit-target installs don't get a stale ``--mdns-address-cache`` hint pointing at the *configured* host's address (which would mislead the CLI's resolver away from the user-named target). Pinned with a regression test.

## UX (frontend, follow-up)
A split-button on the existing Install action:

- Main button: one-click default OTA (no behaviour change).
- Chevron exposes "Install via serial" (existing path) and "Install to specific address…" (new — opens a dialog with IP / hostname input, calls ``firmware/install`` with ``port=<value>``).

Frontend issue to follow.

## Test plan
- [x] ``uv run pytest`` — 476 passed, 3 skipped
- [x] New ``tests/test_install_to_specific_address.py``:
  - 13 parametrised cases for ``_validate_port`` accepting OTA / serial paths (Linux, macOS, Windows, ESP32-S3 native USB) / IPv4 / IPv6 / mDNS hostnames / hyphenated mDNS names / routable DNS hostnames
  - 8 parametrised cases for ``_validate_port`` rejecting typos (truncated IPv4, out-of-range octets, too many octets, embedded spaces, punctuation, leading / trailing dashes)
  - ``test_install_to_ip_emits_device_arg_with_no_cache_args`` — pins the install command shape with an IP target and confirms ``--mdns-address-cache`` / ``--dns-address-cache`` stay out
  - ``test_upload_to_ip_emits_device_arg_with_no_cache_args`` — same shape for ``firmware/upload``
  - ``test_install_to_hostname_routes_through_device_arg`` — hostnames pass through verbatim (the CLI does its own resolution)
  - ``test_install_ota_default_keeps_cache_args`` — regression guard that the OTA fast path still gets the address-cache shortcut