### PR TITLE
Prefer generic over vendor in find_by_pio_board

### DIFF
--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -112,14 +112,27 @@ class BoardCatalog:
 
         Used to derive a board_id from a user-provided YAML config.
         Returns None if no entry has a matching ``esphome.board`` value.
+
+        When multiple catalog entries share the same PlatformIO board
+        id (e.g. several products are physically built on the same
+        ``esp32-c3-devkitm-1`` reference design), prefer the generic
+        fallback (``is_generic=true``) so the dashboard doesn't
+        misidentify a user's plain dev-kit YAML as a specific vendor
+        product like "Athom Smart Plug v3". Mirrors the same
+        generic-preference policy in ``find_by_platform_variant``.
         """
         matches = [b for b in self._boards if b.esphome.board == pio_board]
         if not matches:
             return None
         if pio_variant:
-            for b in matches:
-                if b.esphome.variant and b.esphome.variant.value == pio_variant:
-                    return b
+            variant_matches = [
+                b for b in matches if b.esphome.variant and b.esphome.variant.value == pio_variant
+            ]
+            if variant_matches:
+                matches = variant_matches
+        for b in matches:
+            if b.is_generic:
+                return b
         return matches[0]
 
     def find_by_platform_variant(

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -352,20 +352,48 @@ def test_iter_boards_returns_internal_list(catalog: BoardCatalog) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_find_by_pio_board_returns_first_match(catalog: BoardCatalog) -> None:
-    """A pio_board with no variant hint returns the first matching entry."""
-    # ``esp32-c3-devkitm-1`` is shared by Seeed XIAO and Generic ESP32-C3.
+def test_find_by_pio_board_prefers_generic_when_multiple_match(
+    catalog: BoardCatalog,
+) -> None:
+    """Multiple matches for the same pio_board → prefer the generic.
+
+    Real-world trigger: a user imports a vanilla ``esp32-c3-devkitm-1``
+    YAML; the catalog contains both that generic plus several vendor
+    products built on the same reference design (Seeed XIAO,
+    "Athom Smart Plug v3", etc.). Without the generic preference the
+    dashboard would mislabel a plain dev-kit as the first vendor entry
+    by alphabetical id, which is exactly the regression that motivated
+    this branch.
+    """
     board = catalog.find_by_pio_board("esp32-c3-devkitm-1")
 
     assert board is not None
+    assert board.id == "generic-esp32c3"
+    assert board.is_generic is True
+
+
+def test_find_by_pio_board_returns_first_when_no_generic(
+    catalog: BoardCatalog,
+) -> None:
+    """Without a generic among the matches, fall back to the first match."""
+    # Drop the generics so only vendor entries remain.
+    catalog._boards = [b for b in catalog._boards if not b.is_generic]
+
+    board = catalog.find_by_pio_board("esp32-c3-devkitm-1")
+
+    assert board is not None
+    assert board.is_generic is False
     assert board.esphome.board == "esp32-c3-devkitm-1"
 
 
 def test_find_by_pio_board_prefers_matching_variant(catalog: BoardCatalog) -> None:
-    """When ``pio_variant`` is provided, prefer entries whose variant matches."""
-    # The fixture has two pio_board="esp32-c3-devkitm-1" entries; both
-    # are ESP32-C3 here. Add a different-variant entry to make the
-    # preference observable.
+    """When ``pio_variant`` is provided, prefer entries whose variant matches.
+
+    Variant filter narrows the candidate pool *before* the generic
+    preference applies. Add two same-pio different-variant entries
+    (no generic among them) so the variant filter is the only thing
+    that picks a winner.
+    """
     catalog._boards.append(
         _board(
             board_id="alt-c3-board",

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -375,15 +375,35 @@ def test_find_by_pio_board_prefers_generic_when_multiple_match(
 def test_find_by_pio_board_returns_first_when_no_generic(
     catalog: BoardCatalog,
 ) -> None:
-    """Without a generic among the matches, fall back to the first match."""
-    # Drop the generics so only vendor entries remain.
+    """Without a generic among the matches, fall back to the first match.
+
+    Pin the iteration-order fallback by giving the catalog *two*
+    non-generic entries with the same ``pio_board``: a regression
+    that swapped the fallback to "any match" rather than "first
+    match" would surface here. The fixture-as-shipped only has one
+    non-generic for ``esp32-c3-devkitm-1`` once the generics are
+    dropped, so we add a second to make the order check meaningful.
+    """
     catalog._boards = [b for b in catalog._boards if not b.is_generic]
+    # Insert a second vendor entry with the same pio_board *after*
+    # the existing Seeed XIAO so iteration order is observable.
+    catalog._boards.append(
+        _board(
+            board_id="zzz-second-vendor-c3",
+            name="ZZZ Second Vendor C3",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32C3,
+            pio_board="esp32-c3-devkitm-1",
+        )
+    )
 
     board = catalog.find_by_pio_board("esp32-c3-devkitm-1")
 
     assert board is not None
     assert board.is_generic is False
-    assert board.esphome.board == "esp32-c3-devkitm-1"
+    # First in iteration order wins — Seeed XIAO was added before the
+    # ZZZ stand-in.
+    assert board.id == "seeed-xiao-esp32c3"
 
 
 def test_find_by_pio_board_prefers_matching_variant(catalog: BoardCatalog) -> None:


### PR DESCRIPTION
## Summary
Reported regression: importing a YAML with \`board: esp32-c3-devkitm-1\` / \`variant: esp32c3\` (a vanilla ESP32-C3 dev-kit) was mislabelling the device as "Athom Smart Plug v3".

Root cause: \`find_by_pio_board\` returns the *first* match when multiple catalog entries share the same PlatformIO board id. Several products are physically built on \`esp32-c3-devkitm-1\` (Athom Smart Plug v3, Seeed XIAO, the Generic ESP32-C3, etc.), and alphabetical id order makes \`athom-smart-plug-v3\` win against \`generic-esp32c3\`.

Fix: mirror the same generic-preference policy already in \`find_by_platform_variant\` — filter by variant first when provided, then prefer the \`is_generic=true\` entry, falling back to the first match only when no generic exists.

## Repro (the user's YAML)
\`\`\`yaml
esphome:
  name: ota-web-test
  friendly_name: OTA Web Test

esp32:
  board: esp32-c3-devkitm-1
  variant: esp32c3
  framework:
    type: esp-idf
\`\`\`
Before: dashboard shows "Athom Smart Plug v3". After: dashboard shows "Generic ESP32-C3 Board".

## Test plan
- [x] New \`test_find_by_pio_board_prefers_generic_when_multiple_match\` pins the regression.
- [x] \`test_find_by_pio_board_returns_first_when_no_generic\` keeps the no-generic fallback covered.
- [x] \`test_find_by_pio_board_prefers_matching_variant\` updated to use no-generic candidates so the variant filter is the only thing picking a winner.
- [x] \`uv run pytest\` — 1045 passed
- [x] \`uv run pre-commit run\` clean