### PR TITLE
Hoist late imports in device_builder.py to module level

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -11,27 +11,27 @@ import asyncio
 import contextlib
 import logging
 import re
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from aiohttp import web
 
-from .controllers.config import DashboardSettings
+from .api.legacy import create_legacy_routes
+from .api.ws import create_ws_routes
+from .controllers.auth import AuthController
+from .controllers.automations import AutomationsController
+from .controllers.boards import BoardCatalog
+from .controllers.components import ComponentCatalog
+from .controllers.config import ConfigController, DashboardSettings
+from .controllers.devices import DevicesController
+from .controllers.editor import EditorController
+from .controllers.firmware import FirmwareController
 from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.auth import auth_middleware
-from .helpers.event_bus import EventBus
+from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware
 from .models import EventType
-
-if TYPE_CHECKING:
-    from .controllers.auth import AuthController
-    from .controllers.automations import AutomationsController
-    from .controllers.boards import BoardCatalog
-    from .controllers.components import ComponentCatalog
-    from .controllers.config import ConfigController
-    from .controllers.devices import DevicesController
-    from .controllers.editor import EditorController
-    from .controllers.firmware import FirmwareController
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,8 +66,6 @@ class DeviceBuilder:
 
     def __init__(self, settings: DashboardSettings) -> None:
         """Initialize the Device Builder."""
-        from concurrent.futures import ThreadPoolExecutor
-
         self.settings = settings
         self.bus = EventBus()
         self.loop: asyncio.AbstractEventLoop | None = None
@@ -120,15 +118,6 @@ class DeviceBuilder:
 
     async def start(self) -> None:
         """Start the application — load catalogs, initialize controllers."""
-        from .controllers.auth import AuthController
-        from .controllers.automations import AutomationsController
-        from .controllers.boards import BoardCatalog
-        from .controllers.components import ComponentCatalog
-        from .controllers.config import ConfigController
-        from .controllers.devices import DevicesController
-        from .controllers.editor import EditorController
-        from .controllers.firmware import FirmwareController
-
         self.loop = asyncio.get_running_loop()
         # Pool itself was constructed in ``__init__`` (so callers
         # probing ``self._executor`` pre-start see the right value);
@@ -276,8 +265,6 @@ class DeviceBuilder:
         an overflow doesn't actually leave the UI in a usable
         state — the connection is fucked either way.
         """
-        from .helpers.event_bus import Event, StreamControls, stream_events
-
         if client is None:
             return
 
@@ -368,13 +355,9 @@ class DeviceBuilder:
         app["trusted_site"] = trusted
 
         # WebSocket API
-        from .api.ws import create_ws_routes
-
         app.router.add_routes(create_ws_routes())
 
         # Legacy REST endpoints (HA backward compat)
-        from .api.legacy import create_legacy_routes
-
         app.router.add_routes(create_legacy_routes())
 
         # Static file serving for board images


### PR DESCRIPTION
## Summary

Twelve late imports inside ``device_builder.py`` were leftover cargo from before ``TYPE_CHECKING`` + ``from __future__ import annotations`` made forward references safe:

- Eight ``from .controllers.X import Y`` inside ``start()``.
- ``from concurrent.futures import ThreadPoolExecutor`` inside ``__init__``.
- ``from .helpers.event_bus import Event, StreamControls, stream_events`` inside ``_cmd_subscribe_events``.
- ``from .api.ws import create_ws_routes`` and ``from .api.legacy import create_legacy_routes`` inside ``create_app``.

None of them were load-bearing — every controller's reverse import of ``DeviceBuilder`` is already guarded by ``TYPE_CHECKING``, and the routes / helpers share no circular path with this module either.

Hoisting them to module level surfaces real import-order bugs at process startup instead of letting them lurk until the first call to ``start()`` / ``_cmd_subscribe_events`` / ``create_app`` (often late in test runs or only in production startup). The cold-import cost is paid once per process and the dashboard always boots anyway.

The duplicated ``if TYPE_CHECKING:`` block also goes away since the real imports cover the annotations on the controller attributes.

## Test plan

- [x] ``uv run pytest --ignore=tests/benchmarks`` — 908 passed (no circular imports surfaced).