### PR TITLE
Share catalog parses across the catalog-heavy tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,9 @@ from typing import TYPE_CHECKING
 import pytest
 from blockbuster import blockbuster_ctx
 
+from esphome_device_builder.controllers.boards import BoardCatalog
+from esphome_device_builder.controllers.components import ComponentCatalog
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -77,3 +80,43 @@ def blockbuster() -> Iterator[BlockBuster | None]:
             for filename, func_name in _STARTUP_BLOCKING_OK:
                 fn.can_block_in(filename, func_name)
         yield bb
+
+
+# ---------------------------------------------------------------------------
+# Catalog fixtures
+#
+# ``ComponentCatalog.load`` parses ~40 MB of JSON and instantiates ~900 entry
+# objects — about a second wall-time per call, plus blockbuster overhead on
+# Linux CI. Hoisting the load to a session-scoped fixture lets every test
+# module that wants the real catalog share the same instance per xdist
+# worker, instead of paying the cost in each module's setup.
+# ---------------------------------------------------------------------------
+
+
+class _CatalogContainer:
+    """Minimal ``device_builder``-shaped object the ComponentCatalog reads from."""
+
+    boards: BoardCatalog | None = None
+    components: ComponentCatalog | None = None
+
+
+@pytest.fixture(scope="session")
+def session_board_catalog() -> BoardCatalog:
+    """Real ``BoardCatalog`` loaded once per xdist worker."""
+    cat = BoardCatalog()
+    cat.load()
+    return cat
+
+
+@pytest.fixture(scope="session")
+def session_component_catalog(session_board_catalog: BoardCatalog) -> ComponentCatalog:
+    """Real ``ComponentCatalog`` (with featured registry built) loaded once per worker.
+
+    Tests that mutate the catalog must restore it before yielding back —
+    the instance is shared across every test in the session.
+    """
+    container = _CatalogContainer()
+    container.boards = session_board_catalog
+    container.components = ComponentCatalog(container)
+    container.components.load()
+    return container.components

--- a/tests/test_components_integration_docs.py
+++ b/tests/test_components_integration_docs.py
@@ -14,12 +14,10 @@ import pytest
 from esphome_device_builder.controllers.components import ComponentCatalog
 
 
-@pytest.fixture(scope="module")
-def catalog() -> ComponentCatalog:
-    """Boot the catalog once per module — none of the tests below mutate it."""
-    cat = ComponentCatalog()
-    cat.load()
-    return cat
+@pytest.fixture
+def catalog(session_component_catalog: ComponentCatalog) -> ComponentCatalog:
+    """Reuse the session-scoped catalog — none of the tests below mutate it."""
+    return session_component_catalog
 
 
 async def test_top_level_components_resolved(catalog: ComponentCatalog) -> None:

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -21,7 +21,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices.helpers import _apply_featured_presets
@@ -98,20 +97,10 @@ def test_load_featured_bundle() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="module")
-def catalog() -> ComponentCatalog:
-    """Boot board + component catalogs once per module."""
-
-    class _DB:
-        boards: BoardCatalog | None = None
-        components: ComponentCatalog | None = None
-
-    db = _DB()
-    db.boards = BoardCatalog()
-    db.boards.load()
-    db.components = ComponentCatalog(db)
-    db.components.load()
-    return db.components
+@pytest.fixture
+def catalog(session_component_catalog: ComponentCatalog) -> ComponentCatalog:
+    """Reuse the session-scoped catalog (board catalog already wired in)."""
+    return session_component_catalog
 
 
 def test_registry_indexes_known_boards(catalog: ComponentCatalog) -> None:

--- a/tests/test_validate_featured.py
+++ b/tests/test_validate_featured.py
@@ -8,6 +8,8 @@ manifests in ``definitions/boards/``.
 
 from __future__ import annotations
 
+import pytest
+
 from script.validate_definitions import (  # type: ignore[import-not-found]
     _build_components_index,
     _validate_featured,
@@ -15,7 +17,14 @@ from script.validate_definitions import (  # type: ignore[import-not-found]
 )
 
 
+@pytest.fixture(scope="module")
 def _index() -> dict | None:
+    """Parse ``components.json`` once per module — every test wants the same index.
+
+    ``_build_components_index`` re-reads and JSON-decodes a ~40 MB file
+    on each call; sharing one snapshot across the file's tests turns
+    ten loads into one without changing the validator's contract.
+    """
     return _build_components_index()
 
 
@@ -31,7 +40,7 @@ def _pins(*gpios: int) -> dict[int, dict]:
     return {g: {"gpio": g, "features": []} for g in gpios}
 
 
-def test_valid_locked_pin() -> None:
+def test_valid_locked_pin(_index: dict | None) -> None:
     """A featured switch.gpio with a locked, declared pin passes."""
     errors = _validate_featured(
         "demo",
@@ -45,22 +54,22 @@ def test_valid_locked_pin() -> None:
             ]
         ),
         _pins(12),
-        _index(),
+        _index,
     )
     assert errors == []
 
 
-def test_unknown_component_id() -> None:
+def test_unknown_component_id(_index: dict | None) -> None:
     errors = _validate_featured(
         "demo",
         _board([{"id": "foo", "component_id": "definitely.not.real", "fields": {}}]),
         {},
-        _index(),
+        _index,
     )
     assert any("not found in components.json" in e for e in errors)
 
 
-def test_unknown_field_key() -> None:
+def test_unknown_field_key(_index: dict | None) -> None:
     errors = _validate_featured(
         "demo",
         _board(
@@ -73,12 +82,12 @@ def test_unknown_field_key() -> None:
             ]
         ),
         _pins(12),
-        _index(),
+        _index,
     )
     assert any("not a config_entry on switch.gpio" in e for e in errors)
 
 
-def test_pin_not_declared() -> None:
+def test_pin_not_declared(_index: dict | None) -> None:
     errors = _validate_featured(
         "demo",
         _board(
@@ -91,12 +100,12 @@ def test_pin_not_declared() -> None:
             ]
         ),
         _pins(12),  # GPIO99 is not a declared pin
-        _index(),
+        _index,
     )
     assert any("GPIO 99 not declared in pins" in e for e in errors)
 
 
-def test_suggestions_pin_not_declared() -> None:
+def test_suggestions_pin_not_declared(_index: dict | None) -> None:
     errors = _validate_featured(
         "demo",
         _board(
@@ -109,12 +118,12 @@ def test_suggestions_pin_not_declared() -> None:
             ]
         ),
         _pins(4),
-        _index(),
+        _index,
     )
     assert any("GPIO 99 not declared in pins" in e for e in errors)
 
 
-def test_dict_pin_with_number_validates() -> None:
+def test_dict_pin_with_number_validates(_index: dict | None) -> None:
     """Rich pin form ({number, mode, inverted}) gets its GPIO checked."""
     errors = _validate_featured(
         "demo",
@@ -137,12 +146,12 @@ def test_dict_pin_with_number_validates() -> None:
             ]
         ),
         _pins(0),
-        _index(),
+        _index,
     )
     assert errors == []
 
 
-def test_duplicate_featured_id() -> None:
+def test_duplicate_featured_id(_index: dict | None) -> None:
     errors = _validate_featured(
         "demo",
         _board(
@@ -152,12 +161,12 @@ def test_duplicate_featured_id() -> None:
             ]
         ),
         {},
-        _index(),
+        _index,
     )
     assert any("duplicate id 'relay'" in e for e in errors)
 
 
-def test_duplicate_bundle_id() -> None:
+def test_duplicate_bundle_id(_index: dict | None) -> None:
     errors = _validate_featured(
         "demo",
         _board(
@@ -168,12 +177,12 @@ def test_duplicate_bundle_id() -> None:
             ],
         ),
         {},
-        _index(),
+        _index,
     )
     assert any("duplicate id 'led'" in e for e in errors)
 
 
-def test_bundle_unknown_component_id() -> None:
+def test_bundle_unknown_component_id(_index: dict | None) -> None:
     errors = _validate_featured(
         "demo",
         _board(
@@ -183,12 +192,12 @@ def test_bundle_unknown_component_id() -> None:
             ],
         ),
         {},
-        _index(),
+        _index,
     )
     assert any("'ghost' does not match any" in e for e in errors)
 
 
-def test_locked_and_suggestions_both_set() -> None:
+def test_locked_and_suggestions_both_set(_index: dict | None) -> None:
     errors = _validate_featured(
         "demo",
         _board(
@@ -201,7 +210,7 @@ def test_locked_and_suggestions_both_set() -> None:
             ]
         ),
         _pins(4, 5),
-        _index(),
+        _index,
     )
     assert any("cannot set both 'locked' and 'suggestions'" in e for e in errors)
 
@@ -248,7 +257,7 @@ def test_field_preset_imported_still_requires_pin_declared() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_id_with_hyphens_rejected() -> None:
+def test_id_with_hyphens_rejected(_index: dict | None) -> None:
     """Hyphens in featured-component ids fail validation outright."""
     errors = _validate_featured(
         "demo",
@@ -262,12 +271,12 @@ def test_id_with_hyphens_rejected() -> None:
             ]
         ),
         {},
-        _index(),
+        _index,
     )
     assert any("no hyphens" in e for e in errors)
 
 
-def test_id_collides_with_dotted_domain() -> None:
+def test_id_collides_with_dotted_domain(_index: dict | None) -> None:
     """An id equal to the component_id's domain (e.g. ``output``) is rejected."""
     errors = _validate_featured(
         "demo",
@@ -281,12 +290,12 @@ def test_id_collides_with_dotted_domain() -> None:
             ]
         ),
         {},
-        _index(),
+        _index,
     )
     assert any("clashes with domain 'output'" in e and "output_<role>" in e for e in errors)
 
 
-def test_id_collides_with_single_segment_component_id() -> None:
+def test_id_collides_with_single_segment_component_id(_index: dict | None) -> None:
     """For component_ids without a dot (``i2c``, ``rtttl``), id must not equal it."""
     errors = _validate_featured(
         "demo",
@@ -300,12 +309,12 @@ def test_id_collides_with_single_segment_component_id() -> None:
             ]
         ),
         {},
-        _index(),
+        _index,
     )
     assert any("clashes with domain 'i2c'" in e for e in errors)
 
 
-def test_clean_id_passes_shape_check() -> None:
+def test_clean_id_passes_shape_check(_index: dict | None) -> None:
     """A canonical lowercase-underscore id with a descriptive name passes."""
     errors = _validate_featured(
         "demo",
@@ -319,14 +328,14 @@ def test_clean_id_passes_shape_check() -> None:
             ]
         ),
         {},
-        _index(),
+        _index,
     )
     # Neither shape nor collision messages should appear; the entry is clean.
     assert not any("no hyphens" in e for e in errors)
     assert not any("clashes with domain" in e for e in errors)
 
 
-def test_bundle_id_with_hyphens_rejected() -> None:
+def test_bundle_id_with_hyphens_rejected(_index: dict | None) -> None:
     """The same shape rule applies to ``featured_bundles[].id``."""
     errors = _validate_featured(
         "demo",
@@ -335,6 +344,6 @@ def test_bundle_id_with_hyphens_rejected() -> None:
             [{"id": "rgb-buzzer", "name": "RGB+Buzzer", "component_ids": ["a"]}],
         ),
         {},
-        _index(),
+        _index,
     )
     assert any("no hyphens" in e and "rgb-buzzer" in e for e in errors)


### PR DESCRIPTION
## Summary
- Hoist `BoardCatalog` + `ComponentCatalog` into session-scoped fixtures in `tests/conftest.py`. `test_featured_components` and `test_components_integration_docs` now share one parse per xdist worker instead of paying ~1s of catalog load per module.
- Cache `_build_components_index` once per module in `test_validate_featured`. Each of the file's 17 tests was rebuilding the index from a 40 MB JSON parse (≈0.5s); now they all share one snapshot via a module-scoped fixture.

Targets the slow setups reported on `main`:
- `test_registry_indexes_known_boards` (2.62s setup) and `test_top_level_components_resolved` (1.06s setup) — now share one session-scoped catalog.
- 10× `test_validate_featured` cases at ~0.55s call time — index parse hoisted to module scope.

## Test plan
- [x] `uv run pytest tests/test_validate_featured.py tests/test_components_integration_docs.py tests/test_featured_components.py --durations=20`
- [x] `uv run pytest --durations=10 -q` — full suite passes
- [ ] CI green on Linux (the platform where the slowdowns originally surfaced)