### PR TITLE
Fail-secure on HA add-on without USERNAME/PASSWORD

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -304,7 +304,13 @@ class DeviceBuilder:
     # Web application
     # ------------------------------------------------------------------
 
-    def create_app(self, *, trusted: bool = False, with_lifecycle: bool = True) -> web.Application:
+    def create_app(
+        self,
+        *,
+        trusted: bool = False,
+        with_lifecycle: bool = True,
+        with_ingress_site: bool = True,
+    ) -> web.Application:
         """
         Build the aiohttp application.
 
@@ -349,7 +355,7 @@ class DeviceBuilder:
 
         if with_lifecycle:
             app.on_startup.append(self._on_startup)
-            if self.settings.create_ingress_site:
+            if with_ingress_site and self.settings.create_ingress_site:
                 app.on_startup.append(self._start_ingress_site)
                 app.on_cleanup.append(self._stop_ingress_site)
             app.on_cleanup.append(self._on_cleanup)
@@ -385,8 +391,53 @@ class DeviceBuilder:
     def run(self) -> None:
         """Start the HTTP server (blocking)."""
         # Logging is already configured by __main__.py
+        settings = self.settings
+        # Fail-secure on the HA add-on path. The legacy dashboard
+        # had a supervisor ``/auth`` fallback that gated the public
+        # port with HA credentials when ``PASSWORD`` wasn't set; we
+        # don't carry that forward (see issue #85). Without the
+        # fallback, binding the public port without
+        # ``USERNAME``/``PASSWORD`` would leave the dashboard
+        # wide-open on the LAN whenever the add-on's ``ports:``
+        # mapping exposed it. So when on-ha-addon and no password
+        # is configured, run ingress-only and tell the operator
+        # loudly how to enable LAN access if they want it.
+        if settings.on_ha_addon and not settings.using_password:
+            if not settings.create_ingress_site:
+                # ``DISABLE_HA_AUTHENTICATION`` forces all traffic
+                # through the public port (no trusted ingress site)
+                # — but we have no credentials to gate it. Refuse
+                # to start rather than expose an unauthenticated
+                # dashboard. The supervisor surfaces this in the
+                # add-on log so the operator sees exactly what to
+                # change.
+                msg = (
+                    "Refusing to start: --ha-addon is set, "
+                    "DISABLE_HA_AUTHENTICATION forces public-port auth, "
+                    "and USERNAME/PASSWORD is not configured. Set "
+                    "USERNAME and PASSWORD via the add-on options, or "
+                    "unset DISABLE_HA_AUTHENTICATION to use ingress-only "
+                    "mode."
+                )
+                raise RuntimeError(msg)
+            _LOGGER.warning(
+                "Public port %d NOT bound: --ha-addon is set but "
+                "USERNAME/PASSWORD is not configured. Running "
+                "ingress-only — the dashboard works through the Home "
+                "Assistant UI. To enable LAN access on port %d, set "
+                "USERNAME and PASSWORD via the add-on options.",
+                settings.port,
+                settings.port,
+            )
+            app = self.create_app(trusted=True, with_ingress_site=False)
+            web.run_app(
+                app,
+                host=settings.ingress_host or "0.0.0.0",
+                port=settings.ingress_port,
+            )
+            return
         app = self.create_app()
-        web.run_app(app, host=self.settings.host, port=self.settings.port)
+        web.run_app(app, host=settings.host, port=settings.port)
 
     @staticmethod
     def _get_frontend_dir() -> Path | None:

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -354,6 +354,13 @@ class DeviceBuilder:
         ``with_lifecycle`` toggles startup/cleanup hooks; the ingress
         app reuses the public app's controller singleton and so passes
         ``False`` to avoid re-initialising them.
+        ``with_ingress_site`` controls whether the lifecycle hooks
+        spawn the *separate* trusted ingress site alongside the
+        public site. Defaults to ``True`` for the canonical
+        public+ingress deployment. Pass ``False`` from the
+        ingress-only fail-secure path in ``run`` (where this app
+        IS the ingress) to avoid recursively spawning a second
+        ingress site via ``_start_ingress_site``.
         """
         middlewares: list[Any] = [cors_middleware]
         if not trusted:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,11 @@ _STARTUP_BLOCKING_OK: tuple[tuple[str, str], ...] = (
     # at app construction so a broken frontend wheel surfaces a clear
     # RuntimeError instead of mysterious 404s. Runs once at startup.
     ("device_builder.py", "_register_frontend"),
+    # ``_start_ingress_site`` calls ``create_app`` (which stat-checks
+    # the boards-images directory) and binds a TCP socket. Both run
+    # once at HA-add-on startup as an aiohttp ``on_startup`` hook —
+    # the cost is paid once, not on the request path.
+    ("device_builder.py", "_start_ingress_site"),
 )
 
 

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -1,0 +1,169 @@
+"""Tests for the fail-secure HA-add-on bind logic in ``DeviceBuilder.run``.
+
+The legacy dashboard had a supervisor ``/auth`` fallback that gated
+the public port with HA credentials when ``PASSWORD`` wasn't set;
+we don't carry that forward (see issue #85). Without the fallback,
+binding the public port without ``USERNAME``/``PASSWORD`` would
+leave the dashboard wide-open on the LAN whenever the add-on's
+``ports:`` mapping exposed it.
+
+These tests pin the three branches of the fail-secure logic:
+
+1. on-ha-addon + no password + ingress available → run ingress-only.
+2. on-ha-addon + no password + ingress disabled → refuse to start.
+3. anything else (password set, not on add-on) → public site as
+   normal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.device_builder import DeviceBuilder
+
+
+def _make_db(
+    *,
+    tmp_path: Path,
+    on_ha_addon: bool,
+    using_password: bool,
+    create_ingress_site: bool,
+) -> DeviceBuilder:
+    """Build a DeviceBuilder with the requested settings shape.
+
+    The settings ``create_ingress_site`` property is overridden via
+    a temporary subclass so the test can drive every combination
+    without faking the ``DISABLE_HA_AUTHENTICATION`` env var.
+    """
+    settings = DashboardSettings()
+    settings.config_dir = tmp_path
+    settings.absolute_config_dir = tmp_path.resolve()
+    settings.on_ha_addon = on_ha_addon
+    settings.using_password = using_password
+    if using_password:
+        settings.username = "admin"
+        settings.password_hash = b"x" * 32
+    settings.host = "0.0.0.0"
+    settings.port = 6052
+    settings.ingress_port = 6053
+    settings.ingress_host = ""
+
+    class _SettingsOverride(DashboardSettings):
+        @property
+        def create_ingress_site(self) -> bool:  # type: ignore[override]
+            return create_ingress_site
+
+    settings.__class__ = _SettingsOverride
+    return DeviceBuilder(settings)
+
+
+def test_ha_addon_no_password_with_ingress_runs_ingress_only(tmp_path: Path) -> None:
+    """Public port suppressed; ingress site bound; loud warning logged."""
+    db = _make_db(
+        tmp_path=tmp_path,
+        on_ha_addon=True,
+        using_password=False,
+        create_ingress_site=True,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_run_app(app, *, host: str, port: int) -> None:
+        captured["host"] = host
+        captured["port"] = port
+        captured["trusted"] = bool(app.get("trusted_site"))
+
+    with (
+        patch("esphome_device_builder.device_builder.web.run_app", fake_run_app),
+        patch.object(db, "create_app", wraps=db.create_app) as create_app_spy,
+    ):
+        db.run()
+
+    # Only the ingress site got bound — public port was suppressed.
+    assert captured["port"] == 6053  # ingress_port
+    assert captured["host"] == "0.0.0.0"  # ingress_host fallback
+    assert captured["trusted"] is True  # trusted=True (auth bypass)
+
+    # The single create_app call was for the trusted ingress, with
+    # the ingress-site hook disabled (the app IS the ingress).
+    assert create_app_spy.call_count == 1
+    kwargs = create_app_spy.call_args.kwargs
+    assert kwargs == {"trusted": True, "with_ingress_site": False}
+
+
+def test_ha_addon_no_password_no_ingress_refuses_to_start(tmp_path: Path) -> None:
+    """``DISABLE_HA_AUTHENTICATION`` + no password = refuse to start.
+
+    Without ingress and without credentials there's nothing safe
+    to bind. Failing loudly at startup is the only correct outcome
+    — silently doing nothing would look like a working dashboard
+    that just isn't reachable.
+    """
+    db = _make_db(
+        tmp_path=tmp_path,
+        on_ha_addon=True,
+        using_password=False,
+        create_ingress_site=False,
+    )
+
+    with (
+        patch("esphome_device_builder.device_builder.web.run_app") as run_app_mock,
+        pytest.raises(RuntimeError, match="DISABLE_HA_AUTHENTICATION"),
+    ):
+        db.run()
+
+    # Nothing bound.
+    run_app_mock.assert_not_called()
+
+
+def test_ha_addon_with_password_binds_public_site_normally(tmp_path: Path) -> None:
+    """Password set → normal public-site bind, ingress as a hook."""
+    db = _make_db(
+        tmp_path=tmp_path,
+        on_ha_addon=True,
+        using_password=True,
+        create_ingress_site=True,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_run_app(app, *, host: str, port: int) -> None:
+        captured["host"] = host
+        captured["port"] = port
+        captured["trusted"] = bool(app.get("trusted_site"))
+
+    with patch("esphome_device_builder.device_builder.web.run_app", fake_run_app):
+        db.run()
+
+    # Public port bound (auth gates it via using_password).
+    assert captured["port"] == 6052
+    assert captured["host"] == "0.0.0.0"
+    assert captured["trusted"] is False
+
+
+def test_non_ha_addon_binds_public_site_normally(tmp_path: Path) -> None:
+    """Standalone deployment is unaffected by the HA-add-on logic."""
+    db = _make_db(
+        tmp_path=tmp_path,
+        on_ha_addon=False,
+        using_password=False,
+        create_ingress_site=False,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_run_app(app, *, host: str, port: int) -> None:
+        captured["host"] = host
+        captured["port"] = port
+
+    with patch("esphome_device_builder.device_builder.web.run_app", fake_run_app):
+        db.run()
+
+    # Public port bound — non-add-on deployments get the legacy
+    # default of "no auth required, user opts in via PASSWORD".
+    assert captured["port"] == 6052
+    assert captured["host"] == "0.0.0.0"

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -31,13 +31,13 @@ def _make_db(
     tmp_path: Path,
     on_ha_addon: bool,
     using_password: bool,
-    create_ingress_site: bool,
 ) -> DeviceBuilder:
     """Build a DeviceBuilder with the requested settings shape.
 
-    The settings ``create_ingress_site`` property is overridden via
-    a temporary subclass so the test can drive every combination
-    without faking the ``DISABLE_HA_AUTHENTICATION`` env var.
+    Tests drive ``create_ingress_site`` (the only HA-add-on
+    setting that varies between scenarios) via
+    ``monkeypatch.setenv("DISABLE_HA_AUTHENTICATION", ...)`` —
+    same path the production code reads, no class trickery.
     """
     settings = DashboardSettings()
     settings.config_dir = tmp_path
@@ -51,24 +51,25 @@ def _make_db(
     settings.port = 6052
     settings.ingress_port = 6053
     settings.ingress_host = ""
-
-    class _SettingsOverride(DashboardSettings):
-        @property
-        def create_ingress_site(self) -> bool:  # type: ignore[override]
-            return create_ingress_site
-
-    settings.__class__ = _SettingsOverride
     return DeviceBuilder(settings)
 
 
-def test_ha_addon_no_password_with_ingress_runs_ingress_only(tmp_path: Path) -> None:
-    """Public port suppressed; ingress site bound; loud warning logged."""
-    db = _make_db(
-        tmp_path=tmp_path,
-        on_ha_addon=True,
-        using_password=False,
-        create_ingress_site=True,
-    )
+def test_ha_addon_no_password_with_ingress_runs_ingress_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Public port suppressed; ingress site bound; loud warning logged.
+
+    Drives the ``create_ingress_site`` property via the real
+    ``DISABLE_HA_AUTHENTICATION`` env var (unset = ingress is
+    available) so the property's actual behaviour is exercised.
+    Asserts the operator-facing warning is emitted via ``caplog``
+    so a regression that silently suppresses the public-port bind
+    surfaces immediately.
+    """
+    monkeypatch.delenv("DISABLE_HA_AUTHENTICATION", raising=False)
+    db = _make_db(tmp_path=tmp_path, on_ha_addon=True, using_password=False)
 
     captured: dict[str, object] = {}
 
@@ -78,6 +79,7 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(tmp_path: Path) -> 
         captured["trusted"] = bool(app.get("trusted_site"))
 
     with (
+        caplog.at_level("WARNING", logger="esphome_device_builder.device_builder"),
         patch("esphome_device_builder.device_builder.web.run_app", fake_run_app),
         patch.object(db, "create_app", wraps=db.create_app) as create_app_spy,
     ):
@@ -94,8 +96,27 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(tmp_path: Path) -> 
     kwargs = create_app_spy.call_args.kwargs
     assert kwargs == {"trusted": True, "with_ingress_site": False}
 
+    # The operator-facing safety warning fired. Without this
+    # assertion a regression where the bind is suppressed silently
+    # would still pass the bind-shape checks above — the loud log
+    # is the only signal an operator gets about why their LAN
+    # access doesn't work.
+    warning_messages = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.levelname == "WARNING" and "NOT bound" in rec.getMessage()
+    ]
+    assert warning_messages, (
+        "expected the loud 'Public port ... NOT bound' warning describing "
+        "why the public port was suppressed and how to enable it"
+    )
+    assert "USERNAME and PASSWORD" in warning_messages[0]
 
-def test_ha_addon_no_password_no_ingress_refuses_to_start(tmp_path: Path) -> None:
+
+def test_ha_addon_no_password_no_ingress_refuses_to_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``DISABLE_HA_AUTHENTICATION`` + no password = refuse to start.
 
     Without ingress and without credentials there's nothing safe
@@ -103,12 +124,8 @@ def test_ha_addon_no_password_no_ingress_refuses_to_start(tmp_path: Path) -> Non
     — silently doing nothing would look like a working dashboard
     that just isn't reachable.
     """
-    db = _make_db(
-        tmp_path=tmp_path,
-        on_ha_addon=True,
-        using_password=False,
-        create_ingress_site=False,
-    )
+    monkeypatch.setenv("DISABLE_HA_AUTHENTICATION", "true")
+    db = _make_db(tmp_path=tmp_path, on_ha_addon=True, using_password=False)
 
     with (
         patch("esphome_device_builder.device_builder.web.run_app") as run_app_mock,
@@ -120,14 +137,13 @@ def test_ha_addon_no_password_no_ingress_refuses_to_start(tmp_path: Path) -> Non
     run_app_mock.assert_not_called()
 
 
-def test_ha_addon_with_password_binds_public_site_normally(tmp_path: Path) -> None:
+def test_ha_addon_with_password_binds_public_site_normally(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Password set → normal public-site bind, ingress as a hook."""
-    db = _make_db(
-        tmp_path=tmp_path,
-        on_ha_addon=True,
-        using_password=True,
-        create_ingress_site=True,
-    )
+    monkeypatch.delenv("DISABLE_HA_AUTHENTICATION", raising=False)
+    db = _make_db(tmp_path=tmp_path, on_ha_addon=True, using_password=True)
 
     captured: dict[str, object] = {}
 
@@ -146,13 +162,13 @@ def test_ha_addon_with_password_binds_public_site_normally(tmp_path: Path) -> No
 
 
 def test_non_ha_addon_binds_public_site_normally(tmp_path: Path) -> None:
-    """Standalone deployment is unaffected by the HA-add-on logic."""
-    db = _make_db(
-        tmp_path=tmp_path,
-        on_ha_addon=False,
-        using_password=False,
-        create_ingress_site=False,
-    )
+    """Standalone deployment is unaffected by the HA-add-on logic.
+
+    Doesn't need ``monkeypatch`` for ``DISABLE_HA_AUTHENTICATION``:
+    when ``on_ha_addon=False`` the property short-circuits and
+    returns ``False`` regardless of the env var.
+    """
+    db = _make_db(tmp_path=tmp_path, on_ha_addon=False, using_password=False)
 
     captured: dict[str, object] = {}
 
@@ -179,12 +195,7 @@ async def test_start_and_stop_ingress_site_lifecycle(tmp_path: Path) -> None:
     port — avoids flakes when 6053 is already in use on the
     runner.
     """
-    db = _make_db(
-        tmp_path=tmp_path,
-        on_ha_addon=True,
-        using_password=True,
-        create_ingress_site=True,
-    )
+    db = _make_db(tmp_path=tmp_path, on_ha_addon=True, using_password=True)
     db.settings.ingress_port = 0  # let OS pick a free port
 
     # _start_ingress_site reads self.settings.ingress_port via
@@ -209,12 +220,7 @@ async def test_on_startup_and_on_cleanup_call_through_to_lifecycle(tmp_path: Pat
     would spin up controllers, which is heavier than this test
     needs.
     """
-    db = _make_db(
-        tmp_path=tmp_path,
-        on_ha_addon=False,
-        using_password=False,
-        create_ingress_site=False,
-    )
+    db = _make_db(tmp_path=tmp_path, on_ha_addon=False, using_password=False)
     fake_app: object = object()
 
     with (
@@ -237,12 +243,7 @@ def test_get_frontend_dir_returns_none_when_package_missing(tmp_path: Path) -> N
     branch returns ``None`` so callers can detect the missing
     package and skip the static-route registration.
     """
-    db = _make_db(
-        tmp_path=tmp_path,
-        on_ha_addon=False,
-        using_password=False,
-        create_ingress_site=False,
-    )
+    db = _make_db(tmp_path=tmp_path, on_ha_addon=False, using_password=False)
 
     # Force an ImportError by clearing the module from sys.modules
     # and patching the import to raise.
@@ -268,12 +269,7 @@ def test_create_app_logs_frontend_missing_message(tmp_path: Path) -> None:
     the dashboard still serves the WS API; the log line tells the
     operator why the UI is missing and how to fix it.
     """
-    db = _make_db(
-        tmp_path=tmp_path,
-        on_ha_addon=False,
-        using_password=False,
-        create_ingress_site=False,
-    )
+    db = _make_db(tmp_path=tmp_path, on_ha_addon=False, using_password=False)
 
     with (
         patch.object(db, "_get_frontend_dir", return_value=None),

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -18,7 +18,7 @@ These tests pin the three branches of the fail-secure logic:
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -167,3 +167,119 @@ def test_non_ha_addon_binds_public_site_normally(tmp_path: Path) -> None:
     # default of "no auth required, user opts in via PASSWORD".
     assert captured["port"] == 6052
     assert captured["host"] == "0.0.0.0"
+
+
+async def test_start_and_stop_ingress_site_lifecycle(tmp_path: Path) -> None:
+    """``_start_ingress_site`` / ``_stop_ingress_site`` actually bind+release.
+
+    Drives the lifecycle hooks directly (rather than running the
+    full ``web.run_app``) so the ingress-only path's child app
+    construction, runner setup, port bind, and clean cleanup are
+    all exercised. Uses port=0 so the OS picks a free ephemeral
+    port — avoids flakes when 6053 is already in use on the
+    runner.
+    """
+    db = _make_db(
+        tmp_path=tmp_path,
+        on_ha_addon=True,
+        using_password=True,
+        create_ingress_site=True,
+    )
+    db.settings.ingress_port = 0  # let OS pick a free port
+
+    # _start_ingress_site reads self.settings.ingress_port via
+    # web.TCPSite — a real socket bind. The hook also calls
+    # self.create_app(trusted=True, with_lifecycle=False) to build
+    # the inner app; that path is what we're trying to cover.
+    fake_app: object = object()
+    await db._start_ingress_site(fake_app)  # type: ignore[arg-type]
+    assert db._ingress_runner is not None
+
+    # And shutting it down releases the bind.
+    await db._stop_ingress_site(fake_app)  # type: ignore[arg-type]
+    assert db._ingress_runner is None
+
+
+async def test_on_startup_and_on_cleanup_call_through_to_lifecycle(tmp_path: Path) -> None:
+    """The aiohttp lifecycle hooks delegate to start()/stop() correctly.
+
+    Exercises the trivial ``_on_startup`` / ``_on_cleanup``
+    one-liners by patching ``DeviceBuilder.start`` / ``stop`` and
+    asserting they're awaited. Without the patch a full ``start()``
+    would spin up controllers, which is heavier than this test
+    needs.
+    """
+    db = _make_db(
+        tmp_path=tmp_path,
+        on_ha_addon=False,
+        using_password=False,
+        create_ingress_site=False,
+    )
+    fake_app: object = object()
+
+    with (
+        patch.object(db, "start", new=AsyncMock()) as start_mock,
+        patch.object(db, "stop", new=AsyncMock()) as stop_mock,
+    ):
+        await db._on_startup(fake_app)  # type: ignore[arg-type]
+        await db._on_cleanup(fake_app)  # type: ignore[arg-type]
+
+    start_mock.assert_awaited_once()
+    stop_mock.assert_awaited_once()
+
+
+def test_get_frontend_dir_returns_none_when_package_missing(tmp_path: Path) -> None:
+    """Covers the ``ImportError`` fallback in ``_get_frontend_dir``.
+
+    The frontend ships as a separate wheel
+    (``esphome-device-builder-frontend``) that's optional —
+    without it the dashboard runs in API-only mode. The fallback
+    branch returns ``None`` so callers can detect the missing
+    package and skip the static-route registration.
+    """
+    db = _make_db(
+        tmp_path=tmp_path,
+        on_ha_addon=False,
+        using_password=False,
+        create_ingress_site=False,
+    )
+
+    # Force an ImportError by clearing the module from sys.modules
+    # and patching the import to raise.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "esphome_device_builder_frontend":
+            msg = "fake missing"
+            raise ImportError(msg)
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    with patch.object(builtins, "__import__", fake_import):
+        assert db._get_frontend_dir() is None
+
+
+def test_create_app_logs_frontend_missing_message(tmp_path: Path) -> None:
+    """``create_app`` logs a friendly hint when the frontend package isn't installed.
+
+    Covers the ``elif with_lifecycle:`` branch that runs when
+    ``_get_frontend_dir`` returned ``None``. Without the package
+    the dashboard still serves the WS API; the log line tells the
+    operator why the UI is missing and how to fix it.
+    """
+    db = _make_db(
+        tmp_path=tmp_path,
+        on_ha_addon=False,
+        using_password=False,
+        create_ingress_site=False,
+    )
+
+    with (
+        patch.object(db, "_get_frontend_dir", return_value=None),
+        patch("esphome_device_builder.device_builder._LOGGER") as logger_mock,
+    ):
+        db.create_app(with_lifecycle=True)
+
+    info_calls = [c for c in logger_mock.info.call_args_list if "Frontend package" in str(c)]
+    assert info_calls, "expected the 'Frontend package not installed' log line"


### PR DESCRIPTION
## Summary

Closes the security gap left by closing #85: when the new backend runs as an HA add-on with `--ha-addon` but no `USERNAME`/`PASSWORD`, binding the public TCP port leaves the dashboard wide-open on the LAN. The legacy dashboard had a supervisor `/auth` fallback for this case; we don't carry that forward.

Three branches:

1. **`on-ha-addon` + no password + ingress available** (the canonical default) — bind ingress only, log a loud `WARNING` explaining the public port was suppressed and how to enable it.
2. **`on-ha-addon` + no password + `DISABLE_HA_AUTHENTICATION`** (ingress disabled, public-port-only) — refuse to start with a clear `RuntimeError`. Nothing safe to bind.
3. **Anything else** (password set, or not on the add-on) — public site bound as before. Standalone deployments are unaffected.

## Why

`auth_middleware` short-circuits on `not settings.using_password`, and the WS handler treats every connection as `pre_authenticated` when no password is set. On the trusted ingress site that's correct (supervisor pre-authenticates). On a public TCP port, it means anyone on the LAN gets full control. The legacy dashboard avoided this via supervisor `/auth`; we close the gap differently — by refusing to bind the unauthenticated public port at all.

## Test plan

- [x] `uv run pytest tests/test_ha_addon_failsafe.py` — 4 cases: ingress-only, refuse-to-start, password-set, not-on-add-on.
- [x] Full suite: `uv run pytest --ignore=tests/benchmarks` — 667 passed.
- [ ] Manual on a real add-on: confirm warning shows in supervisor log, ingress UI works, public port doesn't bind.