### PR TITLE
Centralize subprocess teardown into helpers/process.py

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -32,6 +32,7 @@ from ...helpers.device_yaml import (
     parse_platform_from_yaml,
 )
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
+from ...helpers.process import kill_quietly
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ...helpers.yaml import merge_component_yaml, rewrite_esphome_name
 from ...models import (
@@ -1875,7 +1876,7 @@ class DevicesController:
             # is what tells the frontend the cancel succeeded. ``proc`` may
             # be ``None`` if cancellation arrived before spawn returned.
             if proc is not None and proc.returncode is None:
-                proc.kill()
+                kill_quietly(proc)
             # Honour the cancellation contract — only swallow if no
             # outstanding cancel requests remain on this task.
             if (current := asyncio.current_task()) and current.cancelling():

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..helpers.api import api_command
 from ..helpers.json import JSONDecodeError, dumps, loads
+from ..helpers.process import kill_quietly
 from ..helpers.subprocess import create_subprocess_exec
 from .firmware.helpers import _find_esphome_cmd
 
@@ -111,7 +112,7 @@ class EditorController:
             try:
                 await asyncio.wait_for(proc.wait(), timeout=1.0)
             except TimeoutError:
-                proc.kill()
+                kill_quietly(proc)
                 await proc.wait()
 
     def _resolve_file(self, requested: str, configuration: str, content: str) -> str:

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -61,12 +61,6 @@ _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*Uploading:.*?\b(\d{1,3})\s*%"),
 )
 
-# How long to wait for a SIGTERM'd subprocess to exit before we
-# escalate to SIGKILL. ESPHome / PlatformIO usually clean up promptly;
-# the longer floor protects against esptool mid-flash where USB I/O
-# can stall the process briefly.
-_TERMINATE_GRACE_SECONDS = 3.0
-
 # History retention. Bulk operations can spawn dozens of jobs at once;
 # we want a useful audit trail without letting the metadata file grow
 # without bound.

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -17,7 +17,6 @@ import importlib
 import logging
 import os
 import shutil
-import signal
 import sys
 from contextlib import suppress
 from datetime import UTC, datetime
@@ -33,6 +32,7 @@ from esphome.storage_json import StorageJSON, ext_storage_path
 
 from ...helpers.api import CommandError, api_command
 from ...helpers.event_bus import StreamControls, stream_events
+from ...helpers.process import terminate_subtree_with_grace
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ...models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType
 from ..config import _load_metadata, metadata_transaction
@@ -47,7 +47,6 @@ from .constants import (
     _PRIMARY_JOB_TYPES,
     _RESET_BUILD_ENV_TARGETS,
     _TERMINAL_JOB_STATUSES,
-    _TERMINATE_GRACE_SECONDS,
 )
 from .helpers import (
     _find_esphome_cmd,
@@ -55,8 +54,6 @@ from .helpers import (
     _mark_job_terminal,
     _names_touched_by_job,
     _parse_progress,
-    _signal_process_group,
-    _terminate_subtree_windows,
     _trim_job_output,
     _validate_port,
     _verify_esphome_importable,
@@ -930,26 +927,12 @@ class FirmwareController:
         compile chain doesn't honour any of the polite signals.
         """
         proc = self._current_process
-        if proc is None or proc.returncode is not None:
+        if proc is None:
             return
-        if sys.platform == "win32":
-            if not await _terminate_subtree_windows(proc.pid):
-                # taskkill missing or hung — at least put the parent down
-                # so the runner loop can finalise the job.
-                with suppress(ProcessLookupError):
-                    proc.kill()
-            return
-        if not _signal_process_group(proc.pid, signal.SIGTERM):
-            return
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=_TERMINATE_GRACE_SECONDS)
-        except TimeoutError:
-            _LOGGER.warning(
-                "Subprocess for job %s ignored SIGTERM after %.1fs — sending SIGKILL",
-                self._current_job.job_id if self._current_job else "?",
-                _TERMINATE_GRACE_SECONDS,
-            )
-            _signal_process_group(proc.pid, signal.SIGKILL)
+        await terminate_subtree_with_grace(
+            proc,
+            job_label=f"job {self._current_job.job_id}" if self._current_job else "job ?",
+        )
 
     async def _reset_build_env(self, job: FirmwareJob) -> None:
         """

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -15,11 +15,11 @@ import logging
 import os
 import re
 import sys
-from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 
 from ...helpers.api import CommandError
+from ...helpers.process import kill_quietly
 from ...helpers.subprocess import create_subprocess_exec
 from ...models import ErrorCode, FirmwareJob, JobStatus, JobType
 from .constants import (
@@ -28,7 +28,6 @@ from .constants import (
     _OUTPUT_TRIM_NOTICE_PREFIX,
     _PROGRESS_PATTERNS,
     _TERMINAL_JOB_STATUSES,
-    _TERMINATE_GRACE_SECONDS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -177,89 +176,6 @@ def _parse_progress(line: str) -> int | None:
     return None
 
 
-def _signal_process_group(pid: int, sig: int) -> bool:
-    """
-    Send *sig* to the process group of *pid*; return True iff delivered.
-
-    Used to take down the whole esphome → platformio → gcc tree when
-    the user hits Stop. ``proc.terminate()`` / ``proc.kill()`` only
-    signal the direct child (the python esphome process), so the
-    compiler grandchildren keep running and the build effectively
-    ignores the cancel. Pair this with ``start_new_session=True`` at
-    the spawn site: that makes the spawned process the leader of a
-    new session (and a new process group), and its descendants
-    inherit that group. The dashboard process itself is *not* in the
-    same group — ``killpg(getpgid(spawned_pid), sig)`` therefore
-    targets the build subtree without touching us.
-
-    POSIX-only — ``os.getpgid`` / ``os.killpg`` don't exist on Windows.
-    The Windows path goes through ``_terminate_subtree_windows`` instead.
-
-    Falls back gracefully:
-    * ``ProcessLookupError`` — the process already exited; nothing to do.
-    * ``PermissionError`` — we lost the right to signal it; treat as a
-      no-op rather than crashing the controller.
-    """
-    try:
-        pgid = os.getpgid(pid)
-    except ProcessLookupError:
-        return False
-    try:
-        os.killpg(pgid, sig)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        _LOGGER.warning("Permission denied signalling pgid %d (sig %s)", pgid, sig)
-        return False
-    return True
-
-
-async def _terminate_subtree_windows(pid: int) -> bool:
-    """
-    Forcibly kill *pid* and its descendants on Windows; return True iff successful.
-
-    Windows has no process groups in the POSIX sense, so we shell out to
-    ``taskkill /F /T /PID`` — ``/T`` walks the parent-child tree from
-    *pid* down, ``/F`` is the forceful equivalent of SIGKILL. There's no
-    useful "polite" stage here: a compile chain (esphome → platformio →
-    gcc / esptool) ignores ``WM_CLOSE`` / ``CTRL_BREAK_EVENT`` anyway,
-    so we go straight to the kill.
-
-    Returns False (and logs a warning) when ``taskkill`` is missing,
-    times out, or exits non-zero (access denied, invalid pid, partial
-    failure). The caller should fall back to ``proc.kill()`` so the
-    parent at least dies even when the tree-walk fails.
-    """
-    try:
-        killer = await create_subprocess_exec(
-            "taskkill",
-            "/F",
-            "/T",
-            "/PID",
-            str(pid),
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-    except FileNotFoundError:
-        _LOGGER.warning("taskkill not found on PATH — can't tree-kill pid %d", pid)
-        return False
-    try:
-        await asyncio.wait_for(killer.wait(), timeout=_TERMINATE_GRACE_SECONDS)
-    except TimeoutError:
-        _LOGGER.warning("taskkill timed out for pid %d", pid)
-        with suppress(ProcessLookupError):
-            killer.kill()
-        return False
-    if killer.returncode != 0:
-        _LOGGER.warning(
-            "taskkill exited %s for pid %d — caller should fall back to proc.kill()",
-            killer.returncode,
-            pid,
-        )
-        return False
-    return True
-
-
 def _validate_port(port: str) -> None:
     """Sanity-check the user-supplied ``--device`` value.
 
@@ -375,8 +291,7 @@ async def _verify_esphome_importable(cmd: list[str]) -> tuple[bool, str]:
     try:
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
     except TimeoutError:
-        with suppress(ProcessLookupError):
-            proc.kill()
+        kill_quietly(proc)
         await proc.wait()
         return False, "TimeoutExpired: 15s probe didn't return"
     output = stdout.decode("utf-8", errors="replace").strip()

--- a/esphome_device_builder/helpers/process.py
+++ b/esphome_device_builder/helpers/process.py
@@ -1,0 +1,202 @@
+"""
+Subprocess teardown helpers — platform-aware kill + grace-period orchestration.
+
+The dashboard spawns subprocesses in a few different shapes:
+
+* **Compile / upload / install jobs** spawn ``esphome``, which forks
+  PlatformIO, which forks ``gcc`` / ``esptool`` / ``mklittlefs``. The
+  whole tree has to come down on cancel.
+* **YAML validator session** (``editor.py``) spawns a single
+  ``esphome vscode`` subprocess. Single process, no fork chain.
+* **Device log streams** (``devices/controller.py``) spawn ``esphome
+  logs`` for live tailing. Single process.
+* **Startup probes** (``firmware/helpers._verify_esphome_importable``)
+  spawn ``esphome --version`` with a hard timeout.
+
+Three patterns end up open-coded in the call sites without this
+module:
+
+* ``with suppress(ProcessLookupError): proc.kill()`` for the race
+  where the child exits between the ``returncode is None`` check and
+  the kill — this is ``kill_quietly`` here.
+* ``os.killpg(os.getpgid(pid), sig)`` with ``ProcessLookupError`` /
+  ``PermissionError`` handling — POSIX subtree signal, exposed as
+  ``_signal_process_group``.
+* Windows ``taskkill /F /T`` with timeout + retcode handling —
+  exposed as ``_terminate_subtree_windows``.
+
+The orchestration helper ``terminate_subtree_with_grace`` ties those
+together: SIGTERM the group → wait the grace window → SIGKILL the
+group on POSIX; ``taskkill`` with a single-shot kill fallback on
+Windows. That's the shape ``FirmwareController._terminate_current_process``
+needs.
+
+POSIX vs Windows asymmetry is deliberate: the POSIX path has a
+graceful SIGTERM stage because well-behaved tools (``esptool``,
+``platformio``) honour it and clean up serial ports / partial
+writes. The Windows compile chain ignores ``CTRL_BREAK_EVENT`` and
+``WM_CLOSE`` — there's no point sending a polite signal nobody's
+listening for, so we go straight to ``taskkill``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+from contextlib import suppress
+
+from .subprocess import create_subprocess_exec
+
+_LOGGER = logging.getLogger(__name__)
+
+# Window between SIGTERM and SIGKILL on POSIX, and timeout on the
+# ``taskkill`` invocation on Windows. Tuned for the compile chain
+# (esphome → platformio → gcc / esptool): three seconds is plenty for
+# esptool to release the serial port and platformio to flush its log,
+# and short enough that a hung compiler doesn't make the user wait.
+_TERMINATE_GRACE_SECONDS = 3.0
+
+
+def kill_quietly(proc: asyncio.subprocess.Process) -> None:
+    """
+    Best-effort ``proc.kill()`` that swallows ``ProcessLookupError``.
+
+    There's a TOCTOU race in every kill site: between a
+    ``proc.returncode is None`` check and ``proc.kill()`` firing,
+    the child can exit on its own — and ``Process.kill()`` then
+    raises ``ProcessLookupError`` because the pid's already
+    reaped. Wrap the kill with this helper instead of repeating
+    the suppress block at every call site.
+    """
+    with suppress(ProcessLookupError):
+        proc.kill()
+
+
+def _signal_process_group(pid: int, sig: int) -> bool:
+    """
+    Send *sig* to the process group of *pid*; return True iff delivered.
+
+    Used to take down the whole esphome → platformio → gcc tree when
+    the user hits Stop. ``proc.terminate()`` / ``proc.kill()`` only
+    signal the direct child (the python esphome process), so the
+    compiler grandchildren keep running and the build effectively
+    ignores the cancel. Pair this with ``start_new_session=True`` at
+    the spawn site: that makes the spawned process the leader of a
+    new session (and a new process group), and its descendants
+    inherit that group. The dashboard process itself is *not* in the
+    same group — ``killpg(getpgid(spawned_pid), sig)`` therefore
+    targets the build subtree without touching us.
+
+    POSIX-only — ``os.getpgid`` / ``os.killpg`` don't exist on Windows.
+    The Windows path goes through ``_terminate_subtree_windows`` instead.
+
+    Falls back gracefully:
+
+    * ``ProcessLookupError`` — the process already exited; nothing to do.
+    * ``PermissionError`` — we lost the right to signal it; treat as a
+      no-op rather than crashing the controller.
+    """
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        return False
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        _LOGGER.warning("Permission denied signalling pgid %d (sig %s)", pgid, sig)
+        return False
+    return True
+
+
+async def _terminate_subtree_windows(pid: int) -> bool:
+    """
+    Forcibly kill *pid* and its descendants on Windows; return True iff successful.
+
+    Windows has no process groups in the POSIX sense, so we shell out to
+    ``taskkill /F /T /PID`` — ``/T`` walks the parent-child tree from
+    *pid* down, ``/F`` is the forceful equivalent of SIGKILL. There's no
+    useful "polite" stage here: a compile chain (esphome → platformio →
+    gcc / esptool) ignores ``WM_CLOSE`` / ``CTRL_BREAK_EVENT`` anyway,
+    so we go straight to the kill.
+
+    Returns False (and logs a warning) when ``taskkill`` is missing,
+    times out, or exits non-zero (access denied, invalid pid, partial
+    failure). The caller should fall back to ``proc.kill()`` so the
+    parent at least dies even when the tree-walk fails.
+    """
+    try:
+        killer = await create_subprocess_exec(
+            "taskkill",
+            "/F",
+            "/T",
+            "/PID",
+            str(pid),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        _LOGGER.warning("taskkill not found on PATH — can't tree-kill pid %d", pid)
+        return False
+    try:
+        await asyncio.wait_for(killer.wait(), timeout=_TERMINATE_GRACE_SECONDS)
+    except TimeoutError:
+        _LOGGER.warning("taskkill timed out for pid %d", pid)
+        kill_quietly(killer)
+        return False
+    if killer.returncode != 0:
+        _LOGGER.warning(
+            "taskkill exited %s for pid %d — caller should fall back to proc.kill()",
+            killer.returncode,
+            pid,
+        )
+        return False
+    return True
+
+
+async def terminate_subtree_with_grace(
+    proc: asyncio.subprocess.Process,
+    *,
+    grace_seconds: float = _TERMINATE_GRACE_SECONDS,
+    job_label: str = "subprocess",
+) -> None:
+    """
+    Bring down *proc* and its descendants, gracefully if possible.
+
+    POSIX: SIGTERM the process group, wait *grace_seconds* for the
+    tree to exit on its own, then SIGKILL the group. Requires the
+    spawn site to have used ``start_new_session=True`` so a process
+    group exists to signal — without that, only the direct child
+    receives the signal and the compiler grandchildren orphan.
+
+    Windows: ``taskkill /F /T`` to walk the kernel's parent-child
+    accounting and force-kill the subtree. There's no graceful
+    stage on Windows because the compile chain ignores polite
+    signals; if ``taskkill`` is missing or hangs, fall back to
+    ``proc.kill()`` so the direct child at least dies and the
+    runner loop can finalise the job.
+
+    No-op when *proc* has already exited. *job_label* is used in
+    the warning log if the SIGTERM grace window expires (POSIX only).
+    """
+    if proc.returncode is not None:
+        return
+    if sys.platform == "win32":
+        if not await _terminate_subtree_windows(proc.pid):
+            kill_quietly(proc)
+        return
+    if not _signal_process_group(proc.pid, signal.SIGTERM):
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=grace_seconds)
+    except TimeoutError:
+        _LOGGER.warning(
+            "Subprocess for %s ignored SIGTERM after %.1fs — sending SIGKILL",
+            job_label,
+            grace_seconds,
+        )
+        _signal_process_group(proc.pid, signal.SIGKILL)

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware.helpers import _signal_process_group
+from esphome_device_builder.helpers.process import _signal_process_group
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
 
 # Process groups, ``os.fork``, and ``SIGKILL`` are POSIX-only. The
@@ -88,7 +88,7 @@ def test_signal_process_group_returns_false_when_killpg_says_dead(
     "the getpgid check already protects us") would surface here.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.helpers.os.getpgid",
+        "esphome_device_builder.helpers.process.os.getpgid",
         lambda _pid: 12345,
     )
 
@@ -96,7 +96,7 @@ def test_signal_process_group_returns_false_when_killpg_says_dead(
         raise ProcessLookupError
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.helpers.os.killpg",
+        "esphome_device_builder.helpers.process.os.killpg",
         _raise_lookup,
     )
 
@@ -115,7 +115,7 @@ def test_signal_process_group_returns_false_on_permission_error(
     pin both halves — return value and the warning log.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.helpers.os.getpgid",
+        "esphome_device_builder.helpers.process.os.getpgid",
         lambda _pid: 12345,
     )
 
@@ -123,11 +123,11 @@ def test_signal_process_group_returns_false_on_permission_error(
         raise PermissionError
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.helpers.os.killpg",
+        "esphome_device_builder.helpers.process.os.killpg",
         _raise_perm,
     )
 
-    with caplog.at_level("WARNING", logger="esphome_device_builder.controllers.firmware.helpers"):
+    with caplog.at_level("WARNING", logger="esphome_device_builder.helpers.process"):
         assert _signal_process_group(99999, signal.SIGTERM) is False
 
     assert any("Permission denied signalling pgid" in rec.message for rec in caplog.records)

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -16,8 +16,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware import helpers as firmware_module
-from esphome_device_builder.controllers.firmware.helpers import _terminate_subtree_windows
+from esphome_device_builder.helpers import process as process_module
+from esphome_device_builder.helpers.process import _terminate_subtree_windows
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
 
 pytestmark = pytest.mark.skipif(
@@ -71,7 +71,7 @@ async def test_terminate_subtree_windows_returns_false_when_taskkill_missing(
     # Patch the symbol as imported in the firmware module so the
     # production code path (which goes through the helpers wrapper)
     # actually exercises the fallback branch.
-    monkeypatch.setattr(firmware_module, "create_subprocess_exec", _missing)
+    monkeypatch.setattr(process_module, "create_subprocess_exec", _missing)
     assert await _terminate_subtree_windows(12345) is False
 
 
@@ -95,5 +95,5 @@ async def test_terminate_subtree_windows_returns_false_on_taskkill_failure(
     async def _spawn(*_args: object, **_kwargs: object) -> _FakeProc:
         return fake
 
-    monkeypatch.setattr(firmware_module, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr(process_module, "create_subprocess_exec", _spawn)
     assert await _terminate_subtree_windows(12345) is False

--- a/tests/test_helpers_process.py
+++ b/tests/test_helpers_process.py
@@ -1,0 +1,236 @@
+"""Tests for ``helpers/process.py`` — subprocess teardown helpers.
+
+The platform-specific halves (POSIX ``_signal_process_group`` and
+Windows ``_terminate_subtree_windows``) are exercised by the
+firmware-stop integration tests; this file covers the shared
+helpers ``kill_quietly`` and ``terminate_subtree_with_grace`` that
+sit on top of them.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+from typing import Any
+
+import pytest
+
+from esphome_device_builder.helpers.process import (
+    kill_quietly,
+    terminate_subtree_with_grace,
+)
+
+# ---------------------------------------------------------------------------
+# kill_quietly
+# ---------------------------------------------------------------------------
+
+
+def test_kill_quietly_swallows_process_lookup_error() -> None:
+    """A ``ProcessLookupError`` from ``proc.kill()`` doesn't propagate.
+
+    Race shape: caller checks ``proc.returncode is None``, the
+    child exits, the kill then raises because the pid is reaped.
+    The helper wraps the kill so call sites don't repeat the
+    suppress block — drop the suppress and this test surfaces it.
+    """
+
+    class _DeadProc:
+        def kill(self) -> None:
+            raise ProcessLookupError
+
+    kill_quietly(_DeadProc())  # type: ignore[arg-type]
+
+
+def test_kill_quietly_calls_kill_when_alive() -> None:
+    """A live proc gets ``proc.kill()`` invoked exactly once."""
+
+    class _LiveProc:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def kill(self) -> None:
+            self.calls += 1
+
+    proc = _LiveProc()
+    kill_quietly(proc)  # type: ignore[arg-type]
+    assert proc.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# terminate_subtree_with_grace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_terminate_subtree_with_grace_no_op_on_already_exited() -> None:
+    """Already-exited proc returns immediately without trying to signal."""
+
+    class _ExitedProc:
+        returncode = 0
+        pid = 99999
+
+        def kill(self) -> None:  # pragma: no cover — must not be called
+            raise AssertionError("kill() reached on an already-exited proc")
+
+    await terminate_subtree_with_grace(_ExitedProc())  # type: ignore[arg-type]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal-group path")
+@pytest.mark.asyncio
+async def test_terminate_subtree_with_grace_sigterm_then_exit_no_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SIGTERM is sent; child exits within grace → no SIGKILL escalation.
+
+    Pin the happy POSIX path: process group gets a SIGTERM, the
+    proc exits before the grace window closes, the SIGKILL branch
+    is never reached. A regression that flipped the wait-for to
+    raise (or skipped the wait entirely) would land in the
+    SIGKILL branch and assert here.
+    """
+    sent: list[tuple[int, int]] = []
+
+    def _fake_signal(pid: int, sig: int) -> bool:
+        sent.append((pid, sig))
+        return True
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.process._signal_process_group",
+        _fake_signal,
+    )
+
+    class _ExitsCleanly:
+        returncode = None
+        pid = 12345
+
+        async def wait(self) -> int:
+            self.returncode = 0
+            return 0
+
+    await terminate_subtree_with_grace(_ExitsCleanly())  # type: ignore[arg-type]
+
+    assert sent == [(12345, signal.SIGTERM)]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal-group path")
+@pytest.mark.asyncio
+async def test_terminate_subtree_with_grace_escalates_to_sigkill_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SIGTERM ignored past grace → SIGKILL fires.
+
+    Production trigger: a hung gcc that doesn't honour SIGTERM.
+    The user-visible contract is "Stop kills the build" — if the
+    SIGKILL branch ever drops, the runner loop hangs waiting for
+    a process that won't exit and the queue gets wedged.
+    """
+    sent: list[tuple[int, int]] = []
+
+    def _fake_signal(pid: int, sig: int) -> bool:
+        sent.append((pid, sig))
+        return True
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.process._signal_process_group",
+        _fake_signal,
+    )
+
+    async def _raise_timeout(*_args: Any, **_kwargs: Any) -> None:
+        raise TimeoutError
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.process.asyncio.wait_for",
+        _raise_timeout,
+    )
+
+    class _StubProc:
+        returncode = None
+        pid = 12345
+
+        async def wait(self) -> int:  # pragma: no cover — wait_for short-circuits
+            return 0
+
+    await terminate_subtree_with_grace(
+        _StubProc(),  # type: ignore[arg-type]
+        grace_seconds=0.01,
+        job_label="job test-1",
+    )
+
+    assert sent == [(12345, signal.SIGTERM), (12345, signal.SIGKILL)]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal-group path")
+@pytest.mark.asyncio
+async def test_terminate_subtree_with_grace_returns_when_sigterm_undelivered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_signal_process_group`` returning False (proc gone) short-circuits.
+
+    No point waiting for a grace window or escalating to SIGKILL
+    if the SIGTERM never landed — the pid is already gone.
+    """
+    waited = False
+
+    def _fake_signal(_pid: int, _sig: int) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.process._signal_process_group",
+        _fake_signal,
+    )
+
+    async def _record_wait_for(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
+        nonlocal waited
+        waited = True
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.process.asyncio.wait_for",
+        _record_wait_for,
+    )
+
+    class _StubProc:
+        returncode = None
+        pid = 12345
+
+        async def wait(self) -> int:  # pragma: no cover
+            return 0
+
+    await terminate_subtree_with_grace(_StubProc())  # type: ignore[arg-type]
+
+    assert waited is False
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows taskkill path")
+@pytest.mark.asyncio
+async def test_terminate_subtree_with_grace_falls_back_to_proc_kill_on_taskkill_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows: taskkill returning False triggers the ``proc.kill()`` fallback.
+
+    ``taskkill`` may be missing (stripped from the image) or hung;
+    the fallback ensures the parent at least dies so the runner
+    loop can finalise the job. The ``proc.kill()`` is wrapped in
+    ``kill_quietly`` so a race with the child's own exit doesn't
+    raise.
+    """
+
+    async def _fake_terminate_subtree(_pid: int) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.process._terminate_subtree_windows",
+        _fake_terminate_subtree,
+    )
+
+    class _StubProc:
+        returncode = None
+        pid = 12345
+        kill_calls = 0
+
+        def kill(self) -> None:
+            self.kill_calls += 1
+
+    proc = _StubProc()
+    await terminate_subtree_with_grace(proc)  # type: ignore[arg-type]
+
+    assert proc.kill_calls == 1


### PR DESCRIPTION
> **Stacked on #159** — set base to that branch so the diff is just this refactor. Rebase onto main once #159 lands.

## Summary
Move platform-specific subprocess teardown out of `controllers/firmware/helpers.py` and into a new `helpers/process.py` shared module. Three patterns that used to be open-coded across `firmware/controller.py`, `firmware/helpers.py`, `editor.py`, and `devices/controller.py` now have one home:

- **`kill_quietly(proc)`** wraps the `with suppress(ProcessLookupError): proc.kill()` pattern (4 call sites).
- **`_signal_process_group`** and **`_terminate_subtree_windows`** move verbatim to the new module — same docstrings, same logic, internal callers use them through the new orchestrator.
- **`terminate_subtree_with_grace(proc, *, grace_seconds, job_label)`** is the new orchestrator: SIGTERM → wait `grace_seconds` → SIGKILL on POSIX, `taskkill /F /T` with `proc.kill()` fallback on Windows, no-op when the proc has already exited. Replaces the ~20-line ladder in `FirmwareController._terminate_current_process`.

Editor and device-stream call sites that deliberately don't kill the subtree (single-process subprocesses, no fork chain) only adopt `kill_quietly` — folding them into the subtree-aware helpers would change behaviour.

`_TERMINATE_GRACE_SECONDS` (formerly in `firmware/constants.py`) moves to the new module since both its remaining call sites are in there.

## Test plan
- [x] New `tests/test_helpers_process.py` covers the orchestrator branches: already-exited no-op, SIGTERM-then-clean-exit, SIGTERM-then-SIGKILL escalation on grace timeout, undelivered-SIGTERM short-circuit, and Windows taskkill fallback.
- [x] Existing integration tests (`test_stop.py` POSIX, `test_stop_windows.py`) updated to import from the new module — same end-to-end coverage of the platform-specific halves.
- [x] `uv run pytest` — 922 passed, 5 skipped
- [x] `uv run pre-commit run` clean