### PR TITLE
Drop unused error_response helper

### DIFF
--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -83,11 +83,6 @@ def json_response(data: Any, status: int = 200) -> web.Response:
     )
 
 
-def error_response(message: str, status: int = 400) -> web.Response:
-    """Return a JSON error response."""
-    return json_response({"error": message}, status)
-
-
 @web.middleware
 async def cors_middleware(request: web.Request, handler: Any) -> web.StreamResponse:
     """Permissive CORS for local development."""


### PR DESCRIPTION
## Summary
`helpers.json.error_response` had zero callers — `grep -rn 'error_response\b' esphome_device_builder/` only matches the definition site. Every actual error site that wants the `{"error": ...}` envelope shape is already calling `json_response({"error": "..."}, status=...)` inline. Remove the dead helper rather than testing it.

## Test plan
- [x] `uv run pytest` — 938 passed
- [x] `uv run pre-commit run` clean
- [x] `grep -rn 'error_response' esphome_device_builder/` returns nothing after the change