### PR TITLE
Add umbrella catalog entries for legacy bare `ota:` / `time:`

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -119,6 +119,38 @@ _PLATFORM_DOMAINS: frozenset[str] = frozenset(
 # ``core`` is the indexing-only metadata block in esphome.json.
 _HIDDEN_TOP_LEVEL: frozenset[str] = frozenset({"core"})
 
+# Synthetic umbrella entries for legacy bare-key domains. Both ``ota:``
+# and ``time:`` accept a legacy bare-mapping form that predates the
+# platform-based shape — bare ``ota:`` implicitly uses the ``esphome``
+# OTA platform, bare ``time:`` implicitly uses ``homeassistant``. The
+# catalog only ships qualified ``<domain>.<platform>`` entries, so a
+# ``get_component("ota")`` lookup or an ``ota`` value in
+# ``loaded_integrations`` previously had no exact-id hit. The
+# umbrella entries fill that gap with a description that names the
+# implicit default platform and lists the platforms available today.
+#
+# The injector iterates the freshly-built catalog at sync time so
+# the platform list in the description stays accurate as platforms
+# come and go upstream.
+_UMBRELLA_ENTRIES: tuple[dict[str, str], ...] = (
+    {
+        "id": "ota",
+        "name": "OTA Updates",
+        "category": "ota",
+        "default_platform": "esphome",
+        "summary": "Over-the-Air firmware updates",
+        "docs_url": "https://esphome.io/components/ota/",
+    },
+    {
+        "id": "time",
+        "name": "Time Source",
+        "category": "time",
+        "default_platform": "homeassistant",
+        "summary": "Time source / real-time clock for the device",
+        "docs_url": "https://esphome.io/components/time/",
+    },
+)
+
 # Map prebuilt-schema ``type`` strings to our ConfigEntryType enum.
 # Things not in this table fall through to STRING.
 _TYPE_MAP: dict[str, str] = {
@@ -632,6 +664,13 @@ def build_catalog(
     # ``ota.http_request``).
     _backfill_descriptions_from_mdx(out)
 
+    # Synthesise umbrella entries for legacy bare-key domains so that
+    # ``get_component("ota")`` / ``get_component("time")`` resolve for
+    # users still on the pre-platform YAML form. Runs after MDX
+    # backfill so the umbrellas live alongside fully-populated
+    # platform entries.
+    _inject_umbrella_entries(out)
+
     return out
 
 
@@ -702,6 +741,63 @@ def _backfill_descriptions_from_mdx(entries: list[dict]) -> None:
             backfilled_names,
             backfilled_components,
             backfilled_fields,
+        )
+
+
+def _inject_umbrella_entries(entries: list[dict]) -> None:
+    """
+    Add synthetic catalog entries for legacy bare-key domains.
+
+    See ``_UMBRELLA_ENTRIES`` for the configured domains and their
+    implicit default platforms. The description for each umbrella
+    lists every platform present in *entries* under that domain so
+    the text stays in sync with the schema as platforms are added or
+    removed. Image URL is borrowed from the default platform's entry
+    when available so the umbrella renders with the same icon.
+
+    Skips an umbrella whose domain id already exists (defensive) or
+    whose configured default platform is missing from the catalog —
+    the latter would leave the description claiming a default that
+    can't actually be selected.
+    """
+    by_id: dict[str, dict] = {e["id"]: e for e in entries}
+    for spec in _UMBRELLA_ENTRIES:
+        domain = spec["id"]
+        if domain in by_id:
+            continue
+        default_qualified = f"{domain}.{spec['default_platform']}"
+        default_entry = by_id.get(default_qualified)
+        if default_entry is None:
+            _LOGGER.warning(
+                "Skipping %s umbrella entry: default platform %s not in catalog",
+                domain,
+                default_qualified,
+            )
+            continue
+        platforms = sorted(cid.split(".", 1)[1] for cid in by_id if cid.startswith(f"{domain}."))
+        platforms_csv = ", ".join(f"`{p}`" for p in platforms)
+        description = (
+            f"{spec['summary']}. When `{domain}:` is configured as a bare "
+            f"mapping (no `- platform:` list — the legacy form), ESPHome "
+            f"implicitly uses the `{spec['default_platform']}` platform. "
+            f"Modern configs select a platform explicitly: available "
+            f"platforms are {platforms_csv}."
+        )
+        umbrella: dict[str, Any] = {
+            "id": domain,
+            "name": spec["name"],
+            "description": description,
+            "category": spec["category"],
+            "docs_url": spec["docs_url"],
+        }
+        if default_entry.get("image_url"):
+            umbrella["image_url"] = default_entry["image_url"]
+        entries.append(umbrella)
+        _LOGGER.info(
+            "Added umbrella entry %s (default: %s, platforms: %d)",
+            domain,
+            spec["default_platform"],
+            len(platforms),
         )
 
 

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -669,7 +669,15 @@ def build_catalog(
     # users still on the pre-platform YAML form. Runs after MDX
     # backfill so the umbrellas live alongside fully-populated
     # platform entries.
-    _inject_umbrella_entries(out)
+    #
+    # Skipped under ``--limit-component`` because the umbrella
+    # description enumerates every platform in *out* — on a filtered
+    # catalog that list would only reflect the surviving subset and
+    # mislead the reader. ``--limit-component`` is documented as a
+    # local-debugging knob, so debugging individual platform entries
+    # doesn't need the umbrellas anyway.
+    if not limit:
+        _inject_umbrella_entries(out)
 
     return out
 

--- a/tests/test_components_integration_docs.py
+++ b/tests/test_components_integration_docs.py
@@ -94,3 +94,29 @@ async def test_unknown_integration_omitted(catalog: ComponentCatalog) -> None:
     # ``runtime_stats``-style helpers don't have a docs page; verify
     # the contract by picking one that definitely won't exist.
     assert "definitely_not_a_component_xyzzy" not in docs
+
+
+async def test_umbrella_entries_for_legacy_bare_keys(
+    catalog: ComponentCatalog,
+) -> None:
+    """``ota`` and ``time`` resolve to umbrella entries, not just docs URLs.
+
+    Both blocks accept a legacy bare-mapping form (no ``- platform:`` list)
+    that predates platform-based OTA / time. Sync-time umbrella injection
+    gives ``get_component`` an exact-id hit for the bare key with a
+    description that names the implicit default platform — without it,
+    users on the legacy form get ``None`` from the catalog lookup.
+    """
+    for domain, default_platform in (("ota", "esphome"), ("time", "homeassistant")):
+        umbrella = await catalog.get_component(component_id=domain)
+        assert umbrella is not None, f"{domain} umbrella missing from catalog"
+        # The description must name the implicit default platform so the
+        # frontend can surface "esphome is the default OTA provider" to
+        # users still on the bare form.
+        assert f"`{default_platform}`" in umbrella.description, (
+            f"{domain} umbrella description should name `{default_platform}` as default"
+        )
+        # The umbrella shouldn't replace the platform entry — both must
+        # exist independently so explicit-platform configs still resolve.
+        platform_entry = await catalog.get_component(component_id=f"{domain}.{default_platform}")
+        assert platform_entry is not None, f"{domain}.{default_platform} platform entry must remain"

--- a/tests/test_sync_components_umbrellas.py
+++ b/tests/test_sync_components_umbrellas.py
@@ -1,0 +1,131 @@
+"""Unit tests for ``_inject_umbrella_entries`` in ``script/sync_components.py``.
+
+The integration test in ``test_components_integration_docs.py`` exercises the
+shipped ``components.json`` — useful, but a regression in the sync logic
+itself wouldn't fail CI as long as the file isn't regenerated. These tests
+poke the function directly with synthetic catalog fragments so the contract
+holds independent of whatever happens to be checked in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _UMBRELLA_ENTRIES,
+    _inject_umbrella_entries,
+)
+
+
+def _platform_entry(component_id: str, *, image_url: str = "") -> dict:
+    """Build a minimal catalog entry shaped like ``build_entries_from_file``'s output."""
+    domain, _, _stem = component_id.partition(".")
+    entry: dict = {
+        "id": component_id,
+        "name": component_id,
+        "description": "",
+        "category": domain,
+    }
+    if image_url:
+        entry["image_url"] = image_url
+    return entry
+
+
+def test_injects_umbrella_for_each_configured_domain() -> None:
+    """Every domain in ``_UMBRELLA_ENTRIES`` gets a synthesised top-level entry."""
+    entries = [
+        _platform_entry("ota.esphome", image_url="https://example/icon.svg"),
+        _platform_entry("ota.http_request"),
+        _platform_entry("time.homeassistant"),
+        _platform_entry("time.sntp"),
+        _platform_entry("sensor.dht"),  # unrelated, must be left alone
+    ]
+
+    _inject_umbrella_entries(entries)
+
+    by_id = {e["id"]: e for e in entries}
+    for spec in _UMBRELLA_ENTRIES:
+        umbrella = by_id.get(spec["id"])
+        assert umbrella is not None, f"missing umbrella for {spec['id']}"
+        assert umbrella["category"] == spec["category"]
+        # Description must name the implicit default platform — that's the
+        # whole reason the umbrella exists.
+        assert f"`{spec['default_platform']}`" in umbrella["description"]
+
+
+def test_description_lists_every_present_platform() -> None:
+    """The platform list in the description reflects what's in *entries* now.
+
+    Re-derived at sync time so descriptions stay accurate when platforms are
+    added or removed upstream — no hard-coded list to drift.
+    """
+    entries = [
+        _platform_entry("ota.esphome"),
+        _platform_entry("ota.http_request"),
+        _platform_entry("ota.web_server"),
+    ]
+
+    _inject_umbrella_entries(entries)
+
+    ota = next(e for e in entries if e["id"] == "ota")
+    for stem in ("esphome", "http_request", "web_server"):
+        assert f"`{stem}`" in ota["description"]
+    # A platform we didn't include must NOT appear.
+    assert "`zephyr_mcumgr`" not in ota["description"]
+
+
+def test_borrows_image_url_from_default_platform() -> None:
+    """Umbrella picks up the default platform's icon so the UI matches."""
+    entries = [
+        _platform_entry("ota.esphome", image_url="https://example/system-update.svg"),
+        _platform_entry("ota.http_request", image_url="https://example/other.svg"),
+    ]
+
+    _inject_umbrella_entries(entries)
+
+    ota = next(e for e in entries if e["id"] == "ota")
+    assert ota["image_url"] == "https://example/system-update.svg"
+
+
+def test_skips_when_default_platform_missing() -> None:
+    """Defensive guard — without the default platform the umbrella would lie."""
+    entries = [
+        # ota.esphome is intentionally absent; only http_request is available.
+        _platform_entry("ota.http_request"),
+    ]
+
+    _inject_umbrella_entries(entries)
+
+    assert all(e["id"] != "ota" for e in entries), (
+        "ota umbrella should not be added when the configured "
+        "default platform `ota.esphome` is missing"
+    )
+
+
+def test_does_not_overwrite_existing_id() -> None:
+    """If something else already owns the bare id, leave it alone."""
+    pre_existing = {
+        "id": "ota",
+        "name": "Pre-existing",
+        "description": "from elsewhere",
+        "category": "ota",
+    }
+    entries = [
+        _platform_entry("ota.esphome"),
+        pre_existing,
+    ]
+
+    _inject_umbrella_entries(entries)
+
+    ota_entries = [e for e in entries if e["id"] == "ota"]
+    assert ota_entries == [pre_existing]
+
+
+@pytest.mark.parametrize("spec", _UMBRELLA_ENTRIES)
+def test_umbrella_spec_is_self_consistent(spec: dict[str, str]) -> None:
+    """Each spec carries the keys ``_inject_umbrella_entries`` reads."""
+    for required in ("id", "name", "category", "default_platform", "summary", "docs_url"):
+        assert spec.get(required), f"{spec.get('id')!r} missing required field {required!r}"
+    # ``default_platform`` is the bare stem — the function joins it as
+    # ``f"{domain}.{default_platform}"`` to look up the platform entry.
+    assert "." not in spec["default_platform"]


### PR DESCRIPTION
## Problem

Some user configs still carry bare `ota:` / `time:` blocks — the legacy form that predates platform-based OTA / time. The catalog only ships qualified `<domain>.<platform>` entries (e.g. `ota.esphome`), so `components/get_component("ota")` returned `None` and the dashboard had no useful info to surface — name, description, or a hint that `esphome` is the implicit default OTA platform.

## Changes

- `script/sync_components.py` — add `_inject_umbrella_entries` step at the end of `build_catalog`. Each entry is keyed by the bare domain (`ota`, `time`), names the implicit default platform (`esphome`, `homeassistant`), and lists every platform present in the catalog at sync time so the description stays in sync as platforms come and go upstream.
- `esphome_device_builder/definitions/components.json` — regenerated so the change ships now rather than waiting for the next nightly catalog sync.
- `tests/test_components_integration_docs.py` — pin the contract so a regression that drops the umbrella entries fails loudly.

The umbrellas keep their domain category (`ota` / `time`) so the existing `exclude_category=[core,ota,time,update]` filter on the regular catalog browser continues to hide them — they only surface via direct `get_component` lookup or the integration-docs map.