### PR TITLE
Migrate startup esphome probe off subprocess.run

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -100,8 +100,7 @@ class FirmwareController:
             " ".join(self._esphome_cmd),
             sys.executable,
         )
-        loop = asyncio.get_running_loop()
-        ok, detail = await loop.run_in_executor(None, _verify_esphome_importable, self._esphome_cmd)
+        ok, detail = await _verify_esphome_importable(self._esphome_cmd)
         if ok:
             _LOGGER.info("ESPHome CLI sanity check OK — %s", detail)
         else:

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -14,7 +14,6 @@ import ipaddress
 import logging
 import os
 import re
-import subprocess
 import sys
 from contextlib import suppress
 from datetime import UTC, datetime
@@ -341,32 +340,46 @@ def _validate_port(port: str) -> None:
     )
 
 
-def _verify_esphome_importable(cmd: list[str]) -> tuple[bool, str]:
+async def _verify_esphome_importable(cmd: list[str]) -> tuple[bool, str]:
     """Sanity-check that ``cmd`` can actually import esphome.
 
-    Runs ``cmd --dashboard --version`` synchronously with a short
-    timeout. Used at backend startup so misconfigured environments
-    (venv missing esphome, wrong sys.executable, broken shim script)
-    surface as a clear log line rather than a cryptic "No module named
-    esphome" output captured during the user's first compile attempt.
+    Runs ``cmd --dashboard --version`` with a short timeout. Used at
+    backend startup so misconfigured environments (venv missing
+    esphome, wrong sys.executable, broken shim script) surface as a
+    clear log line rather than a cryptic "No module named esphome"
+    output captured during the user's first compile attempt.
 
     ``--dashboard`` is included in the probe so we also fail fast on
     an installed ESPHome that doesn't recognise the flag (very old
     builds): every real job command now passes ``--dashboard``, so a
     sanity check without it would let a broken pairing slip through to
     the user's first compile.
+
+    Async + ``create_subprocess_exec`` so the spawn inherits the
+    ``close_fds=False`` choice every other dashboard subprocess uses
+    (see ``helpers/subprocess.py`` — ``close_fds=True`` walks
+    ``/proc/self/fd`` per spawn and is wasted work on memory-pressured
+    systems). ``subprocess.run`` would have spawned with the stdlib
+    default and skipped the optimisation.
     """
     try:
-        proc = subprocess.run(  # noqa: S603 — cmd is built from sys.executable, not user input
-            [*cmd, "--dashboard", "--version"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-            check=False,
+        proc = await create_subprocess_exec(
+            *cmd,
+            "--dashboard",
+            "--version",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
         )
-    except (OSError, subprocess.TimeoutExpired) as exc:
+    except OSError as exc:
         return False, f"{type(exc).__name__}: {exc}"
-    output = (proc.stdout + proc.stderr).strip()
+    try:
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
+    except TimeoutError:
+        with suppress(ProcessLookupError):
+            proc.kill()
+        await proc.wait()
+        return False, "TimeoutExpired: 15s probe didn't return"
+    output = stdout.decode("utf-8", errors="replace").strip()
     if proc.returncode != 0 or "No module named" in output or "ModuleNotFoundError" in output:
         return False, output or f"exit {proc.returncode}"
     return True, output

--- a/tests/controllers/firmware/test_helpers.py
+++ b/tests/controllers/firmware/test_helpers.py
@@ -1,4 +1,4 @@
-"""Tests for module-level helpers in ``controllers/firmware.py``.
+"""Tests for module-level helpers in ``controllers/firmware/helpers.py``.
 
 The firmware controller has a few pure helpers at file scope
 that aren't covered elsewhere:
@@ -8,12 +8,16 @@ that aren't covered elsewhere:
 * ``_names_touched_by_job`` — feeds the rename-lock collision
   check; a rename touches two YAMLs (old + new), every other
   job type touches one.
+* ``_verify_esphome_importable`` — startup probe, returns
+  ``(True, version)`` on success and ``(False, reason)`` on
+  exit-code failure / error-pattern detection / OSError /
+  timeout.
 
 The other module-level helpers are already covered by their
 own dedicated test files:
 
 * ``_validate_port`` → ``test_install_to_specific_address.py``
-* ``_parse_progress`` → ``test_firmware_progress.py``
+* ``_parse_progress`` → ``test_progress.py``
 * ``_mark_job_terminal`` → ``test_mark_job_terminal.py``
 
 Per Copilot's review, this PR doesn't re-cover those — keeping
@@ -23,7 +27,10 @@ expectations in one place avoids drift.
 from __future__ import annotations
 
 import re
+import sys
 from typing import Any
+
+import pytest
 
 from esphome_device_builder.controllers.firmware.constants import (
     _MAX_OUTPUT_LINES_RETAINED,
@@ -32,6 +39,7 @@ from esphome_device_builder.controllers.firmware.constants import (
 from esphome_device_builder.controllers.firmware.helpers import (
     _names_touched_by_job,
     _trim_job_output,
+    _verify_esphome_importable,
 )
 from esphome_device_builder.models.firmware import (
     FirmwareJob,
@@ -156,3 +164,60 @@ def test_names_touched_by_job_with_empty_configuration_is_empty() -> None:
     """
     job = _make_job(configuration="", job_type=JobType.RESET_BUILD_ENV)
     assert _names_touched_by_job(job) == set()
+
+
+# ---------------------------------------------------------------------------
+# _verify_esphome_importable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_esphome_importable_success_with_known_module() -> None:
+    """A trivial Python ``-c`` that prints its version returns ``(True, output)``.
+
+    Exercises the spawn path against a known-importable command —
+    we don't need the real ``esphome`` CLI for this; a one-liner
+    that exits 0 with no error patterns is enough to lock the
+    happy-path tuple shape.
+    """
+    cmd = [sys.executable, "-c", "print('1.2.3')"]
+    ok, detail = await _verify_esphome_importable(cmd)
+    assert ok
+    assert "1.2.3" in detail
+
+
+@pytest.mark.asyncio
+async def test_verify_esphome_importable_returns_false_on_no_module_named() -> None:
+    """Even on a 0 exit, output containing ``No module named`` flips the result.
+
+    Captures the case where a wrapper script exits 0 but its
+    stderr/stdout still complains about a missing module — the
+    historical class of failure that motivated this probe.
+    """
+    cmd = [sys.executable, "-c", "import sys; print(\"No module named 'esphome'\"); sys.exit(0)"]
+    ok, detail = await _verify_esphome_importable(cmd)
+    assert not ok
+    assert "No module named" in detail
+
+
+@pytest.mark.asyncio
+async def test_verify_esphome_importable_returns_false_on_nonzero_exit() -> None:
+    """Non-zero exit → ``(False, output_or_exit_marker)``."""
+    cmd = [sys.executable, "-c", "import sys; sys.exit(3)"]
+    ok, detail = await _verify_esphome_importable(cmd)
+    assert not ok
+    assert "exit 3" in detail
+
+
+@pytest.mark.asyncio
+async def test_verify_esphome_importable_returns_false_on_oserror() -> None:
+    """A missing executable returns ``(False, "FileNotFoundError: ...")``.
+
+    Pre-migration the sync version caught ``OSError`` directly;
+    the async version uses the same except branch around
+    ``create_subprocess_exec``.
+    """
+    cmd = ["/this/path/does/not/exist/no-such-binary"]
+    ok, detail = await _verify_esphome_importable(cmd)
+    assert not ok
+    assert "FileNotFoundError" in detail or "OSError" in detail


### PR DESCRIPTION
## Summary

The startup probe in ``firmware/helpers.py`` was the last ``subprocess.run`` call in the package — every other spawn already goes through ``helpers.subprocess.create_subprocess_exec`` so it gets ``close_fds=False`` (avoids walking ``/proc/self/fd`` per spawn on memory-pressured systems). The sync version slipped through the original migration because it ran inside a ``loop.run_in_executor`` wrapper rather than on the event loop directly, so it didn't surface in the audit pass that fixed the async sites.

## What changed

- ``_verify_esphome_importable`` is now async and called directly from ``FirmwareController.start`` — no executor wrapper needed because ``create_subprocess_exec`` is itself non-blocking.
- Output capture moves from ``capture_output=True`` / ``text=True`` to ``stdout=PIPE`` / ``stderr=STDOUT`` plus a UTF-8 decode of the ``communicate`` bytes.
- The 15-second timeout uses ``asyncio.wait_for`` and explicitly kills + reaps the lingering process on expiry rather than letting ``subprocess.TimeoutExpired`` do it.
- ``import subprocess`` removed from ``firmware/helpers.py`` — no more sync subprocess imports anywhere in the package.

## Out of scope

The ``script/`` directory still has ``subprocess.run`` in ``sync_components.py`` and ``sync_esphome_devices.py``. Those are build/sync helpers that run independently of the dashboard runtime, so the ``close_fds`` optimisation doesn't apply. Leaving them on the stdlib helper.

## Test plan

- [x] ``tests/controllers/firmware/test_helpers.py`` — four new cases for ``_verify_esphome_importable``: success returns ``(True, output)``, ``No module named`` on 0 exit flips to ``False``, non-zero exit returns ``"exit N"``, ``OSError`` (missing binary) returns ``(False, "FileNotFoundError: ...")``.
- [x] Full local suite: 705 passed, 3 skipped.
- [x] Pre-commit clean.

The timeout branch is left uncovered — driving it deterministically requires a sleeping subprocess + clock manipulation that buys little; the implementation is a small ``wait_for + kill + wait`` shape and the failure mode would be obvious in a real probe.