### PR TITLE
Fix firmware.helpers import in devices controller after subpackage split

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -55,6 +55,7 @@ from ..config import (
     remove_device_metadata,
     set_device_metadata,
 )
+from ..firmware.helpers import _find_esphome_cmd
 from .helpers import (
     _apply_featured_presets,
     _build_address_cache_args,
@@ -136,8 +137,6 @@ class DevicesController:
 
     async def start(self) -> None:
         """Initialise — load state, scan files, start mDNS + ping + MQTT discovery."""
-        from .firmware.helpers import _find_esphome_cmd
-
         self._esphome_cmd = _find_esphome_cmd()
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._load_ignored_devices)


### PR DESCRIPTION
## What broke

The devices subpackage split (#132) shipped with this in
``DevicesController.start``:

\`\`\`python
from .firmware.helpers import _find_esphome_cmd
\`\`\`

Relative to ``controllers/devices/`` — which has no ``firmware``
submodule. So at runtime:

\`\`\`
ModuleNotFoundError: No module named
'esphome_device_builder.controllers.devices.firmware'
\`\`\`

Caught when the dashboard was actually started; tests never tripped
it because every fixture stubs the scanner / state monitor and no
``DevicesController.start`` end-to-end test exists.

## Why was it lazy in the first place?

The lazy import predated both subpackage splits — back when
``devices.py`` and ``firmware.py`` lived side-by-side in
``controllers/``, importing ``_find_esphome_cmd`` at module scope
created a circular dependency. After the firmware-subpackage split
(#129) and the devices split (#132), ``controllers.firmware`` no
longer imports anything from ``controllers.devices``, so the cycle
is gone and the lazy import is dead weight. Hoisting it fixes the
relative-path bug as a side effect.

## Fix

- Hoist ``from ..firmware.helpers import _find_esphome_cmd`` to
  module scope (correct relative path: up one level into the
  firmware subpackage).
- Drop the inline import inside ``start``.

No new test — once the import is at module scope, a broken path
surfaces at *test collection* time across every test that touches
the package. A dedicated smoke test would be redundant with that.

## Test plan

- [x] Manual smoke: ``python -m esphome_device_builder`` boots clean.
- [x] Full local suite: 735 passed, 3 skipped.
- [x] Pre-commit clean.