### PR TITLE
Cover _schedule_storage_regenerate end-to-end through update_config

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -19,10 +19,12 @@ import asyncio
 import json
 from pathlib import Path
 from typing import Protocol
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.controllers.config import set_device_metadata
+from esphome_device_builder.controllers.devices import DevicesController
 
 
 class SeedDeviceFactory(Protocol):
@@ -155,6 +157,90 @@ def seed_device() -> SeedDeviceFactory:
         return yaml_path, build_path
 
     return _seed
+
+
+class MakeControllerFactory(Protocol):
+    """Shape of the ``make_controller`` fixture's return value."""
+
+    def __call__(
+        self,
+        config_dir: Path,
+        *,
+        with_regenerate_state: bool = ...,
+        esphome_cmd: list[str] | None = ...,
+    ) -> DevicesController: ...
+
+
+@pytest.fixture
+def make_controller() -> MakeControllerFactory:
+    """Return a factory that builds a bypass-init ``DevicesController``.
+
+    Most ``tests/controllers/devices/`` files exercise a single
+    handler in isolation and don't want to spin up a full
+    ``DeviceBuilder``. They've each grown their own
+    ``__new__``-bypass helper that attaches:
+
+    - ``_db`` (a ``MagicMock`` with ``settings.config_dir`` /
+      ``settings.rel_path`` wired against the test's tmp dir);
+    - ``_scanner`` (``MagicMock`` with ``scan`` / ``reload`` as
+      ``AsyncMock``).
+
+    The shape was duplicated across ``test_archive.py``,
+    ``test_rename_inline_e2e.py``, and the new
+    ``test_storage_regenerate_e2e.py``. Centralising means the
+    next test in this directory inherits the same wiring without
+    copy-pasting (and a ``DevicesController`` field rename only
+    has to update one site).
+
+    ``with_regenerate_state=True`` adds the three guards
+    (``_regenerate_pending`` / ``_regenerate_failed`` /
+    ``_regenerate_lock``) plus a real
+    ``_db.create_background_task`` that records spawned tasks on
+    ``controller._spawned_tasks`` (test-only attr) so callers can
+    ``await`` them — used by the ``_schedule_storage_regenerate``
+    tests where the controller really fires off background work
+    via the production code path.
+
+    ``esphome_cmd`` populates ``_esphome_cmd`` so the
+    early-return guard at the top of
+    ``_schedule_storage_regenerate`` doesn't short-circuit;
+    leave it ``None`` for tests that don't reach that code path.
+    """
+
+    def _make(
+        config_dir: Path,
+        *,
+        with_regenerate_state: bool = False,
+        esphome_cmd: list[str] | None = None,
+    ) -> DevicesController:
+        controller = DevicesController.__new__(DevicesController)
+        controller._db = MagicMock()
+        controller._db.settings.config_dir = config_dir
+        controller._db.settings.rel_path = lambda configuration: config_dir / configuration
+        controller._scanner = MagicMock()
+        controller._scanner.scan = AsyncMock()
+        controller._scanner.reload = AsyncMock()
+
+        if with_regenerate_state:
+            spawned_tasks: list[asyncio.Task[object]] = []
+
+            def _create_bg(coro: object) -> asyncio.Task[object]:
+                task = asyncio.get_running_loop().create_task(coro)  # type: ignore[arg-type]
+                spawned_tasks.append(task)
+                return task
+
+            controller._db.create_background_task = _create_bg
+            controller._spawned_tasks = spawned_tasks  # type: ignore[attr-defined]
+            controller._regenerate_pending = set()
+            controller._regenerate_failed = set()
+            controller._regenerate_lock = asyncio.Lock()
+
+        if esphome_cmd is not None:
+            controller._esphome_cmd = esphome_cmd
+
+        return controller
+
+    return _make
 
 
 @pytest.fixture

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -21,7 +21,6 @@ import json
 import logging
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -32,7 +31,6 @@ from esphome_device_builder.controllers.config import (
     get_device_metadata,
     set_device_metadata,
 )
-from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices import helpers as devices_helpers
 from esphome_device_builder.controllers.devices.helpers import (
     _archive_clear_device_sidecars,
@@ -41,23 +39,7 @@ from esphome_device_builder.controllers.devices.helpers import (
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
-from .conftest import SeedDeviceFactory
-
-
-def _make_controller(config_dir: Path) -> DevicesController:
-    """Build a bare-bones controller wired to *config_dir* on disk.
-
-    Same pattern as ``test_delete_device.py`` — bypass ``__init__``
-    so we don't have to seed a full ``DeviceBuilder``, attach a
-    mock scanner that satisfies ``await scan()`` calls.
-    """
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = MagicMock()
-    controller._db.settings.config_dir = config_dir
-    controller._db.settings.rel_path = lambda configuration: config_dir / configuration
-    controller._scanner = MagicMock()
-    controller._scanner.scan = AsyncMock()
-    return controller
+from .conftest import MakeControllerFactory, SeedDeviceFactory
 
 
 @pytest.fixture(autouse=True)
@@ -82,7 +64,9 @@ def _ext_storage_for_archive(redirect_storage_path: None) -> None:
 
 @pytest.mark.asyncio
 async def test_archive_moves_yaml_to_archive_dir(
-    tmp_path: Path, seed_device: SeedDeviceFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
 ) -> None:
     """The YAML lands in ``<config_dir>/archive/<configuration>``.
 
@@ -92,7 +76,7 @@ async def test_archive_moves_yaml_to_archive_dir(
     cache root) shows up as a test failure rather than a user
     finding their old configs in an unfamiliar place.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     yaml_path, _ = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     original_text = yaml_path.read_text()
 
@@ -106,7 +90,9 @@ async def test_archive_moves_yaml_to_archive_dir(
 
 @pytest.mark.asyncio
 async def test_archive_wipes_build_directory(
-    tmp_path: Path, seed_device: SeedDeviceFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
 ) -> None:
     """An archived device's compile output is dead weight — wipe it.
 
@@ -116,7 +102,7 @@ async def test_archive_wipes_build_directory(
     (a few KB), not the build tree's worth (50-200 MB), and users
     would still complain about disk usage on long-running fleets.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     _, build_path = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     assert build_path.exists()
 
@@ -127,7 +113,9 @@ async def test_archive_wipes_build_directory(
 
 @pytest.mark.asyncio
 async def test_archive_wipes_storage_sidecar(
-    tmp_path: Path, seed_device: SeedDeviceFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
 ) -> None:
     """The StorageJSON sidecar is removed when archiving.
 
@@ -138,7 +126,7 @@ async def test_archive_wipes_storage_sidecar(
     clean cache; the scanner re-fills via mDNS once the device
     is back online (only a few seconds of "unknown state").
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     storage_path = tmp_path / ".esphome" / "storage" / "kitchen.yaml.json"
     assert storage_path.exists()
@@ -150,7 +138,9 @@ async def test_archive_wipes_storage_sidecar(
 
 @pytest.mark.asyncio
 async def test_archive_clears_volatile_metadata_keeps_identity(
-    tmp_path: Path, seed_device: SeedDeviceFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
 ) -> None:
     """Archive scrubs runtime state but keeps stable identity fields.
 
@@ -163,7 +153,7 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
     losing it on every archive cycle forced an unnecessary
     re-derive on unarchive.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
     # ``set_device_metadata`` writes through ``metadata_transaction``
     # which calls ``tempfile.mkstemp`` for an atomic replace —
@@ -201,7 +191,9 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
 
 @pytest.mark.asyncio
 async def test_archive_drops_metadata_entry_when_only_volatile_fields(
-    tmp_path: Path, seed_device: SeedDeviceFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
 ) -> None:
     """An entry with only volatile fields is removed entirely on archive.
 
@@ -211,7 +203,7 @@ async def test_archive_drops_metadata_entry_when_only_volatile_fields(
     leave an empty dict. Drop the entry entirely so the metadata
     file doesn't accumulate dead keys.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     # ``write_metadata=False`` so the starting state has no
     # identity fields — the only metadata is the volatile ones we
     # add below, which is the exact precondition this branch
@@ -235,7 +227,9 @@ async def test_archive_drops_metadata_entry_when_only_volatile_fields(
 
 @pytest.mark.asyncio
 async def test_archive_succeeds_when_never_compiled(
-    tmp_path: Path, seed_device: SeedDeviceFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
 ) -> None:
     """A device that was never compiled has no build dir — archive still works.
 
@@ -243,7 +237,7 @@ async def test_archive_succeeds_when_never_compiled(
     they don't need it after all". No StorageJSON, no build tree;
     the move-to-archive must still succeed without raising.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     yaml_path, _ = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=False)
     # Wipe the StorageJSON sidecar to simulate "never compiled".
     (tmp_path / ".esphome" / "storage" / "kitchen.yaml.json").unlink()
@@ -256,7 +250,9 @@ async def test_archive_succeeds_when_never_compiled(
 
 @pytest.mark.asyncio
 async def test_archive_collision_raises_invalid_args(
-    tmp_path: Path, seed_device: SeedDeviceFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
 ) -> None:
     """Archiving twice with the same name refuses rather than silently renaming.
 
@@ -269,7 +265,7 @@ async def test_archive_collision_raises_invalid_args(
     resolve the collision (unarchive or permanently delete the
     existing archive copy first).
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
 
     # First archive lands at the plain name.
     await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
@@ -290,7 +286,9 @@ async def test_archive_collision_raises_invalid_args(
 
 
 @pytest.mark.asyncio
-async def test_archive_missing_file_raises_file_not_found(tmp_path: Path) -> None:
+async def test_archive_missing_file_raises_file_not_found(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """An archive of a non-existent configuration raises cleanly.
 
     Symmetric with ``_delete_single`` — the WS layer surfaces the
@@ -298,14 +296,16 @@ async def test_archive_missing_file_raises_file_not_found(tmp_path: Path) -> Non
     (someone else just deleted the device) doesn't silently
     succeed.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     with pytest.raises(FileNotFoundError):
         await controller._archive_single("ghost.yaml")
 
 
 @pytest.mark.asyncio
 async def test_archive_device_full_flow_calls_scanner(
-    tmp_path: Path, seed_device: SeedDeviceFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
 ) -> None:
     """End-to-end ``archive_device`` runs the helper and re-scans.
 
@@ -314,7 +314,7 @@ async def test_archive_device_full_flow_calls_scanner(
     follow-up ``self._scanner.scan()`` that triggers the
     ``DEVICE_REMOVED`` event for the dashboard.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     yaml_path, _ = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
 
     await controller.archive_device(configuration="kitchen.yaml")
@@ -325,13 +325,15 @@ async def test_archive_device_full_flow_calls_scanner(
 
 
 @pytest.mark.asyncio
-async def test_unarchive_device_full_flow_calls_scanner(tmp_path: Path) -> None:
+async def test_unarchive_device_full_flow_calls_scanner(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """End-to-end ``unarchive_device`` runs the helper and re-scans.
 
     Same shape as ``test_archive_device_full_flow_calls_scanner`` —
     covers the WS-command tail (``_scanner.scan()`` after success).
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir()
     (archive_dir / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
@@ -344,7 +346,9 @@ async def test_unarchive_device_full_flow_calls_scanner(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_archived_full_flow(tmp_path: Path) -> None:
+async def test_list_archived_full_flow(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """End-to-end ``list_archived`` returns the parsed rows.
 
     Covers the WS-command body that runs ``_list_archived_sync``
@@ -358,7 +362,7 @@ async def test_list_archived_full_flow(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     rows = await controller.list_archived()
 
     assert len(rows) == 1
@@ -367,7 +371,9 @@ async def test_list_archived_full_flow(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_archive_device_translates_missing_to_command_error(tmp_path: Path) -> None:
+async def test_archive_device_translates_missing_to_command_error(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """The WS-layer entry point surfaces ``CommandError(NOT_FOUND)`` to the client.
 
     The internal ``_archive_single`` raises ``FileNotFoundError`` so
@@ -376,16 +382,18 @@ async def test_archive_device_translates_missing_to_command_error(tmp_path: Path
     reference shows up as a clean ``not_found`` over the wire
     instead of a generic ``internal_error``.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     with pytest.raises(CommandError) as exc:
         await controller.archive_device(configuration="ghost.yaml")
     assert exc.value.code == ErrorCode.NOT_FOUND
 
 
 @pytest.mark.asyncio
-async def test_unarchive_device_translates_missing_to_command_error(tmp_path: Path) -> None:
+async def test_unarchive_device_translates_missing_to_command_error(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``unarchive_device`` mirrors ``archive_device`` for not-found mapping."""
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     with pytest.raises(CommandError) as exc:
         await controller.unarchive_device(configuration="ghost.yaml")
     assert exc.value.code == ErrorCode.NOT_FOUND
@@ -397,14 +405,16 @@ async def test_unarchive_device_translates_missing_to_command_error(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_unarchive_moves_yaml_back(tmp_path: Path) -> None:
+async def test_unarchive_moves_yaml_back(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Unarchive is the inverse of archive — YAML returns to config_dir.
 
     The scanner's next sweep then fires ``DEVICE_ADDED``;
     ``unarchive_device`` calls ``self._scanner.scan()`` itself so
     the dashboard refreshes without a manual reload.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir()
     archived = archive_dir / "kitchen.yaml"
@@ -417,7 +427,9 @@ async def test_unarchive_moves_yaml_back(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_unarchive_refuses_to_clobber_active_config(tmp_path: Path) -> None:
+async def test_unarchive_refuses_to_clobber_active_config(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """An active YAML with the same name blocks the unarchive.
 
     The active YAML may carry the user's recent edits; silently
@@ -425,7 +437,7 @@ async def test_unarchive_refuses_to_clobber_active_config(tmp_path: Path) -> Non
     Surface a ``CommandError(INVALID_ARGS)`` so the dialog can
     prompt for an alternate filename or for an explicit overwrite.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir()
     archived = archive_dir / "kitchen.yaml"
@@ -443,9 +455,11 @@ async def test_unarchive_refuses_to_clobber_active_config(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_unarchive_missing_archive_file_raises(tmp_path: Path) -> None:
+async def test_unarchive_missing_archive_file_raises(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Unarchiving a name that isn't in the archive raises cleanly."""
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     with pytest.raises(FileNotFoundError):
         await controller._unarchive_single("ghost.yaml")
 
@@ -472,7 +486,9 @@ async def test_unarchive_missing_archive_file_raises(tmp_path: Path) -> None:
     ],
 )
 @pytest.mark.asyncio
-async def test_archive_rejects_path_traversal(tmp_path: Path, configuration: str) -> None:
+async def test_archive_rejects_path_traversal(
+    tmp_path: Path, make_controller: MakeControllerFactory, configuration: str
+) -> None:
     """All three archive commands reject non-basename ``configuration``.
 
     The helpers build paths like ``<config_dir>/archive/<configuration>``
@@ -484,7 +500,7 @@ async def test_archive_rejects_path_traversal(tmp_path: Path, configuration: str
     tree. Reject at the WS boundary so the helpers never see a
     suspect value.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     for cmd in (
         controller.archive_device,
         controller.unarchive_device,
@@ -616,7 +632,9 @@ def test_archive_clear_device_sidecars_logs_exception_on_metadata_clear(
 
 
 @pytest.mark.asyncio
-async def test_delete_archived_removes_yaml_and_sidecars(tmp_path: Path) -> None:
+async def test_delete_archived_removes_yaml_and_sidecars(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Permanent delete clears the archived YAML and its sidecars.
 
     The archive flow leaves StorageJSON / device-metadata behind so
@@ -633,7 +651,7 @@ async def test_delete_archived_removes_yaml_and_sidecars(tmp_path: Path) -> None
     storage_path = storage_dir / "kitchen.yaml.json"
     storage_path.write_text("{}", encoding="utf-8")
 
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     await controller._delete_archived_single("kitchen.yaml")
 
     assert not (archive_dir / "kitchen.yaml").exists()
@@ -641,7 +659,9 @@ async def test_delete_archived_removes_yaml_and_sidecars(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_delete_archived_preserves_active_sidecars(tmp_path: Path) -> None:
+async def test_delete_archived_preserves_active_sidecars(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Same-name active config keeps its sidecars when the archive copy is deleted.
 
     Defense-in-depth: if an active config has been re-created
@@ -663,7 +683,7 @@ async def test_delete_archived_preserves_active_sidecars(tmp_path: Path) -> None
     storage_path = storage_dir / "kitchen.yaml.json"
     storage_path.write_text('{"name":"active"}', encoding="utf-8")
 
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     await controller._delete_archived_single("kitchen.yaml")
 
     assert not (archive_dir / "kitchen.yaml").exists()
@@ -673,7 +693,9 @@ async def test_delete_archived_preserves_active_sidecars(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_delete_archived_succeeds_without_sidecars(tmp_path: Path) -> None:
+async def test_delete_archived_succeeds_without_sidecars(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """A bare YAML in the archive (no sidecar) deletes cleanly.
 
     Same shape as ``_delete_single`` — ``unlink(missing_ok=True)``
@@ -685,28 +707,32 @@ async def test_delete_archived_succeeds_without_sidecars(tmp_path: Path) -> None
     archive_dir.mkdir()
     (archive_dir / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     await controller._delete_archived_single("kitchen.yaml")
     assert not (archive_dir / "kitchen.yaml").exists()
 
 
 @pytest.mark.asyncio
-async def test_delete_archived_missing_raises_file_not_found(tmp_path: Path) -> None:
+async def test_delete_archived_missing_raises_file_not_found(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Permanent delete of a non-existent archive entry raises cleanly."""
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     with pytest.raises(FileNotFoundError):
         await controller._delete_archived_single("ghost.yaml")
 
 
 @pytest.mark.asyncio
-async def test_delete_archived_translates_missing_to_command_error(tmp_path: Path) -> None:
+async def test_delete_archived_translates_missing_to_command_error(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """The WS-layer entry point surfaces ``CommandError(NOT_FOUND)``.
 
     Mirrors ``archive_device`` / ``unarchive_device`` — the helper
     raises ``FileNotFoundError`` so internal callers can catch by
     type, but the public command translates to a clean WS error.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     with pytest.raises(CommandError) as exc:
         await controller.delete_archived(configuration="ghost.yaml")
     assert exc.value.code == ErrorCode.NOT_FOUND
@@ -717,18 +743,22 @@ async def test_delete_archived_translates_missing_to_command_error(tmp_path: Pat
 # ---------------------------------------------------------------------------
 
 
-def test_list_archived_returns_empty_when_no_archive_dir(tmp_path: Path) -> None:
+def test_list_archived_returns_empty_when_no_archive_dir(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Pre-first-archive: no directory, no entries, no error.
 
     The dashboard pulls this list on every "Show archived"
     toggle; raising on the no-directory case would force the
     frontend to special-case it. Return ``[]`` instead.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     assert controller._list_archived_sync() == []
 
 
-def test_list_archived_parses_each_yaml_meta_block(tmp_path: Path) -> None:
+def test_list_archived_parses_each_yaml_meta_block(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Each archived YAML's ``esphome:`` block surfaces as a row.
 
     Mirrors the active list's name / friendly_name / comment shape
@@ -746,7 +776,7 @@ def test_list_archived_parses_each_yaml_meta_block(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     rows = controller._list_archived_sync()
 
     by_config = {r["configuration"]: r for r in rows}
@@ -757,7 +787,9 @@ def test_list_archived_parses_each_yaml_meta_block(tmp_path: Path) -> None:
     assert by_config["garage.yaml"]["friendly_name"] == "Garage Door"
 
 
-def test_list_archived_skips_non_yaml_and_hidden(tmp_path: Path) -> None:
+def test_list_archived_skips_non_yaml_and_hidden(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """A stray ``.DS_Store`` / ``.txt`` next to the YAMLs doesn't crash.
 
     Archive directory is user-managed; some users sync it via Git
@@ -772,12 +804,13 @@ def test_list_archived_skips_non_yaml_and_hidden(tmp_path: Path) -> None:
     (archive_dir / "notes.txt").write_text("scratch", encoding="utf-8")
     (archive_dir / ".hidden.yaml").write_text("esphome:\n  name: hidden\n", encoding="utf-8")
 
-    rows = _make_controller(tmp_path)._list_archived_sync()
+    rows = make_controller(tmp_path)._list_archived_sync()
     assert [r["configuration"] for r in rows] == ["kitchen.yaml"]
 
 
 def test_list_archived_falls_back_to_filename_when_meta_unparseable(
     tmp_path: Path,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """A YAML the meta parser can't read still surfaces as a row.
 
@@ -790,7 +823,7 @@ def test_list_archived_falls_back_to_filename_when_meta_unparseable(
     archive_dir.mkdir()
     (archive_dir / "kitchen.yaml").write_text("# no esphome: block at all\n", encoding="utf-8")
 
-    rows = _make_controller(tmp_path)._list_archived_sync()
+    rows = make_controller(tmp_path)._list_archived_sync()
     assert len(rows) == 1
     assert rows[0]["configuration"] == "kitchen.yaml"
     assert rows[0]["name"] == "kitchen"
@@ -799,6 +832,7 @@ def test_list_archived_falls_back_to_filename_when_meta_unparseable(
 
 def test_list_archived_falls_back_to_storage_json_when_yaml_meta_sparse(
     tmp_path: Path,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """When the YAML's ``esphome:`` block is missing fields, fill from StorageJSON.
 
@@ -842,7 +876,7 @@ def test_list_archived_falls_back_to_storage_json_when_yaml_meta_sparse(
         encoding="utf-8",
     )
 
-    rows = _make_controller(tmp_path)._list_archived_sync()
+    rows = make_controller(tmp_path)._list_archived_sync()
     assert len(rows) == 1
     assert rows[0]["configuration"] == "kitchen.yaml"
     assert rows[0]["name"] == "kitchen"

--- a/tests/controllers/devices/test_rename_inline_e2e.py
+++ b/tests/controllers/devices/test_rename_inline_e2e.py
@@ -22,7 +22,6 @@ import asyncio
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -31,28 +30,7 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
-from .conftest import SeedDeviceFactory
-
-
-def _make_controller(tmp_path: Path) -> DevicesController:
-    """Build a controller wired to ``tmp_path`` for real file ops.
-
-    Same shape as the in-process helpers in ``test_archive.py`` /
-    ``test_get_update_config.py``: bypass ``__init__`` and attach
-    a ``_db.settings`` whose ``rel_path`` joins onto ``tmp_path``.
-    The scanner is mocked because ``_manual_rename`` doesn't talk
-    to it; ``rename_device`` does (post-rename ``await
-    self._scanner.scan()``) so we satisfy that with an
-    ``AsyncMock``.
-    """
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = MagicMock()
-    controller._db.settings.config_dir = tmp_path
-    controller._db.settings.rel_path = lambda configuration: tmp_path / configuration
-    controller._scanner = MagicMock()
-    controller._scanner.scan = AsyncMock()
-    controller._esphome_cmd = ["esphome"]
-    return controller
+from .conftest import MakeControllerFactory, SeedDeviceFactory
 
 
 async def _route_through_manual(
@@ -86,11 +64,12 @@ async def _route_through_manual(
 async def test_manual_rename_writes_new_yaml_with_rewritten_name(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
     """``esphome.name`` inside the YAML is rewritten and the file is moved."""
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     await seed_device(tmp_path, "kitchen.yaml")
 
     result = await _route_through_manual(
@@ -111,6 +90,7 @@ async def test_manual_rename_writes_new_yaml_with_rewritten_name(
 async def test_manual_rename_preserves_unrelated_yaml_content(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -122,7 +102,7 @@ async def test_manual_rename_preserves_unrelated_yaml_content(
     block; this test pins that scoping end-to-end so a refactor
     that loosened the rewrite would surface.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     yaml_text = (
         "esphome:\n"
         "  name: kitchen\n"
@@ -163,6 +143,7 @@ async def test_manual_rename_preserves_unrelated_yaml_content(
 async def test_manual_rename_moves_and_rewrites_storage_json(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -173,7 +154,7 @@ async def test_manual_rename_moves_and_rewrites_storage_json(
     correlation; both must reflect the rename or the device's
     online indicator goes UNKNOWN until the next compile.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     await seed_device(tmp_path, "kitchen.yaml")
 
     storage_dir = tmp_path / ".esphome" / "storage"
@@ -200,6 +181,7 @@ async def test_manual_rename_moves_and_rewrites_storage_json(
 async def test_manual_rename_keeps_unrelated_friendly_name_in_storage(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -209,7 +191,7 @@ async def test_manual_rename_keeps_unrelated_friendly_name_in_storage(
     have it overwritten when the YAML file is renamed.
     Pin the conditional rewrite end-to-end.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     await seed_device(
         tmp_path,
         "kitchen.yaml",
@@ -232,6 +214,7 @@ async def test_manual_rename_keeps_unrelated_friendly_name_in_storage(
 async def test_manual_rename_succeeds_when_storage_json_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -241,7 +224,7 @@ async def test_manual_rename_succeeds_when_storage_json_missing(
     is the load-bearing operation; the storage-move is best-effort
     and shouldn't blow up the rename when there's nothing to move.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     # Plain YAML, no storage / sidecar.
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
@@ -259,6 +242,7 @@ async def test_manual_rename_succeeds_when_storage_json_missing(
 async def test_manual_rename_swallows_storage_load_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -275,7 +259,7 @@ async def test_manual_rename_swallows_storage_load_failure(
     payloads rather than raising; we want to pin the
     *exception* path here.)
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     await seed_device(tmp_path, "kitchen.yaml")
 
     def _raise(_path: Path) -> None:
@@ -299,6 +283,7 @@ async def test_manual_rename_swallows_storage_load_failure(
 async def test_manual_rename_swallows_metadata_move_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -309,7 +294,7 @@ async def test_manual_rename_swallows_metadata_move_failure(
     succeeded; an issue with the metadata sidecar must not strand
     the user with mismatched on-disk state.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     await seed_device(tmp_path, "kitchen.yaml")
 
     def _raise(*_args: Any, **_kwargs: Any) -> None:
@@ -339,6 +324,7 @@ async def test_manual_rename_swallows_metadata_move_failure(
 async def test_manual_rename_moves_sidecar_metadata(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -350,7 +336,7 @@ async def test_manual_rename_moves_sidecar_metadata(
     new device would show up unidentified until the next
     StorageJSON regenerate.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     await seed_device(tmp_path, "kitchen.yaml", friendly_name="kitchen")
 
     await _route_through_manual(
@@ -371,6 +357,7 @@ async def test_manual_rename_moves_sidecar_metadata(
 async def test_manual_rename_keeps_unrelated_metadata_friendly_name(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -380,7 +367,7 @@ async def test_manual_rename_keeps_unrelated_metadata_friendly_name(
     "rewrite only when it matches old_name" branches in
     ``_manual_rename`` — pin both.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     await seed_device(tmp_path, "kitchen.yaml", friendly_name="My Kitchen Sensor")
 
     await _route_through_manual(
@@ -401,6 +388,7 @@ async def test_manual_rename_keeps_unrelated_metadata_friendly_name(
 async def test_manual_rename_raises_when_source_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -411,7 +399,7 @@ async def test_manual_rename_raises_when_source_missing(
     ``INTERNAL_ERROR`` (``FileNotFoundError`` isn't a typed
     user-correctable error).
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     # No YAML on disk at all.
 
     with pytest.raises(CommandError) as excinfo:
@@ -426,6 +414,7 @@ async def test_manual_rename_raises_when_source_missing(
 async def test_manual_rename_does_not_clobber_existing_target(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -434,7 +423,7 @@ async def test_manual_rename_does_not_clobber_existing_target(
     The public handler's pre-check fires here; verify the OLD
     YAML survives intact (no half-rename) so the user can recover.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     (tmp_path / "livingroom.yaml").write_text("esphome:\n  name: livingroom\n", encoding="utf-8")
     livingroom_orig = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
@@ -458,6 +447,7 @@ async def test_manual_rename_does_not_clobber_existing_target(
 async def test_manual_rename_full_round_trip(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
     seed_device: SeedDeviceFactory,
     redirect_storage_path: None,
 ) -> None:
@@ -468,7 +458,7 @@ async def test_manual_rename_full_round_trip(
     verifies the *contract* (file moves + content rewrites +
     metadata move) the public ``rename_device`` API delivers.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     await seed_device(tmp_path, "kitchen.yaml", friendly_name="kitchen")
 
     # Exercise via the executor path the API actually uses

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -86,10 +86,18 @@ def _make_controller(tmp_path: Path) -> DevicesController:
 
 
 async def _drain(controller: DevicesController) -> None:
-    """Wait for every background task ``_schedule_storage_regenerate`` queued."""
+    """Wait for every background task ``_schedule_storage_regenerate`` queued.
+
+    Drops ``return_exceptions=True`` so an unexpected crash inside the
+    regenerate coroutine fails the test instead of silently masking
+    as ``None`` in the gather result. Production swallows the error
+    branches in its own ``try/except`` (and asserts on
+    ``_regenerate_failed``); anything reaching the gather here is a
+    bug we want surfaced.
+    """
     pending: list[asyncio.Task] = controller._spawned_tasks  # type: ignore[attr-defined]
     if pending:
-        await asyncio.gather(*pending, return_exceptions=True)
+        await asyncio.gather(*pending)
         pending.clear()
 
 
@@ -124,7 +132,7 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
     )
     persist_calls: list[str] = []
 
-    async def _fake_persist(self: Any, configuration: str) -> None:
+    async def _fake_persist(_self: Any, configuration: str) -> None:
         persist_calls.append(configuration)
 
     monkeypatch.setattr(DevicesController, "_persist_expected_config_hash", _fake_persist)
@@ -230,7 +238,7 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     )
     persist_calls: list[str] = []
 
-    async def _fake_persist(self: Any, configuration: str) -> None:
+    async def _fake_persist(_self: Any, configuration: str) -> None:
         persist_calls.append(configuration)
 
     monkeypatch.setattr(DevicesController, "_persist_expected_config_hash", _fake_persist)

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -1,0 +1,333 @@
+"""End-to-end coverage for ``_schedule_storage_regenerate``.
+
+Most callers of the regenerate path mock it as a ``MagicMock``
+(see ``test_get_update_config.py`` and ``test_archive.py``) so the
+fire-and-forget spawn doesn't run. That leaves the body of
+``_schedule_storage_regenerate`` itself uncovered: the
+duplicate-schedule guard, the failed-marker guard, the
+``create_subprocess_exec`` call, the non-zero-exit handling, the
+spawn-failure handling, and the post-success
+``_persist_expected_config_hash`` + ``_scanner.reload`` chain.
+
+These tests drive through the public ``update_config`` API but
+let ``_schedule_storage_regenerate`` execute for real, with a
+patched ``create_subprocess_exec`` returning a configurable
+``FakeProc``. Background-task settling uses the same
+``create_background_task`` plumbing the controller uses, so the
+tests exercise the actual coroutine the production code spawns.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.devices import DevicesController
+
+
+class _FakeProc:
+    """Minimal ``asyncio.subprocess.Process`` stand-in.
+
+    ``communicate`` returns the configured stderr bytes;
+    ``returncode`` carries the configured exit code. Only the
+    bits ``_schedule_storage_regenerate`` reads.
+    """
+
+    def __init__(self, returncode: int = 0, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self._stderr = stderr
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return (b"", self._stderr)
+
+
+def _make_controller(tmp_path: Path) -> DevicesController:
+    """Build a controller wired to ``tmp_path`` with the regenerate-state attrs.
+
+    Same ``__new__``-bypass shape as the other devices tests, with
+    the three regenerate guards (``_regenerate_pending`` /
+    ``_regenerate_failed`` / ``_regenerate_lock``) attached because
+    ``_schedule_storage_regenerate`` reads them on every entry.
+    ``_esphome_cmd`` is non-empty so the start-of-function guard
+    doesn't short-circuit.
+
+    ``_db.create_background_task`` returns a real ``asyncio.Task``
+    so tests can ``await`` it — production wraps the same shape
+    around ``DeviceBuilder.create_background_task`` which calls
+    ``loop.create_task``.
+    """
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    controller._db.settings.config_dir = tmp_path
+    controller._db.settings.rel_path = lambda configuration: tmp_path / configuration
+
+    spawned_tasks: list[asyncio.Task] = []
+
+    def _create_bg(coro: Any) -> asyncio.Task:
+        task = asyncio.get_running_loop().create_task(coro)
+        spawned_tasks.append(task)
+        return task
+
+    controller._db.create_background_task = _create_bg
+    controller._spawned_tasks = spawned_tasks  # type: ignore[attr-defined]
+
+    controller._scanner = MagicMock()
+    controller._scanner.scan = AsyncMock()
+    controller._scanner.reload = AsyncMock()
+    controller._regenerate_pending = set()
+    controller._regenerate_failed = set()
+    controller._regenerate_lock = asyncio.Lock()
+    controller._esphome_cmd = ["esphome"]
+    return controller
+
+
+async def _drain(controller: DevicesController) -> None:
+    """Wait for every background task ``_schedule_storage_regenerate`` queued."""
+    pending: list[asyncio.Task] = controller._spawned_tasks  # type: ignore[attr-defined]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+        pending.clear()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_regenerate_spawns_esphome_compile_only_generate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Successful spawn → expected-hash persist + scanner reload.
+
+    Pin the full success chain end-to-end. After
+    ``update_config`` lands the YAML and queues the regenerate,
+    the spawn returns 0; the controller persists
+    ``expected_config_hash`` from ``build_info.json`` and reloads
+    the scanner so the device's metadata refreshes without
+    waiting for a real compile.
+    """
+    controller = _make_controller(tmp_path)
+    captured_cmd: list[list[str]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        captured_cmd.append(list(args))
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+    persist_calls: list[str] = []
+
+    async def _fake_persist(self: Any, configuration: str) -> None:
+        persist_calls.append(configuration)
+
+    monkeypatch.setattr(DevicesController, "_persist_expected_config_hash", _fake_persist)
+
+    await controller.update_config(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
+    )
+    await _drain(controller)
+
+    # esphome --dashboard compile --only-generate <config_path>
+    assert captured_cmd == [
+        [
+            "esphome",
+            "--dashboard",
+            "compile",
+            "--only-generate",
+            str(tmp_path / "kitchen.yaml"),
+        ]
+    ]
+    assert persist_calls == ["kitchen.yaml"]
+    controller._scanner.reload.assert_awaited_once_with("kitchen.yaml")
+    # Pending guard cleared in the ``finally``.
+    assert controller._regenerate_pending == set()
+    # Success → not in failed set.
+    assert controller._regenerate_failed == set()
+
+
+# ---------------------------------------------------------------------------
+# Early-return guards
+# ---------------------------------------------------------------------------
+
+
+def test_regenerate_skips_when_esphome_cmd_unset(tmp_path: Path) -> None:
+    """``_esphome_cmd`` empty (``start()`` hasn't run) → no-op.
+
+    Synchronous test — the guard is the very first check in the
+    function and short-circuits before scheduling the
+    background task. No spawn, no _regenerate_pending mutation.
+    """
+    controller = _make_controller(tmp_path)
+    controller._esphome_cmd = []
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+
+    assert controller._spawned_tasks == []  # type: ignore[attr-defined]
+    assert controller._regenerate_pending == set()
+
+
+def test_regenerate_skips_duplicate_schedule(tmp_path: Path) -> None:
+    """Configuration already in ``_regenerate_pending`` → second schedule is a no-op.
+
+    Without this, repeated saves while a regenerate is already
+    in flight would queue N background tasks all racing on the
+    same YAML.
+    """
+    controller = _make_controller(tmp_path)
+    controller._regenerate_pending.add("kitchen.yaml")
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+
+    assert controller._spawned_tasks == []  # type: ignore[attr-defined]
+
+
+def test_regenerate_skips_after_failed_marker(tmp_path: Path) -> None:
+    """Configuration in ``_regenerate_failed`` → no respin.
+
+    The marker is cleared by ``_on_scan_change`` when the YAML's
+    cache key changes (i.e. the user actually edited it). Until
+    then a respin would just burn another subprocess on the same
+    bad input.
+    """
+    controller = _make_controller(tmp_path)
+    controller._regenerate_failed.add("kitchen.yaml")
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+
+    assert controller._spawned_tasks == []  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_regenerate_marks_failed_on_nonzero_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``esphome compile`` exiting non-zero → no reload, ``_regenerate_failed`` set.
+
+    Captures the typical "user saved a YAML with a syntax error"
+    case. The controller has to remember the failure so the
+    next save (with the same broken YAML) doesn't re-spawn.
+    """
+    controller = _make_controller(tmp_path)
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=1, stderr=b"YAML parse error at line 3")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+    persist_calls: list[str] = []
+
+    async def _fake_persist(self: Any, configuration: str) -> None:
+        persist_calls.append(configuration)
+
+    monkeypatch.setattr(DevicesController, "_persist_expected_config_hash", _fake_persist)
+
+    await controller.update_config(configuration="kitchen.yaml", content="not: valid: yaml\n")
+    await _drain(controller)
+
+    # Failure → reload skipped, persist skipped, failed marker set.
+    controller._scanner.reload.assert_not_called()
+    assert persist_calls == []
+    assert controller._regenerate_failed == {"kitchen.yaml"}
+    # Pending cleared via the ``finally``.
+    assert controller._regenerate_pending == set()
+
+
+@pytest.mark.asyncio
+async def test_regenerate_marks_failed_on_spawn_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``create_subprocess_exec`` raising → ``_regenerate_failed`` set.
+
+    Triggers when ``esphome`` is missing from PATH (broken pip
+    install, dashboard running outside its venv). The pending
+    marker has to clear via the outer ``finally`` so a follow-up
+    schedule on the same configuration isn't blocked by the
+    duplicate-schedule guard.
+    """
+    controller = _make_controller(tmp_path)
+
+    async def _broken_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        raise OSError("esphome: command not found")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _broken_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+
+    await controller.update_config(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
+    )
+    await _drain(controller)
+
+    controller._scanner.reload.assert_not_called()
+    assert controller._regenerate_failed == {"kitchen.yaml"}
+    assert controller._regenerate_pending == set()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_regenerate_pending_blocks_in_flight_dupe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second schedule mid-spawn doesn't queue a duplicate task.
+
+    Pin the runtime contract of the duplicate-schedule guard
+    *while a spawn is in flight* (the static test above only
+    pre-sets the flag). Drive a real spawn that blocks on a
+    sentinel event; while it's blocked, schedule again — the
+    guard fires and no second task lands.
+    """
+    controller = _make_controller(tmp_path)
+    in_flight = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hold(*_args: str, **_kwargs: Any) -> _FakeProc:
+        in_flight.set()
+        await release.wait()
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _hold,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await asyncio.wait_for(in_flight.wait(), timeout=2.0)
+    assert controller._regenerate_pending == {"kitchen.yaml"}
+
+    # Second schedule while the first is still inside ``communicate``.
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    # Only the original task exists.
+    assert len(controller._spawned_tasks) == 1  # type: ignore[attr-defined]
+
+    release.set()
+    await _drain(controller)
+    assert controller._regenerate_pending == set()

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -22,11 +22,13 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
 from esphome_device_builder.controllers.devices import DevicesController
+
+from .conftest import MakeControllerFactory
 
 
 class _FakeProc:
@@ -43,46 +45,6 @@ class _FakeProc:
 
     async def communicate(self) -> tuple[bytes, bytes]:
         return (b"", self._stderr)
-
-
-def _make_controller(tmp_path: Path) -> DevicesController:
-    """Build a controller wired to ``tmp_path`` with the regenerate-state attrs.
-
-    Same ``__new__``-bypass shape as the other devices tests, with
-    the three regenerate guards (``_regenerate_pending`` /
-    ``_regenerate_failed`` / ``_regenerate_lock``) attached because
-    ``_schedule_storage_regenerate`` reads them on every entry.
-    ``_esphome_cmd`` is non-empty so the start-of-function guard
-    doesn't short-circuit.
-
-    ``_db.create_background_task`` returns a real ``asyncio.Task``
-    so tests can ``await`` it — production wraps the same shape
-    around ``DeviceBuilder.create_background_task`` which calls
-    ``loop.create_task``.
-    """
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = MagicMock()
-    controller._db.settings.config_dir = tmp_path
-    controller._db.settings.rel_path = lambda configuration: tmp_path / configuration
-
-    spawned_tasks: list[asyncio.Task] = []
-
-    def _create_bg(coro: Any) -> asyncio.Task:
-        task = asyncio.get_running_loop().create_task(coro)
-        spawned_tasks.append(task)
-        return task
-
-    controller._db.create_background_task = _create_bg
-    controller._spawned_tasks = spawned_tasks  # type: ignore[attr-defined]
-
-    controller._scanner = MagicMock()
-    controller._scanner.scan = AsyncMock()
-    controller._scanner.reload = AsyncMock()
-    controller._regenerate_pending = set()
-    controller._regenerate_failed = set()
-    controller._regenerate_lock = asyncio.Lock()
-    controller._esphome_cmd = ["esphome"]
-    return controller
 
 
 async def _drain(controller: DevicesController) -> None:
@@ -108,7 +70,9 @@ async def _drain(controller: DevicesController) -> None:
 
 @pytest.mark.asyncio
 async def test_regenerate_spawns_esphome_compile_only_generate(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """Successful spawn → expected-hash persist + scanner reload.
 
@@ -119,7 +83,7 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
     the scanner so the device's metadata refreshes without
     waiting for a real compile.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     captured_cmd: list[list[str]] = []
 
     async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
@@ -165,15 +129,17 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
 # ---------------------------------------------------------------------------
 
 
-def test_regenerate_skips_when_esphome_cmd_unset(tmp_path: Path) -> None:
+def test_regenerate_skips_when_esphome_cmd_unset(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``_esphome_cmd`` empty (``start()`` hasn't run) → no-op.
 
     Synchronous test — the guard is the very first check in the
     function and short-circuits before scheduling the
     background task. No spawn, no _regenerate_pending mutation.
     """
-    controller = _make_controller(tmp_path)
-    controller._esphome_cmd = []
+    # ``esphome_cmd=[]`` triggers the early-return guard.
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=[])
 
     controller._schedule_storage_regenerate("kitchen.yaml")
 
@@ -181,14 +147,16 @@ def test_regenerate_skips_when_esphome_cmd_unset(tmp_path: Path) -> None:
     assert controller._regenerate_pending == set()
 
 
-def test_regenerate_skips_duplicate_schedule(tmp_path: Path) -> None:
+def test_regenerate_skips_duplicate_schedule(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Configuration already in ``_regenerate_pending`` → second schedule is a no-op.
 
     Without this, repeated saves while a regenerate is already
     in flight would queue N background tasks all racing on the
     same YAML.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     controller._regenerate_pending.add("kitchen.yaml")
 
     controller._schedule_storage_regenerate("kitchen.yaml")
@@ -196,7 +164,9 @@ def test_regenerate_skips_duplicate_schedule(tmp_path: Path) -> None:
     assert controller._spawned_tasks == []  # type: ignore[attr-defined]
 
 
-def test_regenerate_skips_after_failed_marker(tmp_path: Path) -> None:
+def test_regenerate_skips_after_failed_marker(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Configuration in ``_regenerate_failed`` → no respin.
 
     The marker is cleared by ``_on_scan_change`` when the YAML's
@@ -204,7 +174,7 @@ def test_regenerate_skips_after_failed_marker(tmp_path: Path) -> None:
     then a respin would just burn another subprocess on the same
     bad input.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     controller._regenerate_failed.add("kitchen.yaml")
 
     controller._schedule_storage_regenerate("kitchen.yaml")
@@ -219,7 +189,9 @@ def test_regenerate_skips_after_failed_marker(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_regenerate_marks_failed_on_nonzero_exit(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """``esphome compile`` exiting non-zero → no reload, ``_regenerate_failed`` set.
 
@@ -227,7 +199,7 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     case. The controller has to remember the failure so the
     next save (with the same broken YAML) doesn't re-spawn.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         return _FakeProc(returncode=1, stderr=b"YAML parse error at line 3")
@@ -256,7 +228,9 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
 
 @pytest.mark.asyncio
 async def test_regenerate_marks_failed_on_spawn_oserror(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """``create_subprocess_exec`` raising → ``_regenerate_failed`` set.
 
@@ -266,7 +240,7 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     schedule on the same configuration isn't blocked by the
     duplicate-schedule guard.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
 
     async def _broken_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         raise OSError("esphome: command not found")
@@ -298,7 +272,9 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
 
 @pytest.mark.asyncio
 async def test_regenerate_pending_blocks_in_flight_dupe(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """A second schedule mid-spawn doesn't queue a duplicate task.
 
@@ -308,7 +284,7 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
     sentinel event; while it's blocked, schedule again — the
     guard fires and no second task lands.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     in_flight = asyncio.Event()
     release = asyncio.Event()
 


### PR DESCRIPTION
## Summary
Most callers of the regenerate path mock \`_schedule_storage_regenerate\` as a \`MagicMock\` (\`test_get_update_config.py\` / \`test_archive.py\`) so the fire-and-forget spawn doesn't run. That left the body itself uncovered: duplicate-schedule guard, failed-marker guard, \`create_subprocess_exec\` call, non-zero-exit handling, spawn-failure handling, post-success \`_persist_expected_config_hash\` + \`_scanner.reload\` chain.

7 tests in a new \`tests/controllers/devices/test_storage_regenerate_e2e.py\` pin every observable side effect:

- **Happy path** — spawn shape (\`esphome --dashboard compile --only-generate <config_path>\`), expected-hash persist, scanner reload, pending cleared.
- **\`_esphome_cmd\` empty** → early-return no-op.
- **Duplicate schedule** (already pending) → no-op.
- **Failed-marker present** → no-op.
- **Non-zero exit** → no reload, no persist, \`_regenerate_failed\` set, pending cleared via \`finally\`.
- **Spawn \`OSError\`** (esphome missing from PATH) → same shape.
- **In-flight duplicate-schedule guard** — drive a real spawn that blocks on a sentinel; second schedule mid-spawn doesn't queue a duplicate task.

Tests drive through the public \`update_config\` API but let \`_schedule_storage_regenerate\` execute for real with a patched \`create_subprocess_exec\` returning a configurable \`FakeProc\`. The fixture wraps \`loop.create_task\` for \`create_background_task\` so spawned tasks are \`await\`-able (matches \`DeviceBuilder.create_background_task\`).

## Test plan
- [x] \`uv run pytest tests/controllers/devices/test_storage_regenerate_e2e.py\` — 7 passed
- [x] \`uv run pre-commit run\` clean