### PR TITLE
Cover _manual_rename end-to-end through devices/rename

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -435,13 +435,17 @@ class DevicesController:
         # blindly ``write_text``s the new YAML and then OTA-installs
         # it, so a collision would silently overwrite the unrelated
         # device's config and flash that firmware to the wrong device.
+        # ``rel_path`` resolves the filename and ``.exists()`` is an
+        # ``os.stat`` — both blocking syscalls. Push the pair to the
+        # executor so the dashboard's request-path stays
+        # event-loop-friendly on slow / network-mounted config dirs.
+        loop = asyncio.get_running_loop()
         new_path = self._db.settings.rel_path(new_filename)
-        if new_path.exists():
+        if await loop.run_in_executor(None, new_path.exists):
             msg = f"A device named {new_filename} already exists"
             raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         if not await self._yaml_validates(config_path):
-            loop = asyncio.get_running_loop()
             try:
                 await loop.run_in_executor(None, self._manual_rename, configuration, new_name)
             except FileExistsError as exc:

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -1,0 +1,197 @@
+"""Shared fixtures for ``tests/controllers/devices/``.
+
+The seed-a-real-device-on-disk shape (YAML + StorageJSON sidecar +
+``.device-builder.json`` entry) was duplicated across ``test_archive.py``
+and ``test_rename_inline_e2e.py`` and is the natural home for the
+next handful of e2e tests that walk the file-ops layer. Centralising
+keeps the YAML / StorageJSON shape one place to audit when ESPHome
+adds fields to the upstream ``StorageJSON`` schema.
+
+The sync ``set_device_metadata`` write goes through
+``metadata_transaction`` which calls ``tempfile.mkstemp`` — that
+trips ``blockbuster`` from an async test context. The fixture
+wraps it in ``asyncio.to_thread`` so callers don't have to remember.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Protocol
+
+import pytest
+
+from esphome_device_builder.controllers.config import set_device_metadata
+
+
+class SeedDeviceFactory(Protocol):
+    """Shape of the ``seed_device`` fixture's return value."""
+
+    async def __call__(
+        self,
+        config_dir: Path,
+        configuration: str,
+        *,
+        friendly_name: str | None = ...,
+        storage_friendly: str | None = ...,
+        board_id: str = ...,
+        loaded_integrations: list[str] | None = ...,
+        with_build_dir: bool = ...,
+        address: str | None = ...,
+        write_metadata: bool = ...,
+    ) -> tuple[Path, Path]: ...
+
+
+@pytest.fixture
+def seed_device() -> SeedDeviceFactory:
+    """Return a coroutine that seeds a fully-populated device on disk.
+
+    Drops three artefacts mirroring what a real ``devices/create``
+    + first compile would produce:
+
+    - ``<config_dir>/<configuration>`` — a minimal but valid
+      ESPHome YAML with ``esphome.name`` matching the filename
+      stem and a configurable ``friendly_name``.
+    - ``<config_dir>/.esphome/storage/<configuration>.json`` —
+      a full ``StorageJSON`` sidecar shaped like what ``esphome
+      compile --only-generate`` writes (every field the dashboard
+      reads from is present).
+    - ``<config_dir>/.device-builder.json`` — a sidecar metadata
+      entry with ``board_id`` + ``friendly_name`` so tests that
+      exercise the metadata-move branch (rename) or the
+      identity-keep branch (archive) have something to assert.
+
+    ``storage_friendly`` lets a caller pin the StorageJSON's
+    ``friendly_name`` to a value distinct from the YAML stem so
+    rename tests can verify the "friendly_name == old_name →
+    rewrite" conditional branches the helpers under test.
+
+    Async because the sidecar write goes through
+    ``metadata_transaction`` (which calls ``tempfile.mkstemp``);
+    blockbuster on the CI Linux runners flags the underlying
+    ``os.path.abspath`` from a synchronous async-test context.
+    Pushing the write to a thread keeps the seed call cheap to
+    use from any ``@pytest.mark.asyncio`` test.
+    """
+
+    async def _seed(
+        config_dir: Path,
+        configuration: str,
+        *,
+        friendly_name: str | None = None,
+        storage_friendly: str | None = None,
+        board_id: str = "generic-esp32c3",
+        loaded_integrations: list[str] | None = None,
+        with_build_dir: bool = False,
+        address: str | None = None,
+        write_metadata: bool = True,
+    ) -> tuple[Path, Path]:
+        name = configuration.removesuffix(".yaml").removesuffix(".yml")
+        yaml_path = config_dir / configuration
+        yaml_text = (
+            "esphome:\n"
+            f"  name: {name}\n"
+            f'  friendly_name: "{friendly_name or name.title()}"\n'
+            "  platform: ESP32\n"
+            "  board: esp32-c3-devkitm-1\n"
+        )
+        yaml_path.write_text(yaml_text, encoding="utf-8")
+
+        # Build dir is opt-in — only delete / archive flows actually
+        # care about its presence. Default off keeps the seed call
+        # cheap for tests that just need YAML + storage + sidecar.
+        build_path = config_dir / ".esphome" / "build" / name
+        if with_build_dir:
+            build_path.mkdir(parents=True, exist_ok=True)
+            (build_path / "firmware.bin").write_bytes(b"\x00" * 16)
+            (build_path / "src").mkdir()
+            (build_path / "src" / "main.cpp").write_text("// fake\n", encoding="utf-8")
+
+        storage_dir = config_dir / ".esphome" / "storage"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        (storage_dir / f"{configuration}.json").write_text(
+            json.dumps(
+                {
+                    "storage_version": 1,
+                    "name": name,
+                    "friendly_name": (storage_friendly if storage_friendly is not None else name),
+                    "comment": None,
+                    "esphome_version": "2026.5.0-dev",
+                    "src_version": 1,
+                    "address": address if address is not None else f"{name}.local",
+                    "web_port": None,
+                    "esp_platform": "esp32",
+                    "board": "esp32-c3-devkitm-1",
+                    "build_path": str(build_path),
+                    "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
+                    "loaded_integrations": loaded_integrations
+                    if loaded_integrations is not None
+                    else ["api"],
+                    "loaded_platforms": ["esp32"],
+                    "no_mdns": False,
+                    "framework": "esp-idf",
+                    "core_platform": "esp32",
+                    "target_platform": "esp32",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # ``metadata_transaction`` reaches into ``tempfile.mkstemp``
+        # which is sync; push it to a thread so blockbuster doesn't
+        # fault on the ``os.path.abspath`` from inside an async test.
+        # Skip when the caller wants a bare seed (``write_metadata=False``)
+        # — useful for tests that exercise "no identity fields ever
+        # set" branches and need an empty ``.device-builder.json``.
+        if write_metadata:
+            await asyncio.to_thread(
+                set_device_metadata,
+                config_dir,
+                configuration,
+                board_id=board_id,
+                friendly_name=friendly_name or name,
+            )
+        return yaml_path, build_path
+
+    return _seed
+
+
+@pytest.fixture
+def redirect_storage_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point ``ext_storage_path`` at ``tmp_path/.esphome/storage/``.
+
+    The real helper walks ``CORE.config_path`` which isn't set in
+    isolated tests; redirecting keeps the file ops on disk under
+    the test's tmp dir without spinning up a CORE. Used by tests
+    that exercise the StorageJSON-move helpers (rename, archive).
+    """
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def _ext(configuration: str) -> Path:
+        return storage_dir / f"{configuration}.json"
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.ext_storage_path",
+        _ext,
+    )
+    # ``_archive_single`` lives in ``controller.py`` but delegates to
+    # ``_wipe_device_build_dir`` and ``_remove_device_sidecars`` over
+    # in ``helpers.py``. Both files import ``ext_storage_path``
+    # independently; rebinding only one leaves the other path running
+    # against the real CORE.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.helpers.ext_storage_path",
+        _ext,
+    )
+
+    # ``StorageJSON.save`` itself uses the upstream ``ext_storage_path``
+    # if a caller passes the configuration name without a path; for
+    # safety, also patch that lookup so any indirect caller stays
+    # under ``tmp_path``.
+    monkeypatch.setattr(
+        "esphome.storage_json.ext_storage_path",
+        _ext,
+        raising=False,
+    )

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -41,6 +41,8 @@ from esphome_device_builder.controllers.devices.helpers import (
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
+from .conftest import SeedDeviceFactory
+
 
 def _make_controller(config_dir: Path) -> DevicesController:
     """Build a bare-bones controller wired to *config_dir* on disk.
@@ -58,80 +60,19 @@ def _make_controller(config_dir: Path) -> DevicesController:
     return controller
 
 
-def _seed_device(
-    config_dir: Path, configuration: str, *, with_build_dir: bool = True
-) -> tuple[Path, Path]:
-    """Lay out a YAML, StorageJSON sidecar, and (optionally) the build tree.
-
-    Same shape as the delete-test helper. Returns ``(yaml_path,
-    build_path)`` so tests can assert what survives / disappears.
-    """
-    yaml_path = config_dir / configuration
-    name = Path(configuration).stem
-    yaml_path.write_text(
-        f"esphome:\n  name: {name}\n  friendly_name: {name.title()}\n",
-        encoding="utf-8",
-    )
-
-    build_path = config_dir / ".esphome" / "build" / name
-    if with_build_dir:
-        build_path.mkdir(parents=True, exist_ok=True)
-        (build_path / "firmware.bin").write_bytes(b"\x00" * 16)
-        (build_path / "src").mkdir()
-        (build_path / "src" / "main.cpp").write_text("// fake\n", encoding="utf-8")
-
-    storage_dir = config_dir / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-    (storage_dir / f"{configuration}.json").write_text(
-        json.dumps(
-            {
-                "storage_version": 1,
-                "name": name,
-                "comment": None,
-                "esphome_version": "2026.5.0-dev",
-                "src_version": 1,
-                "address": "",
-                "web_port": None,
-                "esp_platform": "esp32",
-                "board": "esp32-c3-devkitm-1",
-                "build_path": str(build_path),
-                "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
-                "loaded_integrations": [],
-                "loaded_platforms": [],
-                "no_mdns": False,
-                "framework": "esp-idf",
-                "core_platform": "esp32",
-            }
-        ),
-        encoding="utf-8",
-    )
-    return yaml_path, build_path
-
-
 @pytest.fixture(autouse=True)
-def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
-    """Pin ``ext_storage_path`` to the tmp config dir.
+def _ext_storage_for_archive(redirect_storage_path: None) -> None:
+    """Re-export ``redirect_storage_path`` as autouse for the archive tests.
 
-    The real ``ext_storage_path`` walks ``CORE.config_path`` which
-    isn't set in the test process; this redirect points it at the
-    on-disk sidecar laid down by ``_seed_device`` so the archive
-    path reads the canonical ``build_path`` from there.
-
-    Autouse because both ``_archive_single`` and ``_list_archived_sync``
-    reach into ``ext_storage_path`` — keeping the redirect in one
-    place avoids future tests accidentally hitting the real CORE.
-
-    Patches both the controller and helpers modules: ``_archive_single``
-    sits in ``controller.py`` but it delegates to ``_wipe_device_build_dir``
-    and ``_remove_device_sidecars`` over in ``helpers.py``. Both files
-    import ``ext_storage_path`` independently; rebinding only one
-    leaves the other path running against the real CORE.
+    Every test in this file exercises a code path that reads
+    ``ext_storage_path`` (``_archive_single`` /
+    ``_list_archived_sync`` / ``_wipe_device_build_dir``).
+    Pulling the conftest fixture in via an autouse wrapper means
+    new tests in this file inherit the redirect automatically —
+    a net-new test that forgot to request it would otherwise
+    silently hit the real ``CORE.config_path`` (which is unset in
+    the test process and crashes deep in ``ext_storage_path``).
     """
-    fake = lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json"  # noqa: E731
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.ext_storage_path", fake
-    )
-    monkeypatch.setattr("esphome_device_builder.controllers.devices.helpers.ext_storage_path", fake)
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +81,9 @@ def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_archive_moves_yaml_to_archive_dir(tmp_path: Path) -> None:
+async def test_archive_moves_yaml_to_archive_dir(
+    tmp_path: Path, seed_device: SeedDeviceFactory
+) -> None:
     """The YAML lands in ``<config_dir>/archive/<configuration>``.
 
     The whole point of archive vs delete: the YAML is reversible.
@@ -150,7 +93,7 @@ async def test_archive_moves_yaml_to_archive_dir(tmp_path: Path) -> None:
     finding their old configs in an unfamiliar place.
     """
     controller = _make_controller(tmp_path)
-    yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml")
+    yaml_path, _ = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     original_text = yaml_path.read_text()
 
     await controller._archive_single("kitchen.yaml")
@@ -162,7 +105,9 @@ async def test_archive_moves_yaml_to_archive_dir(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_archive_wipes_build_directory(tmp_path: Path) -> None:
+async def test_archive_wipes_build_directory(
+    tmp_path: Path, seed_device: SeedDeviceFactory
+) -> None:
     """An archived device's compile output is dead weight — wipe it.
 
     Same shape as ``_delete_single``: read ``StorageJSON.build_path``
@@ -172,7 +117,7 @@ async def test_archive_wipes_build_directory(tmp_path: Path) -> None:
     would still complain about disk usage on long-running fleets.
     """
     controller = _make_controller(tmp_path)
-    _, build_path = _seed_device(tmp_path, "kitchen.yaml")
+    _, build_path = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     assert build_path.exists()
 
     await controller._archive_single("kitchen.yaml")
@@ -181,7 +126,9 @@ async def test_archive_wipes_build_directory(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_archive_wipes_storage_sidecar(tmp_path: Path) -> None:
+async def test_archive_wipes_storage_sidecar(
+    tmp_path: Path, seed_device: SeedDeviceFactory
+) -> None:
     """The StorageJSON sidecar is removed when archiving.
 
     Per-filename keying means a sidecar that survives archive
@@ -192,7 +139,7 @@ async def test_archive_wipes_storage_sidecar(tmp_path: Path) -> None:
     is back online (only a few seconds of "unknown state").
     """
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml")
+    await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     storage_path = tmp_path / ".esphome" / "storage" / "kitchen.yaml.json"
     assert storage_path.exists()
 
@@ -202,7 +149,9 @@ async def test_archive_wipes_storage_sidecar(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_archive_clears_volatile_metadata_keeps_identity(tmp_path: Path) -> None:
+async def test_archive_clears_volatile_metadata_keeps_identity(
+    tmp_path: Path, seed_device: SeedDeviceFactory
+) -> None:
     """Archive scrubs runtime state but keeps stable identity fields.
 
     Volatile fields (``ip``, ``expected_config_hash``) describe
@@ -215,7 +164,7 @@ async def test_archive_clears_volatile_metadata_keeps_identity(tmp_path: Path) -
     re-derive on unarchive.
     """
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml")
+    await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     # ``set_device_metadata`` writes through ``metadata_transaction``
     # which calls ``tempfile.mkstemp`` for an atomic replace —
     # blockbuster (the CI's blocking-call detector) flags the
@@ -251,7 +200,9 @@ async def test_archive_clears_volatile_metadata_keeps_identity(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_archive_drops_metadata_entry_when_only_volatile_fields(tmp_path: Path) -> None:
+async def test_archive_drops_metadata_entry_when_only_volatile_fields(
+    tmp_path: Path, seed_device: SeedDeviceFactory
+) -> None:
     """An entry with only volatile fields is removed entirely on archive.
 
     Edge case: if a device has metadata that consists *only* of
@@ -261,7 +212,11 @@ async def test_archive_drops_metadata_entry_when_only_volatile_fields(tmp_path: 
     file doesn't accumulate dead keys.
     """
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml")
+    # ``write_metadata=False`` so the starting state has no
+    # identity fields — the only metadata is the volatile ones we
+    # add below, which is the exact precondition this branch
+    # exercises.
+    await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True, write_metadata=False)
     await asyncio.to_thread(
         set_device_metadata,
         tmp_path,
@@ -279,7 +234,9 @@ async def test_archive_drops_metadata_entry_when_only_volatile_fields(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_archive_succeeds_when_never_compiled(tmp_path: Path) -> None:
+async def test_archive_succeeds_when_never_compiled(
+    tmp_path: Path, seed_device: SeedDeviceFactory
+) -> None:
     """A device that was never compiled has no build dir — archive still works.
 
     First-archive happy path is "user just made a YAML, decided
@@ -287,7 +244,7 @@ async def test_archive_succeeds_when_never_compiled(tmp_path: Path) -> None:
     the move-to-archive must still succeed without raising.
     """
     controller = _make_controller(tmp_path)
-    yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml", with_build_dir=False)
+    yaml_path, _ = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=False)
     # Wipe the StorageJSON sidecar to simulate "never compiled".
     (tmp_path / ".esphome" / "storage" / "kitchen.yaml.json").unlink()
 
@@ -298,7 +255,9 @@ async def test_archive_succeeds_when_never_compiled(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_archive_collision_raises_invalid_args(tmp_path: Path) -> None:
+async def test_archive_collision_raises_invalid_args(
+    tmp_path: Path, seed_device: SeedDeviceFactory
+) -> None:
     """Archiving twice with the same name refuses rather than silently renaming.
 
     The StorageJSON sidecar and metadata are keyed on the original
@@ -313,13 +272,13 @@ async def test_archive_collision_raises_invalid_args(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
 
     # First archive lands at the plain name.
-    _seed_device(tmp_path, "kitchen.yaml")
+    await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     (tmp_path / "kitchen.yaml").write_text("first version\n", encoding="utf-8")
     await controller._archive_single("kitchen.yaml")
     assert (tmp_path / "archive" / "kitchen.yaml").read_text() == "first version\n"
 
     # Recreate + archive again — must refuse rather than clobber or rename.
-    _seed_device(tmp_path, "kitchen.yaml")
+    await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     (tmp_path / "kitchen.yaml").write_text("second version\n", encoding="utf-8")
     with pytest.raises(CommandError) as exc:
         await controller._archive_single("kitchen.yaml")
@@ -345,7 +304,9 @@ async def test_archive_missing_file_raises_file_not_found(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_archive_device_full_flow_calls_scanner(tmp_path: Path) -> None:
+async def test_archive_device_full_flow_calls_scanner(
+    tmp_path: Path, seed_device: SeedDeviceFactory
+) -> None:
     """End-to-end ``archive_device`` runs the helper and re-scans.
 
     Covers the public-command success path that helper-level tests
@@ -354,7 +315,7 @@ async def test_archive_device_full_flow_calls_scanner(tmp_path: Path) -> None:
     ``DEVICE_REMOVED`` event for the dashboard.
     """
     controller = _make_controller(tmp_path)
-    yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml")
+    yaml_path, _ = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
 
     await controller.archive_device(configuration="kitchen.yaml")
 
@@ -548,8 +509,9 @@ def test_remove_device_sidecars_logs_oserror_on_storage_unlink(
     on the StorageJSON sidecar shouldn't block the rest of the
     archive / delete flow.
     """
+    # ``redirect_storage_path`` (autouse via ``_ext_storage_for_archive``)
+    # already created ``.esphome/storage`` — just lay the JSON.
     storage_dir = tmp_path / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True)
     (storage_dir / "kitchen.yaml.json").write_text("{}", encoding="utf-8")
 
     def _raise_oserror(self: Path, missing_ok: bool = False) -> None:
@@ -587,8 +549,9 @@ def test_archive_clear_device_sidecars_logs_oserror_on_storage_unlink(
     after the storage unlink fails — a permission error on one
     file mustn't block the volatile-fields wipe on the other.
     """
+    # ``redirect_storage_path`` (autouse via ``_ext_storage_for_archive``)
+    # already created ``.esphome/storage`` — just lay the JSON.
     storage_dir = tmp_path / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True)
     (storage_dir / "kitchen.yaml.json").write_text("{}", encoding="utf-8")
 
     def _raise_oserror(self: Path, missing_ok: bool = False) -> None:

--- a/tests/controllers/devices/test_rename_inline_e2e.py
+++ b/tests/controllers/devices/test_rename_inline_e2e.py
@@ -358,10 +358,10 @@ async def test_manual_rename_moves_sidecar_metadata(
     )
 
     # Old entry gone.
-    assert get_device_metadata(tmp_path, "kitchen.yaml") == {}
+    assert await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml") == {}
     # New entry carries the same board_id and the rewritten
     # friendly_name (since it equalled the old name).
-    new_meta = get_device_metadata(tmp_path, "livingroom.yaml")
+    new_meta = await asyncio.to_thread(get_device_metadata, tmp_path, "livingroom.yaml")
     assert new_meta != {}
     assert new_meta["board_id"] == "generic-esp32c3"
     assert new_meta["friendly_name"] == "livingroom"
@@ -387,7 +387,7 @@ async def test_manual_rename_keeps_unrelated_metadata_friendly_name(
         controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
     )
 
-    new_meta = get_device_metadata(tmp_path, "livingroom.yaml")
+    new_meta = await asyncio.to_thread(get_device_metadata, tmp_path, "livingroom.yaml")
     assert new_meta != {}
     assert new_meta["friendly_name"] == "My Kitchen Sensor"
 
@@ -496,7 +496,7 @@ async def test_manual_rename_full_round_trip(
     assert storage["name"] == "livingroom"
     assert storage["address"] == "livingroom.local"
     # Sidecar metadata moved.
-    assert get_device_metadata(tmp_path, "kitchen.yaml") == {}
-    assert get_device_metadata(tmp_path, "livingroom.yaml") != {}
+    assert await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml") == {}
+    assert await asyncio.to_thread(get_device_metadata, tmp_path, "livingroom.yaml") != {}
     # Scanner kicked.
     controller._scanner.scan.assert_awaited_once()

--- a/tests/controllers/devices/test_rename_inline_e2e.py
+++ b/tests/controllers/devices/test_rename_inline_e2e.py
@@ -26,32 +26,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.config import (
-    get_device_metadata,
-    set_device_metadata,
-)
+from esphome_device_builder.controllers.config import get_device_metadata
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
-
-def _redirect_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Point ``ext_storage_path`` at ``tmp_path/.esphome/storage/``.
-
-    The real helper walks ``CORE.config_path`` which isn't set in
-    isolated tests; redirecting keeps the file ops on disk under
-    the test's tmp dir without spinning up a CORE.
-    """
-    storage_dir = tmp_path / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-
-    def _ext(configuration: str) -> Path:
-        return storage_dir / f"{configuration}.json"
-
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.ext_storage_path",
-        _ext,
-    )
+from .conftest import SeedDeviceFactory
 
 
 def _make_controller(tmp_path: Path) -> DevicesController:
@@ -73,72 +53,6 @@ def _make_controller(tmp_path: Path) -> DevicesController:
     controller._scanner.scan = AsyncMock()
     controller._esphome_cmd = ["esphome"]
     return controller
-
-
-def _seed_device(
-    config_dir: Path,
-    configuration: str,
-    *,
-    friendly_name: str | None = None,
-    storage_friendly: str | None = None,
-) -> None:
-    """Lay down a YAML, StorageJSON sidecar, and ``.device-builder.json`` entry.
-
-    ``configuration`` is the YAML filename (e.g. ``kitchen.yaml``).
-    ``storage_friendly`` defaults to the YAML stem so the test
-    can verify the "friendly_name == old_name → also rewrite" branch
-    in ``_manual_rename``; pass an unrelated string to verify that
-    branch *doesn't* fire (friendly_name stays put).
-    """
-    name = configuration.removesuffix(".yaml")
-    yaml_text = (
-        "esphome:\n"
-        f"  name: {name}\n"
-        f'  friendly_name: "{friendly_name or name.title()}"\n'
-        "  platform: ESP32\n"
-        "  board: esp32-c3-devkitm-1\n"
-    )
-    (config_dir / configuration).write_text(yaml_text, encoding="utf-8")
-
-    storage_dir = config_dir / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-    (storage_dir / f"{configuration}.json").write_text(
-        json.dumps(
-            {
-                "storage_version": 1,
-                "name": name,
-                "friendly_name": (storage_friendly if storage_friendly is not None else name),
-                "comment": None,
-                "esphome_version": "2026.5.0-dev",
-                "src_version": 1,
-                "address": f"{name}.local",
-                "web_port": None,
-                "esp_platform": "esp32",
-                "board": "esp32-c3-devkitm-1",
-                "build_path": str(config_dir / ".esphome" / "build" / name),
-                "firmware_bin_path": str(
-                    config_dir / ".esphome" / "build" / name / ".pioenvs" / "firmware.bin"
-                ),
-                "loaded_integrations": ["api"],
-                "loaded_platforms": ["esp32"],
-                "no_mdns": False,
-                "framework": "esp-idf",
-                "core_platform": "esp32",
-                "target_platform": "esp32",
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    # Sidecar metadata — exercise both ``board_id`` and
-    # ``friendly_name`` fields so the move-and-rename branches
-    # are observable.
-    set_device_metadata(
-        config_dir,
-        configuration,
-        board_id="generic-esp32c3",
-        friendly_name=friendly_name or name,
-    )
 
 
 async def _route_through_manual(
@@ -170,12 +84,14 @@ async def _route_through_manual(
 
 @pytest.mark.asyncio
 async def test_manual_rename_writes_new_yaml_with_rewritten_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """``esphome.name`` inside the YAML is rewritten and the file is moved."""
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml")
+    await seed_device(tmp_path, "kitchen.yaml")
 
     result = await _route_through_manual(
         controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
@@ -193,7 +109,10 @@ async def test_manual_rename_writes_new_yaml_with_rewritten_name(
 
 @pytest.mark.asyncio
 async def test_manual_rename_preserves_unrelated_yaml_content(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """Only ``esphome.name`` is touched — substitutions, packages, comments stay.
 
@@ -203,7 +122,6 @@ async def test_manual_rename_preserves_unrelated_yaml_content(
     block; this test pins that scoping end-to-end so a refactor
     that loosened the rewrite would surface.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
     yaml_text = (
         "esphome:\n"
@@ -243,7 +161,10 @@ async def test_manual_rename_preserves_unrelated_yaml_content(
 
 @pytest.mark.asyncio
 async def test_manual_rename_moves_and_rewrites_storage_json(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """StorageJSON moves to the new filename with name + address rewritten.
 
@@ -252,9 +173,8 @@ async def test_manual_rename_moves_and_rewrites_storage_json(
     correlation; both must reflect the rename or the device's
     online indicator goes UNKNOWN until the next compile.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml")
+    await seed_device(tmp_path, "kitchen.yaml")
 
     storage_dir = tmp_path / ".esphome" / "storage"
     old_storage = storage_dir / "kitchen.yaml.json"
@@ -278,7 +198,10 @@ async def test_manual_rename_moves_and_rewrites_storage_json(
 
 @pytest.mark.asyncio
 async def test_manual_rename_keeps_unrelated_friendly_name_in_storage(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """Storage ``friendly_name`` only flips when it equalled the *old* name.
 
@@ -286,9 +209,8 @@ async def test_manual_rename_keeps_unrelated_friendly_name_in_storage(
     have it overwritten when the YAML file is renamed.
     Pin the conditional rewrite end-to-end.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
-    _seed_device(
+    await seed_device(
         tmp_path,
         "kitchen.yaml",
         storage_friendly="My Kitchen Sensor",
@@ -308,7 +230,10 @@ async def test_manual_rename_keeps_unrelated_friendly_name_in_storage(
 
 @pytest.mark.asyncio
 async def test_manual_rename_succeeds_when_storage_json_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """A device without a StorageJSON (never compiled) renames cleanly.
 
@@ -316,7 +241,6 @@ async def test_manual_rename_succeeds_when_storage_json_missing(
     is the load-bearing operation; the storage-move is best-effort
     and shouldn't blow up the rename when there's nothing to move.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
     # Plain YAML, no storage / sidecar.
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
@@ -333,7 +257,10 @@ async def test_manual_rename_succeeds_when_storage_json_missing(
 
 @pytest.mark.asyncio
 async def test_manual_rename_swallows_storage_load_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """A StorageJSON.load that raises doesn't abort the rename.
 
@@ -348,9 +275,8 @@ async def test_manual_rename_swallows_storage_load_failure(
     payloads rather than raising; we want to pin the
     *exception* path here.)
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml")
+    await seed_device(tmp_path, "kitchen.yaml")
 
     def _raise(_path: Path) -> None:
         raise RuntimeError("simulated load failure")
@@ -371,7 +297,10 @@ async def test_manual_rename_swallows_storage_load_failure(
 
 @pytest.mark.asyncio
 async def test_manual_rename_swallows_metadata_move_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """A failure during the sidecar-metadata move doesn't abort the rename.
 
@@ -380,9 +309,8 @@ async def test_manual_rename_swallows_metadata_move_failure(
     succeeded; an issue with the metadata sidecar must not strand
     the user with mismatched on-disk state.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml")
+    await seed_device(tmp_path, "kitchen.yaml")
 
     def _raise(*_args: Any, **_kwargs: Any) -> None:
         raise RuntimeError("simulated metadata write failure")
@@ -409,7 +337,10 @@ async def test_manual_rename_swallows_metadata_move_failure(
 
 @pytest.mark.asyncio
 async def test_manual_rename_moves_sidecar_metadata(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """Sidecar metadata moves to the new filename, preserving ``board_id``.
 
@@ -419,9 +350,8 @@ async def test_manual_rename_moves_sidecar_metadata(
     new device would show up unidentified until the next
     StorageJSON regenerate.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml", friendly_name="kitchen")
+    await seed_device(tmp_path, "kitchen.yaml", friendly_name="kitchen")
 
     await _route_through_manual(
         controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
@@ -439,7 +369,10 @@ async def test_manual_rename_moves_sidecar_metadata(
 
 @pytest.mark.asyncio
 async def test_manual_rename_keeps_unrelated_metadata_friendly_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """Sidecar ``friendly_name`` survives if it didn't match the old name.
 
@@ -447,9 +380,8 @@ async def test_manual_rename_keeps_unrelated_metadata_friendly_name(
     "rewrite only when it matches old_name" branches in
     ``_manual_rename`` — pin both.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml", friendly_name="My Kitchen Sensor")
+    await seed_device(tmp_path, "kitchen.yaml", friendly_name="My Kitchen Sensor")
 
     await _route_through_manual(
         controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
@@ -467,7 +399,10 @@ async def test_manual_rename_keeps_unrelated_metadata_friendly_name(
 
 @pytest.mark.asyncio
 async def test_manual_rename_raises_when_source_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """A typo'd source filename surfaces as ``CommandError(INTERNAL_ERROR)``.
 
@@ -476,7 +411,6 @@ async def test_manual_rename_raises_when_source_missing(
     ``INTERNAL_ERROR`` (``FileNotFoundError`` isn't a typed
     user-correctable error).
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
     # No YAML on disk at all.
 
@@ -490,14 +424,16 @@ async def test_manual_rename_raises_when_source_missing(
 
 @pytest.mark.asyncio
 async def test_manual_rename_does_not_clobber_existing_target(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """Target filename collision is rejected before any file ops run.
 
     The public handler's pre-check fires here; verify the OLD
     YAML survives intact (no half-rename) so the user can recover.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     (tmp_path / "livingroom.yaml").write_text("esphome:\n  name: livingroom\n", encoding="utf-8")
@@ -520,7 +456,10 @@ async def test_manual_rename_does_not_clobber_existing_target(
 
 @pytest.mark.asyncio
 async def test_manual_rename_full_round_trip(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_device: SeedDeviceFactory,
+    redirect_storage_path: None,
 ) -> None:
     """One assertion-rich pass that walks every observable side effect.
 
@@ -529,9 +468,8 @@ async def test_manual_rename_full_round_trip(
     verifies the *contract* (file moves + content rewrites +
     metadata move) the public ``rename_device`` API delivers.
     """
-    _redirect_storage(monkeypatch, tmp_path)
     controller = _make_controller(tmp_path)
-    _seed_device(tmp_path, "kitchen.yaml", friendly_name="kitchen")
+    await seed_device(tmp_path, "kitchen.yaml", friendly_name="kitchen")
 
     # Exercise via the executor path the API actually uses
     # (``rename_device`` calls ``run_in_executor`` to keep the

--- a/tests/controllers/devices/test_rename_inline_e2e.py
+++ b/tests/controllers/devices/test_rename_inline_e2e.py
@@ -1,0 +1,564 @@
+"""End-to-end coverage for the file-level rename path (``_manual_rename``).
+
+The existing ``test_rename.py`` mocks ``_manual_rename`` out and
+asserts the dispatch wiring (invalid-yaml → manual, valid-yaml →
+firmware queue, error mapping). That leaves the body of
+``_manual_rename`` itself uncovered: the YAML rewrite, the
+``StorageJSON`` move, and the metadata-sidecar move all run
+against real on-disk state.
+
+These tests drive through the public ``rename_device`` API but
+let ``_manual_rename`` execute for real against ``tmp_path``,
+so a regression in any of the four file-ops (YAML rewrite,
+YAML rename, StorageJSON load+rewrite+save, sidecar metadata
+move) surfaces here. We patch ``_yaml_validates`` to return
+False so dispatch routes to the manual path; everything else
+runs end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.config import (
+    get_device_metadata,
+    set_device_metadata,
+)
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
+
+
+def _redirect_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point ``ext_storage_path`` at ``tmp_path/.esphome/storage/``.
+
+    The real helper walks ``CORE.config_path`` which isn't set in
+    isolated tests; redirecting keeps the file ops on disk under
+    the test's tmp dir without spinning up a CORE.
+    """
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def _ext(configuration: str) -> Path:
+        return storage_dir / f"{configuration}.json"
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.ext_storage_path",
+        _ext,
+    )
+
+
+def _make_controller(tmp_path: Path) -> DevicesController:
+    """Build a controller wired to ``tmp_path`` for real file ops.
+
+    Same shape as the in-process helpers in ``test_archive.py`` /
+    ``test_get_update_config.py``: bypass ``__init__`` and attach
+    a ``_db.settings`` whose ``rel_path`` joins onto ``tmp_path``.
+    The scanner is mocked because ``_manual_rename`` doesn't talk
+    to it; ``rename_device`` does (post-rename ``await
+    self._scanner.scan()``) so we satisfy that with an
+    ``AsyncMock``.
+    """
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    controller._db.settings.config_dir = tmp_path
+    controller._db.settings.rel_path = lambda configuration: tmp_path / configuration
+    controller._scanner = MagicMock()
+    controller._scanner.scan = AsyncMock()
+    controller._esphome_cmd = ["esphome"]
+    return controller
+
+
+def _seed_device(
+    config_dir: Path,
+    configuration: str,
+    *,
+    friendly_name: str | None = None,
+    storage_friendly: str | None = None,
+) -> None:
+    """Lay down a YAML, StorageJSON sidecar, and ``.device-builder.json`` entry.
+
+    ``configuration`` is the YAML filename (e.g. ``kitchen.yaml``).
+    ``storage_friendly`` defaults to the YAML stem so the test
+    can verify the "friendly_name == old_name → also rewrite" branch
+    in ``_manual_rename``; pass an unrelated string to verify that
+    branch *doesn't* fire (friendly_name stays put).
+    """
+    name = configuration.removesuffix(".yaml")
+    yaml_text = (
+        "esphome:\n"
+        f"  name: {name}\n"
+        f'  friendly_name: "{friendly_name or name.title()}"\n'
+        "  platform: ESP32\n"
+        "  board: esp32-c3-devkitm-1\n"
+    )
+    (config_dir / configuration).write_text(yaml_text, encoding="utf-8")
+
+    storage_dir = config_dir / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / f"{configuration}.json").write_text(
+        json.dumps(
+            {
+                "storage_version": 1,
+                "name": name,
+                "friendly_name": (storage_friendly if storage_friendly is not None else name),
+                "comment": None,
+                "esphome_version": "2026.5.0-dev",
+                "src_version": 1,
+                "address": f"{name}.local",
+                "web_port": None,
+                "esp_platform": "esp32",
+                "board": "esp32-c3-devkitm-1",
+                "build_path": str(config_dir / ".esphome" / "build" / name),
+                "firmware_bin_path": str(
+                    config_dir / ".esphome" / "build" / name / ".pioenvs" / "firmware.bin"
+                ),
+                "loaded_integrations": ["api"],
+                "loaded_platforms": ["esp32"],
+                "no_mdns": False,
+                "framework": "esp-idf",
+                "core_platform": "esp32",
+                "target_platform": "esp32",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Sidecar metadata — exercise both ``board_id`` and
+    # ``friendly_name`` fields so the move-and-rename branches
+    # are observable.
+    set_device_metadata(
+        config_dir,
+        configuration,
+        board_id="generic-esp32c3",
+        friendly_name=friendly_name or name,
+    )
+
+
+async def _route_through_manual(
+    controller: DevicesController,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    configuration: str,
+    new_name: str,
+) -> dict[str, Any]:
+    """Drive ``rename_device`` with ``_yaml_validates`` forced to False.
+
+    That's the only stub — ``_manual_rename`` itself runs for real
+    against the on-disk YAML / storage / sidecar set up by
+    ``_seed_device``. Returns the API command's response so callers
+    can assert the wire shape too.
+    """
+
+    async def _fake_validates(self: Any, config_path: str) -> bool:
+        return False
+
+    monkeypatch.setattr(DevicesController, "_yaml_validates", _fake_validates)
+    return await controller.rename_device(configuration=configuration, new_name=new_name)
+
+
+# ---------------------------------------------------------------------------
+# YAML rewrite + on-disk file ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_writes_new_yaml_with_rewritten_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``esphome.name`` inside the YAML is rewritten and the file is moved."""
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml")
+
+    result = await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    assert result == {"configuration": "livingroom.yaml", "job": None}
+    # New YAML lands with the rewritten ``esphome.name``.
+    new_yaml = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
+    assert "name: livingroom" in new_yaml
+    # Old YAML is gone.
+    assert not (tmp_path / "kitchen.yaml").exists()
+    # Scanner was kicked so the device list refreshes.
+    controller._scanner.scan.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_preserves_unrelated_yaml_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only ``esphome.name`` is touched — substitutions, packages, comments stay.
+
+    The legacy dashboard's manual rename used a regex that
+    chewed through anything matching ``name:`` anywhere in the
+    YAML. ``rewrite_esphome_name`` is scoped to the ``esphome:``
+    block; this test pins that scoping end-to-end so a refactor
+    that loosened the rewrite would surface.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    yaml_text = (
+        "esphome:\n"
+        "  name: kitchen\n"
+        "  friendly_name: Kitchen\n"
+        "\n"
+        "# A wifi block names the network — must NOT get rewritten\n"
+        "wifi:\n"
+        "  ssid: !secret wifi_ssid\n"
+        "\n"
+        "sensor:\n"
+        "  - platform: dht\n"
+        "    name: kitchen-temp  # device label, also must stay\n"
+    )
+    (tmp_path / "kitchen.yaml").write_text(yaml_text, encoding="utf-8")
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+
+    await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    new_yaml = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
+    # esphome.name flipped …
+    assert "  name: livingroom\n" in new_yaml
+    # … but the sensor's ``name: kitchen-temp`` is unchanged …
+    assert "name: kitchen-temp" in new_yaml
+    # … and the wifi/secret/comments survive verbatim.
+    assert "ssid: !secret wifi_ssid" in new_yaml
+    assert "# A wifi block names the network" in new_yaml
+
+
+# ---------------------------------------------------------------------------
+# StorageJSON sidecar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_moves_and_rewrites_storage_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """StorageJSON moves to the new filename with name + address rewritten.
+
+    The dashboard's address resolution leans on ``StorageJSON.address``
+    (``<name>.local``) and the file's logical ``name`` for mDNS
+    correlation; both must reflect the rename or the device's
+    online indicator goes UNKNOWN until the next compile.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml")
+
+    storage_dir = tmp_path / ".esphome" / "storage"
+    old_storage = storage_dir / "kitchen.yaml.json"
+    new_storage = storage_dir / "livingroom.yaml.json"
+    assert old_storage.exists()  # sanity
+
+    await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    assert not old_storage.exists()
+    assert new_storage.exists()
+    parsed = json.loads(new_storage.read_text(encoding="utf-8"))
+    assert parsed["name"] == "livingroom"
+    # When the friendly_name in the storage equals the old esphome
+    # name, ``_manual_rename`` rewrites it to the new name too —
+    # consistent with how a fresh wizard run wires the two together.
+    assert parsed["friendly_name"] == "livingroom"
+    assert parsed["address"] == "livingroom.local"
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_keeps_unrelated_friendly_name_in_storage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Storage ``friendly_name`` only flips when it equalled the *old* name.
+
+    A user who set "My Kitchen Sensor" as the friendly name shouldn't
+    have it overwritten when the YAML file is renamed.
+    Pin the conditional rewrite end-to-end.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    _seed_device(
+        tmp_path,
+        "kitchen.yaml",
+        storage_friendly="My Kitchen Sensor",
+    )
+
+    await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    parsed = json.loads(
+        (tmp_path / ".esphome" / "storage" / "livingroom.yaml.json").read_text(encoding="utf-8")
+    )
+    assert parsed["name"] == "livingroom"
+    # Custom friendly-name is preserved verbatim.
+    assert parsed["friendly_name"] == "My Kitchen Sensor"
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_succeeds_when_storage_json_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A device without a StorageJSON (never compiled) renames cleanly.
+
+    Exercises the ``if old_storage.exists()`` guard. The YAML rename
+    is the load-bearing operation; the storage-move is best-effort
+    and shouldn't blow up the rename when there's nothing to move.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    # Plain YAML, no storage / sidecar.
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    result = await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    assert result["configuration"] == "livingroom.yaml"
+    assert (tmp_path / "livingroom.yaml").exists()
+    # No new storage file should have been created from nothing.
+    assert not (tmp_path / ".esphome" / "storage" / "livingroom.yaml.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_swallows_storage_load_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A StorageJSON.load that raises doesn't abort the rename.
+
+    The except-Exception in ``_manual_rename`` is what keeps the
+    user able to recover from a partially-written ``StorageJSON``
+    (interrupted compile, rsync mid-flight). The YAML rename still
+    has to land; the storage move just logs and moves on.
+
+    Patch ``StorageJSON.load`` to raise — that's the exception
+    surface the code's wrapping. (A garbage JSON file alone
+    doesn't trip it because ``load`` returns ``None`` for invalid
+    payloads rather than raising; we want to pin the
+    *exception* path here.)
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml")
+
+    def _raise(_path: Path) -> None:
+        raise RuntimeError("simulated load failure")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.StorageJSON.load",
+        staticmethod(_raise),
+    )
+
+    result = await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    assert result["configuration"] == "livingroom.yaml"
+    assert (tmp_path / "livingroom.yaml").exists()
+    assert not (tmp_path / "kitchen.yaml").exists()
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_swallows_metadata_move_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure during the sidecar-metadata move doesn't abort the rename.
+
+    Pin the second except-Exception in ``_manual_rename``. Same
+    motivation as the storage one: the YAML rename has already
+    succeeded; an issue with the metadata sidecar must not strand
+    the user with mismatched on-disk state.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml")
+
+    def _raise(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("simulated metadata write failure")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.set_device_metadata",
+        _raise,
+    )
+
+    result = await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    # Rename still completed at the YAML level.
+    assert result["configuration"] == "livingroom.yaml"
+    assert (tmp_path / "livingroom.yaml").exists()
+    assert not (tmp_path / "kitchen.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# Sidecar metadata (.device-builder.json)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_moves_sidecar_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sidecar metadata moves to the new filename, preserving ``board_id``.
+
+    The drawer's "Generic ESP32-C3" label and the install
+    flow's pio_board lookup both key off ``board_id`` from
+    ``.device-builder.json``; if the rename forgot to move it the
+    new device would show up unidentified until the next
+    StorageJSON regenerate.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml", friendly_name="kitchen")
+
+    await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    # Old entry gone.
+    assert get_device_metadata(tmp_path, "kitchen.yaml") == {}
+    # New entry carries the same board_id and the rewritten
+    # friendly_name (since it equalled the old name).
+    new_meta = get_device_metadata(tmp_path, "livingroom.yaml")
+    assert new_meta != {}
+    assert new_meta["board_id"] == "generic-esp32c3"
+    assert new_meta["friendly_name"] == "livingroom"
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_keeps_unrelated_metadata_friendly_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sidecar ``friendly_name`` survives if it didn't match the old name.
+
+    Companion to the StorageJSON test above. Two parallel
+    "rewrite only when it matches old_name" branches in
+    ``_manual_rename`` — pin both.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml", friendly_name="My Kitchen Sensor")
+
+    await _route_through_manual(
+        controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+    )
+
+    new_meta = get_device_metadata(tmp_path, "livingroom.yaml")
+    assert new_meta != {}
+    assert new_meta["friendly_name"] == "My Kitchen Sensor"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_raises_when_source_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A typo'd source filename surfaces as ``CommandError(INTERNAL_ERROR)``.
+
+    ``_manual_rename`` raises ``FileNotFoundError`` which the
+    public ``rename_device`` handler maps to a generic
+    ``INTERNAL_ERROR`` (``FileNotFoundError`` isn't a typed
+    user-correctable error).
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    # No YAML on disk at all.
+
+    with pytest.raises(CommandError) as excinfo:
+        await _route_through_manual(
+            controller, monkeypatch, configuration="ghost.yaml", new_name="livingroom"
+        )
+
+    assert excinfo.value.code == ErrorCode.INTERNAL_ERROR
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_does_not_clobber_existing_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Target filename collision is rejected before any file ops run.
+
+    The public handler's pre-check fires here; verify the OLD
+    YAML survives intact (no half-rename) so the user can recover.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    (tmp_path / "livingroom.yaml").write_text("esphome:\n  name: livingroom\n", encoding="utf-8")
+    livingroom_orig = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
+
+    with pytest.raises(CommandError):
+        await _route_through_manual(
+            controller, monkeypatch, configuration="kitchen.yaml", new_name="livingroom"
+        )
+
+    # Both files survive untouched.
+    assert (tmp_path / "kitchen.yaml").read_text(encoding="utf-8").startswith("esphome:")
+    assert (tmp_path / "livingroom.yaml").read_text(encoding="utf-8") == livingroom_orig
+
+
+# ---------------------------------------------------------------------------
+# End-to-end round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_rename_full_round_trip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One assertion-rich pass that walks every observable side effect.
+
+    Belt-and-suspenders coverage: even if a future refactor
+    splits ``_manual_rename`` into smaller pieces, this test
+    verifies the *contract* (file moves + content rewrites +
+    metadata move) the public ``rename_device`` API delivers.
+    """
+    _redirect_storage(monkeypatch, tmp_path)
+    controller = _make_controller(tmp_path)
+    _seed_device(tmp_path, "kitchen.yaml", friendly_name="kitchen")
+
+    # Exercise via the executor path the API actually uses
+    # (``rename_device`` calls ``run_in_executor`` to keep the
+    # sync ``_manual_rename`` off the event loop).
+    result = await asyncio.wait_for(
+        _route_through_manual(
+            controller,
+            monkeypatch,
+            configuration="kitchen.yaml",
+            new_name="livingroom",
+        ),
+        timeout=5.0,
+    )
+
+    assert result == {"configuration": "livingroom.yaml", "job": None}
+    # YAML moved + rewritten.
+    assert not (tmp_path / "kitchen.yaml").exists()
+    new_yaml = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
+    assert "  name: livingroom\n" in new_yaml
+    # StorageJSON moved + rewritten.
+    storage = json.loads(
+        (tmp_path / ".esphome" / "storage" / "livingroom.yaml.json").read_text(encoding="utf-8")
+    )
+    assert storage["name"] == "livingroom"
+    assert storage["address"] == "livingroom.local"
+    # Sidecar metadata moved.
+    assert get_device_metadata(tmp_path, "kitchen.yaml") == {}
+    assert get_device_metadata(tmp_path, "livingroom.yaml") != {}
+    # Scanner kicked.
+    controller._scanner.scan.assert_awaited_once()


### PR DESCRIPTION
## Summary
The existing \`test_rename.py\` mocks \`_manual_rename\` out and only asserts dispatch wiring. The body of \`_manual_rename\` itself (YAML rewrite + StorageJSON move + sidecar metadata move) was uncovered, so a regression in any of those three file ops surfaced only at runtime.

New \`tests/controllers/devices/test_rename_inline_e2e.py\` drives through the public \`rename_device\` API but lets \`_manual_rename\` execute for real against \`tmp_path\`. Only stub: \`_yaml_validates\` forced to False so dispatch routes to the manual path; everything else runs end-to-end.

12 tests pin every observable side effect:

- **YAML rewrite** — only \`esphome.name\` flips; sensor names, \`!secret\` references, and comments survive verbatim (the legacy dashboard's regex-everything bug).
- **YAML rename** — old file gone, new file present.
- **StorageJSON move** — name + address rewritten; friendly_name rewritten *only* when it equalled the old name (custom friendly_names preserved).
- **Storage edge cases** — no-storage device renames cleanly; \`StorageJSON.load\` raising doesn't abort the rename.
- **Sidecar metadata** — \`board_id\` and \`friendly_name\` move; metadata write failure doesn't abort the rename.
- **Pre-checks** — same-name and target-collision both surface as \`CommandError(INVALID_ARGS)\` with the OLD YAML intact for recovery.
- **Missing source** — \`FileNotFoundError\` propagates as \`CommandError(INTERNAL_ERROR)\`.
- **Round-trip** — one assertion-rich pass through the full helper chain from API call to \`scanner.scan()\`.

## Coverage delta
\`controllers/devices/controller.py\` lines 1554-1603 (\`_manual_rename\` body) now fully covered. The two defensive \`except Exception\` arms (1585-1586, 1602-1603) reach via patched \`StorageJSON.load\` / \`set_device_metadata\`.

## Test plan
- [x] \`uv run pytest tests/controllers/devices/test_rename_inline_e2e.py\` — 12 passed
- [x] \`uv run pre-commit run\` clean