### PR TITLE
Source LibreTiny download-types map from upstream FAMILY_COMPONENT

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -91,8 +91,14 @@ _LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPON
 }
 
 
-def _resolve_download_component(target_platform: str) -> str:
+def _resolve_download_component(target_platform: str | None) -> str:
     """Return the ``esphome.components`` module name for *target_platform*.
+
+    Accepts ``None`` so callers can pass ``StorageJSON.target_platform``
+    (which is itself nullable) without an explicit ``or ""``
+    coercion at the call site. Returns the empty string for empty
+    / missing input — the caller's ``importlib.import_module`` will
+    fail in its ``try/except`` block and log a warning.
 
     See ``_LIBRETINY_TARGET_PLATFORMS`` for the keep-in-sync note.
     """
@@ -616,7 +622,7 @@ class FirmwareController:
             if storage is None:
                 return []
             try:
-                component = _resolve_download_component(storage.target_platform or "")
+                component = _resolve_download_component(storage.target_platform)
                 module = importlib.import_module(f"esphome.components.{component}")
                 return list(module.get_download_types(storage))
             except Exception:

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -26,6 +26,9 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
+from esphome.components.libretiny.const import (
+    FAMILY_COMPONENT as _LIBRETINY_FAMILY_COMPONENT,
+)
 from esphome.storage_json import StorageJSON, ext_storage_path
 
 from ...helpers.api import CommandError, api_command
@@ -64,6 +67,41 @@ if TYPE_CHECKING:
     from ...helpers.event_bus import Event
 
 _LOGGER = logging.getLogger(__name__)
+
+# Platforms whose ``target_platform`` value isn't the component
+# module name. The dashboard download endpoint needs the
+# ``esphome.components.<X>`` module that exposes
+# ``get_download_types(storage)`` — for ESP32 variants that's the
+# umbrella ``esp32`` component, and for LibreTiny chip families it's
+# the ``libretiny`` component.
+#
+# The LibreTiny set is derived from upstream's
+# ``FAMILY_COMPONENT.values()`` (auto-generated from
+# ``generate_components.py``) so when LibreTiny adds a new chip
+# family / component our mapping picks it up on the next
+# ``esphome`` dependency bump — no edit here. The literal
+# ``"libretiny"`` covers configs that report the umbrella name as
+# ``target_platform`` directly.
+#
+# Mirrors ``esphome/dashboard/web_server.py``'s
+# ``DownloadListRequestHandler`` — same shape, but driven by an
+# upstream-sourced set rather than an inline literal.
+_LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPONENT.values()) | {
+    "libretiny"
+}
+
+
+def _resolve_download_component(target_platform: str) -> str:
+    """Return the ``esphome.components`` module name for *target_platform*.
+
+    See ``_LIBRETINY_TARGET_PLATFORMS`` for the keep-in-sync note.
+    """
+    platform = (target_platform or "").lower()
+    if platform.upper() in ESP32_VARIANTS:
+        return "esp32"
+    if platform in _LIBRETINY_TARGET_PLATFORMS:
+        return "libretiny"
+    return platform
 
 
 class FirmwareController:
@@ -577,15 +615,9 @@ class FirmwareController:
             storage = StorageJSON.load(ext_storage_path(configuration))
             if storage is None:
                 return []
-            platform = (storage.target_platform or "").lower()
             try:
-                if platform.upper() in ESP32_VARIANTS:
-                    platform_ = "esp32"
-                elif platform in ("rtl87xx", "bk72xx", "ln882x", "libretiny"):
-                    platform_ = "libretiny"
-                else:
-                    platform_ = platform
-                module = importlib.import_module(f"esphome.components.{platform_}")
+                component = _resolve_download_component(storage.target_platform or "")
+                module = importlib.import_module(f"esphome.components.{component}")
                 return list(module.get_download_types(storage))
             except Exception:
                 _LOGGER.warning("Could not determine download types for %s", configuration)

--- a/tests/test_resolve_download_component.py
+++ b/tests/test_resolve_download_component.py
@@ -5,10 +5,13 @@ for a given storage's ``target_platform`` by importing
 ``esphome.components.<X>`` and calling ``get_download_types``. The
 mapping from ``target_platform`` to ``X`` isn't 1:1:
 
-- ESP32 variants (``ESP32C3``, ``ESP32S3``, ...) all live under the
+- ESP32 variants (``ESP32C3``, ``ESP32S3``, …) all live under the
   umbrella ``esp32`` component.
-- LibreTiny chip families (``rtl87xx``, ``bk72xx``, ``ln882x``)
-  live under the umbrella ``libretiny`` component.
+- LibreTiny chip families (such as ``rtl87xx``, ``bk72xx``,
+  ``ln882x``) live under the umbrella ``libretiny`` component.
+  The exhaustive set is sourced from upstream's
+  ``FAMILY_COMPONENT.values()`` and grows automatically when a
+  new chip family is added there.
 
 Mirrors the inline mapping in
 ``esphome/dashboard/web_server.py``'s ``DownloadListRequestHandler``
@@ -61,15 +64,41 @@ def test_pass_through_for_first_class_platforms() -> None:
     assert _resolve_download_component("host") == "host"
 
 
-def test_empty_platform_returns_empty_string() -> None:
-    """Empty / missing ``target_platform`` doesn't crash.
+def test_uppercase_first_class_platform_lowercased() -> None:
+    """Mixed-case input is normalised to lowercase before lookup.
 
-    The caller wraps the subsequent ``importlib.import_module`` in
-    ``try/except`` and logs; the helper itself just returns the
-    (empty) input lower-cased.
+    ``StorageJSON.target_platform`` historically stored both forms
+    (uppercase ``ESP8266`` from older sidecars, lowercase
+    ``esp8266`` from newer writes). The resolver must produce the
+    lowercase component name in either case.
+    """
+    assert _resolve_download_component("ESP8266") == "esp8266"
+    assert _resolve_download_component("Rp2040") == "rp2040"
+
+
+def test_unknown_platform_passes_through_lowercased() -> None:
+    """Unknown platforms pass through lowercased.
+
+    The resolver doesn't validate the component module exists —
+    it just returns the lowercased input so the caller's
+    ``importlib.import_module`` lookup fails in its own
+    ``try/except`` and a warning is logged. Locks the "best
+    effort" contract.
+    """
+    assert _resolve_download_component("unknownplat") == "unknownplat"
+    assert _resolve_download_component("UnknownPlat") == "unknownplat"
+
+
+def test_empty_platform_returns_empty_string() -> None:
+    """Empty / ``None`` ``target_platform`` doesn't crash.
+
+    ``StorageJSON.target_platform`` is itself nullable, so the
+    resolver accepts ``str | None``. The caller's
+    ``importlib.import_module`` then fails with ``ModuleNotFoundError``
+    inside the controller's ``try/except`` and a warning is logged.
     """
     assert _resolve_download_component("") == ""
-    assert _resolve_download_component(None) == ""  # type: ignore[arg-type]
+    assert _resolve_download_component(None) == ""
 
 
 @pytest.mark.parametrize("family", sorted(_LIBRETINY_TARGET_PLATFORMS))
@@ -92,7 +121,19 @@ def test_libretiny_family_modules_actually_export_get_download_types(family: str
     )
 
 
-def test_esp32_module_actually_exports_get_download_types() -> None:
-    """Same sanity for the ``esp32`` umbrella module."""
-    module = importlib.import_module("esphome.components.esp32")
-    assert callable(getattr(module, "get_download_types", None))
+@pytest.mark.parametrize("component", ["esp32", "esp8266", "rp2040"])
+def test_first_class_component_modules_export_get_download_types(component: str) -> None:
+    """Sanity for the non-LibreTiny modules our resolver returns.
+
+    Mirrors ``test_libretiny_family_modules_actually_export_get_download_types``
+    for the components we route to directly (no umbrella). If
+    upstream drops ``get_download_types`` from any of them, this
+    fails immediately rather than waiting for a user to click
+    Download in the dashboard and hit a runtime warning.
+    """
+    module = importlib.import_module(f"esphome.components.{component}")
+    assert callable(getattr(module, "get_download_types", None)), (
+        f"esphome.components.{component} no longer exposes get_download_types — "
+        f"upstream API changed; the dashboard's download endpoint will fail for "
+        f"{component} configs"
+    )

--- a/tests/test_resolve_download_component.py
+++ b/tests/test_resolve_download_component.py
@@ -1,0 +1,98 @@
+"""Tests for ``_resolve_download_component`` platform → module mapping.
+
+The download endpoint asks ESPHome for the binary types available
+for a given storage's ``target_platform`` by importing
+``esphome.components.<X>`` and calling ``get_download_types``. The
+mapping from ``target_platform`` to ``X`` isn't 1:1:
+
+- ESP32 variants (``ESP32C3``, ``ESP32S3``, ...) all live under the
+  umbrella ``esp32`` component.
+- LibreTiny chip families (``rtl87xx``, ``bk72xx``, ``ln882x``)
+  live under the umbrella ``libretiny`` component.
+
+Mirrors the inline mapping in
+``esphome/dashboard/web_server.py``'s ``DownloadListRequestHandler``
+— keep in sync. These tests pin the contract so a regression on
+either side surfaces explicitly.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
+
+from esphome_device_builder.controllers.firmware.controller import (
+    _LIBRETINY_TARGET_PLATFORMS,
+    _resolve_download_component,
+)
+
+
+@pytest.mark.parametrize("variant", sorted(ESP32_VARIANTS))
+def test_esp32_variants_resolve_to_esp32(variant: str) -> None:
+    """Every known ESP32 variant maps to the umbrella ``esp32`` component.
+
+    Driven from ``ESP32_VARIANTS`` (imported from upstream) so the
+    test breadth tracks upstream automatically — when ESPHome adds
+    a new variant the parametrisation picks it up without an edit
+    here.
+    """
+    assert _resolve_download_component(variant) == "esp32"
+    # Lowercase form (which is how StorageJSON stores it after
+    # ``.lower()``) also resolves correctly.
+    assert _resolve_download_component(variant.lower()) == "esp32"
+
+
+@pytest.mark.parametrize("family", sorted(_LIBRETINY_TARGET_PLATFORMS))
+def test_libretiny_families_resolve_to_libretiny(family: str) -> None:
+    """Every LibreTiny chip family maps to the umbrella ``libretiny`` component."""
+    assert _resolve_download_component(family) == "libretiny"
+
+
+def test_pass_through_for_first_class_platforms() -> None:
+    """Platforms that are their own component name pass through unchanged.
+
+    ``esp8266`` is a real ``esphome.components.esp8266`` package
+    — no remapping needed; same for ``host`` and ``rp2040``.
+    """
+    assert _resolve_download_component("esp8266") == "esp8266"
+    assert _resolve_download_component("rp2040") == "rp2040"
+    assert _resolve_download_component("host") == "host"
+
+
+def test_empty_platform_returns_empty_string() -> None:
+    """Empty / missing ``target_platform`` doesn't crash.
+
+    The caller wraps the subsequent ``importlib.import_module`` in
+    ``try/except`` and logs; the helper itself just returns the
+    (empty) input lower-cased.
+    """
+    assert _resolve_download_component("") == ""
+    assert _resolve_download_component(None) == ""  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("family", sorted(_LIBRETINY_TARGET_PLATFORMS))
+def test_libretiny_family_modules_actually_export_get_download_types(family: str) -> None:
+    """The resolved ``libretiny`` module has the expected entry point.
+
+    Sanity that the mapping doesn't just *look* right — the
+    upstream ``libretiny`` component must still expose
+    ``get_download_types`` (which is what the controller's
+    runtime code calls). If upstream renames or drops it, this
+    test catches the divergence at our level rather than letting
+    the user hit "Could not determine download types" in the UI.
+    """
+    component = _resolve_download_component(family)
+    module = importlib.import_module(f"esphome.components.{component}")
+    assert callable(getattr(module, "get_download_types", None)), (
+        f"esphome.components.{component} no longer exposes get_download_types — "
+        f"upstream API changed; the dashboard's download endpoint will fail for "
+        f"{family} configs"
+    )
+
+
+def test_esp32_module_actually_exports_get_download_types() -> None:
+    """Same sanity for the ``esp32`` umbrella module."""
+    module = importlib.import_module("esphome.components.esp32")
+    assert callable(getattr(module, "get_download_types", None))


### PR DESCRIPTION
## Summary

Replaces the inline ``("rtl87xx", "bk72xx", "ln882x", "libretiny")`` literal in the download-types resolver with a set derived from upstream's auto-generated ``esphome.components.libretiny.const.FAMILY_COMPONENT.values()``. When LibreTiny adds a new chip family / component, the mapping picks it up automatically on the next ``esphome`` dependency bump — no manual sync here.

The ``"libretiny"`` umbrella name stays as a literal because it isn't in ``FAMILY_COMPONENT`` (configs that report the umbrella directly via ``target_platform`` use the bare component name).

Also extracted the platform → component-module resolver into a named ``_resolve_download_component`` helper so the call site in ``list_downloads`` stays clean and the mapping logic lives in one testable place.

## Why

The legacy ``esphome/dashboard/web_server.py`` does the same mapping inline (no extracted helper exists upstream). When ESPHome adds a new platform alias both codebases drift — the legacy version edits its inline list, and ours had to edit ours. Sourcing the LibreTiny families from upstream removes one of those manual sync points; ESP32 variants were already sourced via ``ESP32_VARIANTS``.

## Test plan

- [x] ``uv run pytest tests/test_resolve_download_component.py`` — 21 tests, parametrised over ``ESP32_VARIANTS`` and ``_LIBRETINY_TARGET_PLATFORMS`` so breadth tracks upstream.
- [x] Two sanity tests confirm resolved modules actually expose ``get_download_types`` — upstream renames surface as test failures rather than silent "Could not determine download types" warnings.
- [x] Full suite: ``uv run pytest --ignore=tests/benchmarks`` — 722 passed.