### PR TITLE
Split controllers/devices.py into a subpackage

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -1,0 +1,20 @@
+"""
+Devices controller package — public surface.
+
+Re-exports ``DevicesController`` so existing
+``from .controllers.devices import DevicesController`` imports keep
+resolving after the subpackage split. Submodules:
+
+- ``constants`` — module-level regexes and other static config.
+- ``helpers`` — pure free functions (``_remove_device_sidecars``,
+  ``_apply_featured_presets``, ``_build_address_cache_args``,
+  ``friendly_name_slugify`` re-export).
+- ``controller`` — ``DevicesController`` itself + the scan / state
+  / MQTT bridge.
+"""
+
+from __future__ import annotations
+
+from .controller import DevicesController
+
+__all__ = ["DevicesController"]

--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -16,5 +16,6 @@ resolving after the subpackage split. Submodules:
 from __future__ import annotations
 
 from .controller import DevicesController
+from .helpers import friendly_name_slugify
 
-__all__ = ["DevicesController"]
+__all__ = ["DevicesController", "friendly_name_slugify"]

--- a/esphome_device_builder/controllers/devices/constants.py
+++ b/esphome_device_builder/controllers/devices/constants.py
@@ -1,0 +1,35 @@
+"""
+Static configuration for the devices controller.
+
+Module-level constants shared between the controller and helpers.
+Pure data — no I/O, no controller state.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Match an ANSI conceal-wrapped run. ESPHome's ``command_config``
+# emits this around every ``password|key|psk|ssid`` value when
+# ``--show-secrets`` is off, on the assumption that the terminal
+# will hide it via the Concealed SGR (8) and reveal it again with
+# 28. Browsers don't honour those codes, so the resolved secret
+# bytes render plainly in our HTML ansi-log.
+#
+# Two byte representations to handle:
+#
+# - ``\x1b[8m...\x1b[28m`` — raw ESC byte. What you get reading
+#   ``esphome config`` directly without ``--dashboard``.
+# - ``\033[8m...\033[28m`` — the literal four-character escape
+#   sequence. ``--dashboard`` mode replaces every real ANSI escape
+#   with this so the dashboard can re-decode them on render. We
+#   pass ``--dashboard`` on every validate, so this is the form we
+#   actually see on the wire.
+#
+# Match both so a future ESPHome change to either side stays
+# scrubbed. Replace the whole wrapped run including the escape
+# codes — leaving the literal ``\033[8m`` bytes in the output
+# would still expose the secret to anyone screen-recording the
+# network tab even if a hypothetical conceal-aware renderer hid
+# the visible glyphs.
+_CONCEALED_SECRET_RE = re.compile(r"(?:\x1b|\\033)\[8m.*?(?:\x1b|\\033)\[28m")

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1,4 +1,10 @@
-"""Devices controller — device CRUD, file watching, CLI operations, state management."""
+"""
+Devices controller — device CRUD, file watching, CLI operations, state management.
+
+WS command surface plus the supporting state-monitor / scanner /
+MQTT-coordinator glue. Pure data and free helpers live in
+``constants.py`` and ``helpers.py``; the class itself lives here.
+"""
 
 from __future__ import annotations
 
@@ -6,47 +12,31 @@ import asyncio
 import contextlib
 import logging
 import os
-import re
 import shutil
 from collections.abc import Callable
 from dataclasses import replace
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from esphome import const
 from esphome.components.dashboard_import import import_config
-
-try:
-    # ``friendly_name_slugify`` lives in ``esphome.helpers`` from
-    # esphome/esphome#16206 onwards so it survives the legacy
-    # dashboard's eventual removal. Older esphome releases still
-    # expose it from ``esphome.dashboard.util.text``; fall through
-    # only for that back-compat case so we don't carry a hard
-    # dependency on the dashboard package once it's gone.
-    from esphome.helpers import friendly_name_slugify
-except ImportError:  # pragma: no cover — covered by the import below
-    from esphome.dashboard.util.text import friendly_name_slugify
-
-from esphome.helpers import sort_ip_addresses
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 
-from ..helpers.api import CommandError, api_command
-from ..helpers.config_hash import compute_yaml_config_hash, read_build_info_hash
-from ..helpers.device_yaml import (
+from ...helpers.api import CommandError, api_command
+from ...helpers.config_hash import compute_yaml_config_hash, read_build_info_hash
+from ...helpers.device_yaml import (
     generate_device_yaml,
     get_api_encryption_key,
     load_device_yaml,
     parse_esphome_meta,
     parse_platform_from_yaml,
 )
-from ..helpers.hostname import is_local_hostname, normalize_hostname
-from ..helpers.json import JSONDecodeError, dumps_indent, loads
-from ..helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
-from ..helpers.yaml import merge_component_yaml, rewrite_esphome_name
-from ..models import (
+from ...helpers.json import JSONDecodeError, dumps_indent, loads
+from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
+from ...helpers.yaml import merge_component_yaml, rewrite_esphome_name
+from ...models import (
     AddComponentResponse,
     AdoptableDevice,
-    ConfigEntryType,
     Device,
     DevicesResponse,
     DeviceState,
@@ -57,92 +47,28 @@ from ..models import (
     UpdateDeviceResponse,
     WizardResponse,
 )
-from ._device_mqtt_coordinator import DeviceMqttCoordinator
-from ._device_scanner import DeviceFileMetadata, DeviceScanner, ScanChange
-from ._device_state_monitor import DeviceStateMonitor
-from .config import (
+from .._device_mqtt_coordinator import DeviceMqttCoordinator
+from .._device_scanner import DeviceFileMetadata, DeviceScanner, ScanChange
+from .._device_state_monitor import DeviceStateMonitor
+from ..config import (
     get_device_metadata,
     remove_device_metadata,
     set_device_metadata,
 )
+from .helpers import (
+    _apply_featured_presets,
+    _build_address_cache_args,
+    _redact_concealed_secrets,
+    _remove_device_sidecars,
+    _validate_archive_configuration,
+    _wipe_device_build_dir,
+    friendly_name_slugify,
+)
 
 if TYPE_CHECKING:
-    from ..device_builder import DeviceBuilder
-    from .components import _FeaturedRecord
+    from ...device_builder import DeviceBuilder
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _wipe_device_build_dir(configuration: str) -> None:
-    """Remove the per-device build dir if one exists.
-
-    Reads the canonical ``build_path`` off the StorageJSON sidecar
-    (set during compile) and ``shutil.rmtree``s it. No-op when the
-    sidecar is gone or the device has never been built. Used by
-    archive and delete; both treat compile output as dead weight.
-    """
-    storage_path = ext_storage_path(configuration)
-    storage = StorageJSON.load(storage_path)
-    if storage is not None and storage.build_path:
-        shutil.rmtree(storage.build_path, ignore_errors=True)
-
-
-def _remove_device_sidecars(config_dir: Path, configuration: str) -> None:
-    """Remove the StorageJSON sidecar and device-metadata entry.
-
-    Best-effort — failures are logged but don't propagate, so a
-    partial cleanup (e.g. permission error on one file) doesn't
-    block the rest of the archive / delete flow. Used by archive,
-    delete, and delete_archived; all three want a "leave no
-    trace under this filename" semantic at the end of their flow.
-    """
-    storage_path = ext_storage_path(configuration)
-    try:
-        storage_path.unlink(missing_ok=True)
-    except OSError:
-        _LOGGER.warning("Could not remove storage file for %s", configuration)
-    try:
-        remove_device_metadata(config_dir, configuration)
-    except Exception:
-        _LOGGER.warning("Could not remove metadata for %s", configuration)
-
-
-def _validate_archive_configuration(configuration: str) -> None:
-    """Reject anything that isn't a pure basename.
-
-    Defense-in-depth at the public-command boundary for archive /
-    unarchive / delete_archived. Each helper builds paths from the
-    user-supplied filename (``<config_dir>/archive/<configuration>``,
-    ``ext_storage_path(configuration)`` -> ``data_dir/storage/<configuration>.json``)
-    that don't all flow through ``Settings.rel_path`` — a value
-    containing path separators or ``..`` segments could resolve
-    outside the intended directory and be unlinked / overwritten.
-
-    Reject anything where ``Path(value).name != value`` (catches
-    ``../foo``, ``sub/foo``, backslash-separated paths on Windows),
-    the empty string, and the special path components ``.`` / ``..``
-    that pass the ``.name`` round-trip but are still traversal
-    vectors.
-    """
-    if not configuration:
-        raise CommandError(ErrorCode.INVALID_ARGS, "configuration must not be empty")
-    if configuration in (".", ".."):
-        raise CommandError(
-            ErrorCode.INVALID_ARGS,
-            f"configuration must be a plain filename, not {configuration!r}",
-        )
-    if (
-        "/" in configuration
-        or "\\" in configuration
-        or "\x00" in configuration
-        or PurePosixPath(configuration).name != configuration
-        or PureWindowsPath(configuration).name != configuration
-    ):
-        raise CommandError(
-            ErrorCode.INVALID_ARGS,
-            f"configuration must be a plain filename without path separators, "
-            f"got {configuration!r}",
-        )
 
 
 class DevicesController:
@@ -1934,161 +1860,3 @@ class DevicesController:
         await client.send_event(
             message_id, "result", {"success": exit_code == 0, "code": exit_code}
         )
-
-
-# Match an ANSI conceal-wrapped run. ESPHome's ``command_config``
-# emits this around every ``password|key|psk|ssid`` value when
-# ``--show-secrets`` is off, on the assumption that the terminal
-# will hide it via the Concealed SGR (8) and reveal it again with
-# 28. Browsers don't honour those codes, so the resolved secret
-# bytes render plainly in our HTML ansi-log.
-#
-# Two byte representations to handle:
-#
-# - ``\x1b[8m...\x1b[28m`` — raw ESC byte. What you get reading
-#   ``esphome config`` directly without ``--dashboard``.
-# - ``\033[8m...\033[28m`` — the literal four-character escape
-#   sequence. ``--dashboard`` mode replaces every real ANSI escape
-#   with this so the dashboard can re-decode them on render. We
-#   pass ``--dashboard`` on every validate, so this is the form we
-#   actually see on the wire.
-#
-# Match both so a future ESPHome change to either side stays
-# scrubbed. Replace the whole wrapped run including the escape
-# codes — leaving the literal ``\033[8m`` bytes in the output
-# would still expose the secret to anyone screen-recording the
-# network tab even if a hypothetical conceal-aware renderer hid
-# the visible glyphs.
-_CONCEALED_SECRET_RE = re.compile(r"(?:\x1b|\\033)\[8m.*?(?:\x1b|\\033)\[28m")
-
-
-def _redact_concealed_secrets(line: str) -> str:
-    """Replace ANSI-conceal-wrapped secret runs with ``<removed>``."""
-    return _CONCEALED_SECRET_RE.sub("<removed>", line)
-
-
-def _apply_featured_presets(
-    record: _FeaturedRecord,
-    user_fields: dict[str, Any],
-) -> dict[str, Any]:
-    """
-    Merge a featured component's presets onto *user_fields*.
-
-    Returns a new field map ready for the regular merge logic; raises
-    ``ValueError`` when *user_fields* violates a preset constraint.
-
-    Per-field semantics:
-
-    - Locked: user must omit the key or supply the locked value verbatim.
-    - Suggestions: user-supplied value must be one of the listed values;
-      omission falls back to the preset's ``value`` (when set).
-    - Plain default: filled in only when the user didn't supply one.
-
-    Pin-typed fields can arrive in two ESPHome shapes — bare GPIO
-    (``pin: 12``) or rich mapping (``pin: {number: 12, mode: ..., inverted: ...}``).
-    Equality / membership checks compare on the bare GPIO so a manifest's
-    ``suggestions: [4, 5]`` accepts whichever shape the frontend submits.
-    """
-    entries_by_key = {ce.key: ce for ce in record.underlying.config_entries}
-    merged: dict[str, Any] = dict(user_fields)
-    for key, preset in record.featured.fields.items():
-        user_value = merged.get(key)
-        user_supplied = key in merged
-        is_pin = entries_by_key.get(key) is not None and (
-            entries_by_key[key].type == ConfigEntryType.PIN
-        )
-        compare_user = _normalize_pin_value(user_value) if is_pin else user_value
-        compare_preset = _normalize_pin_value(preset.value) if is_pin else preset.value
-        if preset.locked:
-            # Schema validation rejects ``locked: true`` without a value, but
-            # guard the runtime too so a malformed manifest fails fast with a
-            # clear error instead of "locked to None".
-            if preset.value is None:
-                msg = (
-                    f"Featured component {record.full_id} field '{key}' has "
-                    f"locked=true without a value — board manifest is malformed"
-                )
-                raise ValueError(msg)
-            if user_supplied and compare_user != compare_preset:
-                msg = (
-                    f"Featured component {record.full_id} field '{key}' is "
-                    f"locked to {preset.value!r}; cannot override with "
-                    f"{user_value!r}"
-                )
-                raise ValueError(msg)
-            merged[key] = preset.value
-            continue
-        if preset.suggestions is not None:
-            if user_supplied:
-                if compare_user not in preset.suggestions:
-                    msg = (
-                        f"Featured component {record.full_id} field '{key}' "
-                        f"must be one of {preset.suggestions}; got "
-                        f"{user_value!r}"
-                    )
-                    raise ValueError(msg)
-            elif preset.value is not None:
-                merged[key] = preset.value
-            continue
-        if not user_supplied and preset.value is not None:
-            merged[key] = preset.value
-    return merged
-
-
-def _normalize_pin_value(value: Any) -> Any:
-    """
-    Reduce a rich pin mapping to its bare GPIO for comparison.
-
-    ESPHome accepts pins as either a bare integer / string label or as
-    a ``{number, mode, inverted, ...}`` mapping. Featured-component
-    presets express ``suggestions`` and bare-int ``value``s as scalars;
-    the frontend submits the mapping form. Returning the inner
-    ``number`` (when present) lets the locked / suggestion checks
-    treat both shapes equivalently.
-
-    ``bool`` is excluded explicitly since it's an ``int`` subclass.
-    """
-    if isinstance(value, dict):
-        number = value.get("number")
-        if isinstance(number, (int, str)) and not isinstance(number, bool):
-            return number
-    return value
-
-
-def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None) -> list[str]:
-    """Build CLI cache args from the IPs we already have for *device*."""
-    address = device.address
-    if not address:
-        return []
-
-    # mDNS hostnames are case-insensitive and may carry a trailing dot;
-    # normalise once so the CLI cache key matches what it'll look up.
-    normalized = normalize_hostname(address)
-    is_local = is_local_hostname(address)
-
-    # Preferred source per host type:
-    #   .local  → zeroconf cache (mDNS-only, freshest while the browser is alive)
-    #   non-.local → DNS cache populated by the ping sweep's pre-resolve pass
-    # Either falls back to ``device.ip`` (the last-known resolved IP) so
-    # an expired cache entry doesn't strip the cache args entirely.
-    addresses: list[str] = []
-    if monitor is not None:
-        cached = (
-            monitor.get_cached_addresses(address)
-            if is_local
-            else monitor.get_cached_dns_addresses(address)
-        )
-        if cached:
-            addresses = list(cached)
-
-    if not addresses and device.ip:
-        addresses = [device.ip]
-
-    if not addresses:
-        return []
-
-    cache_type = "mdns" if is_local else "dns"
-    return [
-        f"--{cache_type}-address-cache",
-        f"{normalized}={','.join(sort_ip_addresses(addresses))}",
-    ]

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -1,0 +1,258 @@
+"""
+Pure helpers for the devices controller.
+
+Free functions only — no controller state. ``_remove_device_sidecars``,
+``_apply_featured_presets``, and ``_build_address_cache_args`` are
+imported by tests; the rest are private to the controller. The
+``friendly_name_slugify`` re-export keeps a single import path for
+the rest of the codebase regardless of where esphome upstream
+decides to keep it.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING, Any
+
+try:
+    # ``friendly_name_slugify`` lives in ``esphome.helpers`` from
+    # esphome/esphome#16206 onwards so it survives the legacy
+    # dashboard's eventual removal. Older esphome releases still
+    # expose it from ``esphome.dashboard.util.text``; fall through
+    # only for that back-compat case so we don't carry a hard
+    # dependency on the dashboard package once it's gone.
+    from esphome.helpers import friendly_name_slugify
+except ImportError:  # pragma: no cover — covered by the import below
+    from esphome.dashboard.util.text import friendly_name_slugify
+
+from esphome.helpers import sort_ip_addresses
+from esphome.storage_json import StorageJSON, ext_storage_path
+
+from ...helpers.api import CommandError
+from ...helpers.hostname import is_local_hostname, normalize_hostname
+from ...models import ConfigEntryType, Device, ErrorCode
+from ..config import remove_device_metadata
+from .constants import _CONCEALED_SECRET_RE
+
+if TYPE_CHECKING:
+    from .._device_state_monitor import DeviceStateMonitor
+    from ..components import _FeaturedRecord
+
+__all__ = [
+    "_apply_featured_presets",
+    "_build_address_cache_args",
+    "_normalize_pin_value",
+    "_redact_concealed_secrets",
+    "_remove_device_sidecars",
+    "_validate_archive_configuration",
+    "_wipe_device_build_dir",
+    "friendly_name_slugify",
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _wipe_device_build_dir(configuration: str) -> None:
+    """Remove the per-device build dir if one exists.
+
+    Reads the canonical ``build_path`` off the StorageJSON sidecar
+    (set during compile) and ``shutil.rmtree``s it. No-op when the
+    sidecar is gone or the device has never been built. Used by
+    archive and delete; both treat compile output as dead weight.
+    """
+    storage_path = ext_storage_path(configuration)
+    storage = StorageJSON.load(storage_path)
+    if storage is not None and storage.build_path:
+        shutil.rmtree(storage.build_path, ignore_errors=True)
+
+
+def _remove_device_sidecars(config_dir: Path, configuration: str) -> None:
+    """Remove the StorageJSON sidecar and device-metadata entry.
+
+    Best-effort — failures are logged but don't propagate, so a
+    partial cleanup (e.g. permission error on one file) doesn't
+    block the rest of the archive / delete flow. Used by archive,
+    delete, and delete_archived; all three want a "leave no
+    trace under this filename" semantic at the end of their flow.
+    """
+    storage_path = ext_storage_path(configuration)
+    try:
+        storage_path.unlink(missing_ok=True)
+    except OSError:
+        _LOGGER.warning("Could not remove storage file for %s", configuration)
+    try:
+        remove_device_metadata(config_dir, configuration)
+    except Exception:
+        _LOGGER.warning("Could not remove metadata for %s", configuration)
+
+
+def _validate_archive_configuration(configuration: str) -> None:
+    """Reject anything that isn't a pure basename.
+
+    Defense-in-depth at the public-command boundary for archive /
+    unarchive / delete_archived. Each helper builds paths from the
+    user-supplied filename (``<config_dir>/archive/<configuration>``,
+    ``ext_storage_path(configuration)`` -> ``data_dir/storage/<configuration>.json``)
+    that don't all flow through ``Settings.rel_path`` — a value
+    containing path separators or ``..`` segments could resolve
+    outside the intended directory and be unlinked / overwritten.
+
+    Reject anything where ``Path(value).name != value`` (catches
+    ``../foo``, ``sub/foo``, backslash-separated paths on Windows),
+    the empty string, and the special path components ``.`` / ``..``
+    that pass the ``.name`` round-trip but are still traversal
+    vectors.
+    """
+    if not configuration:
+        raise CommandError(ErrorCode.INVALID_ARGS, "configuration must not be empty")
+    if configuration in (".", ".."):
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            f"configuration must be a plain filename, not {configuration!r}",
+        )
+    if (
+        "/" in configuration
+        or "\\" in configuration
+        or "\x00" in configuration
+        or PurePosixPath(configuration).name != configuration
+        or PureWindowsPath(configuration).name != configuration
+    ):
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            f"configuration must be a plain filename without path separators, "
+            f"got {configuration!r}",
+        )
+
+
+def _redact_concealed_secrets(line: str) -> str:
+    """Replace ANSI-conceal-wrapped secret runs with ``<removed>``."""
+    return _CONCEALED_SECRET_RE.sub("<removed>", line)
+
+
+def _normalize_pin_value(value: Any) -> Any:
+    """
+    Reduce a rich pin mapping to its bare GPIO for comparison.
+
+    ESPHome accepts pins as either a bare integer / string label or as
+    a ``{number, mode, inverted, ...}`` mapping. Featured-component
+    presets express ``suggestions`` and bare-int ``value``s as scalars;
+    the frontend submits the mapping form. Returning the inner
+    ``number`` (when present) lets the locked / suggestion checks
+    treat both shapes equivalently.
+
+    ``bool`` is excluded explicitly since it's an ``int`` subclass.
+    """
+    if isinstance(value, dict):
+        number = value.get("number")
+        if isinstance(number, (int, str)) and not isinstance(number, bool):
+            return number
+    return value
+
+
+def _apply_featured_presets(
+    record: _FeaturedRecord,
+    user_fields: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Merge a featured component's presets onto *user_fields*.
+
+    Returns a new field map ready for the regular merge logic; raises
+    ``ValueError`` when *user_fields* violates a preset constraint.
+
+    Per-field semantics:
+
+    - Locked: user must omit the key or supply the locked value verbatim.
+    - Suggestions: user-supplied value must be one of the listed values;
+      omission falls back to the preset's ``value`` (when set).
+    - Plain default: filled in only when the user didn't supply one.
+
+    Pin-typed fields can arrive in two ESPHome shapes — bare GPIO
+    (``pin: 12``) or rich mapping (``pin: {number: 12, mode: ..., inverted: ...}``).
+    Equality / membership checks compare on the bare GPIO so a manifest's
+    ``suggestions: [4, 5]`` accepts whichever shape the frontend submits.
+    """
+    entries_by_key = {ce.key: ce for ce in record.underlying.config_entries}
+    merged: dict[str, Any] = dict(user_fields)
+    for key, preset in record.featured.fields.items():
+        user_value = merged.get(key)
+        user_supplied = key in merged
+        is_pin = entries_by_key.get(key) is not None and (
+            entries_by_key[key].type == ConfigEntryType.PIN
+        )
+        compare_user = _normalize_pin_value(user_value) if is_pin else user_value
+        compare_preset = _normalize_pin_value(preset.value) if is_pin else preset.value
+        if preset.locked:
+            # Schema validation rejects ``locked: true`` without a value, but
+            # guard the runtime too so a malformed manifest fails fast with a
+            # clear error instead of "locked to None".
+            if preset.value is None:
+                msg = (
+                    f"Featured component {record.full_id} field '{key}' has "
+                    f"locked=true without a value — board manifest is malformed"
+                )
+                raise ValueError(msg)
+            if user_supplied and compare_user != compare_preset:
+                msg = (
+                    f"Featured component {record.full_id} field '{key}' is "
+                    f"locked to {preset.value!r}; cannot override with "
+                    f"{user_value!r}"
+                )
+                raise ValueError(msg)
+            merged[key] = preset.value
+            continue
+        if preset.suggestions is not None:
+            if user_supplied:
+                if compare_user not in preset.suggestions:
+                    msg = (
+                        f"Featured component {record.full_id} field '{key}' "
+                        f"must be one of {preset.suggestions}; got "
+                        f"{user_value!r}"
+                    )
+                    raise ValueError(msg)
+            elif preset.value is not None:
+                merged[key] = preset.value
+            continue
+        if not user_supplied and preset.value is not None:
+            merged[key] = preset.value
+    return merged
+
+
+def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None) -> list[str]:
+    """Build CLI cache args from the IPs we already have for *device*."""
+    address = device.address
+    if not address:
+        return []
+
+    # mDNS hostnames are case-insensitive and may carry a trailing dot;
+    # normalise once so the CLI cache key matches what it'll look up.
+    normalized = normalize_hostname(address)
+    is_local = is_local_hostname(address)
+
+    # Preferred source per host type:
+    #   .local  → zeroconf cache (mDNS-only, freshest while the browser is alive)
+    #   non-.local → DNS cache populated by the ping sweep's pre-resolve pass
+    # Either falls back to ``device.ip`` (the last-known resolved IP) so
+    # an expired cache entry doesn't strip the cache args entirely.
+    addresses: list[str] = []
+    if monitor is not None:
+        cached = (
+            monitor.get_cached_addresses(address)
+            if is_local
+            else monitor.get_cached_dns_addresses(address)
+        )
+        if cached:
+            addresses = list(cached)
+
+    if not addresses and device.ip:
+        addresses = [device.ip]
+
+    if not addresses:
+        return []
+
+    cache_type = "mdns" if is_local else "dns"
+    return [
+        f"--{cache_type}-address-cache",
+        f"{normalized}={','.join(sort_ip_addresses(addresses))}",
+    ]

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -1,12 +1,11 @@
 """
 Pure helpers for the devices controller.
 
-Free functions only — no controller state. ``_remove_device_sidecars``,
-``_apply_featured_presets``, and ``_build_address_cache_args`` are
-imported by tests; the rest are private to the controller. The
-``friendly_name_slugify`` re-export keeps a single import path for
-the rest of the codebase regardless of where esphome upstream
-decides to keep it.
+Free functions only — no controller state. A small subset of helpers
+is imported outside ``controller.py``, including by tests, and
+``friendly_name_slugify`` is re-exported here to keep a single import
+path for the rest of the codebase regardless of where esphome
+upstream decides to keep it.
 """
 
 from __future__ import annotations

--- a/tests/controllers/devices/__init__.py
+++ b/tests/controllers/devices/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``controllers/devices/`` — split mirrors the production subpackage."""

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -106,11 +106,18 @@ def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
     Autouse because both ``_archive_single`` and ``_list_archived_sync``
     reach into ``ext_storage_path`` — keeping the redirect in one
     place avoids future tests accidentally hitting the real CORE.
+
+    Patches both the controller and helpers modules: ``_archive_single``
+    sits in ``controller.py`` but it delegates to ``_wipe_device_build_dir``
+    and ``_remove_device_sidecars`` over in ``helpers.py``. Both files
+    import ``ext_storage_path`` independently; rebinding only one
+    leaves the other path running against the real CORE.
     """
+    fake = lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json"  # noqa: E731
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.ext_storage_path",
-        lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json",
+        "esphome_device_builder.controllers.devices.controller.ext_storage_path", fake
     )
+    monkeypatch.setattr("esphome_device_builder.controllers.devices.helpers.ext_storage_path", fake)
 
 
 # ---------------------------------------------------------------------------
@@ -491,7 +498,7 @@ def test_remove_device_sidecars_logs_oserror_on_storage_unlink(
     on the StorageJSON sidecar shouldn't block the rest of the
     archive / delete flow.
     """
-    from esphome_device_builder.controllers.devices import (
+    from esphome_device_builder.controllers.devices.helpers import (
         _remove_device_sidecars,
     )
 
@@ -514,16 +521,16 @@ def test_remove_device_sidecars_logs_exception_on_metadata_remove(
     tmp_path: Path, monkeypatch: Any, caplog: Any
 ) -> None:
     """Generic Exception from metadata-remove is logged, not raised."""
-    from esphome_device_builder.controllers import devices as devices_module
+    from esphome_device_builder.controllers.devices import helpers as devices_helpers
 
     def _raise(*args: Any, **kwargs: Any) -> None:
         raise RuntimeError("disk full")
 
-    monkeypatch.setattr(devices_module, "remove_device_metadata", _raise)
+    monkeypatch.setattr(devices_helpers, "remove_device_metadata", _raise)
     import logging
 
     with caplog.at_level(logging.WARNING):
-        devices_module._remove_device_sidecars(tmp_path, "kitchen.yaml")
+        devices_helpers._remove_device_sidecars(tmp_path, "kitchen.yaml")
     assert any("Could not remove metadata" in rec.message for rec in caplog.records)
 
 

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -15,8 +15,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers import devices as devices_module
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices import controller as devices_module
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -92,10 +92,11 @@ def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
     on-disk sidecar laid down by ``_seed_device`` is the one the
     delete path reads.
     """
+    fake = lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json"  # noqa: E731
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.ext_storage_path",
-        lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json",
+        "esphome_device_builder.controllers.devices.controller.ext_storage_path", fake
     )
+    monkeypatch.setattr("esphome_device_builder.controllers.devices.helpers.ext_storage_path", fake)
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_friendly_name_slugify_import.py
+++ b/tests/controllers/devices/test_friendly_name_slugify_import.py
@@ -11,7 +11,7 @@ silent drift between the two locations can't sneak past CI.
 
 from __future__ import annotations
 
-from esphome_device_builder.controllers.devices import friendly_name_slugify
+from esphome_device_builder.controllers.devices.helpers import friendly_name_slugify
 
 
 def test_friendly_name_slugify_resolves_via_helpers_or_dashboard_shim() -> None:

--- a/tests/controllers/devices/test_ignored_devices_load.py
+++ b/tests/controllers/devices/test_ignored_devices_load.py
@@ -35,7 +35,7 @@ def _stub_controller(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Devices
     """
     storage_path = tmp_path / "ignored-devices.json"
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.ignored_devices_storage_path",
+        "esphome_device_builder.controllers.devices.controller.ignored_devices_storage_path",
         lambda: storage_path,
     )
     ctrl = DevicesController.__new__(DevicesController)

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -19,8 +19,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers import devices as devices_module
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices import controller as devices_module
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -41,7 +41,7 @@ def _make_controller(monkeypatch: Any, board_id: str = "esp32-c3-devkitm-1") -> 
 def _stub_get_metadata(monkeypatch: Any, payload: dict[str, Any]) -> None:
     """Make ``get_device_metadata`` return *payload* — no JSON IO."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.get_device_metadata",
+        "esphome_device_builder.controllers.devices.controller.get_device_metadata",
         lambda _config_dir, _filename: payload,
     )
 

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -225,7 +225,7 @@ async def test_yaml_validates_returns_false_on_clean_nonzero_exit(
         return fake_proc
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
         fake_create,
     )
 
@@ -253,7 +253,7 @@ async def test_yaml_validates_propagates_unexpected_exception(
         raise FileNotFoundError("esphome")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
         fake_create,
     )
 

--- a/tests/controllers/devices/test_stream_cancel.py
+++ b/tests/controllers/devices/test_stream_cancel.py
@@ -400,7 +400,7 @@ async def test_validate_config_off_attaches_redactor_transform() -> None:
     strips those wrapped runs so the secret never leaves the
     server.
     """
-    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
 
     ctrl = _make_controller_with_settings(["esphome"])
     captured: dict[str, Any] = {}
@@ -450,7 +450,7 @@ def test_redact_concealed_secrets_replaces_wrapped_runs() -> None:
     recording the network tab, even if the visible glyphs were
     hidden by a hypothetical conceal-aware renderer.
     """
-    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
 
     raw = "  password: \x1b[8mhunter2\x1b[28m"
     assert _redact_concealed_secrets(raw) == "  password: <removed>"
@@ -469,7 +469,7 @@ def test_redact_concealed_secrets_handles_dashboard_literal_escape() -> None:
     ``ssid: \\033[8mrocketiot\\033[28m`` in the dialog instead
     of ``ssid: <removed>``.
     """
-    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
 
     # Build the literal four-character form by hand to avoid Python
     # interpreting ``\033`` as the octal escape for ESC.
@@ -480,7 +480,7 @@ def test_redact_concealed_secrets_handles_dashboard_literal_escape() -> None:
 
 def test_redact_concealed_secrets_handles_multiple_runs_per_line() -> None:
     """Multiple wrapped runs in one line all get redacted (non-greedy)."""
-    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
 
     raw = "ssid: \x1b[8mwifi-name\x1b[28m psk: \x1b[8msuper-secret\x1b[28m"
     assert _redact_concealed_secrets(raw) == "ssid: <removed> psk: <removed>"
@@ -494,7 +494,7 @@ def test_redact_concealed_secrets_leaves_unwrapped_lines_alone() -> None:
     every line. The pattern is anchored on ``\\x1b[8m...\\x1b[28m``
     so unrelated SGR runs (colours, bold, dim) pass through.
     """
-    from esphome_device_builder.controllers.devices import _redact_concealed_secrets
+    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
 
     raw = "INFO Reading configuration kitchen.yaml..."
     assert _redact_concealed_secrets(raw) == raw

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-from esphome_device_builder.controllers.devices import _build_address_cache_args
+from esphome_device_builder.controllers.devices.helpers import _build_address_cache_args
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.models import Device, FirmwareJob, JobType
 

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -255,11 +255,11 @@ async def test_refresh_after_compile_persists_hash_and_reloads(
         return "1a2b3c4d"
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.set_device_metadata",
+        "esphome_device_builder.controllers.devices.controller.set_device_metadata",
         _fake_set_metadata,
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.compute_yaml_config_hash",
+        "esphome_device_builder.controllers.devices.controller.compute_yaml_config_hash",
         _fake_compute,
     )
 
@@ -292,11 +292,11 @@ async def test_refresh_after_compile_skips_persist_on_hash_failure(
         return None  # YAML didn't validate, subprocess failed, etc.
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.set_device_metadata",
+        "esphome_device_builder.controllers.devices.controller.set_device_metadata",
         _fake_set_metadata,
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.compute_yaml_config_hash",
+        "esphome_device_builder.controllers.devices.controller.compute_yaml_config_hash",
         _fake_compute,
     )
 
@@ -325,7 +325,7 @@ async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypat
         return "deadbeef"
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.compute_yaml_config_hash",
+        "esphome_device_builder.controllers.devices.controller.compute_yaml_config_hash",
         _fake_compute,
     )
 

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -22,10 +22,8 @@ import pytest
 
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
-from esphome_device_builder.controllers.devices import (
-    DevicesController,
-    _apply_featured_presets,
-)
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices.helpers import _apply_featured_presets
 from esphome_device_builder.definitions import (
     _coerce_field_preset,
     _load_featured_bundle,

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -129,11 +129,11 @@ def _patch_storage(monkeypatch: Any, tmp_path: Any, storage: Any) -> None:
     at ``tmp_path`` keeps the call inert for the test's duration.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.StorageJSON.load",
+        "esphome_device_builder.controllers.devices.controller.StorageJSON.load",
         lambda _path: storage,
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.ext_storage_path",
+        "esphome_device_builder.controllers.devices.controller.ext_storage_path",
         lambda config: tmp_path / f"{config}.json",
     )
 


### PR DESCRIPTION
## Summary

Follow-up to #123 — same shape as the firmware-controller split (PR #129), applied to the now-2094-line ``controllers/devices.py`` which mixes device CRUD, file scanning, mDNS / MQTT bridging, and the WS handler glue.

## Layout

- ``controllers/devices/__init__.py`` — re-exports ``DevicesController`` so existing ``from .controllers.devices import DevicesController`` keeps resolving.
- ``controllers/devices/constants.py`` — ANSI-conceal regex used by the secret redactor.
- ``controllers/devices/helpers.py`` — pure free functions (``_wipe_device_build_dir``, ``_remove_device_sidecars``, ``_validate_archive_configuration``, ``_redact_concealed_secrets``, ``_apply_featured_presets``, ``_normalize_pin_value``, ``_build_address_cache_args``) plus the ``friendly_name_slugify`` re-export.
- ``controllers/devices/controller.py`` — ``DevicesController`` itself + the scan / state-monitor / MQTT bridge.

## No behaviour change

``device_builder.py`` and the rest of the package only ever imported ``DevicesController`` from the package root; that path is unchanged via ``__init__.py`` re-export.

## Tests mirror the production split

``tests/test_{archive,create,delete,rename,import,metadata_resolver,stream_cancel,ignored_devices_load,friendly_name_slugify_import}_device*.py`` moved to ``tests/controllers/devices/test_*.py`` (filename prefix dropped where redundant). Test files that primarily exercise sibling modules (``_device_state_monitor``, ``_device_scanner``, ``_dns_cache``) stay at the top level since they're not the devices-controller subject.

## Monkeypatch fix-ups

Two private-symbol families needed updates:

- ``ext_storage_path`` is imported into both ``controller.py`` and ``helpers.py``; archive/delete fixtures now patch both bindings since ``_archive_single`` / ``_delete_single`` (in ``controller``) delegate to ``_wipe_device_build_dir`` / ``_remove_device_sidecars`` (in ``helpers``) and rebinding only one leaves the other path running against the real ``CORE.config_path``.
- ``devices_module`` aliases (in ``test_create``, ``test_import``, the ``remove_device_metadata`` exception case in ``test_archive``) repointed at ``controllers.devices.controller`` / ``controllers.devices.helpers`` as appropriate.

## Test plan

- [x] Full local suite: 701 passed, 3 skipped (no test changes other than imports + relocations + monkeypatch path fixes).
- [x] Pre-commit clean.
- [x] ``device_builder.py`` import path verified — backend boots without errors.

Closes the follow-up tracked under #123.