### PR TITLE
Drop pointless except CancelledError: pass on background loops

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -810,16 +810,13 @@ class DeviceStateMonitor:
         # is about to flip ONLINE for free, but still gets the UNKNOWN
         # → OFFLINE transition in front of the user within ~10s of
         # startup instead of after a full minute.
-        try:
-            await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
+        await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
+        await self._resolve_non_api_mdns_targets()
+        await self._ping_sweep()
+        while True:
+            await asyncio.sleep(_PING_INTERVAL)
             await self._resolve_non_api_mdns_targets()
             await self._ping_sweep()
-            while True:
-                await asyncio.sleep(_PING_INTERVAL)
-                await self._resolve_non_api_mdns_targets()
-                await self._ping_sweep()
-        except asyncio.CancelledError:
-            pass
 
     async def _resolve_non_api_mdns_targets(self) -> None:
         """Actively resolve ``.local`` hostnames for non-API devices.

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -652,14 +652,11 @@ class FirmwareController:
 
     async def _run_queue(self) -> None:
         """Background loop: process one job at a time."""
-        try:
-            while True:
-                job = await self._queue.get()
-                if job.status == JobStatus.CANCELLED:
-                    continue
-                await self._execute_job(job)
-        except asyncio.CancelledError:
-            pass
+        while True:
+            job = await self._queue.get()
+            if job.status == JobStatus.CANCELLED:
+                continue
+            await self._execute_job(job)
 
     async def _execute_job(self, job: FirmwareJob) -> None:  # noqa: PLR0912, PLR0915
         """Execute a single firmware job."""

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -224,13 +224,10 @@ class DeviceBuilder:
 
     async def _run_background(self) -> None:
         """Background polling loop."""
-        try:
-            while True:
-                await asyncio.sleep(5)
-                if self.devices:
-                    await self.devices.poll()
-        except asyncio.CancelledError:
-            pass
+        while True:
+            await asyncio.sleep(5)
+            if self.devices:
+                await self.devices.poll()
 
     @staticmethod
     async def _cmd_ping(**kwargs: Any) -> dict:


### PR DESCRIPTION
## Summary

Three background-loop coroutines were wrapping their entire body in `try/except asyncio.CancelledError: pass`. The intent was "exit cleanly on shutdown" but cancellation already does that when nothing catches it — the wrapper just turns a `CancelledError` into a normal return, which:

- Hides the cancellation from `asyncio.gather(*tasks, return_exceptions=True)` and similar lifecycle-tracking callers, which then can't tell "I cancelled this" from "this finished by itself".
- Risks masking a `CancelledError` raised from somewhere unexpected.

Removed in three places where the body has no actual cancel work:

- `DeviceStateMonitor._ping_loop`
- `DeviceBuilder._run_background`
- `FirmwareController._runner` (queue consumer)

Other `except CancelledError` sites in the codebase intentionally do work in the cancel branch (kill subprocess, fire `JOB_CANCELLED`, mark job terminal) and `raise` afterwards — those are correct and unchanged.

## Test plan

- [x] `uv run pytest --ignore=tests/benchmarks` — 701 passed.