### PR TITLE
Centralise firmware controller test boilerplate via conftest factory

### DIFF
--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -19,9 +19,8 @@ preload ``_jobs``, set ``with_settings=False`` to skip the
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -31,10 +30,24 @@ from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.models import FirmwareJob
 
 
+class FirmwareControllerFactory(Protocol):
+    """
+    Type for the ``firmware_controller_factory`` fixture.
+
+    Exported so test files can annotate their fixture parameter
+    without each redeclaring the callable shape — pylance / mypy
+    then know that ``factory(...)`` returns a
+    ``FirmwareController`` and that ``with_settings`` is keyword-
+    only.
+    """
+
+    def __call__(self, *jobs: FirmwareJob, with_settings: bool = ...) -> FirmwareController: ...
+
+
 @pytest.fixture
 def firmware_controller_factory(
     tmp_path: Path,
-) -> Callable[..., FirmwareController]:
+) -> FirmwareControllerFactory:
     """
     Build stub ``FirmwareController`` instances wired to ``tmp_path``.
 

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -11,10 +11,13 @@ shifts (every refactor that adds a new ``self._something`` had
 to chase the same pattern across every test file before this).
 
 Tests instantiate via the ``firmware_controller_factory``
-fixture: pass any ``FirmwareJob`` instances positionally to
-preload ``_jobs``, set ``with_settings=False`` to skip the
-``DashboardSettings`` binding for tests that don't exercise
-``rel_path``.
+fixture. The factory exposes three independent opt-ins
+(``with_settings`` / ``with_queue`` / ``with_terminate``) so
+each test file gets exactly the surface its handler-under-test
+actually touches — a refactor that accidentally reaches further
+into the controller (e.g. a ``get_jobs`` call that suddenly
+hits ``_queue``) crashes with ``AttributeError`` instead of
+silently absorbing into a stub.
 """
 
 from __future__ import annotations
@@ -37,11 +40,17 @@ class FirmwareControllerFactory(Protocol):
     Exported so test files can annotate their fixture parameter
     without each redeclaring the callable shape — pylance / mypy
     then know that ``factory(...)`` returns a
-    ``FirmwareController`` and that ``with_settings`` is keyword-
-    only.
+    ``FirmwareController`` and that the kit flags are
+    keyword-only.
     """
 
-    def __call__(self, *jobs: FirmwareJob, with_settings: bool = ...) -> FirmwareController: ...
+    def __call__(
+        self,
+        *jobs: FirmwareJob,
+        with_settings: bool = ...,
+        with_queue: bool = ...,
+        with_terminate: bool = ...,
+    ) -> FirmwareController: ...
 
 
 @pytest.fixture
@@ -51,40 +60,52 @@ def firmware_controller_factory(
     """
     Build stub ``FirmwareController`` instances wired to ``tmp_path``.
 
-    Returns a callable: ``factory(*jobs, with_settings=True)``.
+    Returns a callable: ``factory(*jobs, with_settings=True,
+    with_queue=False, with_terminate=False)``.
 
-    Wires the surface a typical handler-wiring test reaches for:
+    Three kit flags compose, each adding only the attributes the
+    relevant code path reads — keeps the test surface honest
+    about what each test exercises:
 
-    - ``_jobs`` — populated from the positional ``FirmwareJob``
-      arguments (so tests can preload running / queued / terminal
-      jobs without touching the dict directly).
-    - ``_queue`` / ``_persist_jobs`` / ``_supersede_active_jobs`` /
-      ``_terminate_current_process`` — ``AsyncMock`` stubs.
-    - ``_current_job`` / ``_current_process`` — ``None``.
-    - ``_cancel_requested`` — empty set.
-    - ``_db`` — a small namespace exposing ``.bus`` (``MagicMock``)
-      and (when ``with_settings=True``, the default) ``.settings``
-      (a real ``DashboardSettings`` whose ``config_dir`` is
-      ``tmp_path``).
+    - ``with_settings=True`` (default): wire ``self._db.settings``
+      to a ``DashboardSettings`` whose ``config_dir`` is
+      ``tmp_path``. Needed by every handler that calls
+      ``rel_path``. Pass ``False`` for in-memory job inspectors
+      where reading ``settings`` should hard-fail rather than
+      silently use a stub.
 
-    Pass ``with_settings=False`` for tests that don't exercise
-    ``rel_path`` (in-memory job inspectors, rename-lock checks,
-    etc.). Handlers that nevertheless try to read ``settings``
-    will then ``AttributeError`` rather than silently use a
-    stub — which keeps the test surface honest about what each
-    test actually exercises.
+    - ``with_queue=False`` (default): when set ``True``, install
+      ``AsyncMock`` stubs for ``_queue`` and
+      ``_supersede_active_jobs``. The submission handlers
+      (``compile`` / ``upload`` / ``install`` / ``rename`` /
+      ``compile_bulk`` / ``install_bulk`` / ``reset_build_env``)
+      need this kit. The validator-only tests
+      (``test_traversal_validation`` / ``test_get_binaries`` /
+      ``test_download``) do not — leaving ``_queue``
+      unattributed makes a regression that suddenly tries to
+      enqueue a rejected request crash visibly.
+
+    - ``with_terminate=False`` (default): when set ``True``,
+      install ``_current_job`` / ``_current_process`` /
+      ``_cancel_requested`` / ``_terminate_current_process``.
+      Only ``cancel`` reaches into these.
+
+    Always present: ``_jobs`` (populated from positional
+    arguments), ``_persist_jobs`` (``AsyncMock``), ``_db.bus``
+    (``MagicMock``). These three are universal enough that
+    every test either expects them to be called or asserts they
+    were not.
     """
 
-    def _make(*jobs: FirmwareJob, with_settings: bool = True) -> FirmwareController:
+    def _make(
+        *jobs: FirmwareJob,
+        with_settings: bool = True,
+        with_queue: bool = False,
+        with_terminate: bool = False,
+    ) -> FirmwareController:
         controller = FirmwareController.__new__(FirmwareController)
         controller._jobs = {j.job_id: j for j in jobs}
-        controller._current_job = None
-        controller._current_process = None
-        controller._cancel_requested = set()
-        controller._queue = AsyncMock()
         controller._persist_jobs = AsyncMock()
-        controller._supersede_active_jobs = AsyncMock()
-        controller._terminate_current_process = AsyncMock()
 
         bus = MagicMock()
         db_attrs: dict[str, Any] = {"bus": bus}
@@ -94,6 +115,17 @@ def firmware_controller_factory(
             settings.absolute_config_dir = tmp_path.resolve()
             db_attrs["settings"] = settings
         controller._db = type("DB", (), db_attrs)()
+
+        if with_queue:
+            controller._queue = AsyncMock()
+            controller._supersede_active_jobs = AsyncMock()
+
+        if with_terminate:
+            controller._current_job = None
+            controller._current_process = None
+            controller._cancel_requested = set()
+            controller._terminate_current_process = AsyncMock()
+
         return controller
 
     return _make

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -1,0 +1,86 @@
+"""Shared fixtures for ``tests/controllers/firmware/``.
+
+Most handler-level tests in this package were each carrying their
+own ``_controller(tmp_path)`` helper that built a stub
+``FirmwareController`` with ``__new__``, wired a real
+``DashboardSettings`` for path validation, and stubbed the
+queue / persistence / supersede / bus surface. The bodies were
+nearly identical across a dozen files; centralising the build
+here keeps them in sync when the controller's attribute set
+shifts (every refactor that adds a new ``self._something`` had
+to chase the same pattern across every test file before this).
+
+Tests instantiate via the ``firmware_controller_factory``
+fixture: pass any ``FirmwareJob`` instances positionally to
+preload ``_jobs``, set ``with_settings=False`` to skip the
+``DashboardSettings`` binding for tests that don't exercise
+``rel_path``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.models import FirmwareJob
+
+
+@pytest.fixture
+def firmware_controller_factory(
+    tmp_path: Path,
+) -> Callable[..., FirmwareController]:
+    """
+    Build stub ``FirmwareController`` instances wired to ``tmp_path``.
+
+    Returns a callable: ``factory(*jobs, with_settings=True)``.
+
+    Wires the surface a typical handler-wiring test reaches for:
+
+    - ``_jobs`` — populated from the positional ``FirmwareJob``
+      arguments (so tests can preload running / queued / terminal
+      jobs without touching the dict directly).
+    - ``_queue`` / ``_persist_jobs`` / ``_supersede_active_jobs`` /
+      ``_terminate_current_process`` — ``AsyncMock`` stubs.
+    - ``_current_job`` / ``_current_process`` — ``None``.
+    - ``_cancel_requested`` — empty set.
+    - ``_db`` — a small namespace exposing ``.bus`` (``MagicMock``)
+      and (when ``with_settings=True``, the default) ``.settings``
+      (a real ``DashboardSettings`` whose ``config_dir`` is
+      ``tmp_path``).
+
+    Pass ``with_settings=False`` for tests that don't exercise
+    ``rel_path`` (in-memory job inspectors, rename-lock checks,
+    etc.). Handlers that nevertheless try to read ``settings``
+    will then ``AttributeError`` rather than silently use a
+    stub — which keeps the test surface honest about what each
+    test actually exercises.
+    """
+
+    def _make(*jobs: FirmwareJob, with_settings: bool = True) -> FirmwareController:
+        controller = FirmwareController.__new__(FirmwareController)
+        controller._jobs = {j.job_id: j for j in jobs}
+        controller._current_job = None
+        controller._current_process = None
+        controller._cancel_requested = set()
+        controller._queue = AsyncMock()
+        controller._persist_jobs = AsyncMock()
+        controller._supersede_active_jobs = AsyncMock()
+        controller._terminate_current_process = AsyncMock()
+
+        bus = MagicMock()
+        db_attrs: dict[str, Any] = {"bus": bus}
+        if with_settings:
+            settings = DashboardSettings()
+            settings.config_dir = tmp_path
+            settings.absolute_config_dir = tmp_path.resolve()
+            db_attrs["settings"] = settings
+        controller._db = type("DB", (), db_attrs)()
+        return controller
+
+    return _make

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -72,7 +72,7 @@ async def test_cancel_raises_not_found_for_unknown_job_id(
     distinguishes it from ``INVALID_ARGS`` to render a different
     error toast.
     """
-    controller = firmware_controller_factory(with_settings=False)
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.cancel(job_id="bogus")
@@ -97,7 +97,7 @@ async def test_cancel_queued_job_marks_terminal_and_fires_event(
     status until the next page refresh.
     """
     job = _job("j-q", status=JobStatus.QUEUED)
-    controller = firmware_controller_factory(job, with_settings=False)
+    controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
     controller._prune_history = MagicMock()
 
     await controller.cancel(job_id="j-q")
@@ -125,7 +125,7 @@ async def test_cancel_queued_job_prunes_history_before_persisting(
     and lose the cap on the very next read.
     """
     job = _job("j-q", status=JobStatus.QUEUED)
-    controller = firmware_controller_factory(job, with_settings=False)
+    controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
 
     parent = MagicMock()
     parent.prune_history = MagicMock()
@@ -155,7 +155,7 @@ async def test_cancel_queued_does_not_touch_terminate_current_process(
     null case crashes the cancel.
     """
     job = _job("j-q", status=JobStatus.QUEUED)
-    controller = firmware_controller_factory(job, with_settings=False)
+    controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
     controller._prune_history = MagicMock()
 
     await controller.cancel(job_id="j-q")
@@ -181,7 +181,7 @@ async def test_cancel_running_job_records_intent_and_terminates(
     failure in the dashboard log.
     """
     job = _job("j-r", status=JobStatus.RUNNING)
-    controller = firmware_controller_factory(job, with_settings=False)
+    controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
     controller._current_job = job
 
     await controller.cancel(job_id="j-r")
@@ -203,7 +203,7 @@ async def test_cancel_running_job_does_not_fire_event_directly(
     see two cancels for one job.
     """
     job = _job("j-r", status=JobStatus.RUNNING)
-    controller = firmware_controller_factory(job, with_settings=False)
+    controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
     controller._current_job = job
 
     await controller.cancel(job_id="j-r")
@@ -226,7 +226,7 @@ async def test_cancel_running_job_with_no_current_job_raises_runtime_error(
     inconsistency than to mask it.
     """
     job = _job("j-r", status=JobStatus.RUNNING)
-    controller = firmware_controller_factory(job, with_settings=False)
+    controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
     # ``_current_job`` left as ``None`` — out of sync.
 
     with pytest.raises(RuntimeError, match="state out of sync"):
@@ -246,7 +246,7 @@ async def test_cancel_running_job_with_mismatched_current_job_raises(
     """
     job = _job("j-r", status=JobStatus.RUNNING)
     other = _job("j-other", status=JobStatus.RUNNING)
-    controller = firmware_controller_factory(job, other, with_settings=False)
+    controller = firmware_controller_factory(job, other, with_settings=False, with_terminate=True)
     controller._current_job = other  # somebody else is running
 
     with pytest.raises(RuntimeError, match="state out of sync"):
@@ -277,7 +277,7 @@ async def test_cancel_terminal_job_raises_invalid_args(
     can tell why the cancel was refused (race vs. genuinely-finished).
     """
     job = _job("j-t", status=status)
-    controller = firmware_controller_factory(job, with_settings=False)
+    controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.cancel(job_id="j-t")

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -27,7 +27,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import (
     ErrorCode,
@@ -53,35 +52,13 @@ def _job(
     )
 
 
-def _controller(*jobs: FirmwareJob) -> FirmwareController:
-    """Build a controller skeleton with just the bits ``cancel`` reads.
-
-    ``cancel`` consults ``self._jobs`` and ``self._current_job``,
-    calls ``self._prune_history`` / ``self._persist_jobs`` /
-    ``self._terminate_current_process``, and fires through
-    ``self._db.bus``. Everything else (queue, scanner, signal
-    handlers) stays out of the test surface.
-    """
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {j.job_id: j for j in jobs}
-    controller._current_job = None
-    controller._current_process = None
-    controller._cancel_requested = set()
-    controller._persist_jobs = AsyncMock()
-    controller._terminate_current_process = AsyncMock()
-    bus = MagicMock()
-    bus.fire = MagicMock()
-    controller._db = type("DB", (), {"bus": bus})()
-    return controller
-
-
 # ---------------------------------------------------------------------------
 # Lookup failures
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_cancel_raises_not_found_for_unknown_job_id() -> None:
+async def test_cancel_raises_not_found_for_unknown_job_id(firmware_controller_factory) -> None:
     """An unknown ``job_id`` raises ``CommandError(NOT_FOUND)`` with the id named.
 
     Must be a ``CommandError`` (not a bare ``ValueError``) so the
@@ -92,7 +69,7 @@ async def test_cancel_raises_not_found_for_unknown_job_id() -> None:
     distinguishes it from ``INVALID_ARGS`` to render a different
     error toast.
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
 
     with pytest.raises(CommandError) as exc:
         await controller.cancel(job_id="bogus")
@@ -106,7 +83,9 @@ async def test_cancel_raises_not_found_for_unknown_job_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_queued_job_marks_terminal_and_fires_event() -> None:
+async def test_cancel_queued_job_marks_terminal_and_fires_event(
+    firmware_controller_factory,
+) -> None:
     """A queued job flips to ``CANCELLED`` immediately and broadcasts.
 
     Goes through ``_mark_job_terminal`` (the shared helper that
@@ -115,7 +94,7 @@ async def test_cancel_queued_job_marks_terminal_and_fires_event() -> None:
     status until the next page refresh.
     """
     job = _job("j-q", status=JobStatus.QUEUED)
-    controller = _controller(job)
+    controller = firmware_controller_factory(job, with_settings=False)
     controller._prune_history = MagicMock()
 
     await controller.cancel(job_id="j-q")
@@ -126,7 +105,9 @@ async def test_cancel_queued_job_marks_terminal_and_fires_event() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_queued_job_prunes_history_before_persisting() -> None:
+async def test_cancel_queued_job_prunes_history_before_persisting(
+    firmware_controller_factory,
+) -> None:
     """``cancel`` (QUEUED branch) calls ``_prune_history`` *before* ``_persist_jobs``.
 
     Pruning before persist ensures the on-disk metadata reflects
@@ -141,7 +122,7 @@ async def test_cancel_queued_job_prunes_history_before_persisting() -> None:
     and lose the cap on the very next read.
     """
     job = _job("j-q", status=JobStatus.QUEUED)
-    controller = _controller(job)
+    controller = firmware_controller_factory(job, with_settings=False)
 
     parent = MagicMock()
     parent.prune_history = MagicMock()
@@ -158,7 +139,9 @@ async def test_cancel_queued_job_prunes_history_before_persisting() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_queued_does_not_touch_terminate_current_process() -> None:
+async def test_cancel_queued_does_not_touch_terminate_current_process(
+    firmware_controller_factory,
+) -> None:
     """The QUEUED branch never reaches the subprocess terminator.
 
     Belt-and-braces: ``_terminate_current_process`` walks
@@ -169,7 +152,7 @@ async def test_cancel_queued_does_not_touch_terminate_current_process() -> None:
     null case crashes the cancel.
     """
     job = _job("j-q", status=JobStatus.QUEUED)
-    controller = _controller(job)
+    controller = firmware_controller_factory(job, with_settings=False)
     controller._prune_history = MagicMock()
 
     await controller.cancel(job_id="j-q")
@@ -183,7 +166,9 @@ async def test_cancel_queued_does_not_touch_terminate_current_process() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_running_job_records_intent_and_terminates() -> None:
+async def test_cancel_running_job_records_intent_and_terminates(
+    firmware_controller_factory,
+) -> None:
     """A running job's id lands in ``_cancel_requested`` and the terminator runs.
 
     The runner's ``finally`` branch in ``_execute_job`` consults
@@ -193,7 +178,7 @@ async def test_cancel_running_job_records_intent_and_terminates() -> None:
     failure in the dashboard log.
     """
     job = _job("j-r", status=JobStatus.RUNNING)
-    controller = _controller(job)
+    controller = firmware_controller_factory(job, with_settings=False)
     controller._current_job = job
 
     await controller.cancel(job_id="j-r")
@@ -203,7 +188,7 @@ async def test_cancel_running_job_records_intent_and_terminates() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_running_job_does_not_fire_event_directly() -> None:
+async def test_cancel_running_job_does_not_fire_event_directly(firmware_controller_factory) -> None:
     """``JOB_CANCELLED`` is fired by the *runner*, not by ``cancel``.
 
     Pin the responsibility split: ``cancel`` records intent and
@@ -213,7 +198,7 @@ async def test_cancel_running_job_does_not_fire_event_directly() -> None:
     see two cancels for one job.
     """
     job = _job("j-r", status=JobStatus.RUNNING)
-    controller = _controller(job)
+    controller = firmware_controller_factory(job, with_settings=False)
     controller._current_job = job
 
     await controller.cancel(job_id="j-r")
@@ -224,7 +209,9 @@ async def test_cancel_running_job_does_not_fire_event_directly() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_running_job_with_no_current_job_raises_runtime_error() -> None:
+async def test_cancel_running_job_with_no_current_job_raises_runtime_error(
+    firmware_controller_factory,
+) -> None:
     """RUNNING in ``_jobs`` but ``_current_job`` is None → state out of sync.
 
     Defensive: if we ever see a ``RUNNING`` status with no active
@@ -234,7 +221,7 @@ async def test_cancel_running_job_with_no_current_job_raises_runtime_error() -> 
     inconsistency than to mask it.
     """
     job = _job("j-r", status=JobStatus.RUNNING)
-    controller = _controller(job)
+    controller = firmware_controller_factory(job, with_settings=False)
     # ``_current_job`` left as ``None`` — out of sync.
 
     with pytest.raises(RuntimeError, match="state out of sync"):
@@ -243,7 +230,9 @@ async def test_cancel_running_job_with_no_current_job_raises_runtime_error() -> 
 
 
 @pytest.mark.asyncio
-async def test_cancel_running_job_with_mismatched_current_job_raises() -> None:
+async def test_cancel_running_job_with_mismatched_current_job_raises(
+    firmware_controller_factory,
+) -> None:
     """RUNNING ``job_id`` doesn't match ``_current_job.job_id`` → out of sync.
 
     Same hazard as the no-current-job case: signalling the wrong
@@ -252,7 +241,7 @@ async def test_cancel_running_job_with_mismatched_current_job_raises() -> None:
     """
     job = _job("j-r", status=JobStatus.RUNNING)
     other = _job("j-other", status=JobStatus.RUNNING)
-    controller = _controller(job, other)
+    controller = firmware_controller_factory(job, other, with_settings=False)
     controller._current_job = other  # somebody else is running
 
     with pytest.raises(RuntimeError, match="state out of sync"):
@@ -270,7 +259,9 @@ async def test_cancel_running_job_with_mismatched_current_job_raises() -> None:
     [JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED],
 )
 @pytest.mark.asyncio
-async def test_cancel_terminal_job_raises_invalid_args(status: JobStatus) -> None:
+async def test_cancel_terminal_job_raises_invalid_args(
+    status: JobStatus, firmware_controller_factory
+) -> None:
     """A job in any terminal status rejects with ``CommandError(INVALID_ARGS)``.
 
     The frontend's "Cancel" button only shows for queued/running
@@ -281,7 +272,7 @@ async def test_cancel_terminal_job_raises_invalid_args(status: JobStatus) -> Non
     can tell why the cancel was refused (race vs. genuinely-finished).
     """
     job = _job("j-t", status=status)
-    controller = _controller(job)
+    controller = firmware_controller_factory(job, with_settings=False)
 
     with pytest.raises(CommandError) as exc:
         await controller.cancel(job_id="j-t")

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -35,6 +35,7 @@ from esphome_device_builder.models import (
     JobStatus,
     JobType,
 )
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 def _job(
@@ -58,7 +59,9 @@ def _job(
 
 
 @pytest.mark.asyncio
-async def test_cancel_raises_not_found_for_unknown_job_id(firmware_controller_factory) -> None:
+async def test_cancel_raises_not_found_for_unknown_job_id(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """An unknown ``job_id`` raises ``CommandError(NOT_FOUND)`` with the id named.
 
     Must be a ``CommandError`` (not a bare ``ValueError``) so the
@@ -84,7 +87,7 @@ async def test_cancel_raises_not_found_for_unknown_job_id(firmware_controller_fa
 
 @pytest.mark.asyncio
 async def test_cancel_queued_job_marks_terminal_and_fires_event(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """A queued job flips to ``CANCELLED`` immediately and broadcasts.
 
@@ -106,7 +109,7 @@ async def test_cancel_queued_job_marks_terminal_and_fires_event(
 
 @pytest.mark.asyncio
 async def test_cancel_queued_job_prunes_history_before_persisting(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """``cancel`` (QUEUED branch) calls ``_prune_history`` *before* ``_persist_jobs``.
 
@@ -140,7 +143,7 @@ async def test_cancel_queued_job_prunes_history_before_persisting(
 
 @pytest.mark.asyncio
 async def test_cancel_queued_does_not_touch_terminate_current_process(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """The QUEUED branch never reaches the subprocess terminator.
 
@@ -167,7 +170,7 @@ async def test_cancel_queued_does_not_touch_terminate_current_process(
 
 @pytest.mark.asyncio
 async def test_cancel_running_job_records_intent_and_terminates(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """A running job's id lands in ``_cancel_requested`` and the terminator runs.
 
@@ -188,7 +191,9 @@ async def test_cancel_running_job_records_intent_and_terminates(
 
 
 @pytest.mark.asyncio
-async def test_cancel_running_job_does_not_fire_event_directly(firmware_controller_factory) -> None:
+async def test_cancel_running_job_does_not_fire_event_directly(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """``JOB_CANCELLED`` is fired by the *runner*, not by ``cancel``.
 
     Pin the responsibility split: ``cancel`` records intent and
@@ -210,7 +215,7 @@ async def test_cancel_running_job_does_not_fire_event_directly(firmware_controll
 
 @pytest.mark.asyncio
 async def test_cancel_running_job_with_no_current_job_raises_runtime_error(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """RUNNING in ``_jobs`` but ``_current_job`` is None → state out of sync.
 
@@ -231,7 +236,7 @@ async def test_cancel_running_job_with_no_current_job_raises_runtime_error(
 
 @pytest.mark.asyncio
 async def test_cancel_running_job_with_mismatched_current_job_raises(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """RUNNING ``job_id`` doesn't match ``_current_job.job_id`` → out of sync.
 
@@ -260,7 +265,7 @@ async def test_cancel_running_job_with_mismatched_current_job_raises(
 )
 @pytest.mark.asyncio
 async def test_cancel_terminal_job_raises_invalid_args(
-    status: JobStatus, firmware_controller_factory
+    status: JobStatus, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A job in any terminal status rejects with ``CommandError(INVALID_ARGS)``.
 

--- a/tests/controllers/firmware/test_clear.py
+++ b/tests/controllers/firmware/test_clear.py
@@ -21,28 +21,11 @@ surfaces immediately.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
-
-
-def _controller() -> FirmwareController:
-    """Build a controller skeleton for ``clear``.
-
-    Same shape as ``test_install._controller`` minus the
-    settings-driven path validation (``clear`` doesn't read
-    ``config_dir`` / ``rel_path``). All ``clear`` touches is
-    ``self._jobs`` and ``self._persist_jobs`` — stub the latter
-    so the test doesn't write to disk.
-    """
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._persist_jobs = AsyncMock()
-    controller._db = MagicMock()
-    return controller
 
 
 def _job(job_id: str, status: JobStatus, *, job_type: JobType = JobType.COMPILE) -> FirmwareJob:
@@ -61,14 +44,14 @@ def _job(job_id: str, status: JobStatus, *, job_type: JobType = JobType.COMPILE)
 
 
 @pytest.mark.asyncio
-async def test_clear_default_removes_all_terminal_states() -> None:
+async def test_clear_default_removes_all_terminal_states(firmware_controller_factory) -> None:
     """``clear()`` with no args removes every terminal job (COMPLETED/FAILED/CANCELLED).
 
     Pin all three terminal states in one test so a regression that
     forgets to include any one of them in ``_TERMINAL_JOB_STATUSES``
     surfaces here regardless of which state was missed.
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {
         "c": _job("c", JobStatus.COMPLETED),
         "f": _job("f", JobStatus.FAILED),
@@ -81,7 +64,7 @@ async def test_clear_default_removes_all_terminal_states() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_default_keeps_queued_and_running_jobs() -> None:
+async def test_clear_default_keeps_queued_and_running_jobs(firmware_controller_factory) -> None:
     """Active jobs (QUEUED / RUNNING) survive the default clear.
 
     The "Clear finished" button must never remove a build the
@@ -89,7 +72,7 @@ async def test_clear_default_keeps_queued_and_running_jobs() -> None:
     that defaulted to "remove all" would silently nuke the queue
     and follow_job sessions would be left dangling.
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {
         "q": _job("q", JobStatus.QUEUED),
         "r": _job("r", JobStatus.RUNNING),
@@ -102,7 +85,7 @@ async def test_clear_default_keeps_queued_and_running_jobs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_default_with_no_terminal_jobs_is_noop() -> None:
+async def test_clear_default_with_no_terminal_jobs_is_noop(firmware_controller_factory) -> None:
     """Empty terminal-set → nothing removed, but ``_persist_jobs`` still runs.
 
     Pinned because the default branch's filter list ends up empty
@@ -110,7 +93,7 @@ async def test_clear_default_with_no_terminal_jobs_is_noop() -> None:
     was empty would leak a stale on-disk file when the user
     *did* clear something earlier in the same session.
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {
         "q": _job("q", JobStatus.QUEUED),
         "r": _job("r", JobStatus.RUNNING),
@@ -128,14 +111,16 @@ async def test_clear_default_with_no_terminal_jobs_is_noop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_with_specific_status_removes_only_that_status() -> None:
+async def test_clear_with_specific_status_removes_only_that_status(
+    firmware_controller_factory,
+) -> None:
     """``clear(status=COMPLETED)`` leaves FAILED and CANCELLED alone.
 
     The "Clear succeeded" / "Clear failed" buttons feed this path;
     without exact-match filtering they'd nuke the wrong category
     and the user would lose history they wanted to keep.
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {
         "c1": _job("c1", JobStatus.COMPLETED),
         "c2": _job("c2", JobStatus.COMPLETED),
@@ -149,7 +134,7 @@ async def test_clear_with_specific_status_removes_only_that_status() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_with_status_string_matches_enum_value() -> None:
+async def test_clear_with_status_string_matches_enum_value(firmware_controller_factory) -> None:
     """The WS layer passes ``status`` as a bare string; equality must hold.
 
     ``JobStatus`` is a ``StrEnum`` so ``JobStatus.COMPLETED ==
@@ -159,7 +144,7 @@ async def test_clear_with_status_string_matches_enum_value() -> None:
     enum would silently make this comparison false and the
     string-status branch would no-op.
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {
         "c": _job("c", JobStatus.COMPLETED),
         "f": _job("f", JobStatus.FAILED),
@@ -171,7 +156,7 @@ async def test_clear_with_status_string_matches_enum_value() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_with_status_can_remove_active_jobs() -> None:
+async def test_clear_with_status_can_remove_active_jobs(firmware_controller_factory) -> None:
     """Explicit ``status=RUNNING`` removes that exact state.
 
     The default path protects active jobs, but the explicit-status
@@ -180,7 +165,7 @@ async def test_clear_with_status_can_remove_active_jobs() -> None:
     FAILED) is a real recovery scenario. Pin the contract that
     the filter is applied verbatim, not intersected with terminal.
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {
         "r": _job("r", JobStatus.RUNNING),
         "q": _job("q", JobStatus.QUEUED),
@@ -193,9 +178,9 @@ async def test_clear_with_status_can_remove_active_jobs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_with_status_no_matches_is_noop() -> None:
+async def test_clear_with_status_no_matches_is_noop(firmware_controller_factory) -> None:
     """An unmatched status is a no-op (still persists the unchanged map)."""
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {
         "c": _job("c", JobStatus.COMPLETED),
     }
@@ -212,7 +197,7 @@ async def test_clear_with_status_no_matches_is_noop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_persists_after_removal() -> None:
+async def test_clear_persists_after_removal(firmware_controller_factory) -> None:
     """``_persist_jobs`` is awaited after the in-memory delete.
 
     Without persist, a restart would resurrect cleared jobs from
@@ -220,7 +205,7 @@ async def test_clear_persists_after_removal() -> None:
     (persist runs *after* the deletes — the map must be the
     cleared shape when persist serialises it).
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     seen_jobs_at_persist: dict[str, FirmwareJob] = {}
 
     async def _capture() -> None:
@@ -241,7 +226,7 @@ async def test_clear_persists_after_removal() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_accepts_arbitrary_kwargs() -> None:
+async def test_clear_accepts_arbitrary_kwargs(firmware_controller_factory) -> None:
     """``**kwargs`` lets the WS dispatcher's keyword spread through unread fields.
 
     Same contract as every other ``firmware/*`` handler. A regression
@@ -249,7 +234,7 @@ async def test_clear_accepts_arbitrary_kwargs() -> None:
     ``client`` / ``message_id`` / bookkeeping fields the handler
     doesn't read.
     """
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {"c": _job("c", JobStatus.COMPLETED)}
 
     await controller.clear(client=object(), message_id="m1", spurious=True)
@@ -258,9 +243,9 @@ async def test_clear_accepts_arbitrary_kwargs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_with_empty_jobs_map_is_noop() -> None:
+async def test_clear_with_empty_jobs_map_is_noop(firmware_controller_factory) -> None:
     """Calling ``clear`` on an already-empty map doesn't crash and still persists."""
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
 
     await controller.clear()
 

--- a/tests/controllers/firmware/test_clear.py
+++ b/tests/controllers/firmware/test_clear.py
@@ -26,6 +26,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 def _job(job_id: str, status: JobStatus, *, job_type: JobType = JobType.COMPILE) -> FirmwareJob:
@@ -44,7 +45,9 @@ def _job(job_id: str, status: JobStatus, *, job_type: JobType = JobType.COMPILE)
 
 
 @pytest.mark.asyncio
-async def test_clear_default_removes_all_terminal_states(firmware_controller_factory) -> None:
+async def test_clear_default_removes_all_terminal_states(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """``clear()`` with no args removes every terminal job (COMPLETED/FAILED/CANCELLED).
 
     Pin all three terminal states in one test so a regression that
@@ -64,7 +67,9 @@ async def test_clear_default_removes_all_terminal_states(firmware_controller_fac
 
 
 @pytest.mark.asyncio
-async def test_clear_default_keeps_queued_and_running_jobs(firmware_controller_factory) -> None:
+async def test_clear_default_keeps_queued_and_running_jobs(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Active jobs (QUEUED / RUNNING) survive the default clear.
 
     The "Clear finished" button must never remove a build the
@@ -85,7 +90,9 @@ async def test_clear_default_keeps_queued_and_running_jobs(firmware_controller_f
 
 
 @pytest.mark.asyncio
-async def test_clear_default_with_no_terminal_jobs_is_noop(firmware_controller_factory) -> None:
+async def test_clear_default_with_no_terminal_jobs_is_noop(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Empty terminal-set → nothing removed, but ``_persist_jobs`` still runs.
 
     Pinned because the default branch's filter list ends up empty
@@ -112,7 +119,7 @@ async def test_clear_default_with_no_terminal_jobs_is_noop(firmware_controller_f
 
 @pytest.mark.asyncio
 async def test_clear_with_specific_status_removes_only_that_status(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """``clear(status=COMPLETED)`` leaves FAILED and CANCELLED alone.
 
@@ -134,7 +141,9 @@ async def test_clear_with_specific_status_removes_only_that_status(
 
 
 @pytest.mark.asyncio
-async def test_clear_with_status_string_matches_enum_value(firmware_controller_factory) -> None:
+async def test_clear_with_status_string_matches_enum_value(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """The WS layer passes ``status`` as a bare string; equality must hold.
 
     ``JobStatus`` is a ``StrEnum`` so ``JobStatus.COMPLETED ==
@@ -156,7 +165,9 @@ async def test_clear_with_status_string_matches_enum_value(firmware_controller_f
 
 
 @pytest.mark.asyncio
-async def test_clear_with_status_can_remove_active_jobs(firmware_controller_factory) -> None:
+async def test_clear_with_status_can_remove_active_jobs(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Explicit ``status=RUNNING`` removes that exact state.
 
     The default path protects active jobs, but the explicit-status
@@ -178,7 +189,9 @@ async def test_clear_with_status_can_remove_active_jobs(firmware_controller_fact
 
 
 @pytest.mark.asyncio
-async def test_clear_with_status_no_matches_is_noop(firmware_controller_factory) -> None:
+async def test_clear_with_status_no_matches_is_noop(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """An unmatched status is a no-op (still persists the unchanged map)."""
     controller = firmware_controller_factory(with_settings=False)
     controller._jobs = {
@@ -197,7 +210,9 @@ async def test_clear_with_status_no_matches_is_noop(firmware_controller_factory)
 
 
 @pytest.mark.asyncio
-async def test_clear_persists_after_removal(firmware_controller_factory) -> None:
+async def test_clear_persists_after_removal(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """``_persist_jobs`` is awaited after the in-memory delete.
 
     Without persist, a restart would resurrect cleared jobs from
@@ -226,7 +241,9 @@ async def test_clear_persists_after_removal(firmware_controller_factory) -> None
 
 
 @pytest.mark.asyncio
-async def test_clear_accepts_arbitrary_kwargs(firmware_controller_factory) -> None:
+async def test_clear_accepts_arbitrary_kwargs(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """``**kwargs`` lets the WS dispatcher's keyword spread through unread fields.
 
     Same contract as every other ``firmware/*`` handler. A regression
@@ -243,7 +260,9 @@ async def test_clear_accepts_arbitrary_kwargs(firmware_controller_factory) -> No
 
 
 @pytest.mark.asyncio
-async def test_clear_with_empty_jobs_map_is_noop(firmware_controller_factory) -> None:
+async def test_clear_with_empty_jobs_map_is_noop(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Calling ``clear`` on an already-empty map doesn't crash and still persists."""
     controller = firmware_controller_factory(with_settings=False)
 

--- a/tests/controllers/firmware/test_compile.py
+++ b/tests/controllers/firmware/test_compile.py
@@ -22,39 +22,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
 
 
-def _controller(tmp_path: Path) -> FirmwareController:
-    """Build a controller wired to a real ``DashboardSettings`` for path validation.
-
-    Mirrors ``test_install.py`` / ``test_upload.py``'s helper —
-    the validator inside ``compile`` calls ``rel_path``, which
-    needs a real ``config_dir`` / ``absolute_config_dir``.
-    Everything else (queue, persistence, supersede check, bus)
-    is stubbed.
-    """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._queue = AsyncMock()
-    controller._persist_jobs = AsyncMock()
-    controller._supersede_active_jobs = AsyncMock()
-
-    bus = MagicMock()
-    bus.fire = MagicMock()
-    controller._db = type("DB", (), {"settings": settings, "bus": bus})()
-    return controller
-
-
 @pytest.mark.asyncio
-async def test_compile_returns_queued_job_with_compile_type(tmp_path: Path) -> None:
+async def test_compile_returns_queued_job_with_compile_type(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Happy path: handler returns a ``QUEUED`` ``FirmwareJob`` of type ``COMPILE``.
 
     The frontend's "live tasks" panel keys off ``status`` and
@@ -63,7 +38,7 @@ async def test_compile_returns_queued_job_with_compile_type(tmp_path: Path) -> N
     (``INSTALL`` is the obvious accident since the install
     handler delegates through the same queue).
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.compile(configuration="kitchen.yaml")
@@ -74,7 +49,9 @@ async def test_compile_returns_queued_job_with_compile_type(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_compile_rejects_traversal_configuration(tmp_path: Path) -> None:
+async def test_compile_rejects_traversal_configuration(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """A traversal-shaped configuration trips the boundary validator.
 
     The validator helper itself is fully covered in
@@ -85,7 +62,7 @@ async def test_compile_rejects_traversal_configuration(tmp_path: Path) -> None:
     could path-traverse via ``configuration`` even though every
     other handler stays gated.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as exc:
         await controller.compile(configuration="../etc/passwd")
@@ -94,7 +71,9 @@ async def test_compile_rejects_traversal_configuration(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_compile_enqueues_before_firing_job_queued(tmp_path: Path) -> None:
+async def test_compile_enqueues_before_firing_job_queued(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
     Same race-prevention contract as ``install`` and ``upload``:
@@ -115,7 +94,7 @@ async def test_compile_enqueues_before_firing_job_queued(tmp_path: Path) -> None
     parent.queue.put = AsyncMock()
     parent.bus.fire = MagicMock()
 
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     controller._queue = parent.queue
     controller._db.bus = parent.bus
     (tmp_path / "kitchen.yaml").write_text("")
@@ -131,7 +110,9 @@ async def test_compile_enqueues_before_firing_job_queued(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_compile_registers_job_in_jobs_map(tmp_path: Path) -> None:
+async def test_compile_registers_job_in_jobs_map(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """The new job lands in ``self._jobs`` keyed by ``job_id``.
 
     Subsequent ``firmware/get_jobs`` / ``firmware/cancel`` /
@@ -139,7 +120,7 @@ async def test_compile_registers_job_in_jobs_map(tmp_path: Path) -> None:
     forgetting to register it here would leave those handlers
     raising ``"Job not found"`` for a job the user just queued.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.compile(configuration="kitchen.yaml")

--- a/tests/controllers/firmware/test_compile.py
+++ b/tests/controllers/firmware/test_compile.py
@@ -39,7 +39,7 @@ async def test_compile_returns_queued_job_with_compile_type(
     (``INSTALL`` is the obvious accident since the install
     handler delegates through the same queue).
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.compile(configuration="kitchen.yaml")
@@ -63,7 +63,7 @@ async def test_compile_rejects_traversal_configuration(
     could path-traverse via ``configuration`` even though every
     other handler stays gated.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.compile(configuration="../etc/passwd")
@@ -95,7 +95,7 @@ async def test_compile_enqueues_before_firing_job_queued(
     parent.queue.put = AsyncMock()
     parent.bus.fire = MagicMock()
 
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     controller._queue = parent.queue
     controller._db.bus = parent.bus
     (tmp_path / "kitchen.yaml").write_text("")
@@ -121,7 +121,7 @@ async def test_compile_registers_job_in_jobs_map(
     forgetting to register it here would leave those handlers
     raising ``"Job not found"`` for a job the user just queued.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.compile(configuration="kitchen.yaml")

--- a/tests/controllers/firmware/test_compile.py
+++ b/tests/controllers/firmware/test_compile.py
@@ -24,11 +24,12 @@ import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 @pytest.mark.asyncio
 async def test_compile_returns_queued_job_with_compile_type(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Happy path: handler returns a ``QUEUED`` ``FirmwareJob`` of type ``COMPILE``.
 
@@ -50,7 +51,7 @@ async def test_compile_returns_queued_job_with_compile_type(
 
 @pytest.mark.asyncio
 async def test_compile_rejects_traversal_configuration(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A traversal-shaped configuration trips the boundary validator.
 
@@ -72,7 +73,7 @@ async def test_compile_rejects_traversal_configuration(
 
 @pytest.mark.asyncio
 async def test_compile_enqueues_before_firing_job_queued(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
@@ -111,7 +112,7 @@ async def test_compile_enqueues_before_firing_job_queued(
 
 @pytest.mark.asyncio
 async def test_compile_registers_job_in_jobs_map(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """The new job lands in ``self._jobs`` keyed by ``job_id``.
 

--- a/tests/controllers/firmware/test_compile_bulk.py
+++ b/tests/controllers/firmware/test_compile_bulk.py
@@ -26,43 +26,16 @@ specifically.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType
 
 
-def _controller(tmp_path: Path) -> FirmwareController:
-    """Build a controller wired to a real ``DashboardSettings`` for path validation.
-
-    The bulk validator inside ``compile_bulk`` calls ``rel_path``
-    in an executor, which needs a real ``config_dir`` /
-    ``absolute_config_dir``. Everything else (queue, persistence,
-    supersede check, bus) is stubbed.
-    """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._queue = AsyncMock()
-    controller._persist_jobs = AsyncMock()
-    controller._supersede_active_jobs = AsyncMock()
-
-    bus = MagicMock()
-    bus.fire = MagicMock()
-    controller._db = type("DB", (), {"settings": settings, "bus": bus})()
-    return controller
-
-
 @pytest.mark.asyncio
 async def test_compile_bulk_returns_queued_jobs_for_every_config(
-    tmp_path: Path,
+    tmp_path: Path, firmware_controller_factory
 ) -> None:
     """Happy path: one ``COMPILE`` job per configuration, all ``QUEUED``.
 
@@ -72,7 +45,7 @@ async def test_compile_bulk_returns_queued_jobs_for_every_config(
     """
     for name in ("kitchen.yaml", "garage.yaml", "office.yaml"):
         (tmp_path / name).write_text("")
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     jobs = await controller.compile_bulk(
         configurations=["kitchen.yaml", "garage.yaml", "office.yaml"],
@@ -85,7 +58,7 @@ async def test_compile_bulk_returns_queued_jobs_for_every_config(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
-    tmp_path: Path,
+    tmp_path: Path, firmware_controller_factory
 ) -> None:
     """A traversal payload anywhere in the list rejects the whole batch.
 
@@ -99,7 +72,7 @@ async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
     """
     (tmp_path / "kitchen.yaml").write_text("")
     (tmp_path / "garage.yaml").write_text("")
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as exc:
         await controller.compile_bulk(
@@ -115,7 +88,7 @@ async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
-    tmp_path: Path,
+    tmp_path: Path, firmware_controller_factory
 ) -> None:
     """An empty-string configuration rejects the whole batch.
 
@@ -126,7 +99,7 @@ async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
     the validator entirely).
     """
     (tmp_path / "kitchen.yaml").write_text("")
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as exc:
         await controller.compile_bulk(configurations=["kitchen.yaml", ""])
@@ -136,7 +109,7 @@ async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_skips_entries_with_enqueue_command_error(
-    tmp_path: Path,
+    tmp_path: Path, firmware_controller_factory
 ) -> None:
     """A ``CommandError`` from ``_enqueue`` skips that entry but keeps going.
 
@@ -154,7 +127,7 @@ async def test_compile_bulk_skips_entries_with_enqueue_command_error(
     """
     for name in ("kitchen.yaml", "locked.yaml", "office.yaml"):
         (tmp_path / name).write_text("")
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     real_enqueue = controller._enqueue
 
@@ -183,14 +156,16 @@ async def test_compile_bulk_skips_entries_with_enqueue_command_error(
 
 
 @pytest.mark.asyncio
-async def test_compile_bulk_empty_input_returns_empty_list(tmp_path: Path) -> None:
+async def test_compile_bulk_empty_input_returns_empty_list(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """An empty ``configurations`` list returns ``[]`` without raising.
 
     Frontend's "select all and compile" can produce an empty
     list when the user selected nothing — surface a clean empty
     result rather than a confusing error.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     jobs = await controller.compile_bulk(configurations=[])
 
@@ -200,7 +175,7 @@ async def test_compile_bulk_empty_input_returns_empty_list(tmp_path: Path) -> No
 
 @pytest.mark.asyncio
 async def test_compile_bulk_fires_job_queued_per_successful_entry(
-    tmp_path: Path,
+    tmp_path: Path, firmware_controller_factory
 ) -> None:
     """``JOB_QUEUED`` fires exactly once per queued job — no double-fire, no skip.
 
@@ -210,7 +185,7 @@ async def test_compile_bulk_fires_job_queued_per_successful_entry(
     """
     for name in ("kitchen.yaml", "garage.yaml"):
         (tmp_path / name).write_text("")
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     jobs = await controller.compile_bulk(configurations=["kitchen.yaml", "garage.yaml"])
 

--- a/tests/controllers/firmware/test_compile_bulk.py
+++ b/tests/controllers/firmware/test_compile_bulk.py
@@ -31,11 +31,12 @@ import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 @pytest.mark.asyncio
 async def test_compile_bulk_returns_queued_jobs_for_every_config(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Happy path: one ``COMPILE`` job per configuration, all ``QUEUED``.
 
@@ -58,7 +59,7 @@ async def test_compile_bulk_returns_queued_jobs_for_every_config(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A traversal payload anywhere in the list rejects the whole batch.
 
@@ -88,7 +89,7 @@ async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """An empty-string configuration rejects the whole batch.
 
@@ -109,7 +110,7 @@ async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_skips_entries_with_enqueue_command_error(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A ``CommandError`` from ``_enqueue`` skips that entry but keeps going.
 
@@ -157,7 +158,7 @@ async def test_compile_bulk_skips_entries_with_enqueue_command_error(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_empty_input_returns_empty_list(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """An empty ``configurations`` list returns ``[]`` without raising.
 
@@ -175,7 +176,7 @@ async def test_compile_bulk_empty_input_returns_empty_list(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_fires_job_queued_per_successful_entry(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``JOB_QUEUED`` fires exactly once per queued job — no double-fire, no skip.
 

--- a/tests/controllers/firmware/test_compile_bulk.py
+++ b/tests/controllers/firmware/test_compile_bulk.py
@@ -46,7 +46,7 @@ async def test_compile_bulk_returns_queued_jobs_for_every_config(
     """
     for name in ("kitchen.yaml", "garage.yaml", "office.yaml"):
         (tmp_path / name).write_text("")
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     jobs = await controller.compile_bulk(
         configurations=["kitchen.yaml", "garage.yaml", "office.yaml"],
@@ -73,7 +73,7 @@ async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
     """
     (tmp_path / "kitchen.yaml").write_text("")
     (tmp_path / "garage.yaml").write_text("")
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.compile_bulk(
@@ -100,7 +100,7 @@ async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
     the validator entirely).
     """
     (tmp_path / "kitchen.yaml").write_text("")
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.compile_bulk(configurations=["kitchen.yaml", ""])
@@ -128,7 +128,7 @@ async def test_compile_bulk_skips_entries_with_enqueue_command_error(
     """
     for name in ("kitchen.yaml", "locked.yaml", "office.yaml"):
         (tmp_path / name).write_text("")
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     real_enqueue = controller._enqueue
 
@@ -166,7 +166,7 @@ async def test_compile_bulk_empty_input_returns_empty_list(
     list when the user selected nothing — surface a clean empty
     result rather than a confusing error.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     jobs = await controller.compile_bulk(configurations=[])
 
@@ -186,7 +186,7 @@ async def test_compile_bulk_fires_job_queued_per_successful_entry(
     """
     for name in ("kitchen.yaml", "garage.yaml"):
         (tmp_path / name).write_text("")
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     jobs = await controller.compile_bulk(configurations=["kitchen.yaml", "garage.yaml"])
 

--- a/tests/controllers/firmware/test_download.py
+++ b/tests/controllers/firmware/test_download.py
@@ -31,6 +31,7 @@ from typing import Any
 import pytest
 
 from tests._storage_fixtures import write_storage_json
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 @pytest.fixture(autouse=True)
@@ -64,7 +65,7 @@ def _make_firmware(build_dir: Path, name: str, payload: bytes) -> Path:
 
 @pytest.mark.asyncio
 async def test_download_raises_when_storage_missing(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """No StorageJSON sidecar at all → user hasn't compiled this device yet.
 
@@ -81,7 +82,7 @@ async def test_download_raises_when_storage_missing(
 
 @pytest.mark.asyncio
 async def test_download_raises_when_firmware_bin_path_unset(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Sidecar exists but ``firmware_bin_path`` is None → same actionable error.
 
@@ -100,7 +101,7 @@ async def test_download_raises_when_firmware_bin_path_unset(
 
 @pytest.mark.asyncio
 async def test_download_raises_on_traversal_in_file(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A ``file`` value escaping the build dir trips ``Path.relative_to``.
 
@@ -125,7 +126,7 @@ async def test_download_raises_on_traversal_in_file(
 
 @pytest.mark.asyncio
 async def test_download_raises_when_binary_missing(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Sidecar + build dir present but the requested file isn't there.
 
@@ -150,7 +151,7 @@ async def test_download_raises_when_binary_missing(
 
 @pytest.mark.asyncio
 async def test_download_returns_base64_payload_uncompressed(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Default path returns ``{filename, data, size, compressed=False}``.
 
@@ -174,7 +175,7 @@ async def test_download_returns_base64_payload_uncompressed(
 
 @pytest.mark.asyncio
 async def test_download_validator_runs_before_ext_storage_path(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``ext_storage_path`` is unsafe in isolation; the validator gate matters.
 
@@ -220,7 +221,7 @@ async def test_download_validator_runs_before_ext_storage_path(
 
 @pytest.mark.asyncio
 async def test_download_returns_gzipped_payload_when_compressed(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``compressed=True`` gzips the bytes and tacks ``.gz`` onto the filename.
 

--- a/tests/controllers/firmware/test_download.py
+++ b/tests/controllers/firmware/test_download.py
@@ -30,21 +30,7 @@ from typing import Any
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
-from esphome_device_builder.controllers.firmware import FirmwareController
 from tests._storage_fixtures import write_storage_json
-
-
-def _controller(tmp_path: Path) -> FirmwareController:
-    """Stub controller wired to a real ``DashboardSettings.rel_path``."""
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._db = type("DB", (), {"settings": settings})()
-    return controller
 
 
 @pytest.fixture(autouse=True)
@@ -77,7 +63,9 @@ def _make_firmware(build_dir: Path, name: str, payload: bytes) -> Path:
 
 
 @pytest.mark.asyncio
-async def test_download_raises_when_storage_missing(tmp_path: Path) -> None:
+async def test_download_raises_when_storage_missing(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """No StorageJSON sidecar at all → user hasn't compiled this device yet.
 
     The storage sidecar is the only place the dashboard knows where
@@ -85,14 +73,16 @@ async def test_download_raises_when_storage_missing(tmp_path: Path) -> None:
     Surface the actionable error rather than letting an opaque ``None``
     crash deeper in the handler.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(FileNotFoundError, match="No firmware binary"):
         await controller.download(configuration="kitchen.yaml", file="firmware.bin")
 
 
 @pytest.mark.asyncio
-async def test_download_raises_when_firmware_bin_path_unset(tmp_path: Path) -> None:
+async def test_download_raises_when_firmware_bin_path_unset(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Sidecar exists but ``firmware_bin_path`` is None → same actionable error.
 
     Happens when the compile aborted before the link stage (e.g.
@@ -102,14 +92,16 @@ async def test_download_raises_when_firmware_bin_path_unset(tmp_path: Path) -> N
     frontend handles both identically.
     """
     write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=None)
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(FileNotFoundError, match="No firmware binary"):
         await controller.download(configuration="kitchen.yaml", file="firmware.bin")
 
 
 @pytest.mark.asyncio
-async def test_download_raises_on_traversal_in_file(tmp_path: Path) -> None:
+async def test_download_raises_on_traversal_in_file(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """A ``file`` value escaping the build dir trips ``Path.relative_to``.
 
     The traversal guard exists because ``file`` reaches the handler
@@ -125,14 +117,16 @@ async def test_download_raises_on_traversal_in_file(tmp_path: Path) -> None:
     write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
     # Drop a file outside build_dir that the traversal would reach.
     (tmp_path / "secret.txt").write_text("nope", encoding="utf-8")
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(ValueError):
         await controller.download(configuration="kitchen.yaml", file="../../../secret.txt")
 
 
 @pytest.mark.asyncio
-async def test_download_raises_when_binary_missing(tmp_path: Path) -> None:
+async def test_download_raises_when_binary_missing(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Sidecar + build dir present but the requested file isn't there.
 
     Distinct from ``firmware_bin_path`` being unset: the compile
@@ -143,7 +137,7 @@ async def test_download_raises_when_binary_missing(tmp_path: Path) -> None:
     build_dir = tmp_path / ".esphome" / "build" / "kitchen"
     fw = _make_firmware(build_dir, "firmware.bin", b"\x00" * 16)
     write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(FileNotFoundError, match=r"Binary not found: missing\.bin"):
         await controller.download(configuration="kitchen.yaml", file="missing.bin")
@@ -155,7 +149,9 @@ async def test_download_raises_when_binary_missing(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_download_returns_base64_payload_uncompressed(tmp_path: Path) -> None:
+async def test_download_returns_base64_payload_uncompressed(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Default path returns ``{filename, data, size, compressed=False}``.
 
     ``filename`` is ``<storage.name>-<file>``; ``data`` is the
@@ -166,7 +162,7 @@ async def test_download_returns_base64_payload_uncompressed(tmp_path: Path) -> N
     build_dir = tmp_path / ".esphome" / "build" / "kitchen"
     fw = _make_firmware(build_dir, "firmware.bin", payload)
     write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     result = await controller.download(configuration="kitchen.yaml", file="firmware.bin")
 
@@ -177,7 +173,9 @@ async def test_download_returns_base64_payload_uncompressed(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_download_validator_runs_before_ext_storage_path(tmp_path: Path) -> None:
+async def test_download_validator_runs_before_ext_storage_path(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``ext_storage_path`` is unsafe in isolation; the validator gate matters.
 
     Pinning this so a future refactor that drops or re-orders
@@ -211,7 +209,7 @@ async def test_download_validator_runs_before_ext_storage_path(tmp_path: Path) -
 
     controller_module.ext_storage_path = _spy
 
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     with pytest.raises(CommandError) as excinfo:
         await controller.download(configuration="../../etc/passwd", file="firmware.bin")
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
@@ -221,7 +219,9 @@ async def test_download_validator_runs_before_ext_storage_path(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_download_returns_gzipped_payload_when_compressed(tmp_path: Path) -> None:
+async def test_download_returns_gzipped_payload_when_compressed(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``compressed=True`` gzips the bytes and tacks ``.gz`` onto the filename.
 
     Web Serial flashing skips this path — it asks for raw bytes and
@@ -233,7 +233,7 @@ async def test_download_returns_gzipped_payload_when_compressed(tmp_path: Path) 
     build_dir = tmp_path / ".esphome" / "build" / "kitchen"
     fw = _make_firmware(build_dir, "firmware.bin", payload)
     write_storage_json(tmp_path, "kitchen.yaml", firmware_bin_path=fw)
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     result = await controller.download(
         configuration="kitchen.yaml", file="firmware.bin", compressed=True

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -35,6 +35,7 @@ from esphome_device_builder.controllers.firmware.controller import (
     _resolve_download_component,
 )
 from tests._storage_fixtures import write_storage_json
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 @pytest.fixture(autouse=True)
@@ -157,7 +158,7 @@ def test_resolve_download_component_handles_none() -> None:
 
 @pytest.mark.asyncio
 async def test_get_binaries_returns_empty_when_storage_missing(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """No StorageJSON sidecar → empty list, NOT a raise.
 
@@ -177,7 +178,7 @@ async def test_get_binaries_returns_empty_when_storage_missing(
 
 @pytest.mark.asyncio
 async def test_get_binaries_returns_empty_when_target_platform_missing(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Sidecar exists but ``target_platform`` is empty → empty list.
 
@@ -197,7 +198,10 @@ async def test_get_binaries_returns_empty_when_target_platform_missing(
 
 @pytest.mark.asyncio
 async def test_get_binaries_logs_and_returns_empty_on_module_failure(
-    tmp_path: Path, caplog: Any, monkeypatch: Any, firmware_controller_factory
+    tmp_path: Path,
+    caplog: Any,
+    monkeypatch: Any,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """A module that raises from ``get_download_types`` → empty list + warning.
 
@@ -237,7 +241,7 @@ async def test_get_binaries_logs_and_returns_empty_on_module_failure(
 
 @pytest.mark.asyncio
 async def test_get_binaries_routes_esp32_variants_through_umbrella_module(
-    tmp_path: Path, monkeypatch: Any, firmware_controller_factory
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """ESP32 variant in storage → loads the umbrella ``esp32`` component.
 
@@ -272,7 +276,7 @@ async def test_get_binaries_routes_esp32_variants_through_umbrella_module(
 
 @pytest.mark.asyncio
 async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
-    tmp_path: Path, monkeypatch: Any, firmware_controller_factory
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A LibreTiny family target loads the ``libretiny`` component, not the chip module.
 
@@ -303,7 +307,7 @@ async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
 
 @pytest.mark.asyncio
 async def test_get_binaries_returns_module_list_verbatim(
-    tmp_path: Path, monkeypatch: Any, firmware_controller_factory
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """The upstream module's list is returned verbatim — no filtering, no re-shaping.
 

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -30,25 +30,11 @@ from typing import Any
 import pytest
 from esphome.components.esp32 import VARIANTS as _ESP32_VARIANTS
 
-from esphome_device_builder.controllers.config import DashboardSettings
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware.controller import (
     _LIBRETINY_TARGET_PLATFORMS,
     _resolve_download_component,
 )
 from tests._storage_fixtures import write_storage_json
-
-
-def _controller(tmp_path: Path) -> FirmwareController:
-    """Stub controller wired to a real ``DashboardSettings.rel_path``."""
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._db = type("DB", (), {"settings": settings})()
-    return controller
 
 
 @pytest.fixture(autouse=True)
@@ -170,7 +156,9 @@ def test_resolve_download_component_handles_none() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_binaries_returns_empty_when_storage_missing(tmp_path: Path) -> None:
+async def test_get_binaries_returns_empty_when_storage_missing(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """No StorageJSON sidecar → empty list, NOT a raise.
 
     Distinct contract from ``download``: the dashboard's "Web
@@ -180,7 +168,7 @@ async def test_get_binaries_returns_empty_when_storage_missing(tmp_path: Path) -
     whole listing; returning ``[]`` lets the picker show "compile
     first" inline.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     result = await controller.get_binaries(configuration="kitchen.yaml")
 
@@ -189,7 +177,7 @@ async def test_get_binaries_returns_empty_when_storage_missing(tmp_path: Path) -
 
 @pytest.mark.asyncio
 async def test_get_binaries_returns_empty_when_target_platform_missing(
-    tmp_path: Path,
+    tmp_path: Path, firmware_controller_factory
 ) -> None:
     """Sidecar exists but ``target_platform`` is empty → empty list.
 
@@ -200,7 +188,7 @@ async def test_get_binaries_returns_empty_when_target_platform_missing(
     so the listing keeps rendering.
     """
     write_storage_json(tmp_path, "kitchen.yaml", overrides={"esp_platform": ""})
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     result = await controller.get_binaries(configuration="kitchen.yaml")
 
@@ -209,7 +197,7 @@ async def test_get_binaries_returns_empty_when_target_platform_missing(
 
 @pytest.mark.asyncio
 async def test_get_binaries_logs_and_returns_empty_on_module_failure(
-    tmp_path: Path, caplog: Any, monkeypatch: Any
+    tmp_path: Path, caplog: Any, monkeypatch: Any, firmware_controller_factory
 ) -> None:
     """A module that raises from ``get_download_types`` → empty list + warning.
 
@@ -230,7 +218,7 @@ async def test_get_binaries_logs_and_returns_empty_on_module_failure(
     monkeypatch.setitem(sys.modules, "esphome.components.esp32", fake)
 
     write_storage_json(tmp_path, "kitchen.yaml", overrides={"esp_platform": "esp32c3"})
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with caplog.at_level(logging.WARNING):
         result = await controller.get_binaries(configuration="kitchen.yaml")
@@ -249,7 +237,7 @@ async def test_get_binaries_logs_and_returns_empty_on_module_failure(
 
 @pytest.mark.asyncio
 async def test_get_binaries_routes_esp32_variants_through_umbrella_module(
-    tmp_path: Path, monkeypatch: Any
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory
 ) -> None:
     """ESP32 variant in storage → loads the umbrella ``esp32`` component.
 
@@ -271,7 +259,7 @@ async def test_get_binaries_routes_esp32_variants_through_umbrella_module(
         "kitchen.yaml",
         overrides={"esp_platform": "esp32c3"},
     )
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     result = await controller.get_binaries(configuration="kitchen.yaml")
 
@@ -284,7 +272,7 @@ async def test_get_binaries_routes_esp32_variants_through_umbrella_module(
 
 @pytest.mark.asyncio
 async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
-    tmp_path: Path, monkeypatch: Any
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory
 ) -> None:
     """A LibreTiny family target loads the ``libretiny`` component, not the chip module.
 
@@ -305,7 +293,7 @@ async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
         "kitchen.yaml",
         overrides={"esp_platform": "bk72xx"},
     )
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     result = await controller.get_binaries(configuration="kitchen.yaml")
 
@@ -314,7 +302,9 @@ async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
 
 
 @pytest.mark.asyncio
-async def test_get_binaries_returns_module_list_verbatim(tmp_path: Path, monkeypatch: Any) -> None:
+async def test_get_binaries_returns_module_list_verbatim(
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory
+) -> None:
     """The upstream module's list is returned verbatim — no filtering, no re-shaping.
 
     Pin the pass-through so a refactor that adds a "drop entries
@@ -336,7 +326,7 @@ async def test_get_binaries_returns_module_list_verbatim(tmp_path: Path, monkeyp
         "kitchen.yaml",
         overrides={"esp_platform": "esp32"},
     )
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     result = await controller.get_binaries(configuration="kitchen.yaml")
 

--- a/tests/controllers/firmware/test_get_jobs.py
+++ b/tests/controllers/firmware/test_get_jobs.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import pytest
 
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 def _job(
@@ -46,7 +47,9 @@ def _job(
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_returns_every_job_when_unfiltered(firmware_controller_factory) -> None:
+async def test_get_jobs_returns_every_job_when_unfiltered(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """No filters → every job in the map is returned.
 
     The all-jobs panel calls this on cold-start to populate the
@@ -65,7 +68,9 @@ async def test_get_jobs_returns_every_job_when_unfiltered(firmware_controller_fa
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_sorts_newest_first_by_created_at(firmware_controller_factory) -> None:
+async def test_get_jobs_sorts_newest_first_by_created_at(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Result is sorted by ``created_at`` descending (newest first).
 
     The dashboard renders the list top-down; newest at the top
@@ -86,7 +91,9 @@ async def test_get_jobs_sorts_newest_first_by_created_at(firmware_controller_fac
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_filters_by_status(firmware_controller_factory) -> None:
+async def test_get_jobs_filters_by_status(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """``status`` filter keeps only jobs whose status matches.
 
     Frontend uses this to render the "Recently completed" panel
@@ -104,7 +111,9 @@ async def test_get_jobs_filters_by_status(firmware_controller_factory) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_filters_by_configuration(firmware_controller_factory) -> None:
+async def test_get_jobs_filters_by_configuration(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """``configuration`` filter keeps only jobs for that YAML."""
     kitchen = _job("k", configuration="kitchen.yaml")
     garage = _job("g", configuration="garage.yaml")
@@ -118,7 +127,7 @@ async def test_get_jobs_filters_by_configuration(firmware_controller_factory) ->
 
 @pytest.mark.asyncio
 async def test_get_jobs_combines_status_and_configuration_filters(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """Both filters compose with AND semantics."""
     kitchen_queued = _job("kq", configuration="kitchen.yaml", status=JobStatus.QUEUED)
@@ -135,7 +144,7 @@ async def test_get_jobs_combines_status_and_configuration_filters(
 
 @pytest.mark.asyncio
 async def test_get_jobs_filter_with_no_matches_returns_empty_list(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """A filter that matches nothing returns ``[]``, not a raise.
 
@@ -155,7 +164,9 @@ async def test_get_jobs_filter_with_no_matches_returns_empty_list(
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_on_empty_controller_returns_empty_list(firmware_controller_factory) -> None:
+async def test_get_jobs_on_empty_controller_returns_empty_list(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """An empty job map → empty list (cold-start contract)."""
     controller = firmware_controller_factory(with_settings=False)
 
@@ -168,7 +179,9 @@ async def test_get_jobs_on_empty_controller_returns_empty_list(firmware_controll
 
 
 @pytest.mark.asyncio
-async def test_get_job_returns_the_matching_job_for_known_id(firmware_controller_factory) -> None:
+async def test_get_job_returns_the_matching_job_for_known_id(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Known id → the ``FirmwareJob`` instance, full object including ``output``.
 
     Frontend uses this to fetch the full output buffer when the
@@ -185,7 +198,9 @@ async def test_get_job_returns_the_matching_job_for_known_id(firmware_controller
 
 
 @pytest.mark.asyncio
-async def test_get_job_returns_none_for_unknown_id(firmware_controller_factory) -> None:
+async def test_get_job_returns_none_for_unknown_id(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Unknown id → ``None``, NOT a raise.
 
     Distinct from ``cancel`` and ``follow_job``, which both
@@ -200,7 +215,9 @@ async def test_get_job_returns_none_for_unknown_id(firmware_controller_factory) 
 
 
 @pytest.mark.asyncio
-async def test_get_job_does_not_mutate_state(firmware_controller_factory) -> None:
+async def test_get_job_does_not_mutate_state(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Pure read — the call doesn't mutate ``self._jobs`` or persist anything.
 
     Belt-and-braces: a future refactor that, say, lazy-removes

--- a/tests/controllers/firmware/test_get_jobs.py
+++ b/tests/controllers/firmware/test_get_jobs.py
@@ -18,11 +18,8 @@ noticing.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
-
 import pytest
 
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
 
 
@@ -43,24 +40,13 @@ def _job(
     )
 
 
-def _controller(*jobs: FirmwareJob) -> FirmwareController:
-    """Bare-bones controller — ``get_jobs`` / ``get_job`` only read ``self._jobs``."""
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {j.job_id: j for j in jobs}
-    # Stub the bits ``__init__`` would have set so debug logging /
-    # unrelated paths don't ``AttributeError`` if a future
-    # refactor touches them inside the inspectors.
-    controller._persist_jobs = AsyncMock()
-    return controller
-
-
 # ---------------------------------------------------------------------------
 # get_jobs
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_returns_every_job_when_unfiltered() -> None:
+async def test_get_jobs_returns_every_job_when_unfiltered(firmware_controller_factory) -> None:
     """No filters → every job in the map is returned.
 
     The all-jobs panel calls this on cold-start to populate the
@@ -71,7 +57,7 @@ async def test_get_jobs_returns_every_job_when_unfiltered() -> None:
     a = _job("a")
     b = _job("b")
     c = _job("c")
-    controller = _controller(a, b, c)
+    controller = firmware_controller_factory(a, b, c, with_settings=False)
 
     result = await controller.get_jobs()
 
@@ -79,7 +65,7 @@ async def test_get_jobs_returns_every_job_when_unfiltered() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_sorts_newest_first_by_created_at() -> None:
+async def test_get_jobs_sorts_newest_first_by_created_at(firmware_controller_factory) -> None:
     """Result is sorted by ``created_at`` descending (newest first).
 
     The dashboard renders the list top-down; newest at the top
@@ -92,7 +78,7 @@ async def test_get_jobs_sorts_newest_first_by_created_at() -> None:
     new = _job("new", created_at="2026-01-03T00:00:00+00:00")
     # Insert order intentionally not-sorted so the test catches
     # "returns dict insertion order" as a false positive.
-    controller = _controller(middle, old, new)
+    controller = firmware_controller_factory(middle, old, new, with_settings=False)
 
     result = await controller.get_jobs()
 
@@ -100,7 +86,7 @@ async def test_get_jobs_sorts_newest_first_by_created_at() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_filters_by_status() -> None:
+async def test_get_jobs_filters_by_status(firmware_controller_factory) -> None:
     """``status`` filter keeps only jobs whose status matches.
 
     Frontend uses this to render the "Recently completed" panel
@@ -110,7 +96,7 @@ async def test_get_jobs_filters_by_status() -> None:
     queued = _job("q", status=JobStatus.QUEUED)
     running = _job("r", status=JobStatus.RUNNING)
     completed = _job("c", status=JobStatus.COMPLETED)
-    controller = _controller(queued, running, completed)
+    controller = firmware_controller_factory(queued, running, completed, with_settings=False)
 
     result = await controller.get_jobs(status=JobStatus.COMPLETED)
 
@@ -118,12 +104,12 @@ async def test_get_jobs_filters_by_status() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_filters_by_configuration() -> None:
+async def test_get_jobs_filters_by_configuration(firmware_controller_factory) -> None:
     """``configuration`` filter keeps only jobs for that YAML."""
     kitchen = _job("k", configuration="kitchen.yaml")
     garage = _job("g", configuration="garage.yaml")
     office = _job("o", configuration="office.yaml")
-    controller = _controller(kitchen, garage, office)
+    controller = firmware_controller_factory(kitchen, garage, office, with_settings=False)
 
     result = await controller.get_jobs(configuration="garage.yaml")
 
@@ -131,12 +117,16 @@ async def test_get_jobs_filters_by_configuration() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_combines_status_and_configuration_filters() -> None:
+async def test_get_jobs_combines_status_and_configuration_filters(
+    firmware_controller_factory,
+) -> None:
     """Both filters compose with AND semantics."""
     kitchen_queued = _job("kq", configuration="kitchen.yaml", status=JobStatus.QUEUED)
     kitchen_done = _job("kd", configuration="kitchen.yaml", status=JobStatus.COMPLETED)
     garage_done = _job("gd", configuration="garage.yaml", status=JobStatus.COMPLETED)
-    controller = _controller(kitchen_queued, kitchen_done, garage_done)
+    controller = firmware_controller_factory(
+        kitchen_queued, kitchen_done, garage_done, with_settings=False
+    )
 
     result = await controller.get_jobs(configuration="kitchen.yaml", status=JobStatus.COMPLETED)
 
@@ -144,7 +134,9 @@ async def test_get_jobs_combines_status_and_configuration_filters() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_filter_with_no_matches_returns_empty_list() -> None:
+async def test_get_jobs_filter_with_no_matches_returns_empty_list(
+    firmware_controller_factory,
+) -> None:
     """A filter that matches nothing returns ``[]``, not a raise.
 
     Distinct from ``get_job`` (which returns ``None`` for an
@@ -153,7 +145,9 @@ async def test_get_jobs_filter_with_no_matches_returns_empty_list() -> None:
     "no jobs match"; raising would force every caller to add a
     try/except for a perfectly valid query.
     """
-    controller = _controller(_job("a", status=JobStatus.COMPLETED))
+    controller = firmware_controller_factory(
+        _job("a", status=JobStatus.COMPLETED), with_settings=False
+    )
 
     result = await controller.get_jobs(status=JobStatus.RUNNING)
 
@@ -161,9 +155,9 @@ async def test_get_jobs_filter_with_no_matches_returns_empty_list() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_jobs_on_empty_controller_returns_empty_list() -> None:
+async def test_get_jobs_on_empty_controller_returns_empty_list(firmware_controller_factory) -> None:
     """An empty job map → empty list (cold-start contract)."""
-    controller = _controller()
+    controller = firmware_controller_factory(with_settings=False)
 
     assert await controller.get_jobs() == []
 
@@ -174,7 +168,7 @@ async def test_get_jobs_on_empty_controller_returns_empty_list() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_job_returns_the_matching_job_for_known_id() -> None:
+async def test_get_job_returns_the_matching_job_for_known_id(firmware_controller_factory) -> None:
     """Known id → the ``FirmwareJob`` instance, full object including ``output``.
 
     Frontend uses this to fetch the full output buffer when the
@@ -183,7 +177,7 @@ async def test_get_job_returns_the_matching_job_for_known_id() -> None:
     """
     target = _job("target")
     other = _job("other")
-    controller = _controller(target, other)
+    controller = firmware_controller_factory(target, other, with_settings=False)
 
     result = await controller.get_job(job_id="target")
 
@@ -191,7 +185,7 @@ async def test_get_job_returns_the_matching_job_for_known_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_job_returns_none_for_unknown_id() -> None:
+async def test_get_job_returns_none_for_unknown_id(firmware_controller_factory) -> None:
     """Unknown id → ``None``, NOT a raise.
 
     Distinct from ``cancel`` and ``follow_job``, which both
@@ -200,13 +194,13 @@ async def test_get_job_returns_none_for_unknown_id() -> None:
     "is this job still tracked?" without having to handle an
     exception for the negative answer.
     """
-    controller = _controller(_job("present"))
+    controller = firmware_controller_factory(_job("present"), with_settings=False)
 
     assert await controller.get_job(job_id="ghost") is None
 
 
 @pytest.mark.asyncio
-async def test_get_job_does_not_mutate_state() -> None:
+async def test_get_job_does_not_mutate_state(firmware_controller_factory) -> None:
     """Pure read — the call doesn't mutate ``self._jobs`` or persist anything.
 
     Belt-and-braces: a future refactor that, say, lazy-removes
@@ -215,7 +209,7 @@ async def test_get_job_does_not_mutate_state() -> None:
     up here forces a docs / migration discussion.
     """
     target = _job("target")
-    controller = _controller(target)
+    controller = firmware_controller_factory(target, with_settings=False)
     before = dict(controller._jobs)
 
     await controller.get_job(job_id="target")

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -28,11 +28,12 @@ import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 @pytest.mark.asyncio
 async def test_install_returns_queued_job_with_install_type(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Happy path: handler returns a ``QUEUED`` ``FirmwareJob`` of type ``INSTALL``.
 
@@ -51,7 +52,9 @@ async def test_install_returns_queued_job_with_install_type(
 
 
 @pytest.mark.asyncio
-async def test_install_defaults_port_to_ota(tmp_path: Path, firmware_controller_factory) -> None:
+async def test_install_defaults_port_to_ota(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
     """``port`` defaults to ``"OTA"``, not the empty ``upload`` default.
 
     The CLI treats ``"OTA"`` as a request to resolve the configured
@@ -75,7 +78,7 @@ async def test_install_defaults_port_to_ota(tmp_path: Path, firmware_controller_
 )
 @pytest.mark.asyncio
 async def test_install_forwards_custom_port_to_job(
-    tmp_path: Path, port: str, firmware_controller_factory
+    tmp_path: Path, port: str, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Caller-supplied port shapes (serial / IP / hostname) round-trip onto the job.
 
@@ -94,7 +97,7 @@ async def test_install_forwards_custom_port_to_job(
 
 @pytest.mark.asyncio
 async def test_install_validates_port_before_configuration(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A typo'd port raises before the configuration validator runs.
 
@@ -124,7 +127,7 @@ async def test_install_validates_port_before_configuration(
 
 @pytest.mark.asyncio
 async def test_install_rejects_traversal_configuration(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A traversal-shaped configuration trips the boundary validator.
 
@@ -144,7 +147,7 @@ async def test_install_rejects_traversal_configuration(
 
 @pytest.mark.asyncio
 async def test_install_enqueues_before_firing_job_queued(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
@@ -190,7 +193,7 @@ async def test_install_enqueues_before_firing_job_queued(
 
 @pytest.mark.asyncio
 async def test_install_registers_job_in_jobs_map(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """The new job lands in ``self._jobs`` keyed by ``job_id``.
 

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -41,7 +41,7 @@ async def test_install_returns_queued_job_with_install_type(
     ``job_type`` fields; pin both so a future refactor that defaults
     to ``COMPILE`` (the most common job type) shows up immediately.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml")
@@ -64,7 +64,7 @@ async def test_install_defaults_port_to_ota(
     of "flash the device named in the YAML" doesn't need a port
     arg from the caller.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml")
@@ -87,7 +87,7 @@ async def test_install_forwards_custom_port_to_job(
     mutated the value here, the install would silently re-target
     OTA instead of the user-named address.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml", port=port)
@@ -115,7 +115,7 @@ async def test_install_validates_port_before_configuration(
     ("Invalid configuration filename …") instead of the
     port-shape error, and this assertion catches it.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.install(configuration="../etc/passwd", port="not a port")
@@ -137,7 +137,7 @@ async def test_install_rejects_traversal_configuration(
     public entry point and a regression in this handler specifically
     would be felt by every "Update" button click.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.install(configuration="../etc/passwd")
@@ -176,7 +176,7 @@ async def test_install_enqueues_before_firing_job_queued(
     parent.queue.put = AsyncMock()
     parent.bus.fire = MagicMock()
 
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     controller._queue = parent.queue
     controller._db.bus = parent.bus
     (tmp_path / "kitchen.yaml").write_text("")
@@ -202,7 +202,7 @@ async def test_install_registers_job_in_jobs_map(
     forgetting to register it here would leave those handlers
     raising ``"Job not found"`` for a job the user just queued.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml")

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -26,45 +26,21 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
 
 
-def _controller(tmp_path: Path) -> FirmwareController:
-    """Build a controller wired to a real ``DashboardSettings`` for path validation.
-
-    The validator inside ``install`` calls ``rel_path``, which needs
-    a real ``config_dir`` / ``absolute_config_dir``; everything else
-    in the install path (queue, persistence, supersede check, bus)
-    is stubbed so the test stays focused on the handler's wiring.
-    """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._queue = AsyncMock()
-    controller._persist_jobs = AsyncMock()
-    controller._supersede_active_jobs = AsyncMock()
-
-    bus = MagicMock()
-    bus.fire = MagicMock()
-    controller._db = type("DB", (), {"settings": settings, "bus": bus})()
-    return controller
-
-
 @pytest.mark.asyncio
-async def test_install_returns_queued_job_with_install_type(tmp_path: Path) -> None:
+async def test_install_returns_queued_job_with_install_type(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Happy path: handler returns a ``QUEUED`` ``FirmwareJob`` of type ``INSTALL``.
 
     The frontend keys its "live tasks" panel off the ``status`` and
     ``job_type`` fields; pin both so a future refactor that defaults
     to ``COMPILE`` (the most common job type) shows up immediately.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml")
@@ -75,7 +51,7 @@ async def test_install_returns_queued_job_with_install_type(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_install_defaults_port_to_ota(tmp_path: Path) -> None:
+async def test_install_defaults_port_to_ota(tmp_path: Path, firmware_controller_factory) -> None:
     """``port`` defaults to ``"OTA"``, not the empty ``upload`` default.
 
     The CLI treats ``"OTA"`` as a request to resolve the configured
@@ -85,7 +61,7 @@ async def test_install_defaults_port_to_ota(tmp_path: Path) -> None:
     of "flash the device named in the YAML" doesn't need a port
     arg from the caller.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml")
@@ -98,7 +74,9 @@ async def test_install_defaults_port_to_ota(tmp_path: Path) -> None:
     ["/dev/ttyUSB0", "192.168.1.5", "kitchen.local", "fe80::1"],
 )
 @pytest.mark.asyncio
-async def test_install_forwards_custom_port_to_job(tmp_path: Path, port: str) -> None:
+async def test_install_forwards_custom_port_to_job(
+    tmp_path: Path, port: str, firmware_controller_factory
+) -> None:
     """Caller-supplied port shapes (serial / IP / hostname) round-trip onto the job.
 
     ``_build_command`` reads ``job.port`` to render the
@@ -106,7 +84,7 @@ async def test_install_forwards_custom_port_to_job(tmp_path: Path, port: str) ->
     mutated the value here, the install would silently re-target
     OTA instead of the user-named address.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml", port=port)
@@ -115,7 +93,9 @@ async def test_install_forwards_custom_port_to_job(tmp_path: Path, port: str) ->
 
 
 @pytest.mark.asyncio
-async def test_install_validates_port_before_configuration(tmp_path: Path) -> None:
+async def test_install_validates_port_before_configuration(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """A typo'd port raises before the configuration validator runs.
 
     ``_validate_port`` is the first line of the handler. Its check
@@ -132,7 +112,7 @@ async def test_install_validates_port_before_configuration(tmp_path: Path) -> No
     ("Invalid configuration filename …") instead of the
     port-shape error, and this assertion catches it.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as exc:
         await controller.install(configuration="../etc/passwd", port="not a port")
@@ -143,7 +123,9 @@ async def test_install_validates_port_before_configuration(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_install_rejects_traversal_configuration(tmp_path: Path) -> None:
+async def test_install_rejects_traversal_configuration(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """A traversal-shaped configuration trips the boundary validator.
 
     Already covered for every install / compile / upload variant in
@@ -152,7 +134,7 @@ async def test_install_rejects_traversal_configuration(tmp_path: Path) -> None:
     public entry point and a regression in this handler specifically
     would be felt by every "Update" button click.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as exc:
         await controller.install(configuration="../etc/passwd")
@@ -161,7 +143,9 @@ async def test_install_rejects_traversal_configuration(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_install_enqueues_before_firing_job_queued(tmp_path: Path) -> None:
+async def test_install_enqueues_before_firing_job_queued(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
     The all-jobs panel keys off ``JOB_QUEUED`` to add a row when a
@@ -189,7 +173,7 @@ async def test_install_enqueues_before_firing_job_queued(tmp_path: Path) -> None
     parent.queue.put = AsyncMock()
     parent.bus.fire = MagicMock()
 
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     controller._queue = parent.queue
     controller._db.bus = parent.bus
     (tmp_path / "kitchen.yaml").write_text("")
@@ -205,7 +189,9 @@ async def test_install_enqueues_before_firing_job_queued(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_install_registers_job_in_jobs_map(tmp_path: Path) -> None:
+async def test_install_registers_job_in_jobs_map(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """The new job lands in ``self._jobs`` keyed by ``job_id``.
 
     Subsequent ``firmware/get_jobs`` / ``firmware/cancel`` /
@@ -213,7 +199,7 @@ async def test_install_registers_job_in_jobs_map(tmp_path: Path) -> None:
     forgetting to register it here would leave those handlers
     raising ``"Job not found"`` for a job the user just queued.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml")

--- a/tests/controllers/firmware/test_rename_lock.py
+++ b/tests/controllers/firmware/test_rename_lock.py
@@ -28,6 +28,7 @@ from esphome_device_builder.models import (
     JobStatus,
     JobType,
 )
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 def _job(
@@ -47,7 +48,9 @@ def _job(
     )
 
 
-def test_install_on_old_name_is_rejected(firmware_controller_factory) -> None:
+def test_install_on_old_name_is_rejected(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
     controller = firmware_controller_factory(rename, with_settings=False)
     new = _job("inst1", "kitchen.yaml", JobType.INSTALL)
@@ -60,7 +63,9 @@ def test_install_on_old_name_is_rejected(firmware_controller_factory) -> None:
     assert "livingroom.yaml" in excinfo.value.message
 
 
-def test_install_on_new_name_is_rejected(firmware_controller_factory) -> None:
+def test_install_on_new_name_is_rejected(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
     controller = firmware_controller_factory(rename, with_settings=False)
     new = _job("inst1", "livingroom.yaml", JobType.INSTALL)
@@ -69,14 +74,18 @@ def test_install_on_new_name_is_rejected(firmware_controller_factory) -> None:
         controller._check_rename_lock(new)
 
 
-def test_compile_on_unrelated_config_is_allowed(firmware_controller_factory) -> None:
+def test_compile_on_unrelated_config_is_allowed(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
     controller = firmware_controller_factory(rename, with_settings=False)
 
     controller._check_rename_lock(_job("c1", "garage.yaml", JobType.COMPILE))
 
 
-def test_rename_targeting_same_new_name_is_rejected(firmware_controller_factory) -> None:
+def test_rename_targeting_same_new_name_is_rejected(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Two renames pointing at the same target name would fight to write it."""
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
     controller = firmware_controller_factory(rename, with_settings=False)
@@ -86,7 +95,9 @@ def test_rename_targeting_same_new_name_is_rejected(firmware_controller_factory)
         controller._check_rename_lock(second)
 
 
-def test_rename_retry_on_same_old_config_is_allowed(firmware_controller_factory) -> None:
+def test_rename_retry_on_same_old_config_is_allowed(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Fresh rename on the same OLD config goes through so supersede can cancel-and-replace."""
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
     controller = firmware_controller_factory(rename, with_settings=False)
@@ -95,7 +106,9 @@ def test_rename_retry_on_same_old_config_is_allowed(firmware_controller_factory)
     controller._check_rename_lock(retry)
 
 
-def test_lock_lifts_when_rename_terminates(firmware_controller_factory) -> None:
+def test_lock_lifts_when_rename_terminates(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Terminal-status rename no longer holds the lock."""
     rename = _job(
         "rn1",
@@ -110,7 +123,9 @@ def test_lock_lifts_when_rename_terminates(firmware_controller_factory) -> None:
     controller._check_rename_lock(_job("inst2", "livingroom.yaml", JobType.INSTALL))
 
 
-def test_running_rename_blocks_install(firmware_controller_factory) -> None:
+def test_running_rename_blocks_install(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """RUNNING jobs hold the lock just like QUEUED ones do."""
     rename = _job(
         "rn1",
@@ -127,7 +142,7 @@ def test_running_rename_blocks_install(firmware_controller_factory) -> None:
 
 @pytest.mark.asyncio
 async def test_install_bulk_skips_locked_configs_and_queues_the_rest(
-    firmware_controller_factory,
+    firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """A rename-locked device in a bulk request must not abort the others.
 

--- a/tests/controllers/firmware/test_rename_lock.py
+++ b/tests/controllers/firmware/test_rename_lock.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import pytest
 
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import (
     ErrorCode,
@@ -29,13 +28,6 @@ from esphome_device_builder.models import (
     JobStatus,
     JobType,
 )
-
-
-def _controller(*active: FirmwareJob) -> FirmwareController:
-    """Build a stub controller with just the bits ``_check_rename_lock`` reads."""
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {j.job_id: j for j in active}
-    return controller
 
 
 def _job(
@@ -55,9 +47,9 @@ def _job(
     )
 
 
-def test_install_on_old_name_is_rejected() -> None:
+def test_install_on_old_name_is_rejected(firmware_controller_factory) -> None:
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
-    controller = _controller(rename)
+    controller = firmware_controller_factory(rename, with_settings=False)
     new = _job("inst1", "kitchen.yaml", JobType.INSTALL)
 
     with pytest.raises(CommandError) as excinfo:
@@ -68,42 +60,42 @@ def test_install_on_old_name_is_rejected() -> None:
     assert "livingroom.yaml" in excinfo.value.message
 
 
-def test_install_on_new_name_is_rejected() -> None:
+def test_install_on_new_name_is_rejected(firmware_controller_factory) -> None:
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
-    controller = _controller(rename)
+    controller = firmware_controller_factory(rename, with_settings=False)
     new = _job("inst1", "livingroom.yaml", JobType.INSTALL)
 
     with pytest.raises(CommandError):
         controller._check_rename_lock(new)
 
 
-def test_compile_on_unrelated_config_is_allowed() -> None:
+def test_compile_on_unrelated_config_is_allowed(firmware_controller_factory) -> None:
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
-    controller = _controller(rename)
+    controller = firmware_controller_factory(rename, with_settings=False)
 
     controller._check_rename_lock(_job("c1", "garage.yaml", JobType.COMPILE))
 
 
-def test_rename_targeting_same_new_name_is_rejected() -> None:
+def test_rename_targeting_same_new_name_is_rejected(firmware_controller_factory) -> None:
     """Two renames pointing at the same target name would fight to write it."""
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
-    controller = _controller(rename)
+    controller = firmware_controller_factory(rename, with_settings=False)
     second = _job("rn2", "garage.yaml", JobType.RENAME, new_name="livingroom")
 
     with pytest.raises(CommandError):
         controller._check_rename_lock(second)
 
 
-def test_rename_retry_on_same_old_config_is_allowed() -> None:
+def test_rename_retry_on_same_old_config_is_allowed(firmware_controller_factory) -> None:
     """Fresh rename on the same OLD config goes through so supersede can cancel-and-replace."""
     rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
-    controller = _controller(rename)
+    controller = firmware_controller_factory(rename, with_settings=False)
     retry = _job("rn2", "kitchen.yaml", JobType.RENAME, new_name="bedroom")
 
     controller._check_rename_lock(retry)
 
 
-def test_lock_lifts_when_rename_terminates() -> None:
+def test_lock_lifts_when_rename_terminates(firmware_controller_factory) -> None:
     """Terminal-status rename no longer holds the lock."""
     rename = _job(
         "rn1",
@@ -112,13 +104,13 @@ def test_lock_lifts_when_rename_terminates() -> None:
         new_name="livingroom",
         status=JobStatus.COMPLETED,
     )
-    controller = _controller(rename)
+    controller = firmware_controller_factory(rename, with_settings=False)
 
     controller._check_rename_lock(_job("inst1", "kitchen.yaml", JobType.INSTALL))
     controller._check_rename_lock(_job("inst2", "livingroom.yaml", JobType.INSTALL))
 
 
-def test_running_rename_blocks_install() -> None:
+def test_running_rename_blocks_install(firmware_controller_factory) -> None:
     """RUNNING jobs hold the lock just like QUEUED ones do."""
     rename = _job(
         "rn1",
@@ -127,14 +119,16 @@ def test_running_rename_blocks_install() -> None:
         new_name="livingroom",
         status=JobStatus.RUNNING,
     )
-    controller = _controller(rename)
+    controller = firmware_controller_factory(rename, with_settings=False)
 
     with pytest.raises(CommandError):
         controller._check_rename_lock(_job("inst1", "kitchen.yaml", JobType.INSTALL))
 
 
 @pytest.mark.asyncio
-async def test_install_bulk_skips_locked_configs_and_queues_the_rest() -> None:
+async def test_install_bulk_skips_locked_configs_and_queues_the_rest(
+    firmware_controller_factory,
+) -> None:
     """A rename-locked device in a bulk request must not abort the others.
 
     Bulk install is the user pattern for "update everything that has
@@ -151,7 +145,7 @@ async def test_install_bulk_skips_locked_configs_and_queues_the_rest() -> None:
         new_name="livingroom",
         status=JobStatus.RUNNING,
     )
-    controller = _controller(rename)
+    controller = firmware_controller_factory(rename, with_settings=False)
     controller._queue = AsyncMock()
     controller._db = type(
         "DB",

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -49,7 +49,7 @@ async def test_reset_build_env_returns_queued_job_with_reset_type(
     before the runner picks it up) shows up immediately. The
     frontend's job-table renders the row from these two fields.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
 
     job = await controller.reset_build_env()
 
@@ -70,7 +70,7 @@ async def test_reset_build_env_uses_empty_configuration(
     refresh-scheduling logic relies on
     (``test_helpers.test_names_touched_by_job_with_empty_configuration_is_empty``).
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
 
     job = await controller.reset_build_env()
 
@@ -82,7 +82,7 @@ async def test_reset_build_env_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """The new job lands in ``self._jobs`` so ``cancel`` / ``follow_job`` can find it."""
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
 
     job = await controller.reset_build_env()
 
@@ -107,7 +107,7 @@ async def test_reset_build_env_fires_job_queued_after_enqueue(
     parent.queue.put = AsyncMock()
     parent.bus.fire = MagicMock()
 
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     controller._queue = parent.queue
     controller._db.bus = parent.bus
 
@@ -134,7 +134,7 @@ async def test_reset_build_env_accepts_arbitrary_kwargs(
     that tightens the signature would silently break those WS
     calls until they're individually retested.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
 
     job = await controller.reset_build_env(client=object(), message_id="m1", spurious=True)
 
@@ -180,7 +180,7 @@ async def test_reset_build_env_runner_removes_each_target(
     the test passes only if each named directory is gone after
     the runner finishes.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     _seed_targets(tmp_path)
     job = _make_job()
 
@@ -204,7 +204,7 @@ async def test_reset_build_env_runner_marks_job_completed(
     ``JOB_COMPLETED`` event so a frontend reading the post-event
     state sees a fully-finished job.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     _seed_targets(tmp_path)
     job = _make_job()
 
@@ -226,7 +226,7 @@ async def test_reset_build_env_runner_fires_job_completed(
     in the all-jobs view, even though the runner's local state
     flipped to COMPLETED.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     _seed_targets(tmp_path)
     job = _make_job()
 
@@ -247,7 +247,7 @@ async def test_reset_build_env_runner_streams_output_lines(
     see the same content; pin a representative line on each side
     so a refactor that drops one of the two writes surfaces here.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     _seed_targets(tmp_path)
     job = _make_job()
 
@@ -284,7 +284,7 @@ async def test_reset_build_env_runner_skips_missing_targets(
     targets and confirming the runner completes (status COMPLETED)
     while still naming the missing ones in the output.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     # Only seed the build dir; external_components and platformio_cache absent.
     _seed_targets(tmp_path, names=("build",))
     job = _make_job()
@@ -311,7 +311,7 @@ async def test_reset_build_env_runner_no_op_when_esphome_absent(
     because the targets don't exist. Pins the early-exit branch
     that checks ``esphome_root.exists()``.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     # Don't call _seed_targets — leave .esphome absent entirely.
     job = _make_job()
 
@@ -342,7 +342,7 @@ async def test_reset_build_env_runner_honours_cancel_between_targets(
       ``self._cancel_requested``) so a re-queued job with the same
       id wouldn't auto-cancel.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     _seed_targets(tmp_path)
     job = _make_job()
     controller._cancel_requested.add(job.job_id)

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -31,6 +31,7 @@ import pytest
 
 from esphome_device_builder.controllers.firmware.constants import _RESET_BUILD_ENV_TARGETS
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 # ---------------------------------------------------------------------------
 # Handler wiring
@@ -39,7 +40,7 @@ from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, Job
 
 @pytest.mark.asyncio
 async def test_reset_build_env_returns_queued_job_with_reset_type(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Happy path: the handler returns a ``QUEUED`` job of type ``RESET_BUILD_ENV``.
 
@@ -58,7 +59,7 @@ async def test_reset_build_env_returns_queued_job_with_reset_type(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_uses_empty_configuration(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``configuration`` is ``""`` — reset is global, not per-device.
 
@@ -78,7 +79,7 @@ async def test_reset_build_env_uses_empty_configuration(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_registers_job_in_jobs_map(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """The new job lands in ``self._jobs`` so ``cancel`` / ``follow_job`` can find it."""
     controller = firmware_controller_factory()
@@ -90,7 +91,7 @@ async def test_reset_build_env_registers_job_in_jobs_map(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_fires_job_queued_after_enqueue(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
@@ -122,7 +123,7 @@ async def test_reset_build_env_fires_job_queued_after_enqueue(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_accepts_arbitrary_kwargs(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``reset_build_env`` is declared with ``**kwargs`` and ignores extras.
 
@@ -170,7 +171,7 @@ def _seed_targets(config_dir: Path, *, names: tuple[str, ...] = _RESET_BUILD_ENV
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_removes_each_target(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Every directory in ``_RESET_BUILD_ENV_TARGETS`` is removed.
 
@@ -193,7 +194,7 @@ async def test_reset_build_env_runner_removes_each_target(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_marks_job_completed(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Successful completion sets ``COMPLETED`` + ``exit_code=0`` + ``progress=100``.
 
@@ -216,7 +217,7 @@ async def test_reset_build_env_runner_marks_job_completed(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_fires_job_completed(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``JOB_COMPLETED`` fires with the finished job in its payload.
 
@@ -236,7 +237,7 @@ async def test_reset_build_env_runner_fires_job_completed(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_streams_output_lines(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Progress lines hit both ``job.output`` and the bus.
 
@@ -273,7 +274,7 @@ async def test_reset_build_env_runner_streams_output_lines(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_skips_missing_targets(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A target that doesn't exist is logged as skipped, not fatal.
 
@@ -301,7 +302,7 @@ async def test_reset_build_env_runner_skips_missing_targets(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_no_op_when_esphome_absent(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``.esphome/`` not yet created → "Nothing to do" + COMPLETED.
 
@@ -324,7 +325,7 @@ async def test_reset_build_env_runner_no_op_when_esphome_absent(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_honours_cancel_between_targets(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Cancellation requested mid-run stops before the next target.
 

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -29,40 +29,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware.constants import _RESET_BUILD_ENV_TARGETS
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
-
-
-def _controller(tmp_path: Path) -> FirmwareController:
-    """Build a controller with a real config_dir and stubbed queue / persistence.
-
-    Same shape as ``test_install._controller`` — bypass ``__init__``
-    so we don't have to seed a full ``DeviceBuilder``, then attach
-    the surface ``reset_build_env`` and ``_reset_build_env``
-    actually touch (settings.config_dir for ``.esphome``,
-    ``self._queue`` / ``self._persist_jobs`` /
-    ``self._supersede_active_jobs`` for the enqueue path,
-    ``self._db.bus`` for ``JOB_*`` broadcasts,
-    ``self._cancel_requested`` for the mid-run cancel check).
-    """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._queue = AsyncMock()
-    controller._persist_jobs = AsyncMock()
-    controller._supersede_active_jobs = AsyncMock()
-    controller._cancel_requested = set()
-
-    bus = MagicMock()
-    bus.fire = MagicMock()
-    controller._db = type("DB", (), {"settings": settings, "bus": bus})()
-    return controller
-
 
 # ---------------------------------------------------------------------------
 # Handler wiring
@@ -70,7 +38,9 @@ def _controller(tmp_path: Path) -> FirmwareController:
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_returns_queued_job_with_reset_type(tmp_path: Path) -> None:
+async def test_reset_build_env_returns_queued_job_with_reset_type(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Happy path: the handler returns a ``QUEUED`` job of type ``RESET_BUILD_ENV``.
 
     Pin both ``status`` and ``job_type`` so a future regression
@@ -78,7 +48,7 @@ async def test_reset_build_env_returns_queued_job_with_reset_type(tmp_path: Path
     before the runner picks it up) shows up immediately. The
     frontend's job-table renders the row from these two fields.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     job = await controller.reset_build_env()
 
@@ -87,7 +57,9 @@ async def test_reset_build_env_returns_queued_job_with_reset_type(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_uses_empty_configuration(tmp_path: Path) -> None:
+async def test_reset_build_env_uses_empty_configuration(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``configuration`` is ``""`` — reset is global, not per-device.
 
     Documented contract in the handler's docstring; pinned here so
@@ -97,7 +69,7 @@ async def test_reset_build_env_uses_empty_configuration(tmp_path: Path) -> None:
     refresh-scheduling logic relies on
     (``test_helpers.test_names_touched_by_job_with_empty_configuration_is_empty``).
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     job = await controller.reset_build_env()
 
@@ -105,9 +77,11 @@ async def test_reset_build_env_uses_empty_configuration(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_registers_job_in_jobs_map(tmp_path: Path) -> None:
+async def test_reset_build_env_registers_job_in_jobs_map(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """The new job lands in ``self._jobs`` so ``cancel`` / ``follow_job`` can find it."""
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     job = await controller.reset_build_env()
 
@@ -115,7 +89,9 @@ async def test_reset_build_env_registers_job_in_jobs_map(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_fires_job_queued_after_enqueue(tmp_path: Path) -> None:
+async def test_reset_build_env_fires_job_queued_after_enqueue(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
     Same ordering invariant as ``install`` /
@@ -130,7 +106,7 @@ async def test_reset_build_env_fires_job_queued_after_enqueue(tmp_path: Path) ->
     parent.queue.put = AsyncMock()
     parent.bus.fire = MagicMock()
 
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     controller._queue = parent.queue
     controller._db.bus = parent.bus
 
@@ -145,7 +121,9 @@ async def test_reset_build_env_fires_job_queued_after_enqueue(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_accepts_arbitrary_kwargs(tmp_path: Path) -> None:
+async def test_reset_build_env_accepts_arbitrary_kwargs(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``reset_build_env`` is declared with ``**kwargs`` and ignores extras.
 
     Every ``firmware/*`` handler accepts ``**kwargs`` so the WS
@@ -155,7 +133,7 @@ async def test_reset_build_env_accepts_arbitrary_kwargs(tmp_path: Path) -> None:
     that tightens the signature would silently break those WS
     calls until they're individually retested.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     job = await controller.reset_build_env(client=object(), message_id="m1", spurious=True)
 
@@ -191,7 +169,9 @@ def _seed_targets(config_dir: Path, *, names: tuple[str, ...] = _RESET_BUILD_ENV
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_runner_removes_each_target(tmp_path: Path) -> None:
+async def test_reset_build_env_runner_removes_each_target(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Every directory in ``_RESET_BUILD_ENV_TARGETS`` is removed.
 
     Uses the upstream constant so a future addition to the target
@@ -199,7 +179,7 @@ async def test_reset_build_env_runner_removes_each_target(tmp_path: Path) -> Non
     the test passes only if each named directory is gone after
     the runner finishes.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     _seed_targets(tmp_path)
     job = _make_job()
 
@@ -212,7 +192,9 @@ async def test_reset_build_env_runner_removes_each_target(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_runner_marks_job_completed(tmp_path: Path) -> None:
+async def test_reset_build_env_runner_marks_job_completed(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Successful completion sets ``COMPLETED`` + ``exit_code=0`` + ``progress=100``.
 
     The dashboard's job row uses ``status`` for the badge,
@@ -221,7 +203,7 @@ async def test_reset_build_env_runner_marks_job_completed(tmp_path: Path) -> Non
     ``JOB_COMPLETED`` event so a frontend reading the post-event
     state sees a fully-finished job.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     _seed_targets(tmp_path)
     job = _make_job()
 
@@ -233,7 +215,9 @@ async def test_reset_build_env_runner_marks_job_completed(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_runner_fires_job_completed(tmp_path: Path) -> None:
+async def test_reset_build_env_runner_fires_job_completed(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``JOB_COMPLETED`` fires with the finished job in its payload.
 
     Pairs with the run-followers panel: without this event the
@@ -241,7 +225,7 @@ async def test_reset_build_env_runner_fires_job_completed(tmp_path: Path) -> Non
     in the all-jobs view, even though the runner's local state
     flipped to COMPLETED.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     _seed_targets(tmp_path)
     job = _make_job()
 
@@ -251,7 +235,9 @@ async def test_reset_build_env_runner_fires_job_completed(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_runner_streams_output_lines(tmp_path: Path) -> None:
+async def test_reset_build_env_runner_streams_output_lines(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Progress lines hit both ``job.output`` and the bus.
 
     The follower-side ``follow_job`` panel renders lines from
@@ -260,7 +246,7 @@ async def test_reset_build_env_runner_streams_output_lines(tmp_path: Path) -> No
     see the same content; pin a representative line on each side
     so a refactor that drops one of the two writes surfaces here.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     _seed_targets(tmp_path)
     job = _make_job()
 
@@ -286,7 +272,9 @@ async def test_reset_build_env_runner_streams_output_lines(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_runner_skips_missing_targets(tmp_path: Path) -> None:
+async def test_reset_build_env_runner_skips_missing_targets(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """A target that doesn't exist is logged as skipped, not fatal.
 
     Fresh installs don't have ``platformio_cache/`` until the
@@ -295,7 +283,7 @@ async def test_reset_build_env_runner_skips_missing_targets(tmp_path: Path) -> N
     targets and confirming the runner completes (status COMPLETED)
     while still naming the missing ones in the output.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     # Only seed the build dir; external_components and platformio_cache absent.
     _seed_targets(tmp_path, names=("build",))
     job = _make_job()
@@ -312,7 +300,9 @@ async def test_reset_build_env_runner_skips_missing_targets(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_runner_no_op_when_esphome_absent(tmp_path: Path) -> None:
+async def test_reset_build_env_runner_no_op_when_esphome_absent(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``.esphome/`` not yet created → "Nothing to do" + COMPLETED.
 
     Edge case for never-compiled config dirs: the runner shouldn't
@@ -320,7 +310,7 @@ async def test_reset_build_env_runner_no_op_when_esphome_absent(tmp_path: Path) 
     because the targets don't exist. Pins the early-exit branch
     that checks ``esphome_root.exists()``.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     # Don't call _seed_targets — leave .esphome absent entirely.
     job = _make_job()
 
@@ -333,7 +323,9 @@ async def test_reset_build_env_runner_no_op_when_esphome_absent(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_reset_build_env_runner_honours_cancel_between_targets(tmp_path: Path) -> None:
+async def test_reset_build_env_runner_honours_cancel_between_targets(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Cancellation requested mid-run stops before the next target.
 
     ``shutil.rmtree`` isn't interruptible from another coroutine,
@@ -349,7 +341,7 @@ async def test_reset_build_env_runner_honours_cancel_between_targets(tmp_path: P
       ``self._cancel_requested``) so a re-queued job with the same
       id wouldn't auto-cancel.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     _seed_targets(tmp_path)
     job = _make_job()
     controller._cancel_requested.add(job.job_id)

--- a/tests/controllers/firmware/test_traversal_validation.py
+++ b/tests/controllers/firmware/test_traversal_validation.py
@@ -18,9 +18,12 @@ import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
-def test_sync_validate_rejects_traversal(tmp_path: Path, firmware_controller_factory) -> None:
+def test_sync_validate_rejects_traversal(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
     """The sync core raises ``CommandError(INVALID_ARGS)`` on traversal.
 
     This is the single-source-of-truth helper used by both the async
@@ -34,7 +37,9 @@ def test_sync_validate_rejects_traversal(tmp_path: Path, firmware_controller_fac
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
 
 
-def test_sync_validate_rejects_empty_string(tmp_path: Path, firmware_controller_factory) -> None:
+def test_sync_validate_rejects_empty_string(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
     """Empty configuration raises — only ``RESET_BUILD_ENV`` legitimately wants it.
 
     ``reset_build_env`` doesn't go through the validator at all; every
@@ -53,7 +58,7 @@ def test_sync_validate_rejects_empty_string(tmp_path: Path, firmware_controller_
 
 @pytest.mark.asyncio
 async def test_validate_configuration_boundary_runs_in_executor(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """The async wrapper runs ``rel_path`` in an executor.
 
@@ -71,7 +76,7 @@ async def test_validate_configuration_boundary_runs_in_executor(
 
 @pytest.mark.asyncio
 async def test_validate_configurations_boundary_raises_on_bad_entry(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """The bulk validator raises on the first invalid entry.
 
@@ -93,7 +98,7 @@ async def test_validate_configurations_boundary_raises_on_bad_entry(
 
 @pytest.mark.asyncio
 async def test_validate_configurations_boundary_all_valid(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A clean batch validates without raising and returns ``None``."""
     controller = firmware_controller_factory()
@@ -102,7 +107,9 @@ async def test_validate_configurations_boundary_all_valid(
 
 
 @pytest.mark.asyncio
-async def test_get_binaries_rejects_traversal(tmp_path: Path, firmware_controller_factory) -> None:
+async def test_get_binaries_rejects_traversal(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
     """``firmware/get_binaries`` re-validates because it bypasses ``rel_path``.
 
     The handler reads ``ext_storage_path(configuration)`` which lands
@@ -117,7 +124,9 @@ async def test_get_binaries_rejects_traversal(tmp_path: Path, firmware_controlle
 
 
 @pytest.mark.asyncio
-async def test_download_rejects_traversal(tmp_path: Path, firmware_controller_factory) -> None:
+async def test_download_rejects_traversal(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
     """``firmware/download`` re-validates for the same reason."""
     controller = firmware_controller_factory()
 
@@ -128,7 +137,7 @@ async def test_download_rejects_traversal(tmp_path: Path, firmware_controller_fa
 
 @pytest.mark.asyncio
 async def test_rename_rejects_traversal_in_new_name(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``firmware/rename`` validates the derived ``<new_name>.yaml``.
 
@@ -149,7 +158,7 @@ async def test_rename_rejects_traversal_in_new_name(
 
 @pytest.mark.asyncio
 async def test_rename_rejects_collision_with_existing_yaml(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``firmware/rename`` rejects ``new_name`` colliding with another device.
 
@@ -171,7 +180,9 @@ async def test_rename_rejects_collision_with_existing_yaml(
 
 
 @pytest.mark.asyncio
-async def test_rename_rejects_same_name(tmp_path: Path, firmware_controller_factory) -> None:
+async def test_rename_rejects_same_name(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
     """``firmware/rename`` rejects ``new_name`` matching the current stem.
 
     A same-name rename is a no-op at the YAML level but still queues

--- a/tests/controllers/firmware/test_traversal_validation.py
+++ b/tests/controllers/firmware/test_traversal_validation.py
@@ -16,39 +16,25 @@ from pathlib import Path
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
 
-def _controller(tmp_path: Path) -> FirmwareController:
-    """Stub controller wired to a real ``DashboardSettings.rel_path``."""
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._db = type("DB", (), {"settings": settings})()
-    return controller
-
-
-def test_sync_validate_rejects_traversal(tmp_path: Path) -> None:
+def test_sync_validate_rejects_traversal(tmp_path: Path, firmware_controller_factory) -> None:
     """The sync core raises ``CommandError(INVALID_ARGS)`` on traversal.
 
     This is the single-source-of-truth helper used by both the async
     wrapper and the bulk validator — so a future change to validation
     logic only needs one update site.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as excinfo:
         controller._sync_validate_configuration_boundary("../etc/passwd")
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
 
 
-def test_sync_validate_rejects_empty_string(tmp_path: Path) -> None:
+def test_sync_validate_rejects_empty_string(tmp_path: Path, firmware_controller_factory) -> None:
     """Empty configuration raises — only ``RESET_BUILD_ENV`` legitimately wants it.
 
     ``reset_build_env`` doesn't go through the validator at all; every
@@ -58,7 +44,7 @@ def test_sync_validate_rejects_empty_string(tmp_path: Path) -> None:
     and only fail later when the runner hands the empty string to the
     CLI.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     with pytest.raises(CommandError) as excinfo:
         controller._sync_validate_configuration_boundary("")
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
@@ -66,7 +52,9 @@ def test_sync_validate_rejects_empty_string(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_validate_configuration_boundary_runs_in_executor(tmp_path: Path) -> None:
+async def test_validate_configuration_boundary_runs_in_executor(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """The async wrapper runs ``rel_path`` in an executor.
 
     ``Path.resolve`` is a blocking syscall; running it on the event
@@ -74,7 +62,7 @@ async def test_validate_configuration_boundary_runs_in_executor(tmp_path: Path) 
     sync core off to ``run_in_executor`` so the WS dispatcher stays
     non-blocking.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as excinfo:
         await controller._validate_configuration_boundary("../etc/passwd")
@@ -83,7 +71,7 @@ async def test_validate_configuration_boundary_runs_in_executor(tmp_path: Path) 
 
 @pytest.mark.asyncio
 async def test_validate_configurations_boundary_raises_on_bad_entry(
-    tmp_path: Path,
+    tmp_path: Path, firmware_controller_factory
 ) -> None:
     """The bulk validator raises on the first invalid entry.
 
@@ -94,7 +82,7 @@ async def test_validate_configurations_boundary_raises_on_bad_entry(
     phase 2 stay skip-and-continue (transient state, not bad
     input).
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as excinfo:
         await controller._validate_configurations_boundary(
@@ -104,22 +92,24 @@ async def test_validate_configurations_boundary_raises_on_bad_entry(
 
 
 @pytest.mark.asyncio
-async def test_validate_configurations_boundary_all_valid(tmp_path: Path) -> None:
+async def test_validate_configurations_boundary_all_valid(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """A clean batch validates without raising and returns ``None``."""
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     await controller._validate_configurations_boundary(["kitchen.yaml", "garage.yaml"])
 
 
 @pytest.mark.asyncio
-async def test_get_binaries_rejects_traversal(tmp_path: Path) -> None:
+async def test_get_binaries_rejects_traversal(tmp_path: Path, firmware_controller_factory) -> None:
     """``firmware/get_binaries`` re-validates because it bypasses ``rel_path``.
 
     The handler reads ``ext_storage_path(configuration)`` which lands
     in ``<data_dir>/storage/<configuration>.json`` — outside the
     config dir — so the boundary validator is the only gate.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as excinfo:
         await controller.get_binaries(configuration="../../etc/passwd")
@@ -127,9 +117,9 @@ async def test_get_binaries_rejects_traversal(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_download_rejects_traversal(tmp_path: Path) -> None:
+async def test_download_rejects_traversal(tmp_path: Path, firmware_controller_factory) -> None:
     """``firmware/download`` re-validates for the same reason."""
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as excinfo:
         await controller.download(configuration="../etc/passwd", file="firmware.bin")
@@ -137,7 +127,9 @@ async def test_download_rejects_traversal(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rename_rejects_traversal_in_new_name(tmp_path: Path) -> None:
+async def test_rename_rejects_traversal_in_new_name(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``firmware/rename`` validates the derived ``<new_name>.yaml``.
 
     Direct WS clients can bypass ``DevicesController.rename_device``
@@ -147,7 +139,7 @@ async def test_rename_rejects_traversal_in_new_name(tmp_path: Path) -> None:
     traversal at flash time. The handler now reuses the same
     ``_validate_configuration_boundary`` to gate it.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     with pytest.raises(CommandError) as excinfo:
@@ -156,7 +148,9 @@ async def test_rename_rejects_traversal_in_new_name(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rename_rejects_collision_with_existing_yaml(tmp_path: Path) -> None:
+async def test_rename_rejects_collision_with_existing_yaml(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``firmware/rename`` rejects ``new_name`` colliding with another device.
 
     ``esphome rename`` does not check collisions itself — it blindly
@@ -166,7 +160,7 @@ async def test_rename_rejects_collision_with_existing_yaml(tmp_path: Path) -> No
     checks before forwarding, but a direct WS client can bypass it;
     the firmware-layer check closes that gap.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
     (tmp_path / "livingroom.yaml").write_text("")
 
@@ -177,7 +171,7 @@ async def test_rename_rejects_collision_with_existing_yaml(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_rename_rejects_same_name(tmp_path: Path) -> None:
+async def test_rename_rejects_same_name(tmp_path: Path, firmware_controller_factory) -> None:
     """``firmware/rename`` rejects ``new_name`` matching the current stem.
 
     A same-name rename is a no-op at the YAML level but still queues
@@ -186,7 +180,7 @@ async def test_rename_rejects_same_name(tmp_path: Path) -> None:
     intend. ``firmware/install`` is the correct command for "flash
     without renaming".
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     with pytest.raises(CommandError) as excinfo:

--- a/tests/controllers/firmware/test_upload.py
+++ b/tests/controllers/firmware/test_upload.py
@@ -44,7 +44,7 @@ async def test_upload_returns_queued_job_with_upload_type(
     refactor that defaults to ``COMPILE`` (the most common job
     type) by mistake.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml")
@@ -70,7 +70,7 @@ async def test_upload_defaults_port_to_empty_string(
     unifies the defaults breaks visibly here AND in the install
     suite.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml")
@@ -93,7 +93,7 @@ async def test_upload_forwards_custom_port_to_job(
     mutated the value here, the upload would target the wrong
     device.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml", port=port)
@@ -121,7 +121,7 @@ async def test_upload_validates_port_before_configuration(
     ("Invalid configuration filename …") instead of the
     port-shape error.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.upload(configuration="../etc/passwd", port="not a port")
@@ -144,7 +144,7 @@ async def test_upload_rejects_traversal_configuration(
     direct WS client could path-traverse via ``configuration``
     even though every other handler stays gated.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
 
     with pytest.raises(CommandError) as exc:
         await controller.upload(configuration="../etc/passwd")
@@ -175,7 +175,7 @@ async def test_upload_enqueues_before_firing_job_queued(
     parent.queue.put = AsyncMock()
     parent.bus.fire = MagicMock()
 
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     controller._queue = parent.queue
     controller._db.bus = parent.bus
     (tmp_path / "kitchen.yaml").write_text("")
@@ -201,7 +201,7 @@ async def test_upload_registers_job_in_jobs_map(
     forgetting to register it here would leave those handlers
     raising ``"Job not found"`` for a job the user just queued.
     """
-    controller = firmware_controller_factory()
+    controller = firmware_controller_factory(with_queue=True)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml")

--- a/tests/controllers/firmware/test_upload.py
+++ b/tests/controllers/firmware/test_upload.py
@@ -30,11 +30,12 @@ import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
 @pytest.mark.asyncio
 async def test_upload_returns_queued_job_with_upload_type(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Happy path: handler returns a ``QUEUED`` ``FirmwareJob`` of type ``UPLOAD``.
 
@@ -55,7 +56,7 @@ async def test_upload_returns_queued_job_with_upload_type(
 
 @pytest.mark.asyncio
 async def test_upload_defaults_port_to_empty_string(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``port`` defaults to ``""`` — *not* ``"OTA"``.
 
@@ -83,7 +84,7 @@ async def test_upload_defaults_port_to_empty_string(
 )
 @pytest.mark.asyncio
 async def test_upload_forwards_custom_port_to_job(
-    tmp_path: Path, port: str, firmware_controller_factory
+    tmp_path: Path, port: str, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """Caller-supplied port shapes (OTA / serial / IP / hostname) round-trip onto the job.
 
@@ -102,7 +103,7 @@ async def test_upload_forwards_custom_port_to_job(
 
 @pytest.mark.asyncio
 async def test_upload_validates_port_before_configuration(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A typo'd port raises before the configuration validator runs.
 
@@ -132,7 +133,7 @@ async def test_upload_validates_port_before_configuration(
 
 @pytest.mark.asyncio
 async def test_upload_rejects_traversal_configuration(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """A traversal-shaped configuration trips the boundary validator.
 
@@ -153,7 +154,7 @@ async def test_upload_rejects_traversal_configuration(
 
 @pytest.mark.asyncio
 async def test_upload_enqueues_before_firing_job_queued(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
@@ -191,7 +192,7 @@ async def test_upload_enqueues_before_firing_job_queued(
 
 @pytest.mark.asyncio
 async def test_upload_registers_job_in_jobs_map(
-    tmp_path: Path, firmware_controller_factory
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """The new job lands in ``self._jobs`` keyed by ``job_id``.
 

--- a/tests/controllers/firmware/test_upload.py
+++ b/tests/controllers/firmware/test_upload.py
@@ -28,38 +28,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
 
 
-def _controller(tmp_path: Path) -> FirmwareController:
-    """Build a controller wired to a real ``DashboardSettings`` for path validation.
-
-    Mirrors ``test_install.py``'s helper — the validator inside
-    ``upload`` calls ``rel_path``, which needs a real
-    ``config_dir`` / ``absolute_config_dir``. Everything else
-    (queue, persistence, supersede check, bus) is stubbed.
-    """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {}
-    controller._queue = AsyncMock()
-    controller._persist_jobs = AsyncMock()
-    controller._supersede_active_jobs = AsyncMock()
-
-    bus = MagicMock()
-    bus.fire = MagicMock()
-    controller._db = type("DB", (), {"settings": settings, "bus": bus})()
-    return controller
-
-
 @pytest.mark.asyncio
-async def test_upload_returns_queued_job_with_upload_type(tmp_path: Path) -> None:
+async def test_upload_returns_queued_job_with_upload_type(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """Happy path: handler returns a ``QUEUED`` ``FirmwareJob`` of type ``UPLOAD``.
 
     The frontend's "live tasks" panel keys off ``status`` and
@@ -67,7 +43,7 @@ async def test_upload_returns_queued_job_with_upload_type(tmp_path: Path) -> Non
     refactor that defaults to ``COMPILE`` (the most common job
     type) by mistake.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml")
@@ -78,7 +54,9 @@ async def test_upload_returns_queued_job_with_upload_type(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_upload_defaults_port_to_empty_string(tmp_path: Path) -> None:
+async def test_upload_defaults_port_to_empty_string(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``port`` defaults to ``""`` — *not* ``"OTA"``.
 
     The legacy spawn protocol defaults ``upload`` with no port,
@@ -91,7 +69,7 @@ async def test_upload_defaults_port_to_empty_string(tmp_path: Path) -> None:
     unifies the defaults breaks visibly here AND in the install
     suite.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml")
@@ -104,7 +82,9 @@ async def test_upload_defaults_port_to_empty_string(tmp_path: Path) -> None:
     ["OTA", "/dev/ttyUSB0", "192.168.1.5", "kitchen.local", "fe80::1"],
 )
 @pytest.mark.asyncio
-async def test_upload_forwards_custom_port_to_job(tmp_path: Path, port: str) -> None:
+async def test_upload_forwards_custom_port_to_job(
+    tmp_path: Path, port: str, firmware_controller_factory
+) -> None:
     """Caller-supplied port shapes (OTA / serial / IP / hostname) round-trip onto the job.
 
     ``_build_command`` reads ``job.port`` to render the
@@ -112,7 +92,7 @@ async def test_upload_forwards_custom_port_to_job(tmp_path: Path, port: str) -> 
     mutated the value here, the upload would target the wrong
     device.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml", port=port)
@@ -121,7 +101,9 @@ async def test_upload_forwards_custom_port_to_job(tmp_path: Path, port: str) -> 
 
 
 @pytest.mark.asyncio
-async def test_upload_validates_port_before_configuration(tmp_path: Path) -> None:
+async def test_upload_validates_port_before_configuration(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """A typo'd port raises before the configuration validator runs.
 
     ``_validate_port`` is the first line of the handler. Its
@@ -138,7 +120,7 @@ async def test_upload_validates_port_before_configuration(tmp_path: Path) -> Non
     ("Invalid configuration filename …") instead of the
     port-shape error.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as exc:
         await controller.upload(configuration="../etc/passwd", port="not a port")
@@ -149,7 +131,9 @@ async def test_upload_validates_port_before_configuration(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_upload_rejects_traversal_configuration(tmp_path: Path) -> None:
+async def test_upload_rejects_traversal_configuration(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """A traversal-shaped configuration trips the boundary validator.
 
     The validator helper itself is fully covered in
@@ -159,7 +143,7 @@ async def test_upload_rejects_traversal_configuration(tmp_path: Path) -> None:
     direct WS client could path-traverse via ``configuration``
     even though every other handler stays gated.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
 
     with pytest.raises(CommandError) as exc:
         await controller.upload(configuration="../etc/passwd")
@@ -168,7 +152,9 @@ async def test_upload_rejects_traversal_configuration(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_upload_enqueues_before_firing_job_queued(tmp_path: Path) -> None:
+async def test_upload_enqueues_before_firing_job_queued(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
     Same race-prevention contract as ``install``: a frontend
@@ -188,7 +174,7 @@ async def test_upload_enqueues_before_firing_job_queued(tmp_path: Path) -> None:
     parent.queue.put = AsyncMock()
     parent.bus.fire = MagicMock()
 
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     controller._queue = parent.queue
     controller._db.bus = parent.bus
     (tmp_path / "kitchen.yaml").write_text("")
@@ -204,7 +190,9 @@ async def test_upload_enqueues_before_firing_job_queued(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_upload_registers_job_in_jobs_map(tmp_path: Path) -> None:
+async def test_upload_registers_job_in_jobs_map(
+    tmp_path: Path, firmware_controller_factory
+) -> None:
     """The new job lands in ``self._jobs`` keyed by ``job_id``.
 
     Subsequent ``firmware/get_jobs`` / ``firmware/cancel`` /
@@ -212,7 +200,7 @@ async def test_upload_registers_job_in_jobs_map(tmp_path: Path) -> None:
     forgetting to register it here would leave those handlers
     raising ``"Job not found"`` for a job the user just queued.
     """
-    controller = _controller(tmp_path)
+    controller = firmware_controller_factory()
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml")


### PR DESCRIPTION
## Summary

Twelve firmware-controller test files were each carrying their own ``_controller(tmp_path)`` helper that did the same thing — build a stub ``FirmwareController`` via ``__new__``, wire a real ``DashboardSettings`` for path validation, stub the queue / persistence / supersede / bus surface. Bodies were nearly identical; every refactor that added a new ``self._something`` to the controller had to chase the same pattern across every file before this.

## What changed

- New ``tests/controllers/firmware/conftest.py`` with a single ``firmware_controller_factory`` fixture. Returns a callable: ``factory(*jobs, with_settings=True)``. Pass ``FirmwareJob`` instances positionally to preload ``_jobs``; pass ``with_settings=False`` to skip the ``DashboardSettings`` binding for tests that don't exercise ``rel_path``.

- Migrated 12 test files:
  - **Submission-handler flavour** (default ``with_settings=True``): ``test_install``, ``test_compile``, ``test_compile_bulk``, ``test_upload``, ``test_traversal_validation``, ``test_get_binaries``, ``test_download``, ``test_reset_build_env``.
  - **In-memory flavour** (``with_settings=False``): ``test_cancel``, ``test_get_jobs``, ``test_clear``, ``test_rename_lock``.

## Out of scope

The remaining ``test_*.py`` in the package build controllers with bespoke shapes the generic factory doesn't fit:

- ``test_address_cache`` — needs real ``DeviceStateMonitor`` integration.
- ``test_install_to_specific_address`` — exercises ``_build_command`` shape, no need for queue/bus mocks.
- ``test_stop`` / ``test_stop_windows`` — real subprocesses + signal handlers.
- ``test_follow_job_race`` / ``test_follow_jobs_race`` — full event-bus integration.
- ``test_refresh`` — devices-controller bridge + hash recompute.

The generic factory is the right answer for ~50% of the test files but not the right tool for everything; those five keep their bespoke helpers.

## Why ``with_settings=False``

For tests that don't exercise ``rel_path`` (in-memory job inspectors, rename-lock checks), opting out of the ``DashboardSettings`` binding means a handler that nevertheless tries to read ``self._db.settings`` will ``AttributeError`` rather than silently use a stub — which keeps the test surface honest about what each test actually exercises.

## Test plan

- [x] Full local suite: 841 passed, 3 skipped.
- [x] Pre-commit clean.
- [x] Each migrated file's tests still pass with no behaviour changes (the fixture body is the union of the previous helpers; tests opt out of bits they don't want via ``with_settings``).