### PR TITLE
Fix flaky rate-limiter prune test on freshly booted runners

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -308,7 +308,8 @@ def test_rate_limiter_prune_keeps_locked_out_ips() -> None:
     rl.record_failure("9.9.9.1")
     rl.record_failure("9.9.9.1")  # triggers lockout
 
-    rl._last_prune = 0.0
+    # See ``test_rate_limiter_prunes_stale_entries`` for why we don't use 0.0.
+    rl._last_prune = -1e9
     time.sleep(0.06)
     rl.record_failure("9.9.9.2")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -289,7 +289,11 @@ def test_rate_limiter_prunes_stale_entries() -> None:
     assert len(rl._attempts) == 2
 
     # Force the prune interval to trigger on the next record_failure call.
-    rl._last_prune = 0.0
+    # Use a deeply-negative sentinel rather than 0.0 — ``time.monotonic()``
+    # is not anchored to wall time, and on a freshly booted CI runner it
+    # commonly reads at ~60s, which is *inside* the 60s prune interval
+    # relative to 0.0 and would silently skip the prune.
+    rl._last_prune = -1e9
     time.sleep(0.06)
     rl.record_failure("8.8.8.3")
 


### PR DESCRIPTION
## Summary
- ``test_rate_limiter_prunes_stale_entries`` and ``test_rate_limiter_prune_keeps_locked_out_ips`` reset ``rl._last_prune = 0.0`` to force the next ``record_failure`` to actually prune.
- But ``_maybe_prune`` short-circuits when ``now - self._last_prune < _RATE_LIMIT_PRUNE_INTERVAL`` (60s), and ``time.monotonic()`` is not anchored to wall time. On a freshly booted CI runner ``monotonic()`` commonly reads in the ~50–60s range, which falls *inside* the 60s window relative to 0.0 — the prune is skipped and ``"8.8.8.1" not in rl._attempts`` fires.
- Replace 0.0 with a deeply-negative sentinel (``-1e9``) so the comparison is unambiguous regardless of when the runner booted. No production change.

Spotted as a flake on a recent PR run:

```
FAILED tests/test_auth.py::test_rate_limiter_prunes_stale_entries
  AssertionError: assert '8.8.8.1' not in {'8.8.8.1': deque([59.826285391]), ...}
```

The 8.8.8.1/8.8.8.3 timestamps differ by ~0.06s (well past the 0.05s window), so the *contents* of the deque were correctly aged — the prune simply never ran.

## Test plan
- [x] ``pytest tests/test_auth.py::test_rate_limiter_prunes_stale_entries tests/test_auth.py::test_rate_limiter_prune_keeps_locked_out_ips`` — both pass locally.