### PR TITLE
Pass address-cache args for web_server OTA, not just native API

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -244,16 +244,24 @@ class DevicesController:
         """
         Return ``--mdns/--dns-address-cache`` CLI args for *configuration*.
 
-        Empty list when the device is unknown, has no API integration
-        loaded, or has no cached IP available.
+        Empty list when the device is unknown, has no OTA-capable
+        integration loaded, or has no cached IP available.
         """
         target_name = configuration.removesuffix(".yaml").removesuffix(".yml")
         device = next((d for d in self._scanner.devices if d.name == target_name), None)
         if device is None:
             return []
-        # The CLI only consults the address cache through the API client;
-        # non-API devices flash via a different path that wouldn't read it.
-        if "api" not in device.loaded_integrations:
+        # The CLI only consults the address cache from upload paths
+        # that resolve via ``CORE.address_cache``. That used to be just
+        # the Native API OTA client (``espota2``), but esphome/esphome#16207
+        # added an HTTP OTA path through the ``web_server`` component
+        # that goes through the same resolver. Either integration is
+        # enough for the cache to be useful — passing the args to a
+        # build that doesn't read them is harmless. Devices loading
+        # neither (e.g. MQTT-only configs) flash via paths that don't
+        # take a host/port at all, so the cache args are noise there.
+        loaded = device.loaded_integrations
+        if "api" not in loaded and "web_server" not in loaded:
             return []
         return _build_address_cache_args(device, self._state_monitor)
 

--- a/tests/test_address_cache.py
+++ b/tests/test_address_cache.py
@@ -136,6 +136,83 @@ def test_multiple_cached_addresses_sorted() -> None:
 
 
 # ----------------------------------------------------------------------
+# DevicesController.get_address_cache_args integration gate
+# ----------------------------------------------------------------------
+
+
+def _devices_controller_with(*devices: Device) -> Any:
+    """Build a thin DevicesController shell with a stubbed scanner + monitor.
+
+    ``get_address_cache_args`` only reads the scanner's device list,
+    the state monitor's cached-addresses lookup, and the device's
+    ``loaded_integrations`` field — keep the rest of the controller
+    out of the test surface.
+    """
+    from esphome_device_builder.controllers.devices import DevicesController
+
+    controller = DevicesController.__new__(DevicesController)
+    scanner = MagicMock()
+    scanner.devices = list(devices)
+    controller._scanner = scanner
+    controller._state_monitor = _monitor(["192.168.1.50"])
+    return controller
+
+
+def test_get_address_cache_args_returns_cache_for_native_api_device() -> None:
+    """Native API OTA path uses ``CORE.address_cache`` — feed it the args."""
+    controller = _devices_controller_with(_device(loaded_integrations=["api", "wifi"]))
+
+    args = controller.get_address_cache_args("kitchen.yaml")
+
+    assert args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+
+
+def test_get_address_cache_args_returns_cache_for_web_server_only_device() -> None:
+    """web_server OTA path also uses ``CORE.address_cache``.
+
+    esphome/esphome#16207 added an HTTP OTA upload through the
+    ``web_server`` component that resolves IPs via the same
+    ``CORE.address_cache`` plumbing as the native API path. A device
+    whose YAML enables ``web_server`` but not ``api`` (e.g. user lost
+    the API password and falls back to HTTP OTA) should still get
+    the cache args so the upload doesn't pay an unnecessary DNS
+    lookup.
+    """
+    controller = _devices_controller_with(_device(loaded_integrations=["web_server", "wifi"]))
+
+    args = controller.get_address_cache_args("kitchen.yaml")
+
+    assert args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+
+
+def test_get_address_cache_args_skipped_for_neither_api_nor_web_server() -> None:
+    """MQTT-only / sensor-bridge configs don't need the cache.
+
+    Devices with neither ``api`` nor ``web_server`` loaded flash via
+    paths that don't take a host/port — the cache args would be
+    noise the CLI ignores.
+    """
+    controller = _devices_controller_with(_device(loaded_integrations=["mqtt", "wifi"]))
+
+    args = controller.get_address_cache_args("kitchen.yaml")
+
+    assert args == []
+
+
+def test_get_address_cache_args_unknown_configuration_returns_empty() -> None:
+    """Unknown filename → empty list, no exception.
+
+    The firmware controller calls this for every queued job; a stale
+    rename or a deleted YAML shouldn't crash the queue.
+    """
+    controller = _devices_controller_with()  # no devices
+
+    args = controller.get_address_cache_args("ghost.yaml")
+
+    assert args == []
+
+
+# ----------------------------------------------------------------------
 # FirmwareController._build_cache_args / _build_command
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Extend ``DevicesController.get_address_cache_args`` to admit devices with the ``web_server`` integration loaded, not just ``api``. https://github.com/esphome/esphome/pull/16207 added an HTTP OTA upload through the ``web_server`` component that goes through the same ``CORE.address_cache`` resolver as the native API path — without this change, devices that use HTTP OTA pay an unnecessary DNS / mDNS lookup on every install because the dashboard withholds the cached IP it already has.

## Why

Before https://github.com/esphome/esphome/pull/16207 only ``espota2`` (native API OTA) consulted the address cache, so gating on ``"api" in loaded_integrations`` was correct. With the new path landed upstream:

- Device with ``api`` only → cache args returned (existing behaviour).
- Device with ``web_server`` only (e.g. user lost the API password and fell back to HTTP OTA) → cache args now returned. The CLI will use them whether it picks the native or web_server platform.
- Device with both → cache args returned regardless of which platform the CLI auto-selects.
- Device with neither (MQTT-only / sensor-bridge configs) → still empty, those flash via paths that don't take a host/port.

The cache args (``--mdns-address-cache`` / ``--dns-address-cache``) are advisory — passing them to a build that ignores them is harmless. Net effect: same behaviour for everyone today, faster installs for web_server-only devices once https://github.com/esphome/esphome/pull/16207 lands in the user's ESPHome.

Verified the progress-line shape too: the web_server OTA path uploads through ``ProgressBar`` (``esphome/helpers.py``), which emits the same ``Uploading: [====] N% Done...`` line shape the native API OTA path uses. Our existing ``_PROGRESS_PATTERNS`` regex matches both, so no progress-tracking changes are needed alongside this fix.

## Test plan

- [ ] ``uv run pytest tests/test_address_cache.py`` — 20/20 (4 new cases on ``DevicesController.get_address_cache_args``: native-API, web_server-only, neither-integration, unknown-config)
- [ ] Full suite: ``uv run pytest`` (542 passed, 3 skipped — no behaviour change for existing api-loaded paths)