### PR TITLE
Cover _find_esphome_cmd

### DIFF
--- a/tests/controllers/firmware/test_helpers.py
+++ b/tests/controllers/firmware/test_helpers.py
@@ -37,6 +37,7 @@ from esphome_device_builder.controllers.firmware.constants import (
     _OUTPUT_TRIM_NOTICE_PREFIX,
 )
 from esphome_device_builder.controllers.firmware.helpers import (
+    _find_esphome_cmd,
     _names_touched_by_job,
     _trim_job_output,
     _verify_esphome_importable,
@@ -221,3 +222,146 @@ async def test_verify_esphome_importable_returns_false_on_oserror() -> None:
     ok, detail = await _verify_esphome_importable(cmd)
     assert not ok
     assert "FileNotFoundError" in detail or "OSError" in detail
+
+
+# ---------------------------------------------------------------------------
+# _find_esphome_cmd
+# ---------------------------------------------------------------------------
+
+
+def test_find_esphome_cmd_prefers_sibling_binary_when_present(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A standalone ``esphome`` next to ``sys.executable`` wins.
+
+    A sibling script in the same bin directory is slightly cheaper
+    than ``python -m esphome`` (one fewer import-system warmup)
+    and surfaces a friendlier traceback when something goes wrong
+    inside esphome — the wrapper's ``sys.exit(main())`` shape
+    raises with a clear top frame, vs. the ``runpy`` shim that
+    ``-m`` adds to a stack trace.
+
+    Pin the preference so a refactor that swaps the order would
+    surface here.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text("#!/bin/sh\necho fake\n", encoding="utf-8")
+    sibling = bin_dir / ("esphome.exe" if sys.platform.startswith("win") else "esphome")
+    sibling.write_text("#!/bin/sh\necho fake-esphome\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+    cmd = _find_esphome_cmd()
+
+    assert cmd == [str(sibling)]
+
+
+def test_find_esphome_cmd_falls_back_to_python_dash_m(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No sibling binary → ``[sys.executable, '-m', 'esphome']``.
+
+    The fallback path is what runs in most production
+    deployments — pip-installed esphome creates the sibling
+    script in dev / venv installs but not in every package
+    layout (e.g. some Docker images strip the script wrapper
+    to keep the image small). ``python -m esphome`` always works
+    when the package is importable, which is the same condition
+    the dashboard's own startup already requires, so it's the
+    safe default.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text("#!/bin/sh\necho fake\n", encoding="utf-8")
+    # Deliberately don't create a sibling esphome script.
+
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+    cmd = _find_esphome_cmd()
+
+    assert cmd == [str(fake_python), "-m", "esphome"]
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX-extension branch")
+def test_find_esphome_cmd_picks_bare_esphome_on_posix(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On POSIX the helper picks ``esphome`` (no extension).
+
+    Layered with the Windows-only twin below so the CI matrix
+    (Linux + macOS + Windows) covers both branches end-to-end.
+    Faking ``os.name`` mid-process doesn't work — pathlib
+    instantiates ``PosixPath`` / ``WindowsPath`` based on the
+    real ``os.name`` at import time, and switching makes
+    pathlib raise ``NotImplementedError`` — so we let the
+    host OS pick.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    (bin_dir / "esphome").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+    cmd = _find_esphome_cmd()
+
+    assert cmd == [str(bin_dir / "esphome")]
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows-extension branch")
+def test_find_esphome_cmd_picks_esphome_exe_on_windows(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On Windows the helper picks ``esphome.exe``, not ``esphome``.
+
+    Companion to the POSIX test above. Pinned because the
+    wrong-extension lookup is silent in production: a regression
+    that hard-coded ``esphome`` (or flipped the ternary) would
+    just fall through to ``python -m esphome``. The fallback
+    works, but loses the perf + traceback wins the sibling
+    path provides.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python.exe"
+    fake_python.write_text("MZ\n", encoding="utf-8")
+    (bin_dir / "esphome.exe").write_text("MZ\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+    cmd = _find_esphome_cmd()
+
+    assert cmd == [str(bin_dir / "esphome.exe")]
+
+
+def test_find_esphome_cmd_does_not_substitute_sibling_python(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sibling ``python`` next to a non-``python`` executable is irrelevant.
+
+    Documents the deliberate non-feature: the helper anchors on
+    ``sys.executable`` exactly and never tries to find "the
+    python next door". A previous draft of this code looked for
+    a sibling ``python`` interpreter and used *that* to run
+    ``python -m esphome``; on Linux the running interpreter is
+    sometimes ``/opt/python3.12/bin/python3.12`` while a system
+    ``/usr/bin/python`` (no esphome) is on PATH — substituting
+    silently produced "No module named esphome" at compile
+    time. Anchoring on ``sys.executable`` only is the cure.
+
+    Verify by pointing ``sys.executable`` at a non-``python``-named
+    script with a sibling ``python``: the helper must use the
+    weird name verbatim, not the sibling.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    weird = bin_dir / "python3.12"
+    weird.write_text("#!/bin/sh\n", encoding="utf-8")
+    (bin_dir / "python").write_text("#!/bin/sh\n", encoding="utf-8")
+    # No sibling esphome → expect the fallback.
+
+    monkeypatch.setattr(sys, "executable", str(weird))
+    cmd = _find_esphome_cmd()
+
+    assert cmd == [str(weird), "-m", "esphome"]
+    assert str(bin_dir / "python") not in cmd

--- a/tests/controllers/firmware/test_helpers.py
+++ b/tests/controllers/firmware/test_helpers.py
@@ -26,6 +26,7 @@ expectations in one place avoids drift.
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from typing import Any
@@ -248,7 +249,11 @@ def test_find_esphome_cmd_prefers_sibling_binary_when_present(
     bin_dir.mkdir()
     fake_python = bin_dir / "python"
     fake_python.write_text("#!/bin/sh\necho fake\n", encoding="utf-8")
-    sibling = bin_dir / ("esphome.exe" if sys.platform.startswith("win") else "esphome")
+    # Match the helper's own ``os.name == "nt"`` check exactly.
+    # ``sys.platform`` and ``os.name`` can disagree on MSYS / Cygwin
+    # so basing the fixture on ``os.name`` keeps the test in lockstep
+    # with whichever branch the helper is about to take.
+    sibling = bin_dir / ("esphome.exe" if os.name == "nt" else "esphome")
     sibling.write_text("#!/bin/sh\necho fake-esphome\n", encoding="utf-8")
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
@@ -283,11 +288,11 @@ def test_find_esphome_cmd_falls_back_to_python_dash_m(
     assert cmd == [str(fake_python), "-m", "esphome"]
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX-extension branch")
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-extension branch")
 def test_find_esphome_cmd_picks_bare_esphome_on_posix(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """On POSIX the helper picks ``esphome`` (no extension).
+    """On POSIX (``os.name != 'nt'``) the helper picks ``esphome`` (no extension).
 
     Layered with the Windows-only twin below so the CI matrix
     (Linux + macOS + Windows) covers both branches end-to-end.
@@ -296,6 +301,11 @@ def test_find_esphome_cmd_picks_bare_esphome_on_posix(
     real ``os.name`` at import time, and switching makes
     pathlib raise ``NotImplementedError`` — so we let the
     host OS pick.
+
+    Skip predicate matches the helper's branch exactly
+    (``os.name == "nt"``) rather than ``sys.platform`` so MSYS /
+    Cygwin (where the two can disagree) routes to the
+    correct test.
     """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -309,7 +319,7 @@ def test_find_esphome_cmd_picks_bare_esphome_on_posix(
     assert cmd == [str(bin_dir / "esphome")]
 
 
-@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows-extension branch")
+@pytest.mark.skipif(os.name != "nt", reason="Windows-extension branch")
 def test_find_esphome_cmd_picks_esphome_exe_on_windows(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

``_find_esphome_cmd`` was uncovered. Five tests in ``test_helpers.py`` covering each branch:

| Test | Branch |
|---|---|
| ``test_find_esphome_cmd_prefers_sibling_binary_when_present`` | sibling ``esphome`` next to ``sys.executable`` wins over ``python -m esphome`` |
| ``test_find_esphome_cmd_falls_back_to_python_dash_m`` | no sibling → ``[sys.executable, '-m', 'esphome']`` |
| ``test_find_esphome_cmd_picks_bare_esphome_on_posix`` (POSIX-only) | extension-less ``esphome`` on Linux/macOS |
| ``test_find_esphome_cmd_picks_esphome_exe_on_windows`` (Windows-only) | ``esphome.exe`` on Windows |
| ``test_find_esphome_cmd_does_not_substitute_sibling_python`` | the deliberate non-feature: helper anchors on ``sys.executable`` exactly, never substitutes a sibling ``python`` interpreter |

The platform-specific tests use ``skipif(sys.platform)`` instead of ``monkeypatch`` on ``os.name`` because faking ``os.name`` mid-process doesn't work — pathlib picks its concrete class (``PosixPath`` / ``WindowsPath``) based on the real ``os.name`` at import time, and crossing platforms raises ``NotImplementedError``. Letting the CI matrix (Linux + macOS + Windows) dispatch each branch to its native OS is the only correct shape.

The "doesn't substitute sibling python" test pins the deliberate non-feature documented in the helper's docstring — a draft of this code looked for a sibling ``python`` interpreter and used *that* to run ``python -m esphome``; on Linux the running interpreter is sometimes ``/opt/python3.12/bin/python3.12`` while a system ``/usr/bin/python`` (no esphome) is on PATH, and the substitution silently produced "No module named esphome" at compile time.

## Test plan

- [x] ``uv run pytest tests/controllers/firmware/test_helpers.py -k find_esphome`` — 4 passed (Windows test skipped on macOS host).
- [x] ``uv run pytest --ignore=tests/benchmarks`` — 883 passed.