### PR TITLE
Make featured-component id and name explicit in board manifests

### DIFF
--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -481,7 +480,7 @@ def _materialise_featured(
     """
     underlying = record.underlying
     fc = record.featured
-    presets = _featured_field_presets(fc)
+    presets = fc.fields
     return ComponentCatalogEntry(
         id=record.full_id,
         name=fc.name or underlying.name,
@@ -497,40 +496,6 @@ def _materialise_featured(
             for entry in underlying.config_entries
         ],
     )
-
-
-def _featured_field_presets(fc: FeaturedComponent) -> dict[str, FieldPreset]:
-    """
-    Return *fc*'s field presets with sensible ``id`` / ``name`` defaults.
-
-    The board manifest's explicit ``fields`` entries are preserved as-is.
-    For ``id`` and ``name`` the manifest is rarely explicit, so we derive
-    a default from the featured component's local id and display name —
-    without this the frontend pre-fills the ``id`` input with the
-    catalog id verbatim (``featured.<board>.<local>``) and the merge
-    logic falls back to the bare platform stem (``id: gpio``) because
-    there's no ``name`` to slug from.
-    """
-    presets = dict(fc.fields)
-    if "id" not in presets:
-        presets["id"] = FieldPreset(value=_default_id_from_local(fc.id))
-    if "name" not in presets and fc.name:
-        presets["name"] = FieldPreset(value=fc.name)
-    return presets
-
-
-def _default_id_from_local(local_id: str) -> str:
-    """Slugify a featured-component local id for use as an ESPHome ``id:`` value."""
-    slug = re.sub(r"[^a-z0-9]+", "_", local_id.lower()).strip("_")
-    if not slug:
-        return local_id
-    # ESPHome ids must be valid C-style identifiers — they're emitted
-    # as C++ variable names downstream, so a leading digit produces an
-    # invalid build. Prefix with an underscore when the manifest's
-    # local id starts with one.
-    if slug[0].isdigit():
-        slug = f"_{slug}"
-    return slug
 
 
 def _materialise_entry_with_preset(

--- a/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
@@ -96,6 +96,7 @@ featured_components:
     GPIO1 (SDA). Configure I²C once and any of the swappable sensor
     modules (AHT20, additional I²C breakouts) will work.
   fields:
+    id: i2c_bus
     scl:
       value: 0
       locked: true
@@ -109,6 +110,8 @@ featured_components:
     Sensor module shipped with the kit. Plug into either FPC connector;
     it talks I²C so no per-pin config is needed beyond the bus above.
   fields:
+    id: aht20
+    name: AHT20 Temperature & Humidity
     variant: AHT20
 - id: pir_motion
   component_id: binary_sensor.gpio
@@ -118,6 +121,8 @@ featured_components:
     FPC connector you plug it into — pick GPIO4 for connector A or
     GPIO5 for connector B.
   fields:
+    id: pir_motion
+    name: PIR Motion Module
     pin:
       suggestions: [4, 5]
       value: 4
@@ -130,6 +135,8 @@ featured_components:
     FPC connector (GPIO4 for A, GPIO5 for B). Defaults to 8 LEDs in
     GRB order — adjust to match your strip.
   fields:
+    id: rgb_strip
+    name: RGB LED Strip
     pin:
       suggestions: [4, 5]
       value: 4
@@ -142,6 +149,7 @@ featured_components:
     PWM output driving the piezo buzzer on the RGB+buzzer addon.
     Pick the FPC connector pin not used by the strip — GPIO4 or GPIO5.
   fields:
+    id: buzzer_output
     pin:
       suggestions: [4, 5]
       value: 5
@@ -151,6 +159,8 @@ featured_components:
   description: |
     Plays RTTTL ringtones through the piezo buzzer above. Wire the
     ``output`` field to the buzzer output you just added.
+  fields:
+    id: rtttl_player
 featured_bundles:
 - id: rgb_buzzer_module
   name: RGB LED + Buzzer Module

--- a/esphome_device_builder/definitions/boards/athom-smart-plug-v3/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/athom-smart-plug-v3/manifest.yaml
@@ -75,10 +75,11 @@ featured_components:
     16 A relay hard-wired to GPIO6. The pin is fixed; the rest of the
     fields are yours to set.
   fields:
+    id: relay
+    name: Relay
     pin:
       value: 6
       locked: true
-    name: Relay
 - id: button
   component_id: binary_sensor.gpio
   name: Front-Panel Button
@@ -86,6 +87,8 @@ featured_components:
     Front-panel push button on GPIO9 (active low — uses internal pull-up
     via the rich pin form).
   fields:
+    id: button
+    name: Front-Panel Button
     pin:
       value:
         number: 9
@@ -101,6 +104,7 @@ featured_components:
     Low-level GPIO output for the onboard blue LED on GPIO7. Pair with
     a ``Status LED Light`` so Home Assistant can toggle it as a light.
   fields:
+    id: status_led_output
     pin:
       value: 7
       locked: true
@@ -112,6 +116,7 @@ featured_components:
     Binary light entity for the onboard status LED. Wire its ``output``
     to the ``status_led_output`` you added.
   fields:
+    id: status_led_light
     name: Status LED
 - id: power_monitor
   component_id: sensor.hlw8012
@@ -120,6 +125,8 @@ featured_components:
     Energy-metering chip wired to GPIO3 (CF), GPIO4 (CF1), and GPIO5
     (SEL). The pins are physically fixed on this board.
   fields:
+    id: power_monitor
+    name: HLW8012 Power Monitor
     cf_pin:
       value: 3
       locked: true

--- a/esphome_device_builder/definitions/boards/sonoff-basic/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/sonoff-basic/manifest.yaml
@@ -139,10 +139,11 @@ featured_components:
     The 10 A AC relay is hard-wired to GPIO12. This recommendation pre-fills
     the GPIO and gives it a sensible default name.
   fields:
+    id: relay
+    name: Relay
     pin:
       value: 12
       locked: true
-    name: Relay
 - id: button
   component_id: binary_sensor.gpio
   name: Front-Panel Button
@@ -150,6 +151,8 @@ featured_components:
     Front-panel push button on GPIO0 (active low — note ``inverted: true``
     plus the internal pull-up).
   fields:
+    id: button
+    name: Front-Panel Button
     pin:
       value:
         number: 0
@@ -165,6 +168,7 @@ featured_components:
     Low-level GPIO output for the onboard blue LED on GPIO13. Pair with
     a ``Status LED Light`` so Home Assistant can toggle it as a light.
   fields:
+    id: status_led_output
     pin:
       value: 13
       locked: true
@@ -176,6 +180,7 @@ featured_components:
     Binary light entity for the onboard status LED. Wire its ``output``
     to the ``status_led_output`` you added.
   fields:
+    id: status_led_light
     name: Status LED
 featured_bundles:
 - id: status_led

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -318,8 +318,17 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
 
 
 def _generate_id(component_id: str, name: str | None = None) -> str:
-    """Auto-generate a component ID from the component type and optional name."""
-    if name:
-        slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
-        return f"{component_id}_{slug}"
-    return component_id
+    """
+    Auto-generate a component ID from the component type and optional name.
+
+    When the name's slug already starts with the component id (or equals
+    it), drop the redundant prefix — otherwise a featured component
+    whose display name leads with the chip stem produces ids like
+    ``hlw8012_hlw8012_power_monitor`` instead of ``hlw8012_power_monitor``.
+    """
+    if not name:
+        return component_id
+    slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+    if slug == component_id or slug.startswith(f"{component_id}_"):
+        return slug
+    return f"{component_id}_{slug}"

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -321,14 +321,20 @@ def _generate_id(component_id: str, name: str | None = None) -> str:
     """
     Auto-generate a component ID from the component type and optional name.
 
-    When the name's slug already starts with the component id (or equals
-    it), drop the redundant prefix — otherwise a featured component
-    whose display name leads with the chip stem produces ids like
-    ``hlw8012_hlw8012_power_monitor`` instead of ``hlw8012_power_monitor``.
+    Returns ``<component_id>_<name_slug>`` when *name* contributes
+    usable characters, falling back to bare ``component_id`` when
+    *name* is empty / missing or slugifies to nothing (e.g. only
+    punctuation). When the slug already leads with ``component_id``
+    the redundant prefix is dropped — otherwise a display name that
+    starts with the chip stem produces ids like
+    ``hlw8012_hlw8012_power_monitor`` instead of
+    ``hlw8012_power_monitor``.
     """
     if not name:
         return component_id
     slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+    if not slug:
+        return component_id
     if slug == component_id or slug.startswith(f"{component_id}_"):
         return slug
     return f"{component_id}_{slug}"

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -184,7 +184,45 @@ _IMAGE_EXTENSIONS: frozenset[str] = frozenset({".jpg", ".jpeg", ".png", ".webp",
 # component itself; ``id`` is the per-instance variable name our
 # dashboard generates fresh — preserving upstream's would create
 # cross-instance conflicts the moment the user adds a second one.
-_SKIPPED_FIELDS: frozenset[str] = frozenset({"platform", "id"})
+# ``name`` is handled separately: upstream value is used when present,
+# else a derived default is injected (see ``_extract_featured_components``)
+# so the entity always surfaces in Home Assistant without further user
+# editing.
+_SKIPPED_FIELDS: frozenset[str] = frozenset({"platform", "id", "name"})
+
+# HA-entity subset of ``_PLATFORM_LIST_DOMAINS``. Platforms in this set
+# accept a top-level ``name:`` field (it's part of ESPHome's entity-base
+# schema). Non-entity platform-list domains (``output:``) don't — they're
+# referenced by entity wrappers (``light:`` / ``switch:``) and emitting
+# ``name:`` there produces a config ESPHome rejects.
+_HA_ENTITY_DOMAINS: frozenset[str] = frozenset(
+    {
+        "alarm_control_panel",
+        "binary_sensor",
+        "button",
+        "camera",
+        "climate",
+        "cover",
+        "datetime",
+        "display",
+        "event",
+        "fan",
+        "light",
+        "lock",
+        "media_player",
+        "microphone",
+        "number",
+        "select",
+        "sensor",
+        "speaker",
+        "switch",
+        "text",
+        "text_sensor",
+        "touchscreen",
+        "update",
+        "valve",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -602,6 +640,25 @@ def _extract_featured_components(
                 continue
             counters[component_id] = counters.get(component_id, 0) + 1
             local_id = f"{domain}_{platform}_{counters[component_id]}"
+            # Always set ``fields.id`` so the dashboard never has to
+            # auto-derive one at runtime — definitions are the source
+            # of truth for what ends up in the user's YAML.
+            fields["id"] = local_id
+            # For HA entity platforms, also fill ``fields.name`` so the
+            # entity surfaces in Home Assistant. Prefer upstream's name
+            # when the page set one (and it's a simple scalar — skip
+            # ``${friendly_name}`` templates the user can't sensibly
+            # override); otherwise derive a default.
+            if domain in _HA_ENTITY_DOMAINS:
+                upstream_name = item.get("name")
+                if _is_simple_scalar(upstream_name) and isinstance(upstream_name, str):
+                    upstream_name = upstream_name.strip()
+                else:
+                    upstream_name = ""
+                fields["name"] = (
+                    upstream_name
+                    or f"{platform.replace('_', ' ').title()} {counters[component_id]}"
+                )
             entry: dict[str, Any] = {
                 "id": local_id,
                 "component_id": component_id,

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -190,39 +190,17 @@ _IMAGE_EXTENSIONS: frozenset[str] = frozenset({".jpg", ".jpeg", ".png", ".webp",
 # editing.
 _SKIPPED_FIELDS: frozenset[str] = frozenset({"platform", "id", "name"})
 
-# HA-entity subset of ``_PLATFORM_LIST_DOMAINS``. Platforms in this set
-# accept a top-level ``name:`` field (it's part of ESPHome's entity-base
-# schema). Non-entity platform-list domains (``output:``) don't — they're
-# referenced by entity wrappers (``light:`` / ``switch:``) and emitting
-# ``name:`` there produces a config ESPHome rejects.
-_HA_ENTITY_DOMAINS: frozenset[str] = frozenset(
-    {
-        "alarm_control_panel",
-        "binary_sensor",
-        "button",
-        "camera",
-        "climate",
-        "cover",
-        "datetime",
-        "display",
-        "event",
-        "fan",
-        "light",
-        "lock",
-        "media_player",
-        "microphone",
-        "number",
-        "select",
-        "sensor",
-        "speaker",
-        "switch",
-        "text",
-        "text_sensor",
-        "touchscreen",
-        "update",
-        "valve",
-    }
-)
+# Platform-list domains that aren't HA entities — they're referenced
+# by entity wrappers (``light:`` / ``switch:`` reference an ``output:``
+# entry by id) rather than surfaced directly, and emitting a top-level
+# ``name:`` on one of these produces a config ESPHome rejects. Kept
+# explicit so adding a new entry to ``_PLATFORM_LIST_DOMAINS`` doesn't
+# silently flip its name-injection behaviour.
+_NON_ENTITY_PLATFORM_DOMAINS: frozenset[str] = frozenset({"output"})
+
+# HA-entity subset of ``_PLATFORM_LIST_DOMAINS`` — derived so a new
+# entity domain added upstream doesn't get forgotten here.
+_HA_ENTITY_DOMAINS: frozenset[str] = _PLATFORM_LIST_DOMAINS - _NON_ENTITY_PLATFORM_DOMAINS
 
 
 # ---------------------------------------------------------------------------

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -287,6 +287,15 @@ def _validate_featured_component(
 
     for fkey, fval in (entry.get("fields") or {}).items():
         if fkey not in entries_by_key:
+            # ``id`` and ``name`` are entity-base universals — every
+            # ESPHome entity-platform schema accepts them, but the
+            # components.json sync misses ``name`` for a chunk of
+            # entity platforms (binary_sensor.gpio, sensor.aht10, ...)
+            # because of how ENTITY_BASE_SCHEMA inheritance is
+            # surfaced. Allow these through so manifests can be
+            # explicit without tripping the unknown-key gate.
+            if fkey in ("id", "name"):
+                continue
             errors.append(f"{path}.fields.{fkey}: not a config_entry on {component_id}")
             continue
         ce = entries_by_key[fkey]

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -32,10 +32,43 @@ COMPONENTS_JSON = DEFINITIONS_DIR / "components.json"
 _FEATURED_EXCLUDED_CATEGORIES = {"core", "ota", "time", "update"}
 
 # Required shape for featured-component ids: lowercase letters, digits, and
-# underscores only, starting with a letter. Mirrors what the runtime
-# slugifier (controllers/components.py::_default_id_from_local) and the
-# sync script's auto-id format produce, so manifests stay canonical.
+# underscores only, starting with a letter. Mirrors what ESPHome accepts
+# as a valid identifier and what the sync script's auto-id format produces.
 _FEATURED_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# Categories whose ESPHome schema accepts a top-level ``name:`` field
+# (entity-base universals). Used to gate the ``fields.name`` exception
+# below — without this, a manifest could attach ``fields.name`` to an
+# ``output.*`` component and still validate, then later compile-fail
+# because ``output:`` doesn't carry a ``name`` field.
+_HA_ENTITY_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "alarm_control_panel",
+        "binary_sensor",
+        "button",
+        "camera",
+        "climate",
+        "cover",
+        "datetime",
+        "display",
+        "event",
+        "fan",
+        "light",
+        "lock",
+        "media_player",
+        "microphone",
+        "number",
+        "select",
+        "sensor",
+        "speaker",
+        "switch",
+        "text",
+        "text_sensor",
+        "touchscreen",
+        "update",
+        "valve",
+    }
+)
 
 # Pin features the board manifest can declare (mirrors the JSON Schema enum
 # in board.schema.json). Components.json sometimes carries pin_features
@@ -285,16 +318,10 @@ def _validate_featured_component(
         if isinstance(key, str):
             entries_by_key[key] = ce
 
+    component_category = component.get("category")
     for fkey, fval in (entry.get("fields") or {}).items():
         if fkey not in entries_by_key:
-            # ``id`` and ``name`` are entity-base universals — every
-            # ESPHome entity-platform schema accepts them, but the
-            # components.json sync misses ``name`` for a chunk of
-            # entity platforms (binary_sensor.gpio, sensor.aht10, ...)
-            # because of how ENTITY_BASE_SCHEMA inheritance is
-            # surfaced. Allow these through so manifests can be
-            # explicit without tripping the unknown-key gate.
-            if fkey in ("id", "name"):
+            if _is_entity_base_universal(fkey, component_category):
                 continue
             errors.append(f"{path}.fields.{fkey}: not a config_entry on {component_id}")
             continue
@@ -302,6 +329,21 @@ def _validate_featured_component(
         errors.extend(_validate_field_preset(path, fkey, fval, ce, pins_by_gpio, is_imported))
 
     return errors
+
+
+def _is_entity_base_universal(fkey: str, category: str | None) -> bool:
+    """
+    Return ``True`` for fields ESPHome accepts beyond the catalog schema.
+
+    ``id`` is universal across every component. ``name`` is part of
+    ENTITY_BASE_SCHEMA, inherited by every HA-entity-domain platform —
+    but the schema sync misses it for several entity components
+    (binary_sensor.gpio, sensor.aht10, ...), so a manifest setting
+    ``fields.name`` on those would otherwise trip the unknown-key gate.
+    """
+    if fkey == "id":
+        return True
+    return fkey == "name" and category in _HA_ENTITY_CATEGORIES
 
 
 def _validate_field_preset(

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -22,10 +22,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from esphome_device_builder.controllers.boards import BoardCatalog
-from esphome_device_builder.controllers.components import (
-    ComponentCatalog,
-    _default_id_from_local,
-)
+from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices.helpers import _apply_featured_presets
 from esphome_device_builder.definitions import (
@@ -156,11 +153,8 @@ async def test_get_component_suggestions(catalog: ComponentCatalog) -> None:
     assert pin.suggestions == [4, 5]
 
 
-async def test_get_component_id_default_from_local(catalog: ComponentCatalog) -> None:
-    """Featured components without an explicit ``id`` preset default to the slugified local id."""
-    # ``button`` has no manifest preset for ``id`` — without the
-    # auto-derived default the merge logic would render ``id: gpio``,
-    # colliding with the platform stem.
+async def test_get_component_id_from_manifest_field(catalog: ComponentCatalog) -> None:
+    """A featured component's ``fields.id`` preset surfaces as the materialised id default."""
     entry = await catalog.get_component(component_id="featured.athom-smart-plug-v3.button")
     assert entry is not None
     id_field = next(ce for ce in entry.config_entries if ce.key == "id")
@@ -168,43 +162,18 @@ async def test_get_component_id_default_from_local(catalog: ComponentCatalog) ->
     assert id_field.locked is False
 
 
-async def test_get_component_name_default_from_featured_name(
+async def test_get_component_name_from_manifest_field(
     catalog: ComponentCatalog,
 ) -> None:
-    """The featured component's display name pre-fills the underlying ``name`` field."""
-    # apollo-esk-1.rgb_strip has ``name: RGB LED Strip (addon module)``
-    # at the featured level but no field preset for ``name`` — the
-    # auto-derived default lets the user start with a sensible
-    # HA-visible entity name without having to repeat it in the
-    # manifest's ``fields:`` block.
-    entry = await catalog.get_component(component_id="featured.apollo-esk-1.rgb_strip")
-    assert entry is not None
-    name_field = next(ce for ce in entry.config_entries if ce.key == "name")
-    assert name_field.default_value == "RGB LED Strip (addon module)"
-    assert name_field.locked is False
-
-
-async def test_get_component_explicit_field_preset_wins(catalog: ComponentCatalog) -> None:
-    """An explicit ``fields.name`` preset overrides the auto-derived default."""
-    # sonoff-basic.relay sets ``fields.name: Relay`` in the manifest
-    # while the featured display name is ``Onboard Relay`` — the
-    # explicit preset must win.
+    """A featured component's ``fields.name`` preset surfaces as the materialised name default."""
+    # sonoff-basic.relay has ``fields.name: Relay`` in the manifest;
+    # the materialised view exposes that as the underlying switch.gpio
+    # ``name`` config_entry's default.
     entry = await catalog.get_component(component_id="featured.sonoff-basic.relay")
     assert entry is not None
     name_field = next(ce for ce in entry.config_entries if ce.key == "name")
     assert name_field.default_value == "Relay"
-
-
-def test_default_id_from_local_handles_leading_digit() -> None:
-    """Slugified local ids that start with a digit get prefixed with ``_``."""
-    # ESPHome ids become C++ identifiers downstream — a leading digit
-    # produces an invalid build, so the slugifier must guard against
-    # it.
-    assert _default_id_from_local("3v3-rail") == "_3v3_rail"
-    assert _default_id_from_local("4-channel-relay") == "_4_channel_relay"
-    # Non-digit-leading ids stay untouched.
-    assert _default_id_from_local("status-led-output") == "status_led_output"
-    assert _default_id_from_local("button") == "button"
+    assert name_field.locked is False
 
 
 async def test_get_components_featured_only_with_board_id(
@@ -548,11 +517,15 @@ async def test_add_component_featured_resets_dashed_id(
         },
     )
 
-    assert "id: hlw8012" in response.yaml
+    # Auto-id from the manifest's ``fields.name: HLW8012 Power Monitor``;
+    # ``_generate_id`` dedups the leading chip stem so we get
+    # ``hlw8012_power_monitor`` rather than ``hlw8012_hlw8012_power_monitor``.
+    assert "id: hlw8012_power_monitor" in response.yaml
     assert "featured_athom-smart-plug-v3" not in response.yaml
+    assert "name: HLW8012 Power Monitor" in response.yaml
     # Sub-entity autofill rides through the merge step.
     assert "name: Current" in response.yaml
-    assert "id: hlw8012_current" in response.yaml
+    assert "id: hlw8012_power_monitor_current" in response.yaml
 
 
 async def test_add_component_featured_keeps_user_typed_id(
@@ -583,3 +556,54 @@ async def test_add_component_featured_unknown_id_raises(
             component_id="featured.no-such-board.x",
             fields={},
         )
+
+
+async def test_add_component_featured_emits_explicit_name_and_id(
+    catalog: ComponentCatalog, tmp_path: Any
+) -> None:
+    """
+    Regression: featured ``binary_sensor.gpio`` entries emit ``name:`` and ``id:``.
+
+    The Sonoff Basic's "Front-Panel Button" used to emit a YAML block
+    with neither ``name:`` nor ``id:`` — the resulting entity stayed
+    unnamed in Home Assistant. Now the manifest carries explicit
+    ``fields.id`` / ``fields.name`` presets so the YAML always lands
+    with both, no runtime auto-derivation needed.
+    """
+    (tmp_path / "sonoff.yaml").write_text("esphome:\n  name: sonoff\n", "utf-8")
+    ctrl = _make_controller(catalog, tmp_path)
+
+    response = await ctrl.add_component(
+        configuration="sonoff.yaml",
+        component_id="featured.sonoff-basic.button",
+        fields={},
+    )
+
+    assert "binary_sensor:" in response.yaml
+    assert "platform: gpio" in response.yaml
+    assert "name: Front-Panel Button" in response.yaml
+    assert "id: button" in response.yaml
+
+
+async def test_add_component_featured_non_entity_emits_id_only(
+    catalog: ComponentCatalog, tmp_path: Any
+) -> None:
+    """
+    Non-entity featured components (``output:``, ``i2c:``, ...) get only ``id:``.
+
+    Their manifest entries carry ``fields.id`` but no ``fields.name`` —
+    ESPHome's ``output:`` schema doesn't accept a top-level ``name:``,
+    and the manifest is the only source for what fields land in the YAML.
+    """
+    (tmp_path / "sonoff.yaml").write_text("esphome:\n  name: sonoff\n", "utf-8")
+    ctrl = _make_controller(catalog, tmp_path)
+
+    response = await ctrl.add_component(
+        configuration="sonoff.yaml",
+        component_id="featured.sonoff-basic.status_led_output",
+        fields={},
+    )
+
+    assert "output:" in response.yaml
+    assert "id: status_led_output" in response.yaml
+    assert "name:" not in response.yaml.split("output:")[1]

--- a/tests/test_sync_esphome_devices_extract.py
+++ b/tests/test_sync_esphome_devices_extract.py
@@ -1,0 +1,88 @@
+"""Tests for ``_extract_featured_components`` in ``script/sync_esphome_devices.py``.
+
+Focuses on the explicit-fields contract: every emitted featured-component
+entry must carry ``fields.id`` and, for HA entity domains, ``fields.name``
+— so the imported manifests are self-contained and the runtime never
+has to auto-derive these from the local id / display name.
+"""
+
+from __future__ import annotations
+
+from script.sync_esphome_devices import (  # type: ignore[import-not-found]
+    _extract_featured_components,
+)
+
+# Minimal fake components index — only the keys the extractor reads
+# (``config_entries[*].key`` / ``type``). The pin entries make the
+# extractor accept the values as ``locked`` presets.
+_INDEX = {
+    "binary_sensor.gpio": {"config_entries": [{"key": "pin", "type": "pin"}]},
+    "output.gpio": {"config_entries": [{"key": "pin", "type": "pin"}]},
+    "sensor.dht": {
+        "config_entries": [
+            {"key": "pin", "type": "pin"},
+            {"key": "model", "type": "string"},
+        ]
+    },
+}
+
+
+def test_extract_emits_explicit_id_for_every_entry() -> None:
+    """Every featured entry gets ``fields.id`` regardless of platform domain."""
+    inline = {
+        "binary_sensor": [{"platform": "gpio", "pin": 4}],
+        "output": [{"platform": "gpio", "pin": 5}],
+        "sensor": [{"platform": "dht", "pin": 14, "model": "DHT22"}],
+    }
+    featured, _ = _extract_featured_components(inline, _INDEX)
+
+    by_local = {entry["id"]: entry for entry in featured}
+    assert by_local["binary_sensor_gpio_1"]["fields"]["id"] == "binary_sensor_gpio_1"
+    assert by_local["output_gpio_1"]["fields"]["id"] == "output_gpio_1"
+    assert by_local["sensor_dht_1"]["fields"]["id"] == "sensor_dht_1"
+
+
+def test_extract_uses_upstream_name_for_entities() -> None:
+    """Upstream's ``name:`` rides through verbatim for HA entity platforms."""
+    inline = {
+        "binary_sensor": [{"platform": "gpio", "name": "Front Door", "pin": 4}],
+    }
+    featured, _ = _extract_featured_components(inline, _INDEX)
+    assert featured[0]["fields"]["name"] == "Front Door"
+
+
+def test_extract_derives_name_default_when_upstream_omits() -> None:
+    """Entity platforms without an upstream ``name:`` fall back to a derived default."""
+    inline = {
+        "sensor": [{"platform": "dht", "pin": 14, "model": "DHT22"}],
+    }
+    featured, _ = _extract_featured_components(inline, _INDEX)
+    # ``<Platform> <counter>`` — keeps the entity surfaced in HA without
+    # the user having to fill in a name first.
+    assert featured[0]["fields"]["name"] == "Dht 1"
+
+
+def test_extract_skips_name_for_non_entity_platforms() -> None:
+    """Non-entity platforms (``output:``) get only ``id``, never ``name``."""
+    inline = {
+        "output": [{"platform": "gpio", "name": "ignored upstream", "pin": 5}],
+    }
+    featured, _ = _extract_featured_components(inline, _INDEX)
+    fields = featured[0]["fields"]
+    assert "id" in fields
+    assert "name" not in fields
+
+
+def test_extract_counter_distinguishes_multiple_instances() -> None:
+    """Two binary_sensor.gpio entries on the same page get distinct ids + name suffixes."""
+    inline = {
+        "binary_sensor": [
+            {"platform": "gpio", "pin": 4},
+            {"platform": "gpio", "pin": 5},
+        ],
+    }
+    featured, _ = _extract_featured_components(inline, _INDEX)
+    ids = [f["fields"]["id"] for f in featured]
+    names = [f["fields"]["name"] for f in featured]
+    assert ids == ["binary_sensor_gpio_1", "binary_sensor_gpio_2"]
+    assert names == ["Gpio 1", "Gpio 2"]

--- a/tests/test_sync_esphome_devices_extract.py
+++ b/tests/test_sync_esphome_devices_extract.py
@@ -1,4 +1,5 @@
-"""Tests for ``_extract_featured_components`` in ``script/sync_esphome_devices.py``.
+"""
+Tests for ``_extract_featured_components`` in ``script/sync_esphome_devices.py``.
 
 Focuses on the explicit-fields contract: every emitted featured-component
 entry must carry ``fields.id`` and, for HA entity domains, ``fields.name``


### PR DESCRIPTION
testing the sonoff basic featured "Front-Panel Button" produced a YAML block with neither `name:` nor `id:` — the entity stayed unnamed in home assistant. same gap on every featured `binary_sensor.gpio` and a chunk of `sensor.*` whose `components.json` is missing the entity-base `name` field.

definitions are the source of truth, so make them explicit instead of papering over the gap with runtime auto-derivation.

## changes

- **manifests** — every `featured_components` entry in `sonoff-basic`, `athom-smart-plug-v3`, `apollo-esk-1` now carries `fields.id` (and `fields.name` for HA entity platforms — `output:` / `i2c:` / `rtttl:` correctly skip name since their schemas don't accept it)
- **`script/sync_esphome_devices.py`** — imports from devices.esphome.io now emit the same explicit fields. upstream's `name:` is preferred when set; otherwise a derived default (`<Platform> <N>`) is injected
- **`controllers/components.py`** — drop the `_default_id_from_local` slugifier and `_featured_field_presets` auto-derivation. manifests carry the truth, runtime just passes it through
- **`script/validate_definitions.py`** — allow `name` / `id` past the unknown-field gate (entity-base universals that the schema sync misses for some platforms)
- **`helpers/yaml.py`** — dedup `_generate_id` so a name leading with the chip stem produces `hlw8012_power_monitor` rather than `hlw8012_hlw8012_power_monitor`
- new sync-script test covers the explicit-fields contract; existing featured-component tests updated to read from `fields.id` / `fields.name` rather than the removed auto-derivation