### PR TITLE
Cover api/ws Bearer + dispatch error branches

### DIFF
--- a/tests/test_ws_dispatch_branches.py
+++ b/tests/test_ws_dispatch_branches.py
@@ -1,0 +1,216 @@
+"""Coverage for the small dispatch / serialization branches in ``api/ws.py``.
+
+The shared dispatcher (``WebSocketClient._handle_command``) and the
+result/error/event serialisers each carry a handful of one-or-two-line
+branches that can silently break if a future refactor reshapes them
+— e.g. a result type without ``to_dict`` would no longer get coerced,
+or a missing-handler branch would raise instead of returning a typed
+error. The tests below pin one assertion per branch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.api.ws import WebSocketClient
+from esphome_device_builder.controllers.auth import AuthError
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
+
+
+def _make_client(*, authenticated: bool = True) -> tuple[WebSocketClient, AsyncMock]:
+    ws = MagicMock()
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    db = MagicMock()
+    client = WebSocketClient(ws, db, authenticated=authenticated)
+    return client, ws
+
+
+def _last_payload(ws: AsyncMock) -> dict[str, Any]:
+    """Return the dict passed to the most-recent ``send_json`` call."""
+    assert ws.send_json.await_count >= 1
+    return ws.send_json.await_args.args[0]
+
+
+# ---------------------------------------------------------------------------
+# Property accessors
+# ---------------------------------------------------------------------------
+
+
+def test_token_property_returns_value_set_by_authenticator() -> None:
+    """``token`` reflects what ``set_authenticated`` recorded.
+
+    Pin the read path so a refactor that drops ``_token`` (or adds
+    a wrapper that mangles it) breaks here rather than silently
+    desyncing the bearer-validation cache from the per-connection
+    state.
+    """
+    client, _ = _make_client(authenticated=False)
+    assert client.token is None
+    client.set_authenticated("session-abc")
+    assert client.token == "session-abc"
+    assert client.authenticated is True
+
+
+# ---------------------------------------------------------------------------
+# Result serialisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_result_invokes_to_dict_on_dataclass_results() -> None:
+    """``send_result`` flattens ``to_dict``-shaped results before sending.
+
+    Most handler returns are mashumaro dataclasses; the wire layer
+    serialises them via the dataclass's own ``to_dict`` so the
+    JSON shape stays under model control instead of getting
+    auto-derived from ``__dict__``.
+    """
+    client, ws = _make_client()
+
+    class _Result:
+        def to_dict(self) -> dict[str, str]:
+            return {"flavoured": "yes"}
+
+    await client.send_result("m1", _Result())
+
+    payload = _last_payload(ws)
+    assert payload["result"] == {"flavoured": "yes"}
+    assert payload["message_id"] == "m1"
+
+
+@pytest.mark.asyncio
+async def test_send_event_serialises_eventmessage() -> None:
+    """``send_event`` packages the event into the ``EventMessage`` envelope."""
+    client, ws = _make_client()
+
+    await client.send_event("m1", "scan_progress", data={"completed": 3})
+
+    payload = _last_payload(ws)
+    assert payload["event"] == "scan_progress"
+    assert payload["data"] == {"completed": 3}
+    assert payload["message_id"] == "m1"
+
+
+# ---------------------------------------------------------------------------
+# _handle_command — error branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_command_invalid_message_format() -> None:
+    """A raw payload that fails ``CommandMessage.from_dict`` returns INVALID_MESSAGE.
+
+    Pin the empty-string ``message_id`` — the client doesn't yet
+    have a parsed id (parsing is what failed), so the error must
+    use the unauthenticated/empty-id sentinel.
+    """
+    client, ws = _make_client()
+
+    # Missing ``command`` field — ``CommandMessage.from_dict`` raises.
+    await client._handle_command({"message_id": "m1"})
+
+    payload = _last_payload(ws)
+    assert payload["error_code"] == ErrorCode.INVALID_MESSAGE.value
+    assert payload["message_id"] == ""
+
+
+@pytest.mark.asyncio
+async def test_handle_command_unknown_command_returns_typed_error() -> None:
+    """Unrecognised commands surface as ``UNKNOWN_COMMAND``, not as a 500.
+
+    The dispatcher has to look up handlers by string key — a typo'd
+    command from the client must not be allowed to crash the
+    handler loop. Pin the typed error so regressions show up here.
+    """
+    client, ws = _make_client()
+    client.device_builder.command_handlers = {}
+
+    await client._handle_command({"message_id": "m1", "command": "garbage/nonexistent"})
+
+    payload = _last_payload(ws)
+    assert payload["error_code"] == ErrorCode.UNKNOWN_COMMAND.value
+    assert "garbage/nonexistent" in payload["details"]
+
+
+@pytest.mark.asyncio
+async def test_handle_command_pre_auth_blocks_non_auth_commands() -> None:
+    """A non-``auth`` command before authentication is refused with NOT_AUTHENTICATED.
+
+    The pre-auth guard is the one thing standing between an
+    un-authenticated client and the rest of the API — pin it so a
+    refactor that flipped the inversion (or skipped it for a
+    "convenience" command) is caught immediately.
+    """
+    client, ws = _make_client(authenticated=False)
+    # Having a handler registered makes sure the rejection happens
+    # in the auth gate, not because of a missing handler.
+    client.device_builder.command_handlers = {"devices/list": AsyncMock()}
+
+    await client._handle_command({"message_id": "m1", "command": "devices/list"})
+
+    payload = _last_payload(ws)
+    assert payload["error_code"] == ErrorCode.NOT_AUTHENTICATED.value
+    client.device_builder.command_handlers["devices/list"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_command_passes_through_auth_error_code() -> None:
+    """``AuthError`` from a handler keeps its own code/message verbatim.
+
+    The auth controller raises typed errors (rate-limited login,
+    expired session, etc.) that the frontend matches on by code —
+    a generic ``INTERNAL_ERROR`` re-raise would lose that signal
+    and force the client into its "unknown failure" UI.
+    """
+    client, ws = _make_client()
+    client.device_builder.command_handlers = {
+        "auth/login": AsyncMock(side_effect=AuthError(ErrorCode.RATE_LIMITED, "slow down")),
+    }
+
+    await client._handle_command({"message_id": "m1", "command": "auth/login"})
+
+    payload = _last_payload(ws)
+    assert payload["error_code"] == ErrorCode.RATE_LIMITED.value
+    assert payload["details"] == "slow down"
+
+
+@pytest.mark.asyncio
+async def test_handle_command_passes_through_command_error_code() -> None:
+    """``CommandError`` from a handler also keeps its own typed code."""
+    client, ws = _make_client()
+    client.device_builder.command_handlers = {
+        "devices/rename": AsyncMock(
+            side_effect=CommandError(ErrorCode.INVALID_ARGS, "bad name"),
+        ),
+    }
+
+    await client._handle_command({"message_id": "m1", "command": "devices/rename"})
+
+    payload = _last_payload(ws)
+    assert payload["error_code"] == ErrorCode.INVALID_ARGS.value
+    assert payload["details"] == "bad name"
+
+
+@pytest.mark.asyncio
+async def test_handle_command_unexpected_exception_becomes_internal_error() -> None:
+    """A bare ``Exception`` from a handler is logged and surfaced as INTERNAL_ERROR.
+
+    Pin the catch-all so a future ``raise`` from anywhere inside a
+    handler can never crash the dispatcher — the client always
+    gets *some* terminal frame on its message id.
+    """
+    client, ws = _make_client()
+    client.device_builder.command_handlers = {
+        "devices/list": AsyncMock(side_effect=RuntimeError("boom")),
+    }
+
+    await client._handle_command({"message_id": "m1", "command": "devices/list"})
+
+    payload = _last_payload(ws)
+    assert payload["error_code"] == ErrorCode.INTERNAL_ERROR.value
+    assert "devices/list" in payload["details"]

--- a/tests/test_ws_handler_branches.py
+++ b/tests/test_ws_handler_branches.py
@@ -3,8 +3,17 @@
 Two paths the small unit-tests in ``test_ws_dispatch_branches.py``
 can't reach because they live inside the request handler:
 
-- Bearer-token pre-authentication (lines 261-266 of ``api/ws.py``).
-- Invalid-JSON inside the message loop (lines 289-294).
+- Bearer-token pre-authentication: when ``settings.using_password``
+  is on and the request carries an ``Authorization: Bearer ...``
+  header, the handler validates the token via
+  ``device_builder.auth.session_store.validate`` and either marks
+  the connection pre-authenticated (token recorded for later
+  ``auth/refresh`` / ``auth/logout``) or falls through to the
+  in-band ``auth/login`` flow.
+- The WS message loop's invalid-JSON branch: a frame whose body
+  fails ``json.loads`` is answered with an ``INVALID_MESSAGE``
+  error and the loop ``continue``-s — the connection survives so
+  the client can recover instead of getting kicked.
 
 Both require driving ``websocket_handler`` end-to-end through aiohttp,
 so they live in their own file.

--- a/tests/test_ws_handler_branches.py
+++ b/tests/test_ws_handler_branches.py
@@ -1,0 +1,163 @@
+"""Coverage for ``websocket_handler`` branches that need a real aiohttp client.
+
+Two paths the small unit-tests in ``test_ws_dispatch_branches.py``
+can't reach because they live inside the request handler:
+
+- Bearer-token pre-authentication (lines 261-266 of ``api/ws.py``).
+- Invalid-JSON inside the message loop (lines 289-294).
+
+Both require driving ``websocket_handler`` end-to-end through aiohttp,
+so they live in their own file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from aiohttp import WSMsgType, web
+from pytest_aiohttp.plugin import AiohttpClient
+
+from esphome_device_builder.api import ws as ws_module
+from esphome_device_builder.models import ErrorCode
+
+
+def _make_settings(*, using_password: bool) -> MagicMock:
+    settings = MagicMock()
+    settings.using_password = using_password
+    settings.port = 6052
+    settings.on_ha_addon = False
+    settings.trusted_domains = []
+    return settings
+
+
+async def _connect_and_drain_server_info(client: Any, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+    """Open the WS and return ``(ws, server_info_dict)``.
+
+    The handler always pushes a ``ServerInfoMessage`` first; tests
+    inspect it to verify ``requires_auth`` was set correctly by the
+    pre-auth path.
+    """
+    ws = await client.ws_connect("/ws", **kwargs)
+    msg = await ws.receive(timeout=2.0)
+    return ws, msg.json()
+
+
+async def test_bearer_token_with_valid_session_pre_authenticates(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A valid ``Authorization: Bearer ...`` header skips the in-band auth handshake.
+
+    Pin the bearer-validation success path: the session store
+    returns a hit, the connection is marked pre-authenticated, and
+    the ``ServerInfoMessage`` is sent with ``requires_auth=False``.
+    Used by HA integration / CLI tools that don't speak the
+    in-band ``auth/login`` protocol.
+    """
+    session = MagicMock()
+    session.token = "session-token"
+
+    auth = MagicMock()
+    auth.session_store = MagicMock()
+    auth.session_store.validate = AsyncMock(return_value=session)
+
+    device_builder = MagicMock()
+    device_builder.settings = _make_settings(using_password=True)
+    device_builder.auth = auth
+    device_builder.command_handlers = {}
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = False
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+
+    ws, info = await _connect_and_drain_server_info(
+        client, headers={"Authorization": "Bearer session-token"}
+    )
+    try:
+        assert info["requires_auth"] is False
+        # Validate was called with the extracted bearer.
+        auth.session_store.validate.assert_awaited_once_with("session-token")
+    finally:
+        await ws.close()
+
+
+async def test_bearer_token_with_invalid_session_falls_back_to_in_band_auth(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """An invalid bearer leaves the connection unauthenticated.
+
+    ``validate`` returning ``None`` is the typical "expired /
+    revoked / wrong" outcome. The handler keeps going so the
+    client can still drive the in-band ``auth/login`` flow — a
+    blanket 403 here would force every misconfigured CLI client
+    to reconnect after fixing its config.
+    """
+    auth = MagicMock()
+    auth.session_store = MagicMock()
+    auth.session_store.validate = AsyncMock(return_value=None)
+
+    device_builder = MagicMock()
+    device_builder.settings = _make_settings(using_password=True)
+    device_builder.auth = auth
+    device_builder.command_handlers = {}
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = False
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+
+    ws, info = await _connect_and_drain_server_info(
+        client, headers={"Authorization": "Bearer wrong-token"}
+    )
+    try:
+        # Bearer validated but rejected — connection stays in the
+        # un-authenticated bucket and the in-band handshake is
+        # required.
+        assert info["requires_auth"] is True
+    finally:
+        await ws.close()
+
+
+async def test_invalid_json_message_returns_invalid_message_error(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A malformed payload over the wire surfaces as ``INVALID_MESSAGE``.
+
+    Pin the dispatcher's ``loads(msg.data)`` ``except`` branch.
+    Without it, a single garbage byte from a buggy client would
+    crash the per-connection handler and disconnect everyone.
+    """
+    device_builder = MagicMock()
+    device_builder.settings = _make_settings(using_password=False)
+    device_builder.auth = MagicMock()
+    device_builder.command_handlers = {}
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = True  # skip in-band auth so the loop runs immediately
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+
+    ws = await client.ws_connect("/ws")
+    try:
+        # Drain the ServerInfoMessage.
+        await ws.receive(timeout=2.0)
+
+        # Send garbage that ``json.loads`` rejects.
+        await ws.send_str("not-json")
+
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type == WSMsgType.TEXT
+        payload = msg.json()
+        assert payload["error_code"] == ErrorCode.INVALID_MESSAGE.value
+        # Empty ``message_id`` because parsing failed before any
+        # id could be extracted.
+        assert payload["message_id"] == ""
+    finally:
+        await ws.close()

--- a/tests/test_ws_handler_branches.py
+++ b/tests/test_ws_handler_branches.py
@@ -13,12 +13,13 @@ so they live in their own file.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import WSMsgType, web
 from pytest_aiohttp.plugin import AiohttpClient
 
 from esphome_device_builder.api import ws as ws_module
+from esphome_device_builder.api.ws import WebSocketClient
 from esphome_device_builder.models import ErrorCode
 
 
@@ -49,10 +50,14 @@ async def test_bearer_token_with_valid_session_pre_authenticates(
     """A valid ``Authorization: Bearer ...`` header skips the in-band auth handshake.
 
     Pin the bearer-validation success path: the session store
-    returns a hit, the connection is marked pre-authenticated, and
-    the ``ServerInfoMessage`` is sent with ``requires_auth=False``.
-    Used by HA integration / CLI tools that don't speak the
-    in-band ``auth/login`` protocol.
+    returns a hit, the connection is marked pre-authenticated,
+    and the ``ServerInfoMessage`` carries ``requires_auth=False``.
+    Also pin ``client.token = session.token`` because later
+    ``auth/refresh`` / ``auth/logout`` lookups key off it — a
+    regression that left ``token=None`` on a bearer-pre-auth
+    socket would still flip ``requires_auth`` correctly but
+    silently break those endpoints. Used by HA integration / CLI
+    tools that don't speak the in-band ``auth/login`` protocol.
     """
     session = MagicMock()
     session.token = "session-token"
@@ -71,15 +76,31 @@ async def test_bearer_token_with_valid_session_pre_authenticates(
     app["trusted_site"] = False
     app.router.add_routes(ws_module.create_ws_routes())
 
+    # Capture the ``WebSocketClient`` instance the handler builds
+    # so the test can inspect ``token`` / ``authenticated`` after
+    # the bearer-pre-auth path runs.
+    constructed: list[WebSocketClient] = []
+    real_init = WebSocketClient.__init__
+
+    def _capture_init(self: WebSocketClient, *args: Any, **kwargs: Any) -> None:
+        real_init(self, *args, **kwargs)
+        constructed.append(self)
+
     client = await aiohttp_client(app)
 
-    ws, info = await _connect_and_drain_server_info(
-        client, headers={"Authorization": "Bearer session-token"}
-    )
+    with patch.object(WebSocketClient, "__init__", _capture_init):
+        ws, info = await _connect_and_drain_server_info(
+            client, headers={"Authorization": "Bearer session-token"}
+        )
     try:
         assert info["requires_auth"] is False
         # Validate was called with the extracted bearer.
         auth.session_store.validate.assert_awaited_once_with("session-token")
+        # Token was threaded onto the connection for downstream
+        # ``auth/refresh`` / ``auth/logout`` lookups.
+        assert len(constructed) == 1
+        assert constructed[0].token == "session-token"
+        assert constructed[0].authenticated is True
     finally:
         await ws.close()
 
@@ -94,6 +115,12 @@ async def test_bearer_token_with_invalid_session_falls_back_to_in_band_auth(
     client can still drive the in-band ``auth/login`` flow — a
     blanket 403 here would force every misconfigured CLI client
     to reconnect after fixing its config.
+
+    Also pin that ``validate`` was actually awaited with the
+    bearer string. Without that assertion, a regression that
+    stopped reading the ``Authorization`` header (or skipped the
+    validation call entirely) would still satisfy
+    ``requires_auth=True`` and pass this test silently.
     """
     auth = MagicMock()
     auth.session_store = MagicMock()
@@ -119,6 +146,9 @@ async def test_bearer_token_with_invalid_session_falls_back_to_in_band_auth(
         # un-authenticated bucket and the in-band handshake is
         # required.
         assert info["requires_auth"] is True
+        # The handler actually consulted the session store with
+        # the bearer string we sent.
+        auth.session_store.validate.assert_awaited_once_with("wrong-token")
     finally:
         await ws.close()
 
@@ -130,12 +160,33 @@ async def test_invalid_json_message_returns_invalid_message_error(
 
     Pin the dispatcher's ``loads(msg.data)`` ``except`` branch.
     Without it, a single garbage byte from a buggy client would
-    crash the per-connection handler and disconnect everyone.
+    tear down that client's connection mid-loop. The handler is
+    per-connection so the blast radius is one client, but a
+    spuriously-disconnecting CLI tool is still a debugging
+    nightmare we'd rather pin down here.
+
+    Three assertions, in order of importance:
+
+    1. The error frame's ``details`` carry "Invalid JSON" — pins
+       the JSON-parse branch specifically rather than any of the
+       three ways the dispatcher can emit ``INVALID_MESSAGE``
+       (the ``CommandMessage.from_dict`` failure path returns the
+       same code with a different ``details`` string, and a
+       handler that forwarded the raw text into ``_handle_command``
+       would also satisfy a code-only check).
+    2. The connection survives — sending a follow-up valid
+       command and receiving its result proves the dispatcher
+       ``continue``-d instead of breaking out of the message
+       loop.
     """
     device_builder = MagicMock()
     device_builder.settings = _make_settings(using_password=False)
     device_builder.auth = MagicMock()
-    device_builder.command_handlers = {}
+
+    async def _ping_handler(*, client: Any, message_id: str, **_kwargs: Any) -> dict[str, str]:
+        return {"pong": "yes"}
+
+    device_builder.command_handlers = {"ping": _ping_handler}
 
     app = web.Application()
     app["device_builder"] = device_builder
@@ -159,5 +210,19 @@ async def test_invalid_json_message_returns_invalid_message_error(
         # Empty ``message_id`` because parsing failed before any
         # id could be extracted.
         assert payload["message_id"] == ""
+        # Pin the JSON-parse branch specifically, not the
+        # ``CommandMessage.from_dict`` failure (which returns the
+        # same code with different details).
+        assert "Invalid JSON" in payload["details"]
+
+        # Connection still alive: send a valid command and
+        # receive its result. If ``continue`` had been replaced
+        # with ``break``, this round-trip would hang.
+        await ws.send_json({"message_id": "after-bad", "command": "ping"})
+        result = await ws.receive(timeout=2.0)
+        assert result.type == WSMsgType.TEXT
+        result_payload = result.json()
+        assert result_payload["message_id"] == "after-bad"
+        assert result_payload["result"] == {"pong": "yes"}
     finally:
         await ws.close()


### PR DESCRIPTION
## Summary
- Adds focused tests for the small dispatch / serialization branches in `api/ws.py` that previously hit the catch-all `INTERNAL_ERROR` fallback in coverage gaps.
- Lifts `api/ws.py` coverage from **87% → 98%**.

## Files

**`test_ws_dispatch_branches.py`** — fast unit tests against `WebSocketClient._handle_command`:
- `INVALID_MESSAGE` (malformed `CommandMessage`)
- `UNKNOWN_COMMAND` (missing handler)
- `NOT_AUTHENTICATED` (pre-auth gate)
- `AuthError` / `CommandError` typed-code passthrough
- generic exception → `INTERNAL_ERROR`
- `to_dict` coercion in `send_result`, `EventMessage` envelope in `send_event`, `token` property accessor.

**`test_ws_handler_branches.py`** — aiohttp-driven end-to-end tests against `websocket_handler`:
- `Authorization: Bearer <token>` with a valid session → connection pre-authenticated, `requires_auth=False`.
- Same header with an invalid session → falls through to in-band auth, `requires_auth=True`.
- Invalid JSON inside the WS message loop → `INVALID_MESSAGE` error frame.

## Test plan
- [x] `uv run pytest tests/test_ws_dispatch_branches.py tests/test_ws_handler_branches.py -v` — all 12 tests pass locally.
- [x] `uv run pytest tests/ --cov=esphome_device_builder.api.ws` — coverage up to 98%.