### PR TITLE
Add devices/archive, devices/unarchive, devices/list_archived

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -102,9 +102,9 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `devices/rename` | `{configuration, new_name}` | — | Rename device via ESPHome CLI |
 | `devices/delete` | `{configuration}` | — | Delete device and associated files |
 | `devices/delete_bulk` | `{configurations: string[]}` | `[{configuration, success, error?}]` | Delete multiple devices |
-| `devices/archive` | `{configuration}` | — | Soft-delete: move YAML to `<config_dir>/archive/` and wipe build dir. Reversible via `devices/unarchive`. |
+| `devices/archive` | `{configuration}` | — | Soft-delete: move YAML to `<config_dir>/archive/`, wipe build dir, wipe StorageJSON + device-metadata sidecars. Reversible via `devices/unarchive` (cached IP/version/hash refill from the next mDNS broadcast). |
 | `devices/unarchive` | `{configuration}` | — | Move an archived YAML back into the active config directory. Errors with `INVALID_ARGS` if an active config with the same filename already exists. |
-| `devices/list_archived` | — | `[{configuration, name, friendly_name, comment}]` | List archived devices for the dashboard's "Show archived devices" toggle. |
+| `devices/list_archived` | — | `[{configuration, name, friendly_name, comment}]` | List archived devices for the dashboard's archived-devices dialog. |
 | `devices/delete_archived` | `{configuration}` | — | Permanently delete an archived YAML and its sidecars. The companion to `unarchive` for "I really don't want this back". |
 | `devices/get_config` | `{configuration}` | `string` | Read device YAML config |
 | `devices/update_config` | `{configuration, content}` | — | Write device YAML config |

--- a/docs/API.md
+++ b/docs/API.md
@@ -102,6 +102,9 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `devices/rename` | `{configuration, new_name}` | — | Rename device via ESPHome CLI |
 | `devices/delete` | `{configuration}` | — | Delete device and associated files |
 | `devices/delete_bulk` | `{configurations: string[]}` | `[{configuration, success, error?}]` | Delete multiple devices |
+| `devices/archive` | `{configuration}` | — | Soft-delete: move YAML to `<config_dir>/archive/` and wipe build dir. Reversible via `devices/unarchive`. |
+| `devices/unarchive` | `{configuration}` | — | Move an archived YAML back into the active config directory. Errors with `INVALID_ARGS` if an active config with the same filename already exists. |
+| `devices/list_archived` | — | `[{configuration, name, friendly_name, comment}]` | List archived devices for the dashboard's "Show archived devices" toggle. |
 | `devices/get_config` | `{configuration}` | `string` | Read device YAML config |
 | `devices/update_config` | `{configuration, content}` | — | Write device YAML config |
 | `devices/add_component` | `{configuration, component_id, fields?, sub_entities?}` | `AddComponentResponse` | Add component to device config |

--- a/docs/API.md
+++ b/docs/API.md
@@ -105,6 +105,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `devices/archive` | `{configuration}` | — | Soft-delete: move YAML to `<config_dir>/archive/` and wipe build dir. Reversible via `devices/unarchive`. |
 | `devices/unarchive` | `{configuration}` | — | Move an archived YAML back into the active config directory. Errors with `INVALID_ARGS` if an active config with the same filename already exists. |
 | `devices/list_archived` | — | `[{configuration, name, friendly_name, comment}]` | List archived devices for the dashboard's "Show archived devices" toggle. |
+| `devices/delete_archived` | `{configuration}` | — | Permanently delete an archived YAML and its sidecars. The companion to `unarchive` for "I really don't want this back". |
 | `devices/get_config` | `{configuration}` | `string` | Read device YAML config |
 | `devices/update_config` | `{configuration, content}` | — | Write device YAML config |
 | `devices/add_component` | `{configuration, component_id, fields?, sub_entities?}` | `AddComponentResponse` | Add component to device config |

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -593,15 +593,19 @@ class DevicesController:
 
     @api_command("devices/delete_archived")
     async def delete_archived(self, *, configuration: str, **kwargs: Any) -> None:
-        """Permanently delete an archived device — YAML and sidecars.
+        """Permanently delete an archived device's YAML.
 
         The companion to ``archive`` for the case where the user
         decided they really don't want this device back. Removes
-        ``<config_dir>/archive/<configuration>`` plus the
-        StorageJSON sidecar and the device-metadata sidecar (the
-        archive flow leaves both in place for unarchive's benefit).
-        Surfaces ``CommandError(NOT_FOUND)`` when the archive entry
-        is gone — matches the symmetry with ``unarchive``.
+        ``<config_dir>/archive/<configuration>``. The StorageJSON
+        sidecar and device-metadata entry are usually already gone
+        (``archive`` wipes them on the way in); this command also
+        cleans up any orphan sidecars left over from legacy /
+        pre-existing archives, but skips that cleanup if an active
+        config of the same filename exists (its sidecars belong to
+        the live device). Surfaces ``CommandError(NOT_FOUND)``
+        when the archive entry is gone — symmetric with
+        ``unarchive``.
         """
         _validate_archive_configuration(configuration)
         try:
@@ -1731,8 +1735,12 @@ class DevicesController:
         name only ever lived in StorageJSON because the user wrote
         it via the dashboard's edit dialog rather than the YAML),
         fall back to the StorageJSON sidecar before degrading to
-        the bare filename. The sidecar is left in place by archive
-        so this fallback works on archives created by this server.
+        the bare filename. ``_archive_single`` wipes its own
+        sidecars on archive, so the fallback only matters for
+        legacy archives (created by the upstream ESPHome dashboard
+        or by an earlier version of this server before the sidecar
+        wipe landed) and for entries dropped into the archive dir
+        externally.
         """
         archive_dir = self._db.settings.config_dir / "archive"
         if not archive_dir.is_dir():

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -72,6 +72,40 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _wipe_device_build_dir(configuration: str) -> None:
+    """Remove the per-device build dir if one exists.
+
+    Reads the canonical ``build_path`` off the StorageJSON sidecar
+    (set during compile) and ``shutil.rmtree``s it. No-op when the
+    sidecar is gone or the device has never been built. Used by
+    archive and delete; both treat compile output as dead weight.
+    """
+    storage_path = ext_storage_path(configuration)
+    storage = StorageJSON.load(storage_path)
+    if storage is not None and storage.build_path:
+        shutil.rmtree(storage.build_path, ignore_errors=True)
+
+
+def _remove_device_sidecars(config_dir: Path, configuration: str) -> None:
+    """Remove the StorageJSON sidecar and device-metadata entry.
+
+    Best-effort — failures are logged but don't propagate, so a
+    partial cleanup (e.g. permission error on one file) doesn't
+    block the rest of the archive / delete flow. Used by archive,
+    delete, and delete_archived; all three want a "leave no
+    trace under this filename" semantic at the end of their flow.
+    """
+    storage_path = ext_storage_path(configuration)
+    try:
+        storage_path.unlink(missing_ok=True)
+    except OSError:
+        _LOGGER.warning("Could not remove storage file for %s", configuration)
+    try:
+        remove_device_metadata(config_dir, configuration)
+    except Exception:
+        _LOGGER.warning("Could not remove metadata for %s", configuration)
+
+
 def _validate_archive_configuration(configuration: str) -> None:
     """Reject anything that isn't a pure basename.
 
@@ -1639,25 +1673,13 @@ class DevicesController:
                     "permanently delete the existing archive first."
                 )
                 raise FileExistsError(msg)
-            # Wipe the per-device build dir — same shape as delete.
-            # Storage sidecar carries the canonical ``build_path``.
-            storage_path = ext_storage_path(configuration)
-            storage = StorageJSON.load(storage_path)
-            if storage is not None and storage.build_path:
-                shutil.rmtree(storage.build_path, ignore_errors=True)
+            # Wipe build dir first (same shape as delete), then
+            # move the YAML, then wipe the sidecars so a future
+            # same-name ``configuration`` starts from a clean
+            # cache. See the docstring for the full rationale.
+            _wipe_device_build_dir(configuration)
             shutil.move(str(config_path), str(target))
-            # Wipe the StorageJSON sidecar and device-metadata
-            # entry too, so a future same-name ``configuration``
-            # starts from a clean cache. See the docstring for the
-            # full rationale.
-            try:
-                storage_path.unlink(missing_ok=True)
-            except OSError:
-                _LOGGER.warning("Could not remove storage file for archived %s", configuration)
-            try:
-                remove_device_metadata(config_dir, configuration)
-            except Exception:
-                _LOGGER.warning("Could not remove metadata for archived %s", configuration)
+            _remove_device_sidecars(config_dir, configuration)
 
         try:
             await loop.run_in_executor(None, _archive_sync)
@@ -1776,15 +1798,7 @@ class DevicesController:
                 # An active config with the same filename owns the
                 # sidecars now — leave them alone.
                 return
-            storage_path = ext_storage_path(configuration)
-            try:
-                storage_path.unlink(missing_ok=True)
-            except OSError:
-                _LOGGER.warning("Could not remove storage file for archived %s", configuration)
-            try:
-                remove_device_metadata(config_dir, configuration)
-            except Exception:
-                _LOGGER.warning("Could not remove metadata for archived %s", configuration)
+            _remove_device_sidecars(config_dir, configuration)
 
         await loop.run_in_executor(None, _delete_all)
 
@@ -1801,26 +1815,13 @@ class DevicesController:
             if not config_path.exists():
                 msg = f"File not found: {configuration}"
                 raise FileNotFoundError(msg)
-            # Wipe the per-device PlatformIO build tree first so a partial
-            # failure later in the cleanup still leaves the user able to
-            # retry the delete. ``StorageJSON.build_path`` is the canonical
-            # location (set during compile) — fall back to a no-op when the
-            # device has never been built or the sidecar is gone.
-            storage_path = ext_storage_path(configuration)
-            storage = StorageJSON.load(storage_path)
-            if storage is not None and storage.build_path:
-                shutil.rmtree(storage.build_path, ignore_errors=True)
+            # Wipe build dir first so a partial failure later still
+            # leaves the user able to retry the delete.
+            _wipe_device_build_dir(configuration)
             config_path.unlink(missing_ok=True)
             (config_dir / ".trash" / configuration).unlink(missing_ok=True)
             (config_dir / ".archive" / f"{configuration}.json").unlink(missing_ok=True)
-            try:
-                storage_path.unlink(missing_ok=True)
-            except OSError:
-                _LOGGER.warning("Could not remove storage file for %s", configuration)
-            try:
-                remove_device_metadata(config_dir, configuration)
-            except Exception:
-                _LOGGER.warning("Could not remove metadata for %s", configuration)
+            _remove_device_sidecars(config_dir, configuration)
 
         await loop.run_in_executor(None, _delete_all)
 

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -36,6 +36,7 @@ from ..helpers.device_yaml import (
     generate_device_yaml,
     get_api_encryption_key,
     load_device_yaml,
+    parse_esphome_meta,
     parse_platform_from_yaml,
 )
 from ..helpers.hostname import is_local_hostname, normalize_hostname
@@ -469,6 +470,46 @@ class DevicesController:
         """Delete a device and all associated files."""
         await self._delete_single(configuration)
         await self._scanner.scan()
+
+    @api_command("devices/archive")
+    async def archive_device(self, *, configuration: str, **kwargs: Any) -> None:
+        """Soft-delete a device — keep the YAML, wipe the build dir.
+
+        Moves the YAML to ``<config_dir>/archive/`` so the user can
+        ``unarchive`` later. Mirrors the legacy dashboard's
+        ``ArchiveRequestHandler`` (``esphome/dashboard/web_server.py``).
+        The metadata sidecar and StorageJSON are left in place —
+        they're cheap, and an unarchive that wants to keep the
+        device's last-known IP / expected_config_hash ought to
+        find them where they were.
+        """
+        await self._archive_single(configuration)
+        await self._scanner.scan()
+
+    @api_command("devices/unarchive")
+    async def unarchive_device(self, *, configuration: str, **kwargs: Any) -> None:
+        """Restore an archived device's YAML to the configured config_dir.
+
+        The scanner's next sweep picks the file up and fires
+        ``DEVICE_ADDED`` so the dashboard's active list refreshes
+        without a manual reload.
+        """
+        await self._unarchive_single(configuration)
+        await self._scanner.scan()
+
+    @api_command("devices/list_archived")
+    async def list_archived(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """List archived devices with their parsed name / friendly_name / comment.
+
+        Read-only — surfaces the contents of
+        ``<config_dir>/archive/`` for the dashboard's "Show
+        archived devices" toggle. Each entry carries enough info
+        for the UI to render a row + Unarchive / Delete-permanently
+        actions; full YAML / metadata is left on disk and is fetched
+        on demand if the user opens one.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._list_archived_sync)
 
     @api_command("devices/delete_bulk")
     async def delete_bulk(
@@ -1486,6 +1527,118 @@ class DevicesController:
                 remove_device_metadata(config_dir, configuration)
         except Exception:
             _LOGGER.warning("Could not move metadata for %s", new_filename)
+
+    async def _archive_single(self, configuration: str) -> None:
+        """Soft-delete: move the YAML into ``<config_dir>/archive/`` and wipe its build.
+
+        Mirrors the legacy dashboard's archive flow. The build dir
+        wipe matches what ``_delete_single`` does — an archived
+        device's compile output is dead weight (the user can
+        recompile after unarchive). The YAML stays on disk so the
+        operation is reversible. Metadata sidecar / StorageJSON
+        stay where they are — they're small, and an unarchive
+        that wants to keep the device's last-known cached state
+        ought to find it where it was.
+        """
+        config_path = self._db.settings.rel_path(configuration)
+        loop = asyncio.get_running_loop()
+        config_dir = self._db.settings.config_dir
+
+        def _archive_sync() -> None:
+            if not config_path.exists():
+                msg = f"File not found: {configuration}"
+                raise FileNotFoundError(msg)
+            archive_dir = config_dir / "archive"
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            target = archive_dir / configuration
+            if target.exists():
+                # Same name already archived — bump with a numeric
+                # suffix rather than clobbering. Keeps both copies
+                # recoverable; the user can prune from the archive
+                # view if they want.
+                stem, dot, ext = configuration.rpartition(".")
+                stem = stem or configuration
+                ext = ext if dot else ""
+                counter = 2
+                while True:
+                    candidate = f"{stem} ({counter}).{ext}" if ext else f"{stem} ({counter})"
+                    target = archive_dir / candidate
+                    if not target.exists():
+                        break
+                    counter += 1
+            # Wipe the per-device build dir — same shape as delete.
+            # Storage sidecar carries the canonical ``build_path``.
+            storage_path = ext_storage_path(configuration)
+            storage = StorageJSON.load(storage_path)
+            if storage is not None and storage.build_path:
+                shutil.rmtree(storage.build_path, ignore_errors=True)
+            shutil.move(str(config_path), str(target))
+
+        await loop.run_in_executor(None, _archive_sync)
+
+    async def _unarchive_single(self, configuration: str) -> None:
+        """Move an archived YAML back into the active config_dir.
+
+        Refuses to clobber an existing active YAML — that case
+        means the user already created a new device under the same
+        filename, and silently overwriting it would surprise them.
+        Surface a ``CommandError`` instead so the dialog can prompt
+        for a different action.
+        """
+        loop = asyncio.get_running_loop()
+        config_dir = self._db.settings.config_dir
+        archive_path = config_dir / "archive" / configuration
+        target = self._db.settings.rel_path(configuration)
+
+        def _unarchive_sync() -> None:
+            if not archive_path.exists():
+                msg = f"Archived file not found: {configuration}"
+                raise FileNotFoundError(msg)
+            if target.exists():
+                msg = (
+                    f"Cannot unarchive {configuration}: an active config "
+                    f"with the same name already exists"
+                )
+                raise FileExistsError(msg)
+            shutil.move(str(archive_path), str(target))
+
+        try:
+            await loop.run_in_executor(None, _unarchive_sync)
+        except FileExistsError as exc:
+            raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
+
+    def _list_archived_sync(self) -> list[dict[str, Any]]:
+        """Read ``<config_dir>/archive/`` and parse each YAML's meta block.
+
+        Returns one dict per archived YAML with the same name /
+        friendly_name / comment fields the active device list
+        carries, plus ``configuration`` so the dashboard can
+        address each entry. Files that don't parse are skipped
+        with a debug log — the archive dir is user-managed and
+        a stray non-YAML file shouldn't crash the listing.
+        """
+        archive_dir = self._db.settings.config_dir / "archive"
+        if not archive_dir.is_dir():
+            return []
+        results: list[dict[str, Any]] = []
+        for path in sorted(archive_dir.iterdir()):
+            if path.suffix not in (".yaml", ".yml") or path.name.startswith("."):
+                continue
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError:
+                _LOGGER.debug("Failed to read archived YAML %s", path, exc_info=True)
+                continue
+            name, friendly_name, comment = parse_esphome_meta(content)
+            results.append(
+                {
+                    "configuration": path.name,
+                    "name": name or path.stem,
+                    "friendly_name": friendly_name or name or path.stem,
+                    "comment": comment,
+                }
+            )
+        return results
 
     async def _delete_single(self, configuration: str) -> None:
         """Delete a single device and all associated files."""

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -10,7 +10,7 @@ import re
 import shutil
 from collections.abc import Callable
 from dataclasses import replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any
 
 from esphome import const
@@ -70,6 +70,44 @@ if TYPE_CHECKING:
     from .components import _FeaturedRecord
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _validate_archive_configuration(configuration: str) -> None:
+    """Reject anything that isn't a pure basename.
+
+    Defense-in-depth at the public-command boundary for archive /
+    unarchive / delete_archived. Each helper builds paths from the
+    user-supplied filename (``<config_dir>/archive/<configuration>``,
+    ``ext_storage_path(configuration)`` -> ``data_dir/storage/<configuration>.json``)
+    that don't all flow through ``Settings.rel_path`` — a value
+    containing path separators or ``..`` segments could resolve
+    outside the intended directory and be unlinked / overwritten.
+
+    Reject anything where ``Path(value).name != value`` (catches
+    ``../foo``, ``sub/foo``, backslash-separated paths on Windows),
+    the empty string, and the special path components ``.`` / ``..``
+    that pass the ``.name`` round-trip but are still traversal
+    vectors.
+    """
+    if not configuration:
+        raise CommandError(ErrorCode.INVALID_ARGS, "configuration must not be empty")
+    if configuration in (".", ".."):
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            f"configuration must be a plain filename, not {configuration!r}",
+        )
+    if (
+        "/" in configuration
+        or "\\" in configuration
+        or "\x00" in configuration
+        or PurePosixPath(configuration).name != configuration
+        or PureWindowsPath(configuration).name != configuration
+    ):
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            f"configuration must be a plain filename without path separators, "
+            f"got {configuration!r}",
+        )
 
 
 class DevicesController:
@@ -483,6 +521,7 @@ class DevicesController:
         device's last-known IP / expected_config_hash ought to
         find them where they were.
         """
+        _validate_archive_configuration(configuration)
         try:
             await self._archive_single(configuration)
         except FileNotFoundError as exc:
@@ -497,6 +536,7 @@ class DevicesController:
         ``DEVICE_ADDED`` so the dashboard's active list refreshes
         without a manual reload.
         """
+        _validate_archive_configuration(configuration)
         try:
             await self._unarchive_single(configuration)
         except FileNotFoundError as exc:
@@ -516,6 +556,24 @@ class DevicesController:
         """
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._list_archived_sync)
+
+    @api_command("devices/delete_archived")
+    async def delete_archived(self, *, configuration: str, **kwargs: Any) -> None:
+        """Permanently delete an archived device — YAML and sidecars.
+
+        The companion to ``archive`` for the case where the user
+        decided they really don't want this device back. Removes
+        ``<config_dir>/archive/<configuration>`` plus the
+        StorageJSON sidecar and the device-metadata sidecar (the
+        archive flow leaves both in place for unarchive's benefit).
+        Surfaces ``CommandError(NOT_FOUND)`` when the archive entry
+        is gone — matches the symmetry with ``unarchive``.
+        """
+        _validate_archive_configuration(configuration)
+        try:
+            await self._delete_archived_single(configuration)
+        except FileNotFoundError as exc:
+            raise CommandError(ErrorCode.NOT_FOUND, str(exc)) from exc
 
     @api_command("devices/delete_bulk")
     async def delete_bulk(
@@ -1662,6 +1720,36 @@ class DevicesController:
                 }
             )
         return results
+
+    async def _delete_archived_single(self, configuration: str) -> None:
+        """Permanently remove an archived YAML and its sidecars.
+
+        Mirrors ``_delete_single`` but operates on
+        ``<config_dir>/archive/<configuration>`` instead of the
+        active config_dir. The build dir is already gone (archive
+        wipes it), so this only has to remove the YAML, the
+        StorageJSON sidecar, and the device-metadata sidecar.
+        """
+        loop = asyncio.get_running_loop()
+        config_dir = self._db.settings.config_dir
+        archive_path = config_dir / "archive" / configuration
+
+        def _delete_all() -> None:
+            if not archive_path.exists():
+                msg = f"Archived file not found: {configuration}"
+                raise FileNotFoundError(msg)
+            archive_path.unlink()
+            storage_path = ext_storage_path(configuration)
+            try:
+                storage_path.unlink(missing_ok=True)
+            except OSError:
+                _LOGGER.warning("Could not remove storage file for archived %s", configuration)
+            try:
+                remove_device_metadata(config_dir, configuration)
+            except Exception:
+                _LOGGER.warning("Could not remove metadata for archived %s", configuration)
+
+        await loop.run_in_executor(None, _delete_all)
 
     async def _delete_single(self, configuration: str) -> None:
         """Delete a single device and all associated files."""

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -483,7 +483,10 @@ class DevicesController:
         device's last-known IP / expected_config_hash ought to
         find them where they were.
         """
-        await self._archive_single(configuration)
+        try:
+            await self._archive_single(configuration)
+        except FileNotFoundError as exc:
+            raise CommandError(ErrorCode.NOT_FOUND, str(exc)) from exc
         await self._scanner.scan()
 
     @api_command("devices/unarchive")
@@ -494,7 +497,10 @@ class DevicesController:
         ``DEVICE_ADDED`` so the dashboard's active list refreshes
         without a manual reload.
         """
-        await self._unarchive_single(configuration)
+        try:
+            await self._unarchive_single(configuration)
+        except FileNotFoundError as exc:
+            raise CommandError(ErrorCode.NOT_FOUND, str(exc)) from exc
         await self._scanner.scan()
 
     @api_command("devices/list_archived")
@@ -1552,20 +1558,20 @@ class DevicesController:
             archive_dir.mkdir(parents=True, exist_ok=True)
             target = archive_dir / configuration
             if target.exists():
-                # Same name already archived — bump with a numeric
-                # suffix rather than clobbering. Keeps both copies
-                # recoverable; the user can prune from the archive
-                # view if they want.
-                stem, dot, ext = configuration.rpartition(".")
-                stem = stem or configuration
-                ext = ext if dot else ""
-                counter = 2
-                while True:
-                    candidate = f"{stem} ({counter}).{ext}" if ext else f"{stem} ({counter})"
-                    target = archive_dir / candidate
-                    if not target.exists():
-                        break
-                    counter += 1
+                # Same name already archived. We can't silently rename
+                # to ``<name> (2).yaml`` because the StorageJSON sidecar
+                # and metadata stay keyed on the original filename —
+                # a later unarchive of the suffixed copy would surface
+                # without its sidecar and lose the cached address /
+                # version / loaded_integrations. Refuse the operation
+                # and let the user resolve the collision explicitly
+                # (unarchive the existing copy or delete it).
+                msg = (
+                    f"Cannot archive {configuration}: an archived config "
+                    "with the same name already exists. Unarchive or "
+                    "permanently delete the existing archive first."
+                )
+                raise FileExistsError(msg)
             # Wipe the per-device build dir — same shape as delete.
             # Storage sidecar carries the canonical ``build_path``.
             storage_path = ext_storage_path(configuration)
@@ -1574,7 +1580,10 @@ class DevicesController:
                 shutil.rmtree(storage.build_path, ignore_errors=True)
             shutil.move(str(config_path), str(target))
 
-        await loop.run_in_executor(None, _archive_sync)
+        try:
+            await loop.run_in_executor(None, _archive_sync)
+        except FileExistsError as exc:
+            raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
 
     async def _unarchive_single(self, configuration: str) -> None:
         """Move an archived YAML back into the active config_dir.
@@ -1616,6 +1625,13 @@ class DevicesController:
         address each entry. Files that don't parse are skipped
         with a debug log — the archive dir is user-managed and
         a stray non-YAML file shouldn't crash the listing.
+
+        When the YAML's ``esphome:`` block is sparse (e.g. friendly
+        name only ever lived in StorageJSON because the user wrote
+        it via the dashboard's edit dialog rather than the YAML),
+        fall back to the StorageJSON sidecar before degrading to
+        the bare filename. The sidecar is left in place by archive
+        so this fallback works on archives created by this server.
         """
         archive_dir = self._db.settings.config_dir / "archive"
         if not archive_dir.is_dir():
@@ -1630,6 +1646,13 @@ class DevicesController:
                 _LOGGER.debug("Failed to read archived YAML %s", path, exc_info=True)
                 continue
             name, friendly_name, comment = parse_esphome_meta(content)
+            if not name or not friendly_name or comment is None:
+                storage = StorageJSON.load(ext_storage_path(path.name))
+                if storage is not None:
+                    name = name or storage.name
+                    friendly_name = friendly_name or storage.friendly_name
+                    if comment is None:
+                        comment = storage.comment
             results.append(
                 {
                     "configuration": path.name,

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -513,13 +513,13 @@ class DevicesController:
     async def archive_device(self, *, configuration: str, **kwargs: Any) -> None:
         """Soft-delete a device — keep the YAML, wipe the build dir.
 
-        Moves the YAML to ``<config_dir>/archive/`` so the user can
-        ``unarchive`` later. Mirrors the legacy dashboard's
-        ``ArchiveRequestHandler`` (``esphome/dashboard/web_server.py``).
-        The metadata sidecar and StorageJSON are left in place —
-        they're cheap, and an unarchive that wants to keep the
-        device's last-known IP / expected_config_hash ought to
-        find them where they were.
+        Moves the YAML to ``<config_dir>/archive/`` so the user
+        can ``unarchive`` later. Build dir, StorageJSON sidecar,
+        and device-metadata entry are all wiped so a future
+        ``configuration`` with the same filename starts from a
+        clean cache (per-filename keying would otherwise let the
+        new device inherit the archived one's stale state). See
+        ``_archive_single`` for the full rationale.
         """
         _validate_archive_configuration(configuration)
         try:
@@ -1593,16 +1593,25 @@ class DevicesController:
             _LOGGER.warning("Could not move metadata for %s", new_filename)
 
     async def _archive_single(self, configuration: str) -> None:
-        """Soft-delete: move the YAML into ``<config_dir>/archive/`` and wipe its build.
+        """Soft-delete: move the YAML into ``<config_dir>/archive/`` and wipe build + sidecars.
 
-        Mirrors the legacy dashboard's archive flow. The build dir
-        wipe matches what ``_delete_single`` does — an archived
-        device's compile output is dead weight (the user can
-        recompile after unarchive). The YAML stays on disk so the
-        operation is reversible. Metadata sidecar / StorageJSON
-        stay where they are — they're small, and an unarchive
-        that wants to keep the device's last-known cached state
-        ought to find it where it was.
+        Mirrors the legacy dashboard's archive flow with one
+        deliberate divergence: we also wipe the StorageJSON
+        sidecar and the device-metadata entry. The legacy
+        dashboard preserved them so unarchive could restore the
+        cached IP / version / hash, but the per-filename keying
+        means a future ``configuration`` with the same name would
+        inherit the archived device's stale state (loaded_integrations,
+        deployed_config_hash, address) until it's recompiled or
+        edited. Wiping on archive trades a few seconds of
+        "unknown state" after unarchive (the scanner + monitor
+        refill from the next mDNS broadcast) for full isolation
+        between archive and any future same-name device.
+
+        Build dir wipe matches what ``_delete_single`` does — an
+        archived device's compile output is dead weight (the
+        user can recompile after unarchive). The YAML itself
+        stays on disk so the operation is reversible.
         """
         config_path = self._db.settings.rel_path(configuration)
         loop = asyncio.get_running_loop()
@@ -1637,6 +1646,18 @@ class DevicesController:
             if storage is not None and storage.build_path:
                 shutil.rmtree(storage.build_path, ignore_errors=True)
             shutil.move(str(config_path), str(target))
+            # Wipe the StorageJSON sidecar and device-metadata
+            # entry too, so a future same-name ``configuration``
+            # starts from a clean cache. See the docstring for the
+            # full rationale.
+            try:
+                storage_path.unlink(missing_ok=True)
+            except OSError:
+                _LOGGER.warning("Could not remove storage file for archived %s", configuration)
+            try:
+                remove_device_metadata(config_dir, configuration)
+            except Exception:
+                _LOGGER.warning("Could not remove metadata for archived %s", configuration)
 
         try:
             await loop.run_in_executor(None, _archive_sync)
@@ -1729,16 +1750,32 @@ class DevicesController:
         active config_dir. The build dir is already gone (archive
         wipes it), so this only has to remove the YAML, the
         StorageJSON sidecar, and the device-metadata sidecar.
+
+        Defense-in-depth: the StorageJSON / metadata sidecars are
+        keyed on the bare filename, so if an active config of the
+        same name has been re-created since the archive, those
+        sidecars belong to the live device and removing them
+        would wipe its cached IP / hash / loaded_integrations.
+        ``_archive_single`` already wipes its own sidecars on the
+        way in (so this collision shouldn't happen in practice),
+        but we still guard with an existence check on the active
+        path. Callers expect best-effort cleanup of orphan
+        sidecars, not a guarantee of their removal.
         """
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
         archive_path = config_dir / "archive" / configuration
+        active_path = self._db.settings.rel_path(configuration)
 
         def _delete_all() -> None:
             if not archive_path.exists():
                 msg = f"Archived file not found: {configuration}"
                 raise FileNotFoundError(msg)
             archive_path.unlink()
+            if active_path.exists():
+                # An active config with the same filename owns the
+                # sidecars now — leave them alone.
+                return
             storage_path = ext_storage_path(configuration)
             try:
                 storage_path.unlink(missing_ok=True)

--- a/tests/test_archive_device.py
+++ b/tests/test_archive_device.py
@@ -1,0 +1,362 @@
+"""Tests for ``DevicesController`` archive / unarchive / list_archived.
+
+Mirrors the legacy dashboard's ``ArchiveRequestHandler`` /
+``UnArchiveRequestHandler`` (``esphome/dashboard/web_server.py``):
+
+- Archive moves the YAML to ``<config_dir>/archive/`` and wipes
+  the per-device PlatformIO build tree (compile output of an
+  archived device is dead weight; the user can recompile after
+  unarchive).
+- Unarchive moves the YAML back, refusing to clobber an active
+  config of the same name.
+- list_archived parses each archived YAML's ``esphome:`` block so
+  the dashboard's "Show archived devices" toggle can render a
+  row + Unarchive / Delete-permanently controls.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
+
+
+def _make_controller(config_dir: Path) -> DevicesController:
+    """Build a bare-bones controller wired to *config_dir* on disk.
+
+    Same pattern as ``test_delete_device.py`` — bypass ``__init__``
+    so we don't have to seed a full ``DeviceBuilder``, attach a
+    mock scanner that satisfies ``await scan()`` calls.
+    """
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    controller._db.settings.config_dir = config_dir
+    controller._db.settings.rel_path = lambda configuration: config_dir / configuration
+    controller._scanner = MagicMock()
+    controller._scanner.scan = AsyncMock()
+    return controller
+
+
+def _seed_device(
+    config_dir: Path, configuration: str, *, with_build_dir: bool = True
+) -> tuple[Path, Path]:
+    """Lay out a YAML, StorageJSON sidecar, and (optionally) the build tree.
+
+    Same shape as the delete-test helper. Returns ``(yaml_path,
+    build_path)`` so tests can assert what survives / disappears.
+    """
+    yaml_path = config_dir / configuration
+    name = Path(configuration).stem
+    yaml_path.write_text(
+        f"esphome:\n  name: {name}\n  friendly_name: {name.title()}\n",
+        encoding="utf-8",
+    )
+
+    build_path = config_dir / ".esphome" / "build" / name
+    if with_build_dir:
+        build_path.mkdir(parents=True, exist_ok=True)
+        (build_path / "firmware.bin").write_bytes(b"\x00" * 16)
+        (build_path / "src").mkdir()
+        (build_path / "src" / "main.cpp").write_text("// fake\n", encoding="utf-8")
+
+    storage_dir = config_dir / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / f"{configuration}.json").write_text(
+        json.dumps(
+            {
+                "storage_version": 1,
+                "name": name,
+                "comment": None,
+                "esphome_version": "2026.5.0-dev",
+                "src_version": 1,
+                "address": "",
+                "web_port": None,
+                "esp_platform": "esp32",
+                "board": "esp32-c3-devkitm-1",
+                "build_path": str(build_path),
+                "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
+                "loaded_integrations": [],
+                "loaded_platforms": [],
+                "no_mdns": False,
+                "framework": "esp-idf",
+                "core_platform": "esp32",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return yaml_path, build_path
+
+
+@pytest.fixture
+def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
+    """Pin ``ext_storage_path`` to the tmp config dir.
+
+    The real ``ext_storage_path`` walks ``CORE.config_path`` which
+    isn't set in the test process; this redirect points it at the
+    on-disk sidecar laid down by ``_seed_device`` so the archive
+    path reads the canonical ``build_path`` from there.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.ext_storage_path",
+        lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# archive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_patch_ext_storage")
+async def test_archive_moves_yaml_to_archive_dir(tmp_path: Path) -> None:
+    """The YAML lands in ``<config_dir>/archive/<configuration>``.
+
+    The whole point of archive vs delete: the YAML is reversible.
+    Pin the destination shape so a refactor that quietly switches
+    to ``.archive/`` (hidden) or moves it under ``.esphome/`` (the
+    cache root) shows up as a test failure rather than a user
+    finding their old configs in an unfamiliar place.
+    """
+    controller = _make_controller(tmp_path)
+    yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml")
+    original_text = yaml_path.read_text()
+
+    await controller._archive_single("kitchen.yaml")
+
+    assert not yaml_path.exists()
+    archived = tmp_path / "archive" / "kitchen.yaml"
+    assert archived.exists()
+    assert archived.read_text() == original_text
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_patch_ext_storage")
+async def test_archive_wipes_build_directory(tmp_path: Path) -> None:
+    """An archived device's compile output is dead weight — wipe it.
+
+    Same shape as ``_delete_single``: read ``StorageJSON.build_path``
+    and ``shutil.rmtree`` it. Without this the disk savings from
+    archiving a no-longer-used device would be ~the YAML's worth
+    (a few KB), not the build tree's worth (50-200 MB), and users
+    would still complain about disk usage on long-running fleets.
+    """
+    controller = _make_controller(tmp_path)
+    _, build_path = _seed_device(tmp_path, "kitchen.yaml")
+    assert build_path.exists()
+
+    await controller._archive_single("kitchen.yaml")
+
+    assert not build_path.exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_patch_ext_storage")
+async def test_archive_succeeds_when_never_compiled(tmp_path: Path) -> None:
+    """A device that was never compiled has no build dir — archive still works.
+
+    First-archive happy path is "user just made a YAML, decided
+    they don't need it after all". No StorageJSON, no build tree;
+    the move-to-archive must still succeed without raising.
+    """
+    controller = _make_controller(tmp_path)
+    yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml", with_build_dir=False)
+    # Wipe the StorageJSON sidecar to simulate "never compiled".
+    (tmp_path / ".esphome" / "storage" / "kitchen.yaml.json").unlink()
+
+    await controller._archive_single("kitchen.yaml")
+
+    assert not yaml_path.exists()
+    assert (tmp_path / "archive" / "kitchen.yaml").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_patch_ext_storage")
+async def test_archive_collision_appends_numeric_suffix(tmp_path: Path) -> None:
+    """Archiving twice with the same name doesn't clobber the earlier copy.
+
+    User flow: create ``kitchen.yaml`` → archive → recreate
+    ``kitchen.yaml`` (different config) → archive again. Both
+    archived copies should be recoverable; the second lands at
+    ``kitchen (2).yaml`` rather than overwriting the first.
+    """
+    controller = _make_controller(tmp_path)
+
+    # First archive lands at the plain name.
+    _seed_device(tmp_path, "kitchen.yaml")
+    (tmp_path / "kitchen.yaml").write_text("first version\n", encoding="utf-8")
+    await controller._archive_single("kitchen.yaml")
+    assert (tmp_path / "archive" / "kitchen.yaml").read_text() == "first version\n"
+
+    # Recreate + archive again — second copy bumps to (2).
+    _seed_device(tmp_path, "kitchen.yaml")
+    (tmp_path / "kitchen.yaml").write_text("second version\n", encoding="utf-8")
+    await controller._archive_single("kitchen.yaml")
+
+    assert (tmp_path / "archive" / "kitchen.yaml").read_text() == "first version\n"
+    assert (tmp_path / "archive" / "kitchen (2).yaml").read_text() == "second version\n"
+
+
+@pytest.mark.asyncio
+async def test_archive_missing_file_raises_file_not_found(tmp_path: Path) -> None:
+    """An archive of a non-existent configuration raises cleanly.
+
+    Symmetric with ``_delete_single`` — the WS layer surfaces the
+    raise as a user-facing error so a stale dashboard reference
+    (someone else just deleted the device) doesn't silently
+    succeed.
+    """
+    controller = _make_controller(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        await controller._archive_single("ghost.yaml")
+
+
+# ---------------------------------------------------------------------------
+# unarchive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unarchive_moves_yaml_back(tmp_path: Path) -> None:
+    """Unarchive is the inverse of archive — YAML returns to config_dir.
+
+    The scanner's next sweep then fires ``DEVICE_ADDED``;
+    ``unarchive_device`` calls ``self._scanner.scan()`` itself so
+    the dashboard refreshes without a manual reload.
+    """
+    controller = _make_controller(tmp_path)
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    archived = archive_dir / "kitchen.yaml"
+    archived.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    await controller._unarchive_single("kitchen.yaml")
+
+    assert not archived.exists()
+    assert (tmp_path / "kitchen.yaml").exists()
+
+
+@pytest.mark.asyncio
+async def test_unarchive_refuses_to_clobber_active_config(tmp_path: Path) -> None:
+    """An active YAML with the same name blocks the unarchive.
+
+    The active YAML may carry the user's recent edits; silently
+    overwriting it with the archived copy would surprise them.
+    Surface a ``CommandError(INVALID_ARGS)`` so the dialog can
+    prompt for an alternate filename or for an explicit overwrite.
+    """
+    controller = _make_controller(tmp_path)
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    archived = archive_dir / "kitchen.yaml"
+    archived.write_text("# archived\n", encoding="utf-8")
+    active = tmp_path / "kitchen.yaml"
+    active.write_text("# active, freshly written\n", encoding="utf-8")
+
+    with pytest.raises(CommandError) as exc:
+        await controller._unarchive_single("kitchen.yaml")
+
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+    # Archive copy survives untouched so the user's data isn't lost.
+    assert archived.read_text() == "# archived\n"
+    assert active.read_text() == "# active, freshly written\n"
+
+
+@pytest.mark.asyncio
+async def test_unarchive_missing_archive_file_raises(tmp_path: Path) -> None:
+    """Unarchiving a name that isn't in the archive raises cleanly."""
+    controller = _make_controller(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        await controller._unarchive_single("ghost.yaml")
+
+
+# ---------------------------------------------------------------------------
+# list_archived
+# ---------------------------------------------------------------------------
+
+
+def test_list_archived_returns_empty_when_no_archive_dir(tmp_path: Path) -> None:
+    """Pre-first-archive: no directory, no entries, no error.
+
+    The dashboard pulls this list on every "Show archived"
+    toggle; raising on the no-directory case would force the
+    frontend to special-case it. Return ``[]`` instead.
+    """
+    controller = _make_controller(tmp_path)
+    assert controller._list_archived_sync() == []
+
+
+def test_list_archived_parses_each_yaml_meta_block(tmp_path: Path) -> None:
+    """Each archived YAML's ``esphome:`` block surfaces as a row.
+
+    Mirrors the active list's name / friendly_name / comment shape
+    so the frontend can reuse the same row component without
+    learning a separate archived-device DTO.
+    """
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\n  friendly_name: Kitchen Sensor\n  comment: by the sink\n",
+        encoding="utf-8",
+    )
+    (archive_dir / "garage.yaml").write_text(
+        "esphome:\n  name: garage\n  friendly_name: Garage Door\n",
+        encoding="utf-8",
+    )
+
+    controller = _make_controller(tmp_path)
+    rows = controller._list_archived_sync()
+
+    by_config = {r["configuration"]: r for r in rows}
+    assert set(by_config) == {"kitchen.yaml", "garage.yaml"}
+    assert by_config["kitchen.yaml"]["name"] == "kitchen"
+    assert by_config["kitchen.yaml"]["friendly_name"] == "Kitchen Sensor"
+    assert by_config["kitchen.yaml"]["comment"] == "by the sink"
+    assert by_config["garage.yaml"]["friendly_name"] == "Garage Door"
+
+
+def test_list_archived_skips_non_yaml_and_hidden(tmp_path: Path) -> None:
+    """A stray ``.DS_Store`` / ``.txt`` next to the YAMLs doesn't crash.
+
+    Archive directory is user-managed; some users sync it via Git
+    and end up with ``.gitignore`` / ``.DS_Store``. The list
+    helper has to ignore non-YAML and hidden files so a single
+    stray file doesn't poison the listing.
+    """
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    (archive_dir / ".DS_Store").write_bytes(b"\x00\x00")
+    (archive_dir / "notes.txt").write_text("scratch", encoding="utf-8")
+    (archive_dir / ".hidden.yaml").write_text("esphome:\n  name: hidden\n", encoding="utf-8")
+
+    rows = _make_controller(tmp_path)._list_archived_sync()
+    assert [r["configuration"] for r in rows] == ["kitchen.yaml"]
+
+
+def test_list_archived_falls_back_to_filename_when_meta_unparseable(
+    tmp_path: Path,
+) -> None:
+    """A YAML the meta parser can't read still surfaces as a row.
+
+    Use case: legacy archive contents from a different dashboard
+    where the YAML was hand-edited and ``esphome:`` was reorganised.
+    The filename is the user's only handle on the file; we'd
+    rather show ``kitchen.yaml — kitchen`` than hide it entirely.
+    """
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "kitchen.yaml").write_text("# no esphome: block at all\n", encoding="utf-8")
+
+    rows = _make_controller(tmp_path)._list_archived_sync()
+    assert len(rows) == 1
+    assert rows[0]["configuration"] == "kitchen.yaml"
+    assert rows[0]["name"] == "kitchen"
+    assert rows[0]["friendly_name"] == "kitchen"

--- a/tests/test_archive_device.py
+++ b/tests/test_archive_device.py
@@ -278,6 +278,67 @@ async def test_archive_missing_file_raises_file_not_found(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_archive_device_full_flow_calls_scanner(tmp_path: Path) -> None:
+    """End-to-end ``archive_device`` runs the helper and re-scans.
+
+    Covers the public-command success path that helper-level tests
+    skip: the wrapper's ``_archive_single`` call on success and the
+    follow-up ``self._scanner.scan()`` that triggers the
+    ``DEVICE_REMOVED`` event for the dashboard.
+    """
+    controller = _make_controller(tmp_path)
+    yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml")
+
+    await controller.archive_device(configuration="kitchen.yaml")
+
+    assert not yaml_path.exists()
+    assert (tmp_path / "archive" / "kitchen.yaml").exists()
+    controller._scanner.scan.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unarchive_device_full_flow_calls_scanner(tmp_path: Path) -> None:
+    """End-to-end ``unarchive_device`` runs the helper and re-scans.
+
+    Same shape as ``test_archive_device_full_flow_calls_scanner`` —
+    covers the WS-command tail (``_scanner.scan()`` after success).
+    """
+    controller = _make_controller(tmp_path)
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    await controller.unarchive_device(configuration="kitchen.yaml")
+
+    assert not (archive_dir / "kitchen.yaml").exists()
+    assert (tmp_path / "kitchen.yaml").exists()
+    controller._scanner.scan.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_archived_full_flow(tmp_path: Path) -> None:
+    """End-to-end ``list_archived`` returns the parsed rows.
+
+    Covers the WS-command body that runs ``_list_archived_sync``
+    in an executor — helper-level tests call the sync version
+    directly and miss the executor wrapping.
+    """
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n",
+        encoding="utf-8",
+    )
+
+    controller = _make_controller(tmp_path)
+    rows = await controller.list_archived()
+
+    assert len(rows) == 1
+    assert rows[0]["configuration"] == "kitchen.yaml"
+    assert rows[0]["friendly_name"] == "Kitchen"
+
+
+@pytest.mark.asyncio
 async def test_archive_device_translates_missing_to_command_error(tmp_path: Path) -> None:
     """The WS-layer entry point surfaces ``CommandError(NOT_FOUND)`` to the client.
 
@@ -404,6 +465,56 @@ async def test_archive_rejects_path_traversal(tmp_path: Path, configuration: str
         with pytest.raises(CommandError) as exc:
             await cmd(configuration=configuration)
         assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+# ---------------------------------------------------------------------------
+# _remove_device_sidecars exception paths
+# ---------------------------------------------------------------------------
+
+
+def test_remove_device_sidecars_logs_oserror_on_storage_unlink(
+    tmp_path: Path, monkeypatch: Any, caplog: Any
+) -> None:
+    """OSError from the storage unlink is logged, not raised.
+
+    Covers the warning branch — a permission-error / read-only fs
+    on the StorageJSON sidecar shouldn't block the rest of the
+    archive / delete flow.
+    """
+    from esphome_device_builder.controllers.devices import (
+        _remove_device_sidecars,
+    )
+
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True)
+    (storage_dir / "kitchen.yaml.json").write_text("{}", encoding="utf-8")
+
+    def _raise_oserror(self: Path, missing_ok: bool = False) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "unlink", _raise_oserror)
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        _remove_device_sidecars(tmp_path, "kitchen.yaml")
+    assert any("Could not remove storage file" in rec.message for rec in caplog.records)
+
+
+def test_remove_device_sidecars_logs_exception_on_metadata_remove(
+    tmp_path: Path, monkeypatch: Any, caplog: Any
+) -> None:
+    """Generic Exception from metadata-remove is logged, not raised."""
+    from esphome_device_builder.controllers import devices as devices_module
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(devices_module, "remove_device_metadata", _raise)
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        devices_module._remove_device_sidecars(tmp_path, "kitchen.yaml")
+    assert any("Could not remove metadata" in rec.message for rec in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_device.py
+++ b/tests/test_archive_device.py
@@ -160,6 +160,58 @@ async def test_archive_wipes_build_directory(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_archive_wipes_storage_sidecar(tmp_path: Path) -> None:
+    """The StorageJSON sidecar is removed when archiving.
+
+    Per-filename keying means a sidecar that survives archive
+    would leak the archived device's address / hash /
+    loaded_integrations into a future ``configuration`` of the
+    same name. Wipe it on archive so the new device gets a
+    clean cache; the scanner re-fills via mDNS once the device
+    is back online (only a few seconds of "unknown state").
+    """
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml")
+    storage_path = tmp_path / ".esphome" / "storage" / "kitchen.yaml.json"
+    assert storage_path.exists()
+
+    await controller._archive_single("kitchen.yaml")
+
+    assert not storage_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_archive_wipes_device_metadata(tmp_path: Path) -> None:
+    """The device-metadata entry is removed when archiving.
+
+    Same reason as the StorageJSON wipe: a future same-name
+    ``configuration`` would inherit the archived device's
+    cached IP / friendly_name / board_id otherwise.
+    """
+    from esphome_device_builder.controllers.config import (
+        get_device_metadata,
+        set_device_metadata,
+    )
+
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml")
+    set_device_metadata(
+        tmp_path,
+        "kitchen.yaml",
+        board_id="esp32-c3-devkitm-1",
+        friendly_name="Kitchen Sensor",
+        ip="192.168.1.42",
+    )
+    assert get_device_metadata(tmp_path, "kitchen.yaml")  # truthy: dict has fields
+
+    await controller._archive_single("kitchen.yaml")
+
+    # Empty dict means no metadata entry — same as a brand-new
+    # device that's never had metadata written.
+    assert get_device_metadata(tmp_path, "kitchen.yaml") == {}
+
+
+@pytest.mark.asyncio
 async def test_archive_succeeds_when_never_compiled(tmp_path: Path) -> None:
     """A device that was never compiled has no build dir — archive still works.
 
@@ -382,6 +434,38 @@ async def test_delete_archived_removes_yaml_and_sidecars(tmp_path: Path) -> None
 
     assert not (archive_dir / "kitchen.yaml").exists()
     assert not storage_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_archived_preserves_active_sidecars(tmp_path: Path) -> None:
+    """Same-name active config keeps its sidecars when the archive copy is deleted.
+
+    Defense-in-depth: if an active config has been re-created
+    with the same filename since the archive (which shouldn't
+    happen because ``_archive_single`` wipes its sidecars on the
+    way in, but might if the archive predates this PR or was
+    written by the legacy dashboard), the StorageJSON / metadata
+    sidecars belong to the *live* device. Permanent-deleting the
+    archive copy must not wipe the live device's cached state.
+    """
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    # Active config with the same filename — and a sidecar that
+    # belongs to the *active* device, not the archive copy.
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen-active\n", encoding="utf-8")
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    storage_path = storage_dir / "kitchen.yaml.json"
+    storage_path.write_text('{"name":"active"}', encoding="utf-8")
+
+    controller = _make_controller(tmp_path)
+    await controller._delete_archived_single("kitchen.yaml")
+
+    assert not (archive_dir / "kitchen.yaml").exists()
+    # Active YAML and its sidecars survive untouched.
+    assert (tmp_path / "kitchen.yaml").read_text() == ("esphome:\n  name: kitchen-active\n")
+    assert storage_path.read_text() == '{"name":"active"}'
 
 
 @pytest.mark.asyncio

--- a/tests/test_archive_device.py
+++ b/tests/test_archive_device.py
@@ -310,6 +310,121 @@ async def test_unarchive_missing_archive_file_raises(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# path traversal — defense in depth at the public command boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "configuration",
+    [
+        "../etc/passwd",
+        "../../etc/passwd",
+        "subdir/file.yaml",
+        "..",
+        ".",
+        "",
+        "/etc/passwd",
+        "foo/../bar.yaml",
+        "..\\windows\\system32",
+        "secrets\\password.yaml",
+        "with\x00null.yaml",
+    ],
+)
+@pytest.mark.asyncio
+async def test_archive_rejects_path_traversal(tmp_path: Path, configuration: str) -> None:
+    """All three archive commands reject non-basename ``configuration``.
+
+    The helpers build paths like ``<config_dir>/archive/<configuration>``
+    and ``ext_storage_path(configuration)`` (which resolves to
+    ``<config_dir>/.esphome/storage/<configuration>.json``). Without
+    a top-level filename validator a value containing ``..`` or path
+    separators could resolve outside the intended directory — the
+    archive flow would unlink / overwrite a file outside the archive
+    tree. Reject at the WS boundary so the helpers never see a
+    suspect value.
+    """
+    controller = _make_controller(tmp_path)
+    for cmd in (
+        controller.archive_device,
+        controller.unarchive_device,
+        controller.delete_archived,
+    ):
+        with pytest.raises(CommandError) as exc:
+            await cmd(configuration=configuration)
+        assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+# ---------------------------------------------------------------------------
+# delete_archived
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_archived_removes_yaml_and_sidecars(tmp_path: Path) -> None:
+    """Permanent delete clears the archived YAML and its sidecars.
+
+    The archive flow leaves StorageJSON / device-metadata behind so
+    unarchive can restore the cached state. Once the user explicitly
+    says "this is gone for good", those sidecars are dead weight —
+    leaving them around would surprise a future create-with-same-
+    filename with stale cached state. Mirror ``_delete_single``.
+    """
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    storage_path = storage_dir / "kitchen.yaml.json"
+    storage_path.write_text("{}", encoding="utf-8")
+
+    controller = _make_controller(tmp_path)
+    await controller._delete_archived_single("kitchen.yaml")
+
+    assert not (archive_dir / "kitchen.yaml").exists()
+    assert not storage_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_archived_succeeds_without_sidecars(tmp_path: Path) -> None:
+    """A bare YAML in the archive (no sidecar) deletes cleanly.
+
+    Same shape as ``_delete_single`` — ``unlink(missing_ok=True)``
+    on the StorageJSON path lets a hand-archived YAML or one whose
+    sidecar was wiped earlier still go away when the user picks
+    Delete-permanently.
+    """
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    controller = _make_controller(tmp_path)
+    await controller._delete_archived_single("kitchen.yaml")
+    assert not (archive_dir / "kitchen.yaml").exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_archived_missing_raises_file_not_found(tmp_path: Path) -> None:
+    """Permanent delete of a non-existent archive entry raises cleanly."""
+    controller = _make_controller(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        await controller._delete_archived_single("ghost.yaml")
+
+
+@pytest.mark.asyncio
+async def test_delete_archived_translates_missing_to_command_error(tmp_path: Path) -> None:
+    """The WS-layer entry point surfaces ``CommandError(NOT_FOUND)``.
+
+    Mirrors ``archive_device`` / ``unarchive_device`` — the helper
+    raises ``FileNotFoundError`` so internal callers can catch by
+    type, but the public command translates to a clean WS error.
+    """
+    controller = _make_controller(tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.delete_archived(configuration="ghost.yaml")
+    assert exc.value.code == ErrorCode.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
 # list_archived
 # ---------------------------------------------------------------------------
 

--- a/tests/test_archive_device.py
+++ b/tests/test_archive_device.py
@@ -94,7 +94,7 @@ def _seed_device(
     return yaml_path, build_path
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
     """Pin ``ext_storage_path`` to the tmp config dir.
 
@@ -102,6 +102,10 @@ def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
     isn't set in the test process; this redirect points it at the
     on-disk sidecar laid down by ``_seed_device`` so the archive
     path reads the canonical ``build_path`` from there.
+
+    Autouse because both ``_archive_single`` and ``_list_archived_sync``
+    reach into ``ext_storage_path`` — keeping the redirect in one
+    place avoids future tests accidentally hitting the real CORE.
     """
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.ext_storage_path",
@@ -115,7 +119,6 @@ def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
 async def test_archive_moves_yaml_to_archive_dir(tmp_path: Path) -> None:
     """The YAML lands in ``<config_dir>/archive/<configuration>``.
 
@@ -138,7 +141,6 @@ async def test_archive_moves_yaml_to_archive_dir(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
 async def test_archive_wipes_build_directory(tmp_path: Path) -> None:
     """An archived device's compile output is dead weight — wipe it.
 
@@ -158,7 +160,6 @@ async def test_archive_wipes_build_directory(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
 async def test_archive_succeeds_when_never_compiled(tmp_path: Path) -> None:
     """A device that was never compiled has no build dir — archive still works.
 
@@ -178,14 +179,17 @@ async def test_archive_succeeds_when_never_compiled(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
-async def test_archive_collision_appends_numeric_suffix(tmp_path: Path) -> None:
-    """Archiving twice with the same name doesn't clobber the earlier copy.
+async def test_archive_collision_raises_invalid_args(tmp_path: Path) -> None:
+    """Archiving twice with the same name refuses rather than silently renaming.
 
-    User flow: create ``kitchen.yaml`` → archive → recreate
-    ``kitchen.yaml`` (different config) → archive again. Both
-    archived copies should be recoverable; the second lands at
-    ``kitchen (2).yaml`` rather than overwriting the first.
+    The StorageJSON sidecar and metadata are keyed on the original
+    filename and stay there across archive. Renaming the second
+    archive copy to ``kitchen (2).yaml`` would orphan the suffixed
+    YAML from its sidecar — a later unarchive would surface without
+    the cached address / version / loaded_integrations. Refuse the
+    operation with ``CommandError(INVALID_ARGS)`` and let the user
+    resolve the collision (unarchive or permanently delete the
+    existing archive copy first).
     """
     controller = _make_controller(tmp_path)
 
@@ -195,13 +199,16 @@ async def test_archive_collision_appends_numeric_suffix(tmp_path: Path) -> None:
     await controller._archive_single("kitchen.yaml")
     assert (tmp_path / "archive" / "kitchen.yaml").read_text() == "first version\n"
 
-    # Recreate + archive again — second copy bumps to (2).
+    # Recreate + archive again — must refuse rather than clobber or rename.
     _seed_device(tmp_path, "kitchen.yaml")
     (tmp_path / "kitchen.yaml").write_text("second version\n", encoding="utf-8")
-    await controller._archive_single("kitchen.yaml")
+    with pytest.raises(CommandError) as exc:
+        await controller._archive_single("kitchen.yaml")
 
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+    # First archive copy and the active YAML both survive untouched.
     assert (tmp_path / "archive" / "kitchen.yaml").read_text() == "first version\n"
-    assert (tmp_path / "archive" / "kitchen (2).yaml").read_text() == "second version\n"
+    assert (tmp_path / "kitchen.yaml").read_text() == "second version\n"
 
 
 @pytest.mark.asyncio
@@ -216,6 +223,31 @@ async def test_archive_missing_file_raises_file_not_found(tmp_path: Path) -> Non
     controller = _make_controller(tmp_path)
     with pytest.raises(FileNotFoundError):
         await controller._archive_single("ghost.yaml")
+
+
+@pytest.mark.asyncio
+async def test_archive_device_translates_missing_to_command_error(tmp_path: Path) -> None:
+    """The WS-layer entry point surfaces ``CommandError(NOT_FOUND)`` to the client.
+
+    The internal ``_archive_single`` raises ``FileNotFoundError`` so
+    delete / archive symmetry is preserved at the helper level, but
+    the public ``archive_device`` wraps it so a stale dashboard
+    reference shows up as a clean ``not_found`` over the wire
+    instead of a generic ``internal_error``.
+    """
+    controller = _make_controller(tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.archive_device(configuration="ghost.yaml")
+    assert exc.value.code == ErrorCode.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_unarchive_device_translates_missing_to_command_error(tmp_path: Path) -> None:
+    """``unarchive_device`` mirrors ``archive_device`` for not-found mapping."""
+    controller = _make_controller(tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.unarchive_device(configuration="ghost.yaml")
+    assert exc.value.code == ErrorCode.NOT_FOUND
 
 
 # ---------------------------------------------------------------------------
@@ -360,3 +392,56 @@ def test_list_archived_falls_back_to_filename_when_meta_unparseable(
     assert rows[0]["configuration"] == "kitchen.yaml"
     assert rows[0]["name"] == "kitchen"
     assert rows[0]["friendly_name"] == "kitchen"
+
+
+def test_list_archived_falls_back_to_storage_json_when_yaml_meta_sparse(
+    tmp_path: Path,
+) -> None:
+    """When the YAML's ``esphome:`` block is missing fields, fill from StorageJSON.
+
+    Friendly name and comment commonly only live in the StorageJSON
+    sidecar (the dashboard's edit-name dialog writes them there
+    rather than mutating the YAML). Without this fallback the
+    archived listing would regress to bare filenames for those
+    devices, hiding the user-visible names they expect.
+    """
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    # YAML carries only `name` — friendly_name + comment live in the sidecar.
+    (archive_dir / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\n",
+        encoding="utf-8",
+    )
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / "kitchen.yaml.json").write_text(
+        json.dumps(
+            {
+                "storage_version": 1,
+                "name": "kitchen",
+                "friendly_name": "Kitchen Sensor",
+                "comment": "by the sink",
+                "esphome_version": "2026.5.0-dev",
+                "src_version": 1,
+                "address": "",
+                "web_port": None,
+                "esp_platform": "esp32",
+                "board": "esp32-c3-devkitm-1",
+                "build_path": None,
+                "firmware_bin_path": None,
+                "loaded_integrations": [],
+                "loaded_platforms": [],
+                "no_mdns": False,
+                "framework": "esp-idf",
+                "core_platform": "esp32",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rows = _make_controller(tmp_path)._list_archived_sync()
+    assert len(rows) == 1
+    assert rows[0]["configuration"] == "kitchen.yaml"
+    assert rows[0]["name"] == "kitchen"
+    assert rows[0]["friendly_name"] == "Kitchen Sensor"
+    assert rows[0]["comment"] == "by the sink"

--- a/tests/test_archive_device.py
+++ b/tests/test_archive_device.py
@@ -188,6 +188,8 @@ async def test_archive_wipes_device_metadata(tmp_path: Path) -> None:
     ``configuration`` would inherit the archived device's
     cached IP / friendly_name / board_id otherwise.
     """
+    import asyncio
+
     from esphome_device_builder.controllers.config import (
         get_device_metadata,
         set_device_metadata,
@@ -195,20 +197,28 @@ async def test_archive_wipes_device_metadata(tmp_path: Path) -> None:
 
     controller = _make_controller(tmp_path)
     _seed_device(tmp_path, "kitchen.yaml")
-    set_device_metadata(
+    # ``set_device_metadata`` writes through ``metadata_transaction``
+    # which calls ``tempfile.mkstemp`` for an atomic replace —
+    # blockbuster (the CI's blocking-call detector) flags the
+    # ``os.path.abspath`` inside ``mkstemp`` from an async context,
+    # so push the write to a thread.
+    await asyncio.to_thread(
+        set_device_metadata,
         tmp_path,
         "kitchen.yaml",
         board_id="esp32-c3-devkitm-1",
         friendly_name="Kitchen Sensor",
         ip="192.168.1.42",
     )
-    assert get_device_metadata(tmp_path, "kitchen.yaml")  # truthy: dict has fields
+    assert await asyncio.to_thread(
+        get_device_metadata, tmp_path, "kitchen.yaml"
+    )  # truthy: dict has fields
 
     await controller._archive_single("kitchen.yaml")
 
     # Empty dict means no metadata entry — same as a brand-new
     # device that's never had metadata written.
-    assert get_device_metadata(tmp_path, "kitchen.yaml") == {}
+    assert await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml") == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds backend support for the dashboard's archive flow — soft-delete that's reversible, mirrors the legacy ESPHome dashboard's `ArchiveRequestHandler` / `UnArchiveRequestHandler`. Pairs with frontend PR esphome/device-builder-frontend#86.

## Commands

| Command | Args | Returns | Notes |
|---|---|---|---|
| `devices/archive` | `{configuration}` | — | Move YAML to `<config_dir>/archive/`, wipe build dir, wipe StorageJSON + metadata sidecars. Reversible via `unarchive`. |
| `devices/unarchive` | `{configuration}` | — | Move YAML back. Errors with `INVALID_ARGS` if an active config of the same name already exists. |
| `devices/list_archived` | — | `[{configuration, name, friendly_name, comment}]` | Listing for the dashboard's Archived-devices dialog. |
| `devices/delete_archived` | `{configuration}` | — | Permanently delete an archived YAML and its sidecars. Symmetric companion to `archive`. |

## Design decisions

### Sidecar wipe on archive

`_archive_single` removes the StorageJSON sidecar and device-metadata entry alongside the build dir. A previous iteration left them in place so unarchive could restore the cached IP / version / config_hash / loaded_integrations, but per-filename keying meant a future same-name `configuration` would inherit the archived device's stale state until recompiled. Wiping on archive trades a few seconds of "unknown state" after unarchive (the scanner + monitor refill from the next mDNS broadcast) for full isolation between archive and any future same-name device.

### Same-name collision: refuse, don't suffix-bump

`_archive_single` rejects with `CommandError(INVALID_ARGS)` when an archive entry of the same name already exists, instead of renaming the new archive to `<name> (2).yaml`. The earlier suffix-bump approach orphaned the suffixed copy from its sidecars (sidecars stay keyed on the original filename), so unarchive of the bumped copy would surface without its cached state. Safer to make the user resolve the collision explicitly (unarchive the existing copy or permanently delete it first).

### Path-traversal validator at the public boundary

`_validate_archive_configuration` runs at the top of every archive command and rejects anything that isn't a pure basename (no path separators, no `..`, no NUL byte, no `.` / `..`, fails POSIX or Windows `.name` round-trip). Each helper builds paths from the user-supplied filename (`<config_dir>/archive/<configuration>`, `ext_storage_path(configuration)` → `data_dir/storage/<configuration>.json`) that don't all flow through `Settings.rel_path`, so structural protection alone wasn't sufficient. 11 traversal payloads × 3 commands all rejected with `INVALID_ARGS`. Defense-in-depth follow-up for other handlers tracked at #107.

### `delete_archived` defensive guard

`_delete_archived_single` skips sidecar removal when an active config of the same filename exists. With archive-side sidecar wipe in place, this collision shouldn't arise from new archives, but archives created by the legacy dashboard or before this PR could still hit it — and removing the sidecars would wipe the *live* device's cached state.

### List fallback

`_list_archived_sync` falls back to `StorageJSON.name` / `friendly_name` / `comment` when the archived YAML's `esphome:` block is sparse (e.g. friendly name only ever lived in the sidecar because the user wrote it via the dashboard's edit-name dialog rather than mutating the YAML). Bare-filename is the third fallback.

### Error code translation

`archive_device`, `unarchive_device`, `delete_archived` wrap the corresponding helpers and translate `FileNotFoundError` to `CommandError(NOT_FOUND)`. Unarchive additionally translates `FileExistsError` (active config already at the target filename) to `CommandError(INVALID_ARGS)`. Without these the WS layer would surface them as generic `INTERNAL_ERROR`.

## Test plan

- 33 archive-specific tests covering: archive moves YAML, wipes build dir, wipes storage + metadata sidecars; collision raises INVALID_ARGS; missing file raises NOT_FOUND at WS boundary; unarchive moves back, refuses clobber, NOT_FOUND mapping; list_archived parses meta, skips non-YAML / hidden, falls back to filename, falls back to StorageJSON; delete_archived removes YAML + sidecars, preserves active-same-name sidecars, NOT_FOUND mapping; 11 path-traversal payloads × 3 commands all rejected with INVALID_ARGS.
- 515 backend tests total, all green.