### PR TITLE
Fix featured component pin matching and id generation

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -32,6 +32,7 @@ from ..helpers.yaml import merge_component_yaml, rewrite_esphome_name
 from ..models import (
     AddComponentResponse,
     AdoptableDevice,
+    ConfigEntryType,
     Device,
     DevicesResponse,
     DeviceState,
@@ -651,6 +652,13 @@ class DevicesController:
                 raise ValueError(msg)
             underlying_component_id = record.underlying_id
             fields = _apply_featured_presets(record, fields)
+            # The frontend's catalog-derived id suggestion for featured
+            # components is the dashed ``featured_<board>_<local>``
+            # form (e.g. ``featured_athom-smart-plug-v3_power-monitor_1``),
+            # which ESPHome rejects. Reset to empty so
+            # ``generate_component_yaml`` produces a valid auto-id from
+            # the underlying component + name.
+            fields["id"] = ""
 
         component = await self._db.components.get_component(component_id=underlying_component_id)
         if component is None:
@@ -1521,11 +1529,22 @@ def _apply_featured_presets(
     - Suggestions: user-supplied value must be one of the listed values;
       omission falls back to the preset's ``value`` (when set).
     - Plain default: filled in only when the user didn't supply one.
+
+    Pin-typed fields can arrive in two ESPHome shapes — bare GPIO
+    (``pin: 12``) or rich mapping (``pin: {number: 12, mode: ..., inverted: ...}``).
+    Equality / membership checks compare on the bare GPIO so a manifest's
+    ``suggestions: [4, 5]`` accepts whichever shape the frontend submits.
     """
+    entries_by_key = {ce.key: ce for ce in record.underlying.config_entries}
     merged: dict[str, Any] = dict(user_fields)
     for key, preset in record.featured.fields.items():
         user_value = merged.get(key)
         user_supplied = key in merged
+        is_pin = entries_by_key.get(key) is not None and (
+            entries_by_key[key].type == ConfigEntryType.PIN
+        )
+        compare_user = _normalize_pin_value(user_value) if is_pin else user_value
+        compare_preset = _normalize_pin_value(preset.value) if is_pin else preset.value
         if preset.locked:
             # Schema validation rejects ``locked: true`` without a value, but
             # guard the runtime too so a malformed manifest fails fast with a
@@ -1536,7 +1555,7 @@ def _apply_featured_presets(
                     f"locked=true without a value — board manifest is malformed"
                 )
                 raise ValueError(msg)
-            if user_supplied and user_value != preset.value:
+            if user_supplied and compare_user != compare_preset:
                 msg = (
                     f"Featured component {record.full_id} field '{key}' is "
                     f"locked to {preset.value!r}; cannot override with "
@@ -1547,7 +1566,7 @@ def _apply_featured_presets(
             continue
         if preset.suggestions is not None:
             if user_supplied:
-                if user_value not in preset.suggestions:
+                if compare_user not in preset.suggestions:
                     msg = (
                         f"Featured component {record.full_id} field '{key}' "
                         f"must be one of {preset.suggestions}; got "
@@ -1560,6 +1579,26 @@ def _apply_featured_presets(
         if not user_supplied and preset.value is not None:
             merged[key] = preset.value
     return merged
+
+
+def _normalize_pin_value(value: Any) -> Any:
+    """
+    Reduce a rich pin mapping to its bare GPIO for comparison.
+
+    ESPHome accepts pins as either a bare integer / string label or as
+    a ``{number, mode, inverted, ...}`` mapping. Featured-component
+    presets express ``suggestions`` and bare-int ``value``s as scalars;
+    the frontend submits the mapping form. Returning the inner
+    ``number`` (when present) lets the locked / suggestion checks
+    treat both shapes equivalently.
+
+    ``bool`` is excluded explicitly since it's an ``int`` subclass.
+    """
+    if isinstance(value, dict):
+        number = value.get("number")
+        if isinstance(number, (int, str)) and not isinstance(number, bool):
+            return number
+    return value
 
 
 def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None) -> list[str]:

--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -655,10 +655,13 @@ class DevicesController:
             # The frontend's catalog-derived id suggestion for featured
             # components is the dashed ``featured_<board>_<local>``
             # form (e.g. ``featured_athom-smart-plug-v3_power-monitor_1``),
-            # which ESPHome rejects. Reset to empty so
-            # ``generate_component_yaml`` produces a valid auto-id from
-            # the underlying component + name.
-            fields["id"] = ""
+            # which ESPHome rejects. Reset to empty when the supplied
+            # id contains a dash so ``generate_component_yaml`` produces
+            # a valid auto-id from the underlying component + name —
+            # a user-typed custom id without dashes passes through.
+            user_id = fields.get("id")
+            if isinstance(user_id, str) and "-" in user_id:
+                fields["id"] = ""
 
         component = await self._db.components.get_component(component_id=underlying_component_id)
         if component is None:

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -197,8 +197,19 @@ def generate_component_yaml(
     Nested values in ``fields`` (dicts as values) are emitted as
     indented YAML mappings — frontend submits the full structure as a
     single ``fields`` argument, no separate sub-entries dict needed.
+
+    Two kinds of identifier auto-fill happen here:
+
+    - Top-level ``id`` when the caller explicitly passed ``id: ""``
+      (a marker that says "give me the default"). Result is
+      ``<unqualified>[_<name_slug>]``.
+    - Nested entity sub-blocks (entries marked with ``platform_type``,
+      e.g. HLW8012's ``current`` / ``energy`` / ``power`` / ``voltage``)
+      get a default ``name`` and ``id`` when the caller didn't set
+      one — without these the sub-sensor either won't surface in HA
+      (no name) or can't be referenced from automations (no id).
     """
-    lines: list[str] = []
+    fields = dict(fields)
     category = component.category
     comp_id = component.id
 
@@ -210,19 +221,51 @@ def generate_component_yaml(
         # share a stem across categories. ESPHome YAML expects the bare
         # platform stem under ``platform:``, so strip the qualifier.
         unqualified = comp_id.split(".", 1)[1] if "." in comp_id else comp_id
+    else:
+        unqualified = comp_id
+
+    # Resolve the top-level id once. We only emit it when the caller
+    # explicitly opted in by including ``id`` in fields; when they
+    # did but left it empty, fill in the auto-generated value here so
+    # nested entity sub-blocks can prefix their own ids consistently.
+    if "id" in fields and not fields["id"]:
+        fields["id"] = _generate_id(unqualified, fields.get("name"))
+    parent_id = fields.get("id") or _generate_id(unqualified, fields.get("name"))
+
+    # Auto-fill name + id on nested entity sub-blocks the caller left
+    # empty. ESPHome multi-sensor parents (HLW8012, BME280, ...)
+    # expose their readings as ``platform_type``-tagged ConfigEntry
+    # blocks; an unnamed sub-sensor won't surface in HA, and one
+    # without an id can't be referenced from automations.
+    for entry in component.config_entries:
+        if not entry.platform_type or not entry.config_entries:
+            continue
+        sub = fields.get(entry.key)
+        if not isinstance(sub, dict):
+            continue
+        if sub.get("name") and sub.get("id"):
+            continue
+        # Build a fresh dict with name/id at the front so the emitted
+        # YAML reads naturally (humans put name/id first).
+        autofill: dict[str, Any] = {}
+        if not sub.get("name"):
+            autofill["name"] = entry.label or entry.key.replace("_", " ").title()
+        if not sub.get("id"):
+            autofill["id"] = f"{parent_id}_{entry.key}"
+        autofill.update(sub)
+        fields[entry.key] = autofill
+
+    lines: list[str] = []
+    if is_platform:
         lines.append(f"{category}:")
         lines.append(f"  - platform: {unqualified}")
         indent = "    "
     else:
-        unqualified = comp_id
         lines.append(f"{comp_id}:")
         indent = "  "
 
     for key, value in fields.items():
-        emit_value = (
-            _generate_id(unqualified, fields.get("name")) if key == "id" and not value else value
-        )
-        lines.extend(_emit_field(key, emit_value, indent))
+        lines.extend(_emit_field(key, value, indent))
 
     return "\n".join(lines)
 

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -27,6 +27,7 @@ from esphome_device_builder.definitions import (
     _load_featured_bundle,
     _load_featured_component,
 )
+from esphome_device_builder.helpers.yaml import generate_component_yaml
 from esphome_device_builder.models import ComponentCategory
 
 # ---------------------------------------------------------------------------
@@ -289,6 +290,47 @@ async def test_apply_presets_suggestion_rejects_off_list(
         _apply_featured_presets(record, {"pin": 99})
 
 
+async def test_apply_presets_suggestion_accepts_rich_pin_form(
+    catalog: ComponentCatalog,
+) -> None:
+    """
+    Frontend submits pin fields as the rich ``{number, mode, ...}`` shape.
+
+    The suggestion check must compare on the GPIO number so a
+    manifest's ``suggestions: [4, 5]`` accepts ``{"number": 5, ...}``
+    too — and the rich dict rides through to the merger unchanged so
+    the YAML keeps its full pin block.
+    """
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    assert record is not None
+    rich_pin = {"number": 5, "mode": {"input": True}}
+    out = _apply_featured_presets(record, {"pin": rich_pin})
+    assert out["pin"] == rich_pin
+
+
+async def test_apply_presets_suggestion_rejects_rich_pin_off_list(
+    catalog: ComponentCatalog,
+) -> None:
+    """Rich pin form whose ``number`` is off-list still raises."""
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    assert record is not None
+    with pytest.raises(ValueError, match="must be one of"):
+        _apply_featured_presets(record, {"pin": {"number": 99, "mode": {"input": True}}})
+
+
+async def test_apply_presets_locked_accepts_rich_pin_form(
+    catalog: ComponentCatalog,
+) -> None:
+    """A bare-int locked pin must also accept the rich-form echo from the frontend."""
+    record = catalog.get_featured_record("featured.sonoff-basic.relay")
+    assert record is not None
+    rich_pin = {"number": 12, "mode": {"output": True}}
+    out = _apply_featured_presets(record, {"pin": rich_pin})
+    # Locked wins — the merged value is the manifest's bare GPIO, not the
+    # frontend's rich echo (the locked branch always replaces the value).
+    assert out["pin"] == 12
+
+
 async def test_apply_presets_suggestion_falls_back_to_value(
     catalog: ComponentCatalog,
 ) -> None:
@@ -320,3 +362,97 @@ async def test_apply_presets_locked_without_value_fails_fast(
     record.featured.fields["pin"] = FieldPreset(value=None, locked=True)
     with pytest.raises(ValueError, match="locked=true without a value"):
         _apply_featured_presets(record, {})
+
+
+# ---------------------------------------------------------------------------
+# YAML generation: top-level id auto-gen + nested entity sub-block autofill
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_yaml_drops_dashed_id_via_empty_marker(
+    catalog: ComponentCatalog,
+) -> None:
+    """An ``id: ""`` marker triggers the standard ``_generate_id`` auto-fill.
+
+    ``add_component`` uses this for featured components so the frontend's
+    dashed catalog-derived suggestion is replaced by a clean
+    ``<unqualified>[_<name_slug>]``.
+    """
+    component = await catalog.get_component(component_id="switch.gpio")
+    assert component is not None
+    yaml = generate_component_yaml(component, {"pin": 12, "name": "Relay", "id": ""})
+    assert "id: gpio_relay" in yaml
+    assert "-" not in yaml.split("id: ")[1].splitlines()[0]
+
+
+async def test_generate_yaml_autofills_subentity_name_and_id(
+    catalog: ComponentCatalog,
+) -> None:
+    """Multi-sensor parents get ``name`` + ``id`` filled in on each reading.
+
+    HLW8012-style components tag each reading with ``platform_type``; an
+    empty ``current: {device_class: current}`` block must come back with
+    a name and id or the sub-sensor won't surface in HA.
+    """
+    component = await catalog.get_component(component_id="sensor.hlw8012")
+    assert component is not None
+    yaml = generate_component_yaml(
+        component,
+        {
+            "cf_pin": 3,
+            "cf1_pin": 4,
+            "sel_pin": 5,
+            "model": "BL0937",
+            "id": "",
+            "current": {"device_class": "current", "unit_of_measurement": "A"},
+            "energy": {"device_class": "energy"},
+        },
+    )
+    # Top-level id auto-generated from the bare component stem.
+    assert "id: hlw8012" in yaml
+    # Sub-entities get a default ``name`` (from the entry label) and a
+    # ``<parent_id>_<key>`` id, prepended ahead of user-supplied keys.
+    assert "name: Current" in yaml
+    assert "id: hlw8012_current" in yaml
+    assert "name: Energy" in yaml
+    assert "id: hlw8012_energy" in yaml
+
+
+async def test_generate_yaml_preserves_user_supplied_subentity_name(
+    catalog: ComponentCatalog,
+) -> None:
+    """The autofill only fills gaps — it never overwrites user input."""
+    component = await catalog.get_component(component_id="sensor.hlw8012")
+    assert component is not None
+    yaml = generate_component_yaml(
+        component,
+        {
+            "cf_pin": 3,
+            "id": "plug",
+            "current": {"name": "Plug Current", "id": "plug_amps"},
+        },
+    )
+    assert "name: Plug Current" in yaml
+    assert "id: plug_amps" in yaml
+    # And the auto-id prefix tracks the user's chosen parent id.
+    assert "id: plug" in yaml
+
+
+async def test_generate_yaml_skips_autofill_for_non_entity_subblocks(
+    catalog: ComponentCatalog,
+) -> None:
+    """Plain scalars / non-entity nested groups pass through untouched.
+
+    Only entries with ``platform_type`` get the name/id autofill — a
+    bare ``model: BL0937`` scalar must never grow a synthetic name.
+    """
+    component = await catalog.get_component(component_id="sensor.hlw8012")
+    assert component is not None
+    # A nested entry without platform_type should still emit verbatim.
+    yaml = generate_component_yaml(
+        component,
+        {"cf_pin": 3, "id": "", "model": "BL0937"},
+    )
+    # ``model`` is a plain scalar — no name/id should attach to it.
+    assert "name: Model" not in yaml
+    assert "id: hlw8012_model" not in yaml

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -16,12 +16,16 @@ Covers four layers:
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
-from esphome_device_builder.controllers.devices import _apply_featured_presets
+from esphome_device_builder.controllers.devices import (
+    DevicesController,
+    _apply_featured_presets,
+)
 from esphome_device_builder.definitions import (
     _coerce_field_preset,
     _load_featured_bundle,
@@ -456,3 +460,72 @@ async def test_generate_yaml_skips_autofill_for_non_entity_subblocks(
     # ``model`` is a plain scalar — no name/id should attach to it.
     assert "name: Model" not in yaml
     assert "id: hlw8012_model" not in yaml
+
+
+# ---------------------------------------------------------------------------
+# add_component integration: featured-id reset + end-to-end YAML
+# ---------------------------------------------------------------------------
+
+
+def _make_controller(catalog: ComponentCatalog, tmp_path: Any) -> DevicesController:
+    """Build a DevicesController with just enough plumbing for ``add_component``."""
+    ctrl = DevicesController.__new__(DevicesController)
+    ctrl._db = MagicMock()
+    ctrl._db.settings.rel_path = lambda name: tmp_path / name
+    ctrl._db.components = catalog
+    ctrl._scanner = MagicMock()
+    ctrl._scanner.scan = AsyncMock()
+    return ctrl
+
+
+async def test_add_component_featured_resets_dashed_id(
+    catalog: ComponentCatalog, tmp_path: Any
+) -> None:
+    """Frontend's dashed featured suggestion gets replaced by the standard auto-id."""
+    (tmp_path / "plug.yaml").write_text("esphome:\n  name: plug\n", "utf-8")
+    ctrl = _make_controller(catalog, tmp_path)
+
+    response = await ctrl.add_component(
+        configuration="plug.yaml",
+        component_id="featured.athom-smart-plug-v3.power-monitor",
+        fields={
+            "id": "featured_athom-smart-plug-v3_power-monitor_1",
+            "current": {"device_class": "current"},
+        },
+    )
+
+    assert "id: hlw8012" in response.yaml
+    assert "featured_athom-smart-plug-v3" not in response.yaml
+    # Sub-entity autofill rides through the merge step.
+    assert "name: Current" in response.yaml
+    assert "id: hlw8012_current" in response.yaml
+
+
+async def test_add_component_featured_keeps_user_typed_id(
+    catalog: ComponentCatalog, tmp_path: Any
+) -> None:
+    """A clean user-typed id (no dashes) survives the featured id-reset."""
+    (tmp_path / "plug.yaml").write_text("esphome:\n  name: plug\n", "utf-8")
+    ctrl = _make_controller(catalog, tmp_path)
+
+    response = await ctrl.add_component(
+        configuration="plug.yaml",
+        component_id="featured.sonoff-basic.relay",
+        fields={"pin": 12, "name": "Relay", "id": "main_relay"},
+    )
+
+    assert "id: main_relay" in response.yaml
+
+
+async def test_add_component_featured_unknown_id_raises(
+    catalog: ComponentCatalog, tmp_path: Any
+) -> None:
+    """An unknown ``featured.*`` id surfaces as a clear ValueError."""
+    ctrl = _make_controller(catalog, tmp_path)
+
+    with pytest.raises(ValueError, match="Unknown featured component"):
+        await ctrl.add_component(
+            configuration="plug.yaml",
+            component_id="featured.no-such-board.x",
+            fields={},
+        )


### PR DESCRIPTION
Three follow-ups to #33 surfaced when adding a featured component on a real device.

The WebSocket handler blew up with a `ValueError` from `_apply_featured_presets` because the suggestion check compared the frontend's rich pin object (`{number: 4, ...}`) against the manifest's bare-int suggestions list (`[4, 5]`). Once that was past, the resulting YAML still had two issues: the top-level `id` was the dashed catalog-derived suggestion (`featured_athom-smart-plug-v3_power-monitor_1` — ESPHome rejects dashes), and the HLW8012 sub-sensors (`current` / `energy` / `power` / `voltage`) had no `name` or `id` so they wouldn't surface in HA.

## Changes

- `_apply_featured_presets` normalises the rich pin form (`{number, mode, ...}`) before comparing against `suggestions` and locked values, matching what `script/validate_definitions.py:_extract_gpio` already does on the manifest-loading side
- `add_component` resets `id` to `""` for featured components so `generate_component_yaml` produces a clean auto-id from the underlying component + name, instead of letting the dashed `featured_<board>_<local>` suggestion through
- `generate_component_yaml` auto-fills `name` and `id` on nested entity sub-blocks tagged with `platform_type` (HLW8012-style multi-readings) when missing — name from the entry's label, id as `<parent_id>_<key>`