### PR TITLE
Enable ruff PLC0415 (import-outside-top-level) and hoist late imports

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -465,9 +465,11 @@ class DeviceBuilder:
     @staticmethod
     def _get_frontend_dir() -> Path | None:
         """Return the path to the built frontend, or None if unavailable."""
-        # Optional companion wheel ``esphome-device-builder-frontend``
-        # ships the prebuilt assets. Keep the import lazy (the
-        # PLC0415 suppression below) so this method can be patched in
+        # The companion wheel ``esphome-device-builder-frontend``
+        # normally ships the prebuilt assets for dependency-managed
+        # installs, but keep the import lazy (the PLC0415
+        # suppression below) so this method still handles runtime
+        # environments where it is unavailable and can be patched in
         # tests via ``builtins.__import__`` without re-importing the
         # module — see test_ha_addon_failsafe's ImportError coverage.
         try:

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -465,8 +465,13 @@ class DeviceBuilder:
     @staticmethod
     def _get_frontend_dir() -> Path | None:
         """Return the path to the built frontend, or None if unavailable."""
+        # Optional companion wheel ``esphome-device-builder-frontend``
+        # ships the prebuilt assets. Keep the import lazy (the
+        # PLC0415 suppression below) so this method can be patched in
+        # tests via ``builtins.__import__`` without re-importing the
+        # module — see test_ha_addon_failsafe's ImportError coverage.
         try:
-            from esphome_device_builder_frontend import where  # type: ignore[import-not-found]
+            from esphome_device_builder_frontend import where  # noqa: PLC0415
 
             return Path(where())
         except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ ignore = [
   "D203", # conflicts with D211
   "D213", # conflicts with D212
   "D417", # false positives
-  "PLC0415", # late imports are deliberate (avoid circular deps, lazy esphome load)
   "PLR0913", # too many arguments — not a useful constraint here
   "PLR2004", # magic value comparison — too noisy for status codes / structural checks
   "S101", # assert used for type checking
@@ -116,7 +115,9 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501"] # CLI scripts
+# CLI scripts: noisy print is fine, late imports gate optional esphome introspection
+# behind try/except ImportError, and several subprocess invocations are inherent.
+"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415"]
 "tests/*" = ["S105", "S106"] # hardcoded test credentials
 
 [tool.codespell]

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -37,6 +37,7 @@ exercised — not just the handler bodies.
 from __future__ import annotations
 
 import asyncio
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,7 @@ import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
+from esphome_device_builder.api import legacy
 from esphome_device_builder.api.legacy import create_legacy_routes
 from esphome_device_builder.controllers.config import DashboardSettings
 
@@ -635,10 +637,6 @@ async def test_spawn_ws_real_subprocess_streams_output(
     # Replace the esphome command with a Python one-liner that
     # prints two lines and exits 0. Using ``compile`` as the
     # command so the existing route mapping doesn't change.
-    import sys
-
-    from esphome_device_builder.api import legacy
-
     original_cmd = legacy._ESPHOME_CMD
     try:
         legacy._ESPHOME_CMD = [

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -27,6 +27,8 @@ import pytest
 
 from esphome_device_builder.controllers.config import (
     _load_metadata,
+    _save_metadata,
+    clear_volatile_device_metadata,
     get_device_metadata,
     set_device_metadata,
 )
@@ -609,12 +611,6 @@ def test_clear_volatile_device_metadata_drops_corrupt_non_dict_entry(
     would crash that path. Drop the bad value so the next write
     starts from a clean shape.
     """
-    from esphome_device_builder.controllers.config import (
-        _save_metadata,
-        clear_volatile_device_metadata,
-        get_device_metadata,
-    )
-
     # Seed a corrupt entry (string instead of dict) directly via
     # the persistence helper — ``set_device_metadata`` won't let
     # us write a non-dict value through its public surface.
@@ -625,8 +621,6 @@ def test_clear_volatile_device_metadata_drops_corrupt_non_dict_entry(
     # ``get_device_metadata`` returns ``{}`` when the value is
     # not a dict — but here the entry should be gone entirely.
     # Read the raw file to distinguish.
-    from esphome_device_builder.controllers.config import _load_metadata
-
     raw = _load_metadata(tmp_path)
     assert "kitchen.yaml" not in raw
     assert get_device_metadata(tmp_path, "kitchen.yaml") == {}

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -10,11 +10,16 @@ exception.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from esphome_device_builder.controllers.config import (
+    get_device_metadata,
+    set_device_metadata,
+)
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices import controller as devices_module
 from esphome_device_builder.helpers.api import CommandError
@@ -119,13 +124,6 @@ async def test_create_device_clears_residual_metadata_from_archived_same_name(
     and the dashboard renders the new YAML's friendly_name as
     the archived one's. Pin the wipe-on-create contract.
     """
-    import asyncio
-
-    from esphome_device_builder.controllers.config import (
-        get_device_metadata,
-        set_device_metadata,
-    )
-
     config_dir = tmp_path
     storage_path = tmp_path / "storage.json"
     monkeypatch.setattr(devices_module, "ext_storage_path", lambda _filename: storage_path)
@@ -166,13 +164,6 @@ async def test_create_device_with_board_id_overwrites_archived_board_id(
     called WITH a board_id, the new value must replace the
     archived one rather than be merged or skipped.
     """
-    import asyncio
-
-    from esphome_device_builder.controllers.config import (
-        get_device_metadata,
-        set_device_metadata,
-    )
-
     config_dir = tmp_path
     storage_path = tmp_path / "storage.json"
     monkeypatch.setattr(devices_module, "ext_storage_path", lambda _filename: storage_path)

--- a/tests/controllers/devices/test_friendly_name_slugify_import.py
+++ b/tests/controllers/devices/test_friendly_name_slugify_import.py
@@ -23,15 +23,19 @@ def test_friendly_name_slugify_resolves_via_helpers_or_dashboard_shim() -> None:
     both locations fails loudly on import — not at the first
     adoption flow that calls it.
     """
+    # Each import is gated by try/except ImportError to tolerate
+    # whichever esphome release ships the symbol — keeping them inside
+    # the test (PLC0415 noqa) is the point: a top-level failing import
+    # would prevent collection, masking the real test failure.
     sources: list = []
     try:
-        from esphome.helpers import friendly_name_slugify as helpers_impl
+        from esphome.helpers import friendly_name_slugify as helpers_impl  # noqa: PLC0415
 
         sources.append(helpers_impl)
     except ImportError:
         pass
     try:
-        from esphome.dashboard.util.text import (
+        from esphome.dashboard.util.text import (  # noqa: PLC0415
             friendly_name_slugify as dashboard_impl,
         )
 

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -22,7 +22,7 @@ import pytest
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices import controller as devices_module
 from esphome_device_builder.helpers.api import CommandError
-from esphome_device_builder.models import ErrorCode
+from esphome_device_builder.models import AdoptableDevice, DeviceState, ErrorCode, EventType
 
 
 def _make_controller(tmp_path: Any) -> DevicesController:
@@ -104,8 +104,6 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
     ``package_import_url`` the dialog passes and forward its
     ``network`` field to ``import_config``.
     """
-    from esphome_device_builder.models import AdoptableDevice
-
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
         devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
@@ -151,8 +149,6 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
     Ethernet, one stock) that meant a coin-flip on which network
     the imported YAML got.
     """
-    from esphome_device_builder.models import AdoptableDevice
-
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
         devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
@@ -203,8 +199,6 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
     Wi-Fi is the historical default and matches what the legacy
     dashboard wrote.
     """
-    from esphome_device_builder.models import AdoptableDevice
-
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
         devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
@@ -297,8 +291,6 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     can't clobber it) and pulls the cached IP out of zeroconf so the
     new card has an address right away.
     """
-    from esphome_device_builder.models import DeviceState
-
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
     ctrl = _make_controller(tmp_path)
     ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=["192.168.1.42"])
@@ -320,8 +312,6 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """No cached IP → state still flips ONLINE, just no apply_ip call."""
-    from esphome_device_builder.models import DeviceState
-
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
     ctrl = _make_controller(tmp_path)
     ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=None)
@@ -349,8 +339,6 @@ async def test_import_device_drops_matching_import_result_entry(
     so we drop the right entry even when the user typed a different
     YAML name in the dialog.
     """
-    from esphome_device_builder.models import AdoptableDevice, EventType
-
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
     ctrl = _make_controller(tmp_path)
     discovered = AdoptableDevice(

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -17,7 +17,9 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.models import Device, EventType
 
 
 def _make_controller(monkeypatch: Any, board_id: str = "esp32-c3-devkitm-1") -> Any:
@@ -206,9 +208,6 @@ def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None
     ``not loaded_integrations or not expected_config_hash`` schedules
     the regenerate so the next scan picks up the canonical hash.
     """
-    from esphome_device_builder.controllers._device_scanner import ScanChange
-    from esphome_device_builder.models import Device, EventType
-
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller._regenerate_failed = set()
@@ -243,9 +242,6 @@ def test_added_device_fully_populated_does_not_regenerate(
     spawn an ``--only-generate`` per device on a fully-warmed
     config_dir.
     """
-    from esphome_device_builder.controllers._device_scanner import ScanChange
-    from esphome_device_builder.models import Device
-
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller._regenerate_failed = set()

--- a/tests/controllers/devices/test_stream_cancel.py
+++ b/tests/controllers/devices/test_stream_cancel.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import orjson
 import pytest
 
 from esphome_device_builder.api.ws import WebSocketClient
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
 
 
 class _FakeWS:
@@ -22,8 +24,6 @@ class _FakeWS:
         self.closed = False
 
     async def send_str(self, payload: str) -> None:
-        import orjson
-
         self.sent.append(orjson.loads(payload))
 
     async def close(self) -> None:
@@ -400,8 +400,6 @@ async def test_validate_config_off_attaches_redactor_transform() -> None:
     strips those wrapped runs so the secret never leaves the
     server.
     """
-    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
-
     ctrl = _make_controller_with_settings(["esphome"])
     captured: dict[str, Any] = {}
 
@@ -450,8 +448,6 @@ def test_redact_concealed_secrets_replaces_wrapped_runs() -> None:
     recording the network tab, even if the visible glyphs were
     hidden by a hypothetical conceal-aware renderer.
     """
-    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
-
     raw = "  password: \x1b[8mhunter2\x1b[28m"
     assert _redact_concealed_secrets(raw) == "  password: <removed>"
 
@@ -469,8 +465,6 @@ def test_redact_concealed_secrets_handles_dashboard_literal_escape() -> None:
     ``ssid: \\033[8mrocketiot\\033[28m`` in the dialog instead
     of ``ssid: <removed>``.
     """
-    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
-
     # Build the literal four-character form by hand to avoid Python
     # interpreting ``\033`` as the octal escape for ESC.
     backslash = "\\"
@@ -480,8 +474,6 @@ def test_redact_concealed_secrets_handles_dashboard_literal_escape() -> None:
 
 def test_redact_concealed_secrets_handles_multiple_runs_per_line() -> None:
     """Multiple wrapped runs in one line all get redacted (non-greedy)."""
-    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
-
     raw = "ssid: \x1b[8mwifi-name\x1b[28m psk: \x1b[8msuper-secret\x1b[28m"
     assert _redact_concealed_secrets(raw) == "ssid: <removed> psk: <removed>"
 
@@ -494,8 +486,6 @@ def test_redact_concealed_secrets_leaves_unwrapped_lines_alone() -> None:
     every line. The pattern is anchored on ``\\x1b[8m...\\x1b[28m``
     so unrelated SGR runs (colours, bold, dim) pass through.
     """
-    from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
-
     raw = "INFO Reading configuration kitchen.yaml..."
     assert _redact_concealed_secrets(raw) == raw
 

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices.helpers import _build_address_cache_args
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.models import Device, FirmwareJob, JobType
@@ -148,8 +149,6 @@ def _devices_controller_with(*devices: Device) -> Any:
     ``loaded_integrations`` field — keep the rest of the controller
     out of the test surface.
     """
-    from esphome_device_builder.controllers.devices import DevicesController
-
     controller = DevicesController.__new__(DevicesController)
     scanner = MagicMock()
     scanner.devices = list(devices)

--- a/tests/controllers/firmware/test_download.py
+++ b/tests/controllers/firmware/test_download.py
@@ -30,6 +30,9 @@ from typing import Any
 
 import pytest
 
+import esphome_device_builder.controllers.firmware.controller as controller_module
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
 from tests._storage_fixtures import write_storage_json
 from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
@@ -196,9 +199,6 @@ async def test_download_validator_runs_before_ext_storage_path(
     both halves: the handler raises a ``CommandError``, and the
     autouse ``ext_storage_path`` redirect is never invoked.
     """
-    from esphome_device_builder.helpers.api import CommandError
-    from esphome_device_builder.models import ErrorCode
-
     invocations: list[str] = []
 
     def _spy(configuration: str) -> Path:
@@ -206,8 +206,6 @@ async def test_download_validator_runs_before_ext_storage_path(
         return tmp_path / ".esphome" / "storage" / f"{configuration}.json"
 
     # Replace the autouse redirect with our spy for this test.
-    import esphome_device_builder.controllers.firmware.controller as controller_module
-
     controller_module.ext_storage_path = _spy
 
     controller = firmware_controller_factory()

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -23,6 +23,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware.constants import _MAX_OUTPUT_LINES_INFLIGHT
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
 
@@ -235,8 +236,6 @@ async def test_slow_follower_drops_lines_above_queue_cap() -> None:
     hold; the producer stays unblocked because ``put_nowait``
     drops on full instead of awaiting drain capacity.
     """
-    from esphome_device_builder.controllers.firmware.constants import _MAX_OUTPUT_LINES_INFLIGHT
-
     job = FirmwareJob(
         job_id="abc",
         configuration="kitchen.yaml",
@@ -304,8 +303,6 @@ async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full() -> No
     output, reach cap, then a JOB_COMPLETED would silently
     no-op and the follower would hang.
     """
-    from esphome_device_builder.controllers.firmware.constants import _MAX_OUTPUT_LINES_INFLIGHT
-
     job = FirmwareJob(
         job_id="abc",
         configuration="kitchen.yaml",

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -22,11 +22,13 @@ configuration-traversal branch is already covered in
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from pathlib import Path
 from typing import Any
 
+import esphome.components as parent
 import pytest
 from esphome.components.esp32 import VARIANTS as _ESP32_VARIANTS
 
@@ -69,8 +71,6 @@ def _install_fake_component(
     attribute access in later tests, which can break a downstream
     ``from esphome.components import esp32`` lookup.
     """
-    import esphome.components as parent
-
     captured: list[Any] = []
 
     def _get_download_types(storage: Any) -> list[dict]:
@@ -212,7 +212,6 @@ async def test_get_binaries_logs_and_returns_empty_on_module_failure(
     so an operator notices the regression in the dashboard log
     rather than seeing silent empty rows everywhere.
     """
-    import logging
 
     def _boom(_storage: Any) -> list[dict]:
         raise RuntimeError("upstream regression")

--- a/tests/controllers/firmware/test_helpers.py
+++ b/tests/controllers/firmware/test_helpers.py
@@ -33,6 +33,7 @@ from typing import Any
 
 import pytest
 
+from esphome_device_builder.controllers.firmware import helpers as _helpers
 from esphome_device_builder.controllers.firmware.constants import (
     _MAX_OUTPUT_LINES_RETAINED,
     _OUTPUT_TRIM_NOTICE_PREFIX,
@@ -245,7 +246,6 @@ async def test_verify_esphome_importable_returns_false_on_timeout(
     Python one-liner here is fast-exiting, so we exercise that
     suppress branch incidentally.
     """
-    from esphome_device_builder.controllers.firmware import helpers as _helpers
 
     async def _raise_timeout(*_args: Any, **_kwargs: Any) -> None:
         raise TimeoutError

--- a/tests/controllers/firmware/test_job_output_cap.py
+++ b/tests/controllers/firmware/test_job_output_cap.py
@@ -16,12 +16,16 @@ process OOMs first.
 from __future__ import annotations
 
 from esphome_device_builder.controllers.firmware.constants import (
+    _ERROR_PATTERNS,
     _INFLIGHT_TRIM_KEEP,
     _MAX_OUTPUT_LINES_INFLIGHT,
     _MAX_OUTPUT_LINES_RETAINED,
     _OUTPUT_TRIM_NOTICE_PREFIX,
 )
-from esphome_device_builder.controllers.firmware.helpers import _trim_job_output
+from esphome_device_builder.controllers.firmware.helpers import (
+    _is_no_module_named_esphome,
+    _trim_job_output,
+)
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
 
 
@@ -119,8 +123,6 @@ def test_is_no_module_named_esphome_matches_exact_quoted_form() -> None:
     different reasons) would tell users to reinstall ESPHome
     itself when the real fix is to install a different dependency.
     """
-    from esphome_device_builder.controllers.firmware.helpers import _is_no_module_named_esphome
-
     # CPython's exact ModuleNotFoundError emission — the format we
     # actually need to detect.
     assert _is_no_module_named_esphome("ModuleNotFoundError: No module named 'esphome'\n")
@@ -158,11 +160,6 @@ def test_saw_no_esphome_module_flag_survives_inflight_trim() -> None:
     ``test_is_no_module_named_esphome_matches_exact_quoted_form``
     above.
     """
-    from esphome_device_builder.controllers.firmware.constants import _ERROR_PATTERNS
-    from esphome_device_builder.controllers.firmware.helpers import (
-        _is_no_module_named_esphome,
-    )
-
     has_error_in_output = False
     saw_no_esphome_module = False
 

--- a/tests/controllers/firmware/test_rename_lock.py
+++ b/tests/controllers/firmware/test_rename_lock.py
@@ -19,6 +19,8 @@ tests pin down the lock policy:
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from esphome_device_builder.helpers.api import CommandError
@@ -151,8 +153,6 @@ async def test_install_bulk_skips_locked_configs_and_queues_the_rest(
     should still go ahead for every other selected device. This is
     the regression guard for that.
     """
-    from unittest.mock import AsyncMock
-
     rename = _job(
         "rn1",
         "kitchen.yaml",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.api.ws import _origin_matches_host
+from esphome_device_builder.api.ws import WebSocketClient, _origin_matches_host
 from esphome_device_builder.controllers.auth import AuthController, AuthError
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.helpers.auth import (
@@ -610,8 +610,6 @@ def _make_ws_client(
     auth_ctrl: AuthController, *, authenticated: bool = False, remote: str = "127.0.0.1"
 ) -> Any:
     """Build a WebSocketClient with a mocked underlying WebSocket."""
-    from esphome_device_builder.api.ws import WebSocketClient
-
     db = MagicMock()
     db.settings = auth_ctrl._db.settings
     db.auth = auth_ctrl
@@ -719,6 +717,4 @@ async def test_ws_auth_alias_command_works(tmp_path: Path) -> None:
 
 async def _advance_clock(seconds: float) -> None:
     """Block briefly so ``time.time()`` reads a fresh value."""
-    import asyncio
-
     await asyncio.sleep(seconds)

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -48,7 +49,11 @@ from esphome_device_builder.controllers.config import (
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
-from esphome_device_builder.models.preferences import UserPreferences
+from esphome_device_builder.models.preferences import (
+    DashboardView,
+    Theme,
+    UserPreferences,
+)
 
 
 def _make_controller(config_dir: Path) -> ConfigController:
@@ -133,7 +138,6 @@ def test_save_metadata_cleans_up_tmpfile_on_failure(tmp_path: Path, monkeypatch:
     ``.device-builder.json.<random>.tmp`` files that nothing
     cleans up.
     """
-    import os
 
     def _boom(*args: Any, **kwargs: Any) -> None:
         raise OSError("rename failed")
@@ -252,8 +256,6 @@ def test_save_preferences_round_trip(tmp_path: Path) -> None:
     use a non-default value (``dashboard_view=TABLE``) to
     actually exercise the marshalling.
     """
-    from esphome_device_builder.models.preferences import DashboardView
-
     prefs = UserPreferences(dashboard_view=DashboardView.TABLE)
     save_preferences(tmp_path, prefs)
     assert load_preferences(tmp_path) == prefs
@@ -278,8 +280,6 @@ async def test_get_prefs_returns_loaded_preferences(tmp_path: Path) -> None:
     ``os.path.abspath`` blocks the event loop, and blockbuster
     flags it from inside an async test.
     """
-    from esphome_device_builder.models.preferences import DashboardView
-
     persisted = UserPreferences(dashboard_view=DashboardView.TABLE)
     await asyncio.to_thread(save_preferences, tmp_path, persisted)
     controller = _make_controller(tmp_path)
@@ -303,11 +303,6 @@ async def test_set_prefs_merges_partial_update(tmp_path: Path) -> None:
     ``metadata_transaction`` -> ``tempfile.mkstemp`` write
     doesn't trip blockbuster on Linux CI.
     """
-    from esphome_device_builder.models.preferences import (
-        DashboardView,
-        Theme,
-    )
-
     initial = UserPreferences(dashboard_view=DashboardView.TABLE, theme=Theme.DARK)
     await asyncio.to_thread(save_preferences, tmp_path, initial)
     controller = _make_controller(tmp_path)

--- a/tests/test_config_hash.py
+++ b/tests/test_config_hash.py
@@ -13,6 +13,7 @@ of ``read_build_info_hash`` (the sync entry point) and
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -190,23 +191,20 @@ def test_returns_none_when_build_info_unreadable(
     permission error mid-read; pin both halves: ``None`` returned,
     warning emitted naming the offending path.
     """
-    import logging
-    from pathlib import Path as _Path
-
     yaml_path = _setup(tmp_path, hash_value=None)
     build_path = tmp_path / ".esphome" / "build" / "kitchen"
     build_path.mkdir(parents=True, exist_ok=True)
     build_info = build_path / "build_info.json"
     build_info.write_text('{"config_hash": 1}', encoding="utf-8")
 
-    real_read_bytes = _Path.read_bytes
+    real_read_bytes = Path.read_bytes
 
-    def _raise_permission(self: _Path) -> bytes:
+    def _raise_permission(self: Path) -> bytes:
         if self == build_info:
             raise PermissionError("simulated permission denied")
         return real_read_bytes(self)
 
-    monkeypatch.setattr(_Path, "read_bytes", _raise_permission)
+    monkeypatch.setattr(Path, "read_bytes", _raise_permission)
 
     with caplog.at_level(logging.WARNING, logger="esphome_device_builder.helpers.config_hash"):
         result = read_build_info_hash(yaml_path)

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import time
 from collections.abc import Awaitable, Callable
+from concurrent.futures import ThreadPoolExecutor
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,6 +18,13 @@ from esphome_device_builder.controllers import (
 )
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.controllers._dns_cache import DNSCache
+from esphome_device_builder.controllers.config import (
+    get_board_id,
+    get_device_ip,
+    set_device_metadata,
+)
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.models import Device, DeviceState
 
 
@@ -333,8 +341,6 @@ async def test_ping_sweep_marks_offline_directly_on_dns_failure(fake_resolver) -
     cache-confirmed lookup failure as the "we tried, can't reach"
     signal and apply OFFLINE directly.
     """
-    from esphome_device_builder.models import DeviceState
-
     devices = [_device()]
     state_changes: list[tuple[str, DeviceState, str]] = []
     monitor = DeviceStateMonitor(
@@ -375,8 +381,6 @@ async def test_ping_sweep_skips_devices_with_cached_dns_failure(fake_resolver) -
     won't reach. The resolver call must also be skipped so we don't
     re-attempt a known-bad lookup every minute.
     """
-    from esphome_device_builder.models import DeviceState
-
     devices = [_device()]
     state_changes: list[tuple[str, DeviceState, str]] = []
     monitor = DeviceStateMonitor(
@@ -419,10 +423,6 @@ async def test_ping_marks_offline_when_icmp_raises(fake_resolver) -> None:
     couldn't reach it" and the state flips to OFFLINE; a subsequent
     successful ping flips it right back to ONLINE.
     """
-    from esphome_device_builder.controllers import _device_state_monitor as sm
-    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-    from esphome_device_builder.models import DeviceState
-
     devices = [_device()]
     state_changes: list[tuple[str, DeviceState, str]] = []
     monitor = DeviceStateMonitor(
@@ -452,11 +452,6 @@ async def test_ping_marks_offline_when_icmp_raises(fake_resolver) -> None:
 
 def test_set_device_ip_writes_to_metadata(tmp_path) -> None:  # type: ignore[no-untyped-def]
     """``set_device_metadata(ip=...)`` round-trips through ``get_device_ip``."""
-    from esphome_device_builder.controllers.config import (
-        get_device_ip,
-        set_device_metadata,
-    )
-
     set_device_metadata(tmp_path, "kitchen.yaml", ip="10.0.0.1")
     assert get_device_ip(tmp_path, "kitchen.yaml") == "10.0.0.1"
 
@@ -469,11 +464,6 @@ def test_set_device_ip_preserves_existing_when_empty(tmp_path) -> None:  # type:
     in-memory IP whenever a device drops off, but we still want the
     cache to be warm next time we OTA.
     """
-    from esphome_device_builder.controllers.config import (
-        get_device_ip,
-        set_device_metadata,
-    )
-
     set_device_metadata(tmp_path, "kitchen.yaml", ip="10.0.0.1")
     set_device_metadata(tmp_path, "kitchen.yaml", ip="")
     set_device_metadata(tmp_path, "kitchen.yaml", ip=None)
@@ -482,26 +472,17 @@ def test_set_device_ip_preserves_existing_when_empty(tmp_path) -> None:  # type:
 
 def test_set_device_ip_unrelated_field_does_not_clobber_ip(tmp_path) -> None:  # type: ignore[no-untyped-def]
     """Setting ``board_id`` later doesn't drop the persisted ``ip`` field."""
-    from esphome_device_builder.controllers.config import (
-        get_device_ip,
-        set_device_metadata,
-    )
-
     set_device_metadata(tmp_path, "kitchen.yaml", ip="10.0.0.1")
     set_device_metadata(tmp_path, "kitchen.yaml", board_id="esp32-devkit")
     assert get_device_ip(tmp_path, "kitchen.yaml") == "10.0.0.1"
 
 
 def test_get_device_ip_returns_empty_for_unknown_device(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    from esphome_device_builder.controllers.config import get_device_ip
-
     assert get_device_ip(tmp_path, "kitchen.yaml") == ""
 
 
 def test_load_device_from_storage_threads_ip_through(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
     """Scanner-loaded devices carry the persisted IP into the model."""
-    from esphome_device_builder.helpers import device_yaml
-
     # ``ext_storage_path`` walks ``CORE.config_path`` which isn't set
     # in this test; redirect it to ``tmp_path`` and short-circuit
     # ``StorageJSON.load`` so we exercise just the YAML + ip plumbing.
@@ -531,8 +512,6 @@ def test_load_device_from_storage_address_falls_back_to_filename_local(  # type:
     stayed UNKNOWN forever — that's what the user reported with
     ``wr2-test`` and friends.
     """
-    from esphome_device_builder.helpers import device_yaml
-
     monkeypatch.setattr(
         device_yaml,
         "ext_storage_path",
@@ -560,8 +539,6 @@ def test_load_device_from_storage_address_uses_filename_not_parsed_name(  # type
     ``largegarage.yaml`` — exactly the bug the user reported. The
     filename stem is canonical and matches what the user types.
     """
-    from esphome_device_builder.helpers import device_yaml
-
     monkeypatch.setattr(
         device_yaml,
         "ext_storage_path",
@@ -584,8 +561,6 @@ def test_load_device_from_storage_address_uses_storage_when_set(  # type: ignore
     monkeypatch, tmp_path
 ) -> None:
     """A real ``StorageJSON.address`` wins over the ``<name>.local`` fallback."""
-    from esphome_device_builder.helpers import device_yaml
-
     monkeypatch.setattr(
         device_yaml,
         "ext_storage_path",
@@ -616,11 +591,6 @@ def test_load_device_from_storage_address_uses_storage_when_set(  # type: ignore
 
 def test_on_ip_change_persists_non_empty_value(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """``_on_ip_change`` schedules a metadata write for non-empty IPs."""
-    from unittest.mock import MagicMock
-
-    from esphome_device_builder.controllers.devices import DevicesController
-    from esphome_device_builder.models import Device
-
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
     db = MagicMock()
     scheduled: list[object] = []
@@ -640,11 +610,6 @@ def test_on_ip_change_persists_non_empty_value(monkeypatch) -> None:  # type: ig
 
 def test_on_ip_change_skips_persist_for_empty_value() -> None:
     """Empty IP (device went offline) doesn't schedule a write — keeps the cache warm."""
-    from unittest.mock import MagicMock
-
-    from esphome_device_builder.controllers.devices import DevicesController
-    from esphome_device_builder.models import Device
-
     device = Device(
         name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml", ip="10.0.0.1"
     )
@@ -671,13 +636,6 @@ def test_metadata_transaction_serialises_concurrent_writers(tmp_path) -> None:  
     own field, and the later save would clobber the earlier. The lock
     serialises the cycle so every write lands.
     """
-    from concurrent.futures import ThreadPoolExecutor
-
-    from esphome_device_builder.controllers.config import (
-        get_board_id,
-        set_device_metadata,
-    )
-
     writer_count = 32
 
     def _write(i: int) -> None:

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -15,13 +15,17 @@ Covers four layers:
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.controllers.boards import BoardCatalog
-from esphome_device_builder.controllers.components import ComponentCatalog
+from esphome_device_builder.controllers.components import (
+    ComponentCatalog,
+    _default_id_from_local,
+)
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices.helpers import _apply_featured_presets
 from esphome_device_builder.definitions import (
@@ -31,6 +35,7 @@ from esphome_device_builder.definitions import (
 )
 from esphome_device_builder.helpers.yaml import generate_component_yaml
 from esphome_device_builder.models import ComponentCategory
+from esphome_device_builder.models.common import FieldPreset
 
 # ---------------------------------------------------------------------------
 # Loader-level (pure unit tests, no catalog)
@@ -195,8 +200,6 @@ def test_default_id_from_local_handles_leading_digit() -> None:
     # ESPHome ids become C++ identifiers downstream — a leading digit
     # produces an invalid build, so the slugifier must guard against
     # it.
-    from esphome_device_builder.controllers.components import _default_id_from_local
-
     assert _default_id_from_local("3v3-rail") == "_3v3_rail"
     assert _default_id_from_local("4-channel-relay") == "_4_channel_relay"
     # Non-digit-leading ids stay untouched.
@@ -408,10 +411,6 @@ async def test_apply_presets_locked_without_value_fails_fast(
     catalog: ComponentCatalog,
 ) -> None:
     """A malformed manifest (locked=True with no value) fails fast at add time."""
-    from copy import deepcopy
-
-    from esphome_device_builder.models import FieldPreset
-
     record = deepcopy(catalog.get_featured_record("featured.sonoff-basic.relay"))
     assert record is not None
     record.featured.fields["pin"] = FieldPreset(value=None, locked=True)

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -17,6 +17,7 @@ These tests pin the three branches of the fail-secure logic:
 
 from __future__ import annotations
 
+import builtins
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -247,8 +248,6 @@ def test_get_frontend_dir_returns_none_when_package_missing(tmp_path: Path) -> N
 
     # Force an ImportError by clearing the module from sys.modules
     # and patching the import to raise.
-    import builtins
-
     real_import = builtins.__import__
 
     def fake_import(name: str, *args: object, **kwargs: object) -> object:

--- a/tests/test_helpers_api.py
+++ b/tests/test_helpers_api.py
@@ -11,6 +11,8 @@ that changes the scan rules surfaces.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from esphome_device_builder.helpers.api import api_command, collect_api_commands
@@ -108,8 +110,6 @@ def test_api_command_decorator_attaches_marker() -> None:
     assert handler._api_command == "ns/example"  # type: ignore[attr-defined]
     # And the function still behaves like a plain coroutine function —
     # not wrapped, not transformed.
-    import asyncio
-
     assert asyncio.run(handler()) == "ok"
 
 

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -17,7 +17,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.models import Device, DeviceState
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.models import Device, DeviceState, EventType
 
 
 def _device(**overrides: Any) -> Device:
@@ -158,9 +159,6 @@ def test_apply_config_hash_no_callback_silently_drops() -> None:
 @pytest.mark.asyncio
 async def test_on_config_hash_change_updates_device_and_fires_event() -> None:
     """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
-    from esphome_device_builder.controllers.devices import DevicesController
-    from esphome_device_builder.models import EventType
-
     device = _device(deployed_config_hash="")
 
     db = MagicMock()
@@ -182,8 +180,6 @@ async def test_on_config_hash_change_updates_device_and_fires_event() -> None:
 @pytest.mark.asyncio
 async def test_on_config_hash_change_skips_when_same() -> None:
     """No-op when in-memory device already has the announced hash."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     device = _device(deployed_config_hash="1a2b3c4d")
 
     db = MagicMock()
@@ -201,8 +197,6 @@ async def test_on_config_hash_change_skips_when_same() -> None:
 @pytest.mark.asyncio
 async def test_on_config_hash_change_unknown_device_is_noop() -> None:
     """A stray callback for an unknown device must not raise or fire events."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     db = MagicMock()
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
@@ -218,8 +212,6 @@ async def test_on_config_hash_change_unknown_device_is_noop() -> None:
 @pytest.mark.asyncio
 async def test_on_config_hash_change_flips_pending_when_hashes_diverge() -> None:
     """Hashes don't match → ``has_pending_changes`` flips True."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     device = _device(
         expected_config_hash="abc12345",
         deployed_config_hash="",
@@ -242,8 +234,6 @@ async def test_on_config_hash_change_flips_pending_when_hashes_diverge() -> None
 @pytest.mark.asyncio
 async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
     """Hashes match → ``has_pending_changes`` flips False."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     device = _device(
         expected_config_hash="abc12345",
         deployed_config_hash="",
@@ -266,8 +256,6 @@ async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
 @pytest.mark.asyncio
 async def test_on_config_hash_change_leaves_pending_alone_without_expected_hash() -> None:
     """No expected hash on file → don't touch has_pending_changes (mtime fallback owns it)."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     device = _device(
         expected_config_hash="",
         deployed_config_hash="",

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -17,7 +17,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.models import Device, DeviceState
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.models import Device, DeviceState, EventType
 
 
 def _device(**overrides: Any) -> Device:
@@ -140,8 +141,6 @@ def _patch_storage(monkeypatch: Any, tmp_path: Any, storage: Any) -> None:
 
 def test_persist_storage_version_writes_when_different(monkeypatch: Any, tmp_path: Any) -> None:
     """``_persist_storage_version`` saves when the on-disk value differs."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     storage = MagicMock()
     storage.esphome_version = "2026.4.0"
     _patch_storage(monkeypatch, tmp_path, storage)
@@ -159,8 +158,6 @@ def test_persist_storage_version_skips_when_same(monkeypatch: Any, tmp_path: Any
     bump the StorageJSON mtime, defeat the scanner's mtime-based cache,
     and force a full re-parse of every YAML on the next poll.
     """
-    from esphome_device_builder.controllers.devices import DevicesController
-
     storage = MagicMock()
     storage.esphome_version = "2026.5.0"
     _patch_storage(monkeypatch, tmp_path, storage)
@@ -172,8 +169,6 @@ def test_persist_storage_version_skips_when_same(monkeypatch: Any, tmp_path: Any
 
 def test_persist_storage_version_handles_missing_storage(monkeypatch: Any, tmp_path: Any) -> None:
     """Device that's never been compiled has no StorageJSON — bail out cleanly."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     _patch_storage(monkeypatch, tmp_path, storage=None)
 
     # Should not raise.
@@ -188,9 +183,6 @@ def test_persist_storage_version_handles_missing_storage(monkeypatch: Any, tmp_p
 @pytest.mark.asyncio
 async def test_on_version_change_updates_device_and_fires_event(monkeypatch: Any) -> None:
     """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
-    from esphome_device_builder.controllers.devices import DevicesController
-    from esphome_device_builder.models import EventType
-
     device = _device(deployed_version="2026.4.0")
 
     db = MagicMock()
@@ -223,8 +215,6 @@ async def test_on_version_change_updates_device_and_fires_event(monkeypatch: Any
 @pytest.mark.asyncio
 async def test_on_version_change_skips_when_same(monkeypatch: Any) -> None:
     """No-op when in-memory device already has the announced version."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     device = _device(deployed_version="2026.5.0")
 
     db = MagicMock()
@@ -244,8 +234,6 @@ async def test_on_version_change_skips_when_same(monkeypatch: Any) -> None:
 @pytest.mark.asyncio
 async def test_on_version_change_marks_update_available_when_behind() -> None:
     """A device on an older version than the dashboard → ``update_available`` flips on."""
-    from esphome_device_builder.controllers.devices import DevicesController
-
     device = _device(current_version="2026.5.0", deployed_version="2026.4.0")
 
     db = MagicMock()

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -16,6 +16,7 @@ dashboard's ``async_refresh_hosts`` path
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -348,8 +349,6 @@ async def test_multiple_devices_resolve_in_parallel(monkeypatch: Any) -> None:
         pending += 1
         max_concurrent = max(max_concurrent, pending)
         try:
-            import asyncio
-
             await asyncio.sleep(0)  # let other coroutines start
             return ["10.0.0.1"]
         finally:

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -20,6 +20,7 @@ import pytest
 from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
 )
+from esphome_device_builder.models import Device, DeviceState
 
 
 def _make_monitor() -> DeviceStateMonitor:
@@ -144,8 +145,6 @@ async def test_apply_service_info_claims_online() -> None:
     monitor._on_api_encryption_change = MagicMock()
     monitor._state_source = {}
     # ``apply()`` validates against the configured-devices catalog.
-    from esphome_device_builder.models import Device, DeviceState
-
     device = Device(
         name="kitchen",
         friendly_name="Kitchen",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -17,14 +17,18 @@ from __future__ import annotations
 
 def test_package_imports() -> None:
     """Top-level package imports without side effects."""
-    import esphome_device_builder  # noqa: F401
+    # Import inside the test (PLC0415 noqa) so a failure surfaces
+    # as this single test failing rather than as a collection-time
+    # error that prevents the rest of the suite from running.
+    import esphome_device_builder  # noqa: F401, PLC0415
 
 
 def test_controllers_import() -> None:
     """Each controller module is importable on its own."""
-    # Import lazily so a failure in one controller doesn't poison
-    # diagnosis of the others.
-    from esphome_device_builder.controllers import (  # noqa: F401
+    # Import lazily (PLC0415 noqa) so a failure in one controller
+    # doesn't poison diagnosis of the others — the whole point of
+    # the per-test-function isolation here.
+    from esphome_device_builder.controllers import (  # noqa: F401, PLC0415
         automations,
         boards,
         components,
@@ -37,7 +41,7 @@ def test_controllers_import() -> None:
 
 def test_models_import() -> None:
     """Public model surface is importable."""
-    from esphome_device_builder.models import (  # noqa: F401
+    from esphome_device_builder.models import (  # noqa: F401, PLC0415
         ComponentCatalogEntry,
         ConfigEntry,
         ConfigEntryType,

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, DeviceState
 
@@ -181,8 +182,6 @@ def test_apply_state_repairs_stale_sibling_when_first_match_is_in_sync() -> None
     that ``apply()`` looks at *every* matching device's state and
     fires the callback when any one of them is stale.
     """
-    from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-
     primary = _device("kitchen.yaml")
     primary.state = DeviceState.ONLINE  # already in-sync
     sibling = _device("kitchen (1).yaml")  # state=UNKNOWN — was rebuilt

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pytest
 
+from esphome_device_builder.helpers import event_bus
 from esphome_device_builder.helpers.event_bus import (
     _DEFAULT_STREAM_QUEUE_MAX,
     Event,
@@ -430,7 +431,6 @@ async def test_force_enqueue_returns_when_get_nowait_finds_empty_queue(
     ``_force_enqueue(None)``) returns instead of spinning, the
     drain finds its sentinel, and ``stream_events`` exits.
     """
-    from esphome_device_builder.helpers import event_bus
 
     class _ForeverFullEverEmptyQueue:
         """Always raises QueueFull on put + QueueEmpty on get_nowait.

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import esphome_device_builder
 from esphome_device_builder.helpers import subprocess as subprocess_helper
 
 
@@ -65,13 +67,7 @@ async def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> No
     ``asyncio.create_subprocess_exec`` call (which would skip the
     ``close_fds=False`` optimisation) anywhere outside the helper itself.
     """
-    import esphome_device_builder
-
-    pkg_root = (
-        # Resolve the package's filesystem location without depending on
-        # ``__file__`` typing nuances under from __future__ annotations.
-        __import__("pathlib").Path(esphome_device_builder.__file__).parent
-    )
+    pkg_root = Path(esphome_device_builder.__file__).parent
     helper_path = pkg_root / "helpers" / "subprocess.py"
 
     offenders: list[str] = []

--- a/tests/test_subscribe_events_cleanup.py
+++ b/tests/test_subscribe_events_cleanup.py
@@ -20,7 +20,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.device_builder import DeviceBuilder
-from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.helpers.event_bus import (
+    _DEFAULT_STREAM_QUEUE_MAX,
+    EventBus,
+    StreamBackpressureError,
+)
 from esphome_device_builder.models import EventType
 
 
@@ -260,8 +264,6 @@ async def test_subscribe_events_terminates_on_overflow_uniformly(
     per-event-type policy surfaces here regardless of which
     path it touched.
     """
-    from esphome_device_builder.helpers.event_bus import StreamBackpressureError
-
     db = _make_db()
     drain_can_run = asyncio.Event()
     received: list[tuple[str, str, Any]] = []
@@ -276,8 +278,6 @@ async def test_subscribe_events_terminates_on_overflow_uniformly(
     await asyncio.sleep(0)
 
     # Fill past the cap.
-    from esphome_device_builder.helpers.event_bus import _DEFAULT_STREAM_QUEUE_MAX
-
     for _ in range(_DEFAULT_STREAM_QUEUE_MAX + 1):
         db.bus.fire(event_type, payload)
 


### PR DESCRIPTION
## Summary

Drops ``PLC0415`` from the ruff ignore list so late imports surface
at lint time. Late imports defer ``ImportError``s until the line
runs — a real import bug (typo, removed symbol, missing optional
dep) only shows up when a specific test or codepath exercises it,
which is easy to merge past.

Hoisted ~95 lazy imports across 28 test files and one production
file. Two callsites stay lazy with a documented exception:

* ``DeviceBuilder._get_frontend_dir`` keeps the lazy
  ``esphome_device_builder_frontend`` import (PLC0415 noqa) so the
  ImportError-coverage test in ``test_ha_addon_failsafe`` can
  patch ``builtins.__import__`` per call without re-importing the
  whole module.
* ``test_friendly_name_slugify_resolves_via_helpers_or_dashboard_shim``
  keeps two try/except ImportError shims inside the test (PLC0415
  noqa) — the test's purpose is to exercise the version-tolerant
  import shim, which has to live inside the function to give the
  try/except its own scope.

CLI scripts (``script/*``) get ``PLC0415`` added to
per-file-ignores; several lazy imports there are deliberate
(try/except shims around optional ``esphome`` introspection,
``subprocess`` only loaded in the docs-clone path).

## Test plan

- [x] ``ruff check`` clean across the whole tree
- [x] full ``pytest`` passes (982 tests, 5 skipped)
- [x] ``pre-commit run --all-files`` passes