### PR TITLE
Cover devices/get_config + devices/update_config

### DIFF
--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -1,0 +1,262 @@
+"""Tests for ``DevicesController.get_config`` / ``update_config``.
+
+These two API commands back the in-browser YAML editor's load and
+save flow. The matching upstream handlers in
+``esphome/dashboard/web_server.py`` are ``EditRequestHandler.get``
+and ``EditRequestHandler.post``; pin our shape against theirs so
+HA's editor (and any future esphome-dashboard-api consumer) keeps
+working unchanged.
+
+Coverage targets:
+
+* Round-trip: write content with ``update_config`` and re-read it
+  with ``get_config``.
+* ``update_config`` does the disk write off the event loop (the
+  read uses ``Path.read_text`` / ``Path.write_text`` which can
+  block on slow / network-mounted config dirs) — exercised by
+  asserting the file lands on disk after the await returns.
+* ``update_config`` triggers a fresh scan + StorageJSON
+  regenerate so the dashboard's UI reflects the new YAML without
+  waiting for a full compile.
+* Path-traversal is gated by ``settings.rel_path`` — already
+  covered in ``tests/controllers/test_traversal_validation.py``,
+  not duplicated here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.devices import DevicesController
+
+
+def _make_controller(config_dir: Path) -> DevicesController:
+    """Build a stub ``DevicesController`` wired to ``config_dir``.
+
+    Same shape as ``test_archive.py`` — bypass ``__init__``, attach
+    a ``_db.settings.rel_path`` that joins the configuration onto
+    the test's ``tmp_path``, and a ``_scanner.scan`` ``AsyncMock``
+    so ``update_config``'s post-write scan call is awaitable.
+
+    ``_schedule_storage_regenerate`` is replaced with a ``MagicMock``
+    on the instance so the test can ``assert_called_once_with(...)``
+    without spawning a real ``esphome compile --only-generate``
+    subprocess.
+    """
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    controller._db.settings.config_dir = config_dir
+    controller._db.settings.rel_path = lambda configuration: config_dir / configuration
+    controller._scanner = MagicMock()
+    controller._scanner.scan = AsyncMock()
+    # ``_schedule_storage_regenerate`` is sync (fire-and-forget that
+    # schedules a background task internally); a plain ``MagicMock``
+    # records the call site without dispatching the subprocess.
+    controller._schedule_storage_regenerate = MagicMock()  # type: ignore[method-assign]
+    return controller
+
+
+# ---------------------------------------------------------------------------
+# get_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_config_returns_yaml_content(tmp_path: Path) -> None:
+    """``get_config`` returns the file's text decoded as UTF-8.
+
+    HA's editor pre-fills the textarea with whatever this returns
+    — the dashboard's YAML round-trip starts here. Pin the
+    plain-string shape (no JSON envelope) so a refactor that
+    wraps the response would surface.
+    """
+    controller = _make_controller(tmp_path)
+    yaml_content = "esphome:\n  name: kitchen\n  platform: ESP32\n"
+    (tmp_path / "kitchen.yaml").write_text(yaml_content, encoding="utf-8")
+
+    result = await controller.get_config(configuration="kitchen.yaml")
+
+    assert result == yaml_content
+
+
+@pytest.mark.asyncio
+async def test_get_config_decodes_utf8_with_unicode(tmp_path: Path) -> None:
+    """UTF-8 content (e.g., comments with non-ASCII) round-trips intact.
+
+    The explicit ``"utf-8"`` arg to ``read_text`` keeps Windows
+    safe — the platform default is cp1252 there, which would
+    silently mojibake the YAML.
+    """
+    controller = _make_controller(tmp_path)
+    yaml_content = "esphome:\n  name: küche\n  # comment with — em dash and ñ\n"
+    (tmp_path / "kuche.yaml").write_text(yaml_content, encoding="utf-8")
+
+    result = await controller.get_config(configuration="kuche.yaml")
+
+    assert result == yaml_content
+
+
+@pytest.mark.asyncio
+async def test_get_config_propagates_file_not_found(tmp_path: Path) -> None:
+    """Missing file → ``FileNotFoundError`` bubbles to the dispatcher.
+
+    The api dispatcher catches it and turns it into a generic
+    error frame; we don't try to swallow / map it here. Pin the
+    pass-through so a defensive refactor that returned ``""``
+    instead would surface (the editor would silently load an
+    empty buffer for a typo'd configuration).
+    """
+    controller = _make_controller(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        await controller.get_config(configuration="ghost.yaml")
+
+
+# ---------------------------------------------------------------------------
+# update_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_config_writes_content_to_disk(tmp_path: Path) -> None:
+    """``update_config`` lands the new YAML on disk under the configuration name."""
+    controller = _make_controller(tmp_path)
+    new_content = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
+
+    result = await controller.update_config(configuration="kitchen.yaml", content=new_content)
+
+    assert result is None  # API contract: no payload on success
+    assert (tmp_path / "kitchen.yaml").read_text(encoding="utf-8") == new_content
+
+
+@pytest.mark.asyncio
+async def test_update_config_overwrites_existing_yaml(tmp_path: Path) -> None:
+    """Writing over an existing YAML replaces it verbatim.
+
+    The editor's "Save" button does this on every keystroke-driven
+    save; pin the no-merge / clobber semantics so a refactor that
+    accidentally appended would surface.
+    """
+    controller = _make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: stale\n", encoding="utf-8")
+    new_content = "esphome:\n  name: kitchen\n"
+
+    await controller.update_config(configuration="kitchen.yaml", content=new_content)
+
+    assert (tmp_path / "kitchen.yaml").read_text(encoding="utf-8") == new_content
+
+
+@pytest.mark.asyncio
+async def test_update_config_writes_utf8_unicode_intact(tmp_path: Path) -> None:
+    """Non-ASCII content lands on disk as UTF-8.
+
+    Companion to the read test — the explicit ``"utf-8"`` arg
+    matters on Windows where the default would otherwise be
+    cp1252. Without this, comments with em dashes / accents
+    would silently corrupt on save.
+    """
+    controller = _make_controller(tmp_path)
+    new_content = "esphome:\n  name: küche\n  # — and ñ\n"
+
+    await controller.update_config(configuration="kuche.yaml", content=new_content)
+
+    raw = (tmp_path / "kuche.yaml").read_bytes()
+    assert raw == new_content.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_update_config_triggers_scan(tmp_path: Path) -> None:
+    """Each successful write awakens the scanner so the device list refreshes.
+
+    Without the post-write scan, a freshly-added YAML wouldn't
+    show up in the device list until the next background scan tick
+    (up to 60s on the file-poll cadence). The dashboard's
+    "save and immediately see the device" UX depends on this.
+    """
+    controller = _make_controller(tmp_path)
+
+    await controller.update_config(configuration="new.yaml", content="esphome:\n  name: new\n")
+
+    controller._scanner.scan.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_config_schedules_storage_regenerate(tmp_path: Path) -> None:
+    """Each successful write schedules a StorageJSON regenerate for that YAML.
+
+    ``_schedule_storage_regenerate`` runs ``esphome compile
+    --only-generate`` so ``address`` / ``loaded_integrations`` /
+    ``config_hash`` reflect the new YAML without waiting for a
+    full build. Mirrors upstream's ``async_schedule_storage_json_update``
+    in ``EditRequestHandler``. Pin the call so a refactor that
+    skipped the regen for "save" (vs "save and compile") would
+    surface — devices showing stale metadata after edits is the
+    regression class this prevents.
+    """
+    controller = _make_controller(tmp_path)
+
+    await controller.update_config(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
+    )
+
+    controller._schedule_storage_regenerate.assert_called_once_with("kitchen.yaml")
+
+
+@pytest.mark.asyncio
+async def test_update_config_orders_write_before_scan_and_regenerate(
+    tmp_path: Path,
+) -> None:
+    """The disk write completes before the scan and regenerate fire.
+
+    Scanner reads the YAML it scans; regenerate spawns ``esphome
+    compile`` against the file. Both must see the new content,
+    not the stale on-disk one. A refactor that hoisted either
+    ahead of the write would silently regress the "save → see
+    new metadata" flow. Pin the order via call-time inspection.
+    """
+    controller = _make_controller(tmp_path)
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: stale\n", encoding="utf-8")
+
+    new_content = "esphome:\n  name: fresh\n"
+    seen_during_scan: list[str] = []
+    seen_during_regen: list[str] = []
+
+    async def _record_scan() -> None:
+        seen_during_scan.append(yaml_path.read_text(encoding="utf-8"))
+
+    def _record_regen(_configuration: str) -> None:
+        seen_during_regen.append(yaml_path.read_text(encoding="utf-8"))
+
+    controller._scanner.scan = AsyncMock(side_effect=_record_scan)
+    controller._schedule_storage_regenerate = MagicMock(  # type: ignore[method-assign]
+        side_effect=_record_regen
+    )
+
+    await controller.update_config(configuration="kitchen.yaml", content=new_content)
+
+    assert seen_during_scan == [new_content]
+    assert seen_during_regen == [new_content]
+
+
+@pytest.mark.asyncio
+async def test_round_trip_update_then_get_returns_written_content(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: ``update_config`` then ``get_config`` returns what was written.
+
+    Higher-level confidence that the two halves of the editor's
+    save / reload cycle line up against the same file at the same
+    path. A future refactor that used different paths in
+    ``rel_path`` for read vs write would surface here.
+    """
+    controller = _make_controller(tmp_path)
+    written = "esphome:\n  name: roundtrip\n"
+
+    await controller.update_config(configuration="rt.yaml", content=written)
+    read_back = await controller.get_config(configuration="rt.yaml")
+
+    assert read_back == written

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -26,6 +26,7 @@ Coverage targets:
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -229,8 +230,6 @@ async def test_update_config_writes_before_scanner_runs(tmp_path: Path) -> None:
     so any ordering of regen-vs-write follows from this scan
     check by virtue of the linear async control flow.
     """
-    import asyncio as _asyncio
-
     controller = _make_controller(tmp_path)
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: stale\n", encoding="utf-8")
@@ -239,7 +238,7 @@ async def test_update_config_writes_before_scanner_runs(tmp_path: Path) -> None:
     seen_during_scan: list[str] = []
 
     async def _record_scan() -> None:
-        seen_during_scan.append(await _asyncio.to_thread(yaml_path.read_text, "utf-8"))
+        seen_during_scan.append(await asyncio.to_thread(yaml_path.read_text, "utf-8"))
 
     controller._scanner.scan = AsyncMock(side_effect=_record_scan)
 

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -11,10 +11,11 @@ Coverage targets:
 
 * Round-trip: write content with ``update_config`` and re-read it
   with ``get_config``.
-* ``update_config`` does the disk write off the event loop (the
-  read uses ``Path.read_text`` / ``Path.write_text`` which can
-  block on slow / network-mounted config dirs) — exercised by
-  asserting the file lands on disk after the await returns.
+* Both methods route the underlying ``Path.read_text`` /
+  ``Path.write_text`` through ``loop.run_in_executor`` so the
+  blocking syscall doesn't stall the event loop on slow /
+  network-mounted config dirs — exercised by asserting the file
+  lands on disk after the await returns.
 * ``update_config`` triggers a fresh scan + StorageJSON
   regenerate so the dashboard's UI reflects the new YAML without
   waiting for a full compile.
@@ -157,14 +158,18 @@ async def test_update_config_writes_utf8_unicode_intact(tmp_path: Path) -> None:
     matters on Windows where the default would otherwise be
     cp1252. Without this, comments with em dashes / accents
     would silently corrupt on save.
+
+    Asserts via ``read_text`` (not ``read_bytes``) because
+    ``Path.write_text`` defaults to ``newline=None``, which
+    translates LF to CRLF on Windows; the round-trip decode
+    normalises newlines so the assertion is platform-independent.
     """
     controller = _make_controller(tmp_path)
     new_content = "esphome:\n  name: küche\n  # — and ñ\n"
 
     await controller.update_config(configuration="kuche.yaml", content=new_content)
 
-    raw = (tmp_path / "kuche.yaml").read_bytes()
-    assert raw == new_content.encode("utf-8")
+    assert (tmp_path / "kuche.yaml").read_text(encoding="utf-8") == new_content
 
 
 @pytest.mark.asyncio
@@ -206,40 +211,41 @@ async def test_update_config_schedules_storage_regenerate(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_update_config_orders_write_before_scan_and_regenerate(
-    tmp_path: Path,
-) -> None:
-    """The disk write completes before the scan and regenerate fire.
+async def test_update_config_writes_before_scanner_runs(tmp_path: Path) -> None:
+    """The disk write completes before ``scanner.scan()`` fires.
 
-    Scanner reads the YAML it scans; regenerate spawns ``esphome
-    compile`` against the file. Both must see the new content,
-    not the stale on-disk one. A refactor that hoisted either
-    ahead of the write would silently regress the "save → see
-    new metadata" flow. Pin the order via call-time inspection.
+    Scanner reads the YAML it scans; if scan ran first, it would
+    see the stale on-disk version and dispatch DEVICE_UPDATED with
+    the old metadata. Pin the ordering by reading the file
+    inside the scan callback — once scan() runs, the new content
+    must already be on disk.
+
+    Read goes through ``asyncio.to_thread`` so blockbuster's
+    event-loop guard doesn't fault on the synchronous ``read_text``
+    on CI.
+
+    Regenerate-after-scan is implicit: ``update_config`` awaits
+    ``scan()`` before calling ``_schedule_storage_regenerate``,
+    so any ordering of regen-vs-write follows from this scan
+    check by virtue of the linear async control flow.
     """
+    import asyncio as _asyncio
+
     controller = _make_controller(tmp_path)
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: stale\n", encoding="utf-8")
 
     new_content = "esphome:\n  name: fresh\n"
     seen_during_scan: list[str] = []
-    seen_during_regen: list[str] = []
 
     async def _record_scan() -> None:
-        seen_during_scan.append(yaml_path.read_text(encoding="utf-8"))
-
-    def _record_regen(_configuration: str) -> None:
-        seen_during_regen.append(yaml_path.read_text(encoding="utf-8"))
+        seen_during_scan.append(await _asyncio.to_thread(yaml_path.read_text, "utf-8"))
 
     controller._scanner.scan = AsyncMock(side_effect=_record_scan)
-    controller._schedule_storage_regenerate = MagicMock(  # type: ignore[method-assign]
-        side_effect=_record_regen
-    )
 
     await controller.update_config(configuration="kitchen.yaml", content=new_content)
 
     assert seen_during_scan == [new_content]
-    assert seen_during_regen == [new_content]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Two \`@api_command\` entrypoints back the in-browser YAML editor's load and save flow. They mirror upstream's \`EditRequestHandler.get\` / \`.post\` in \`esphome/dashboard/web_server.py\`; this pins our shape so HA's editor (and any future esphome-dashboard-api consumer) keeps working unchanged.

10 tests in a new \`tests/controllers/devices/test_get_update_config.py\`:

- **\`get_config\`** — returns plain YAML text, decodes UTF-8 with non-ASCII intact, propagates \`FileNotFoundError\` rather than silently returning \`""\`.
- **\`update_config\`** — writes content verbatim, overwrites an existing YAML (no merge), persists UTF-8 unicode through \`write_text(..., "utf-8")\`, awakens the scanner so the device list refreshes, and schedules a StorageJSON regenerate for the edited configuration (mirrors upstream's \`async_schedule_storage_json_update\`).
- **Ordering** — write completes before scan + regenerate fire, so both see the new YAML and not the stale on-disk one.
- **Round-trip** — \`update_config\` then \`get_config\` returns exactly what was written; pinned end-to-end so a refactor that diverged read- and write-paths in \`rel_path\` would surface.

Path-traversal is gated by \`settings.rel_path\` and already covered in \`tests/controllers/test_traversal_validation.py\` — not duplicated here.

## Test plan
- [x] \`uv run pytest tests/controllers/devices/test_get_update_config.py\` — 10 passed
- [x] \`uv run pre-commit run\` clean