### PR TITLE
Cover ValueError fallbacks in WS origin/host helpers

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from esphome_device_builder.api.ws import _origin_matches_host
 from esphome_device_builder.controllers.auth import AuthController, AuthError
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.helpers.auth import (
@@ -323,24 +324,31 @@ def test_rate_limiter_prune_keeps_locked_out_ips() -> None:
 
 
 def test_origin_matches_host_accepts_same_origin() -> None:
-    from esphome_device_builder.api.ws import _origin_matches_host
-
     assert _origin_matches_host("http://homeassistant.local:6052", "homeassistant.local:6052")
     assert _origin_matches_host("https://esphome.example.com", "esphome.example.com")
 
 
 def test_origin_matches_host_rejects_cross_origin() -> None:
-    from esphome_device_builder.api.ws import _origin_matches_host
-
     assert not _origin_matches_host("https://attacker.com", "homeassistant.local:6052")
     assert not _origin_matches_host("http://homeassistant.local:9999", "homeassistant.local:6052")
 
 
 def test_origin_matches_host_rejects_garbage() -> None:
-    from esphome_device_builder.api.ws import _origin_matches_host
-
     assert not _origin_matches_host("", "homeassistant.local:6052")
     assert not _origin_matches_host("not-a-url", "homeassistant.local:6052")
+
+
+def test_origin_matches_host_rejects_invalid_ipv6_url() -> None:
+    """An Origin with an unclosed IPv6 bracket makes ``urlparse`` raise.
+
+    ``urlparse("http://[invalid")`` raises ``ValueError("Invalid
+    IPv6 URL")`` rather than returning a parsed result. The
+    ``except ValueError`` branch turns that into a clean rejection
+    — without it, the cross-origin gate would 500 on a malformed
+    Origin header instead of returning the 403 the rest of the
+    rejection branches produce.
+    """
+    assert not _origin_matches_host("http://[invalid", "homeassistant.local:6052")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -83,6 +83,20 @@ def test_normalize_host_falls_back_on_malformed() -> None:
     assert _normalize_host("WeirdInput") == "weirdinput"
 
 
+def test_normalize_host_falls_back_on_invalid_ipv6_url() -> None:
+    """An unclosed IPv6 bracket makes ``urlsplit`` raise — falls through to lowercase.
+
+    ``urlsplit("//[invalid")`` raises ``ValueError("Invalid IPv6
+    URL")`` rather than returning a parsed result. The
+    ``except ValueError`` branch sets ``hostname = None`` so the
+    function lands on the bottom fallback (lowercase input
+    verbatim). Without it a malformed ``Host`` header would 500
+    the WS handshake instead of falling through to the
+    allowlist's normal "doesn't match" rejection path.
+    """
+    assert _normalize_host("[invalid") == "[invalid"
+
+
 # ---------------------------------------------------------------------------
 # _host_in_allowlist
 # ---------------------------------------------------------------------------
@@ -197,6 +211,18 @@ def test_origin_in_allowlist_rejects_malformed() -> None:
     """Garbage Origin header -> reject."""
     # Empty hostname after parsing -> not a useful match candidate.
     assert _origin_in_allowlist("not-a-url", ["dashboard.example.com"]) is False
+
+
+def test_origin_in_allowlist_rejects_invalid_ipv6_url() -> None:
+    """An Origin with an unclosed IPv6 bracket makes ``urlparse`` raise.
+
+    ``urlparse("http://[invalid")`` raises ``ValueError("Invalid
+    IPv6 URL")`` rather than returning a parsed result. The
+    ``except ValueError`` branch turns that into a clean rejection
+    so the allowlist check returns ``False`` instead of 500-ing
+    the WS handshake on a malformed Origin header.
+    """
+    assert _origin_in_allowlist("http://[invalid", ["dashboard.example.com"]) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Three `except ValueError` branches in `api/ws.py` had no test exercising them — the existing "malformed input" tests use `"not-a-url"`, which `urlparse` accepts (returns an empty hostname rather than raising). An unclosed IPv6 bracket like `http://[invalid` actually triggers `ValueError("Invalid IPv6 URL")` from `urlparse` / `urlsplit`.

Adds focused tests for each branch:
- `_origin_matches_host` — same-origin gate returns `False` on `ValueError` instead of 500-ing the WS handshake.
- `_origin_in_allowlist` — cross-origin allowlist check returns `False` on the same shape.
- `_normalize_host` — falls through to the lowercase-input fallback so an allowlist comparison still has something deterministic to compare against.

Also hoists the `_origin_matches_host` import to the top of `tests/test_auth.py` (was repeated inside each test).

## Test plan
- [x] `uv run pytest tests/test_auth.py tests/test_trusted_domains.py` — 94 passed
- [x] `uv run pre-commit run` clean