### PR TITLE
Speed up the three slowest test cases

### DIFF
--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -19,11 +19,14 @@ import subprocess
 import sys
 import time
 from contextlib import suppress
+from functools import partial
 from unittest.mock import MagicMock
 
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware import controller as _firmware_controller_mod
+from esphome_device_builder.helpers import process as _process_mod
 from esphome_device_builder.helpers.process import _signal_process_group
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
 
@@ -149,6 +152,7 @@ def controller() -> FirmwareController:
 
 async def test_terminate_kills_grandchild_via_process_group(
     controller: FirmwareController,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cancel-while-compiling must kill platformio/gcc grandchildren too.
 
@@ -156,6 +160,15 @@ async def test_terminate_kills_grandchild_via_process_group(
     forks ``gcc``. ``proc.terminate()`` only hits the direct child, so
     the toolchain runs on regardless. Group-signalling fixes that.
     """
+    # Production grace is 3s so well-behaved tools can flush on SIGTERM;
+    # this test deliberately traps SIGTERM, so the grace is pure dead
+    # time. Wrap the controller's binding so the SIGKILL escalation
+    # fires after 0.1s instead of the full window.
+    monkeypatch.setattr(
+        _firmware_controller_mod,
+        "terminate_subtree_with_grace",
+        partial(_process_mod.terminate_subtree_with_grace, grace_seconds=0.1),
+    )
     # Parent spawns a grandchild that traps SIGTERM (so a parent-only
     # signal would not cascade) and prints its pid for the assertion.
     script = (

--- a/tests/test_components_integration_docs.py
+++ b/tests/test_components_integration_docs.py
@@ -14,8 +14,9 @@ import pytest
 from esphome_device_builder.controllers.components import ComponentCatalog
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def catalog() -> ComponentCatalog:
+    """Boot the catalog once per module — none of the tests below mutate it."""
     cat = ComponentCatalog()
     cat.load()
     return cat

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -60,7 +60,7 @@ async def test_create_subprocess_exec_actually_runs() -> None:
     assert b"subprocess-helper-ok" in stdout
 
 
-async def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> None:
+def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> None:
     """Guard against regressions: no callsite should bypass the helper.
 
     Catches future commits that re-introduce a direct
@@ -69,15 +69,22 @@ async def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> No
     """
     pkg_root = Path(esphome_device_builder.__file__).parent
     helper_path = pkg_root / "helpers" / "subprocess.py"
+    needle = b"asyncio.create_subprocess_exec"
 
+    # Bytes-mode short-circuit: most files don't contain the needle, so
+    # one ``in`` check on the file blob beats decoding + walking every
+    # line. Run as a sync test so blockbuster doesn't wrap each
+    # ``read_bytes`` on Linux CI.
     offenders: list[str] = []
     for path in pkg_root.rglob("*.py"):
         if path == helper_path:
             continue
-        text = path.read_text(encoding="utf-8")
-        for lineno, line in enumerate(text.splitlines(), start=1):
-            if "asyncio.create_subprocess_exec" in line:
-                offenders.append(f"{path.relative_to(pkg_root)}:{lineno}: {line.strip()}")
+        blob = path.read_bytes()
+        if needle not in blob:
+            continue
+        for lineno, line in enumerate(blob.splitlines(), start=1):
+            if needle in line:
+                offenders.append(f"{path.relative_to(pkg_root)}:{lineno}: {line.decode().strip()}")
 
     assert not offenders, (
         "Found direct asyncio.create_subprocess_exec calls — use "


### PR DESCRIPTION
## Summary
- Shrink the SIGTERM grace in `test_terminate_kills_grandchild_via_process_group` from 3s to 0.1s by patching the firmware controller's binding of `terminate_subtree_with_grace`. The test deliberately traps SIGTERM, so the full grace window was pure dead time before SIGKILL escalation (3.11s -> 0.12s).
- Promote the `catalog` fixture in `tests/test_components_integration_docs.py` from function- to module-scope. None of the tests there mutate the catalog, so we load it once instead of seven times.
- Drop async + `read_text` in `test_no_call_site_uses_asyncio_create_subprocess_exec_directly` for sync `read_bytes` with a blob-level `in` check before any per-line walk. Avoids blockbuster wrapping each decode on Linux CI, and most files skip the line walk entirely.

## Test plan
- [x] `uv run pytest tests/test_subprocess_helper.py tests/test_components_integration_docs.py tests/controllers/firmware/test_stop.py --durations=20`
- [ ] CI green on Linux (the platform where the slowdowns originally surfaced)