### PR TITLE
Cover error branches in firmware-helper subprocess kill paths

### DIFF
--- a/tests/controllers/firmware/test_helpers.py
+++ b/tests/controllers/firmware/test_helpers.py
@@ -225,6 +225,40 @@ async def test_verify_esphome_importable_returns_false_on_oserror() -> None:
     assert "FileNotFoundError" in detail or "OSError" in detail
 
 
+@pytest.mark.asyncio
+async def test_verify_esphome_importable_returns_false_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe that doesn't return within 15s gets killed and reports the timeout.
+
+    Real-world trigger: a wrapper script that hangs on a network
+    call before importing ``esphome``. The probe has to put the
+    spawn down (``proc.kill`` + ``await proc.wait()``) and surface
+    a clear message rather than letting the dashboard startup
+    block indefinitely.
+
+    Patches ``asyncio.wait_for`` in the helper's namespace to
+    raise immediately so the test doesn't have to actually wait
+    15 seconds. The ``with suppress(ProcessLookupError)`` guard
+    around ``proc.kill()`` covers the race where the child
+    exited on its own between the timeout and our kill — the
+    Python one-liner here is fast-exiting, so we exercise that
+    suppress branch incidentally.
+    """
+    from esphome_device_builder.controllers.firmware import helpers as _helpers
+
+    async def _raise_timeout(*_args: Any, **_kwargs: Any) -> None:
+        raise TimeoutError
+
+    monkeypatch.setattr(_helpers.asyncio, "wait_for", _raise_timeout)
+
+    cmd = [sys.executable, "-c", "pass"]
+    ok, detail = await _verify_esphome_importable(cmd)
+
+    assert not ok
+    assert detail == "TimeoutExpired: 15s probe didn't return"
+
+
 # ---------------------------------------------------------------------------
 # _find_esphome_cmd
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -75,6 +75,64 @@ def test_signal_process_group_returns_false_for_dead_pid() -> None:
     assert _signal_process_group(proc.pid, signal.SIGTERM) is False
 
 
+def test_signal_process_group_returns_false_when_killpg_says_dead(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``os.killpg`` racing with the child exiting also returns False.
+
+    There's a TOCTOU window between ``os.getpgid`` succeeding and
+    ``os.killpg`` firing — the process can exit in between, in
+    which case ``killpg`` raises ``ProcessLookupError``. The
+    earlier dead-pid test catches the ``getpgid`` arm; this one
+    pins the ``killpg`` arm so a refactor that drops it (e.g.
+    "the getpgid check already protects us") would surface here.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.firmware.helpers.os.getpgid",
+        lambda _pid: 12345,
+    )
+
+    def _raise_lookup(_pgid: int, _sig: int) -> None:
+        raise ProcessLookupError
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.firmware.helpers.os.killpg",
+        _raise_lookup,
+    )
+
+    assert _signal_process_group(99999, signal.SIGTERM) is False
+
+
+def test_signal_process_group_returns_false_on_permission_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``EPERM`` from ``killpg`` is logged and returns False, not raised.
+
+    Happens when something downgrades our privileges between
+    spawn and signal (rare in production, but the branch exists
+    for defense in depth). The user-visible contract is "Stop
+    didn't kill the build" rather than "the controller crashed";
+    pin both halves — return value and the warning log.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.firmware.helpers.os.getpgid",
+        lambda _pid: 12345,
+    )
+
+    def _raise_perm(_pgid: int, _sig: int) -> None:
+        raise PermissionError
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.firmware.helpers.os.killpg",
+        _raise_perm,
+    )
+
+    with caplog.at_level("WARNING", logger="esphome_device_builder.controllers.firmware.helpers"):
+        assert _signal_process_group(99999, signal.SIGTERM) is False
+
+    assert any("Permission denied signalling pgid" in rec.message for rec in caplog.records)
+
+
 # ---------------------------------------------------------------------------
 # _terminate_current_process — full integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Three uncovered `except` arms in `controllers/firmware/helpers.py`:

- `_signal_process_group` — `os.killpg` raising `ProcessLookupError` (TOCTOU race between `getpgid` and `killpg`). Existing dead-pid test covers the `getpgid` arm; this adds coverage for the `killpg` arm.
- `_signal_process_group` — `os.killpg` raising `PermissionError`. Logs a warning and returns `False`. Pin both the return value and the log record so a refactor that drops the warning branch surfaces here.
- `_verify_esphome_importable` — the 15s probe timing out. Patches `asyncio.wait_for` in the helper's namespace so the test doesn't actually wait 15 seconds. Verifies the `(False, "TimeoutExpired: 15s probe didn't return")` return tuple and exercises the `with suppress(ProcessLookupError)` guard incidentally (the spawn is fast-exiting).

## Test plan
- [x] `uv run pytest tests/controllers/firmware/test_stop.py tests/controllers/firmware/test_helpers.py` — passes
- [x] `uv run pre-commit run` clean