### PR TITLE
Cover boards + editor controllers to 100%

### DIFF
--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -1,0 +1,513 @@
+"""Tests for the board catalog controller.
+
+``BoardCatalog`` is the in-memory cache + filter/search layer over
+the on-disk ``definitions/boards/<id>/manifest.yaml`` set. The
+loader (``load_board_catalog``) is exercised by
+``script/validate_definitions.py``; this file pins the
+*controller's* behaviour with a hand-built fixture catalog so the
+tests don't drift with the real catalog churn.
+
+The controller has two consumer surfaces:
+
+* WebSocket commands ``boards/get_board`` and ``boards/get_boards``
+  (decorated with ``@api_command``).
+* In-process lookups ``get_by_id`` / ``find_by_pio_board`` /
+  ``find_by_platform_variant`` / ``iter_boards``, used by the
+  components controller and the device-import flow.
+
+Both surfaces are covered here against the same fixture set so a
+filter regression hits both halves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.controllers.boards import BoardCatalog
+from esphome_device_builder.models import (
+    BoardCatalogEntry,
+    BoardTag,
+    Esp32Variant,
+    Platform,
+)
+from esphome_device_builder.models.boards import BoardEsphomeConfig
+
+
+def _board(
+    *,
+    board_id: str,
+    name: str | None = None,
+    description: str = "",
+    manufacturer: str = "Acme",
+    platform: Platform = Platform.ESP32,
+    variant: Esp32Variant | None = None,
+    pio_board: str = "esp32dev",
+    tags: list[BoardTag] | None = None,
+    featured: bool = False,
+    is_generic: bool = False,
+) -> BoardCatalogEntry:
+    """Compact factory for catalog entries — defaults to a plausible ESP32 board."""
+    return BoardCatalogEntry(
+        id=board_id,
+        name=name or board_id,
+        description=description,
+        manufacturer=manufacturer,
+        esphome=BoardEsphomeConfig(platform=platform, board=pio_board, variant=variant),
+        tags=tags or [],
+        featured=featured,
+        is_generic=is_generic,
+    )
+
+
+@pytest.fixture
+def catalog() -> BoardCatalog:
+    """Build a controller pre-loaded with a deterministic mini-catalog.
+
+    Avoids ``BoardCatalog.load()`` and the real on-disk YAML so the
+    tests are stable across catalog updates. Mix: two ESP32 variants
+    (S3 + C3), one ESP8266, plus generic fallbacks; one entry per
+    platform is featured.
+    """
+    cat = BoardCatalog()
+    cat._boards = [
+        _board(
+            board_id="seeed-xiao-esp32c3",
+            name="Seeed XIAO ESP32-C3",
+            description="Compact dev board",
+            manufacturer="Seeed",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32C3,
+            pio_board="esp32-c3-devkitm-1",
+            tags=[BoardTag.COMPACT, BoardTag.USB_C],
+            featured=True,
+        ),
+        _board(
+            board_id="m5stack-cores3",
+            name="M5Stack CoreS3",
+            description="Display-equipped ESP32-S3",
+            manufacturer="M5Stack",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32S3,
+            pio_board="m5stack-cores3",
+            tags=[BoardTag.DISPLAY],
+        ),
+        _board(
+            board_id="generic-esp32c3",
+            name="Generic ESP32-C3",
+            manufacturer="Generic",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32C3,
+            pio_board="esp32-c3-devkitm-1",
+            is_generic=True,
+        ),
+        _board(
+            board_id="generic-esp32s3",
+            name="Generic ESP32-S3",
+            manufacturer="Generic",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32S3,
+            pio_board="esp32-s3-devkitc-1",
+            is_generic=True,
+        ),
+        _board(
+            board_id="d1-mini",
+            name="Wemos D1 Mini",
+            description="Classic ESP8266 dev board",
+            manufacturer="Wemos",
+            platform=Platform.ESP8266,
+            pio_board="d1_mini",
+            tags=[BoardTag.COMPACT],
+            featured=True,
+        ),
+        _board(
+            board_id="generic-esp8266",
+            name="Generic ESP8266",
+            manufacturer="Generic",
+            platform=Platform.ESP8266,
+            pio_board="nodemcuv2",
+            is_generic=True,
+        ),
+    ]
+    return cat
+
+
+# ---------------------------------------------------------------------------
+# get_board / get_by_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_board_returns_match_by_id(catalog: BoardCatalog) -> None:
+    """``boards/get_board`` returns the entry whose ``id`` matches."""
+    board = await catalog.get_board(board_id="m5stack-cores3")
+    assert board is not None
+    assert board.id == "m5stack-cores3"
+    assert board.esphome.variant == Esp32Variant.ESP32S3
+
+
+@pytest.mark.asyncio
+async def test_get_board_returns_none_for_unknown_id(catalog: BoardCatalog) -> None:
+    """Unknown board id → ``None`` (not an exception).
+
+    The frontend treats ``None`` as "board no longer in catalog";
+    raising would surface as a generic 500 instead of letting the
+    UI render the device with a stale label.
+    """
+    assert await catalog.get_board(board_id="not-a-real-board") is None
+
+
+def test_get_by_id_is_synchronous_alias_for_get_board(catalog: BoardCatalog) -> None:
+    """``get_by_id`` is the in-process counterpart used by other controllers.
+
+    Pinned separately from ``get_board`` because the components
+    controller and import flow depend on the synchronous shape —
+    a refactor that turned ``get_by_id`` into an async method would
+    surface here.
+    """
+    board = catalog.get_by_id("d1-mini")
+    assert board is not None
+    assert board.esphome.platform == Platform.ESP8266
+    assert catalog.get_by_id("ghost") is None
+
+
+# ---------------------------------------------------------------------------
+# get_boards — filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_boards_unfiltered_returns_everything_with_total(
+    catalog: BoardCatalog,
+) -> None:
+    """No filters → every board, paged response carries the full ``total``."""
+    resp = await catalog.get_boards()
+    assert resp.total == 6
+    assert len(resp.boards) == 6
+    assert resp.offset == 0
+    assert resp.limit == 50
+
+
+@pytest.mark.asyncio
+async def test_get_boards_filters_by_platform(catalog: BoardCatalog) -> None:
+    """``platform=esp8266`` drops every entry on a different platform."""
+    resp = await catalog.get_boards(platform=Platform.ESP8266)
+
+    assert resp.total == 2
+    assert {b.id for b in resp.boards} == {"d1-mini", "generic-esp8266"}
+
+
+@pytest.mark.asyncio
+async def test_get_boards_filters_by_variant_case_insensitive(
+    catalog: BoardCatalog,
+) -> None:
+    """``variant`` filter is case-insensitive — ``ESP32C3`` matches ``esp32c3``.
+
+    Frontend may send the upper-cased enum name (``ESP32C3``)
+    while the catalog stores the lowercase value (``esp32c3``).
+    The controller lowercases both sides so the dropdown's
+    selected value round-trips.
+    """
+    resp = await catalog.get_boards(variant="ESP32C3")
+
+    assert resp.total == 2
+    assert {b.id for b in resp.boards} == {"seeed-xiao-esp32c3", "generic-esp32c3"}
+
+
+@pytest.mark.asyncio
+async def test_get_boards_filters_by_tag(catalog: BoardCatalog) -> None:
+    """``tag=display`` returns only the entry tagged for it."""
+    resp = await catalog.get_boards(tag=BoardTag.DISPLAY)
+
+    assert resp.total == 1
+    assert resp.boards[0].id == "m5stack-cores3"
+
+
+@pytest.mark.asyncio
+async def test_get_boards_query_searches_name_description_manufacturer_id_tags(
+    catalog: BoardCatalog,
+) -> None:
+    """The free-text ``query`` matches across multiple fields, case-insensitive."""
+    # Name match.
+    by_name = await catalog.get_boards(query="xiao")
+    assert {b.id for b in by_name.boards} == {"seeed-xiao-esp32c3"}
+
+    # Manufacturer match.
+    by_mfr = await catalog.get_boards(query="WEMOS")
+    assert {b.id for b in by_mfr.boards} == {"d1-mini"}
+
+    # Description match.
+    by_desc = await catalog.get_boards(query="display-equipped")
+    assert {b.id for b in by_desc.boards} == {"m5stack-cores3"}
+
+    # Tag match.
+    by_tag_query = await catalog.get_boards(query="usb-c")
+    assert {b.id for b in by_tag_query.boards} == {"seeed-xiao-esp32c3"}
+
+    # ID match.
+    by_id = await catalog.get_boards(query="generic-esp8266")
+    assert {b.id for b in by_id.boards} == {"generic-esp8266"}
+
+
+@pytest.mark.asyncio
+async def test_get_boards_filters_compose(catalog: BoardCatalog) -> None:
+    """Multiple filters AND together — platform + variant + tag.
+
+    Pin the composition: a refactor that swapped any filter for
+    OR semantics would silently widen results.
+    """
+    resp = await catalog.get_boards(
+        platform=Platform.ESP32,
+        variant=Esp32Variant.ESP32C3,
+        tag=BoardTag.COMPACT,
+    )
+
+    assert resp.total == 1
+    assert resp.boards[0].id == "seeed-xiao-esp32c3"
+
+
+# ---------------------------------------------------------------------------
+# get_boards — sorting + pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_boards_sorts_featured_first_generic_last(
+    catalog: BoardCatalog,
+) -> None:
+    """Featured first, generic fallbacks last, the rest alphabetical.
+
+    Drives the dashboard's "browse all" listing — featured boards
+    are what users actually buy, generics are the fallback catch-
+    all. A refactor that flipped the sort key tuple would surface
+    here.
+    """
+    resp = await catalog.get_boards()
+    ids = [b.id for b in resp.boards]
+
+    # Featured pair, tie-broken alphabetically by name —
+    # "Seeed ..." < "Wemos D1 Mini" so Seeed comes first.
+    assert ids[0:2] == ["seeed-xiao-esp32c3", "d1-mini"]
+    # Generic fallbacks at the end.
+    assert ids[-3:] == ["generic-esp32c3", "generic-esp32s3", "generic-esp8266"]
+    # Non-featured non-generic in the middle.
+    assert ids[2] == "m5stack-cores3"
+
+
+@pytest.mark.asyncio
+async def test_get_boards_paginates_via_offset_and_limit(
+    catalog: BoardCatalog,
+) -> None:
+    """``offset`` + ``limit`` slice the sorted list; ``total`` is the unsliced count.
+
+    Page-2 view: skip the first two and take two. ``total`` stays
+    at the full count so the frontend can render "showing 3-4 of
+    6" without a second request.
+    """
+    resp = await catalog.get_boards(offset=2, limit=2)
+
+    assert resp.total == 6
+    assert resp.offset == 2
+    assert resp.limit == 2
+    assert len(resp.boards) == 2
+    # After-featured slice: the non-featured M5Stack and the first
+    # generic alphabetically.
+    assert [b.id for b in resp.boards] == ["m5stack-cores3", "generic-esp32c3"]
+
+
+@pytest.mark.asyncio
+async def test_get_boards_offset_past_end_returns_empty_page(
+    catalog: BoardCatalog,
+) -> None:
+    """Offset past the result count → empty page, ``total`` still accurate.
+
+    Frontend handles "no more results" by checking
+    ``len(boards) < limit``; ``total`` lets it short-circuit
+    further requests.
+    """
+    resp = await catalog.get_boards(offset=100, limit=10)
+
+    assert resp.total == 6
+    assert resp.boards == []
+
+
+# ---------------------------------------------------------------------------
+# iter_boards
+# ---------------------------------------------------------------------------
+
+
+def test_iter_boards_returns_internal_list(catalog: BoardCatalog) -> None:
+    """``iter_boards`` returns the underlying list directly.
+
+    Documented contract: callers (the components controller's
+    featured-component registry build) treat it as read-only.
+    Pin so a refactor that wraps it in ``list(...)`` doesn't
+    silently change the identity guarantee.
+    """
+    assert catalog.iter_boards() is catalog._boards
+    assert len(catalog.iter_boards()) == 6
+
+
+# ---------------------------------------------------------------------------
+# find_by_pio_board
+# ---------------------------------------------------------------------------
+
+
+def test_find_by_pio_board_returns_first_match(catalog: BoardCatalog) -> None:
+    """A pio_board with no variant hint returns the first matching entry."""
+    # ``esp32-c3-devkitm-1`` is shared by Seeed XIAO and Generic ESP32-C3.
+    board = catalog.find_by_pio_board("esp32-c3-devkitm-1")
+
+    assert board is not None
+    assert board.esphome.board == "esp32-c3-devkitm-1"
+
+
+def test_find_by_pio_board_prefers_matching_variant(catalog: BoardCatalog) -> None:
+    """When ``pio_variant`` is provided, prefer entries whose variant matches."""
+    # The fixture has two pio_board="esp32-c3-devkitm-1" entries; both
+    # are ESP32-C3 here. Add a different-variant entry to make the
+    # preference observable.
+    catalog._boards.append(
+        _board(
+            board_id="alt-c3-board",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32C3,
+            pio_board="some-shared-pio",
+        )
+    )
+    catalog._boards.append(
+        _board(
+            board_id="alt-s3-board",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32S3,
+            pio_board="some-shared-pio",
+        )
+    )
+
+    board = catalog.find_by_pio_board("some-shared-pio", pio_variant="esp32s3")
+
+    assert board is not None
+    assert board.id == "alt-s3-board"
+
+
+def test_find_by_pio_board_falls_back_to_first_when_variant_unmatched(
+    catalog: BoardCatalog,
+) -> None:
+    """``pio_variant`` not matching any candidate → still return the first match.
+
+    "Best effort" semantics — a YAML referencing a known PlatformIO
+    board with a stale variant should still resolve to *something*
+    rather than dropping the device from the dashboard.
+    """
+    board = catalog.find_by_pio_board("esp32-c3-devkitm-1", pio_variant="esp32c6-not-in-fixture")
+
+    assert board is not None
+    assert board.esphome.board == "esp32-c3-devkitm-1"
+
+
+def test_find_by_pio_board_returns_none_for_unknown(catalog: BoardCatalog) -> None:
+    """No matching ``esphome.board`` value → ``None``."""
+    assert catalog.find_by_pio_board("nonexistent-board") is None
+
+
+# ---------------------------------------------------------------------------
+# find_by_platform_variant
+# ---------------------------------------------------------------------------
+
+
+def test_find_by_platform_variant_prefers_generic_fallback(
+    catalog: BoardCatalog,
+) -> None:
+    """When matches include a generic, prefer the generic.
+
+    Documented in the function's docstring: a YAML naming only
+    the platform should resolve to "Generic ESP32-C3" rather than
+    a vendor-specific board that happens to share the variant.
+    """
+    board = catalog.find_by_platform_variant("esp32", variant="esp32c3")
+
+    assert board is not None
+    assert board.id == "generic-esp32c3"
+    assert board.is_generic is True
+
+
+def test_find_by_platform_variant_no_generic_returns_first(
+    catalog: BoardCatalog,
+) -> None:
+    """When no generic exists for the variant, fall back to the first match.
+
+    Removes the two generics so the helper has to land on the
+    non-generic ESP32-S3 (M5Stack).
+    """
+    catalog._boards = [b for b in catalog._boards if not b.is_generic]
+
+    board = catalog.find_by_platform_variant("esp32", variant="esp32s3")
+
+    assert board is not None
+    assert board.id == "m5stack-cores3"
+
+
+def test_find_by_platform_variant_without_variant_falls_through(
+    catalog: BoardCatalog,
+) -> None:
+    """No variant supplied → first matching platform entry (may be generic)."""
+    board = catalog.find_by_platform_variant("esp8266")
+
+    assert board is not None
+    assert board.esphome.platform == Platform.ESP8266
+    # The generic preference still kicks in when present.
+    assert board.id == "generic-esp8266"
+
+
+def test_find_by_platform_variant_unknown_platform_returns_none(
+    catalog: BoardCatalog,
+) -> None:
+    """A platform not represented in the catalog → ``None``."""
+    assert catalog.find_by_platform_variant("rp2040") is None
+
+
+def test_find_by_platform_variant_empty_platform_returns_none(
+    catalog: BoardCatalog,
+) -> None:
+    """Empty string short-circuits — guard against accidentally matching everything.
+
+    Without the guard, an empty ``platform.value`` comparison
+    would still succeed against entries whose ``platform`` is
+    ``None`` / empty (none in our enum, but the early-return is
+    cheap defense).
+    """
+    assert catalog.find_by_platform_variant("") is None
+
+
+# ---------------------------------------------------------------------------
+# load
+# ---------------------------------------------------------------------------
+
+
+def test_load_replaces_internal_list_from_catalog_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``load()`` swaps the internal list for what ``load_board_catalog`` returns.
+
+    Patches the loader so the test doesn't depend on the on-disk
+    YAML (covered separately by
+    ``script/validate_definitions.py``). Pins the controller-loader
+    contract: ``BoardCatalog._boards`` becomes ``list(catalog.boards)``
+    after ``load()``.
+    """
+    fake_boards = [_board(board_id="from-loader", platform=Platform.ESP32)]
+
+    class _FakeResponse:
+        boards = fake_boards
+
+    def _fake_load() -> _FakeResponse:
+        return _FakeResponse()
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.boards.load_board_catalog",
+        _fake_load,
+    )
+
+    cat = BoardCatalog()
+    assert cat._boards == []
+    cat.load()
+    assert cat._boards == fake_boards

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -305,3 +305,439 @@ async def test_stop_terminates_all_sessions(tmp_path: Path) -> None:
 
     assert controller._sessions == {}
     assert controller._terminate_subprocess.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# __init__ + start
+# ---------------------------------------------------------------------------
+
+
+def test_init_sets_default_state() -> None:
+    """Constructor wires the device builder, no sessions, empty cmd."""
+    db = MagicMock()
+    controller = EditorController(db)
+    assert controller._db is db
+    assert controller._sessions == {}
+    assert controller._esphome_cmd == []
+
+
+@pytest.mark.asyncio
+async def test_start_resolves_esphome_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``start()`` populates ``_esphome_cmd`` via ``_find_esphome_cmd``.
+
+    The cmd is later spliced with ``vscode <config_dir> --ace`` to
+    spawn the validator. Pin the lookup so a refactor that moved
+    the resolution elsewhere (or skipped it) surfaces here rather
+    than at the first ``editor/validate_yaml`` call.
+    """
+    controller = _make_controller(tmp_path)
+    controller._esphome_cmd = []  # ensure start() actually populates it
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor._find_esphome_cmd",
+        lambda: ["python", "-m", "esphome"],
+    )
+
+    await controller.start()
+
+    assert controller._esphome_cmd == ["python", "-m", "esphome"]
+
+
+# ---------------------------------------------------------------------------
+# _ensure_subprocess
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_subprocess_no_op_when_proc_already_running(
+    tmp_path: Path,
+) -> None:
+    """A live proc on the session → no respawn.
+
+    Sessions are warm: a single ``esphome vscode`` subprocess
+    serves every validate call for that configuration. A respawn
+    would lose the validator's component-import cache and double
+    every validation's wall-clock cost.
+    """
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    proc, *_ = _make_fake_proc([])
+    session.proc = proc
+    spawned = False
+
+    async def _no_spawn(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal spawned
+        spawned = True
+        return MagicMock()
+
+    # Patch the spawn entry point — should never be reached.
+    import esphome_device_builder.controllers.editor as _editor_mod
+
+    _editor_mod.create_subprocess_exec = _no_spawn  # type: ignore[assignment]
+
+    await controller._ensure_subprocess(session)
+
+    assert spawned is False
+    assert session.proc is proc
+
+
+@pytest.mark.asyncio
+async def test_ensure_subprocess_spawns_and_drains_version_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cold-start: spawn the subprocess and drain the initial version line.
+
+    Without the drain, the next ``validate`` call would land on the
+    stale version line and never reach the real result — pinning
+    this branch protects against a refactor that drops the readline.
+    """
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    proc, reader, _ = _make_fake_proc([dumps({"type": "version", "version": "1.0"}) + b"\n"])
+
+    async def _fake_spawn(*_args: Any, **_kwargs: Any) -> Any:
+        return proc
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    await controller._ensure_subprocess(session)
+
+    assert session.proc is proc
+    # The version line should already have been consumed — feed_eof
+    # on the reader and a follow-up readline returns nothing.
+    reader.feed_eof()
+    assert await proc.stdout.readline() == b""
+
+
+@pytest.mark.asyncio
+async def test_ensure_subprocess_terminates_session_and_raises_on_startup_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Subprocess never emits version line within ``_STARTUP_TIMEOUT``.
+
+    The validator hung before printing its handshake. Tear down the
+    session and raise so the dispatcher surfaces a clear error
+    instead of leaving a half-initialised subprocess pinned. Verify
+    both: ``RuntimeError`` propagates, and ``_terminate_subprocess``
+    runs.
+    """
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    proc, _reader, _ = _make_fake_proc([])  # no lines → readline blocks
+
+    async def _fake_spawn(*_args: Any, **_kwargs: Any) -> Any:
+        return proc
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    async def _raise_timeout(awaitable: Any, *_args: Any, **_kwargs: Any) -> None:
+        # Close the awaitable so a "coroutine was never awaited"
+        # warning doesn't fire on the never-consumed readline.
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        raise TimeoutError
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor.asyncio.wait_for",
+        _raise_timeout,
+    )
+
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="did not start in time"):
+        await controller._ensure_subprocess(session)
+
+    terminated.assert_awaited_once_with(session)
+
+
+# ---------------------------------------------------------------------------
+# _terminate_subprocess
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_terminate_subprocess_no_op_when_session_proc_is_none(
+    tmp_path: Path,
+) -> None:
+    """No proc → return immediately, no surprise calls."""
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    session.proc = None
+    await controller._terminate_subprocess(session)
+
+
+@pytest.mark.asyncio
+async def test_terminate_subprocess_no_op_when_proc_already_exited(
+    tmp_path: Path,
+) -> None:
+    """Already-exited proc skips the exit/terminate/kill ladder."""
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    proc, *_ = _make_fake_proc([])
+    proc.returncode = 0
+    session.proc = proc
+
+    await controller._terminate_subprocess(session)
+
+    proc.terminate.assert_not_called()
+    proc.kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_terminate_subprocess_sends_exit_and_waits(tmp_path: Path) -> None:
+    """Happy path: write ``{"type": "exit"}``, drain, close stdin, wait."""
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    proc, _reader, stdin_capture = _make_fake_proc([])
+    session.proc = proc
+
+    await controller._terminate_subprocess(session)
+
+    # Exit message went out.
+    assert any(b'"type":"exit"' in chunk for chunk in stdin_capture)
+    # No escalation needed — proc.wait() returned cleanly.
+    proc.terminate.assert_not_called()
+    proc.kill.assert_not_called()
+    # Session's reference cleared so the next ensure() respawns.
+    assert session.proc is None
+
+
+@pytest.mark.asyncio
+async def test_terminate_subprocess_escalates_through_terminate_then_kill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Subprocess ignores exit + terminate → final ``kill_quietly`` fires.
+
+    Pin the full ladder. The validator may be wedged in C extension
+    code that doesn't honour the ``exit`` message or SIGTERM (rare,
+    but the branch exists for it); the SIGKILL fallback is what
+    keeps shutdown from hanging.
+    """
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    proc, _reader, _ = _make_fake_proc([])
+    session.proc = proc
+
+    timeouts = [True, True, False]  # exit-wait, terminate-wait, kill-wait
+
+    async def _wait_for(awaitable: Any, *_args: Any, **_kwargs: Any) -> Any:
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        if timeouts.pop(0):
+            raise TimeoutError
+        return 0
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor.asyncio.wait_for",
+        _wait_for,
+    )
+
+    kill_quietly_calls: list[Any] = []
+
+    def _track_kill_quietly(p: Any) -> None:
+        kill_quietly_calls.append(p)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor.kill_quietly",
+        _track_kill_quietly,
+    )
+
+    await controller._terminate_subprocess(session)
+
+    proc.terminate.assert_called_once()
+    assert kill_quietly_calls == [proc]
+
+
+@pytest.mark.asyncio
+async def test_terminate_subprocess_swallows_stdin_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken stdin doesn't abort termination — fall through to wait/kill.
+
+    Production trigger: the validator died between the wedge check
+    and the exit-message write, so ``proc.stdin.write`` raises
+    ``BrokenPipeError``. We need to keep going and still ``wait()``
+    so the session reference clears; the ``except Exception`` is
+    what makes that work.
+    """
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    proc, _reader, _ = _make_fake_proc([])
+
+    def _broken_write(_data: bytes) -> None:
+        raise BrokenPipeError
+
+    proc.stdin.write = _broken_write
+    session.proc = proc
+
+    await controller._terminate_subprocess(session)
+
+    # Cleared the session reference even after the write failure.
+    assert session.proc is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_file — OSError on Path.resolve
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_file_falls_back_when_requested_path_unresolvable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``Path.resolve()`` raising on the requested path → use the unresolved Path.
+
+    macOS / Linux with a long enough path (or a path through a
+    broken symlink) can fault ``resolve()`` even when ``read_text``
+    later succeeds against the unresolved form. The except branch
+    keeps the read-from-disk fallback usable in that case rather
+    than 500-ing the validator round-trip.
+    """
+    controller = _make_controller(tmp_path)
+    include = tmp_path / "common.yaml"
+    include.write_text("ok\n", encoding="utf-8")
+
+    real_resolve = Path.resolve
+
+    def _raise_for_requested(self: Path, *args: Any, **kwargs: Any) -> Path:
+        # Only fault for the requested file — the controller resolves
+        # the config_dir too, which has to keep working for the
+        # main_path comparison.
+        if self.name == "common.yaml":
+            raise OSError("simulated resolve failure")
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", _raise_for_requested)
+
+    result = controller._resolve_file(str(include), "kitchen.yaml", "")
+
+    assert result == "ok\n"
+
+
+# ---------------------------------------------------------------------------
+# _validate_locked — JSON-decoding tolerance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_locked_skips_unparseable_lines(tmp_path: Path) -> None:
+    """A malformed JSON line is dropped; the loop reads the next line.
+
+    The validator may emit a stray non-JSON line (debug log, version
+    banner that escaped the startup drain). The loop's
+    ``except JSONDecodeError`` keeps reading instead of raising —
+    pin the branch so a refactor that moved the loads outside the
+    try/except surfaces here.
+    """
+    controller = _make_controller(tmp_path)
+    session = _EditorSession()
+    proc, _reader, _ = _make_fake_proc(
+        [
+            b"this is not json\n",
+            dumps({"type": "result", "yaml_errors": [], "validation_errors": []}) + b"\n",
+        ]
+    )
+    session.proc = proc
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
+
+    result = await controller._validate_locked(session, "kitchen.yaml", "")
+
+    assert result == {"yaml_errors": [], "validation_errors": []}
+
+
+# ---------------------------------------------------------------------------
+# validate_yaml — public api_command entrypoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_yaml_creates_session_and_delegates(
+    tmp_path: Path,
+) -> None:
+    """First call for a config creates a session and forwards to ``_validate_locked``.
+
+    Each configuration gets exactly one ``_EditorSession`` (so
+    concurrent edits on the same YAML are serialised through
+    ``session.lock``). Pin both halves: the session lands in
+    ``_sessions``, and ``_validate_locked`` receives the same
+    instance.
+    """
+    controller = _make_controller(tmp_path)
+
+    async def _fake_validate(session: _EditorSession, configuration: str, content: str) -> dict:
+        # Stash the session on the controller so the test can
+        # confirm it's the same instance the registry holds.
+        controller._captured_session = session  # type: ignore[attr-defined]
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _fake_validate  # type: ignore[method-assign]
+
+    result = await controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n")
+
+    assert result == {"yaml_errors": [], "validation_errors": []}
+    assert "kitchen.yaml" in controller._sessions
+    assert controller._captured_session is controller._sessions["kitchen.yaml"]  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_validate_yaml_terminates_session_on_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Timeout from ``_validate_locked`` → session torn down + re-raise.
+
+    Subprocess wedged or unreachable — kill it so the next call
+    spawns fresh. Without the teardown, the next validate call
+    would hit the same wedged process and block forever.
+    """
+    controller = _make_controller(tmp_path)
+
+    async def _hangs(*_args: Any, **_kwargs: Any) -> dict:  # pragma: no cover
+        return {}
+
+    controller._validate_locked = _hangs  # type: ignore[method-assign]
+
+    async def _raise_timeout(awaitable: Any, *_args: Any, **_kwargs: Any) -> None:
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        raise TimeoutError
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor.asyncio.wait_for",
+        _raise_timeout,
+    )
+
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    with pytest.raises(TimeoutError):
+        await controller.validate_yaml(configuration="kitchen.yaml", content="")
+
+    terminated.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_validate_yaml_terminates_session_on_runtime_error(
+    tmp_path: Path,
+) -> None:
+    """``_validate_locked`` raising ``RuntimeError`` (subprocess died) → teardown + re-raise."""
+    controller = _make_controller(tmp_path)
+
+    async def _raise_runtime(*_args: Any, **_kwargs: Any) -> dict:
+        raise RuntimeError("subprocess closed stdout")
+
+    controller._validate_locked = _raise_runtime  # type: ignore[method-assign]
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="closed stdout"):
+        await controller.validate_yaml(configuration="kitchen.yaml", content="")
+
+    terminated.assert_awaited_once()


### PR DESCRIPTION
## Summary
Two controllers had no / partial coverage:

- **`controllers/boards.py`** (0% → 100%): 23 new tests in `tests/controllers/test_boards.py` against a hand-built fixture catalog so the assertions don't drift with real catalog churn. Covers `get_board` / `get_boards` (filtering by platform / variant / tag, free-text query against name/description/manufacturer/id/tags, sort with featured-first / generic-last, pagination), `get_by_id` / `iter_boards`, `find_by_pio_board` (variant preference + fallback), `find_by_platform_variant` (generic-preference, empty-platform short-circuit), and `load` (loader patched).

- **`controllers/editor.py`** (57% → 100%): 15 new tests on top of the existing `_resolve_file` / `_validate_locked` / `stop()` coverage:
  - `__init__` + `start` — wires defaults, resolves the esphome cmd via `_find_esphome_cmd`.
  - `_ensure_subprocess` — three paths: no-op when proc is already running, cold-start spawn + drain version line, startup-timeout teardown + `RuntimeError`.
  - `_terminate_subprocess` — five paths: proc is `None` / proc already exited / happy exit-message path / full exit → terminate → `kill_quietly` ladder / broken-stdin tolerance.
  - `_resolve_file` — OSError on `Path.resolve` for the requested path falls through to disk read.
  - `_validate_locked` — JSONDecodeError on a stray non-JSON line is skipped instead of raising.
  - `validate_yaml` — public api_command entry: creates the session, delegates, terminates on `TimeoutError` / `RuntimeError` and re-raises.

## Test plan
- [x] `uv run pytest tests/controllers/test_boards.py tests/test_editor_controller.py` — 46 passed
- [x] `uv run coverage report` shows 100% on both files
- [x] `uv run pre-commit run` clean