### PR TITLE
Sync boards from devices.esphome.io

### DIFF
--- a/.github/workflows/sync-device-catalog.yml
+++ b/.github/workflows/sync-device-catalog.yml
@@ -1,0 +1,241 @@
+name: Sync device catalog
+
+# Re-runs ``script/sync_esphome_devices.py`` against the
+# devices.esphome.io upstream and opens a pull request when imported
+# manifests under ``definitions/boards/`` change.
+#
+# Triggers
+# --------
+# - schedule : weekly Monday at 04:00 UTC. The upstream repo gets
+#              ~1-2 PRs/week, so weekly is enough to keep up. The
+#              script is fully cached when nothing has changed
+#              (content_hash short-circuit), so no-op runs are cheap.
+# - manual   : ``workflow_dispatch`` for ad-hoc rebuilds.
+#
+# Output
+# ------
+# Pushes to a stable branch named ``catalog/sync-devices`` so each
+# run keeps updating the same in-flight PR rather than spawning a
+# new one. ``peter-evans/create-pull-request`` deletes the branch
+# automatically when no diff remains.
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-device-catalog
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          # The device sync only needs the base package (pyyaml +
+          # components.json reader). No esphome introspection here.
+          pip install -e '.[test]'
+
+      - name: Run sync_esphome_devices
+        run: python script/sync_esphome_devices.py
+
+      - name: Smoke-test imported boards
+        # Catches regressions in the extractor (broken board id
+        # resolution, missing featured components on known devices).
+        # Runs BEFORE the diff check so a broken catalog never gets
+        # proposed for merge.
+        run: python script/check_device_catalog.py
+
+      - name: Validate definitions
+        # Re-validates every board (curated + imported) against the
+        # JSON Schema and the components.json cross-references.
+        run: python script/validate_definitions.py
+
+      - name: Detect device-catalog changes + summarise diff
+        id: diff
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- esphome_device_builder/definitions/boards/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+          # Build a human-friendly delta summary the PR body embeds.
+          # We compare the freshly-synced imported manifests against
+          # what's currently on main so the reviewer sees added /
+          # removed devices and per-platform counts at a glance.
+          python <<'PY' > /tmp/devices-diff.md
+          import subprocess
+          from collections import Counter
+          from pathlib import Path
+
+          import yaml
+
+          BOARDS = Path("esphome_device_builder/definitions/boards")
+
+          def load_imported_now() -> dict[str, dict]:
+              out: dict[str, dict] = {}
+              for child in sorted(BOARDS.iterdir()):
+                  if not child.is_dir():
+                      continue
+                  manifest = child / "manifest.yaml"
+                  if not manifest.is_file():
+                      continue
+                  data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+                  if not isinstance(data, dict):
+                      continue
+                  source = data.get("source")
+                  if not isinstance(source, dict) or source.get("type") != "esphome-devices":
+                      continue
+                  out[child.name] = data
+              return out
+
+          def load_imported_main() -> dict[str, dict]:
+              # Walk the current main snapshot via ``git ls-tree`` +
+              # ``git show`` so we avoid checking out a second copy.
+              try:
+                  blob = subprocess.check_output(
+                      ["git", "ls-tree", "-r", "--name-only", "HEAD",
+                       "esphome_device_builder/definitions/boards/"],
+                      text=True,
+                  )
+              except subprocess.CalledProcessError:
+                  return {}
+              out: dict[str, dict] = {}
+              for line in blob.splitlines():
+                  if not line.endswith("/manifest.yaml"):
+                      continue
+                  try:
+                      content = subprocess.check_output(
+                          ["git", "show", f"HEAD:{line}"], text=True,
+                      )
+                  except subprocess.CalledProcessError:
+                      continue
+                  data = yaml.safe_load(content)
+                  if not isinstance(data, dict):
+                      continue
+                  source = data.get("source")
+                  if not isinstance(source, dict) or source.get("type") != "esphome-devices":
+                      continue
+                  # The folder name is the second-to-last segment.
+                  folder = Path(line).parent.name
+                  out[folder] = data
+              return out
+
+          new = load_imported_now()
+          old = load_imported_main()
+
+          new_ids = set(new)
+          old_ids = set(old)
+          added = sorted(new_ids - old_ids)
+          removed = sorted(old_ids - new_ids)
+
+          def family_counts(snapshot: dict[str, dict]) -> Counter:
+              counter: Counter[str] = Counter()
+              for board in snapshot.values():
+                  esphome = board.get("esphome") or {}
+                  platform = esphome.get("platform") or "?"
+                  counter[platform] += 1
+              return counter
+
+          old_fam = family_counts(old)
+          new_fam = family_counts(new)
+          all_fam = sorted(set(old_fam) | set(new_fam))
+
+          lines = [
+              f"**Imported boards**: {len(old)} → {len(new)} ({len(new) - len(old):+d})  ",
+              f"**Added**: {len(added)} · **Removed**: {len(removed)}",
+              "",
+          ]
+
+          if added or removed:
+              lines.append("<details><summary>Device churn</summary>")
+              lines.append("")
+              if added:
+                  lines.append(f"**Added ({len(added)}):** " + ", ".join(f"`{i}`" for i in added[:30]))
+                  if len(added) > 30:
+                      lines.append(f" _…and {len(added) - 30} more_")
+              if removed:
+                  lines.append(f"**Removed ({len(removed)}):** " + ", ".join(f"`{i}`" for i in removed[:30]))
+                  if len(removed) > 30:
+                      lines.append(f" _…and {len(removed) - 30} more_")
+              lines.append("")
+              lines.append("</details>")
+              lines.append("")
+
+          lines.append("<details><summary>Per-SoC family counts</summary>")
+          lines.append("")
+          lines.append("| Platform | Old | New | Δ |")
+          lines.append("|------|----:|----:|---:|")
+          for fam in all_fam:
+              o = old_fam.get(fam, 0)
+              n = new_fam.get(fam, 0)
+              if o == n and o == 0:
+                  continue
+              lines.append(f"| `{fam}` | {o} | {n} | {n - o:+d} |")
+          lines.append("")
+          lines.append("</details>")
+
+          print("\n".join(lines))
+          PY
+
+          {
+            echo "summary<<DIFF_EOF"
+            cat /tmp/devices-diff.md
+            echo "DIFF_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open / update pull request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        with:
+          branch: catalog/sync-devices
+          base: main
+          commit-message: |
+            Sync device catalog from devices.esphome.io
+
+            Auto-generated by .github/workflows/sync-device-catalog.yml.
+          title: "Sync device catalog from devices.esphome.io"
+          body: |
+            Automated catalog refresh from [`esphome/esphome-devices`](https://github.com/esphome/esphome-devices).
+
+            Triggered by: **${{ github.event_name == 'schedule' && 'weekly schedule' || format('manual dispatch by @{0}', github.actor) }}**.
+
+            ${{ steps.diff.outputs.summary }}
+
+            **Smoke test:** ✅ passes [`script/check_device_catalog.py`](../blob/main/script/check_device_catalog.py) — known well-formed pages still extract with the expected board, variant, and featured-component shape.
+
+            ---
+
+            Review checklist:
+            - Skim the **Added** / **Removed** lists above for anything unexpected. A removed device usually means the upstream page was deleted or renamed.
+            - Hand-curated boards (no `source:` block) are never touched — only manifests with `source.type: esphome-devices` are owned by this sync.
+            - If the diff looks weird, run `script/sync_esphome_devices.py --device <name>` locally to inspect a single device.
+            - Merge to ship the new device catalog.
+          labels: |
+            catalog
+            automated
+          delete-branch: true
+
+      - name: No-op summary
+        if: steps.diff.outputs.changed == 'false'
+        run: |
+          echo "::notice::Device catalog is already up to date - no PR opened."

--- a/esphome_device_builder/definitions/schemas/board.schema.json
+++ b/esphome_device_builder/definitions/schemas/board.schema.json
@@ -136,6 +136,36 @@
       "type": "array",
       "description": "Logical groups of featured components added together (hardware addon modules, status-LED setups, ...).",
       "items": { "$ref": "#/$defs/featured_bundle" }
+    },
+    "source": {
+      "type": "object",
+      "description": "Marks the manifest as imported from an external catalog. Hand-curated boards omit this block; the sync script regenerates manifests where it's present and never touches manifests where it's absent.",
+      "required": ["type", "remote_id"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Origin marker. Drives which sync script owns this manifest.",
+          "enum": ["esphome-devices"]
+        },
+        "remote_id": {
+          "type": "string",
+          "description": "Upstream identifier (folder name, page slug, ...) used to match this manifest back to its source on subsequent syncs."
+        },
+        "upstream_url": {
+          "type": "string",
+          "description": "Direct link to the source page on the upstream repo or site.",
+          "format": "uri"
+        },
+        "upstream_revision": {
+          "type": "string",
+          "description": "Commit SHA (or version string) the manifest was generated from."
+        },
+        "content_hash": {
+          "type": "string",
+          "description": "SHA-256 of the upstream source content. Lets the sync skip already-up-to-date entries without re-rendering."
+        }
+      }
     }
   },
   "$defs": {

--- a/script/check_device_catalog.py
+++ b/script/check_device_catalog.py
@@ -94,13 +94,13 @@ _EXPECTED_OK: list[dict[str, Any]] = [
     },
 ]
 
-# Pages we expect the importer to *skip*, with the reason it should
-# report. These have no inline yaml or no local images and should
-# never sneak into the catalog.
-_EXPECTED_SKIP: list[tuple[str, str]] = [
-    ("Adonno-Tagreader", "no parseable inline yaml"),
-    ("Aqara-FP2", "no parseable inline yaml"),
-]
+# Negative fixtures used to assert "should skip" cases would be brittle
+# against a community-maintained upstream — a contributor could later
+# add an inline yaml block to a page we currently expect to skip and
+# break our CI without anything actually regressing in our code.
+# Instead, we rely on the upstream-wide sync run (in CI, the previous
+# step) to surface skip-rate drift via its summary; the smoke test
+# only enforces the positive cases we care about.
 
 
 # ---------------------------------------------------------------------------
@@ -165,7 +165,10 @@ def _featured_has(
 
 def main() -> int:
     """Run the smoke test, returning ``0`` on success and ``1`` on any mismatch."""
-    repo = _ensure_devices_repo()
+    # Use the cache the sync step just produced — skipping the pull
+    # keeps us pinned to the same upstream revision that generated the
+    # manifests under review.
+    repo = _ensure_devices_repo(pull=False)
     if repo is None:
         print("ERROR: Could not clone esphome-devices.", file=sys.stderr)
         return 1
@@ -175,9 +178,7 @@ def main() -> int:
     by_remote_id: dict[str, dict[str, Any]] = {}
     skipped_by_remote_id: dict[str, str] = {}
 
-    expected_remote_ids = {s["remote_id"] for s in _EXPECTED_OK} | {
-        rid for rid, _ in _EXPECTED_SKIP
-    }
+    expected_remote_ids = {s["remote_id"] for s in _EXPECTED_OK}
 
     for src in _iter_devices(repo):
         if src.folder_name not in expected_remote_ids:
@@ -200,23 +201,13 @@ def main() -> int:
             continue
         errors.extend(_check_ok(by_remote_id[rid], spec))
 
-    for rid, expected_reason in _EXPECTED_SKIP:
-        if rid in by_remote_id:
-            errors.append(f"{rid}: expected skip but was imported")
-            continue
-        actual_reason = skipped_by_remote_id.get(rid, "<not seen>")
-        if actual_reason != expected_reason:
-            errors.append(f"{rid}: expected skip reason {expected_reason!r}, got {actual_reason!r}")
-
     if errors:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)
         print(f"\n{len(errors)} error(s) found", file=sys.stderr)
         return 1
 
-    ok = len(_EXPECTED_OK)
-    skip = len(_EXPECTED_SKIP)
-    print(f"OK: {ok} expected imports, {skip} expected skips, all match")
+    print(f"OK: {len(_EXPECTED_OK)} expected imports, all match")
     return 0
 
 

--- a/script/check_device_catalog.py
+++ b/script/check_device_catalog.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Smoke-test the imported device-board catalog after sync_esphome_devices.
+
+Re-runs ``sync_esphome_devices.py`` worth of extraction logic against a
+small list of well-known upstream pages and asserts that each lands the
+right ``board:``, ``variant:``, and at least one expected featured
+component preset. Catches:
+
+- A breaking change in the upstream front-matter contract
+- A SoC family or variant rename
+- Featured-component extraction regressions
+- A change in the components.json catalog that quietly drops a
+  ``component_id`` we depend on
+
+Designed to run in CI right after ``script/sync_esphome_devices.py``,
+before the diff check / PR creation. Exits non-zero on the first
+violation with a "[device].[expectation] expected X, got Y" message so
+the operator can read the workflow log without spelunking.
+
+Run locally:
+
+    python script/check_device_catalog.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow running via ``python script/check_device_catalog.py`` without
+# installing the package — keeps the smoke test runnable in an
+# uninstalled CI checkout, same pattern as ``check_catalog.py``.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from script.sync_esphome_devices import (
+    _DEVICES_CLONE_DIR,
+    _ensure_devices_repo,
+    _get_repo_revision,
+    _iter_devices,
+    _load_components_index,
+    _make_record,
+)
+
+# A handful of upstream pages we expect to import cleanly with the
+# right shape. Picked to cover:
+#
+# - the simplest classic case (Sonoff BASIC R2 v1.4 — esp8266/esp8285)
+# - an esp32 variant-only config (Shelly EM Gen3 — esp32c3 + esp-idf)
+# - a multi-output light bulb (Athom BR30 — five PWM outputs + rgbct)
+#
+# Each entry asserts the platform / board / variant / framework
+# resolved by ``_make_record`` plus a list of (component_id, field, key,
+# expected_value) tuples that must appear *somewhere* in the resulting
+# featured_components. The smoke test fails fast on any mismatch.
+_EXPECTED_OK: list[dict[str, Any]] = [
+    {
+        "remote_id": "Sonoff-BASIC-R2-v1.4",
+        "platform": "esp8266",
+        "board": "esp8285",
+        "variant": None,
+        "framework": None,
+        "featured": [
+            ("switch.gpio", "pin", "value", 12),
+            ("binary_sensor.gpio", "pin", "value", {"number": 0}),
+            ("light.status_led", "pin", "value", {"number": 13}),
+        ],
+    },
+    {
+        "remote_id": "Shelly-EM-Gen3",
+        "platform": "esp32",
+        "board": "esp32-c3-devkitm-1",
+        "variant": "esp32c3",
+        "framework": "esp-idf",
+        "featured": [
+            ("switch.gpio", "pin", "value", 0),
+            ("sensor.adc", "pin", "value", 3),
+        ],
+    },
+    {
+        "remote_id": "Athom-BR30-Bulb",
+        "platform": "esp8266",
+        "board": "esp8285",
+        "variant": None,
+        "framework": None,
+        "featured": [
+            ("output.esp8266_pwm", "pin", "value", 4),  # red
+            ("output.esp8266_pwm", "pin", "value", 12),  # green
+            ("output.esp8266_pwm", "pin", "value", 14),  # blue
+            ("output.esp8266_pwm", "pin", "value", 5),  # white
+            ("output.esp8266_pwm", "pin", "value", 13),  # ct
+        ],
+    },
+]
+
+# Pages we expect the importer to *skip*, with the reason it should
+# report. These have no inline yaml or no local images and should
+# never sneak into the catalog.
+_EXPECTED_SKIP: list[tuple[str, str]] = [
+    ("Adonno-Tagreader", "no parseable inline yaml"),
+    ("Aqara-FP2", "no parseable inline yaml"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def _expect_value(actual: Any, expected: Any) -> bool:
+    """Match *actual* against *expected*, allowing partial dict containment."""
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            return False
+        return all(_expect_value(actual.get(k), v) for k, v in expected.items())
+    return actual == expected
+
+
+def _check_ok(record: dict[str, Any], spec: dict[str, Any]) -> list[str]:
+    """Return a list of mismatch errors when *record* doesn't match *spec*."""
+    errors: list[str] = []
+    remote_id = spec["remote_id"]
+
+    esphome = record.get("esphome", {}) or {}
+    for key in ("platform", "board", "variant", "framework"):
+        actual = esphome.get(key)
+        expected = spec[key]
+        if actual != expected:
+            errors.append(f"{remote_id}.esphome.{key}: expected {expected!r}, got {actual!r}")
+
+    featured = record.get("featured_components") or []
+    for component_id, field_key, value_key, expected_value in spec["featured"]:
+        if not _featured_has(featured, component_id, field_key, value_key, expected_value):
+            errors.append(
+                f"{remote_id}: missing featured {component_id}.{field_key}.{value_key}={expected_value!r}"
+            )
+    return errors
+
+
+def _featured_has(
+    featured: list[dict[str, Any]],
+    component_id: str,
+    field_key: str,
+    value_key: str,
+    expected_value: Any,
+) -> bool:
+    """Return True when *featured* contains an entry matching the given coordinates."""
+    for entry in featured:
+        if entry.get("component_id") != component_id:
+            continue
+        fields = entry.get("fields") or {}
+        preset = fields.get(field_key)
+        if not isinstance(preset, dict):
+            continue
+        if _expect_value(preset.get(value_key), expected_value):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Run the smoke test, returning ``0`` on success and ``1`` on any mismatch."""
+    repo = _ensure_devices_repo()
+    if repo is None:
+        print("ERROR: Could not clone esphome-devices.", file=sys.stderr)
+        return 1
+    revision = _get_repo_revision(repo)
+    components_index = _load_components_index()
+
+    by_remote_id: dict[str, dict[str, Any]] = {}
+    skipped_by_remote_id: dict[str, str] = {}
+
+    expected_remote_ids = {s["remote_id"] for s in _EXPECTED_OK} | {
+        rid for rid, _ in _EXPECTED_SKIP
+    }
+
+    for src in _iter_devices(repo):
+        if src.folder_name not in expected_remote_ids:
+            continue
+        record, skip_reason = _make_record(src, components_index, revision)
+        if skip_reason is not None:
+            skipped_by_remote_id[src.folder_name] = skip_reason
+        else:
+            assert record is not None
+            by_remote_id[src.folder_name] = record
+
+    errors: list[str] = []
+
+    for spec in _EXPECTED_OK:
+        rid = spec["remote_id"]
+        if rid not in by_remote_id:
+            errors.append(
+                f"{rid}: expected import but got skip ({skipped_by_remote_id.get(rid, '<not seen>')})"
+            )
+            continue
+        errors.extend(_check_ok(by_remote_id[rid], spec))
+
+    for rid, expected_reason in _EXPECTED_SKIP:
+        if rid in by_remote_id:
+            errors.append(f"{rid}: expected skip but was imported")
+            continue
+        actual_reason = skipped_by_remote_id.get(rid, "<not seen>")
+        if actual_reason != expected_reason:
+            errors.append(f"{rid}: expected skip reason {expected_reason!r}, got {actual_reason!r}")
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        print(f"\n{len(errors)} error(s) found", file=sys.stderr)
+        return 1
+
+    ok = len(_EXPECTED_OK)
+    skip = len(_EXPECTED_SKIP)
+    print(f"OK: {ok} expected imports, {skip} expected skips, all match")
+    return 0
+
+
+if __name__ == "__main__":
+    # Surface the cache-dir hint so a missing cache doesn't look like a
+    # mysterious failure mode in CI logs.
+    if not _DEVICES_CLONE_DIR.exists():
+        print(
+            f"NOTE: cache {_DEVICES_CLONE_DIR} does not exist — will be cloned on first run.",
+            file=sys.stderr,
+        )
+    sys.exit(main())

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""
+Generate ``definitions/boards/<id>/manifest.yaml`` from devices.esphome.io.
+
+The upstream repo (https://github.com/esphome/esphome-devices) is a
+Docusaurus site whose 760+ device pages each have YAML front matter
+plus an inline ``yaml`` config. This script clones the repo, walks
+the device pages, and emits one ``boards/<id>/manifest.yaml`` per
+device that meets the strict acceptance bar (parseable inline yaml,
+identifiable board id, at least one local image, at least one
+extractable featured component).
+
+Imported manifests carry a ``source:`` block. Hand-curated manifests
+in ``boards/`` (no ``source:``) are never read or written; the
+sync only touches its own previous output, identified by
+``source.type: esphome-devices``.
+
+Usage
+-----
+
+    python script/sync_esphome_devices.py
+    python script/sync_esphome_devices.py --clean        # wipe cache
+    python script/sync_esphome_devices.py --limit 20     # debug subset
+    python script/sync_esphome_devices.py --dry-run      # no writes
+    python script/sync_esphome_devices.py --device <name>  # single device
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_LOGGER = logging.getLogger("sync_esphome_devices")
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFINITIONS_DIR = _REPO_ROOT / "esphome_device_builder" / "definitions"
+_BOARDS_DIR = _DEFINITIONS_DIR / "boards"
+_COMPONENTS_JSON = _DEFINITIONS_DIR / "components.json"
+_CACHE_ROOT = _REPO_ROOT / ".cache"
+_DEVICES_CLONE_DIR = _CACHE_ROOT / "esphome-devices"
+_DEVICES_REPO_URL = "https://github.com/esphome/esphome-devices.git"
+_DEVICES_REPO_BRANCH = "main"
+_DEVICES_SUBDIR = Path("src/docs/devices")
+_DEVICES_PAGE_BASE = "https://devices.esphome.io/devices"
+_DEVICES_REPO_BLOB_BASE = "https://github.com/esphome/esphome-devices/blob/main"
+
+_SOURCE_TYPE = "esphome-devices"
+
+# Closed enums upstream enforces (mirror of
+# esphome-devices/src/utils/validFrontmatter.ts).
+_VALID_SOC_FAMILIES: frozenset[str] = frozenset({"esp32", "esp8266", "bk72xx", "rp2040", "rtl87xx"})
+
+# Map ESP32 chip variants to a sensible default PlatformIO board id —
+# used when an upstream page declares ``esp32: { variant: esp32c3 }``
+# without an explicit ``board:``. Picked to match what ESPHome itself
+# defaults to for each variant.
+_ESP32_VARIANT_DEFAULT_BOARD: dict[str, str] = {
+    "esp32": "esp32dev",
+    "esp32s2": "esp32-s2-saola-1",
+    "esp32s3": "esp32-s3-devkitc-1",
+    "esp32c2": "esp32-c2-devkitm-1",
+    "esp32c3": "esp32-c3-devkitm-1",
+    "esp32c5": "esp32-c5-devkitc-1",
+    "esp32c6": "esp32-c6-devkitc-1",
+    "esp32c61": "esp32-c61-devkitc1",
+    "esp32h2": "esp32-h2-devkitm-1",
+    "esp32p4": "esp32-p4-function-ev-board",
+}
+
+# Connectivity defaults inferred from the SoC family. ESP32 always has
+# wifi+BT/BLE; everything else is wifi-only out of the box. Imports
+# don't try to cover ethernet / zigbee — those would need explicit
+# evidence we can't reliably mine from upstream.
+_SOC_CONNECTIVITY: dict[str, list[str]] = {
+    "esp32": ["wifi", "bluetooth"],
+    "esp8266": ["wifi"],
+    "bk72xx": ["wifi"],
+    "rp2040": ["wifi"],
+    "rtl87xx": ["wifi"],
+}
+
+# Top-level platform-list keys in ESPHome configs. Each list item
+# carries a ``platform: <stem>`` and we project to ``<domain>.<stem>``
+# in our component catalog.
+_PLATFORM_LIST_DOMAINS: frozenset[str] = frozenset(
+    {
+        "binary_sensor",
+        "button",
+        "climate",
+        "cover",
+        "datetime",
+        "display",
+        "fan",
+        "light",
+        "lock",
+        "media_player",
+        "number",
+        "output",
+        "select",
+        "sensor",
+        "switch",
+        "text",
+        "text_sensor",
+        "valve",
+    }
+)
+
+# Tag mapping from frontmatter ``type:`` to BoardTag values. Most
+# upstream types map to no tag because our enum is about *hardware*
+# features (relay, display, ...) while the upstream types are about
+# *use* (light, plug, dimmer). Only relay-bearing devices get a tag.
+_TYPE_TAG_MAP: dict[str, list[str]] = {
+    "relay": ["relay"],
+    "plug": ["relay", "compact"],
+}
+
+# Ecosystem tags inferred from the device name. Conservative — only
+# adds tags we can be confident about from the brand name alone.
+_NAME_TAG_RULES: list[tuple[str, str]] = [
+    ("sonoff", "sonoff"),
+    ("shelly", "shelly"),
+]
+
+# Field-name patterns that look hardware-fixed enough to lock. Anything
+# else is a suggestion (the user can override in the dashboard).
+_LOCKABLE_FIELD_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^pin$"),
+    re.compile(r"_pin$"),
+    re.compile(r"^pin_[a-z]+$"),  # pin_a, pin_b, ...
+    re.compile(r"^inverted$"),
+]
+
+# Maximum images to copy per device. Some pages list 30+ photos —
+# we cap to the first few so the repo doesn't bloat with PCB galleries.
+_MAX_IMAGES_PER_DEVICE = 8
+
+# Image extensions we mirror locally.
+_IMAGE_EXTENSIONS: frozenset[str] = frozenset({".jpg", ".jpeg", ".png", ".webp", ".svg"})
+
+# Fields we never lift, even if the underlying component schema lists
+# them as config_entries. ``platform`` is consumed to pick the
+# component itself; ``id`` is the per-instance variable name our
+# dashboard generates fresh — preserving upstream's would create
+# cross-instance conflicts the moment the user adds a second one.
+_SKIPPED_FIELDS: frozenset[str] = frozenset({"platform", "id"})
+
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _DeviceSource:
+    """Raw inputs extracted from one upstream page before validation."""
+
+    folder_name: str
+    page_path: Path  # absolute path to index.md
+    frontmatter: dict[str, Any]
+    body: str
+    content_hash: str
+    inline_yaml: dict[str, Any] | None
+    images: list[str]  # filenames relative to the device folder
+
+
+@dataclass
+class _SkippedDevice:
+    """A device that didn't pass acceptance — kept for the report."""
+
+    folder_name: str
+    reason: str
+
+
+@dataclass
+class _SyncReport:
+    """Aggregate result of a sync run."""
+
+    imported: list[str] = field(default_factory=list)
+    skipped: list[_SkippedDevice] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# YAML loader / dumper
+# ---------------------------------------------------------------------------
+
+
+class _TolerantSafeLoader(yaml.SafeLoader):
+    """
+    SafeLoader that swallows ESPHome-only tags as plain scalars/mappings.
+
+    The upstream device pages happily use ``!secret``, ``!lambda``,
+    ``!include``, ``!extend``, ``!remove``, ``!env_var``. The default
+    SafeLoader raises on those — we just want to keep parsing the
+    surrounding structure.
+    """
+
+
+def _passthrough_constructor(loader: yaml.SafeLoader, node: yaml.Node) -> Any:
+    """Construct *node* as the closest plain Python value, ignoring its tag."""
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node, deep=True)
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node, deep=True)
+    return None
+
+
+for _tag in ("!secret", "!lambda", "!include", "!extend", "!remove", "!env_var"):
+    _TolerantSafeLoader.add_constructor(_tag, _passthrough_constructor)
+
+
+def _safe_load_yaml(text: str) -> Any:
+    """Parse YAML with the tolerant loader. Returns ``None`` on error."""
+    try:
+        # ``_TolerantSafeLoader`` only adds passthrough constructors for
+        # ESPHome-only tags — no arbitrary-object instantiation is
+        # reachable, so the bandit S506 warning here is a false positive.
+        return yaml.load(text, Loader=_TolerantSafeLoader)  # noqa: S506
+    except yaml.YAMLError:
+        return None
+
+
+class _ManifestDumper(yaml.SafeDumper):
+    """SafeDumper that produces stable, human-readable manifest YAML."""
+
+
+def _represent_str(dumper: yaml.SafeDumper, data: str) -> yaml.ScalarNode:
+    """Render strings with embedded newlines as ``|`` literal blocks."""
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_ManifestDumper.add_representer(str, _represent_str)
+
+
+def _dump_manifest(data: dict[str, Any]) -> str:
+    """Render a manifest dict to YAML in our preferred style."""
+    return yaml.dump(
+        data,
+        Dumper=_ManifestDumper,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=100,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repo cache
+# ---------------------------------------------------------------------------
+
+
+def _ensure_devices_repo() -> Path | None:
+    """
+    Clone or update the esphome-devices repo. Returns its path or None.
+
+    Mirrors the docs-repo handling in script/sync_components.py:
+    shallow clone on first run, ``git pull --ff-only`` afterwards. A
+    pull failure is non-fatal — we keep using whatever's on disk.
+    """
+    target = _DEVICES_CLONE_DIR
+    if (target / ".git").exists():
+        result = subprocess.run(
+            ["git", "-C", str(target), "pull", "-q", "--ff-only"],
+            check=False,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            _LOGGER.warning("git pull failed in %s — using existing snapshot", target)
+        return target
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _LOGGER.info("Cloning esphome-devices (shallow) to %s", target)
+    try:
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "-q",
+                "--depth=1",
+                "--single-branch",
+                f"--branch={_DEVICES_REPO_BRANCH}",
+                _DEVICES_REPO_URL,
+                str(target),
+            ],
+            check=True,
+            timeout=300,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        _LOGGER.error("Could not clone esphome-devices: %s", exc)
+        return None
+    return target
+
+
+def _get_repo_revision(repo: Path) -> str:
+    """Return the current commit SHA, or empty string on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip()
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Page parsing
+# ---------------------------------------------------------------------------
+
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)$", re.DOTALL)
+_YAML_FENCE_RE = re.compile(r"```ya?ml\s*\n(.*?)\n```", re.DOTALL)
+_IMAGE_REF_RE = re.compile(r"!\[[^\]]*\]\(([^)\s]+?)(?:\s+\"[^\"]*\")?\)")
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, Any] | None, str]:
+    """Return ``(frontmatter, body)`` from a markdown file with `---` block."""
+    match = _FRONTMATTER_RE.match(text)
+    if match is None:
+        return None, text
+    fm_text, body = match.group(1), match.group(2)
+    parsed = _safe_load_yaml(fm_text)
+    if not isinstance(parsed, dict):
+        return None, body
+    # Normalize keys — upstream has a few stray uppercased fields
+    # ("Difficulty", "Made-for-esphome", ...). Lowercase everything for
+    # consistent lookup.
+    return {str(k).lower(): v for k, v in parsed.items()}, body
+
+
+def _extract_first_yaml_block(body: str) -> dict[str, Any] | None:
+    """Find the first fenced ```yaml block in *body* and parse it."""
+    for match in _YAML_FENCE_RE.finditer(body):
+        parsed = _safe_load_yaml(match.group(1))
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _extract_local_images(body: str, device_dir: Path) -> list[str]:
+    """Return a list of local image filenames referenced in *body*."""
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    for match in _IMAGE_REF_RE.finditer(body):
+        ref = match.group(1).strip()
+        if not ref or ref.startswith(("http://", "https://", "data:")):
+            continue
+        # Strip any leading "./" — paths in the source are relative
+        # to the device folder.
+        ref = ref.removeprefix("./")
+        suffix = Path(ref).suffix.lower()
+        if suffix not in _IMAGE_EXTENSIONS:
+            continue
+        # Reject path traversal; we stay strictly inside the device dir.
+        if "/" in ref or "\\" in ref or ".." in ref:
+            continue
+        if not (device_dir / ref).is_file():
+            continue
+        if ref in seen_set:
+            continue
+        seen.append(ref)
+        seen_set.add(ref)
+        if len(seen) >= _MAX_IMAGES_PER_DEVICE:
+            break
+    return seen
+
+
+def _hash_content(text: str) -> str:
+    """Return the SHA-256 hex digest of *text*."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _iter_devices(repo: Path) -> Iterator[_DeviceSource]:
+    """Walk *repo* and yield one record per usable device page."""
+    devices_root = repo / _DEVICES_SUBDIR
+    for device_dir in sorted(devices_root.iterdir()):
+        if not device_dir.is_dir():
+            continue
+        page_path = device_dir / "index.md"
+        if not page_path.is_file():
+            continue
+        try:
+            text = page_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        frontmatter, body = _split_frontmatter(text)
+        if frontmatter is None:
+            continue
+        yield _DeviceSource(
+            folder_name=device_dir.name,
+            page_path=page_path,
+            frontmatter=frontmatter,
+            body=body,
+            content_hash=_hash_content(text),
+            inline_yaml=_extract_first_yaml_block(body),
+            images=_extract_local_images(body, device_dir),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance + record building
+# ---------------------------------------------------------------------------
+
+
+def _slugify(name: str) -> str:
+    """Lowercase and underscore-normalize *name* for use as a board id."""
+    slug = re.sub(r"[^a-z0-9]+", "_", name.lower())
+    return slug.strip("_")
+
+
+def _gpio_number(raw: Any) -> int | None:
+    """Extract a GPIO integer from any supported ESPHome pin shorthand."""
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        match = re.match(r"^\s*(?:GPIO)?(\d+)\s*$", raw, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+    if isinstance(raw, dict):
+        return _gpio_number(raw.get("number"))
+    return None
+
+
+def _normalize_pin_value(raw: Any) -> Any:
+    """
+    Return *raw* with any GPIO string normalized to an int.
+
+    ``GPIO12`` → ``12`` for both the bare-int form and the rich
+    ``{number: GPIO12, ...}`` form. Mode dicts are passed through.
+    """
+    if isinstance(raw, str):
+        gpio = _gpio_number(raw)
+        return gpio if gpio is not None else raw
+    if isinstance(raw, dict):
+        out: dict[str, Any] = {}
+        for k, v in raw.items():
+            if k == "number":
+                num = _gpio_number(v)
+                out[k] = num if num is not None else v
+            else:
+                out[k] = v
+        return out
+    return raw
+
+
+def _resolve_soc(
+    frontmatter: dict[str, Any], inline: dict[str, Any]
+) -> tuple[str | None, dict[str, Any] | None]:
+    """
+    Pick the SoC family + its inline-yaml block.
+
+    Frontmatter ``board:`` is the upstream-validated SoC family; we
+    cross-check that the inline yaml has a matching block. Falls back
+    to whichever family-block actually appears in the inline yaml when
+    frontmatter is missing it.
+    """
+    fm_board = frontmatter.get("board")
+    candidates: list[str] = []
+    if isinstance(fm_board, str):
+        for raw_token in fm_board.split(","):
+            token = raw_token.strip().lower()
+            if token in _VALID_SOC_FAMILIES:
+                candidates.append(token)
+    for family in _VALID_SOC_FAMILIES:
+        if family not in candidates and family in inline:
+            candidates.append(family)
+    for family in candidates:
+        block = inline.get(family)
+        if isinstance(block, dict):
+            return family, block
+    return (candidates[0] if candidates else None), None
+
+
+def _resolve_board_and_variant(
+    soc: str, soc_block: dict[str, Any] | None
+) -> tuple[str | None, str | None, str | None]:
+    """
+    Return ``(board, variant, framework)`` for the manifest.
+
+    ``soc_block`` is the parsed inline-yaml block keyed under the SoC
+    family (e.g. the value of ``esp32:``). For esp32, ``variant``
+    falls back to a default board id when ``board:`` isn't supplied.
+    """
+    if soc_block is None:
+        return None, None, None
+
+    raw_board = soc_block.get("board")
+    raw_variant = soc_block.get("variant")
+    raw_framework = soc_block.get("framework")
+
+    board = raw_board if isinstance(raw_board, str) else None
+    # Upstream pages sometimes write the variant in uppercase (``ESP32C3``)
+    # — normalize to match our enum.
+    variant = raw_variant.lower() if isinstance(raw_variant, str) else None
+    framework: str | None = None
+    if isinstance(raw_framework, dict):
+        ftype = raw_framework.get("type")
+        if isinstance(ftype, str):
+            framework = ftype
+    elif isinstance(raw_framework, str):
+        framework = raw_framework
+
+    if soc == "esp32" and not board and variant:
+        board = _ESP32_VARIANT_DEFAULT_BOARD.get(variant)
+
+    return board, variant, framework
+
+
+def _extract_featured_components(
+    inline: dict[str, Any], components_index: dict[str, dict[str, Any]]
+) -> tuple[list[dict[str, Any]], dict[int, str]]:
+    """
+    Build featured_components entries from inline-yaml platform lists.
+
+    Returns ``(featured_components, gpio_occupancy)``. The occupancy
+    map captures one human-readable label per GPIO referenced by an
+    extracted component — used to synthesize ``pins[]`` entries.
+    """
+    featured: list[dict[str, Any]] = []
+    gpio_occupancy: dict[int, str] = {}
+
+    counters: dict[str, int] = {}
+    for domain in sorted(inline.keys()):
+        if domain not in _PLATFORM_LIST_DOMAINS:
+            continue
+        items = inline[domain]
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            platform = item.get("platform")
+            if not isinstance(platform, str) or not platform:
+                continue
+            component_id = f"{domain}.{platform}"
+            component = components_index.get(component_id)
+            if component is None:
+                continue
+            fields = _extract_fields(item, component, gpio_occupancy, component_id)
+            # No-field components are generic catalog entries the user
+            # can add from the regular flow; including them here just
+            # adds noise (sensor.uptime, switch.restart, ...). Keeping
+            # only those with a real hardware-specific preset.
+            if not fields:
+                continue
+            counters[component_id] = counters.get(component_id, 0) + 1
+            local_id = f"{domain}_{platform}_{counters[component_id]}"
+            entry: dict[str, Any] = {
+                "id": local_id,
+                "component_id": component_id,
+                "fields": fields,
+            }
+            featured.append(entry)
+    return featured, gpio_occupancy
+
+
+def _extract_fields(
+    inline_item: dict[str, Any],
+    component: dict[str, Any],
+    gpio_occupancy: dict[int, str],
+    component_id: str,
+) -> dict[str, Any]:
+    """
+    Lift hardware-fixed fields out of an inline platform-list item.
+
+    Pin / inverted fields are written as ``locked`` presets; other
+    scalars come through as bare values (unlocked suggestions).
+    Per-instance fields (``id``) are skipped — the dashboard generates
+    its own ids and pre-filling the upstream value would just create
+    rename friction or duplicate-id collisions.
+    """
+    valid_keys: dict[str, dict[str, Any]] = {}
+    for ce in component.get("config_entries") or []:
+        key = ce.get("key")
+        if isinstance(key, str):
+            valid_keys[key] = ce
+
+    out: dict[str, Any] = {}
+    for fkey, fval in inline_item.items():
+        if fkey in _SKIPPED_FIELDS:
+            continue
+        ce = valid_keys.get(fkey)
+        if ce is None:
+            continue
+        ce_type = ce.get("type")
+        if ce_type == "pin":
+            normalized = _normalize_pin_value(fval)
+            gpio = _gpio_number(normalized)
+            if gpio is None:
+                # Reference-style pins or lambdas — skip silently.
+                continue
+            label = _occupancy_label(inline_item, component_id)
+            if gpio not in gpio_occupancy:
+                gpio_occupancy[gpio] = label
+            out[fkey] = {"value": normalized, "locked": True}
+            continue
+        if not _is_simple_scalar(fval):
+            continue
+        if _looks_lockable(fkey):
+            out[fkey] = {"value": fval, "locked": True}
+        else:
+            out[fkey] = fval
+    return out
+
+
+def _occupancy_label(inline_item: dict[str, Any], component_id: str) -> str:
+    """Build a human-readable label for a GPIO's ``occupied_by`` field."""
+    for key in ("name", "id"):
+        candidate = inline_item.get(key)
+        if isinstance(candidate, str) and candidate.strip():
+            return f"{component_id} ({candidate.strip()})"
+    return component_id
+
+
+def _is_simple_scalar(value: Any) -> bool:
+    """Return True if *value* is a primitive we can safely round-trip."""
+    if value is None or isinstance(value, bool | int | float):
+        return True
+    if isinstance(value, str):
+        # Keep things short — long strings are usually templated names
+        # we don't want to lock the user into.
+        return "${" not in value and "\n" not in value and len(value) <= 80
+    return False
+
+
+def _looks_lockable(field_name: str) -> bool:
+    """Return True for field names that look hardware-fixed (pin, inverted, ...)."""
+    return any(p.search(field_name) for p in _LOCKABLE_FIELD_PATTERNS)
+
+
+def _build_pins(gpio_occupancy: dict[int, str]) -> list[dict[str, Any]]:
+    """Synthesize one minimal pin entry per GPIO referenced by featured components."""
+    return [
+        {"gpio": gpio, "available": False, "occupied_by": gpio_occupancy[gpio]}
+        for gpio in sorted(gpio_occupancy)
+    ]
+
+
+def _build_tags(name: str, type_field: str | None) -> list[str]:
+    """Map the upstream ``type:`` and device name to the closest BoardTag values."""
+    tags: list[str] = []
+    if isinstance(type_field, str):
+        tags.extend(_TYPE_TAG_MAP.get(type_field.strip().lower(), []))
+    name_l = name.lower()
+    for needle, tag in _NAME_TAG_RULES:
+        if needle in name_l and tag not in tags:
+            tags.append(tag)
+    return tags
+
+
+def _make_record(  # noqa: PLR0911 — distinct skip reasons each get their own early exit
+    src: _DeviceSource,
+    components_index: dict[str, dict[str, Any]],
+    revision: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """
+    Apply acceptance criteria + build a manifest dict.
+
+    Returns ``(record, None)`` on success or ``(None, skip_reason)``.
+    """
+    fm = src.frontmatter
+    title = fm.get("title")
+    if not isinstance(title, str) or not title.strip():
+        return None, "no frontmatter title"
+    type_field = fm.get("type")
+    if not isinstance(type_field, str) or not type_field.strip():
+        return None, "no frontmatter type"
+    if src.inline_yaml is None:
+        return None, "no parseable inline yaml"
+    if not src.images:
+        return None, "no local images"
+
+    soc, soc_block = _resolve_soc(fm, src.inline_yaml)
+    if soc is None:
+        return None, "soc family not in upstream enum"
+    board, variant, framework = _resolve_board_and_variant(soc, soc_block)
+    if not board:
+        return None, f"no concrete board id for {soc}"
+
+    featured, gpio_occupancy = _extract_featured_components(src.inline_yaml, components_index)
+    if not featured:
+        return None, "no extractable featured components"
+
+    record: dict[str, Any] = {
+        "id": _slugify(src.folder_name),
+        "name": title.strip(),
+        "description": "Imported from devices.esphome.io — see linked docs for community notes.",
+        "esphome": _build_esphome_block(soc, board, variant, framework),
+    }
+
+    connectivity = _SOC_CONNECTIVITY.get(soc)
+    if connectivity:
+        record["hardware"] = {"connectivity": list(connectivity)}
+
+    if src.images:
+        record["images"] = list(src.images)
+
+    tags = _build_tags(src.folder_name, type_field)
+    if tags:
+        record["tags"] = tags
+
+    pins = _build_pins(gpio_occupancy)
+    if pins:
+        record["pins"] = pins
+
+    record["docs_url"] = f"{_DEVICES_PAGE_BASE}/{src.folder_name}/"
+    project_url = fm.get("project-url")
+    if isinstance(project_url, str) and project_url.startswith(("http://", "https://")):
+        record["product_url"] = project_url
+
+    record["featured_components"] = featured
+
+    record["source"] = _build_source_block(src.folder_name, revision, src.content_hash)
+
+    return record, None
+
+
+def _build_esphome_block(
+    soc: str, board: str, variant: str | None, framework: str | None
+) -> dict[str, Any]:
+    """Compose the manifest's ``esphome:`` block, omitting empty optional fields."""
+    out: dict[str, Any] = {"platform": soc, "board": board}
+    if variant:
+        out["variant"] = variant
+    if framework in ("arduino", "esp-idf"):
+        out["framework"] = framework
+    return out
+
+
+def _build_source_block(folder_name: str, revision: str, content_hash: str) -> dict[str, Any]:
+    """Compose the manifest's ``source:`` block (origin + drift-detection metadata)."""
+    block: dict[str, Any] = {
+        "type": _SOURCE_TYPE,
+        "remote_id": folder_name,
+        "upstream_url": f"{_DEVICES_REPO_BLOB_BASE}/{_DEVICES_SUBDIR.as_posix()}/"
+        f"{folder_name}/index.md",
+    }
+    if revision:
+        block["upstream_revision"] = revision
+    block["content_hash"] = content_hash
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Emit + prune
+# ---------------------------------------------------------------------------
+
+
+def _emit_manifest(record: dict[str, Any], src: _DeviceSource) -> Path:
+    """Write boards/<id>/manifest.yaml and copy images. Returns target dir."""
+    target_dir = _BOARDS_DIR / record["id"]
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    images_dir = target_dir / "images"
+    if record.get("images"):
+        images_dir.mkdir(exist_ok=True)
+        device_dir = src.page_path.parent
+        for image_name in record["images"]:
+            src_path = device_dir / image_name
+            if src_path.is_file():
+                shutil.copy2(src_path, images_dir / image_name)
+
+    manifest_path = target_dir / "manifest.yaml"
+    manifest_path.write_text(_dump_manifest(record), encoding="utf-8")
+    return target_dir
+
+
+def _is_imported_manifest(manifest_path: Path) -> tuple[bool, str | None]:
+    """Return ``(is_imported, remote_id)`` for an existing board manifest."""
+    try:
+        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return False, None
+    if not isinstance(data, dict):
+        return False, None
+    source = data.get("source")
+    if not isinstance(source, dict) or source.get("type") != _SOURCE_TYPE:
+        return False, None
+    remote_id = source.get("remote_id")
+    return True, remote_id if isinstance(remote_id, str) else None
+
+
+def _prune_removed(active_remote_ids: set[str]) -> list[str]:
+    """Delete boards/<id>/ for any imported manifest no longer upstream."""
+    removed: list[str] = []
+    if not _BOARDS_DIR.is_dir():
+        return removed
+    for child in sorted(_BOARDS_DIR.iterdir()):
+        if not child.is_dir():
+            continue
+        manifest = child / "manifest.yaml"
+        if not manifest.is_file():
+            continue
+        is_imported, remote_id = _is_imported_manifest(manifest)
+        if not is_imported:
+            continue
+        if remote_id and remote_id in active_remote_ids:
+            continue
+        shutil.rmtree(child)
+        removed.append(child.name)
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _load_components_index() -> dict[str, dict[str, Any]]:
+    """Index ``definitions/components.json`` by component id."""
+    if not _COMPONENTS_JSON.is_file():
+        raise SystemExit(f"{_COMPONENTS_JSON} not found — run script/sync_components.py first.")
+    raw = json.loads(_COMPONENTS_JSON.read_text(encoding="utf-8"))
+    return {comp["id"]: comp for comp in raw.get("components", []) if comp.get("id")}
+
+
+def _parse_args() -> argparse.Namespace:
+    """Build the CLI ArgumentParser and return parsed args."""
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Wipe the upstream cache before pulling.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Stop after N successful imports (debugging). Disables pruning.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run extraction but don't write any manifests or images.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Process only this upstream folder name (e.g. Sonoff-BASIC-R2-v1.4).",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print every skip reason.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point: clone the upstream repo, sync, and print a report."""
+    args = _parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    if args.clean and _DEVICES_CLONE_DIR.is_dir():
+        _LOGGER.info("Removing %s (--clean)", _DEVICES_CLONE_DIR)
+        shutil.rmtree(_DEVICES_CLONE_DIR)
+
+    repo = _ensure_devices_repo()
+    if repo is None:
+        return 1
+    revision = _get_repo_revision(repo)
+
+    components_index = _load_components_index()
+
+    report = _SyncReport()
+    active_remote_ids: set[str] = set()
+
+    for src in _iter_devices(repo):
+        if args.device and src.folder_name != args.device:
+            continue
+        record, skip_reason = _make_record(src, components_index, revision)
+        if skip_reason is not None:
+            report.skipped.append(_SkippedDevice(src.folder_name, skip_reason))
+            if args.verbose:
+                _LOGGER.debug("skip %s: %s", src.folder_name, skip_reason)
+            continue
+        active_remote_ids.add(src.folder_name)
+        if not args.dry_run:
+            _emit_manifest(record, src)
+        report.imported.append(record["id"])
+        if args.limit is not None and len(report.imported) >= args.limit:
+            break
+
+    # Pruning is dangerous when --limit / --device is in effect, since
+    # we haven't actually visited the rest of the upstream tree.
+    if not args.dry_run and args.limit is None and args.device is None:
+        report.removed = _prune_removed(active_remote_ids)
+
+    _print_report(report, args.verbose)
+    return 0
+
+
+def _print_report(report: _SyncReport, verbose: bool) -> None:
+    """Pretty-print *report* to stdout."""
+    print(f"Imported: {len(report.imported)}")
+    print(f"Skipped:  {len(report.skipped)}")
+    print(f"Removed:  {len(report.removed)}")
+
+    if report.skipped:
+        from collections import Counter
+
+        reasons = Counter(s.reason for s in report.skipped)
+        print("\nTop skip reasons:")
+        for reason, count in reasons.most_common(10):
+            print(f"  {count:>4}  {reason}")
+
+    if verbose and report.skipped:
+        print("\nAll skips:")
+        for s in report.skipped:
+            print(f"  - {s.folder_name}: {s.reason}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -83,40 +83,66 @@ _ESP32_VARIANT_DEFAULT_BOARD: dict[str, str] = {
     "esp32p4": "esp32-p4-function-ev-board",
 }
 
-# Connectivity defaults inferred from the SoC family. ESP32 always has
-# wifi+BT/BLE; everything else is wifi-only out of the box. Imports
-# don't try to cover ethernet / zigbee — those would need explicit
-# evidence we can't reliably mine from upstream.
+# Connectivity defaults inferred from the SoC family / variant. ESP32
+# variants differ on what's built in: classic + S3 + C3 + C5 + C6 +
+# C61 carry both wifi + BLE; S2 has wifi only; H2 has BLE/Thread but
+# no wifi; P4 has neither built in. Imports don't try to cover
+# ethernet / zigbee / matter — those need explicit evidence we can't
+# reliably mine from upstream.
 _SOC_CONNECTIVITY: dict[str, list[str]] = {
-    "esp32": ["wifi", "bluetooth"],
     "esp8266": ["wifi"],
     "bk72xx": ["wifi"],
     "rp2040": ["wifi"],
     "rtl87xx": ["wifi"],
 }
 
+# Per-variant overrides for the esp32 family. ``None`` means "no
+# built-in radio" (esp32p4) — we omit ``hardware.connectivity``
+# entirely so the manifest doesn't claim wifi the chip can't deliver.
+_ESP32_VARIANT_CONNECTIVITY: dict[str, list[str] | None] = {
+    "esp32": ["wifi", "bluetooth"],
+    "esp32s2": ["wifi"],
+    "esp32s3": ["wifi", "bluetooth"],
+    "esp32c2": ["wifi", "bluetooth"],
+    "esp32c3": ["wifi", "bluetooth"],
+    "esp32c5": ["wifi", "bluetooth"],
+    "esp32c6": ["wifi", "bluetooth"],
+    "esp32c61": ["wifi", "bluetooth"],
+    "esp32h2": ["bluetooth"],
+    "esp32p4": None,
+}
+
 # Top-level platform-list keys in ESPHome configs. Each list item
 # carries a ``platform: <stem>`` and we project to ``<domain>.<stem>``
-# in our component catalog.
+# in our component catalog. Mirrors the ``ComponentCategory`` entity
+# domains in the catalog so we don't reject hardware that's actually
+# representable (speakers, microphones, touchscreens, alarm panels).
 _PLATFORM_LIST_DOMAINS: frozenset[str] = frozenset(
     {
+        "alarm_control_panel",
         "binary_sensor",
         "button",
+        "camera",
         "climate",
         "cover",
         "datetime",
         "display",
+        "event",
         "fan",
         "light",
         "lock",
         "media_player",
+        "microphone",
         "number",
         "output",
         "select",
         "sensor",
+        "speaker",
         "switch",
         "text",
         "text_sensor",
+        "touchscreen",
+        "update",
         "valve",
     }
 )
@@ -269,16 +295,22 @@ def _dump_manifest(data: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _ensure_devices_repo() -> Path | None:
+def _ensure_devices_repo(*, pull: bool = True) -> Path | None:
     """
     Clone or update the esphome-devices repo. Returns its path or None.
 
     Mirrors the docs-repo handling in script/sync_components.py:
     shallow clone on first run, ``git pull --ff-only`` afterwards. A
     pull failure is non-fatal — we keep using whatever's on disk.
+
+    Pass ``pull=False`` to skip the pull when the cache already exists,
+    which is what the smoke test does so it inspects the same revision
+    the sync just produced.
     """
     target = _DEVICES_CLONE_DIR
     if (target / ".git").exists():
+        if not pull:
+            return target
         result = subprocess.run(
             ["git", "-C", str(target), "pull", "-q", "--ff-only"],
             check=False,
@@ -687,13 +719,13 @@ def _make_record(  # noqa: PLR0911 — distinct skip reasons each get their own 
     title = fm.get("title")
     if not isinstance(title, str) or not title.strip():
         return None, "no frontmatter title"
-    type_field = fm.get("type")
-    if not isinstance(type_field, str) or not type_field.strip():
-        return None, "no frontmatter type"
     if src.inline_yaml is None:
         return None, "no parseable inline yaml"
     if not src.images:
         return None, "no local images"
+    # ``type:`` is optional — only used downstream for tag inference.
+    # A page without it is still importable.
+    type_field = fm.get("type") if isinstance(fm.get("type"), str) else None
 
     soc, soc_block = _resolve_soc(fm, src.inline_yaml)
     if soc is None:
@@ -713,12 +745,17 @@ def _make_record(  # noqa: PLR0911 — distinct skip reasons each get their own 
         "esphome": _build_esphome_block(soc, board, variant, framework),
     }
 
-    connectivity = _SOC_CONNECTIVITY.get(soc)
+    connectivity = _connectivity_for(soc, variant)
     if connectivity:
         record["hardware"] = {"connectivity": list(connectivity)}
 
     if src.images:
-        record["images"] = list(src.images)
+        # The loader (``_resolve_images``) resolves manifest entries
+        # relative to the board directory; storing them with the
+        # ``images/`` prefix preserves the upstream order. Without
+        # this prefix the explicit references don't resolve and the
+        # loader silently falls back to alphabetic auto-discovery.
+        record["images"] = [f"images/{name}" for name in src.images]
 
     tags = _build_tags(src.folder_name, type_field)
     if tags:
@@ -752,6 +789,15 @@ def _build_esphome_block(
     return out
 
 
+def _connectivity_for(soc: str, variant: str | None) -> list[str] | None:
+    """Return the built-in radio mix for *soc*/*variant*, or ``None`` for none."""
+    if soc == "esp32":
+        # Variants without an explicit override fall through to the
+        # classic esp32 default (wifi + bluetooth).
+        return _ESP32_VARIANT_CONNECTIVITY.get(variant or "esp32", ["wifi", "bluetooth"])
+    return _SOC_CONNECTIVITY.get(soc)
+
+
 def _build_source_block(folder_name: str, revision: str, content_hash: str) -> dict[str, Any]:
     """Compose the manifest's ``source:`` block (origin + drift-detection metadata)."""
     block: dict[str, Any] = {
@@ -771,16 +817,35 @@ def _build_source_block(folder_name: str, revision: str, content_hash: str) -> d
 # ---------------------------------------------------------------------------
 
 
-def _emit_manifest(record: dict[str, Any], src: _DeviceSource) -> Path:
-    """Write boards/<id>/manifest.yaml and copy images. Returns target dir."""
+def _emit_manifest(record: dict[str, Any], src: _DeviceSource) -> Path | None:
+    """
+    Write ``boards/<id>/manifest.yaml`` and refresh the images.
+
+    Skips with a warning when *target_dir* already holds a non-imported
+    manifest (slug collision with a hand-curated board). Otherwise
+    cleans the existing ``images/`` subdir before copying so an
+    upstream image-set shrink doesn't leave stale files behind.
+    """
     target_dir = _BOARDS_DIR / record["id"]
+    if not _is_writable_target(target_dir):
+        _LOGGER.warning(
+            "Skipping %s — slug collides with a hand-curated board (no source.type)",
+            record["id"],
+        )
+        return None
     target_dir.mkdir(parents=True, exist_ok=True)
 
     images_dir = target_dir / "images"
-    if record.get("images"):
-        images_dir.mkdir(exist_ok=True)
+    if images_dir.is_dir():
+        # Wipe the directory first so a removed upstream image
+        # disappears from the local copy too. Only the ``images/``
+        # subdir is touched — the manifest itself is overwritten
+        # below in a single write.
+        shutil.rmtree(images_dir)
+    if src.images:
+        images_dir.mkdir()
         device_dir = src.page_path.parent
-        for image_name in record["images"]:
+        for image_name in src.images:
             src_path = device_dir / image_name
             if src_path.is_file():
                 shutil.copy2(src_path, images_dir / image_name)
@@ -788,6 +853,15 @@ def _emit_manifest(record: dict[str, Any], src: _DeviceSource) -> Path:
     manifest_path = target_dir / "manifest.yaml"
     manifest_path.write_text(_dump_manifest(record), encoding="utf-8")
     return target_dir
+
+
+def _is_writable_target(target_dir: Path) -> bool:
+    """Return True when the sync owns *target_dir* (or it doesn't exist yet)."""
+    manifest = target_dir / "manifest.yaml"
+    if not manifest.is_file():
+        return True
+    is_imported, _ = _is_imported_manifest(manifest)
+    return is_imported
 
 
 def _is_imported_manifest(manifest_path: Path) -> tuple[bool, str | None]:
@@ -904,9 +978,12 @@ def main() -> int:
             if args.verbose:
                 _LOGGER.debug("skip %s: %s", src.folder_name, skip_reason)
             continue
+        if not args.dry_run and _emit_manifest(record, src) is None:
+            report.skipped.append(
+                _SkippedDevice(src.folder_name, "slug collides with hand-curated board")
+            )
+            continue
         active_remote_ids.add(src.folder_name)
-        if not args.dry_run:
-            _emit_manifest(record, src)
         report.imported.append(record["id"])
         if args.limit is not None and len(report.imported) >= args.limit:
             break

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -122,9 +122,17 @@ def validate_board(manifest: Path, components_index: dict | None = None) -> list
                 seen_gpios.add(gpio)
                 pins_by_gpio[gpio] = pin
 
+    # Imported boards (source.type set) carry only synthesized pin
+    # entries with empty ``features`` — we don't have a per-chip pin-
+    # feature DB to populate them. Skip the per-pin feature
+    # intersection check for these; the rest of featured-component
+    # validation (component_id present, fields key match,
+    # GPIO declared) still runs.
+    is_imported = isinstance(data.get("source"), dict) and bool(data["source"].get("type"))
+
     # Featured components & bundles — cross-catalog validation against
     # the loaded component index when available.
-    errors.extend(_validate_featured(board_id, data, pins_by_gpio, components_index))
+    errors.extend(_validate_featured(board_id, data, pins_by_gpio, components_index, is_imported))
 
     return errors
 
@@ -158,6 +166,7 @@ def _validate_featured(
     data: dict,
     pins_by_gpio: dict[int, dict],
     components_index: dict | None,
+    is_imported: bool = False,
 ) -> list[str]:
     """Validate featured_components / featured_bundles cross-references."""
     errors: list[str] = []
@@ -179,7 +188,9 @@ def _validate_featured(
         seen_fc_ids.add(fc_id)
 
         errors.extend(
-            _validate_featured_component(board_id, idx, entry, pins_by_gpio, components_index)
+            _validate_featured_component(
+                board_id, idx, entry, pins_by_gpio, components_index, is_imported
+            )
         )
 
     seen_bundle_ids: set[str] = set()
@@ -206,6 +217,7 @@ def _validate_featured_component(
     entry: dict,
     pins_by_gpio: dict[int, dict],
     components_index: dict | None,
+    is_imported: bool = False,
 ) -> list[str]:
     """Validate a single featured_components[i] entry against the catalog."""
     errors: list[str] = []
@@ -242,7 +254,7 @@ def _validate_featured_component(
             errors.append(f"{path}.fields.{fkey}: not a config_entry on {component_id}")
             continue
         ce = entries_by_key[fkey]
-        errors.extend(_validate_field_preset(path, fkey, fval, ce, pins_by_gpio))
+        errors.extend(_validate_field_preset(path, fkey, fval, ce, pins_by_gpio, is_imported))
 
     return errors
 
@@ -253,6 +265,7 @@ def _validate_field_preset(
     fval: object,
     ce: dict,
     pins_by_gpio: dict[int, dict],
+    is_imported: bool = False,
 ) -> list[str]:
     """Validate a single field preset against its config-entry constraints."""
     errors: list[str] = []
@@ -276,6 +289,11 @@ def _validate_field_preset(
             pin = pins_by_gpio.get(gpio)
             if pin is None:
                 errors.append(f"{path}.fields.{fkey}: GPIO {gpio} not declared in pins")
+                continue
+            if is_imported:
+                # Imported boards have synthesized pin entries with no
+                # features filled in — skip the intersection check.
+                # Pin-declared check above still runs.
                 continue
             pin_features = set(pin.get("features") or [])
             missing = required_features - pin_features

--- a/tests/test_validate_featured.py
+++ b/tests/test_validate_featured.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from script.validate_definitions import (  # type: ignore[import-not-found]
     _build_components_index,
     _validate_featured,
+    _validate_field_preset,
 )
 
 
@@ -203,3 +204,40 @@ def test_locked_and_suggestions_both_set() -> None:
         _index(),
     )
     assert any("cannot set both 'locked' and 'suggestions'" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# is_imported relaxation
+# ---------------------------------------------------------------------------
+
+
+def _pin_entry_requiring(*features: str) -> dict:
+    """Build a synthetic ``pin``-typed config entry that demands *features*."""
+    return {"key": "pin", "type": "pin", "pin_features": list(features)}
+
+
+def test_field_preset_imported_skips_pin_feature_check() -> None:
+    """Imported boards bypass the pin-feature intersection check."""
+    # Synthesised case: the component requires ``adc`` on its pin but
+    # the board's synthesized pin entry has empty features (the only
+    # shape the importer produces). On a hand-curated board this would
+    # error; with ``is_imported=True`` it must pass.
+    pins = {3: {"gpio": 3, "features": []}}
+    ce = _pin_entry_requiring("adc")
+    preset = {"value": 3, "locked": True}
+
+    curated = _validate_field_preset("demo", "pin", preset, ce, pins, is_imported=False)
+    assert any("missing required pin features ['adc']" in e for e in curated)
+
+    imported = _validate_field_preset("demo", "pin", preset, ce, pins, is_imported=True)
+    assert imported == []
+
+
+def test_field_preset_imported_still_requires_pin_declared() -> None:
+    """The pin-declared check stays in effect for imported boards."""
+    pins = {3: {"gpio": 3, "features": []}}
+    ce = _pin_entry_requiring("adc")
+    preset = {"value": 99, "locked": True}  # GPIO99 absent from pins
+
+    errors = _validate_field_preset("demo", "pin", preset, ce, pins, is_imported=True)
+    assert any("GPIO 99 not declared in pins" in e for e in errors)


### PR DESCRIPTION
## what & why

we want to grow the board catalog beyond the 81 hand-curated entries — devices.esphome.io has 760+ community-maintained device pages, and ~78% of them are structured enough to import automatically (yaml frontmatter + a parseable inline esphome config + at least one local image).

this adds a weekly ci sync that pulls from `esphome/esphome-devices` and emits one `definitions/boards/<id>/manifest.yaml` per device that passes the acceptance bar. imported manifests carry a `source:` block so the sync only owns its own output — hand-curated boards (no `source:`) are never touched, even on slug collisions.

a fresh local run produces ~430 imported boards in ~5s.

## changes

- `script/sync_esphome_devices.py` — the sync script. shallow-clones `esphome-devices`, walks `src/docs/devices/<Name>/index.md`, parses frontmatter + first ```yaml fence (with a tag-tolerant loader for `!secret` / `!lambda` / `!include` / `!extend` / `!remove` / `!env_var`), and emits a manifest per accepted device. supports `--clean`, `--limit`, `--dry-run`, `--device` for local debugging.
- `script/check_device_catalog.py` — smoke test that re-runs the extractor against a few well-known pages (sonoff basic r2 v1.4, shelly em gen3, athom br30) and asserts the resolved board / variant / featured-component shape. fails fast in ci before any pr opens.
- `.github/workflows/sync-device-catalog.yml` — weekly monday 04:00 utc cron, mirrors the components-sync workflow style. opens / updates `catalog/sync-devices` via `peter-evans/create-pull-request` with a per-soc-family diff summary.
- `esphome_device_builder/definitions/schemas/board.schema.json` — adds the optional `source:` block (`type`, `remote_id`, `upstream_url`, `upstream_revision`, `content_hash`).
- `script/validate_definitions.py` — relaxes the per-pin `pin_features` intersection check for boards with `source:` set. imports synthesize minimal pin entries (one per gpio referenced by an extracted featured component) and we don't have a per-chip pin-feature db yet — pin-declared check still runs.

## notes

- imported board ids use underscore separator (`sonoff_basic_r2_v1_4`) — matches the existing pio-board-id-derived style (`arduino_nano_esp32`, `seeed_xiao_esp32c6`).
- the first sync after merge will produce a big follow-up pr (~430 boards). subsequent runs are small (only added/changed/removed since last sync, gated by `content_hash`).
- pin-feature db, `featured_bundles` for imports, and markdown gpio-table parsing are explicitly deferred to v2.