### PR TITLE
Reject same-name and colliding firmware/rename targets

### DIFF
--- a/esphome_device_builder/controllers/devices.py
+++ b/esphome_device_builder/controllers/devices.py
@@ -479,17 +479,26 @@ class DevicesController:
         config_path = str(self._db.settings.rel_path(configuration))
         new_filename = f"{new_name}.yaml"
 
+        # Reject same-name renames up-front. Both downstream branches
+        # (manual rewrite, ``esphome rename``) would treat this as a
+        # no-op rewrite + redundant flash — wasted work the caller
+        # almost certainly didn't intend. Frontend should call
+        # ``firmware/install`` for "flash without renaming".
+        if new_filename == configuration:
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                "new_name must differ from the current device name",
+            )
         # Reject up-front if the target filename is already in use.
         # The manual-rename branch already checks ``new_path.exists()``
         # itself, but the CLI ``esphome rename`` path does *not* — it
         # blindly ``write_text``s the new YAML and then OTA-installs
         # it, so a collision would silently overwrite the unrelated
         # device's config and flash that firmware to the wrong device.
-        if new_filename != configuration:
-            new_path = self._db.settings.rel_path(new_filename)
-            if new_path.exists():
-                msg = f"A device named {new_filename} already exists"
-                raise CommandError(ErrorCode.INVALID_ARGS, msg)
+        new_path = self._db.settings.rel_path(new_filename)
+        if new_path.exists():
+            msg = f"A device named {new_filename} already exists"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         if not await self._yaml_validates(config_path):
             loop = asyncio.get_running_loop()

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -641,11 +641,30 @@ class FirmwareController:
         # the derived filename via ``rel_path`` at the WS boundary so a
         # direct ``firmware/rename`` request can't pass a traversal-shaped
         # name (``../etc/passwd``) and have it surface as a failed job
-        # later. Filename-collision is checked upstream by
-        # ``DevicesController.rename_device``; direct WS callers that
-        # bypass the controller layer are responsible for their own
-        # collision check.
-        await self._validate_configuration_boundary(f"{new_name}.yaml")
+        # later.
+        new_filename = f"{new_name}.yaml"
+        await self._validate_configuration_boundary(new_filename)
+        # Reject up-front if the target filename is already in use.
+        # ``DevicesController.rename_device`` checks the same thing
+        # before forwarding to this handler — but a direct WS client
+        # can bypass that layer, and ``esphome rename`` itself does
+        # not check collisions: it blindly ``write_text``s the new
+        # YAML and OTA-installs it, silently overwriting the unrelated
+        # device's config and flashing that firmware to the wrong
+        # device. Same error-message shape as the controller-layer
+        # check so the frontend handles both identically.
+        if new_filename != configuration:
+            # ``new_filename`` already passed ``rel_path`` validation
+            # above, so we can build the path directly and stat it in
+            # one executor hop instead of paying a second ``rel_path``
+            # round-trip just to get back the same result.
+            new_path = self._db.settings.config_dir / new_filename
+            loop = asyncio.get_running_loop()
+            if await loop.run_in_executor(None, new_path.exists):
+                raise CommandError(
+                    ErrorCode.INVALID_ARGS,
+                    f"A device named {new_filename} already exists",
+                )
         job = self._create_job(configuration, JobType.RENAME, new_name=new_name)
         return await self._enqueue(job)
 

--- a/esphome_device_builder/controllers/firmware.py
+++ b/esphome_device_builder/controllers/firmware.py
@@ -644,6 +644,16 @@ class FirmwareController:
         # later.
         new_filename = f"{new_name}.yaml"
         await self._validate_configuration_boundary(new_filename)
+        # Reject same-name renames up-front: the operation is a no-op
+        # at the YAML level but still queues a real ``esphome rename``
+        # job that re-compiles and OTA-flashes the device, so the
+        # waste is real. Force the caller to use ``firmware/install``
+        # instead — that's what they actually want.
+        if new_filename == configuration:
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                "new_name must differ from the current device name",
+            )
         # Reject up-front if the target filename is already in use.
         # ``DevicesController.rename_device`` checks the same thing
         # before forwarding to this handler — but a direct WS client
@@ -653,18 +663,17 @@ class FirmwareController:
         # device's config and flashing that firmware to the wrong
         # device. Same error-message shape as the controller-layer
         # check so the frontend handles both identically.
-        if new_filename != configuration:
-            # ``new_filename`` already passed ``rel_path`` validation
-            # above, so we can build the path directly and stat it in
-            # one executor hop instead of paying a second ``rel_path``
-            # round-trip just to get back the same result.
-            new_path = self._db.settings.config_dir / new_filename
-            loop = asyncio.get_running_loop()
-            if await loop.run_in_executor(None, new_path.exists):
-                raise CommandError(
-                    ErrorCode.INVALID_ARGS,
-                    f"A device named {new_filename} already exists",
-                )
+        # ``new_filename`` already passed ``rel_path`` validation
+        # above, so we can build the path directly and stat it in
+        # one executor hop instead of paying a second ``rel_path``
+        # round-trip just to get back the same result.
+        new_path = self._db.settings.config_dir / new_filename
+        loop = asyncio.get_running_loop()
+        if await loop.run_in_executor(None, new_path.exists):
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                f"A device named {new_filename} already exists",
+            )
         job = self._create_job(configuration, JobType.RENAME, new_name=new_name)
         return await self._enqueue(job)
 

--- a/tests/test_firmware_traversal_validation.py
+++ b/tests/test_firmware_traversal_validation.py
@@ -177,22 +177,19 @@ async def test_rename_rejects_collision_with_existing_yaml(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_rename_allows_renaming_to_same_name(tmp_path: Path) -> None:
-    """Renaming to the same filename skips the collision check.
+async def test_rename_rejects_same_name(tmp_path: Path) -> None:
+    """``firmware/rename`` rejects ``new_name`` matching the current stem.
 
-    A no-op rename (``new_name`` matches the existing stem) is the
-    pattern users hit when re-flashing without changing the device
-    identity — the file is "already there" by definition, not a
-    collision with an unrelated device. Mirrors the
-    ``new_filename != configuration`` guard in
-    ``DevicesController.rename_device``.
+    A same-name rename is a no-op at the YAML level but still queues
+    a real ``esphome rename`` job that re-compiles and OTA-flashes
+    the device — wasted work the caller almost certainly didn't
+    intend. ``firmware/install`` is the correct command for "flash
+    without renaming".
     """
-    from unittest.mock import AsyncMock
-
     controller = _controller(tmp_path)
-    controller._enqueue = AsyncMock(side_effect=lambda job: job)
     (tmp_path / "kitchen.yaml").write_text("")
 
-    job = await controller.rename(configuration="kitchen.yaml", new_name="kitchen")
-    assert job.configuration == "kitchen.yaml"
-    assert job.new_name == "kitchen"
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename(configuration="kitchen.yaml", new_name="kitchen")
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "must differ" in excinfo.value.message

--- a/tests/test_firmware_traversal_validation.py
+++ b/tests/test_firmware_traversal_validation.py
@@ -153,3 +153,46 @@ async def test_rename_rejects_traversal_in_new_name(tmp_path: Path) -> None:
     with pytest.raises(CommandError) as excinfo:
         await controller.rename(configuration="kitchen.yaml", new_name="../etc/passwd")
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_rename_rejects_collision_with_existing_yaml(tmp_path: Path) -> None:
+    """``firmware/rename`` rejects ``new_name`` colliding with another device.
+
+    ``esphome rename`` does not check collisions itself — it blindly
+    ``write_text``s the new YAML and OTA-installs it, silently
+    overwriting the unrelated device's config and flashing that
+    firmware to the wrong device. ``DevicesController.rename_device``
+    checks before forwarding, but a direct WS client can bypass it;
+    the firmware-layer check closes that gap.
+    """
+    controller = _controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text("")
+    (tmp_path / "livingroom.yaml").write_text("")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename(configuration="kitchen.yaml", new_name="livingroom")
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "livingroom.yaml already exists" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_rename_allows_renaming_to_same_name(tmp_path: Path) -> None:
+    """Renaming to the same filename skips the collision check.
+
+    A no-op rename (``new_name`` matches the existing stem) is the
+    pattern users hit when re-flashing without changing the device
+    identity — the file is "already there" by definition, not a
+    collision with an unrelated device. Mirrors the
+    ``new_filename != configuration`` guard in
+    ``DevicesController.rename_device``.
+    """
+    from unittest.mock import AsyncMock
+
+    controller = _controller(tmp_path)
+    controller._enqueue = AsyncMock(side_effect=lambda job: job)
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.rename(configuration="kitchen.yaml", new_name="kitchen")
+    assert job.configuration == "kitchen.yaml"
+    assert job.new_name == "kitchen"

--- a/tests/test_rename_device.py
+++ b/tests/test_rename_device.py
@@ -93,6 +93,26 @@ async def test_rename_target_filename_collision_raises(monkeypatch: Any) -> None
 
 
 @pytest.mark.asyncio
+async def test_rename_same_name_raises() -> None:
+    """Renaming a device to its current name rejects up-front.
+
+    A same-name rename is a no-op at the YAML level but every
+    downstream branch (manual rewrite, CLI ``esphome rename``)
+    would still rewrite the file and (for the CLI path) re-flash.
+    Wasted work the caller almost certainly didn't intend —
+    ``firmware/install`` is the right command for "flash without
+    renaming."
+    """
+    controller = _make_controller()
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(configuration="kitchen.yaml", new_name="kitchen")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "must differ" in excinfo.value.message
+
+
+@pytest.mark.asyncio
 async def test_rename_invalid_yaml_uses_manual_path(monkeypatch: Any) -> None:
     """Invalid config → inline ``_manual_rename`` and ``job: None`` response."""
     controller = _make_controller()


### PR DESCRIPTION
## Summary

Two related bad-input cases now reject at the rename boundary with `CommandError(INVALID_ARGS)`:

1. **Same-name rename** — `new_name` matches the current device stem. A no-op at the YAML level, but every downstream branch still does real work: the manual-rewrite path rewrites the YAML to itself, the CLI ``esphome rename`` path re-compiles and OTA-flashes the device. Wasted work the caller almost certainly didn't intend; ``firmware/install`` is the correct command for "flash without renaming."
2. **Filename collision** — ``new_name`` resolves to a YAML that already exists for an unrelated device. ``esphome rename`` does not check collisions itself; it blindly ``write_text``s the new YAML and OTA-installs it, silently overwriting the unrelated device's config and flashing that firmware to the wrong device.

Both checks land at **both layers** for symmetry:

- `DevicesController.rename_device` — the legitimate frontend entry point. Catches earlier so the error shows before YAML-validate picks a strategy.
- `FirmwareController.rename` — covers direct WS clients that bypass the controller layer (the original `firmware/rename` was only gated by `_validate_configuration_boundary` after the merge of #124).

Same error-message shapes the controller already used (`"new_name must differ from the current device name"`, `"A device named <new>.yaml already exists"`) so the frontend handles all three layers identically.

## Implementation notes

- The previous `if new_filename != configuration` guard around the controller's collision check is gone — it was only there to allow same-name pass-through. Now that same-name is rejected up front, the guard was dead code.
- `new_filename` already passes `rel_path` validation immediately above the firmware-layer collision check; the check builds `config_dir / new_filename` directly and stats in **one** executor hop instead of paying a second `rel_path` round-trip just to get back the same resolved path.

## Test plan

- [x] `tests/test_firmware_traversal_validation.py::test_rename_rejects_collision_with_existing_yaml` — direct `firmware/rename` to an existing YAML raises `INVALID_ARGS` with the matching message.
- [x] `tests/test_firmware_traversal_validation.py::test_rename_rejects_same_name` — direct `firmware/rename` with `new_name` matching the current stem raises `INVALID_ARGS`.
- [x] `tests/test_rename_device.py::test_rename_same_name_raises` — controller-layer rejection of same-name.
- [x] Existing traversal coverage on `new_name` still passes.
- [x] Full local suite: 693 passed, 3 skipped.
- [x] Pre-commit clean.

Closes #126.