### PR TITLE
Fix Copilot doc-accuracy nits from PR #153

### DIFF
--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -77,9 +77,9 @@ def firmware_controller_factory(
 
     - ``with_queue=False`` (default): when set ``True``, install
       an ``AsyncMock`` stub for ``_queue``. The submission handlers
-      (``compile`` / ``upload`` / ``install`` / ``rename`` /
-      ``compile_bulk`` / ``install_bulk`` / ``reset_build_env``)
-      need this kit. The validator-only tests
+      (``compile`` / ``upload`` / ``install`` / ``clean`` /
+      ``rename`` / ``compile_bulk`` / ``install_bulk`` /
+      ``reset_build_env``) need this kit. The validator-only tests
       (``test_traversal_validation`` / ``test_get_binaries`` /
       ``test_download``) do not — leaving ``_queue``
       unattributed makes a regression that suddenly tries to

--- a/tests/controllers/firmware/test_supersede.py
+++ b/tests/controllers/firmware/test_supersede.py
@@ -20,9 +20,9 @@ the user-visible contract is:
   ``QUEUED`` entry, and immediately cancel it.
 
 Drives through public API only — submit via ``compile`` /
-``install``, assert via ``get_jobs``. The supersede happens
-as a side effect of the second ``_enqueue``; tests don't call
-``_supersede_active_jobs`` directly.
+``reset_build_env``, assert via ``get_jobs``. The supersede
+happens as a side effect of the second ``_enqueue``; tests
+don't call ``_supersede_active_jobs`` directly.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Two docstring fixes from Copilot's review on the merged #153:

- `tests/controllers/firmware/conftest.py` — the `with_queue=True` block listed submission handlers needing the kit but omitted `clean()`, which also routes through `_enqueue` (controller.py:199).
- `tests/controllers/firmware/test_supersede.py` — module docstring said tests submit via `compile` / `install`, but no test in the file calls `install()`. Replaced with `compile` / `reset_build_env`, which is what the file actually exercises.

Doc-only — no behavior change.

## Test plan
- [x] `uv run pytest tests/controllers/firmware/test_supersede.py tests/controllers/firmware/test_clean.py` — passes
- [x] `uv run pre-commit run` clean