### PR TITLE
Promote FakeWebSocketClient to top-level conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,9 @@ regressions, not async hygiene.
 
 from __future__ import annotations
 
+import asyncio
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from blockbuster import blockbuster_ctx
@@ -120,3 +121,55 @@ def session_component_catalog(session_board_catalog: BoardCatalog) -> ComponentC
     container.components = ComponentCatalog(container)
     container.components.load()
     return container.components
+
+
+# ---------------------------------------------------------------------------
+# WebSocketClient stand-in
+#
+# Three test files (``test_subscribe_events_cleanup.py`` and the two
+# ``controllers/firmware/test_follow_job*_race.py`` files) had grown
+# near-identical ``_FakeClient`` shells that capture ``send_event`` /
+# ``send_result`` calls without standing up a real aiohttp WebSocket.
+# Centralising means the next handler-test that needs to record
+# streaming output gets a battle-tested stub for free.
+# ---------------------------------------------------------------------------
+
+
+class FakeWebSocketClient:
+    """Minimal ``WebSocketClient`` stand-in capturing send calls in order.
+
+    ``events`` records ``(message_id, event, data)`` tuples; ``results``
+    records ``(message_id, result)``. Tests inspect those lists directly
+    instead of poking at a real aiohttp WebSocket.
+
+    ``yield_per_event=True`` makes ``send_event`` ``await
+    asyncio.sleep(0)`` before recording. The firmware
+    ``follow_job`` race tests need it: without the yield, a tight
+    history-snapshot loop would drain in a single uninterrupted task
+    slice and the "fire JOB_OUTPUT mid-history" race-window the fix
+    targets would never be observable. Defaults to ``False`` because
+    most callers just want a passive recorder.
+    """
+
+    def __init__(self, *, yield_per_event: bool = False) -> None:
+        self.events: list[tuple[str, str, Any]] = []
+        self.results: list[tuple[str, Any]] = []
+        self._yield_per_event = yield_per_event
+
+    async def send_event(self, message_id: str, event: str, data: Any) -> None:
+        if self._yield_per_event:
+            await asyncio.sleep(0)
+        self.events.append((message_id, event, data))
+
+    async def send_result(self, message_id: str, result: Any) -> None:
+        self.results.append((message_id, result))
+
+    def events_for(self, name: str) -> list[Any]:
+        """Return the ``data`` payloads for every captured ``send_event(name, …)``.
+
+        Most assertions only care about the data attached to a
+        specific event ("show me every ``output`` line"); collapsing
+        the (message_id, event, data) tuple unpack into one helper
+        keeps the test bodies readable.
+        """
+        return [data for (_mid, event, data) in self.events if event == name]

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -27,28 +27,7 @@ from esphome_device_builder.controllers.firmware.constants import _MAX_OUTPUT_LI
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
 
-
-class _FakeClient:
-    """Captures send_event calls in order without an actual WS.
-
-    ``send_event`` yields control via ``asyncio.sleep(0)`` on every
-    call so the history-send loop interleaves with whatever else
-    the test scheduled — without that yield the entire history
-    snapshot would be drained in a single uninterrupted task slice
-    (``send_event`` is sync work otherwise) and the race-window
-    tests below would never actually observe a mid-history-send
-    state. The yield makes the test loop's "fire JOB_OUTPUT now"
-    scheduling actually land inside the history send rather than
-    after it, which is the critical case the race-fix was added
-    for.
-    """
-
-    def __init__(self) -> None:
-        self.events: list[tuple[str, Any]] = []
-
-    async def send_event(self, _message_id: str, event: str, data: Any) -> None:
-        await asyncio.sleep(0)
-        self.events.append((event, data))
+from ...conftest import FakeWebSocketClient
 
 
 def _make_controller_with_job(job: FirmwareJob) -> FirmwareController:
@@ -77,12 +56,12 @@ async def test_terminal_job_replays_full_history_and_returns() -> None:
         exit_code=0,
     )
     controller = _make_controller_with_job(job)
-    client = _FakeClient()
+    client = FakeWebSocketClient(yield_per_event=True)
 
     await controller.follow_job(job_id="abc", client=client, message_id="m1")
 
-    output_events = [(e, d) for (e, d) in client.events if e == "output"]
-    result_events = [(e, d) for (e, d) in client.events if e == "result"]
+    output_events = [("output", d) for d in client.events_for("output")]
+    result_events = [("result", d) for d in client.events_for("result")]
     assert [d for _e, d in output_events] == ["line a\n", "line b\n", "line c\n"]
     assert len(result_events) == 1
     assert result_events[0][1] == {"status": "completed", "exit_code": 0}
@@ -105,7 +84,7 @@ async def test_history_lines_arrive_before_live_lines_in_order() -> None:
         output=["history-1\n", "history-2\n"],
     )
     controller = _make_controller_with_job(job)
-    client = _FakeClient()
+    client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
     async def follower() -> None:
@@ -130,7 +109,7 @@ async def test_history_lines_arrive_before_live_lines_in_order() -> None:
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_lines = [d for (e, d) in client.events if e == "output"]
+    output_lines = client.events_for("output")
     # Strict ordering: every history line strictly precedes every
     # live line, and within each group the original order is
     # preserved.
@@ -152,7 +131,7 @@ async def test_live_events_for_other_jobs_are_filtered_out() -> None:
         output=[],
     )
     controller = _make_controller_with_job(job)
-    client = _FakeClient()
+    client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
     async def follower() -> None:
@@ -171,7 +150,7 @@ async def test_live_events_for_other_jobs_are_filtered_out() -> None:
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_lines = [d for (e, d) in client.events if e == "output"]
+    output_lines = client.events_for("output")
     assert output_lines == ["from us\n"]
 
 
@@ -199,7 +178,7 @@ async def test_streaming_loop_cannot_append_between_snapshot_and_subscribe() -> 
         output=["pre-snapshot\n"],
     )
     controller = _make_controller_with_job(job)
-    client = _FakeClient()
+    client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
     async def follower() -> None:
@@ -218,7 +197,7 @@ async def test_streaming_loop_cannot_append_between_snapshot_and_subscribe() -> 
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_lines = [d for (e, d) in client.events if e == "output"]
+    output_lines = client.events_for("output")
     # Exactly one of each — no duplication of pre-snapshot, no
     # missing post-snapshot.
     assert output_lines == ["pre-snapshot\n", "post-snapshot\n"]
@@ -373,7 +352,7 @@ async def test_cancelled_terminal_event_returns_with_status() -> None:
         output=["pre-cancel\n"],
     )
     controller = _make_controller_with_job(job)
-    client = _FakeClient()
+    client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
     async def follower() -> None:
@@ -387,8 +366,8 @@ async def test_cancelled_terminal_event_returns_with_status() -> None:
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_lines = [d for (e, d) in client.events if e == "output"]
-    result_events = [d for (e, d) in client.events if e == "result"]
+    output_lines = client.events_for("output")
+    result_events = client.events_for("result")
     assert output_lines == ["pre-cancel\n"]
     assert len(result_events) == 1
     assert result_events[0]["status"] == "cancelled"

--- a/tests/controllers/firmware/test_follow_jobs_race.py
+++ b/tests/controllers/firmware/test_follow_jobs_race.py
@@ -20,14 +20,7 @@ from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
 
-
-class _FakeClient:
-    def __init__(self) -> None:
-        self.events: list[tuple[str, Any]] = []
-
-    async def send_event(self, _message_id: str, event: str, data: Any) -> None:
-        await asyncio.sleep(0)
-        self.events.append((event, data))
+from ...conftest import FakeWebSocketClient
 
 
 def _make_controller(jobs: list[FirmwareJob]) -> FirmwareController:
@@ -63,7 +56,7 @@ async def test_follow_jobs_replays_snapshot_then_live_events_in_order() -> None:
         output=[],
     )
     controller = _make_controller([job_a, job_b])
-    client = _FakeClient()
+    client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
     follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
@@ -86,23 +79,23 @@ async def test_follow_jobs_replays_snapshot_then_live_events_in_order() -> None:
     # Yield enough that the snapshot + the live event get drained.
     for _ in range(20):
         await asyncio.sleep(0)
-        if any(e == "job_queued" for (e, _d) in client.events):
+        if any(e == "job_queued" for (_mid, e, _d) in client.events):
             break
 
     follow_task.cancel()
     with suppress(asyncio.CancelledError):
         await follow_task
 
-    snapshot_events = [d for (e, d) in client.events if e == "snapshot"]
-    queued_events = [d for (e, d) in client.events if e == "job_queued"]
+    snapshot_events = client.events_for("snapshot")
+    queued_events = client.events_for("job_queued")
     # Both jobs are in the snapshot (sorted by created_at).
     assert {s["job_id"] for s in snapshot_events} == {"a", "b"}
     # The live JOB_QUEUED arrives after the snapshot.
     assert len(queued_events) == 1
     assert queued_events[0]["job_id"] == "c"
     # Strict ordering: every snapshot event precedes the live event.
-    snapshot_indices = [i for i, (e, _d) in enumerate(client.events) if e == "snapshot"]
-    queued_index = next(i for i, (e, _d) in enumerate(client.events) if e == "job_queued")
+    snapshot_indices = [i for i, (_mid, e, _d) in enumerate(client.events) if e == "snapshot"]
+    queued_index = next(i for i, (_mid, e, _d) in enumerate(client.events) if e == "job_queued")
     assert max(snapshot_indices) < queued_index
 
 
@@ -203,7 +196,7 @@ async def test_follow_jobs_unsubscribes_on_cancellation() -> None:
     """
     controller = _make_controller([])
     bus = controller._db.bus
-    client = _FakeClient()
+    client = FakeWebSocketClient(yield_per_event=True)
 
     follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
     await asyncio.sleep(0)

--- a/tests/test_subscribe_events_cleanup.py
+++ b/tests/test_subscribe_events_cleanup.py
@@ -27,19 +27,7 @@ from esphome_device_builder.helpers.event_bus import (
 )
 from esphome_device_builder.models import EventType
 
-
-class _FakeClient:
-    """Minimal WebSocketClient stand-in for the subscribe_events handler."""
-
-    def __init__(self) -> None:
-        self.events: list[tuple[str, str, Any]] = []
-        self.results: list[tuple[str, Any]] = []
-
-    async def send_event(self, message_id: str, event: str, data: Any) -> None:
-        self.events.append((message_id, event, data))
-
-    async def send_result(self, message_id: str, result: Any) -> None:
-        self.results.append((message_id, result))
+from .conftest import FakeWebSocketClient
 
 
 def _make_db() -> DeviceBuilder:
@@ -64,7 +52,7 @@ async def test_subscribe_events_unsubscribes_on_cancellation() -> None:
     left every listener attached forever.
     """
     db = _make_db()
-    client = _FakeClient()
+    client = FakeWebSocketClient()
 
     handler_task = asyncio.create_task(db._cmd_subscribe_events(client=client, message_id="m1"))
 
@@ -104,7 +92,7 @@ async def test_subscribe_events_listener_forwards_bus_events() -> None:
     detaches listeners without forwarding.
     """
     db = _make_db()
-    client = _FakeClient()
+    client = FakeWebSocketClient()
 
     handler_task = asyncio.create_task(db._cmd_subscribe_events(client=client, message_id="m1"))
 
@@ -156,7 +144,7 @@ async def test_subscribe_events_subscribed_arrives_before_live_events() -> None:
     class YieldingClient:
         """``send_event`` / ``send_result`` actually yield the loop.
 
-        The default ``_FakeClient`` returns synchronously, so the
+        The default ``FakeWebSocketClient`` returns synchronously, so the
         handler's ``send_initial`` would never yield and a fired
         event would arrive *after* parking — turning this from an
         ordering test into a "drain delivers what was fired"


### PR DESCRIPTION
## Summary
Three test files had grown near-identical `_FakeClient` shells that capture `send_event` / `send_result` calls without standing up a real aiohttp WebSocket:
- `tests/test_subscribe_events_cleanup.py`
- `tests/controllers/firmware/test_follow_job_race.py`
- `tests/controllers/firmware/test_follow_jobs_race.py`

Centralized as `FakeWebSocketClient` on `tests/conftest.py`.

**Knobs:**
- `yield_per_event=True` makes `send_event` `await asyncio.sleep(0)` before recording — the firmware race tests need this so the history-snapshot loop interleaves with whatever else the test scheduled. Without the yield, the race-window the fix targets is unobservable.
- `events_for(name)` helper collapses the `[d for (_mid, event, data) in client.events if event == name]` comprehension callers were repeating.

## Test plan
- [x] `uv run pytest tests/test_subscribe_events_cleanup.py tests/controllers/firmware/test_follow_job_race.py tests/controllers/firmware/test_follow_jobs_race.py -q` — all 15 pass.
- [x] `uv run pytest tests/ -q` — full suite passes.