### PR TITLE
Promote make_settings for DashboardSettings to top-level conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,8 +206,9 @@ def make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MakeSettin
     ``config_dir`` and ``absolute_config_dir``.
 
     ``with_core_path=True`` additionally patches ``CORE.config_path``
-    to ``tmp_path / ".dashboard-sentinel"``. Production sets this in
-    ``DashboardSettings.parse_args``; without it, code paths that
+    to the same sentinel filename ``DashboardSettings.parse_args``
+    writes in production (``_DASHBOARD_SENTINEL_FILE`` in
+    ``controllers/config.py``). Without it, code paths that
     reach into the catalog loaders crash on
     ``CORE.config_dir.is_dir`` because ``CORE.config_path`` is the
     package-default ``None``. Routing through ``monkeypatch``
@@ -220,7 +221,7 @@ def make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MakeSettin
         settings.config_dir = tmp_path
         settings.absolute_config_dir = tmp_path.resolve()
         if with_core_path:
-            monkeypatch.setattr(CORE, "config_path", tmp_path / ".dashboard-sentinel")
+            monkeypatch.setattr(CORE, "config_path", tmp_path / "___DASHBOARD_SENTINEL___.yaml")
         return settings
 
     return _make

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,16 +18,19 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 import pytest
 from blockbuster import blockbuster_ctx
+from esphome.core import CORE
 
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
+from esphome_device_builder.controllers.config import DashboardSettings
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
     from blockbuster import BlockBuster
 
@@ -173,3 +176,51 @@ class FakeWebSocketClient:
         keeps the test bodies readable.
         """
         return [data for (_mid, event, data) in self.events if event == name]
+
+
+# ---------------------------------------------------------------------------
+# DashboardSettings factory
+#
+# Several test modules build a ``DashboardSettings`` rooted at ``tmp_path``
+# without going through ``parse_args`` — config_controller, executor pool,
+# device_builder lifecycle, ws handler branches, ha addon failsafe. They
+# all reproduce the same two-line wiring (``config_dir`` /
+# ``absolute_config_dir``); some additionally patch ``CORE.config_path``
+# because the catalog loaders crash on ``CORE.config_dir.is_dir`` when
+# the package-default ``None`` leaks in.
+# ---------------------------------------------------------------------------
+
+
+class MakeSettingsFactory(Protocol):
+    """Shape of the ``make_settings`` fixture's return value."""
+
+    def __call__(self, *, with_core_path: bool = ...) -> DashboardSettings: ...
+
+
+@pytest.fixture
+def make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MakeSettingsFactory:
+    """Return a factory that builds a ``DashboardSettings`` rooted at ``tmp_path``.
+
+    The minimal shape ``DeviceBuilder.__init__`` /
+    ``ConfigController`` / ``DashboardSettings.rel_path`` need:
+    ``config_dir`` and ``absolute_config_dir``.
+
+    ``with_core_path=True`` additionally patches ``CORE.config_path``
+    to ``tmp_path / ".dashboard-sentinel"``. Production sets this in
+    ``DashboardSettings.parse_args``; without it, code paths that
+    reach into the catalog loaders crash on
+    ``CORE.config_dir.is_dir`` because ``CORE.config_path`` is the
+    package-default ``None``. Routing through ``monkeypatch``
+    auto-restores the value after the test so sibling tests in the
+    same xdist worker don't see leaked process-globals.
+    """
+
+    def _make(*, with_core_path: bool = False) -> DashboardSettings:
+        settings = DashboardSettings()
+        settings.config_dir = tmp_path
+        settings.absolute_config_dir = tmp_path.resolve()
+        if with_core_path:
+            monkeypatch.setattr(CORE, "config_path", tmp_path / ".dashboard-sentinel")
+        return settings
+
+    return _make

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -36,7 +36,6 @@ import pytest
 
 from esphome_device_builder.controllers.config import (
     ConfigController,
-    DashboardSettings,
     _load_metadata,
     _save_metadata,
     get_device_ip,
@@ -54,6 +53,8 @@ from esphome_device_builder.models.preferences import (
     Theme,
     UserPreferences,
 )
+
+from .conftest import MakeSettingsFactory
 
 
 def _make_controller(config_dir: Path) -> ConfigController:
@@ -347,7 +348,7 @@ async def test_get_secrets_returns_sorted_keys(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_info_rejects_path_traversal(tmp_path: Path) -> None:
+async def test_get_info_rejects_path_traversal(make_settings: MakeSettingsFactory) -> None:
     """Traversal-shaped configuration raises ``CommandError(INVALID_ARGS)``.
 
     Wires the controller to the real ``DashboardSettings.rel_path``
@@ -359,9 +360,7 @@ async def test_get_info_rejects_path_traversal(tmp_path: Path) -> None:
     yield. A regression in either side of the boundary breaks the
     test.
     """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
+    settings = make_settings()
 
     controller = ConfigController.__new__(ConfigController)
     controller._db = MagicMock()
@@ -383,7 +382,9 @@ async def test_get_info_rejects_path_traversal(tmp_path: Path) -> None:
         "..",
     ],
 )
-def test_rel_path_translates_traversal_to_command_error(tmp_path: Path, payload: str) -> None:
+def test_rel_path_translates_traversal_to_command_error(
+    make_settings: MakeSettingsFactory, payload: str
+) -> None:
     """``rel_path`` raises ``CommandError(INVALID_ARGS)`` on every traversal shape.
 
     This is the chokepoint behind issue #107 — every WS handler that
@@ -393,9 +394,7 @@ def test_rel_path_translates_traversal_to_command_error(tmp_path: Path, payload:
     truncated + ``!r``-quoted so a pathological payload can't break
     the JSON error response.
     """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
+    settings = make_settings()
 
     with pytest.raises(CommandError) as excinfo:
         settings.rel_path(payload)
@@ -403,15 +402,13 @@ def test_rel_path_translates_traversal_to_command_error(tmp_path: Path, payload:
     assert "Invalid configuration filename" in excinfo.value.message
 
 
-def test_rel_path_truncates_long_payload(tmp_path: Path) -> None:
+def test_rel_path_truncates_long_payload(make_settings: MakeSettingsFactory) -> None:
     """A multi-KB ``configuration`` payload is truncated in the error message.
 
     Keeps the JSON error response bounded so a pathological payload
     can't blow up the WS frame.
     """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
+    settings = make_settings()
 
     payload = "../" + "A" * 5000
     with pytest.raises(CommandError) as excinfo:
@@ -420,7 +417,7 @@ def test_rel_path_truncates_long_payload(tmp_path: Path) -> None:
     assert len(excinfo.value.message) < 200
 
 
-def test_rel_path_bounds_control_byte_payload(tmp_path: Path) -> None:
+def test_rel_path_bounds_control_byte_payload(make_settings: MakeSettingsFactory) -> None:
     r"""Control-heavy payloads stay bounded after ``!r`` expansion.
 
     A single ``\x00`` repr's to 4 chars; a naive "truncate the raw
@@ -429,9 +426,7 @@ def test_rel_path_bounds_control_byte_payload(tmp_path: Path) -> None:
     unbounded-error hazard. ``!r`` runs *before* the bound, so a
     payload of 100 NUL bytes still produces a message ≤ 200 chars.
     """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
+    settings = make_settings()
 
     payload = "../" + "\x00" * 100
     with pytest.raises(CommandError) as excinfo:

--- a/tests/test_device_builder_lifecycle.py
+++ b/tests/test_device_builder_lifecycle.py
@@ -18,7 +18,6 @@ loads and the command-handler registration walk.
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -32,9 +31,10 @@ from esphome_device_builder.controllers._device_state_monitor import (
 )
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
-from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.device_builder import DeviceBuilder
+
+from .conftest import MakeSettingsFactory
 
 
 @pytest.fixture
@@ -103,32 +103,12 @@ def _hermetic_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(CORE, "config_path", None)
 
 
-def _make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DashboardSettings:
-    """Build a ``DashboardSettings`` rooted at ``tmp_path``.
-
-    Matches the shape ``DeviceBuilder.__init__`` expects without
-    going through the CLI parser. ``CORE.config_path`` is patched
-    via ``monkeypatch`` because the production parser sets it as a
-    side effect (see ``DashboardSettings.parse_args``); without it
-    the catalog loaders crash on ``CORE.config_dir.is_dir`` when
-    ``CORE.config_path`` is still the package-default ``None``.
-    Routing through ``monkeypatch`` (instead of a bare assignment)
-    auto-restores the value after the test so sibling tests in the
-    same xdist worker don't see leaked state.
-    """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-    monkeypatch.setattr(CORE, "config_path", tmp_path / ".dashboard-sentinel")
-    return settings
-
-
 # ---------------------------------------------------------------------------
 # Pre-start state
 # ---------------------------------------------------------------------------
 
 
-def test_init_leaves_controllers_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_init_leaves_controllers_unset(make_settings: MakeSettingsFactory) -> None:
     """``DeviceBuilder()`` instantiates with controllers ``None`` until ``start()``.
 
     Pin the documented "controllers populated in start()" contract
@@ -137,7 +117,7 @@ def test_init_leaves_controllers_unset(tmp_path: Path, monkeypatch: pytest.Monke
     ``settings`` dependency wouldn't crash until first command
     instead of at construction time, which is a worse failure mode.
     """
-    db = DeviceBuilder(_make_settings(tmp_path, monkeypatch))
+    db = DeviceBuilder(make_settings(with_core_path=True))
 
     assert db.auth is None
     assert db.boards is None
@@ -160,7 +140,7 @@ def test_init_leaves_controllers_unset(tmp_path: Path, monkeypatch: pytest.Monke
 
 @pytest.mark.asyncio
 async def test_start_initialises_all_controllers(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _hermetic_lifecycle: None
+    make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
     """``start()`` populates every controller attr.
 
@@ -171,7 +151,7 @@ async def test_start_initialises_all_controllers(
     ``NoneType``. Pin the full set so the regression class can't
     hide.
     """
-    db = DeviceBuilder(_make_settings(tmp_path, monkeypatch))
+    db = DeviceBuilder(make_settings(with_core_path=True))
     try:
         await db.start()
 
@@ -190,7 +170,7 @@ async def test_start_initialises_all_controllers(
 
 @pytest.mark.asyncio
 async def test_start_registers_command_handlers_from_every_controller(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _hermetic_lifecycle: None
+    make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
     """``command_handlers`` includes one entry per controller's @api_command set.
 
@@ -199,7 +179,7 @@ async def test_start_registers_command_handlers_from_every_controller(
     catch a refactor that dropped a controller from the
     ``collect_api_commands`` loop.
     """
-    db = DeviceBuilder(_make_settings(tmp_path, monkeypatch))
+    db = DeviceBuilder(make_settings(with_core_path=True))
     try:
         await db.start()
 
@@ -224,7 +204,7 @@ async def test_start_registers_command_handlers_from_every_controller(
 
 @pytest.mark.asyncio
 async def test_start_spawns_background_polling_task(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _hermetic_lifecycle: None
+    make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
     """``_bg_task`` is created and live after ``start``.
 
@@ -233,7 +213,7 @@ async def test_start_spawns_background_polling_task(
     misses; if ``start()`` ever forgot to spawn the task the
     dashboard would silently stop seeing scan changes.
     """
-    db = DeviceBuilder(_make_settings(tmp_path, monkeypatch))
+    db = DeviceBuilder(make_settings(with_core_path=True))
     try:
         await db.start()
 
@@ -250,7 +230,7 @@ async def test_start_spawns_background_polling_task(
 
 @pytest.mark.asyncio
 async def test_stop_cancels_background_tasks_and_tears_down_controllers(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _hermetic_lifecycle: None
+    make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
     """``stop()`` cancels the background task, drains tracked tasks, stops controllers.
 
@@ -259,7 +239,7 @@ async def test_stop_cancels_background_tasks_and_tears_down_controllers(
     exiting on SIGINT — exactly the class of bug a smoke test
     catches that a per-method test doesn't.
     """
-    db = DeviceBuilder(_make_settings(tmp_path, monkeypatch))
+    db = DeviceBuilder(make_settings(with_core_path=True))
     await db.start()
     bg_task = db._bg_task
     assert bg_task is not None
@@ -293,7 +273,7 @@ async def test_stop_cancels_background_tasks_and_tears_down_controllers(
 
 
 @pytest.mark.asyncio
-async def test_stop_is_safe_without_start(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_stop_is_safe_without_start(make_settings: MakeSettingsFactory) -> None:
     """``stop()`` on a never-started instance doesn't crash.
 
     Production calls ``stop()`` from the aiohttp ``on_shutdown``
@@ -302,7 +282,7 @@ async def test_stop_is_safe_without_start(tmp_path: Path, monkeypatch: pytest.Mo
     not None`` guards in ``stop()`` are what make that path
     survivable. Pin them.
     """
-    db = DeviceBuilder(_make_settings(tmp_path, monkeypatch))
+    db = DeviceBuilder(make_settings(with_core_path=True))
 
     # Never called start(); controllers are still ``None``.
     await db.stop()

--- a/tests/test_executor_pool.py
+++ b/tests/test_executor_pool.py
@@ -14,22 +14,15 @@ from __future__ import annotations
 import asyncio
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.device_builder import _EXECUTOR_MAX_WORKERS, DeviceBuilder
 
-
-def _settings(tmp_path: Any) -> DashboardSettings:
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-    return settings
+from .conftest import MakeSettingsFactory
 
 
-def test_executor_created_in_init(tmp_path: Any) -> None:
+def test_executor_created_in_init(make_settings: MakeSettingsFactory) -> None:
     """``__init__`` populates ``_executor`` so callers can probe it pre-start.
 
     Doesn't reach into ``ThreadPoolExecutor._max_workers`` — that's a
@@ -40,7 +33,7 @@ def test_executor_created_in_init(tmp_path: Any) -> None:
     sensible number is reviewed at the source — locking it down to
     a literal here just couples the test to the runtime knob.
     """
-    builder = DeviceBuilder(_settings(tmp_path))
+    builder = DeviceBuilder(make_settings())
     assert isinstance(builder._executor, ThreadPoolExecutor)
     # Sanity-check that the constant exists and is a reasonable
     # positive value — guards against someone setting it to 0 / None
@@ -50,7 +43,7 @@ def test_executor_created_in_init(tmp_path: Any) -> None:
     builder._executor.shutdown(wait=False)
 
 
-async def test_run_in_executor_uses_dashboard_pool(tmp_path: Any) -> None:
+async def test_run_in_executor_uses_dashboard_pool(make_settings: MakeSettingsFactory) -> None:
     """``run_in_executor`` lands on the dashboard's named pool, not asyncio's default.
 
     Drives the same ``_install_default_executor`` helper that
@@ -60,7 +53,7 @@ async def test_run_in_executor_uses_dashboard_pool(tmp_path: Any) -> None:
     the helper would have to disappear from ``start()`` for the
     binding to be skipped.
     """
-    builder = DeviceBuilder(_settings(tmp_path))
+    builder = DeviceBuilder(make_settings())
     builder.loop = asyncio.get_running_loop()
     try:
         builder._install_default_executor()
@@ -75,13 +68,13 @@ async def test_run_in_executor_uses_dashboard_pool(tmp_path: Any) -> None:
         await builder.stop()
 
 
-async def test_stop_drains_executor(tmp_path: Any) -> None:
+async def test_stop_drains_executor(make_settings: MakeSettingsFactory) -> None:
     """``stop()`` shuts down our pool and clears ``_executor``.
 
     Drives ``_install_default_executor`` rather than poking the loop
     directly so the test exercises the production registration path.
     """
-    builder = DeviceBuilder(_settings(tmp_path))
+    builder = DeviceBuilder(make_settings())
     builder.loop = asyncio.get_running_loop()
     builder._install_default_executor()
     pool = builder._executor
@@ -95,7 +88,7 @@ async def test_stop_drains_executor(tmp_path: Any) -> None:
         pool.submit(lambda: None)
 
 
-async def test_stop_without_start_drains_executor(tmp_path: Any) -> None:
+async def test_stop_without_start_drains_executor(make_settings: MakeSettingsFactory) -> None:
     """``stop()`` cleans up the pool even when ``start()`` never bound a loop.
 
     The pool is created eagerly in ``__init__``, so an instance that's
@@ -103,7 +96,7 @@ async def test_stop_without_start_drains_executor(tmp_path: Any) -> None:
     ``ThreadPoolExecutor`` to shut down. Without this path, a test
     helper or short-lived caller would leak threads.
     """
-    builder = DeviceBuilder(_settings(tmp_path))
+    builder = DeviceBuilder(make_settings())
     pool = builder._executor
     assert pool is not None
     # ``self.loop`` is None at this point — start() never ran.

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -18,18 +18,18 @@ These tests pin the three branches of the fail-secure logic:
 from __future__ import annotations
 
 import builtins
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.device_builder import DeviceBuilder
+
+from .conftest import MakeSettingsFactory
 
 
 def _make_db(
+    make_settings: MakeSettingsFactory,
     *,
-    tmp_path: Path,
     on_ha_addon: bool,
     using_password: bool,
 ) -> DeviceBuilder:
@@ -40,9 +40,7 @@ def _make_db(
     ``monkeypatch.setenv("DISABLE_HA_AUTHENTICATION", ...)`` —
     same path the production code reads, no class trickery.
     """
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
+    settings = make_settings()
     settings.on_ha_addon = on_ha_addon
     settings.using_password = using_password
     if using_password:
@@ -56,7 +54,7 @@ def _make_db(
 
 
 def test_ha_addon_no_password_with_ingress_runs_ingress_only(
-    tmp_path: Path,
+    make_settings: MakeSettingsFactory,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -70,7 +68,7 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(
     surfaces immediately.
     """
     monkeypatch.delenv("DISABLE_HA_AUTHENTICATION", raising=False)
-    db = _make_db(tmp_path=tmp_path, on_ha_addon=True, using_password=False)
+    db = _make_db(make_settings, on_ha_addon=True, using_password=False)
 
     captured: dict[str, object] = {}
 
@@ -115,7 +113,7 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(
 
 
 def test_ha_addon_no_password_no_ingress_refuses_to_start(
-    tmp_path: Path,
+    make_settings: MakeSettingsFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``DISABLE_HA_AUTHENTICATION`` + no password = refuse to start.
@@ -126,7 +124,7 @@ def test_ha_addon_no_password_no_ingress_refuses_to_start(
     that just isn't reachable.
     """
     monkeypatch.setenv("DISABLE_HA_AUTHENTICATION", "true")
-    db = _make_db(tmp_path=tmp_path, on_ha_addon=True, using_password=False)
+    db = _make_db(make_settings, on_ha_addon=True, using_password=False)
 
     with (
         patch("esphome_device_builder.device_builder.web.run_app") as run_app_mock,
@@ -139,12 +137,12 @@ def test_ha_addon_no_password_no_ingress_refuses_to_start(
 
 
 def test_ha_addon_with_password_binds_public_site_normally(
-    tmp_path: Path,
+    make_settings: MakeSettingsFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Password set → normal public-site bind, ingress as a hook."""
     monkeypatch.delenv("DISABLE_HA_AUTHENTICATION", raising=False)
-    db = _make_db(tmp_path=tmp_path, on_ha_addon=True, using_password=True)
+    db = _make_db(make_settings, on_ha_addon=True, using_password=True)
 
     captured: dict[str, object] = {}
 
@@ -162,14 +160,14 @@ def test_ha_addon_with_password_binds_public_site_normally(
     assert captured["trusted"] is False
 
 
-def test_non_ha_addon_binds_public_site_normally(tmp_path: Path) -> None:
+def test_non_ha_addon_binds_public_site_normally(make_settings: MakeSettingsFactory) -> None:
     """Standalone deployment is unaffected by the HA-add-on logic.
 
     Doesn't need ``monkeypatch`` for ``DISABLE_HA_AUTHENTICATION``:
     when ``on_ha_addon=False`` the property short-circuits and
     returns ``False`` regardless of the env var.
     """
-    db = _make_db(tmp_path=tmp_path, on_ha_addon=False, using_password=False)
+    db = _make_db(make_settings, on_ha_addon=False, using_password=False)
 
     captured: dict[str, object] = {}
 
@@ -186,7 +184,7 @@ def test_non_ha_addon_binds_public_site_normally(tmp_path: Path) -> None:
     assert captured["host"] == "0.0.0.0"
 
 
-async def test_start_and_stop_ingress_site_lifecycle(tmp_path: Path) -> None:
+async def test_start_and_stop_ingress_site_lifecycle(make_settings: MakeSettingsFactory) -> None:
     """``_start_ingress_site`` / ``_stop_ingress_site`` actually bind+release.
 
     Drives the lifecycle hooks directly (rather than running the
@@ -196,7 +194,7 @@ async def test_start_and_stop_ingress_site_lifecycle(tmp_path: Path) -> None:
     port — avoids flakes when 6053 is already in use on the
     runner.
     """
-    db = _make_db(tmp_path=tmp_path, on_ha_addon=True, using_password=True)
+    db = _make_db(make_settings, on_ha_addon=True, using_password=True)
     db.settings.ingress_port = 0  # let OS pick a free port
 
     # _start_ingress_site reads self.settings.ingress_port via
@@ -212,7 +210,9 @@ async def test_start_and_stop_ingress_site_lifecycle(tmp_path: Path) -> None:
     assert db._ingress_runner is None
 
 
-async def test_on_startup_and_on_cleanup_call_through_to_lifecycle(tmp_path: Path) -> None:
+async def test_on_startup_and_on_cleanup_call_through_to_lifecycle(
+    make_settings: MakeSettingsFactory,
+) -> None:
     """The aiohttp lifecycle hooks delegate to start()/stop() correctly.
 
     Exercises the trivial ``_on_startup`` / ``_on_cleanup``
@@ -221,7 +221,7 @@ async def test_on_startup_and_on_cleanup_call_through_to_lifecycle(tmp_path: Pat
     would spin up controllers, which is heavier than this test
     needs.
     """
-    db = _make_db(tmp_path=tmp_path, on_ha_addon=False, using_password=False)
+    db = _make_db(make_settings, on_ha_addon=False, using_password=False)
     fake_app: object = object()
 
     with (
@@ -235,7 +235,9 @@ async def test_on_startup_and_on_cleanup_call_through_to_lifecycle(tmp_path: Pat
     stop_mock.assert_awaited_once()
 
 
-def test_get_frontend_dir_returns_none_when_package_missing(tmp_path: Path) -> None:
+def test_get_frontend_dir_returns_none_when_package_missing(
+    make_settings: MakeSettingsFactory,
+) -> None:
     """Covers the ``ImportError`` fallback in ``_get_frontend_dir``.
 
     The frontend ships as a separate wheel
@@ -244,7 +246,7 @@ def test_get_frontend_dir_returns_none_when_package_missing(tmp_path: Path) -> N
     branch returns ``None`` so callers can detect the missing
     package and skip the static-route registration.
     """
-    db = _make_db(tmp_path=tmp_path, on_ha_addon=False, using_password=False)
+    db = _make_db(make_settings, on_ha_addon=False, using_password=False)
 
     # Force an ImportError by clearing the module from sys.modules
     # and patching the import to raise.
@@ -260,7 +262,7 @@ def test_get_frontend_dir_returns_none_when_package_missing(tmp_path: Path) -> N
         assert db._get_frontend_dir() is None
 
 
-def test_create_app_logs_frontend_missing_message(tmp_path: Path) -> None:
+def test_create_app_logs_frontend_missing_message(make_settings: MakeSettingsFactory) -> None:
     """``create_app`` logs a friendly hint when the frontend package isn't installed.
 
     Covers the ``elif with_lifecycle:`` branch that runs when
@@ -268,7 +270,7 @@ def test_create_app_logs_frontend_missing_message(tmp_path: Path) -> None:
     the dashboard still serves the WS API; the log line tells the
     operator why the UI is missing and how to fix it.
     """
-    db = _make_db(tmp_path=tmp_path, on_ha_addon=False, using_password=False)
+    db = _make_db(make_settings, on_ha_addon=False, using_password=False)
 
     with (
         patch.object(db, "_get_frontend_dir", return_value=None),


### PR DESCRIPTION
## Summary
Four test modules built a `DashboardSettings` rooted at `tmp_path` without going through `parse_args`:
- `test_device_builder_lifecycle.py`
- `test_config_controller.py`
- `test_executor_pool.py`
- `test_ha_addon_failsafe.py`

They all reproduced the same two-line wiring (`config_dir` / `absolute_config_dir`); the lifecycle test additionally patched `CORE.config_path` because the catalog loaders crash on `CORE.config_dir.is_dir` when the package-default `None` leaks in.

Centralized as `make_settings` on `tests/conftest.py` with a `with_core_path=True` knob. Routing through `monkeypatch` auto-restores `CORE.config_path` after the test so sibling tests in the same xdist worker don't see leaked process-globals.

**Intentionally left alone:**
- `test_auth.py` — doesn't use a tmp_path-based settings shape (just tests password checks).
- `test_trusted_domains.py` — drives `parse_args` directly to exercise CLI/env var handling.

## Test plan
- [x] `uv run pytest tests/ -q` — all 1136 tests pass locally.