### PR TITLE
Add trusted-domains allowlist for WS handshake

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,6 +147,26 @@ This is the Music Assistant pattern: physically separating the listeners is the 
 
 The legacy `DISABLE_HA_AUTHENTICATION=true` env var skips the ingress site entirely — operators get only the password-gated public port.
 
+### Reverse-proxy / cross-origin deployments
+
+When the dashboard is exposed behind a reverse proxy (nginx, Caddy, Traefik, nginx-proxy-manager, …) under a hostname that doesn't match the upstream bind address, the WS handshake's strict `Origin === Host` check rejects the connection. Operators set `--trusted-domains` (or `$ESPHOME_TRUSTED_DOMAINS`, the legacy ESPHome dashboard env var name) to a comma-separated allowlist of hostnames they want the dashboard to accept:
+
+```bash
+# CLI
+esphome-device-builder /config --username dash --password ... \
+  --trusted-domains dashboard.example.com,proxy.example.com
+
+# Env var (matches the legacy ESPHome dashboard's name)
+ESPHOME_TRUSTED_DOMAINS=dashboard.example.com esphome-device-builder /config ...
+```
+
+The allowlist drives two checks in the WS handshake (both opt-in; empty = strict legacy behaviour):
+
+- **Origin allowlist** — accepts cross-origin connections whose `Origin` header's hostname is in the list. Required for any reverse-proxy deployment where the proxy hostname differs from the upstream Host.
+- **Host allowlist** — rejects any connection whose `Host` header isn't in the list. Defense in depth against DNS rebinding (an attacker domain that resolves to the victim's LAN IP would carry an unfamiliar Host).
+
+Match is case-insensitive and port-tolerant: `dashboard.example.com` accepts `Dashboard.Example.com:8443`. IPv6 may be entered with or without brackets (`::1` and `[::1]` both work). Use `*` as the only entry to opt out of the Host restriction while still permitting cross-origin handshakes (handy when the Host varies per request).
+
 ## Deployment
 
 ### Beta (HA add-on)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -165,6 +165,8 @@ The allowlist drives two checks in the WS handshake (both opt-in; empty = strict
 - **Origin allowlist** — accepts cross-origin connections whose `Origin` header's hostname is in the list. Required for any reverse-proxy deployment where the proxy hostname differs from the upstream Host.
 - **Host allowlist** — rejects any connection whose `Host` header isn't in the list. Defense in depth against DNS rebinding (an attacker domain that resolves to the victim's LAN IP would carry an unfamiliar Host).
 
+Both gates apply only to requests that carry an `Origin` header. Browsers always set `Origin` for the WebSocket opening handshake, so DNS-rebinding attempts land inside the gate; non-browser clients (CLI tools, the HA integration, direct `websockets` clients) omit `Origin` and skip both gates. The bearer-token / in-band auth path is doing the work for those clients, and gating on `Origin` means an operator hardening against rebinding doesn't accidentally lock out their HA integration.
+
 Match is case-insensitive and port-tolerant: `dashboard.example.com` accepts `Dashboard.Example.com:8443`. IPv6 may be entered with or without brackets (`::1` and `[::1]` both work). Use `*` as the only entry to opt out of the Host restriction while still permitting cross-origin handshakes (handy when the Host varies per request).
 
 ## Deployment

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -99,6 +99,25 @@ def main() -> None:
             "is fine in production."
         ),
     )
+    parser.add_argument(
+        "--trusted-domains",
+        default="",
+        help=(
+            "Comma-separated hostnames the WebSocket handshake trusts "
+            "(case-insensitive, port-tolerant). Two effects when password "
+            "auth is on: (1) accept cross-origin connections whose Origin "
+            "header's hostname is in the list — required for reverse-proxy "
+            "deployments where Origin is ``dashboard.example.com`` but the "
+            "upstream Host is ``localhost``; (2) reject any connection "
+            "whose Host header isn't in the list — defense in depth against "
+            "DNS rebinding. Empty (default) preserves the existing strict "
+            "Origin/Host equality behaviour with no Host allowlist. Use "
+            "``*`` as the only entry to opt out of host-restriction while "
+            "keeping cross-origin acceptance permissive. Falls back to "
+            "$ESPHOME_TRUSTED_DOMAINS env var when unset (legacy ESPHome "
+            "dashboard compatibility)."
+        ),
+    )
 
     args = parser.parse_args()
 

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -101,7 +101,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--trusted-domains",
-        default="",
+        default=None,
         help=(
             "Comma-separated hostnames the WebSocket handshake trusts "
             "(case-insensitive, port-tolerant). Two effects when password "
@@ -110,12 +110,12 @@ def main() -> None:
             "deployments where Origin is ``dashboard.example.com`` but the "
             "upstream Host is ``localhost``; (2) reject any connection "
             "whose Host header isn't in the list — defense in depth against "
-            "DNS rebinding. Empty (default) preserves the existing strict "
-            "Origin/Host equality behaviour with no Host allowlist. Use "
-            "``*`` as the only entry to opt out of host-restriction while "
-            "keeping cross-origin acceptance permissive. Falls back to "
-            "$ESPHOME_TRUSTED_DOMAINS env var when unset (legacy ESPHome "
-            "dashboard compatibility)."
+            "DNS rebinding. Default (flag unset) consults the "
+            "$ESPHOME_TRUSTED_DOMAINS env var (legacy ESPHome dashboard "
+            'compatibility); pass ``--trusted-domains ""`` to explicitly '
+            "ignore the env var and disable both checks. Use ``*`` as the "
+            "only entry to opt out of host-restriction while keeping "
+            "cross-origin acceptance permissive."
         ),
     )
 

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -105,17 +105,21 @@ def main() -> None:
         help=(
             "Comma-separated hostnames the WebSocket handshake trusts "
             "(case-insensitive, port-tolerant). Two effects when password "
-            "auth is on: (1) accept cross-origin connections whose Origin "
-            "header's hostname is in the list — required for reverse-proxy "
+            "auth is on AND the request carries an Origin header: (1) "
+            "accept cross-origin connections whose Origin header's "
+            "hostname is in the list — required for reverse-proxy "
             "deployments where Origin is ``dashboard.example.com`` but the "
             "upstream Host is ``localhost``; (2) reject any connection "
             "whose Host header isn't in the list — defense in depth against "
-            "DNS rebinding. Default (flag unset) consults the "
-            "$ESPHOME_TRUSTED_DOMAINS env var (legacy ESPHome dashboard "
-            'compatibility); pass ``--trusted-domains ""`` to explicitly '
-            "ignore the env var and disable both checks. Use ``*`` as the "
-            "only entry to opt out of host-restriction while keeping "
-            "cross-origin acceptance permissive."
+            "DNS rebinding. Both gates skip Origin-less requests (CLI "
+            "tools, HA integration, direct websockets clients) since "
+            "DNS-rebinding is a browser-only attack vector and those "
+            "clients are already gated by bearer-token auth. Default "
+            "(flag unset) consults the $ESPHOME_TRUSTED_DOMAINS env var "
+            '(legacy ESPHome dashboard compatibility); pass --trusted-domains "" '
+            "to explicitly ignore the env var and disable both checks. "
+            "Use ``*`` as the only entry to opt out of host-restriction "
+            "while keeping cross-origin acceptance permissive."
         ),
     )
 

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -199,25 +199,35 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     # without an Origin header (CLI tools, HA integration) are unaffected.
     if settings.using_password and not trusted_site:
         origin = request.headers.get("Origin")
-        # Cross-origin acceptance gate (closes #80): the Origin must
-        # equal Host OR the Origin's hostname must be in the
-        # operator-supplied trusted-domains allowlist. Without the
-        # allowlist branch, reverse-proxy deployments where Origin is
-        # ``https://dashboard.example.com`` but Host is the upstream
-        # ``localhost:6052`` lose dashboard access entirely.
-        if (
-            origin
-            and not _origin_matches_host(origin, request.host)
-            and not _origin_in_allowlist(origin, settings.trusted_domains)
-        ):
-            return web.Response(status=403, text="Cross-origin connection rejected")
-        # Defense-in-depth Host allowlist (closes B-5 from #120).
-        # Empty list = not configured = pass through. When set, the
-        # request's Host must be one of the trusted domains —
-        # mitigates DNS-rebinding on top of the auth + per-IP rate
-        # limit chain.
-        if not _host_in_allowlist(request.host, settings.trusted_domains):
-            return web.Response(status=403, text="Host not in trusted-domains allowlist")
+        # Both Origin / Host gates apply only to requests that
+        # carry an ``Origin`` header — browser-driven WebSocket
+        # connections always set it (spec-mandated for any WS
+        # opening handshake), so any DNS-rebinding attack lands
+        # here. CLI tools / HA integration / direct ``websockets``
+        # clients omit Origin and skip both checks; the existing
+        # bearer-token / in-band auth gate is doing the work for
+        # them. Without this gate, an operator who sets
+        # ``trusted_domains`` to harden against rebinding would
+        # also lock out their HA integration.
+        if origin:
+            # Cross-origin acceptance gate: the Origin must equal
+            # Host OR the Origin's hostname must be in the
+            # operator-supplied trusted-domains allowlist. Without
+            # the allowlist branch, reverse-proxy deployments where
+            # Origin is ``https://dashboard.example.com`` but Host
+            # is the upstream ``localhost:6052`` lose dashboard
+            # access entirely.
+            if not _origin_matches_host(origin, request.host) and not _origin_in_allowlist(
+                origin, settings.trusted_domains
+            ):
+                return web.Response(status=403, text="Cross-origin connection rejected")
+            # Defense-in-depth Host allowlist. Empty list = not
+            # configured = pass through. When set, the request's
+            # Host must be one of the trusted domains — mitigates
+            # DNS-rebinding on top of the auth + per-IP rate limit
+            # chain.
+            if not _host_in_allowlist(request.host, settings.trusted_domains):
+                return web.Response(status=403, text="Host not in trusted-domains allowlist")
 
     ws = web.WebSocketResponse(heartbeat=_WS_HEARTBEAT_SECONDS)
     await ws.prepare(request)

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -363,17 +363,17 @@ def _normalize_host(host: str) -> str:
 def _host_in_allowlist(request_host: str, allowlist: list[str]) -> bool:
     """Return True when ``request_host`` is permitted by ``allowlist``.
 
-    ``allowlist`` is the operator-supplied ``--trusted-hosts`` /
-    ``$TRUSTED_HOSTS`` list — empty means "no allowlist, anything
-    goes" and the caller skips the check entirely.
+    ``allowlist`` is the operator-supplied ``--trusted-domains`` /
+    ``$ESPHOME_TRUSTED_DOMAINS`` list — empty means "no allowlist,
+    anything goes" and the caller skips the check entirely.
 
-    The allowlist match is case-insensitive and port-tolerant.
-    ``request_host`` is normalised to its lowercase host (port
-    stripped, IPv6 brackets stripped) before comparison; allowlist
-    entries are pre-normalised at parse time so an entry of
-    ``Dashboard.Local`` matches a Host header of
-    ``dashboard.local:6052`` and an entry of ``[::1]`` matches a
-    Host header of ``[::1]:6052`` (or its un-bracketed equivalent).
+    Both ``request_host`` and each allowlist entry go through
+    ``_normalize_host`` (lower-case, port stripped, IPv6 brackets
+    stripped). ``DashboardSettings.parse_args`` strips whitespace
+    and lower-cases the entries on load but does NOT canonicalise
+    bracket / port shape, so an entry of ``[::1]`` and a Host
+    header of ``[::1]:6052`` (or an un-bracketed ``::1``) all
+    end up normalised to ``::1`` here and compare equal.
 
     The literal ``"*"`` is an explicit "match anything" escape hatch
     for operators who want to record the config knob is set without

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import ipaddress
 import logging
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit
 
 from aiohttp import WSMsgType, web
 from esphome.const import __version__ as esphome_version
@@ -198,8 +199,25 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     # without an Origin header (CLI tools, HA integration) are unaffected.
     if settings.using_password and not trusted_site:
         origin = request.headers.get("Origin")
-        if origin and not _origin_matches_host(origin, request.host):
+        # Cross-origin acceptance gate (closes #80): the Origin must
+        # equal Host OR the Origin's hostname must be in the
+        # operator-supplied trusted-domains allowlist. Without the
+        # allowlist branch, reverse-proxy deployments where Origin is
+        # ``https://dashboard.example.com`` but Host is the upstream
+        # ``localhost:6052`` lose dashboard access entirely.
+        if (
+            origin
+            and not _origin_matches_host(origin, request.host)
+            and not _origin_in_allowlist(origin, settings.trusted_domains)
+        ):
             return web.Response(status=403, text="Cross-origin connection rejected")
+        # Defense-in-depth Host allowlist (closes B-5 from #120).
+        # Empty list = not configured = pass through. When set, the
+        # request's Host must be one of the trusted domains —
+        # mitigates DNS-rebinding on top of the auth + per-IP rate
+        # limit chain.
+        if not _host_in_allowlist(request.host, settings.trusted_domains):
+            return web.Response(status=403, text="Host not in trusted-domains allowlist")
 
     ws = web.WebSocketResponse(heartbeat=_WS_HEARTBEAT_SECONDS)
     await ws.prepare(request)
@@ -272,3 +290,103 @@ def _origin_matches_host(origin: str, request_host: str) -> bool:
     except ValueError:
         return False
     return bool(parsed.netloc) and parsed.netloc == request_host
+
+
+def _origin_in_allowlist(origin: str, allowlist: list[str]) -> bool:
+    """Return True when ``origin``'s hostname is in the allowlist.
+
+    Used by the cross-origin acceptance gate: reverse-proxy
+    deployments where Origin is ``https://dashboard.example.com``
+    but Host is ``localhost:6052`` (proxy upstream) need the
+    operator-supplied ``ESPHOME_TRUSTED_DOMAINS`` allowlist to
+    accept the cross-origin handshake.
+
+    The allowlist match is on the Origin URL's hostname (port and
+    scheme stripped), case-insensitive. A bare hostname entry like
+    ``dashboard.example.com`` matches an Origin of
+    ``https://Dashboard.Example.com`` regardless of port; an entry
+    of ``[::1]`` matches ``http://[::1]:6052``.
+
+    ``"*"`` matches anything (escape hatch for operators who set
+    the env var without a specific host list).
+    """
+    if not allowlist:
+        return False
+    if "*" in allowlist:
+        return True
+    try:
+        parsed = urlparse(origin)
+    except ValueError:
+        return False
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        return False
+    return any(_normalize_host(entry) == hostname for entry in allowlist)
+
+
+def _normalize_host(host: str) -> str:
+    """Lower-case ``host`` and strip the port + IPv6 brackets, if any.
+
+    HTTP ``Host`` headers carry IPv6 addresses bracket-wrapped
+    (``[::1]:6052``); naive ``split(":", 1)`` would chop the first
+    segment of the address. ``urlsplit("//" + host).hostname``
+    handles both shapes (IPv4 / hostname:port and ``[ipv6]:port``)
+    and returns the unbracketed lowercase hostname.
+
+    There's one edge case ``urlsplit`` mis-handles: a bare IPv6
+    address typed *without* brackets (operator's allowlist entry
+    of ``fe80::1`` rather than ``[fe80::1]``) — ``urlsplit``
+    parses the leading ``fe80`` as the host and ``:1`` as the
+    port. Short-circuit those via ``ipaddress.ip_address`` before
+    falling through to the URL-parser branch. Bracketed Host
+    headers go straight to ``urlsplit`` which handles them
+    correctly. Falls back to the input verbatim when ``urlsplit``
+    returns nothing usable (malformed Host header).
+    """
+    stripped = host.strip()
+    if not stripped.startswith("["):
+        try:
+            ipaddress.ip_address(stripped)
+        except ValueError:
+            pass
+        else:
+            return stripped.lower()
+    try:
+        hostname = urlsplit(f"//{stripped}").hostname
+    except ValueError:
+        hostname = None
+    if hostname is None:
+        return stripped.lower()
+    return hostname.lower()
+
+
+def _host_in_allowlist(request_host: str, allowlist: list[str]) -> bool:
+    """Return True when ``request_host`` is permitted by ``allowlist``.
+
+    ``allowlist`` is the operator-supplied ``--trusted-hosts`` /
+    ``$TRUSTED_HOSTS`` list — empty means "no allowlist, anything
+    goes" and the caller skips the check entirely.
+
+    The allowlist match is case-insensitive and port-tolerant.
+    ``request_host`` is normalised to its lowercase host (port
+    stripped, IPv6 brackets stripped) before comparison; allowlist
+    entries are pre-normalised at parse time so an entry of
+    ``Dashboard.Local`` matches a Host header of
+    ``dashboard.local:6052`` and an entry of ``[::1]`` matches a
+    Host header of ``[::1]:6052`` (or its un-bracketed equivalent).
+
+    The literal ``"*"`` is an explicit "match anything" escape hatch
+    for operators who want to record the config knob is set without
+    restricting hosts (handy for split-hostname proxy setups where
+    the Host header varies per request and the existing Origin/Host
+    equality + auth chain is doing the work).
+
+    Defense in depth on top of the existing Origin/Host equality
+    check + per-IP-rate-limited ``auth/login``.
+    """
+    if not allowlist:
+        return True
+    if "*" in allowlist:
+        return True
+    normalised = _normalize_host(request_host)
+    return any(_normalize_host(entry) == normalised for entry in allowlist)

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -118,8 +118,17 @@ class DashboardSettings:
         # Comma-separated. Lower-cased for the case-insensitive match
         # in the WS handshake. Empty list = both Origin and Host
         # allowlists disabled.
-        raw_trusted = getattr(args, "trusted_domains", None) or os.getenv(
-            "ESPHOME_TRUSTED_DOMAINS", ""
+        #
+        # Precedence: a CLI flag value of ``None`` (argparse default
+        # when ``--trusted-domains`` wasn't passed) means "flag not
+        # set, consult the env var"; any string value, including the
+        # empty string, is an explicit override and wins over the
+        # env var. Lets operators say ``--trusted-domains ""`` to
+        # disable the checks even when ``$ESPHOME_TRUSTED_DOMAINS``
+        # is set in the environment (e.g. inherited from a parent).
+        cli_value = getattr(args, "trusted_domains", None)
+        raw_trusted = (
+            cli_value if cli_value is not None else os.getenv("ESPHOME_TRUSTED_DOMAINS", "")
         )
         self.trusted_domains = [
             host.strip().lower() for host in raw_trusted.split(",") if host.strip()

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -64,6 +64,27 @@ class DashboardSettings:
     # production we let the browser apply its default heuristic; the
     # hashed bundles are still served as ``immutable`` regardless.
     dev_mode: bool = False
+    # Hostnames we trust for cross-origin / Host validation in the
+    # WebSocket handshake. Carries the legacy
+    # ``ESPHOME_TRUSTED_DOMAINS`` semantics from the upstream
+    # dashboard, plus a DNS-rebinding-defense Host check:
+    #
+    #   * Origin allowlist - when the browser's Origin header
+    #     doesn't match the request's Host (reverse-proxy hostname
+    #     mismatch), accept the connection if Origin's hostname is
+    #     in this list. Fixes the
+    #     "lose-dashboard-access-behind-nginx" papercut.
+    #   * Host allowlist - reject the request entirely if its Host
+    #     header isn't in this list. Defense in depth against DNS
+    #     rebinding, on top of the existing per-IP-rate-limited
+    #     ``auth/login`` gate.
+    #
+    # Empty list = both checks disabled (existing strict
+    # Origin/Host equality is the only gate; no Host allowlist).
+    # ``"*"`` is the explicit "match anything" escape hatch for
+    # operators who want to acknowledge the knob without
+    # restricting hosts.
+    trusted_domains: list[str] = field(default_factory=list)
 
     def parse_args(self, args: Any) -> None:
         """Parse CLI arguments into settings."""
@@ -93,6 +114,16 @@ class DashboardSettings:
         self.ingress_port = getattr(args, "ingress_port", DEFAULT_INGRESS_PORT)
         self.ingress_host = getattr(args, "ingress_host", "") or ""
         self.dev_mode = bool(getattr(args, "dev", False))
+        # ``--trusted-domains a,b,c`` (or ``$ESPHOME_TRUSTED_DOMAINS``).
+        # Comma-separated. Lower-cased for the case-insensitive match
+        # in the WS handshake. Empty list = both Origin and Host
+        # allowlists disabled.
+        raw_trusted = getattr(args, "trusted_domains", None) or os.getenv(
+            "ESPHOME_TRUSTED_DOMAINS", ""
+        )
+        self.trusted_domains = [
+            host.strip().lower() for host in raw_trusted.split(",") if host.strip()
+        ]
         CORE.config_path = self.config_dir / _DASHBOARD_SENTINEL_FILE
 
     def rel_path(self, *parts: str) -> Path:

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -1,0 +1,290 @@
+"""Tests for the ``ESPHOME_TRUSTED_DOMAINS`` allowlist on the WS handshake.
+
+Single allowlist (``DashboardSettings.trusted_domains``) drives two
+checks in ``api/ws.py``:
+
+* **Origin allowlist** — when the browser's ``Origin`` doesn't
+  equal ``Host`` (reverse-proxy deployments where the proxy
+  hostname differs from the upstream bind address), accept the
+  cross-origin handshake if Origin's hostname is in the allowlist.
+* **Host allowlist** — reject any handshake whose ``Host`` header
+  isn't in the allowlist. Defense in depth against DNS rebinding,
+  on top of the existing ``auth/login`` gate.
+
+These tests exercise the pure helpers and the parsing on
+``DashboardSettings``. Full WS-handshake integration is covered by
+the existing aiohttp-client tests.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder.api.ws import (
+    _host_in_allowlist,
+    _normalize_host,
+    _origin_in_allowlist,
+)
+from esphome_device_builder.controllers.config import DashboardSettings
+
+# ---------------------------------------------------------------------------
+# _normalize_host
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("dashboard.local", "dashboard.local"),
+        ("Dashboard.Local", "dashboard.local"),
+        ("dashboard.local:6052", "dashboard.local"),
+        ("DASHBOARD.LOCAL:6052", "dashboard.local"),
+        ("192.168.1.10", "192.168.1.10"),
+        ("192.168.1.10:6052", "192.168.1.10"),
+        ("[::1]", "::1"),
+        ("[::1]:6052", "::1"),
+        ("[FE80::1]:6052", "fe80::1"),
+        ("[2001:db8::1]:443", "2001:db8::1"),
+    ],
+)
+def test_normalize_host_strips_port_and_brackets(raw: str, expected: str) -> None:
+    """Lower-case, port-stripped, IPv6 brackets stripped.
+
+    HTTP Host headers carry IPv6 in brackets (``[::1]:6052``) so a
+    naive ``split(":", 1)[0]`` would chop off the first segment of
+    the address. ``urlsplit`` handles both shapes (IPv4/hostname
+    plus port, ``[ipv6]`` plus port) and returns the unbracketed
+    hostname; this test pins both branches.
+    """
+    assert _normalize_host(raw) == expected
+
+
+def test_normalize_host_falls_back_on_malformed() -> None:
+    """``urlsplit`` of garbage may return empty hostname — fall back to lowercase."""
+    # Empty string and lone colon both yield None from .hostname; the
+    # fallback returns the lowercase input verbatim so the comparison
+    # in _host_in_allowlist still has something deterministic.
+    assert _normalize_host("") == ""
+    assert _normalize_host("WeirdInput") == "weirdinput"
+
+
+# ---------------------------------------------------------------------------
+# _host_in_allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_host_in_allowlist_empty_means_pass_through() -> None:
+    """Empty allowlist = check disabled = always allow.
+
+    The opt-in shape: operators who don't set the env var see no
+    behaviour change. Test pins this so a refactor that flips the
+    truthiness check (returning False on empty) doesn't break
+    every default deployment.
+    """
+    assert _host_in_allowlist("dashboard.local:6052", []) is True
+
+
+def test_host_in_allowlist_wildcard_match_anything() -> None:
+    """``"*"`` is the explicit "match anything" escape hatch."""
+    assert _host_in_allowlist("anything.example.com", ["*"]) is True
+    assert _host_in_allowlist("[::1]:6052", ["*"]) is True
+
+
+@pytest.mark.parametrize(
+    ("host", "allowlist"),
+    [
+        ("dashboard.local:6052", ["dashboard.local"]),
+        ("Dashboard.Local:6052", ["dashboard.local"]),
+        ("dashboard.local", ["DASHBOARD.LOCAL"]),
+        ("192.168.1.10:6052", ["192.168.1.10"]),
+        ("[::1]:6052", ["::1"]),
+        ("[::1]:6052", ["[::1]"]),
+        ("[fe80::1]:6052", ["FE80::1"]),
+    ],
+)
+def test_host_in_allowlist_match(host: str, allowlist: list[str]) -> None:
+    """Match is case-insensitive, port-tolerant, and bracket-tolerant for IPv6.
+
+    Operators may type ``[::1]`` or ``::1`` — both should match
+    a request Host of ``[::1]:6052``. The test catalogues the
+    accepted shapes so a normaliser tweak that breaks any of
+    them shows up in CI.
+    """
+    assert _host_in_allowlist(host, allowlist) is True
+
+
+@pytest.mark.parametrize(
+    ("host", "allowlist"),
+    [
+        ("evil.example.com:6052", ["dashboard.local"]),
+        ("dashboard.example.com", ["dashboard.local"]),
+        ("192.168.1.20:6052", ["192.168.1.10"]),
+    ],
+)
+def test_host_in_allowlist_reject_non_match(host: str, allowlist: list[str]) -> None:
+    """Anything not in the allowlist is rejected.
+
+    DNS-rebinding payload would land here: attacker's hostname
+    resolves to victim's LAN IP, browser sends Host header for
+    the attacker domain, the allowlist (set to the operator's
+    real domain) catches it.
+    """
+    assert _host_in_allowlist(host, allowlist) is False
+
+
+# ---------------------------------------------------------------------------
+# _origin_in_allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_origin_in_allowlist_empty_means_no_grant() -> None:
+    """Empty allowlist + cross-origin = reject (existing strict behaviour).
+
+    Different polarity from the host check — this one only EXTENDS
+    acceptance. Empty allowlist falls through to the existing
+    Origin-equals-Host hard reject.
+    """
+    assert _origin_in_allowlist("https://dashboard.example.com", []) is False
+
+
+def test_origin_in_allowlist_wildcard_accepts_any() -> None:
+    """``"*"`` accepts any cross-origin connection.
+
+    Escape hatch for operators who want to disable the
+    cross-origin restriction entirely (e.g. they trust their
+    network and just want the dashboard usable from any
+    proxy hostname).
+    """
+    assert _origin_in_allowlist("https://anything.example.com", ["*"]) is True
+
+
+@pytest.mark.parametrize(
+    ("origin", "allowlist"),
+    [
+        ("https://dashboard.example.com", ["dashboard.example.com"]),
+        ("https://Dashboard.Example.com", ["dashboard.example.com"]),
+        ("https://dashboard.example.com:8443", ["dashboard.example.com"]),
+        ("http://192.168.1.10:6052", ["192.168.1.10"]),
+        ("http://[::1]:6052", ["::1"]),
+    ],
+)
+def test_origin_in_allowlist_match(origin: str, allowlist: list[str]) -> None:
+    """Match is on the Origin URL's hostname (port + scheme stripped)."""
+    assert _origin_in_allowlist(origin, allowlist) is True
+
+
+def test_origin_in_allowlist_rejects_unmatched() -> None:
+    """An attacker domain that's not in the list stays rejected."""
+    assert _origin_in_allowlist("https://evil.example.com", ["dashboard.example.com"]) is False
+
+
+def test_origin_in_allowlist_rejects_malformed() -> None:
+    """Garbage Origin header -> reject."""
+    # Empty hostname after parsing -> not a useful match candidate.
+    assert _origin_in_allowlist("not-a-url", ["dashboard.example.com"]) is False
+
+
+# ---------------------------------------------------------------------------
+# DashboardSettings.parse_args
+# ---------------------------------------------------------------------------
+
+
+def _ns(configuration: str, **kwargs: object) -> SimpleNamespace:
+    """Minimal argparse-namespace stub for ``DashboardSettings.parse_args``.
+
+    Caller supplies ``configuration`` (always a ``tmp_path``-derived
+    path); defaults stand in for the rest of the argparse Namespace
+    so the parse code path doesn't need to special-case missing
+    attributes.
+    """
+    defaults: dict[str, object] = {
+        "ha_addon": False,
+        "configuration": configuration,
+        "username": "",
+        "password": "",
+        "log_level": "info",
+        "port": 6052,
+        "host": "0.0.0.0",
+        "ingress_port": 6053,
+        "ingress_host": "",
+        "dev": False,
+        "trusted_domains": "",
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_settings_parses_cli_flag(tmp_path: object) -> None:
+    """``--trusted-domains a,b,c`` lands in the dataclass field, lower-cased."""
+    settings = DashboardSettings()
+    settings.parse_args(
+        _ns(
+            configuration=str(tmp_path),
+            trusted_domains="Dashboard.Local,192.168.1.10",
+        )
+    )
+    assert settings.trusted_domains == ["dashboard.local", "192.168.1.10"]
+
+
+def test_settings_parses_env_var_when_flag_unset(tmp_path: object) -> None:
+    """``$ESPHOME_TRUSTED_DOMAINS`` is the legacy-compat fallback.
+
+    Matches the upstream ESPHome dashboard's env var name so
+    operators migrating from the legacy dashboard don't have to
+    learn a new knob.
+    """
+    settings = DashboardSettings()
+    with patch.dict(
+        os.environ,
+        {"ESPHOME_TRUSTED_DOMAINS": "dashboard.example.com,proxy.example.com"},
+    ):
+        settings.parse_args(_ns(configuration=str(tmp_path)))
+    assert settings.trusted_domains == [
+        "dashboard.example.com",
+        "proxy.example.com",
+    ]
+
+
+def test_settings_cli_flag_wins_over_env_var(tmp_path: object) -> None:
+    """When both are set, the CLI flag wins.
+
+    Standard precedence — explicit CLI overrides the inherited
+    environment.
+    """
+    settings = DashboardSettings()
+    with patch.dict(os.environ, {"ESPHOME_TRUSTED_DOMAINS": "from-env.example.com"}):
+        settings.parse_args(
+            _ns(configuration=str(tmp_path), trusted_domains="from-cli.example.com")
+        )
+    assert settings.trusted_domains == ["from-cli.example.com"]
+
+
+def test_settings_strips_whitespace_and_blanks(tmp_path: object) -> None:
+    """Trailing commas / spaces don't produce empty list entries.
+
+    Operators copy-pasting from docs occasionally leave
+    ``"a, b,, c, "`` — make the parser tolerant. Empty entries
+    in the allowlist would silently match a Host header of
+    ``""`` (the empty string normalises to itself), which would
+    be a real bug.
+    """
+    settings = DashboardSettings()
+    settings.parse_args(_ns(configuration=str(tmp_path), trusted_domains="  a,, b,c,   "))
+    assert settings.trusted_domains == ["a", "b", "c"]
+
+
+def test_settings_empty_when_neither_set(tmp_path: object) -> None:
+    """Default = empty list = checks disabled.
+
+    Backwards-compatible: existing deployments don't suddenly
+    start rejecting their own Host headers.
+    """
+    settings = DashboardSettings()
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("ESPHOME_TRUSTED_DOMAINS", None)
+        settings.parse_args(_ns(configuration=str(tmp_path)))
+    assert settings.trusted_domains == []

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -11,19 +11,30 @@ checks in ``api/ws.py``:
   isn't in the allowlist. Defense in depth against DNS rebinding,
   on top of the existing ``auth/login`` gate.
 
-These tests exercise the pure helpers and the parsing on
-``DashboardSettings``. Full WS-handshake integration is covered by
-the existing aiohttp-client tests.
+These tests exercise three layers:
+
+* The pure ``_normalize_host`` / ``_host_in_allowlist`` /
+  ``_origin_in_allowlist`` helpers.
+* ``DashboardSettings.parse_args`` — CLI / env-var precedence,
+  whitespace handling, the ``--trusted-domains ""`` explicit
+  override path.
+* End-to-end ``websocket_handler`` integration via
+  ``aiohttp_client``: confirms the 403 paths fire on the right
+  branches and that a valid Origin / Host pair reaches the WS
+  upgrade.
 """
 
 from __future__ import annotations
 
 import os
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from aiohttp import web
+from pytest_aiohttp.plugin import AiohttpClient
 
+from esphome_device_builder.api import ws as ws_module
 from esphome_device_builder.api.ws import (
     _host_in_allowlist,
     _normalize_host,
@@ -212,7 +223,10 @@ def _ns(configuration: str, **kwargs: object) -> SimpleNamespace:
         "ingress_port": 6053,
         "ingress_host": "",
         "dev": False,
-        "trusted_domains": "",
+        # ``None`` matches the argparse default — the test mirrors
+        # production where ``--trusted-domains`` was not passed and
+        # ``parse_args`` should consult ``$ESPHOME_TRUSTED_DOMAINS``.
+        "trusted_domains": None,
     }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -288,3 +302,195 @@ def test_settings_empty_when_neither_set(tmp_path: object) -> None:
         os.environ.pop("ESPHOME_TRUSTED_DOMAINS", None)
         settings.parse_args(_ns(configuration=str(tmp_path)))
     assert settings.trusted_domains == []
+
+
+def test_settings_explicit_empty_cli_overrides_env_var(tmp_path: object) -> None:
+    """``--trusted-domains ""`` wins over the env var.
+
+    Argparse default is ``None`` (flag not passed); any string
+    value, including the empty string, is an explicit override.
+    Lets operators disable the checks from the CLI even when
+    ``$ESPHOME_TRUSTED_DOMAINS`` is inherited from the parent
+    process. Without this, the previous ``getattr(...) or
+    os.getenv(...)`` chain treated ``""`` as falsy and silently
+    fell back to the env var.
+    """
+    settings = DashboardSettings()
+    with patch.dict(os.environ, {"ESPHOME_TRUSTED_DOMAINS": "from-env.example.com"}):
+        settings.parse_args(_ns(configuration=str(tmp_path), trusted_domains=""))
+    assert settings.trusted_domains == []
+
+
+# ---------------------------------------------------------------------------
+# websocket_handler integration — exercise the 403 branches end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _password_protected_app(trusted_domains: list[str]) -> web.Application:
+    """Build a minimal aiohttp app wired to ``websocket_handler``.
+
+    Mirrors the pattern in ``test_websocket_heartbeat.py``: stub
+    settings + auth so ``websocket_handler``'s gating branches run
+    without spinning up the real DeviceBuilder. Password is set
+    (``using_password=True``) so the Origin/Host checks actually
+    execute — the gate is skipped on unauthenticated deployments
+    and on the trusted ingress site.
+    """
+    settings = MagicMock()
+    settings.using_password = True
+    settings.trusted_domains = trusted_domains
+    settings.port = 6052
+    settings.on_ha_addon = False
+
+    device_builder = MagicMock()
+    device_builder.settings = settings
+    device_builder.auth = MagicMock()
+    device_builder.auth.session_store = MagicMock()
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = False  # public site -> gating runs
+    app.router.add_routes(ws_module.create_ws_routes())
+    return app
+
+
+async def test_handler_rejects_cross_origin_without_allowlist(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Origin doesn't match Host, no allowlist → 403 Cross-origin.
+
+    Pin the existing strict behaviour so a refactor of the
+    Origin gate doesn't silently remove the protection.
+    """
+    client = await aiohttp_client(_password_protected_app([]))
+    resp = await client.get("/ws", headers={"Origin": "https://evil.example.com"})
+    assert resp.status == 403
+    assert "Cross-origin" in await resp.text()
+
+
+async def test_handler_accepts_cross_origin_when_origin_in_allowlist(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Cross-origin with Origin's hostname in trusted_domains → handshake succeeds.
+
+    Reverse-proxy deployments where Origin is the proxy hostname
+    and Host is the upstream bind address. Pinning that the
+    handler reaches the WS upgrade (status 101 / TEXT message)
+    proves the gate let it through.
+    """
+    # Allowlist needs ``127.0.0.1`` too because aiohttp_client
+    # binds the test server there and the Host-allowlist check
+    # runs after the Origin gate; without the IP entry, the test
+    # would pass the Origin gate but trip the Host gate.
+    client = await aiohttp_client(_password_protected_app(["dashboard.example.com", "127.0.0.1"]))
+    async with client.ws_connect("/ws", headers={"Origin": "https://dashboard.example.com"}) as ws:
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type.name in ("TEXT", "BINARY")
+
+
+async def test_handler_rejects_host_not_in_allowlist(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Host header not in allowlist → 403 Host not in trusted-domains.
+
+    DNS-rebinding payload: attacker's hostname resolves to
+    victim's LAN IP, browser sends the attacker's Host header,
+    operator's allowlist (set to the real dashboard hostname)
+    catches it. We pass a matching ``Origin`` so the cross-origin
+    gate doesn't short-circuit before the host-allowlist check.
+    """
+    client = await aiohttp_client(_password_protected_app(["dashboard.example.com"]))
+    resp = await client.get(
+        "/ws",
+        headers={
+            "Host": "evil.example.com",
+            "Origin": "https://evil.example.com",
+        },
+    )
+    assert resp.status == 403
+    assert "Host not in trusted-domains" in await resp.text()
+
+
+async def test_handler_accepts_host_in_allowlist(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Host header in allowlist + same-origin → handshake succeeds."""
+    client = await aiohttp_client(_password_protected_app(["dashboard.example.com"]))
+    async with client.ws_connect(
+        "/ws",
+        headers={
+            "Host": "dashboard.example.com",
+            "Origin": "https://dashboard.example.com",
+        },
+    ) as ws:
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type.name in ("TEXT", "BINARY")
+
+
+async def test_handler_skips_gating_on_trusted_site(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """The trusted ingress site bypasses both checks.
+
+    HA Ingress runs upstream auth + bind-network isolation —
+    enforcing Origin / Host gating there would block legitimate
+    supervisor-routed requests with synthesised headers.
+    """
+    settings = MagicMock()
+    settings.using_password = True
+    settings.trusted_domains = ["dashboard.example.com"]
+    settings.port = 6052
+    settings.on_ha_addon = True
+
+    device_builder = MagicMock()
+    device_builder.settings = settings
+    device_builder.auth = MagicMock()
+    device_builder.auth.session_store = MagicMock()
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = True  # ingress site -> gating skipped
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+    async with client.ws_connect(
+        "/ws",
+        headers={
+            "Host": "evil.example.com",
+            "Origin": "https://evil.example.com",
+        },
+    ) as ws:
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type.name in ("TEXT", "BINARY")
+
+
+async def test_handler_accepts_when_no_password(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Unauthenticated public site bypasses gating.
+
+    The Origin / Host checks fire only when ``using_password``.
+    A dashboard running without auth is already in
+    "trust-the-LAN" mode; adding hostname checks would break
+    first-run access from another machine.
+    """
+    settings = MagicMock()
+    settings.using_password = False
+    settings.trusted_domains = []
+    settings.port = 6052
+    settings.on_ha_addon = False
+
+    device_builder = MagicMock()
+    device_builder.settings = settings
+    device_builder.auth = MagicMock()
+    device_builder.auth.session_store = MagicMock()
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = False
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+    async with client.ws_connect("/ws", headers={"Origin": "https://evil.example.com"}) as ws:
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type.name in ("TEXT", "BINARY")

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -464,6 +464,31 @@ async def test_handler_skips_gating_on_trusted_site(
         assert msg.type.name in ("TEXT", "BINARY")
 
 
+async def test_handler_no_origin_skips_both_gates(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Origin-less requests bypass Origin AND Host allowlist gates.
+
+    CLI tools / HA integration / direct ``websockets`` clients
+    don't send ``Origin`` (it's a browser-only header). The
+    DNS-rebinding attack vector is browser-only by construction
+    — a script in evil.com can only re-bind via the browser's
+    DNS resolver. Skipping the gates when Origin is absent keeps
+    non-browser clients working under a tightened
+    ``trusted_domains`` config without weakening the defense.
+
+    Pin both halves: a 403 here would mean an operator who set
+    ``trusted_domains`` to harden against rebinding accidentally
+    locked their HA integration out.
+    """
+    client = await aiohttp_client(_password_protected_app(["dashboard.example.com"]))
+    # No Origin header → CLI-style request. Host is the test
+    # client's local IP:port, deliberately NOT in the allowlist.
+    async with client.ws_connect("/ws") as ws:
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type.name in ("TEXT", "BINARY")
+
+
 async def test_handler_accepts_when_no_password(
     aiohttp_client: AiohttpClient,
 ) -> None:


### PR DESCRIPTION
Closes #80. Resolves finding B-5 from the security audit (#120).

## Summary

Single allowlist (`DashboardSettings.trusted_domains` / `--trusted-domains` / `$ESPHOME_TRUSTED_DOMAINS`) drives two checks in the WebSocket handshake:

1. **Origin allowlist** (closes #80) — when the browser's `Origin` header doesn't equal the request's `Host` (reverse-proxy deployments where the proxy hostname differs from the upstream bind address), accept the cross-origin connection if Origin's hostname is in the allowlist. Without this, users hitting the dashboard through nginx-proxy-manager / Caddy / Traefik / etc. lose dashboard access entirely on the password-gated public site.

2. **Host allowlist** (closes B-5 from #120) — reject any handshake whose `Host` header isn't in the allowlist. Defense in depth against DNS rebinding, on top of the existing per-IP-rate-limited `auth/login` gate.

Empty list (default) preserves today's strict Origin-equals-Host behaviour with no Host restriction — backwards compatible. `*` is the explicit "match anything" escape hatch.

## Why one allowlist, not two

Operators thinking about either problem ("my reverse proxy can't connect" or "I want DNS-rebinding defense") land on the same answer: a list of hostnames the dashboard trusts. Splitting them into two env vars would be confusing and double the doc burden.

## Compatibility

Env-var name (`ESPHOME_TRUSTED_DOMAINS`) matches the upstream legacy ESPHome dashboard's so operators migrating don't have to learn a new knob. CLI flag is `--trusted-domains` (CLI takes precedence over env var when both are set).

## Edge cases pinned

- Match is case-insensitive and port-tolerant.
- IPv6 may be entered with or without brackets — `::1` and `[::1]` both match a request Host of `[::1]:6052`. The bare-IPv6 case short-circuits via `ipaddress.ip_address` because `urlsplit("//fe80::1")` mis-parses the leading segment as host with `:1` as port.
- Whitespace and empty entries in the comma-separated list are stripped (`"a, b,, c, "` → `["a", "b", "c"]`) so empty strings don't sneak into the allowlist and silently match a malformed Host.

## Test plan

- [x] `uv run pytest tests/test_trusted_domains.py` — 37 new tests pass
- [x] `uv run pytest tests/ --ignore=tests/benchmarks` — 624 total pass
- [x] `pre-commit run` — clean

Tests cover: `_normalize_host` across IPv4 / hostname / bracketed-IPv6 / bare-IPv6 / malformed; `_host_in_allowlist` match-and-reject + wildcard + empty; `_origin_in_allowlist` ditto; `DashboardSettings.parse_args` CLI / env-var precedence + whitespace handling.

Docs: new "Reverse-proxy / cross-origin deployments" section in `docs/ARCHITECTURE.md` covering the two checks, the deployment shapes that benefit, and the legacy env-var name.