### PR TITLE
Extract _mark_job_terminal helper for the status + completed_at pair

### DIFF
--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -133,6 +133,28 @@ def _trim_job_output(job: FirmwareJob) -> None:
     ]
 
 
+def _mark_job_terminal(job: FirmwareJob, status: JobStatus) -> None:
+    """
+    Set *job* to a terminal *status* and stamp its completion time.
+
+    The two writes go together at every job-finalisation site
+    (queued cancel, mid-run cancel, normal completion, runner-shutdown
+    cancel, exception, reset-build-env cancel/complete), and forgetting
+    one or the other is a recurring footgun — a status without a
+    ``completed_at`` confuses the dashboard's relative-time tooltip,
+    and a ``completed_at`` without a status leaves the job stuck on
+    ``RUNNING`` even though the subprocess is gone.
+
+    Pulling them into one call keeps the call sites readable and the
+    pair atomic. Doesn't fire the lifecycle event — the call site
+    decides which event to fire and in what order relative to
+    ``_persist_jobs`` / ``_prune_history`` so the existing observable
+    sequencing is preserved.
+    """
+    job.status = status
+    job.completed_at = datetime.now(UTC).isoformat()
+
+
 def _names_touched_by_job(job: FirmwareJob) -> set[str]:
     """YAML filenames a job will read or write.
 
@@ -652,8 +674,7 @@ class FirmwareController:
             raise ValueError(msg)
 
         if job.status == JobStatus.QUEUED:
-            job.status = JobStatus.CANCELLED
-            job.completed_at = datetime.now(UTC).isoformat()
+            _mark_job_terminal(job, JobStatus.CANCELLED)
             self._prune_history()
             await self._persist_jobs()
             self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
@@ -893,19 +914,18 @@ class FirmwareController:
 
             exit_code = await proc.wait()
             job.exit_code = exit_code
-            job.completed_at = datetime.now(UTC).isoformat()
 
             # If the user cancelled this job mid-run, the subprocess
             # exits non-zero (terminated by signal). Honour that
             # intent rather than reporting it as a generic failure.
             if job.job_id in self._cancel_requested:
                 self._cancel_requested.discard(job.job_id)
-                job.status = JobStatus.CANCELLED
+                _mark_job_terminal(job, JobStatus.CANCELLED)
                 self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
                 _LOGGER.info("Job %s cancelled mid-run (exit %s)", job.job_id, exit_code)
             else:
                 success = exit_code == 0 and not has_error_in_output
-                job.status = JobStatus.COMPLETED if success else JobStatus.FAILED
+                _mark_job_terminal(job, JobStatus.COMPLETED if success else JobStatus.FAILED)
                 if has_error_in_output and exit_code == 0:
                     full_output = "".join(job.output)
                     if "No module named esphome" in full_output:
@@ -932,16 +952,14 @@ class FirmwareController:
         except asyncio.CancelledError:
             if self._current_process:
                 self._current_process.terminate()
-            job.status = JobStatus.CANCELLED
-            job.completed_at = datetime.now(UTC).isoformat()
+            _mark_job_terminal(job, JobStatus.CANCELLED)
             self._cancel_requested.discard(job.job_id)
             self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
             _LOGGER.info("Job %s cancelled (runner shutdown)", job.job_id)
             raise
         except Exception as exc:
-            job.status = JobStatus.FAILED
             job.error = str(exc)
-            job.completed_at = datetime.now(UTC).isoformat()
+            _mark_job_terminal(job, JobStatus.FAILED)
             self._db.bus.fire(EventType.JOB_FAILED, {"job": job})
             _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
         finally:
@@ -1028,8 +1046,7 @@ class FirmwareController:
                 if job.job_id in self._cancel_requested:
                     self._cancel_requested.discard(job.job_id)
                     _emit("Reset cancelled by user.")
-                    job.status = JobStatus.CANCELLED
-                    job.completed_at = datetime.now(UTC).isoformat()
+                    _mark_job_terminal(job, JobStatus.CANCELLED)
                     self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
                     return
 
@@ -1046,9 +1063,8 @@ class FirmwareController:
             "toolchains and re-fetch external components."
         )
         job.exit_code = 0
-        job.completed_at = datetime.now(UTC).isoformat()
-        job.status = JobStatus.COMPLETED
         job.progress = 100
+        _mark_job_terminal(job, JobStatus.COMPLETED)
         self._db.bus.fire(EventType.JOB_COMPLETED, {"job": job})
         _LOGGER.info("Job %s reset_build_env completed", job.job_id)
 

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -89,6 +89,14 @@ _PRIMARY_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL}
 )
 
+# Terminal job states — a job in any of these isn't running and
+# isn't waiting to run. Used by ``_mark_job_terminal`` to validate
+# its argument and by the prune / clear / restore paths to identify
+# completed jobs.
+_TERMINAL_JOB_STATUSES: frozenset[JobStatus] = frozenset(
+    {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
+)
+
 # Per-job output cap for retained terminal jobs. Compile output for a
 # successful build runs ~3-10k lines; the head is mostly toolchain
 # noise that's rarely useful once the build finished. Live job output
@@ -150,7 +158,16 @@ def _mark_job_terminal(job: FirmwareJob, status: JobStatus) -> None:
     decides which event to fire and in what order relative to
     ``_persist_jobs`` / ``_prune_history`` so the existing observable
     sequencing is preserved.
+
+    Raises ``ValueError`` for any non-terminal *status* so a
+    stray call (e.g. ``_mark_job_terminal(job, JobStatus.RUNNING)``)
+    fails loudly instead of silently stamping ``completed_at`` on a
+    still-running job — that would mis-order the dashboard's
+    relative-time strings and confuse the prune-on-shutdown logic.
     """
+    if status not in _TERMINAL_JOB_STATUSES:
+        msg = f"_mark_job_terminal called with non-terminal status {status!r}"
+        raise ValueError(msg)
     job.status = status
     job.completed_at = datetime.now(UTC).isoformat()
 
@@ -699,7 +716,7 @@ class FirmwareController:
         If ``status`` is given, only remove jobs with that status.
         Otherwise removes completed, failed, and cancelled jobs.
         """
-        terminal = {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
+        terminal = _TERMINAL_JOB_STATUSES
         to_remove = [
             jid
             for jid, job in self._jobs.items()
@@ -1307,7 +1324,7 @@ class FirmwareController:
         kept in a separate pool capped at ``_MAX_AUX_TERMINAL_JOBS``.
         Caller persists the result.
         """
-        terminal_states = {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
+        terminal_states = _TERMINAL_JOB_STATUSES
 
         active: list[FirmwareJob] = []
         primary: list[FirmwareJob] = []

--- a/tests/test_mark_job_terminal.py
+++ b/tests/test_mark_job_terminal.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pytest
+
 from esphome_device_builder.controllers.firmware import _mark_job_terminal
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
 
@@ -68,3 +70,21 @@ def test_mark_job_terminal_overwrites_existing_completed_at() -> None:
 
     assert job.completed_at != "2020-01-01T00:00:00+00:00"
     assert job.status is JobStatus.FAILED
+
+
+def test_mark_job_terminal_rejects_non_terminal_status() -> None:
+    """Calling with QUEUED or RUNNING raises rather than silently stamping.
+
+    Stamping ``completed_at`` on a still-running job mis-orders the
+    dashboard's relative-time strings (the UI thinks the job
+    finished N seconds ago when it's still actively producing
+    output) and confuses the prune-on-shutdown path. Fail loudly on
+    the misuse instead.
+    """
+    for status in (JobStatus.QUEUED, JobStatus.RUNNING):
+        job = _job()
+        with pytest.raises(ValueError, match="non-terminal"):
+            _mark_job_terminal(job, status)
+        # Job state is left untouched — neither field gets written.
+        assert job.completed_at is None
+        assert job.status is JobStatus.RUNNING  # the seed value

--- a/tests/test_mark_job_terminal.py
+++ b/tests/test_mark_job_terminal.py
@@ -1,0 +1,70 @@
+"""Tests for ``firmware._mark_job_terminal``.
+
+The helper consolidates the ``status = X; completed_at = isoformat``
+pair that every terminal-job site (queued cancel, mid-run cancel,
+normal completion, runner-shutdown cancel, exception path,
+reset-build-env cancel/complete) was repeating verbatim. Pin the
+contract so a future drive-by edit can't drop one half of the pair
+and silently leave a finished job stuck on ``RUNNING`` in the UI.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from esphome_device_builder.controllers.firmware import _mark_job_terminal
+from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
+
+
+def _job() -> FirmwareJob:
+    return FirmwareJob(
+        job_id="abc123",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.RUNNING,
+    )
+
+
+def test_mark_job_terminal_sets_status_and_completed_at() -> None:
+    """Both writes happen atomically — neither slot left as the prior value."""
+    job = _job()
+    assert job.completed_at is None  # sanity
+
+    _mark_job_terminal(job, JobStatus.COMPLETED)
+
+    assert job.status is JobStatus.COMPLETED
+    assert job.completed_at is not None
+    # ISO 8601 UTC: ``...+00:00``. Don't pin the exact value — just
+    # verify it parses as a real timestamp so a future swap to a
+    # different formatter doesn't silently produce garbage.
+    parsed = datetime.fromisoformat(job.completed_at)
+    assert parsed.tzinfo is not None
+
+
+def test_mark_job_terminal_supports_failed_and_cancelled() -> None:
+    """All three terminal states accepted — helper isn't COMPLETED-only."""
+    for status in (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED):
+        job = _job()
+        _mark_job_terminal(job, status)
+        assert job.status is status
+        assert job.completed_at is not None
+
+
+def test_mark_job_terminal_overwrites_existing_completed_at() -> None:
+    """Re-marking refreshes the timestamp.
+
+    The reset-build-env path can finalise a job either via the
+    cancel branch (status=CANCELLED) or the success branch
+    (status=COMPLETED) depending on how the loop exits — and the
+    cancel branch can fire mid-iteration. If both paths somehow run
+    against the same job (defensive pruning during shutdown), the
+    final ``completed_at`` should reflect the actual final
+    transition, not whichever one happened first.
+    """
+    job = _job()
+    job.completed_at = "2020-01-01T00:00:00+00:00"
+
+    _mark_job_terminal(job, JobStatus.FAILED)
+
+    assert job.completed_at != "2020-01-01T00:00:00+00:00"
+    assert job.status is JobStatus.FAILED


### PR DESCRIPTION
## Summary

Pull the ``job.status = X; job.completed_at = datetime.now(UTC).isoformat()`` pair into a module-level ``_mark_job_terminal(job, status)`` helper. Six firmware-job finalisation sites were repeating both writes verbatim, and forgetting one half is a recurring footgun.

## Why

Each call site shrinks from two lines of mutation to one helper call. The lifecycle event (``bus.fire``) and persistence (``_persist_jobs`` / ``_prune_history``) stay at the call site so the existing observable ordering (when the event fires relative to disk write) is preserved verbatim — pure refactor, not a behaviour change.

Sites consolidated:

- ``firmware/cancel`` for a queued job
- subprocess-exit cancel branch (``cancel_requested`` mid-run)
- subprocess-exit success / failure branch
- runner ``CancelledError`` (shutdown)
- generic ``Exception`` in the runner
- reset-build-env cancel branch
- reset-build-env complete branch

## Test plan

- [ ] ``uv run pytest tests/test_mark_job_terminal.py`` — 3 new tests covering atomic write, all three terminal states, refresh-on-redo
- [ ] Full suite: ``uv run pytest`` (451 passed, 3 skipped — no behaviour change)