### PR TITLE
Surface config-entry totals in catalog sync diff summary

### DIFF
--- a/.github/workflows/sync-component-catalog.yml
+++ b/.github/workflows/sync-component-catalog.yml
@@ -155,11 +155,19 @@ jobs:
           old_types = count_types(old_components)
           new_types = count_types(new_components)
           all_types = sorted(set(old_types) | set(new_types))
+          old_total = sum(old_types.values())
+          new_total = sum(new_types.values())
 
+          # Headline includes the config-entry total so a refresh that
+          # leaves the component count stable but adds thousands of
+          # nested fields (e.g. a more complete MQTT_COMPONENT_SCHEMA
+          # bundle landing upstream) doesn't read as "no change".
           lines = [
               f"**Schema version**: `{new_data.get('esphome_schema_version', '?')}`  ",
               f"**Components**: {len(old_components)} → {len(new_components)} "
               f"({len(new_components) - len(old_components):+d})  ",
+              f"**Config entries**: {old_total} → {new_total} "
+              f"({new_total - old_total:+d})  ",
               f"**Added**: {len(added)} · **Removed**: {len(removed)}",
               "",
           ]


### PR DESCRIPTION
PR [#185](https://github.com/esphome/device-builder/pull/185) is a catalog refresh
where the component count is unchanged (898 → 898) but ~22 000 nested config
entries got added — mostly the MQTT-entity field block (`availability`,
`discovery`, `qos`, `retain`, `state_topic`, …) being filled in for every entity
component. The auto-generated PR body's headline reads `Components: 898 → 898
(+0), Added: 0, Removed: 0`, which makes a 145k-line diff look like a no-op until
you expand the `<details>` block with the type-distribution table.

Adding a `Config entries` total to the headline so the next reviewer doesn't
have to do a double-take.

## Changes

- compute `old_total` / `new_total` from the existing per-type counters
- append a `**Config entries**: X → Y (+Δ)` line to the PR body headline
- short comment on why the line exists (so a future cleanup doesn't strip it)