### PR TITLE
Fix sync workflow change-detection and tighten featured-component id validation

### DIFF
--- a/.github/workflows/sync-device-catalog.yml
+++ b/.github/workflows/sync-device-catalog.yml
@@ -72,7 +72,12 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          if git diff --quiet -- esphome_device_builder/definitions/boards/; then
+          # ``git diff --quiet`` only sees modified tracked files — on the
+          # initial sync (or whenever upstream adds a brand-new board) the
+          # script writes untracked manifests that diff would silently miss,
+          # so we'd never open a PR. ``git status --porcelain`` covers
+          # added / modified / deleted in one go.
+          if [ -z "$(git status --porcelain -- esphome_device_builder/definitions/boards/)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -762,11 +762,12 @@ class DevicesController:
             fields = _apply_featured_presets(record, fields)
             # The frontend's catalog-derived id suggestion for featured
             # components is the dashed ``featured_<board>_<local>``
-            # form (e.g. ``featured_athom-smart-plug-v3_power-monitor_1``),
-            # which ESPHome rejects. Reset to empty when the supplied
-            # id contains a dash so ``generate_component_yaml`` produces
-            # a valid auto-id from the underlying component + name —
-            # a user-typed custom id without dashes passes through.
+            # form (e.g. ``featured_athom-smart-plug-v3_power_monitor_1``
+            # — the board id still carries dashes), which ESPHome rejects.
+            # Reset to empty when the supplied id contains a dash so
+            # ``generate_component_yaml`` produces a valid auto-id from
+            # the underlying component + name — a user-typed custom id
+            # without dashes passes through.
             user_id = fields.get("id")
             if isinstance(user_id, str) and "-" in user_id:
                 fields["id"] = ""

--- a/esphome_device_builder/definitions/README.md
+++ b/esphome_device_builder/definitions/README.md
@@ -142,7 +142,7 @@ featured_components:
       name: Relay   # primitive shorthand → value="Relay", locked=false
 
   # 3) Suggestions — short list of allowed values (frontend renders a picker).
-  - id: pir-motion
+  - id: pir_motion
     component_id: binary_sensor.gpio
     name: PIR Motion Module
     fields:
@@ -151,6 +151,11 @@ featured_components:
         value: 4    # initial pick
       device_class: motion
 ```
+
+`id` must be lowercase letters / digits / underscores (no hyphens) and must
+not equal the domain of `component_id` — e.g. `id: output` under
+`component_id: output.gpio` would clash with the ESPHome `output:` block;
+use `output_relay` instead.
 
 Inside `fields:`:
 
@@ -166,10 +171,10 @@ case is a status LED that needs both `output.gpio` and `light.binary`:
 
 ```yaml
 featured_bundles:
-  - id: status-led
+  - id: status_led
     name: Status LED (full setup)
     description: GPIO output plus a binary light entity.
-    component_ids: [status-led-output, status-led-light]
+    component_ids: [status_led_output, status_led_light]
 ```
 
 `component_ids` references the local `id` of entries in

--- a/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
@@ -88,7 +88,7 @@ pins:
   - uart_tx
   available: true
 featured_components:
-- id: i2c-bus
+- id: i2c_bus
   component_id: i2c
   name: I²C Bus (sensor modules)
   description: |
@@ -110,7 +110,7 @@ featured_components:
     it talks I²C so no per-pin config is needed beyond the bus above.
   fields:
     variant: AHT20
-- id: pir-motion
+- id: pir_motion
   component_id: binary_sensor.gpio
   name: PIR Motion Module (MH-SR602)
   description: |
@@ -122,7 +122,7 @@ featured_components:
       suggestions: [4, 5]
       value: 4
     device_class: motion
-- id: rgb-strip
+- id: rgb_strip
   component_id: light.esp32_rmt_led_strip
   name: RGB LED Strip (addon module)
   description: |
@@ -135,7 +135,7 @@ featured_components:
       value: 4
     num_leds: 8
     rgb_order: GRB
-- id: buzzer-output
+- id: buzzer_output
   component_id: output.ledc
   name: Piezo Buzzer (addon module)
   description: |
@@ -145,17 +145,17 @@ featured_components:
     pin:
       suggestions: [4, 5]
       value: 5
-- id: rtttl-player
+- id: rtttl_player
   component_id: rtttl
   name: RTTTL Player (addon buzzer)
   description: |
     Plays RTTTL ringtones through the piezo buzzer above. Wire the
     ``output`` field to the buzzer output you just added.
 featured_bundles:
-- id: rgb-buzzer-module
+- id: rgb_buzzer_module
   name: RGB LED + Buzzer Module
   description: |
     Plug-in addon shipped with the starter kit — addressable LED
     strip plus a piezo buzzer. Adds the strip, the buzzer PWM output,
     and the RTTTL player as one logical unit.
-  component_ids: [rgb-strip, buzzer-output, rtttl-player]
+  component_ids: [rgb_strip, buzzer_output, rtttl_player]

--- a/esphome_device_builder/definitions/boards/athom-smart-plug-v3/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/athom-smart-plug-v3/manifest.yaml
@@ -94,7 +94,7 @@ featured_components:
           pullup: true
         inverted: true
       locked: true
-- id: status-led-output
+- id: status_led_output
   component_id: output.gpio
   name: Status LED Output
   description: |
@@ -105,15 +105,15 @@ featured_components:
       value: 7
       locked: true
     inverted: true
-- id: status-led-light
+- id: status_led_light
   component_id: light.binary
   name: Status LED Light
   description: |
     Binary light entity for the onboard status LED. Wire its ``output``
-    to the ``status-led-output`` you added.
+    to the ``status_led_output`` you added.
   fields:
     name: Status LED
-- id: power-monitor
+- id: power_monitor
   component_id: sensor.hlw8012
   name: HLW8012 Power Monitor
   description: |
@@ -131,9 +131,9 @@ featured_components:
       locked: true
     model: BL0937
 featured_bundles:
-- id: status-led
+- id: status_led
   name: Status LED (full setup)
   description: |
     Adds the onboard LED's GPIO output plus a binary light entity so it
     surfaces as a light in Home Assistant.
-  component_ids: [status-led-output, status-led-light]
+  component_ids: [status_led_output, status_led_light]

--- a/esphome_device_builder/definitions/boards/sonoff-basic/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/sonoff-basic/manifest.yaml
@@ -158,7 +158,7 @@ featured_components:
           pullup: true
         inverted: true
       locked: true
-- id: status-led-output
+- id: status_led_output
   component_id: output.gpio
   name: Status LED Output
   description: |
@@ -169,18 +169,18 @@ featured_components:
       value: 13
       locked: true
     inverted: true
-- id: status-led-light
+- id: status_led_light
   component_id: light.binary
   name: Status LED Light
   description: |
     Binary light entity for the onboard status LED. Wire its ``output``
-    to the ``status-led-output`` you added.
+    to the ``status_led_output`` you added.
   fields:
     name: Status LED
 featured_bundles:
-- id: status-led
+- id: status_led
   name: Status LED (full setup)
   description: |
     Adds the GPIO output for the onboard LED plus a binary light entity
     so it surfaces as a controllable light in Home Assistant.
-  component_ids: [status-led-output, status-led-light]
+  component_ids: [status_led_output, status_led_light]

--- a/esphome_device_builder/definitions/schemas/board.schema.json
+++ b/esphome_device_builder/definitions/schemas/board.schema.json
@@ -222,7 +222,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Local id, unique within this board (e.g. 'relay', 'pir-motion').",
+          "description": "Local id, unique within this board (e.g. 'relay', 'pir_motion'). Lowercase letters / digits / underscores; must not equal the domain of component_id.",
           "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
         },
         "component_id": {

--- a/esphome_device_builder/definitions/schemas/board.schema.json
+++ b/esphome_device_builder/definitions/schemas/board.schema.json
@@ -223,7 +223,7 @@
         "id": {
           "type": "string",
           "description": "Local id, unique within this board (e.g. 'relay', 'pir_motion'). Lowercase letters / digits / underscores; must not equal the domain of component_id.",
-          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+          "pattern": "^[a-z][a-z0-9_]*$"
         },
         "component_id": {
           "type": "string",
@@ -253,8 +253,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Local id, unique within this board.",
-          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+          "description": "Local id, unique within this board. Lowercase letters / digits / underscores.",
+          "pattern": "^[a-z][a-z0-9_]*$"
         },
         "name": {
           "type": "string",
@@ -270,7 +270,7 @@
           "minItems": 1,
           "items": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+            "pattern": "^[a-z][a-z0-9_]*$"
           }
         }
       }

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -138,7 +138,7 @@ class FeaturedComponent(DataClassORJSONMixin):
     ``ConfigEntry.key``.
     """
 
-    # Local id, unique within this board (e.g. "relay", "pir-motion").
+    # Local id, unique within this board (e.g. "relay", "pir_motion").
     id: str
     component_id: str
     name: str | None = None

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -10,6 +10,7 @@ Used as a pre-commit hook and in CI.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -29,6 +30,12 @@ COMPONENTS_JSON = DEFINITIONS_DIR / "components.json"
 # Categories excluded from featured-component eligibility — these belong in
 # the dedicated "Add core configuration" dialog, not in board recommendations.
 _FEATURED_EXCLUDED_CATEGORIES = {"core", "ota", "time", "update"}
+
+# Required shape for featured-component ids: lowercase letters, digits, and
+# underscores only, starting with a letter. Mirrors what the runtime
+# slugifier (controllers/components.py::_default_id_from_local) and the
+# sync script's auto-id format produce, so manifests stay canonical.
+_FEATURED_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 
 # Pin features the board manifest can declare (mirrors the JSON Schema enum
 # in board.schema.json). Components.json sometimes carries pin_features
@@ -202,6 +209,12 @@ def _validate_featured(
             if b_id in seen_bundle_ids:
                 errors.append(f"{board_id}.featured_bundles[{idx}]: duplicate id '{b_id}'")
             seen_bundle_ids.add(b_id)
+            if not _FEATURED_ID_PATTERN.fullmatch(b_id):
+                errors.append(
+                    f"{board_id}.featured_bundles[{idx}]({b_id}): id '{b_id}' must match "
+                    f"{_FEATURED_ID_PATTERN.pattern} (lowercase letters, digits, "
+                    "underscores; no hyphens)"
+                )
         errors.extend(
             f"{board_id}.featured_bundles[{idx}].component_ids: "
             f"'{cid}' does not match any featured_components[].id"
@@ -224,6 +237,29 @@ def _validate_featured_component(
     fc_id = entry.get("id", f"#{idx}")
     component_id = entry.get("component_id")
     path = f"{board_id}.featured_components[{idx}]({fc_id})"
+
+    # Shape + collision checks on the local id. Run before the
+    # components_index gate so they catch bad ids even when the catalog
+    # isn't loaded.
+    if isinstance(fc_id, str) and entry.get("id") is not None:
+        if not _FEATURED_ID_PATTERN.fullmatch(fc_id):
+            errors.append(
+                f"{path}: id '{fc_id}' must match {_FEATURED_ID_PATTERN.pattern} "
+                "(lowercase letters, digits, underscores; no hyphens)"
+            )
+        if isinstance(component_id, str):
+            # Collision check: an id equal to the component_id's domain
+            # (the bit before the dot, or the whole string for single-
+            # domain ids like ``i2c``) clashes with the ESPHome block
+            # name (``output:``, ``i2c:``). Pick a descriptive role,
+            # e.g. ``output_relay`` instead of ``output``.
+            domain = component_id.split(".", 1)[0]
+            if fc_id == domain:
+                errors.append(
+                    f"{path}: id '{fc_id}' clashes with domain '{domain}' of "
+                    f"component_id '{component_id}'; use a descriptive name "
+                    f"like '{domain}_<role>' instead"
+                )
 
     if components_index is None:
         # Without a component index we can only sanity-check the local

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -81,14 +81,14 @@ def test_load_featured_bundle() -> None:
     """Bundle just stores ids — uniqueness/cross-refs come at validate time."""
     fb = _load_featured_bundle(
         {
-            "id": "status-led",
+            "id": "status_led",
             "name": "Status LED",
             "description": "...",
-            "component_ids": ["status-led-output", "status-led-light"],
+            "component_ids": ["status_led_output", "status_led_light"],
         }
     )
-    assert fb.id == "status-led"
-    assert fb.component_ids == ["status-led-output", "status-led-light"]
+    assert fb.id == "status_led"
+    assert fb.component_ids == ["status_led_output", "status_led_light"]
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +115,7 @@ def catalog() -> ComponentCatalog:
 def test_registry_indexes_known_boards(catalog: ComponentCatalog) -> None:
     """Tier-1 manifests register their featured components under the right ids."""
     assert "featured.sonoff-basic.relay" in catalog._featured_by_id
-    assert "featured.apollo-esk-1.pir-motion" in catalog._featured_by_id
+    assert "featured.apollo-esk-1.pir_motion" in catalog._featured_by_id
     assert "featured.athom-smart-plug-v3.relay" in catalog._featured_by_id
 
 
@@ -143,7 +143,7 @@ async def test_get_component_locked_field(catalog: ComponentCatalog) -> None:
 
 async def test_get_component_suggestions(catalog: ComponentCatalog) -> None:
     """ESK-1 PIR materialisation surfaces the pin suggestions list."""
-    entry = await catalog.get_component(component_id="featured.apollo-esk-1.pir-motion")
+    entry = await catalog.get_component(component_id="featured.apollo-esk-1.pir_motion")
     assert entry is not None
     pin = next(ce for ce in entry.config_entries if ce.key == "pin")
     assert pin.default_value == 4
@@ -163,26 +163,16 @@ async def test_get_component_id_default_from_local(catalog: ComponentCatalog) ->
     assert id_field.locked is False
 
 
-async def test_get_component_id_default_slugifies_dashes(catalog: ComponentCatalog) -> None:
-    """Featured local ids with dashes (``status-led-output``) become valid esphome ids."""
-    entry = await catalog.get_component(
-        component_id="featured.athom-smart-plug-v3.status-led-output",
-    )
-    assert entry is not None
-    id_field = next(ce for ce in entry.config_entries if ce.key == "id")
-    assert id_field.default_value == "status_led_output"
-
-
 async def test_get_component_name_default_from_featured_name(
     catalog: ComponentCatalog,
 ) -> None:
     """The featured component's display name pre-fills the underlying ``name`` field."""
-    # apollo-esk-1.rgb-strip has ``name: RGB LED Strip (addon module)``
+    # apollo-esk-1.rgb_strip has ``name: RGB LED Strip (addon module)``
     # at the featured level but no field preset for ``name`` — the
     # auto-derived default lets the user start with a sensible
     # HA-visible entity name without having to repeat it in the
     # manifest's ``fields:`` block.
-    entry = await catalog.get_component(component_id="featured.apollo-esk-1.rgb-strip")
+    entry = await catalog.get_component(component_id="featured.apollo-esk-1.rgb_strip")
     assert entry is not None
     name_field = next(ce for ce in entry.config_entries if ce.key == "name")
     assert name_field.default_value == "RGB LED Strip (addon module)"
@@ -339,7 +329,7 @@ async def test_apply_presets_locked_accepts_matching_value(
 
 
 async def test_apply_presets_suggestion_in_set(catalog: ComponentCatalog) -> None:
-    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir_motion")
     assert record is not None
     out = _apply_featured_presets(record, {"pin": 5})
     assert out["pin"] == 5
@@ -349,7 +339,7 @@ async def test_apply_presets_suggestion_in_set(catalog: ComponentCatalog) -> Non
 async def test_apply_presets_suggestion_rejects_off_list(
     catalog: ComponentCatalog,
 ) -> None:
-    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir_motion")
     assert record is not None
     with pytest.raises(ValueError, match="must be one of"):
         _apply_featured_presets(record, {"pin": 99})
@@ -366,7 +356,7 @@ async def test_apply_presets_suggestion_accepts_rich_pin_form(
     too — and the rich dict rides through to the merger unchanged so
     the YAML keeps its full pin block.
     """
-    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir_motion")
     assert record is not None
     rich_pin = {"number": 5, "mode": {"input": True}}
     out = _apply_featured_presets(record, {"pin": rich_pin})
@@ -377,7 +367,7 @@ async def test_apply_presets_suggestion_rejects_rich_pin_off_list(
     catalog: ComponentCatalog,
 ) -> None:
     """Rich pin form whose ``number`` is off-list still raises."""
-    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir_motion")
     assert record is not None
     with pytest.raises(ValueError, match="must be one of"):
         _apply_featured_presets(record, {"pin": {"number": 99, "mode": {"input": True}}})
@@ -400,7 +390,7 @@ async def test_apply_presets_suggestion_falls_back_to_value(
     catalog: ComponentCatalog,
 ) -> None:
     """Omitting a suggestion field falls back to the preset's initial value."""
-    record = catalog.get_featured_record("featured.apollo-esk-1.pir-motion")
+    record = catalog.get_featured_record("featured.apollo-esk-1.pir_motion")
     assert record is not None
     out = _apply_featured_presets(record, {})
     assert out["pin"] == 4
@@ -548,9 +538,13 @@ async def test_add_component_featured_resets_dashed_id(
 
     response = await ctrl.add_component(
         configuration="plug.yaml",
-        component_id="featured.athom-smart-plug-v3.power-monitor",
+        component_id="featured.athom-smart-plug-v3.power_monitor",
         fields={
-            "id": "featured_athom-smart-plug-v3_power-monitor_1",
+            # The frontend's catalog-derived id format is
+            # ``featured_<board>_<local>_<n>``. The board portion
+            # (``athom-smart-plug-v3``) carries dashes that the dashed-id
+            # reset still has to detect and replace.
+            "id": "featured_athom-smart-plug-v3_power_monitor_1",
             "current": {"device_class": "current"},
         },
     )

--- a/tests/test_validate_featured.py
+++ b/tests/test_validate_featured.py
@@ -241,3 +241,100 @@ def test_field_preset_imported_still_requires_pin_declared() -> None:
 
     errors = _validate_field_preset("demo", "pin", preset, ce, pins, is_imported=True)
     assert any("GPIO 99 not declared in pins" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# id shape + collision checks
+# ---------------------------------------------------------------------------
+
+
+def test_id_with_hyphens_rejected() -> None:
+    """Hyphens in featured-component ids fail validation outright."""
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "status-led-output",
+                    "component_id": "output.gpio",
+                    "fields": {},
+                }
+            ]
+        ),
+        {},
+        _index(),
+    )
+    assert any("no hyphens" in e for e in errors)
+
+
+def test_id_collides_with_dotted_domain() -> None:
+    """An id equal to the component_id's domain (e.g. ``output``) is rejected."""
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "output",
+                    "component_id": "output.gpio",
+                    "fields": {},
+                }
+            ]
+        ),
+        {},
+        _index(),
+    )
+    assert any("clashes with domain 'output'" in e and "output_<role>" in e for e in errors)
+
+
+def test_id_collides_with_single_segment_component_id() -> None:
+    """For component_ids without a dot (``i2c``, ``rtttl``), id must not equal it."""
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "i2c",
+                    "component_id": "i2c",
+                    "fields": {},
+                }
+            ]
+        ),
+        {},
+        _index(),
+    )
+    assert any("clashes with domain 'i2c'" in e for e in errors)
+
+
+def test_clean_id_passes_shape_check() -> None:
+    """A canonical lowercase-underscore id with a descriptive name passes."""
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [
+                {
+                    "id": "relay_main",
+                    "component_id": "switch.gpio",
+                    "fields": {},
+                }
+            ]
+        ),
+        {},
+        _index(),
+    )
+    # Neither shape nor collision messages should appear; the entry is clean.
+    assert not any("no hyphens" in e for e in errors)
+    assert not any("clashes with domain" in e for e in errors)
+
+
+def test_bundle_id_with_hyphens_rejected() -> None:
+    """The same shape rule applies to ``featured_bundles[].id``."""
+    errors = _validate_featured(
+        "demo",
+        _board(
+            [{"id": "a", "component_id": "switch.gpio", "fields": {}}],
+            [{"id": "rgb-buzzer", "name": "RGB+Buzzer", "component_ids": ["a"]}],
+        ),
+        {},
+        _index(),
+    )
+    assert any("no hyphens" in e and "rgb-buzzer" in e for e in errors)


### PR DESCRIPTION
the catalog sync workflow added in #119 used `git diff --quiet` to decide whether to open a pr — but `--quiet` only sees *modified* tracked files. on the initial sync (or any run that adds new boards), every manifest is untracked, so the script writes them to disk and then the workflow silently reports "already up to date". that's why the sync infrastructure has been sitting unused with 0 imported boards since #119 merged.

separately, the hand-curated featured components from #33 use hyphens in `id:` values (e.g. `status-led-output`, `power-monitor`). esphome rejects hyphens in identifiers — the runtime slugifier in `controllers/components.py` was the only thing making them work. the validator never caught this, and there's nothing stopping a future hand edit from writing `id: output` under `output.gpio` either, which would clash with the esphome `output:` block.

## changes

- **workflow** — swap `git diff --quiet` for `git status --porcelain` in `.github/workflows/sync-device-catalog.yml` so untracked manifests trigger pr creation
- **validator** — hard-error in `script/validate_definitions.py` when a featured-component / bundle `id:` contains hyphens, or when the `id:` equals the domain of `component_id` (e.g. `id: output` under `output.gpio` — suggests `output_<role>` instead)
- **manifests** — rename 13 hyphenated ids in `sonoff-basic`, `athom-smart-plug-v3`, `apollo-esk-1` (`status-led-output` → `status_led_output`, `pir-motion` → `pir_motion`, etc.) and update the bundle `component_ids` references that point at them
- **docs/comments** — schema description, definitions readme, and a model comment refreshed to teach the new convention

once this lands, manually dispatch the sync workflow to pull in the full ~430-board catalog as a follow-up pr.