### PR TITLE
Adopt shared make_controller factory across devices tests

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -222,6 +222,8 @@ class MakeControllerFactory(Protocol):
         config_dir: Path,
         *,
         with_regenerate_state: bool = ...,
+        with_state_monitor: bool = ...,
+        with_boards: bool = ...,
         esphome_cmd: list[str] | None = ...,
     ) -> DevicesController: ...
 
@@ -260,12 +262,26 @@ def make_controller() -> MakeControllerFactory:
     early-return guard at the top of
     ``_schedule_storage_regenerate`` doesn't short-circuit;
     leave it ``None`` for tests that don't reach that code path.
+
+    ``with_state_monitor=True`` attaches a ``MagicMock``-shaped
+    ``_state_monitor`` for tests that exercise paths reading the
+    cached-address / get_cached_addresses lookup (``import_device``,
+    ``create_device``). The monitor's ``get_cached_addresses``
+    defaults to returning ``None`` so the fast-online branch
+    short-circuits unless a test overrides it.
+
+    ``with_boards=True`` attaches a ``MagicMock``-shaped
+    ``_db.boards`` for tests that go through the
+    board-catalog lookup path (``create_device`` and the
+    board-id derivation).
     """
 
     def _make(
         config_dir: Path,
         *,
         with_regenerate_state: bool = False,
+        with_state_monitor: bool = False,
+        with_boards: bool = False,
         esphome_cmd: list[str] | None = None,
     ) -> DevicesController:
         controller = DevicesController.__new__(DevicesController)
@@ -275,6 +291,13 @@ def make_controller() -> MakeControllerFactory:
         controller._scanner = MagicMock()
         controller._scanner.scan = AsyncMock()
         controller._scanner.reload = AsyncMock()
+
+        if with_state_monitor:
+            controller._state_monitor = MagicMock()
+            controller._state_monitor.get_cached_addresses = MagicMock(return_value=None)
+
+        if with_boards:
+            controller._db.boards = MagicMock()
 
         if with_regenerate_state:
             spawned_tasks: list[asyncio.Task[object]] = []

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -11,7 +11,7 @@ exception.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -20,28 +20,16 @@ from esphome_device_builder.controllers.config import (
     get_device_metadata,
     set_device_metadata,
 )
-from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices import controller as devices_module
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
-
-def _make_controller(tmp_path: Any) -> DevicesController:
-    """Stand up a controller without booting the full DeviceBuilder."""
-    ctrl = DevicesController.__new__(DevicesController)
-    ctrl._db = MagicMock()
-    ctrl._db.settings.rel_path = lambda name: tmp_path / name
-    # ``_db.boards`` is truthy in production; tests that exercise the
-    # board lookup override ``get_board`` with an ``AsyncMock``.
-    ctrl._db.boards = MagicMock()
-    ctrl._scanner = MagicMock()
-    ctrl._scanner.scan = AsyncMock()
-    ctrl._state_monitor = MagicMock()
-    return ctrl
+from .conftest import MakeControllerFactory
 
 
 async def test_create_device_translates_file_exists_to_command_error(
-    tmp_path: Any,
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """Re-creating an existing config raises ``INVALID_ARGS``, not ``INTERNAL_ERROR``.
 
@@ -49,7 +37,7 @@ async def test_create_device_translates_file_exists_to_command_error(
     "Command failed" and the wizard can't tell the user the name is
     already taken — they just see a 500-equivalent.
     """
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", "utf-8")
 
     with pytest.raises(CommandError) as excinfo:
@@ -61,9 +49,11 @@ async def test_create_device_translates_file_exists_to_command_error(
     ctrl._scanner.scan.assert_not_called()
 
 
-async def test_create_device_rejects_empty_name(tmp_path: Any) -> None:
+async def test_create_device_rejects_empty_name(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Whitespace-only names produce ``INVALID_ARGS`` instead of a bare ``ValueError``."""
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
 
     with pytest.raises(CommandError) as excinfo:
         await ctrl.create_device(name="   ")
@@ -73,9 +63,11 @@ async def test_create_device_rejects_empty_name(tmp_path: Any) -> None:
     ctrl._scanner.scan.assert_not_called()
 
 
-async def test_create_device_rejects_unknown_board_id(tmp_path: Any) -> None:
+async def test_create_device_rejects_unknown_board_id(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """An unknown ``board_id`` produces ``INVALID_ARGS`` and names the bad id."""
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     ctrl._db.boards.get_board = AsyncMock(return_value=None)
 
     with pytest.raises(CommandError) as excinfo:
@@ -87,14 +79,16 @@ async def test_create_device_rejects_unknown_board_id(tmp_path: Any) -> None:
 
 
 async def test_create_device_writes_stub_yaml_and_scans(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """Happy path with no board / no file_content: stub YAML lands on disk and scan fires."""
     storage_path = tmp_path / "storage.json"
     monkeypatch.setattr(devices_module, "ext_storage_path", lambda _filename: storage_path)
     monkeypatch.setattr(devices_module, "set_device_metadata", lambda *args, **kwargs: None)
     monkeypatch.setattr(devices_module, "remove_device_metadata", lambda *args, **kwargs: None)
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     # Catalog lookups must return ``None`` so the derive-from-yaml
     # branch leaves ``board`` unset; otherwise ``StorageJSON``'s
     # ``target_platform`` would receive a ``MagicMock``.
@@ -111,7 +105,9 @@ async def test_create_device_writes_stub_yaml_and_scans(
 
 
 async def test_create_device_clears_residual_metadata_from_archived_same_name(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """Stub create at a previously-archived filename starts with a clean entry.
 
@@ -142,7 +138,7 @@ async def test_create_device_clears_residual_metadata_from_archived_same_name(
     pre = await asyncio.to_thread(get_device_metadata, config_dir, "kitchen.yaml")
     assert pre["board_id"] == "esp32-archived-board"
 
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     ctrl._db.settings.config_dir = config_dir
     ctrl._db.boards.find_by_pio_board = MagicMock(return_value=None)
     ctrl._db.boards.find_by_platform_variant = MagicMock(return_value=None)
@@ -156,7 +152,9 @@ async def test_create_device_clears_residual_metadata_from_archived_same_name(
 
 
 async def test_create_device_with_board_id_overwrites_archived_board_id(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """An explicit ``board_id`` on create wins over any residual archived value.
 
@@ -176,7 +174,7 @@ async def test_create_device_with_board_id_overwrites_archived_board_id(
         friendly_name="Archived Kitchen",
     )
 
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     ctrl._db.settings.config_dir = config_dir
     # Catalog returns a usable board for the new id.
     new_board = MagicMock()

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -16,22 +16,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.devices import DevicesController
-
-
-def _make_controller(config_dir: Path) -> DevicesController:
-    """Build a bare-bones controller wired to *config_dir* on disk."""
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = MagicMock()
-    controller._db.settings.config_dir = config_dir
-    controller._db.settings.rel_path = lambda configuration: config_dir / configuration
-    controller._scanner = MagicMock()
-    controller._scanner.scan = AsyncMock()
-    return controller
+from .conftest import MakeControllerFactory
 
 
 def _seed_device(
@@ -101,13 +89,15 @@ def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("_patch_ext_storage")
-async def test_delete_wipes_build_directory(tmp_path: Path) -> None:
+async def test_delete_wipes_build_directory(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """The PlatformIO build tree goes away with the device.
 
     Without this, a recycled device name picks up stale ``.pioenvs``
     state on the next compile and we leak disk on every churn.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     yaml_path, build_path = _seed_device(tmp_path, "kitchen.yaml")
 
     await controller._delete_single("kitchen.yaml")
@@ -119,9 +109,11 @@ async def test_delete_wipes_build_directory(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("_patch_ext_storage")
-async def test_delete_succeeds_when_never_compiled(tmp_path: Path) -> None:
+async def test_delete_succeeds_when_never_compiled(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """A device that's never been built has no sidecar — delete must still succeed."""
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
@@ -132,9 +124,11 @@ async def test_delete_succeeds_when_never_compiled(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("_patch_ext_storage")
-async def test_delete_tolerates_missing_build_directory(tmp_path: Path) -> None:
+async def test_delete_tolerates_missing_build_directory(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Sidecar present but build tree already wiped — delete must not raise."""
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     yaml_path, build_path = _seed_device(tmp_path, "kitchen.yaml", with_build_dir=False)
     assert not build_path.exists()
 
@@ -144,9 +138,11 @@ async def test_delete_tolerates_missing_build_directory(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_raises_when_yaml_missing(tmp_path: Path) -> None:
+async def test_delete_raises_when_yaml_missing(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Missing YAML pre-check still fires before any cleanup runs."""
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
 
     with pytest.raises(FileNotFoundError):
         await controller._delete_single("ghost.yaml")

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -34,31 +34,20 @@ import pytest
 
 from esphome_device_builder.controllers.devices import DevicesController
 
+from .conftest import MakeControllerFactory
 
-def _make_controller(config_dir: Path) -> DevicesController:
-    """Build a stub ``DevicesController`` wired to ``config_dir``.
 
-    Same shape as ``test_archive.py`` — bypass ``__init__``, attach
-    a ``_db.settings.rel_path`` that joins the configuration onto
-    the test's ``tmp_path``, and a ``_scanner.scan`` ``AsyncMock``
-    so ``update_config``'s post-write scan call is awaitable.
+def _stub_regenerate(controller: DevicesController) -> MagicMock:
+    """Replace ``_schedule_storage_regenerate`` with a sync MagicMock.
 
-    ``_schedule_storage_regenerate`` is replaced with a ``MagicMock``
-    on the instance so the test can ``assert_called_once_with(...)``
-    without spawning a real ``esphome compile --only-generate``
-    subprocess.
+    The production helper is fire-and-forget that internally schedules
+    a background task; a ``MagicMock`` records the call site without
+    dispatching the subprocess so tests can
+    ``assert_called_once_with(...)``.
     """
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = MagicMock()
-    controller._db.settings.config_dir = config_dir
-    controller._db.settings.rel_path = lambda configuration: config_dir / configuration
-    controller._scanner = MagicMock()
-    controller._scanner.scan = AsyncMock()
-    # ``_schedule_storage_regenerate`` is sync (fire-and-forget that
-    # schedules a background task internally); a plain ``MagicMock``
-    # records the call site without dispatching the subprocess.
-    controller._schedule_storage_regenerate = MagicMock()  # type: ignore[method-assign]
-    return controller
+    stub = MagicMock()
+    controller._schedule_storage_regenerate = stub  # type: ignore[method-assign]
+    return stub
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +56,9 @@ def _make_controller(config_dir: Path) -> DevicesController:
 
 
 @pytest.mark.asyncio
-async def test_get_config_returns_yaml_content(tmp_path: Path) -> None:
+async def test_get_config_returns_yaml_content(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``get_config`` returns the file's text decoded as UTF-8.
 
     HA's editor pre-fills the textarea with whatever this returns
@@ -75,7 +66,8 @@ async def test_get_config_returns_yaml_content(tmp_path: Path) -> None:
     plain-string shape (no JSON envelope) so a refactor that
     wraps the response would surface.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
     yaml_content = "esphome:\n  name: kitchen\n  platform: ESP32\n"
     (tmp_path / "kitchen.yaml").write_text(yaml_content, encoding="utf-8")
 
@@ -85,14 +77,17 @@ async def test_get_config_returns_yaml_content(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_config_decodes_utf8_with_unicode(tmp_path: Path) -> None:
+async def test_get_config_decodes_utf8_with_unicode(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """UTF-8 content (e.g., comments with non-ASCII) round-trips intact.
 
     The explicit ``"utf-8"`` arg to ``read_text`` keeps Windows
     safe — the platform default is cp1252 there, which would
     silently mojibake the YAML.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
     yaml_content = "esphome:\n  name: küche\n  # comment with — em dash and ñ\n"
     (tmp_path / "kuche.yaml").write_text(yaml_content, encoding="utf-8")
 
@@ -102,7 +97,9 @@ async def test_get_config_decodes_utf8_with_unicode(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_config_propagates_file_not_found(tmp_path: Path) -> None:
+async def test_get_config_propagates_file_not_found(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Missing file → ``FileNotFoundError`` bubbles to the dispatcher.
 
     The api dispatcher catches it and turns it into a generic
@@ -111,7 +108,8 @@ async def test_get_config_propagates_file_not_found(tmp_path: Path) -> None:
     instead would surface (the editor would silently load an
     empty buffer for a typo'd configuration).
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
 
     with pytest.raises(FileNotFoundError):
         await controller.get_config(configuration="ghost.yaml")
@@ -123,9 +121,12 @@ async def test_get_config_propagates_file_not_found(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_config_writes_content_to_disk(tmp_path: Path) -> None:
+async def test_update_config_writes_content_to_disk(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``update_config`` lands the new YAML on disk under the configuration name."""
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
     new_content = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
 
     result = await controller.update_config(configuration="kitchen.yaml", content=new_content)
@@ -135,14 +136,17 @@ async def test_update_config_writes_content_to_disk(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_config_overwrites_existing_yaml(tmp_path: Path) -> None:
+async def test_update_config_overwrites_existing_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Writing over an existing YAML replaces it verbatim.
 
     The editor's "Save" button does this on every keystroke-driven
     save; pin the no-merge / clobber semantics so a refactor that
     accidentally appended would surface.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: stale\n", encoding="utf-8")
     new_content = "esphome:\n  name: kitchen\n"
 
@@ -152,7 +156,9 @@ async def test_update_config_overwrites_existing_yaml(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_config_writes_utf8_unicode_intact(tmp_path: Path) -> None:
+async def test_update_config_writes_utf8_unicode_intact(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Non-ASCII content lands on disk as UTF-8.
 
     Companion to the read test — the explicit ``"utf-8"`` arg
@@ -165,7 +171,8 @@ async def test_update_config_writes_utf8_unicode_intact(tmp_path: Path) -> None:
     translates LF to CRLF on Windows; the round-trip decode
     normalises newlines so the assertion is platform-independent.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
     new_content = "esphome:\n  name: küche\n  # — and ñ\n"
 
     await controller.update_config(configuration="kuche.yaml", content=new_content)
@@ -174,7 +181,9 @@ async def test_update_config_writes_utf8_unicode_intact(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_config_triggers_scan(tmp_path: Path) -> None:
+async def test_update_config_triggers_scan(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Each successful write awakens the scanner so the device list refreshes.
 
     Without the post-write scan, a freshly-added YAML wouldn't
@@ -182,7 +191,8 @@ async def test_update_config_triggers_scan(tmp_path: Path) -> None:
     (up to 60s on the file-poll cadence). The dashboard's
     "save and immediately see the device" UX depends on this.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
 
     await controller.update_config(configuration="new.yaml", content="esphome:\n  name: new\n")
 
@@ -190,7 +200,9 @@ async def test_update_config_triggers_scan(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_config_schedules_storage_regenerate(tmp_path: Path) -> None:
+async def test_update_config_schedules_storage_regenerate(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Each successful write schedules a StorageJSON regenerate for that YAML.
 
     ``_schedule_storage_regenerate`` runs ``esphome compile
@@ -202,7 +214,8 @@ async def test_update_config_schedules_storage_regenerate(tmp_path: Path) -> Non
     surface — devices showing stale metadata after edits is the
     regression class this prevents.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
 
     await controller.update_config(
         configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
@@ -212,7 +225,9 @@ async def test_update_config_schedules_storage_regenerate(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_update_config_writes_before_scanner_runs(tmp_path: Path) -> None:
+async def test_update_config_writes_before_scanner_runs(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """The disk write completes before ``scanner.scan()`` fires.
 
     Scanner reads the YAML it scans; if scan ran first, it would
@@ -230,7 +245,8 @@ async def test_update_config_writes_before_scanner_runs(tmp_path: Path) -> None:
     so any ordering of regen-vs-write follows from this scan
     check by virtue of the linear async control flow.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: stale\n", encoding="utf-8")
 
@@ -250,6 +266,7 @@ async def test_update_config_writes_before_scanner_runs(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_round_trip_update_then_get_returns_written_content(
     tmp_path: Path,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """End-to-end: ``update_config`` then ``get_config`` returns what was written.
 
@@ -258,7 +275,8 @@ async def test_round_trip_update_then_get_returns_written_content(
     path. A future refactor that used different paths in
     ``rel_path`` for read vs write would surface here.
     """
-    controller = _make_controller(tmp_path)
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
     written = "esphome:\n  name: roundtrip\n"
 
     await controller.update_config(configuration="rt.yaml", content=written)

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -14,6 +14,7 @@ Covers two regressions discovered while wiring up the adoption flow:
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -24,24 +25,17 @@ from esphome_device_builder.controllers.devices import controller as devices_mod
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import AdoptableDevice, DeviceState, ErrorCode, EventType
 
+from .conftest import MakeControllerFactory
 
-def _make_controller(tmp_path: Any) -> DevicesController:
-    """Stand up a controller without booting the full DeviceBuilder."""
-    ctrl = DevicesController.__new__(DevicesController)
-    ctrl._db = MagicMock()
-    ctrl._db.settings.rel_path = lambda name: tmp_path / name
-    ctrl._scanner = MagicMock()
-    ctrl._scanner.scan = AsyncMock()
-    # The fast-online seed pulls the cached IP out of the state
-    # monitor and forces ONLINE on success; tests use a Mock so they
-    # can assert the calls without standing up a real zeroconf.
-    ctrl._state_monitor = MagicMock()
-    ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=None)
-    # ``import_result`` must be a real dict so the iteration in
-    # ``import_device`` works; the discovery callback path is
-    # exercised separately in ``test_importable_discovery``.
-    ctrl.import_result = {}
-    return ctrl
+
+def _seed_import_state(controller: DevicesController) -> None:
+    """Initialise ``import_result`` to an empty dict.
+
+    ``import_device`` iterates ``import_result`` for the cached
+    AdoptableDevice — production wires this up in ``__init__``,
+    but the bypass-init factory leaves it unset.
+    """
+    controller.import_result = {}
 
 
 def test_import_config_resolves_at_import_time() -> None:
@@ -59,7 +53,9 @@ def test_import_config_resolves_at_import_time() -> None:
 
 
 async def test_import_device_invokes_import_config_and_returns_path(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """Happy path: write the YAML, run a scan, return the configuration name."""
     captured: dict[str, Any] = {}
@@ -68,7 +64,8 @@ async def test_import_device_invokes_import_config_and_returns_path(
         captured["args"] = args
 
     monkeypatch.setattr(devices_module, "import_config", fake_import_config)
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
 
     result = await ctrl.import_device(
         name="kitchen-1a2b3c",
@@ -94,7 +91,9 @@ async def test_import_device_invokes_import_config_and_returns_path(
 
 
 async def test_import_device_passes_ethernet_network_through_to_import_config(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """An ESP32-PoE / Olimex broadcasts ``network=ethernet`` — preserve it.
 
@@ -109,7 +108,8 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
         devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
     )
 
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
     ctrl.import_result["olimex-poe-aabbcc"] = AdoptableDevice(
         name="olimex-poe-aabbcc",
         friendly_name="Olimex PoE",
@@ -132,7 +132,9 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
 
 
 async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """Multiple identical products on the LAN don't get the wrong network.
 
@@ -154,7 +156,8 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
         devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
     )
 
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
     # Two Apollo PLT-1s — same firmware, different network types.
     # The import dict's insertion order would otherwise pick whichever
     # arrived first; the direct-name lookup ignores order.
@@ -189,7 +192,9 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
 
 
 async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """Older factory firmwares didn't advertise ``network=`` — fall back to wifi.
 
@@ -204,7 +209,8 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
         devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
     )
 
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
     ctrl.import_result["legacy-bulb-001122"] = AdoptableDevice(
         name="legacy-bulb-001122",
         friendly_name="Legacy Bulb",
@@ -225,7 +231,9 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
 
 
 async def test_import_device_translates_file_exists_to_command_error(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """``FileExistsError`` becomes a user-facing ``CommandError``.
 
@@ -240,7 +248,8 @@ async def test_import_device_translates_file_exists_to_command_error(
         raise FileExistsError
 
     monkeypatch.setattr(devices_module, "import_config", raises_file_exists)
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
 
     with pytest.raises(CommandError) as excinfo:
         await ctrl.import_device(
@@ -257,7 +266,9 @@ async def test_import_device_translates_file_exists_to_command_error(
 
 
 async def test_import_device_returns_even_when_post_scan_fails(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """A scan failure after a successful YAML write must not roll back.
 
@@ -267,7 +278,8 @@ async def test_import_device_returns_even_when_post_scan_fails(
     whatever this attempt missed.
     """
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
     ctrl._scanner.scan = AsyncMock(side_effect=RuntimeError("transient"))
 
     result = await ctrl.import_device(
@@ -280,7 +292,9 @@ async def test_import_device_returns_even_when_post_scan_fails(
 
 
 async def test_import_device_seeds_online_state_from_zeroconf_cache(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """A freshly-adopted device should land ONLINE without waiting for ping.
 
@@ -292,7 +306,8 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     new card has an address right away.
     """
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
     ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=["192.168.1.42"])
 
     await ctrl.import_device(
@@ -309,11 +324,14 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
 
 
 async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """No cached IP → state still flips ONLINE, just no apply_ip call."""
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
     ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=None)
 
     await ctrl.import_device(
@@ -329,7 +347,9 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
 
 
 async def test_import_device_drops_matching_import_result_entry(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """The discovery banner entry disappears the moment adoption finishes.
 
@@ -340,7 +360,8 @@ async def test_import_device_drops_matching_import_result_entry(
     YAML name in the dialog.
     """
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
-    ctrl = _make_controller(tmp_path)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
     discovered = AdoptableDevice(
         name="apollo-plt-1-983300",
         friendly_name="Apollo PLT-1",

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -20,6 +20,7 @@ old name when something goes wrong mid-rename:
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
@@ -34,16 +35,18 @@ from esphome_device_builder.models import (
     JobType,
 )
 
+from .conftest import MakeControllerFactory
 
-def _make_controller() -> DevicesController:
-    """Build a bare-bones controller with the bits ``rename_device`` touches."""
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = MagicMock()
+
+def _wire_fake_path(controller: DevicesController) -> None:
+    """Swap the factory's tmp_path-based ``rel_path`` for the ``_FakePath`` shim.
+
+    These tests don't touch the real filesystem; they assert which
+    branch of ``rename_device`` runs based on a synthetic
+    ``_FakePath.existing`` set rather than poking actual files
+    under ``tmp_path``.
+    """
     controller._db.settings.rel_path = _FakePath
-    controller._scanner = MagicMock()
-    controller._scanner.scan = AsyncMock()
-    controller._esphome_cmd = ["esphome"]
-    return controller
 
 
 class _FakePath:
@@ -75,14 +78,17 @@ def _reset_fake_path_existing() -> Any:
 
 
 @pytest.mark.asyncio
-async def test_rename_target_filename_collision_raises(monkeypatch: Any) -> None:
+async def test_rename_target_filename_collision_raises(
+    tmp_path: Path, monkeypatch: Any, make_controller: MakeControllerFactory
+) -> None:
     """Renaming onto an existing config rejects before any work runs.
 
     The CLI ``esphome rename`` path doesn't check this itself — it
     would happily overwrite the unrelated device's YAML and install
     the wrong firmware. We have to catch it ourselves at the gate.
     """
-    controller = _make_controller()
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    _wire_fake_path(controller)
     _FakePath.existing.add("livingroom.yaml")
 
     with pytest.raises(CommandError) as excinfo:
@@ -93,7 +99,9 @@ async def test_rename_target_filename_collision_raises(monkeypatch: Any) -> None
 
 
 @pytest.mark.asyncio
-async def test_rename_same_name_raises() -> None:
+async def test_rename_same_name_raises(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Renaming a device to its current name rejects up-front.
 
     A same-name rename is a no-op at the YAML level but every
@@ -103,7 +111,8 @@ async def test_rename_same_name_raises() -> None:
     ``firmware/install`` is the right command for "flash without
     renaming."
     """
-    controller = _make_controller()
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    _wire_fake_path(controller)
 
     with pytest.raises(CommandError) as excinfo:
         await controller.rename_device(configuration="kitchen.yaml", new_name="kitchen")
@@ -113,9 +122,12 @@ async def test_rename_same_name_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rename_invalid_yaml_uses_manual_path(monkeypatch: Any) -> None:
+async def test_rename_invalid_yaml_uses_manual_path(
+    tmp_path: Path, monkeypatch: Any, make_controller: MakeControllerFactory
+) -> None:
     """Invalid config → inline ``_manual_rename`` and ``job: None`` response."""
-    controller = _make_controller()
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    _wire_fake_path(controller)
 
     async def fake_validates(self: Any, config_path: str) -> bool:
         return False
@@ -137,10 +149,13 @@ async def test_rename_invalid_yaml_uses_manual_path(monkeypatch: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_rename_invalid_yaml_collision_raises_command_error(
+    tmp_path: Path,
     monkeypatch: Any,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """Manual rename's FileExistsError surfaces as INVALID_ARGS."""
-    controller = _make_controller()
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    _wire_fake_path(controller)
 
     async def fake_validates(self: Any, config_path: str) -> bool:
         return False
@@ -160,9 +175,12 @@ async def test_rename_invalid_yaml_collision_raises_command_error(
 
 
 @pytest.mark.asyncio
-async def test_rename_valid_yaml_queues_firmware_job(monkeypatch: Any) -> None:
+async def test_rename_valid_yaml_queues_firmware_job(
+    tmp_path: Path, monkeypatch: Any, make_controller: MakeControllerFactory
+) -> None:
     """Valid config → firmware queue, response carries the queued job."""
-    controller = _make_controller()
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    _wire_fake_path(controller)
 
     async def fake_validates(self: Any, config_path: str) -> bool:
         return True
@@ -193,9 +211,12 @@ async def test_rename_valid_yaml_queues_firmware_job(monkeypatch: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rename_missing_firmware_controller_raises(monkeypatch: Any) -> None:
+async def test_rename_missing_firmware_controller_raises(
+    tmp_path: Path, monkeypatch: Any, make_controller: MakeControllerFactory
+) -> None:
     """Lifecycle race where firmware controller hasn't started yet."""
-    controller = _make_controller()
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    _wire_fake_path(controller)
 
     async def fake_validates(self: Any, config_path: str) -> bool:
         return True
@@ -211,10 +232,13 @@ async def test_rename_missing_firmware_controller_raises(monkeypatch: Any) -> No
 
 @pytest.mark.asyncio
 async def test_yaml_validates_returns_false_on_clean_nonzero_exit(
+    tmp_path: Path,
     monkeypatch: Any,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """``esphome config`` exited non-zero → False (the only "invalid" signal)."""
-    controller = _make_controller()
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    _wire_fake_path(controller)
 
     fake_proc = MagicMock()
     fake_proc.wait = AsyncMock(return_value=1)
@@ -237,7 +261,9 @@ async def test_yaml_validates_returns_false_on_clean_nonzero_exit(
 
 @pytest.mark.asyncio
 async def test_yaml_validates_propagates_unexpected_exception(
+    tmp_path: Path,
     monkeypatch: Any,
+    make_controller: MakeControllerFactory,
 ) -> None:
     """CLI missing / permission errors must NOT silently fall back.
 
@@ -247,7 +273,8 @@ async def test_yaml_validates_propagates_unexpected_exception(
     is meant to prevent. We now raise so the rename is rejected
     with a real reason instead.
     """
-    controller = _make_controller()
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    _wire_fake_path(controller)
 
     async def fake_create(*args: Any, **kwargs: Any) -> Any:
         raise FileNotFoundError("esphome")

--- a/tests/controllers/devices/test_stream_cancel.py
+++ b/tests/controllers/devices/test_stream_cancel.py
@@ -15,6 +15,8 @@ from esphome_device_builder.api.ws import WebSocketClient
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices.helpers import _redact_concealed_secrets
 
+from .conftest import MakeControllerFactory
+
 
 class _FakeWS:
     """Minimal WebSocket stand-in capturing sent messages."""
@@ -208,16 +210,26 @@ async def test_cleanup_kills_running_streams() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_controller_with_settings(esphome_cmd: list[str]) -> DevicesController:
-    """Stand up a controller far enough to exercise ``stream_logs`` / ``validate_config``."""
-    ctrl = DevicesController.__new__(DevicesController)
-    ctrl._esphome_cmd = esphome_cmd
-    ctrl._db = MagicMock()
+def _make_controller_with_settings(
+    make_controller: MakeControllerFactory,
+    tmp_path: Path,
+    esphome_cmd: list[str],
+) -> DevicesController:
+    """Stand up a controller far enough to exercise ``stream_logs`` / ``validate_config``.
+
+    Uses the shared ``make_controller`` factory and overrides
+    ``rel_path`` with the bare ``Path`` constructor — the streaming
+    tests pass absolute-style configuration arguments and don't
+    care which tmp dir they're rooted under.
+    """
+    ctrl = make_controller(tmp_path, esphome_cmd=esphome_cmd)
     ctrl._db.settings.rel_path = Path
     return ctrl
 
 
-async def test_stream_logs_command_includes_dashboard_flag() -> None:
+async def test_stream_logs_command_includes_dashboard_flag(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``devices/logs`` invokes esphome with ``--dashboard`` before the subcommand.
 
     Without the flag ESPHome's ``ESPHomeLogFormatter`` lets ``colorama``
@@ -225,7 +237,7 @@ async def test_stream_logs_command_includes_dashboard_flag() -> None:
     view ends up monochrome. The flag has to land before ``logs``
     because esphome's argparse only accepts it on the top-level parser.
     """
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
     async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
@@ -243,9 +255,11 @@ async def test_stream_logs_command_includes_dashboard_flag() -> None:
     assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA"]]
 
 
-async def test_stream_logs_command_without_port_omits_device_arg() -> None:
+async def test_stream_logs_command_without_port_omits_device_arg(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """No port given → no ``--device`` arg, ``--dashboard`` still present."""
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
     async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
@@ -258,9 +272,11 @@ async def test_stream_logs_command_without_port_omits_device_arg() -> None:
     assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml"]]
 
 
-async def test_stream_logs_command_appends_no_states_when_requested() -> None:
+async def test_stream_logs_command_appends_no_states_when_requested(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``no_states=True`` → ``--no-states`` is appended after the device arg."""
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
     async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
@@ -281,9 +297,11 @@ async def test_stream_logs_command_appends_no_states_when_requested() -> None:
     ]
 
 
-async def test_stream_logs_command_no_states_without_port() -> None:
+async def test_stream_logs_command_no_states_without_port(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``no_states=True`` and no ``port`` → ``--no-states`` lands without ``--device``."""
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
     async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
@@ -301,9 +319,11 @@ async def test_stream_logs_command_no_states_without_port() -> None:
     assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--no-states"]]
 
 
-async def test_stream_logs_command_omits_no_states_by_default() -> None:
+async def test_stream_logs_command_omits_no_states_by_default(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """Default ``no_states=False`` → no ``--no-states`` in argv (regression guard)."""
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
     async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
@@ -321,9 +341,11 @@ async def test_stream_logs_command_omits_no_states_by_default() -> None:
     assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA"]]
 
 
-async def test_validate_config_command_includes_dashboard_flag() -> None:
+async def test_validate_config_command_includes_dashboard_flag(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``devices/validate`` invokes ``esphome --dashboard config <yaml>``."""
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
     async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
@@ -336,7 +358,9 @@ async def test_validate_config_command_includes_dashboard_flag() -> None:
     assert captured == [["esphome", "--dashboard", "config", "kitchen.yaml"]]
 
 
-async def test_validate_config_omits_show_secrets_by_default() -> None:
+async def test_validate_config_omits_show_secrets_by_default(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``--show-secrets`` is not appended unless the caller explicitly opts in.
 
     Resolved secrets are sensitive — the legacy dashboard surfaced
@@ -344,7 +368,7 @@ async def test_validate_config_omits_show_secrets_by_default() -> None:
     off. The new dashboard inverts the default so they only appear
     when the user actively asks for them.
     """
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
     async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
@@ -363,9 +387,11 @@ async def test_validate_config_omits_show_secrets_by_default() -> None:
     assert captured == [["esphome", "--dashboard", "config", "kitchen.yaml"]]
 
 
-async def test_validate_config_passes_show_secrets_flag_when_enabled() -> None:
+async def test_validate_config_passes_show_secrets_flag_when_enabled(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``show_secrets=True`` appends ``--show-secrets`` to the esphome command."""
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
     async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
@@ -388,7 +414,9 @@ async def test_validate_config_passes_show_secrets_flag_when_enabled() -> None:
     ]
 
 
-async def test_validate_config_off_attaches_redactor_transform() -> None:
+async def test_validate_config_off_attaches_redactor_transform(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     r"""``show_secrets=False`` wires the line transform that scrubs concealed runs.
 
     ``esphome config`` without ``--show-secrets`` doesn't redact —
@@ -400,7 +428,7 @@ async def test_validate_config_off_attaches_redactor_transform() -> None:
     strips those wrapped runs so the secret never leaves the
     server.
     """
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: dict[str, Any] = {}
 
     async def fake_stream(
@@ -415,9 +443,11 @@ async def test_validate_config_off_attaches_redactor_transform() -> None:
     assert captured["line_transform"] is _redact_concealed_secrets
 
 
-async def test_validate_config_on_passes_no_line_transform() -> None:
+async def test_validate_config_on_passes_no_line_transform(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
     """``show_secrets=True`` ships raw output — no redactor wired."""
-    ctrl = _make_controller_with_settings(["esphome"])
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: dict[str, Any] = {}
 
     async def fake_stream(

--- a/tests/controllers/devices/test_stream_cancel.py
+++ b/tests/controllers/devices/test_stream_cancel.py
@@ -218,9 +218,9 @@ def _make_controller_with_settings(
     """Stand up a controller far enough to exercise ``stream_logs`` / ``validate_config``.
 
     Uses the shared ``make_controller`` factory and overrides
-    ``rel_path`` with the bare ``Path`` constructor — the streaming
-    tests pass absolute-style configuration arguments and don't
-    care which tmp dir they're rooted under.
+    ``rel_path`` with the bare ``Path`` constructor so these tests
+    can assert the raw configuration argument in argv (for example,
+    ``"kitchen.yaml"``) without ``tmp_path`` being prepended.
     """
     ctrl = make_controller(tmp_path, esphome_cmd=esphome_cmd)
     ctrl._db.settings.rel_path = Path


### PR DESCRIPTION
## Summary
Six `tests/controllers/devices/test_*.py` files still carried their own `__new__`-bypass `DevicesController` helpers after the conftest's `make_controller` factory landed. This PR collapses the duplication so a future `DevicesController` field rename only has to update one site.

**Files refactored:**
- `test_create.py`, `test_delete.py`, `test_get_update_config.py`, `test_import.py`, `test_rename.py`, `test_stream_cancel.py` (the `_make_controller_with_settings` variant).

**Two new factory kwargs** to support shapes the previous helpers carried:
- `with_state_monitor=True` attaches `_state_monitor` (with `get_cached_addresses` stubbed to `None`).
- `with_boards=True` attaches `_db.boards`.

**Intentionally not refactored:**
- `test_metadata_resolver.py` — its helper is a one-line monkeypatch that doesn't fit the bypass-init shape.
- The bare `__new__` shell at the top of `test_stream_cancel.py` — literally a single line, and the tests want zero attached state.

## Test plan
- [x] `uv run pytest tests/controllers/devices/ -q` — all 139 tests pass locally.