### PR TITLE
Cover firmware/download branches + pin ext_storage_path gate

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -567,8 +567,11 @@ class FirmwareController:
         ``firmware/download`` to retrieve the binary content.
         """
         # ``ext_storage_path`` resolves to ``<data_dir>/storage/...``
-        # outside the config dir, so ``rel_path`` is the gate that
-        # rejects traversal payloads at the WS boundary.
+        # outside the config dir AND does no traversal sanitisation
+        # of its own (upstream definition is just
+        # ``CORE.data_dir / "storage" / f"{config_filename}.json"``),
+        # so the validator below is the only gate that keeps a
+        # traversal payload out of the inner closure. Do not reorder.
         await self._validate_configuration_boundary(configuration)
         loop = asyncio.get_running_loop()
 
@@ -610,6 +613,14 @@ class FirmwareController:
         """
         # See ``get_binaries`` — ``ext_storage_path`` skips the config
         # dir entirely, so we re-validate at the WS boundary.
+        # ``ext_storage_path`` itself does NOT path-sanitise — its
+        # upstream definition is literally
+        # ``CORE.data_dir / "storage" / f"{config_filename}.json"``,
+        # so a traversal-shaped configuration would escape the
+        # storage tree if it ever reached the inner closure. The
+        # ``_validate_configuration_boundary`` line above is the only
+        # gate; do not reorder. Coverage:
+        # ``test_download.py::test_download_validator_runs_before_ext_storage_path``.
         await self._validate_configuration_boundary(configuration)
         loop = asyncio.get_running_loop()
 

--- a/tests/_storage_fixtures.py
+++ b/tests/_storage_fixtures.py
@@ -1,0 +1,88 @@
+"""
+Shared StorageJSON sidecar fixtures for tests that touch the build-output cache.
+
+Several tests stand up a fake ``<config_dir>/.esphome/storage/<configuration>.json``
+sidecar to exercise paths that read it (``firmware/download``,
+``DevicesController._delete_single`` / ``_archive_single``, the
+metadata resolver). They were each writing the same JSON shape
+inline; centralising the layout here keeps them in sync when
+upstream esphome bumps ``StorageJSON``'s schema.
+
+Currently consumed by ``tests/controllers/firmware/test_download.py``.
+The duplicates in ``tests/test_archive_device.py`` and
+``tests/test_delete_device.py`` will migrate over once
+``device-builder#132`` lands (those files are renamed by that PR
+and editing them in parallel would conflict).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Schema-snapshot defaults — what an upstream
+# ``StorageJSON.save()`` would land on disk for a typical
+# esp32-c3-devkitm-1 ESP-IDF build. Kept verbose so a test that
+# needs to override one field doesn't have to learn the full
+# shape.
+_STORAGE_DEFAULTS: dict[str, Any] = {
+    "storage_version": 1,
+    "name": None,  # filled from ``configuration`` stem when omitted
+    "comment": None,
+    "esphome_version": "2026.5.0-dev",
+    "src_version": 1,
+    "address": "",
+    "web_port": None,
+    "esp_platform": "esp32",
+    "board": "esp32-c3-devkitm-1",
+    "build_path": None,  # filled from ``tmp_path/.esphome/build/<stem>`` when omitted
+    "firmware_bin_path": None,
+    "loaded_integrations": [],
+    "loaded_platforms": [],
+    "no_mdns": False,
+    "framework": "esp-idf",
+    "core_platform": "esp32",
+}
+
+
+def write_storage_json(
+    tmp_path: Path,
+    configuration: str,
+    *,
+    firmware_bin_path: Path | None = None,
+    build_path: Path | None = None,
+    overrides: dict[str, Any] | None = None,
+) -> Path:
+    """
+    Write a StorageJSON sidecar for *configuration* under *tmp_path*.
+
+    Returns the sidecar path so the test can wipe it for "missing
+    sidecar" cases. Mirrors ``ext_storage_path``'s layout
+    (``<tmp_path>/.esphome/storage/<configuration>.json``) so a
+    monkeypatched redirect of ``ext_storage_path`` to ``tmp_path``
+    lands on the right file.
+
+    ``firmware_bin_path`` is the typical override knob — pass
+    ``None`` (the default) to model "compile aborted before link",
+    pass a real path to model "compile finished and produced this
+    binary". ``build_path`` defaults to
+    ``<tmp_path>/.esphome/build/<stem>``; override to pin a
+    different location. Anything else (``loaded_integrations``,
+    ``framework``, ``board``, …) goes through *overrides* — fields
+    not listed there fall through to the defaults above.
+    """
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    sidecar = storage_dir / f"{configuration}.json"
+
+    stem = Path(configuration).stem
+    payload = dict(_STORAGE_DEFAULTS)
+    payload["name"] = stem
+    payload["build_path"] = str(build_path or (tmp_path / ".esphome" / "build" / stem))
+    payload["firmware_bin_path"] = str(firmware_bin_path) if firmware_bin_path else None
+    if overrides:
+        payload.update(overrides)
+
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+    return sidecar

--- a/tests/controllers/firmware/test_download.py
+++ b/tests/controllers/firmware/test_download.py
@@ -1,0 +1,283 @@
+"""Tests for ``FirmwareController.download``.
+
+The handler reads a compiled firmware binary off disk and returns
+it base64-encoded for Web Serial flashing. Coverage targets the
+five branches that decide what comes back:
+
+- Storage sidecar missing → ``FileNotFoundError("No firmware binary…")``.
+- Sidecar present but ``firmware_bin_path`` unset (compile never
+  reached the link stage) → same ``FileNotFoundError``.
+- ``file`` argument resolving outside the build dir → traversal
+  guard raises ``ValueError`` (``Path.relative_to`` semantics).
+- Requested binary not present on disk → ``FileNotFoundError("Binary
+  not found: …")``.
+- Happy path uncompressed and compressed — returns the right
+  filename / base64 data / size / compressed flag.
+
+Configuration-level traversal (the ``await
+_validate_configuration_boundary`` line at the top of the handler)
+is already covered in ``test_traversal_validation.py``; this file
+is only about what happens once the configuration argument
+validates.
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.controllers.firmware import FirmwareController
+
+
+def _controller(tmp_path: Path) -> FirmwareController:
+    """Stub controller wired to a real ``DashboardSettings.rel_path``."""
+    settings = DashboardSettings()
+    settings.config_dir = tmp_path
+    settings.absolute_config_dir = tmp_path.resolve()
+
+    controller = FirmwareController.__new__(FirmwareController)
+    controller._jobs = {}
+    controller._db = type("DB", (), {"settings": settings})()
+    return controller
+
+
+def _seed_storage(
+    tmp_path: Path,
+    configuration: str,
+    *,
+    firmware_bin_path: Path | None,
+) -> Path:
+    """Lay out a StorageJSON sidecar pointing at *firmware_bin_path*.
+
+    Returns the sidecar path so the test can wipe it for the
+    "missing sidecar" case. Uses ``ext_storage_path``-style layout
+    so the monkeypatched redirect lands on the right file.
+    """
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    sidecar = storage_dir / f"{configuration}.json"
+    payload: dict[str, Any] = {
+        "storage_version": 1,
+        "name": Path(configuration).stem,
+        "comment": None,
+        "esphome_version": "2026.5.0-dev",
+        "src_version": 1,
+        "address": "",
+        "web_port": None,
+        "esp_platform": "esp32",
+        "board": "esp32-c3-devkitm-1",
+        "build_path": str(tmp_path / ".esphome" / "build" / Path(configuration).stem),
+        "firmware_bin_path": str(firmware_bin_path) if firmware_bin_path else None,
+        "loaded_integrations": [],
+        "loaded_platforms": [],
+        "no_mdns": False,
+        "framework": "esp-idf",
+        "core_platform": "esp32",
+    }
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+    return sidecar
+
+
+@pytest.fixture(autouse=True)
+def _redirect_ext_storage_path(monkeypatch: Any, tmp_path: Path) -> None:
+    """Pin ``ext_storage_path`` at ``<tmp>/.esphome/storage/<config>.json``.
+
+    The real ``ext_storage_path`` derives from ``CORE.config_path``,
+    which isn't initialised in the test process. Both the firmware
+    controller and its helpers import it independently, so patch the
+    binding in the controller submodule (the only one ``download``
+    reads through).
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.firmware.controller.ext_storage_path",
+        lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json",
+    )
+
+
+def _make_firmware(build_dir: Path, name: str, payload: bytes) -> Path:
+    """Lay out a ``firmware.bin`` inside *build_dir* and return its path."""
+    build_dir.mkdir(parents=True, exist_ok=True)
+    fw = build_dir / name
+    fw.write_bytes(payload)
+    return fw
+
+
+# ---------------------------------------------------------------------------
+# Failure branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_raises_when_storage_missing(tmp_path: Path) -> None:
+    """No StorageJSON sidecar at all → user hasn't compiled this device yet.
+
+    The storage sidecar is the only place the dashboard knows where
+    the firmware bin lives; without it there's nothing to serve.
+    Surface the actionable error rather than letting an opaque ``None``
+    crash deeper in the handler.
+    """
+    controller = _controller(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="No firmware binary"):
+        await controller.download(configuration="kitchen.yaml", file="firmware.bin")
+
+
+@pytest.mark.asyncio
+async def test_download_raises_when_firmware_bin_path_unset(tmp_path: Path) -> None:
+    """Sidecar exists but ``firmware_bin_path`` is None → same actionable error.
+
+    Happens when the compile aborted before the link stage (e.g.
+    syntax error caught by validate, missing toolchain) — the
+    sidecar got written by ``--only-generate`` but the bin never
+    landed. Same error message as the missing-sidecar case so the
+    frontend handles both identically.
+    """
+    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=None)
+    controller = _controller(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="No firmware binary"):
+        await controller.download(configuration="kitchen.yaml", file="firmware.bin")
+
+
+@pytest.mark.asyncio
+async def test_download_raises_on_traversal_in_file(tmp_path: Path) -> None:
+    """A ``file`` value escaping the build dir trips ``Path.relative_to``.
+
+    The traversal guard exists because ``file`` reaches the handler
+    from a WS request — a malicious client could pass
+    ``"../../../etc/passwd"`` and read host files. ``relative_to``
+    raises ``ValueError`` when the resolved path falls outside the
+    build dir; the handler doesn't translate it because the guard
+    is defense-in-depth — the legitimate frontend never sends a
+    traversal-shaped ``file``.
+    """
+    build_dir = tmp_path / ".esphome" / "build" / "kitchen"
+    fw = _make_firmware(build_dir, "firmware.bin", b"\x00" * 16)
+    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
+    # Drop a file outside build_dir that the traversal would reach.
+    (tmp_path / "secret.txt").write_text("nope", encoding="utf-8")
+    controller = _controller(tmp_path)
+
+    with pytest.raises(ValueError):
+        await controller.download(configuration="kitchen.yaml", file="../../../secret.txt")
+
+
+@pytest.mark.asyncio
+async def test_download_raises_when_binary_missing(tmp_path: Path) -> None:
+    """Sidecar + build dir present but the requested file isn't there.
+
+    Distinct from ``firmware_bin_path`` being unset: the compile
+    succeeded but the user asked for a binary the build didn't emit
+    (e.g. ``firmware-factory.bin`` on a board that only emits the
+    OTA bin). Returns the actionable per-file error.
+    """
+    build_dir = tmp_path / ".esphome" / "build" / "kitchen"
+    fw = _make_firmware(build_dir, "firmware.bin", b"\x00" * 16)
+    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
+    controller = _controller(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match=r"Binary not found: missing\.bin"):
+        await controller.download(configuration="kitchen.yaml", file="missing.bin")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_returns_base64_payload_uncompressed(tmp_path: Path) -> None:
+    """Default path returns ``{filename, data, size, compressed=False}``.
+
+    ``filename`` is ``<storage.name>-<file>``; ``data`` is the
+    base64-encoded raw bytes; ``size`` is the *encoded* payload's
+    pre-base64 length; ``compressed`` is False.
+    """
+    payload = b"firmware bytes \x01\x02\x03\x04"
+    build_dir = tmp_path / ".esphome" / "build" / "kitchen"
+    fw = _make_firmware(build_dir, "firmware.bin", payload)
+    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
+    controller = _controller(tmp_path)
+
+    result = await controller.download(configuration="kitchen.yaml", file="firmware.bin")
+
+    assert result["filename"] == "kitchen-firmware.bin"
+    assert result["compressed"] is False
+    assert result["size"] == len(payload)
+    assert base64.b64decode(result["data"]) == payload
+
+
+@pytest.mark.asyncio
+async def test_download_validator_runs_before_ext_storage_path(tmp_path: Path) -> None:
+    """``ext_storage_path`` is unsafe in isolation; the validator gate matters.
+
+    Pinning this so a future refactor that drops or re-orders
+    ``_validate_configuration_boundary`` in ``download`` immediately
+    surfaces the regression.
+
+    The function in upstream esphome is literally
+    ``CORE.data_dir / "storage" / f"{config_filename}.json"`` — no
+    sanitisation, no ``relative_to`` check. A traversal-shaped
+    configuration (``"../../../etc/passwd"``) feeds straight through
+    and would resolve outside the storage tree if the call ever ran.
+
+    The handler avoids that by validating ``configuration`` first
+    via ``rel_path`` (raises ``CommandError(INVALID_ARGS)``), so a
+    traversal payload trips the gate and never reaches the
+    ``ext_storage_path`` call inside the executor closure. We assert
+    both halves: the handler raises a ``CommandError``, and the
+    autouse ``ext_storage_path`` redirect is never invoked.
+    """
+    from esphome_device_builder.helpers.api import CommandError
+    from esphome_device_builder.models import ErrorCode
+
+    invocations: list[str] = []
+
+    def _spy(configuration: str) -> Path:
+        invocations.append(configuration)
+        return tmp_path / ".esphome" / "storage" / f"{configuration}.json"
+
+    # Replace the autouse redirect with our spy for this test.
+    import esphome_device_builder.controllers.firmware.controller as controller_module
+
+    controller_module.ext_storage_path = _spy
+
+    controller = _controller(tmp_path)
+    with pytest.raises(CommandError) as excinfo:
+        await controller.download(configuration="../../etc/passwd", file="firmware.bin")
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    # Validator short-circuited *before* the executor closure ran —
+    # ``ext_storage_path`` was never invoked with the traversal value.
+    assert invocations == []
+
+
+@pytest.mark.asyncio
+async def test_download_returns_gzipped_payload_when_compressed(tmp_path: Path) -> None:
+    """``compressed=True`` gzips the bytes and tacks ``.gz`` onto the filename.
+
+    Web Serial flashing skips this path — it asks for raw bytes and
+    decodes the base64 itself. The gz path is for the legacy HTTP
+    download flow where the browser receives a real ``.bin.gz`` so
+    a download manager can stream it to disk under the right name.
+    """
+    payload = b"larger payload to compress: " + (b"abc" * 200)
+    build_dir = tmp_path / ".esphome" / "build" / "kitchen"
+    fw = _make_firmware(build_dir, "firmware.bin", payload)
+    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
+    controller = _controller(tmp_path)
+
+    result = await controller.download(
+        configuration="kitchen.yaml", file="firmware.bin", compressed=True
+    )
+
+    assert result["filename"] == "kitchen-firmware.bin.gz"
+    assert result["compressed"] is True
+    decoded = base64.b64decode(result["data"])
+    assert gzip.decompress(decoded) == payload
+    assert result["size"] == len(decoded)

--- a/tests/controllers/firmware/test_download.py
+++ b/tests/controllers/firmware/test_download.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import base64
 import gzip
-import json
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +32,7 @@ import pytest
 
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.firmware import FirmwareController
+from tests._storage_fixtures import write_storage_json
 
 
 def _controller(tmp_path: Path) -> FirmwareController:
@@ -45,43 +45,6 @@ def _controller(tmp_path: Path) -> FirmwareController:
     controller._jobs = {}
     controller._db = type("DB", (), {"settings": settings})()
     return controller
-
-
-def _seed_storage(
-    tmp_path: Path,
-    configuration: str,
-    *,
-    firmware_bin_path: Path | None,
-) -> Path:
-    """Lay out a StorageJSON sidecar pointing at *firmware_bin_path*.
-
-    Returns the sidecar path so the test can wipe it for the
-    "missing sidecar" case. Uses ``ext_storage_path``-style layout
-    so the monkeypatched redirect lands on the right file.
-    """
-    storage_dir = tmp_path / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-    sidecar = storage_dir / f"{configuration}.json"
-    payload: dict[str, Any] = {
-        "storage_version": 1,
-        "name": Path(configuration).stem,
-        "comment": None,
-        "esphome_version": "2026.5.0-dev",
-        "src_version": 1,
-        "address": "",
-        "web_port": None,
-        "esp_platform": "esp32",
-        "board": "esp32-c3-devkitm-1",
-        "build_path": str(tmp_path / ".esphome" / "build" / Path(configuration).stem),
-        "firmware_bin_path": str(firmware_bin_path) if firmware_bin_path else None,
-        "loaded_integrations": [],
-        "loaded_platforms": [],
-        "no_mdns": False,
-        "framework": "esp-idf",
-        "core_platform": "esp32",
-    }
-    sidecar.write_text(json.dumps(payload), encoding="utf-8")
-    return sidecar
 
 
 @pytest.fixture(autouse=True)
@@ -138,7 +101,7 @@ async def test_download_raises_when_firmware_bin_path_unset(tmp_path: Path) -> N
     landed. Same error message as the missing-sidecar case so the
     frontend handles both identically.
     """
-    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=None)
+    write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=None)
     controller = _controller(tmp_path)
 
     with pytest.raises(FileNotFoundError, match="No firmware binary"):
@@ -159,7 +122,7 @@ async def test_download_raises_on_traversal_in_file(tmp_path: Path) -> None:
     """
     build_dir = tmp_path / ".esphome" / "build" / "kitchen"
     fw = _make_firmware(build_dir, "firmware.bin", b"\x00" * 16)
-    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
+    write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
     # Drop a file outside build_dir that the traversal would reach.
     (tmp_path / "secret.txt").write_text("nope", encoding="utf-8")
     controller = _controller(tmp_path)
@@ -179,7 +142,7 @@ async def test_download_raises_when_binary_missing(tmp_path: Path) -> None:
     """
     build_dir = tmp_path / ".esphome" / "build" / "kitchen"
     fw = _make_firmware(build_dir, "firmware.bin", b"\x00" * 16)
-    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
+    write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
     controller = _controller(tmp_path)
 
     with pytest.raises(FileNotFoundError, match=r"Binary not found: missing\.bin"):
@@ -202,7 +165,7 @@ async def test_download_returns_base64_payload_uncompressed(tmp_path: Path) -> N
     payload = b"firmware bytes \x01\x02\x03\x04"
     build_dir = tmp_path / ".esphome" / "build" / "kitchen"
     fw = _make_firmware(build_dir, "firmware.bin", payload)
-    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
+    write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
     controller = _controller(tmp_path)
 
     result = await controller.download(configuration="kitchen.yaml", file="firmware.bin")
@@ -269,7 +232,7 @@ async def test_download_returns_gzipped_payload_when_compressed(tmp_path: Path) 
     payload = b"larger payload to compress: " + (b"abc" * 200)
     build_dir = tmp_path / ".esphome" / "build" / "kitchen"
     fw = _make_firmware(build_dir, "firmware.bin", payload)
-    _seed_storage(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
+    write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
     controller = _controller(tmp_path)
 
     result = await controller.download(


### PR DESCRIPTION
## Summary

``firmware/download`` had only one test before this — the configuration-boundary traversal rejection in ``test_traversal_validation.py``. Five other branches were unverified.

### What's covered now

- **Storage sidecar missing** → ``FileNotFoundError("No firmware binary…")``. The user hasn't compiled this device yet.
- **Sidecar present but ``firmware_bin_path`` unset** → same error. Happens when compile aborted before the link stage; sidecar got written by ``--only-generate`` but the bin never landed.
- **``file`` arg escaping ``base_dir``** → ``ValueError`` from the inline ``Path.relative_to`` traversal guard.
- **File requested but not on disk** → ``FileNotFoundError("Binary not found: <name>")``. Distinct from the unset-bin-path case: the compile succeeded but the user asked for a binary the build didn't emit.
- **Happy path uncompressed** → ``{filename: "<storage.name>-<file>", data: <b64>, size, compressed=False}``.
- **Happy path ``compressed=True``** → gzipped data, ``.gz`` filename suffix, ``compressed=True``.

### Plus: pin the `ext_storage_path` ordering invariant

You asked me to verify ``ext_storage_path`` is path-traversal-safe. **It isn't, on its own.** The upstream definition is literally:

```python
def ext_storage_path(config_filename: str) -> Path:
    return CORE.data_dir / "storage" / f"{config_filename}.json"
```

No sanitisation, no ``relative_to`` check. A traversal-shaped ``configuration`` would escape the storage tree if the call ever ran with one. The protection in ``download`` (and ``get_binaries``) comes entirely from the ``await self._validate_configuration_boundary(configuration)`` line that runs first — ``rel_path`` raises ``CommandError(INVALID_ARGS)`` and the executor closure never gets to ``ext_storage_path``.

The new ``test_download_validator_runs_before_ext_storage_path`` pins both halves of that invariant: a traversal configuration trips the ``CommandError`` *and* the spy on ``ext_storage_path`` records zero invocations. Production-side comments on both ``get_binaries`` and ``download`` now spell out the ordering so a future refactor that drops or reorders the validator surfaces the regression in code review, not just in CI.

## Test plan

- [x] ``tests/controllers/firmware/test_download.py`` — 7 new cases (5 failure branches + 2 happy paths + 1 ordering pin).
- [x] Existing traversal coverage in ``test_traversal_validation.py`` still passes.
- [x] Full local suite: 712 passed, 3 skipped.
- [x] Pre-commit clean.