### PR TITLE
Emit auto-name on featured-component YAML for HA entity platforms

### DIFF
--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -481,7 +481,7 @@ def _materialise_featured(
     """
     underlying = record.underlying
     fc = record.featured
-    presets = _featured_field_presets(fc)
+    presets = _featured_field_presets(record)
     return ComponentCatalogEntry(
         id=record.full_id,
         name=fc.name or underlying.name,
@@ -499,9 +499,60 @@ def _materialise_featured(
     )
 
 
-def _featured_field_presets(fc: FeaturedComponent) -> dict[str, FieldPreset]:
+# HA entity domains where ESPHome's entity-base schema (the source of
+# the top-level ``name:`` field) is inherited. Used to decide whether
+# the auto-name preset for a featured component is safe to flow into
+# the generated YAML — emitting ``name:`` on a non-entity platform
+# (``output:``, ``i2c:``, ``rtttl:``, ...) produces a config ESPHome
+# rejects. Narrower than ``helpers.yaml._ENTITY_CATEGORIES``: that set
+# also covers platform-pattern domains that aren't HA entities
+# (``output``, ``ota``, ``audio_adc``, ...).
+_HA_ENTITY_CATEGORIES = frozenset(
+    {
+        "sensor",
+        "binary_sensor",
+        "switch",
+        "light",
+        "fan",
+        "cover",
+        "climate",
+        "button",
+        "number",
+        "select",
+        "text",
+        "text_sensor",
+        "lock",
+        "valve",
+        "media_player",
+        "datetime",
+        "event",
+        "update",
+        "alarm_control_panel",
+    }
+)
+
+
+def _supports_name(component: ComponentCatalogEntry) -> bool:
     """
-    Return *fc*'s field presets with sensible ``id`` / ``name`` defaults.
+    Return ``True`` when *component* accepts a top-level ``name:`` field.
+
+    Two paths: either the sync script captured ``name`` as a real
+    ``config_entry`` (the happy case), or the component sits in an HA
+    entity domain where ``name`` is inherited from
+    ``ENTITY_BASE_SCHEMA`` even though the sync output happens to be
+    missing it. The second branch covers a known sync gap on several
+    entity platforms (notably ``binary_sensor.gpio`` and a chunk of
+    ``sensor.*``) so the auto-name preset still flows through to the
+    YAML for the user instead of producing an HA-nameless entity.
+    """
+    if any(ce.key == "name" for ce in component.config_entries):
+        return True
+    return str(component.category) in _HA_ENTITY_CATEGORIES
+
+
+def _featured_field_presets(record: _FeaturedRecord) -> dict[str, FieldPreset]:
+    """
+    Return *record*'s field presets with sensible ``id`` / ``name`` defaults.
 
     The board manifest's explicit ``fields`` entries are preserved as-is.
     For ``id`` and ``name`` the manifest is rarely explicit, so we derive
@@ -510,11 +561,16 @@ def _featured_field_presets(fc: FeaturedComponent) -> dict[str, FieldPreset]:
     catalog id verbatim (``featured.<board>.<local>``) and the merge
     logic falls back to the bare platform stem (``id: gpio``) because
     there's no ``name`` to slug from.
+
+    The auto-name preset is gated on :func:`_supports_name` so we don't
+    inject ``name:`` on non-entity platforms (``output:``, ``i2c:``,
+    ``rtttl:``, ...) where ESPHome would reject the resulting YAML.
     """
+    fc = record.featured
     presets = dict(fc.fields)
     if "id" not in presets:
         presets["id"] = FieldPreset(value=_default_id_from_local(fc.id))
-    if "name" not in presets and fc.name:
+    if "name" not in presets and fc.name and _supports_name(record.underlying):
         presets["name"] = FieldPreset(value=fc.name)
     return presets
 

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -32,6 +32,7 @@ from esphome.storage_json import StorageJSON, ext_storage_path
 from ...helpers.api import CommandError
 from ...helpers.hostname import is_local_hostname, normalize_hostname
 from ...models import ConfigEntryType, Device, ErrorCode
+from ..components import _featured_field_presets
 from ..config import clear_volatile_device_metadata, remove_device_metadata
 from .constants import _CONCEALED_SECRET_RE
 
@@ -208,10 +209,18 @@ def _apply_featured_presets(
     (``pin: 12``) or rich mapping (``pin: {number: 12, mode: ..., inverted: ...}``).
     Equality / membership checks compare on the bare GPIO so a manifest's
     ``suggestions: [4, 5]`` accepts whichever shape the frontend submits.
+
+    The preset map iterated here is the auto-augmented one from
+    :func:`_featured_field_presets` — so the same ``id`` / ``name``
+    defaults the frontend sees on the catalog entry also flow into the
+    YAML output, even when the underlying component doesn't surface
+    those keys as its own ``config_entries`` (e.g. ``binary_sensor.gpio``
+    has no top-level ``name`` entry; without this, adding a featured
+    button would emit YAML with neither ``name:`` nor ``id:``).
     """
     entries_by_key = {ce.key: ce for ce in record.underlying.config_entries}
     merged: dict[str, Any] = dict(user_fields)
-    for key, preset in record.featured.fields.items():
+    for key, preset in _featured_field_presets(record).items():
         user_value = merged.get(key)
         user_supplied = key in merged
         is_pin = entries_by_key.get(key) is not None and (

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -318,8 +318,18 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
 
 
 def _generate_id(component_id: str, name: str | None = None) -> str:
-    """Auto-generate a component ID from the component type and optional name."""
-    if name:
-        slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
-        return f"{component_id}_{slug}"
-    return component_id
+    """
+    Auto-generate a component ID from the component type and optional name.
+
+    When the name's slug already starts with the component id (or equals
+    it), drop the redundant prefix — otherwise a featured component
+    whose display name leads with the chip name produces ids like
+    ``hlw8012_hlw8012_power_monitor`` instead of the cleaner
+    ``hlw8012_power_monitor``.
+    """
+    if not name:
+        return component_id
+    slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+    if slug == component_id or slug.startswith(f"{component_id}_"):
+        return slug
+    return f"{component_id}_{slug}"

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -549,11 +549,15 @@ async def test_add_component_featured_resets_dashed_id(
         },
     )
 
-    assert "id: hlw8012" in response.yaml
+    # Auto-id from the featured display name "HLW8012 Power Monitor"
+    # — the redundant ``hlw8012_`` prefix is dropped by ``_generate_id``.
+    assert "id: hlw8012_power_monitor" in response.yaml
     assert "featured_athom-smart-plug-v3" not in response.yaml
+    # Auto-name preset from the featured display name flows into the YAML.
+    assert "name: HLW8012 Power Monitor" in response.yaml
     # Sub-entity autofill rides through the merge step.
     assert "name: Current" in response.yaml
-    assert "id: hlw8012_current" in response.yaml
+    assert "id: hlw8012_power_monitor_current" in response.yaml
 
 
 async def test_add_component_featured_keeps_user_typed_id(
@@ -584,3 +588,59 @@ async def test_add_component_featured_unknown_id_raises(
             component_id="featured.no-such-board.x",
             fields={},
         )
+
+
+async def test_add_component_featured_emits_name_for_binary_sensor(
+    catalog: ComponentCatalog, tmp_path: Any
+) -> None:
+    """
+    Regression: featured ``binary_sensor.gpio`` entries must get a ``name:``.
+
+    ``binary_sensor.gpio``'s sync output is missing the entity-base
+    ``name`` field, so the materialised view doesn't expose a ``name``
+    config_entry — without the auto-name preset flowing through the
+    apply path, adding the Sonoff Basic's "Front-Panel Button" produced
+    a YAML block with neither ``name:`` nor ``id:``, leaving the
+    resulting entity unnamed in Home Assistant.
+    """
+    (tmp_path / "sonoff.yaml").write_text("esphome:\n  name: sonoff\n", "utf-8")
+    ctrl = _make_controller(catalog, tmp_path)
+
+    response = await ctrl.add_component(
+        configuration="sonoff.yaml",
+        component_id="featured.sonoff-basic.button",
+        fields={},
+    )
+
+    assert "binary_sensor:" in response.yaml
+    assert "platform: gpio" in response.yaml
+    assert "name: Front-Panel Button" in response.yaml
+    assert "id: button" in response.yaml
+
+
+async def test_add_component_featured_skips_name_for_non_entity_platform(
+    catalog: ComponentCatalog, tmp_path: Any
+) -> None:
+    """
+    Auto-name must NOT flow into non-entity platforms (``output:``, ``i2c:``, ...).
+
+    ESPHome's ``output.gpio`` schema doesn't accept a top-level
+    ``name:`` field — it's an internal building block referenced by a
+    parent ``light:`` / ``switch:`` entry, not a HA-visible entity.
+    Emitting ``name:`` here would produce a config ESPHome rejects.
+    """
+    (tmp_path / "sonoff.yaml").write_text("esphome:\n  name: sonoff\n", "utf-8")
+    ctrl = _make_controller(catalog, tmp_path)
+
+    response = await ctrl.add_component(
+        configuration="sonoff.yaml",
+        component_id="featured.sonoff-basic.status_led_output",
+        fields={},
+    )
+
+    assert "output:" in response.yaml
+    assert "platform: gpio" in response.yaml
+    # id is universal — every component accepts it.
+    assert "id: status_led_output" in response.yaml
+    # name must NOT appear under the output block.
+    assert "name:" not in response.yaml.split("output:")[1]


### PR DESCRIPTION
testing the sonoff basic featured "Front-Panel Button" produced a YAML block with neither `name:` nor `id:` — so the entity showed up unnamed in home assistant. same pattern affects every featured `binary_sensor.gpio` (and a chunk of `sensor.*` whose schema sync is missing the entity-base `name` field).

root cause is two layers:

- `_featured_field_presets` in `controllers/components.py` already auto-derives `id` and `name` defaults from the manifest's local id and display name. the materialised view (`get_component`) used these.
- `_apply_featured_presets` in `controllers/devices/helpers.py` — the path that actually builds the YAML — was reading `record.featured.fields` directly instead of the auto-augmented preset map, so the auto defaults never reached the merge step.

## changes

- route both call sites through `_featured_field_presets(record)` so manifest-explicit fields and auto-derived `id` / `name` defaults flow into the YAML the same way they flow into the catalog entry
- gate the auto-name preset on a new `_supports_name` check (HA entity domains + components that already declare `name:`) so non-entity platforms (`output:`, `i2c:`, `rtttl:`, ...) stay clean — they don't accept a top-level `name:` field
- small bonus: dedup `_generate_id` so a featured display name that leads with the chip name produces `id: hlw8012_power_monitor` rather than `id: hlw8012_hlw8012_power_monitor`
- two regression tests cover the `binary_sensor.gpio` name injection and the non-entity `output.gpio` exclusion

audited all 15 featured components on the 3 hand-curated boards — entities (`sensor`, `binary_sensor`, `switch`, `light`) now get both `id` and `name`; non-entities (`output`, `bus`, `misc`) correctly skip `name`.

note: the underlying sync issue — `binary_sensor.gpio` and a chunk of `sensor.*` are missing the entity-base `name` config_entry — is a separate concern in `script/sync_components.py`. addressed at runtime here so user YAML is correct today; a sync fix would additionally restore the `name` input field in the dashboard UI for those platforms.