### PR TITLE
CI: run pytest under xdist (-n auto) and switch to uv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,16 +39,27 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
-          cache: pip
+
+      - name: Set up uv
+        # uv replaces pip for the install step (an order of
+        # magnitude faster on cold boots, with its own wheel cache).
+        # ``actions/setup-python`` provides the interpreter — its
+        # Python isn't marked externally-managed, so ``uv pip
+        # install --system`` works on macos / windows runners that
+        # would otherwise refuse a brew-shipped Python under PEP 668.
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
 
       - name: Install package + dev tools
-        run: |
-          python -m pip install --upgrade pip
-          # ``[esphome]`` is needed so the catalog smoke test below
-          # can construct a ``ComponentCatalog`` against the same
-          # esphome version the dashboard ships with.
-          pip install -e '.[esphome]'
-          pip install -e '.[test]'
+        # ``[esphome]`` is needed so the catalog smoke test below
+        # can construct a ``ComponentCatalog`` against the same
+        # esphome version the dashboard ships with. ``--system``
+        # installs into the runner's Python instead of a venv —
+        # matches the existing pip-based CI shape so subsequent
+        # ``pre-commit`` / ``python script/...`` steps keep working
+        # without a ``uv run`` prefix.
+        run: uv pip install --system -e '.[esphome,test]'
 
       - name: Run pre-commit (ruff lint + format, codespell, yaml/json checks)
         # ``no-commit-to-branch`` is a local-only guard; CI runs on
@@ -91,23 +102,29 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
 
       - name: Install package + test deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e '.[esphome]'
-          pip install -e '.[test]'
+        run: uv pip install --system -e '.[esphome,test]'
 
       - name: Run pytest
         # Single-line command — Windows runners default to PowerShell,
         # which doesn't accept bash-style ``\`` line continuation.
+        # ``-n auto`` runs the suite under pytest-xdist with one
+        # worker per logical CPU; pytest-cov auto-merges the
+        # per-worker ``.coverage`` files at the end so the xml
+        # report still reflects the whole suite. Mirrors the
+        # upstream esphome workflow's ``-n auto`` invocation.
         # ``--maxfail=5`` keeps CI snappy when something fundamental
         # is broken; ``-q`` keeps the log readable without ``-vv``.
         # The ``benchmarks/`` subtree is excluded — it's CodSpeed-driven,
         # runs in a separate job, and its assertions only check chunk
         # counts (not behaviour).
-        run: pytest -q --maxfail=5 --durations=10 --ignore=tests/benchmarks --cov=esphome_device_builder --cov-report=xml --cov-report=term
+        run: pytest -q -n auto --maxfail=5 --durations=10 --ignore=tests/benchmarks --cov=esphome_device_builder --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
@@ -133,16 +150,17 @@ jobs:
       matrix:
         include:
           - channel: beta
-            # ``--pre`` opts into pre-release versions; ``--upgrade``
-            # makes pip pick the highest one even if a stable is also
-            # installed transitively.
-            install: pip install --upgrade --pre esphome
+            # ``--prerelease=allow`` opts into pre-release versions
+            # (uv's flag — pip's ``--pre`` doesn't apply here).
+            # ``--upgrade`` makes uv pick the highest one even if a
+            # stable is already installed transitively.
+            install: uv pip install --system --upgrade --prerelease=allow esphome
             allow_failure: false
           - channel: dev
             # The ``dev`` branch is ESPHome's nightly working copy;
             # it can break at any time and we want the signal but
             # not the gate.
-            install: pip install --upgrade git+https://github.com/esphome/esphome.git@dev
+            install: uv pip install --system --upgrade git+https://github.com/esphome/esphome.git@dev
             allow_failure: true
     # Job-level ``continue-on-error`` decides whether a failure of
     # this matrix entry fails the whole workflow. ``dev`` opts into
@@ -158,13 +176,14 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.14"
-          cache: pip
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
 
       - name: Install package + test deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e '.[esphome]'
-          pip install -e '.[test]'
+        run: uv pip install --system -e '.[esphome,test]'
 
       - name: Install esphome (${{ matrix.channel }} channel)
         run: ${{ matrix.install }}
@@ -172,13 +191,15 @@ jobs:
       - name: Show installed esphome version
         # Logs the resolved version so a failure tied to a specific
         # release is greppable in the workflow log without re-running.
-        run: pip show esphome | grep -E '^(Name|Version):'
+        run: uv pip show --system esphome | grep -E '^(Name|Version):'
 
       - name: Run pytest
-        # No ``--cov`` here — the merged coverage report comes from
-        # the OS-axis ``test`` job; this run is purely a "does the
-        # suite still pass against upstream X" probe.
-        run: pytest -q --maxfail=5 --durations=10 --ignore=tests/benchmarks
+        # ``-n auto`` runs under pytest-xdist for the same speedup
+        # the OS-axis matrix gets. No ``--cov`` here — the merged
+        # coverage report comes from the OS-axis ``test`` job; this
+        # run is purely a "does the suite still pass against
+        # upstream X" probe.
+        run: pytest -q -n auto --maxfail=5 --durations=10 --ignore=tests/benchmarks
 
   benchmarks:
     name: Run benchmarks (CodSpeed)
@@ -197,13 +218,14 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
-          cache: pip
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
 
       - name: Install package + test deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e '.[esphome]'
-          pip install -e '.[test]'
+        run: uv pip install --system -e '.[esphome,test]'
 
       - name: Run benchmarks
         # ``simulation`` is the new name for what used to be called

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
   "pytest-aiohttp==1.1.0",
   "pytest-codspeed==4.5.0",
   "pytest-cov==7.1.0",
+  "pytest-xdist==3.8.0",
   "ruff==0.15.12",
 ]
 


### PR DESCRIPTION
## Summary

Two CI speedups that reinforce each other.

### pytest-xdist
- Adds ``pytest-xdist==3.8.0`` to the ``test`` extra (matches the version upstream esphome pins).
- All four jobs (``lint``, ``test``, ``test-esphome-channels``, ``benchmarks``) run pytest with ``-n auto``.
- Local timing on the current 1030-test suite: ~13s → ~8s; CI runners have more cores and see a larger gain.
- ``pytest-cov`` auto-merges per-worker ``.coverage`` files, so the xml report uploaded to Codecov still reflects the whole suite.
- Mirrors the upstream esphome workflow's ``-n auto`` invocation.
- The channels matrix that landed via #184 was running serially (~1m 8s on beta); xdist trims that significantly without changing semantics.

### uv
- Switches every job from ``actions/setup-python`` + manual ``pip install`` to ``astral-sh/setup-uv`` + ``uv pip install --system``.
- ``uv`` is an order of magnitude faster than pip on cold boots and handles its own caching of resolved wheels.
- Local tooling already uses ``uv``; CI was the last pip holdout.
- Setup shape: ``actions/setup-python`` still provides the interpreter (its standalone build isn't marked externally-managed under PEP 668, so ``uv pip install --system`` works on macos / windows runners that would otherwise reject a brew-shipped Python), ``astral-sh/setup-uv`` installs uv with its wheel cache, and ``uv pip install --system`` does the install. The ``--system`` flag keeps everything in the runner's interpreter so later ``pre-commit`` / ``python script/...`` / ``pytest`` steps don't need a ``uv run`` prefix.
- Channels matrix uses ``--prerelease=allow`` instead of pip's ``--pre`` for the beta channel (uv's flag for opting into pre-release versions).

## Test plan

- [x] ``uv run pytest -n auto -q --ignore=tests/benchmarks`` — 1025 passed, 5 skipped in 8.14s
- [x] ``pre-commit run`` clean on the workflow + pyproject changes
- [ ] First push to PR shows lint / test / channels / benchmark jobs all green and notably faster than baseline