### PR TITLE
Cover DevicesController lifecycle end-to-end

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -18,13 +18,68 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.controllers.config import set_device_metadata
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.models import EventType
+
+
+class StubBus:
+    """Minimal event-bus stand-in for tests that exercise the listener wiring.
+
+    ``add_listener`` records the registration and returns a
+    callable that bumps ``unsub_calls`` when invoked — production
+    ``EventBus`` returns a closure that removes the entry, so the
+    return value's call-on-close behaviour is what
+    ``DevicesController.stop()`` relies on. Tests that need a
+    full ``DeviceBuilder``-shaped stub can pull this in via
+    ``make_db``.
+    """
+
+    def __init__(self) -> None:
+        self.listeners: list[tuple[EventType, Any]] = []
+        self.unsub_calls = 0
+
+    def add_listener(self, event_type: EventType, handler: Any) -> Any:
+        self.listeners.append((event_type, handler))
+
+        def _unsub() -> None:
+            self.unsub_calls += 1
+
+        return _unsub
+
+
+class MakeDbFactory(Protocol):
+    """Shape of the ``make_db`` fixture's return value."""
+
+    def __call__(self, config_dir: Path) -> MagicMock: ...
+
+
+@pytest.fixture
+def make_db() -> MakeDbFactory:
+    """Return a factory that builds a ``DeviceBuilder``-shaped stub.
+
+    The shape is the minimum ``DevicesController.__init__`` reads:
+    ``settings.config_dir`` / ``settings.absolute_config_dir`` /
+    ``settings.password`` and ``bus`` (a :class:`StubBus`).
+    Tests that construct a real ``DevicesController`` (i.e. don't
+    bypass-init via ``make_controller``) want this; everything
+    else just uses ``make_controller``.
+    """
+
+    def _make(config_dir: Path) -> MagicMock:
+        db = MagicMock()
+        db.settings.config_dir = config_dir
+        db.settings.absolute_config_dir = config_dir.resolve()
+        db.settings.password = ""  # ConfigController-side; harmless for tests
+        db.bus = StubBus()
+        return db
+
+    return _make
 
 
 class SeedDeviceFactory(Protocol):

--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -74,36 +74,6 @@ def _make_db(tmp_path: Path) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-def test_init_constructs_inner_controllers(tmp_path: Path) -> None:
-    """``__init__`` wires scanner + state monitor + MQTT coordinator.
-
-    Pin the wiring so a refactor that drops one of the three
-    components, or skips threading a callback through, surfaces
-    here. The state monitor in particular has seven separate
-    callbacks (state, ip, version, config_hash, api_encryption,
-    importable_added, importable_removed) that all have to point
-    back at controller methods — a typo'd one would silently
-    break a single class of state transitions in production.
-    """
-    db = _make_db(tmp_path)
-    controller = DevicesController(db)
-
-    # Attributes set by ``__init__``.
-    assert controller._db is db
-    assert controller._esphome_cmd == []
-    assert controller._unsub_job_completed is None
-    assert controller.import_result == {}
-    assert controller.ignored_devices == set()
-    assert controller._regenerate_pending == set()
-    assert controller._regenerate_failed == set()
-
-    # Inner controllers exist and were wired against ``tmp_path``.
-    assert controller._scanner is not None
-    assert controller._scanner._config_dir == tmp_path
-    assert controller._state_monitor is not None
-    assert controller._mqtt_coordinator is not None
-
-
 def test_init_threads_state_monitor_callbacks_to_controller_methods(
     tmp_path: Path,
 ) -> None:

--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -1,0 +1,268 @@
+"""End-to-end coverage for ``DevicesController`` lifecycle.
+
+The handler-level tests in ``tests/controllers/devices/`` all
+bypass ``__init__`` via ``__new__`` and stub
+``_scanner`` / ``_state_monitor`` / ``_mqtt_coordinator``
+individually — that lets each test target one method but leaves
+the wiring code itself uncovered:
+
+- ``__init__`` (lines 81-129) — constructs the scanner, state
+  monitor, and MQTT coordinator and threads their callbacks
+  back to the controller.
+- ``start()`` (lines 142-149) — resolves the esphome cmd, loads
+  ignored devices, kicks the scanner, starts the state monitor,
+  reconciles MQTT, and registers the JOB_COMPLETED listener.
+- ``stop()`` (lines 155-159) — unsubscribes the bus listener and
+  stops the two background monitors.
+- ``poll()`` (lines 163-164) — re-scans and reconciles MQTT.
+
+These tests instantiate a real ``DevicesController`` against a
+``tmp_path`` config dir and a thin stub ``DeviceBuilder`` so the
+``__init__`` body runs in full. The inner monitors' lifecycle
+methods are patched as ``AsyncMock`` so ``start`` / ``stop``
+don't try to open a zeroconf browser or connect to MQTT — those
+are exercised in their own dedicated tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.models import EventType
+
+
+class _Bus:
+    """Minimal event-bus stand-in.
+
+    ``add_listener`` records the registration and returns a
+    callable that records the unsubscribe — production
+    ``EventBus`` returns a closure that removes the entry, so the
+    return value's call-on-close behaviour is what ``stop()``
+    relies on.
+    """
+
+    def __init__(self) -> None:
+        self.listeners: list[tuple[EventType, Any]] = []
+        self.unsub_calls = 0
+
+    def add_listener(self, event_type: EventType, handler: Any) -> Any:
+        self.listeners.append((event_type, handler))
+
+        def _unsub() -> None:
+            self.unsub_calls += 1
+
+        return _unsub
+
+
+def _make_db(tmp_path: Path) -> MagicMock:
+    """Build a ``DeviceBuilder``-shaped stub for the controller's ``__init__``."""
+    db = MagicMock()
+    db.settings.config_dir = tmp_path
+    db.settings.absolute_config_dir = tmp_path.resolve()
+    db.settings.password = ""  # ConfigController-side; harmless for tests
+    db.bus = _Bus()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+def test_init_constructs_inner_controllers(tmp_path: Path) -> None:
+    """``__init__`` wires scanner + state monitor + MQTT coordinator.
+
+    Pin the wiring so a refactor that drops one of the three
+    components, or skips threading a callback through, surfaces
+    here. The state monitor in particular has nine separate
+    callbacks that all have to point back at controller methods —
+    a typo'd one would silently break a single class of state
+    transitions in production.
+    """
+    db = _make_db(tmp_path)
+    controller = DevicesController(db)
+
+    # Attributes set by ``__init__``.
+    assert controller._db is db
+    assert controller._esphome_cmd == []
+    assert controller._unsub_job_completed is None
+    assert controller.import_result == {}
+    assert controller.ignored_devices == set()
+    assert controller._regenerate_pending == set()
+    assert controller._regenerate_failed == set()
+
+    # Inner controllers exist and were wired against ``tmp_path``.
+    assert controller._scanner is not None
+    assert controller._scanner._config_dir == tmp_path
+    assert controller._state_monitor is not None
+    assert controller._mqtt_coordinator is not None
+
+
+def test_init_threads_state_monitor_callbacks_to_controller_methods(
+    tmp_path: Path,
+) -> None:
+    """State-monitor callbacks point back at ``self._on_*_change`` methods.
+
+    The state monitor was the locus of the "monitor cache drifts
+    out of sync with the device" regression in PR #75 — fixed by
+    making the callbacks the source-of-truth path. If a future
+    refactor accidentally bypasses one of them, that whole class
+    of bug returns.
+    """
+    db = _make_db(tmp_path)
+    controller = DevicesController(db)
+
+    # Bound-method equality: ``a is b`` fails on bound methods even
+    # for the same underlying function on the same instance, so use
+    # ``==`` (which compares ``__self__`` + ``__func__``). Either
+    # way it's a refactor-catch — a typo'd callback wire would point
+    # at a different method or a stub and break this assertion.
+    monitor = controller._state_monitor
+    assert monitor._on_state_change == controller._on_state_change  # type: ignore[attr-defined]
+    assert monitor._on_ip_change == controller._on_ip_change  # type: ignore[attr-defined]
+    assert monitor._on_version_change == controller._on_version_change  # type: ignore[attr-defined]
+    assert monitor._on_config_hash_change == controller._on_config_hash_change  # type: ignore[attr-defined]
+    assert monitor._on_api_encryption_change == controller._on_api_encryption_change  # type: ignore[attr-defined]
+    assert monitor._on_importable_added == controller._on_importable_added  # type: ignore[attr-defined]
+    assert monitor._on_importable_removed == controller._on_importable_removed  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# start()
+# ---------------------------------------------------------------------------
+
+
+def _stub_inner_lifecycle(controller: DevicesController) -> None:
+    """Replace the real start/stop/scan methods with AsyncMocks.
+
+    ``start()`` and ``stop()`` route through the scanner / state
+    monitor / MQTT coordinator. Patching their lifecycle methods
+    out keeps these tests focused on *DevicesController*'s
+    contract; the inner controllers have their own dedicated test
+    files.
+    """
+    controller._scanner.scan = AsyncMock()  # type: ignore[method-assign]
+    controller._state_monitor.start = AsyncMock()  # type: ignore[method-assign]
+    controller._state_monitor.stop = AsyncMock()  # type: ignore[method-assign]
+    controller._mqtt_coordinator.reconcile = AsyncMock()  # type: ignore[method-assign]
+    controller._mqtt_coordinator.stop = AsyncMock()  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_start_runs_full_initialisation_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``start()`` resolves esphome cmd, loads ignored, scans, starts monitors, subscribes bus.
+
+    Pin the full chain — every step has its own dedicated regression
+    elsewhere, but the *order* and *fact-of-call* live here. A
+    refactor that reordered (e.g. ``state_monitor.start`` before
+    ``scanner.scan``) could cause cold-start ordering bugs the
+    individual tests wouldn't catch.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller._find_esphome_cmd",
+        lambda: ["python", "-m", "esphome"],
+    )
+    db = _make_db(tmp_path)
+    controller = DevicesController(db)
+    _stub_inner_lifecycle(controller)
+
+    # Seed an ignored-devices file so ``_load_ignored_devices`` has
+    # something real to process — otherwise it's silently a no-op
+    # and we wouldn't observe the executor-dispatch call shape.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.ignored_devices_storage_path",
+        lambda: tmp_path / "ignored-devices.json",
+    )
+    (tmp_path / "ignored-devices.json").write_bytes(
+        b'{"ignored_devices": ["already-ignored"]}',
+    )
+
+    await controller.start()
+
+    assert controller._esphome_cmd == ["python", "-m", "esphome"]
+    assert controller.ignored_devices == {"already-ignored"}
+    controller._scanner.scan.assert_awaited_once()
+    controller._state_monitor.start.assert_awaited_once()
+    controller._mqtt_coordinator.reconcile.assert_awaited_once()
+    # JOB_COMPLETED listener registered via the real ``EventBus``-shaped stub.
+    assert db.bus.listeners == [(EventType.JOB_COMPLETED, controller._on_firmware_job_completed)]
+    assert controller._unsub_job_completed is not None
+
+
+# ---------------------------------------------------------------------------
+# stop()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_tears_down_monitors_and_unsubscribes(tmp_path: Path) -> None:
+    """``stop()`` unsubscribes the bus listener and stops both monitors."""
+    db = _make_db(tmp_path)
+    controller = DevicesController(db)
+    _stub_inner_lifecycle(controller)
+    # Pretend ``start()`` already ran and registered a listener.
+    unsub_calls: list[bool] = []
+
+    def _unsub() -> None:
+        unsub_calls.append(True)
+
+    controller._unsub_job_completed = _unsub
+
+    await controller.stop()
+
+    assert unsub_calls == [True]
+    assert controller._unsub_job_completed is None
+    controller._mqtt_coordinator.stop.assert_awaited_once()
+    controller._state_monitor.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent_without_started_listener(
+    tmp_path: Path,
+) -> None:
+    """``stop()`` before ``start()`` (or after a previous ``stop()``) doesn't crash.
+
+    Pin the ``if self._unsub_job_completed is not None`` guard —
+    a refactor that dropped it would crash the second teardown
+    on a process restart that calls stop+start+stop.
+    """
+    db = _make_db(tmp_path)
+    controller = DevicesController(db)
+    _stub_inner_lifecycle(controller)
+    # Never started; ``_unsub_job_completed`` is the ``__init__`` default.
+    assert controller._unsub_job_completed is None
+
+    await controller.stop()
+
+    controller._mqtt_coordinator.stop.assert_awaited_once()
+    controller._state_monitor.stop.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# poll()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_rescans_and_reconciles_mqtt(tmp_path: Path) -> None:
+    """``poll()`` runs a fresh scan + MQTT reconcile.
+
+    The dashboard's periodic poll path; pin both calls so a
+    refactor that dropped either silently breaks file-change /
+    broker-rediscovery detection.
+    """
+    db = _make_db(tmp_path)
+    controller = DevicesController(db)
+    _stub_inner_lifecycle(controller)
+
+    await controller.poll()
+
+    controller._scanner.scan.assert_awaited_once()
+    controller._mqtt_coordinator.reconcile.assert_awaited_once()

--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -6,15 +6,15 @@ bypass ``__init__`` via ``__new__`` and stub
 individually — that lets each test target one method but leaves
 the wiring code itself uncovered:
 
-- ``__init__`` (lines 81-129) — constructs the scanner, state
-  monitor, and MQTT coordinator and threads their callbacks
-  back to the controller.
-- ``start()`` (lines 142-149) — resolves the esphome cmd, loads
-  ignored devices, kicks the scanner, starts the state monitor,
+- ``__init__`` — constructs the scanner, state monitor, and
+  MQTT coordinator and threads their callbacks back to the
+  controller.
+- ``start()`` — resolves the esphome cmd, loads ignored
+  devices, kicks the scanner, starts the state monitor,
   reconciles MQTT, and registers the JOB_COMPLETED listener.
-- ``stop()`` (lines 155-159) — unsubscribes the bus listener and
-  stops the two background monitors.
-- ``poll()`` (lines 163-164) — re-scans and reconciles MQTT.
+- ``stop()`` — unsubscribes the bus listener and stops the two
+  background monitors.
+- ``poll()`` — re-scans and reconciles MQTT.
 
 These tests instantiate a real ``DevicesController`` against a
 ``tmp_path`` config dir and a thin stub ``DeviceBuilder`` so the
@@ -165,6 +165,14 @@ async def test_start_runs_full_initialisation_chain(
     refactor that reordered (e.g. ``state_monitor.start`` before
     ``scanner.scan``) could cause cold-start ordering bugs the
     individual tests wouldn't catch.
+
+    Call ordering is asserted via a parent ``MagicMock`` that all
+    three inner lifecycle hooks attach to: the production code
+    awaits ``scanner.scan`` first, then ``state_monitor.start``,
+    then ``mqtt_coordinator.reconcile``. The state monitor reads
+    ``self._scanner.devices`` for its first sweep, so swapping
+    those two would have it iterate over an empty list at
+    cold-start.
     """
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.controller._find_esphome_cmd",
@@ -173,6 +181,14 @@ async def test_start_runs_full_initialisation_chain(
     db = _make_db(tmp_path)
     controller = DevicesController(db)
     _stub_inner_lifecycle(controller)
+
+    # Attach each AsyncMock to a single parent so ``mock_calls`` on
+    # the parent records the relative ordering across the three
+    # inner controllers.
+    parent = MagicMock()
+    parent.attach_mock(controller._scanner.scan, "scan")  # type: ignore[arg-type]
+    parent.attach_mock(controller._state_monitor.start, "state_monitor_start")  # type: ignore[arg-type]
+    parent.attach_mock(controller._mqtt_coordinator.reconcile, "reconcile")  # type: ignore[arg-type]
 
     # Seed an ignored-devices file so ``_load_ignored_devices`` has
     # something real to process — otherwise it's silently a no-op
@@ -192,6 +208,9 @@ async def test_start_runs_full_initialisation_chain(
     controller._scanner.scan.assert_awaited_once()
     controller._state_monitor.start.assert_awaited_once()
     controller._mqtt_coordinator.reconcile.assert_awaited_once()
+    # Pin the relative order: scan → state_monitor.start → reconcile.
+    observed_order = [c[0] for c in parent.mock_calls]
+    assert observed_order == ["scan", "state_monitor_start", "reconcile"]
     # JOB_COMPLETED listener registered via the real ``EventBus``-shaped stub.
     assert db.bus.listeners == [(EventType.JOB_COMPLETED, controller._on_firmware_job_completed)]
     assert controller._unsub_job_completed is not None

--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -79,10 +79,11 @@ def test_init_constructs_inner_controllers(tmp_path: Path) -> None:
 
     Pin the wiring so a refactor that drops one of the three
     components, or skips threading a callback through, surfaces
-    here. The state monitor in particular has nine separate
-    callbacks that all have to point back at controller methods —
-    a typo'd one would silently break a single class of state
-    transitions in production.
+    here. The state monitor in particular has seven separate
+    callbacks (state, ip, version, config_hash, api_encryption,
+    importable_added, importable_removed) that all have to point
+    back at controller methods — a typo'd one would silently
+    break a single class of state transitions in production.
     """
     db = _make_db(tmp_path)
     controller = DevicesController(db)

--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -27,7 +27,6 @@ are exercised in their own dedicated tests.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -35,39 +34,7 @@ import pytest
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import EventType
 
-
-class _Bus:
-    """Minimal event-bus stand-in.
-
-    ``add_listener`` records the registration and returns a
-    callable that records the unsubscribe — production
-    ``EventBus`` returns a closure that removes the entry, so the
-    return value's call-on-close behaviour is what ``stop()``
-    relies on.
-    """
-
-    def __init__(self) -> None:
-        self.listeners: list[tuple[EventType, Any]] = []
-        self.unsub_calls = 0
-
-    def add_listener(self, event_type: EventType, handler: Any) -> Any:
-        self.listeners.append((event_type, handler))
-
-        def _unsub() -> None:
-            self.unsub_calls += 1
-
-        return _unsub
-
-
-def _make_db(tmp_path: Path) -> MagicMock:
-    """Build a ``DeviceBuilder``-shaped stub for the controller's ``__init__``."""
-    db = MagicMock()
-    db.settings.config_dir = tmp_path
-    db.settings.absolute_config_dir = tmp_path.resolve()
-    db.settings.password = ""  # ConfigController-side; harmless for tests
-    db.bus = _Bus()
-    return db
-
+from .conftest import MakeDbFactory
 
 # ---------------------------------------------------------------------------
 # __init__
@@ -75,7 +42,7 @@ def _make_db(tmp_path: Path) -> MagicMock:
 
 
 def test_init_threads_state_monitor_callbacks_to_controller_methods(
-    tmp_path: Path,
+    tmp_path: Path, make_db: MakeDbFactory
 ) -> None:
     """State-monitor callbacks point back at ``self._on_*_change`` methods.
 
@@ -85,7 +52,7 @@ def test_init_threads_state_monitor_callbacks_to_controller_methods(
     refactor accidentally bypasses one of them, that whole class
     of bug returns.
     """
-    db = _make_db(tmp_path)
+    db = make_db(tmp_path)
     controller = DevicesController(db)
 
     # Bound-method equality: ``a is b`` fails on bound methods even
@@ -126,7 +93,7 @@ def _stub_inner_lifecycle(controller: DevicesController) -> None:
 
 @pytest.mark.asyncio
 async def test_start_runs_full_initialisation_chain(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_db: MakeDbFactory
 ) -> None:
     """``start()`` resolves esphome cmd, loads ignored, scans, starts monitors, subscribes bus.
 
@@ -148,7 +115,7 @@ async def test_start_runs_full_initialisation_chain(
         "esphome_device_builder.controllers.devices.controller._find_esphome_cmd",
         lambda: ["python", "-m", "esphome"],
     )
-    db = _make_db(tmp_path)
+    db = make_db(tmp_path)
     controller = DevicesController(db)
     _stub_inner_lifecycle(controller)
 
@@ -192,9 +159,11 @@ async def test_start_runs_full_initialisation_chain(
 
 
 @pytest.mark.asyncio
-async def test_stop_tears_down_monitors_and_unsubscribes(tmp_path: Path) -> None:
+async def test_stop_tears_down_monitors_and_unsubscribes(
+    tmp_path: Path, make_db: MakeDbFactory
+) -> None:
     """``stop()`` unsubscribes the bus listener and stops both monitors."""
-    db = _make_db(tmp_path)
+    db = make_db(tmp_path)
     controller = DevicesController(db)
     _stub_inner_lifecycle(controller)
     # Pretend ``start()`` already ran and registered a listener.
@@ -215,7 +184,7 @@ async def test_stop_tears_down_monitors_and_unsubscribes(tmp_path: Path) -> None
 
 @pytest.mark.asyncio
 async def test_stop_is_idempotent_without_started_listener(
-    tmp_path: Path,
+    tmp_path: Path, make_db: MakeDbFactory
 ) -> None:
     """``stop()`` before ``start()`` (or after a previous ``stop()``) doesn't crash.
 
@@ -223,7 +192,7 @@ async def test_stop_is_idempotent_without_started_listener(
     a refactor that dropped it would crash the second teardown
     on a process restart that calls stop+start+stop.
     """
-    db = _make_db(tmp_path)
+    db = make_db(tmp_path)
     controller = DevicesController(db)
     _stub_inner_lifecycle(controller)
     # Never started; ``_unsub_job_completed`` is the ``__init__`` default.
@@ -241,14 +210,14 @@ async def test_stop_is_idempotent_without_started_listener(
 
 
 @pytest.mark.asyncio
-async def test_poll_rescans_and_reconciles_mqtt(tmp_path: Path) -> None:
+async def test_poll_rescans_and_reconciles_mqtt(tmp_path: Path, make_db: MakeDbFactory) -> None:
     """``poll()`` runs a fresh scan + MQTT reconcile.
 
     The dashboard's periodic poll path; pin both calls so a
     refactor that dropped either silently breaks file-change /
     broker-rediscovery detection.
     """
-    db = _make_db(tmp_path)
+    db = make_db(tmp_path)
     controller = DevicesController(db)
     _stub_inner_lifecycle(controller)
 


### PR DESCRIPTION
## Summary
The handler-level tests in \`tests/controllers/devices/\` all bypass \`__init__\` via \`__new__\` and stub the inner controllers individually. That left the wiring code itself uncovered: \`__init__\` (lines 81-129) constructing the scanner / state monitor / MQTT coordinator and threading their nine callbacks back to the controller, plus \`start\` / \`stop\` / \`poll\` (lines 142-164).

6 tests in \`tests/controllers/devices/test_lifecycle_e2e.py\` instantiate a real \`DevicesController\` against a \`tmp_path\` config dir and a thin stub \`DeviceBuilder\`:

- **\`__init__\`** constructs all three inner controllers, sets the documented default attrs, wires the scanner against \`tmp_path\`.
- **State-monitor callbacks** point back at \`self._on_*_change\` — pin the seven distinct wires (regression class from PR #75).
- **\`start\`** resolves esphome cmd, loads ignored, scans, starts the state monitor, reconciles MQTT, registers the JOB_COMPLETED bus listener.
- **\`stop\`** unsubscribes the bus listener and stops both monitors.
- **\`stop\` is idempotent** without a started listener (cold process restart).
- **\`poll\`** rescans + reconciles MQTT.

Inner monitor lifecycle methods are patched as \`AsyncMock\` so \`start\` / \`stop\` don't try to open a zeroconf browser or connect to MQTT — those have their own dedicated test files.

## Test plan
- [x] \`uv run pytest tests/controllers/devices/test_lifecycle_e2e.py\` — 6 passed
- [x] \`uv run pre-commit run\` clean