### PR TITLE
Clarify events_for docstring (PR #202 follow-up)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,11 +165,13 @@ class FakeWebSocketClient:
         self.results.append((message_id, result))
 
     def events_for(self, name: str) -> list[Any]:
-        """Return the ``data`` payloads for every captured ``send_event(name, …)``.
+        """Return the ``data`` payloads for every captured ``send_event(..., event=name, ...)``.
 
-        Most assertions only care about the data attached to a
-        specific event ("show me every ``output`` line"); collapsing
-        the (message_id, event, data) tuple unpack into one helper
-        keeps the test bodies readable.
+        ``send_event`` takes ``(message_id, event, data)`` —
+        ``name`` here filters by the ``event`` argument. Most
+        assertions only care about the data attached to a
+        specific event ("show me every ``output`` line");
+        collapsing the (message_id, event, data) tuple unpack
+        into one helper keeps the test bodies readable.
         """
         return [data for (_mid, event, data) in self.events if event == name]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,7 @@ class FakeWebSocketClient:
         ``name`` here filters by the ``event`` argument. Most
         assertions only care about the data attached to a
         specific event ("show me every ``output`` line");
-        collapsing the (message_id, event, data) tuple unpack
+        collapsing the (message_id, event, data) tuple unpacking
         into one helper keeps the test bodies readable.
         """
         return [data for (_mid, event, data) in self.events if event == name]


### PR DESCRIPTION
## Summary
Copilot flagged on PR #202 that the \`events_for()\` docstring said \`send_event(name, …)\`, which is misleading — \`send_event\` actually takes \`(message_id, event, data)\`, and \`name\` here filters by the \`event\` argument.

Reworded to \`send_event(..., event=name, ...)\` and added a sentence calling out the actual signature explicitly so a future reader can tell at a glance which parameter \`name\` lines up with.

## Test plan
- Docstring-only change.