### PR TITLE
Auto-derive id/name defaults for featured components

### DIFF
--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -522,7 +522,15 @@ def _featured_field_presets(fc: FeaturedComponent) -> dict[str, FieldPreset]:
 def _default_id_from_local(local_id: str) -> str:
     """Slugify a featured-component local id for use as an ESPHome ``id:`` value."""
     slug = re.sub(r"[^a-z0-9]+", "_", local_id.lower()).strip("_")
-    return slug or local_id
+    if not slug:
+        return local_id
+    # ESPHome ids must be valid C-style identifiers — they're emitted
+    # as C++ variable names downstream, so a leading digit produces an
+    # invalid build. Prefix with an underscore when the manifest's
+    # local id starts with one.
+    if slug[0].isdigit():
+        slug = f"_{slug}"
+    return slug
 
 
 def _materialise_entry_with_preset(

--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -480,6 +481,7 @@ def _materialise_featured(
     """
     underlying = record.underlying
     fc = record.featured
+    presets = _featured_field_presets(fc)
     return ComponentCatalogEntry(
         id=record.full_id,
         name=fc.name or underlying.name,
@@ -491,10 +493,36 @@ def _materialise_featured(
         multi_conf=underlying.multi_conf,
         supported_platforms=list(underlying.supported_platforms),
         config_entries=[
-            _materialise_entry_with_preset(entry, target_platform, fc.fields.get(entry.key))
+            _materialise_entry_with_preset(entry, target_platform, presets.get(entry.key))
             for entry in underlying.config_entries
         ],
     )
+
+
+def _featured_field_presets(fc: FeaturedComponent) -> dict[str, FieldPreset]:
+    """
+    Return *fc*'s field presets with sensible ``id`` / ``name`` defaults.
+
+    The board manifest's explicit ``fields`` entries are preserved as-is.
+    For ``id`` and ``name`` the manifest is rarely explicit, so we derive
+    a default from the featured component's local id and display name —
+    without this the frontend pre-fills the ``id`` input with the
+    catalog id verbatim (``featured.<board>.<local>``) and the merge
+    logic falls back to the bare platform stem (``id: gpio``) because
+    there's no ``name`` to slug from.
+    """
+    presets = dict(fc.fields)
+    if "id" not in presets:
+        presets["id"] = FieldPreset(value=_default_id_from_local(fc.id))
+    if "name" not in presets and fc.name:
+        presets["name"] = FieldPreset(value=fc.name)
+    return presets
+
+
+def _default_id_from_local(local_id: str) -> str:
+    """Slugify a featured-component local id for use as an ESPHome ``id:`` value."""
+    slug = re.sub(r"[^a-z0-9]+", "_", local_id.lower()).strip("_")
+    return slug or local_id
 
 
 def _materialise_entry_with_preset(

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1447,20 +1447,29 @@ def _resolve_extends(ref: str, schema_dir: Path) -> dict[str, dict]:
         return {}
     file_name = parts[0]
     schema_name = ".".join(parts[1:])
-    path = schema_dir / f"{file_name}.json"
-    if not path.exists():
-        return {}
-    raw = json.loads(path.read_text())
 
-    # The schema may live under ``raw[file_name]`` (our usual case) or
-    # at deeper qualified keys. Search both layers.
+    # ``<file_name>.json`` is the obvious lookup, but a few shared
+    # scopes are housed in ``esphome.json`` under a top-level key
+    # matching their ref prefix — most importantly ``core``, which
+    # holds ``ENTITY_BASE_SCHEMA`` (the inheritance source for the
+    # entity-level ``name`` / ``icon`` / ``internal`` /
+    # ``disabled_by_default`` / ``entity_category`` fields). Without
+    # the esphome.json fallback those fields silently disappear from
+    # every entity-platform component (binary_sensor.gpio,
+    # output.gpio, sensor.aht10, ...).
     candidates: list[dict] = []
-    for top_value in raw.values():
-        if not isinstance(top_value, dict):
+    for path in (schema_dir / f"{file_name}.json", schema_dir / "esphome.json"):
+        if not path.exists():
             continue
-        schemas = top_value.get("schemas") or {}
-        if schema_name in schemas:
-            candidates.append(schemas[schema_name])
+        raw = json.loads(path.read_text())
+        for top_value in raw.values():
+            if not isinstance(top_value, dict):
+                continue
+            schemas = top_value.get("schemas") or {}
+            if schema_name in schemas:
+                candidates.append(schemas[schema_name])
+        if candidates:
+            break
 
     if not candidates:
         return {}

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -202,6 +202,20 @@ async def test_get_component_explicit_field_preset_wins(catalog: ComponentCatalo
     assert name_field.default_value == "Relay"
 
 
+def test_default_id_from_local_handles_leading_digit() -> None:
+    """Slugified local ids that start with a digit get prefixed with ``_``."""
+    # ESPHome ids become C++ identifiers downstream — a leading digit
+    # produces an invalid build, so the slugifier must guard against
+    # it.
+    from esphome_device_builder.controllers.components import _default_id_from_local
+
+    assert _default_id_from_local("3v3-rail") == "_3v3_rail"
+    assert _default_id_from_local("4-channel-relay") == "_4_channel_relay"
+    # Non-digit-leading ids stay untouched.
+    assert _default_id_from_local("status-led-output") == "status_led_output"
+    assert _default_id_from_local("button") == "button"
+
+
 async def test_get_components_featured_only_with_board_id(
     catalog: ComponentCatalog,
 ) -> None:

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -153,6 +153,55 @@ async def test_get_component_suggestions(catalog: ComponentCatalog) -> None:
     assert pin.suggestions == [4, 5]
 
 
+async def test_get_component_id_default_from_local(catalog: ComponentCatalog) -> None:
+    """Featured components without an explicit ``id`` preset default to the slugified local id."""
+    # ``button`` has no manifest preset for ``id`` — without the
+    # auto-derived default the merge logic would render ``id: gpio``,
+    # colliding with the platform stem.
+    entry = await catalog.get_component(component_id="featured.athom-smart-plug-v3.button")
+    assert entry is not None
+    id_field = next(ce for ce in entry.config_entries if ce.key == "id")
+    assert id_field.default_value == "button"
+    assert id_field.locked is False
+
+
+async def test_get_component_id_default_slugifies_dashes(catalog: ComponentCatalog) -> None:
+    """Featured local ids with dashes (``status-led-output``) become valid esphome ids."""
+    entry = await catalog.get_component(
+        component_id="featured.athom-smart-plug-v3.status-led-output",
+    )
+    assert entry is not None
+    id_field = next(ce for ce in entry.config_entries if ce.key == "id")
+    assert id_field.default_value == "status_led_output"
+
+
+async def test_get_component_name_default_from_featured_name(
+    catalog: ComponentCatalog,
+) -> None:
+    """The featured component's display name pre-fills the underlying ``name`` field."""
+    # apollo-esk-1.rgb-strip has ``name: RGB LED Strip (addon module)``
+    # at the featured level but no field preset for ``name`` — the
+    # auto-derived default lets the user start with a sensible
+    # HA-visible entity name without having to repeat it in the
+    # manifest's ``fields:`` block.
+    entry = await catalog.get_component(component_id="featured.apollo-esk-1.rgb-strip")
+    assert entry is not None
+    name_field = next(ce for ce in entry.config_entries if ce.key == "name")
+    assert name_field.default_value == "RGB LED Strip (addon module)"
+    assert name_field.locked is False
+
+
+async def test_get_component_explicit_field_preset_wins(catalog: ComponentCatalog) -> None:
+    """An explicit ``fields.name`` preset overrides the auto-derived default."""
+    # sonoff-basic.relay sets ``fields.name: Relay`` in the manifest
+    # while the featured display name is ``Onboard Relay`` — the
+    # explicit preset must win.
+    entry = await catalog.get_component(component_id="featured.sonoff-basic.relay")
+    assert entry is not None
+    name_field = next(ce for ce in entry.config_entries if ce.key == "name")
+    assert name_field.default_value == "Relay"
+
+
 async def test_get_components_featured_only_with_board_id(
     catalog: ComponentCatalog,
 ) -> None:


### PR DESCRIPTION
## what & why

testing the athom smart plug v3 surfaced two related bugs in the featured-components flow from #33:

1. adding the front-panel button featured component (`binary_sensor.gpio`) rendered yaml with `id: gpio` — colliding with the platform stem. root cause: no field preset for `id`, and `merge_component_yaml` falls back to `_generate_id(unqualified, name)` which returns just `"gpio"` when name is missing too.
2. the add-component dialog showed the `id` input pre-filled with the synthetic catalog id verbatim — `featured_athom-smart-plug-v3_status-led-output_1` — invalid (dashes) and ugly. it got corrected on submit but the dialog default was wrong.

both stem from the same gap: featured components rarely preset `id` / `name` because the manifest's top-level `name:` is the catalog display name, not an underlying field default. fixing this centrally in `_materialise_featured` covers all current and future featured components without per-manifest churn.

verified across all three boards with featured components today (apollo-esk-1, athom-smart-plug-v3, sonoff-basic).

## changes

- `esphome_device_builder/controllers/components.py` — new `_featured_field_presets` helper that copies the manifest's explicit presets and fills in `id` / `name` defaults when missing. `id` slugifies the featured local id (`status-led-output` → `status_led_output`); `name` falls back to `featured.name`. explicit `fields.id` / `fields.name` in the manifest still win.
- `tests/test_featured_components.py` — 4 new cases: id default from local id, slug normalisation for dashes, name default from featured display name, manifest-explicit preset wins.