### PR TITLE
Pin catalog-heavy tests onto one xdist worker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,12 @@ warn_unused_configs = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+# ``loadgroup`` keeps the round-robin scheduler for unmarked tests but
+# pins anything tagged ``@pytest.mark.xdist_group("<name>")`` to a
+# single worker. The catalog-heavy modules use that to share one
+# ``ComponentCatalog.load`` (~2s on Linux CI) per run instead of
+# paying it on every xdist worker.
+addopts = "--dist=loadgroup"
 
 [build-system]
 build-backend = "setuptools.build_meta"

--- a/tests/test_components_integration_docs.py
+++ b/tests/test_components_integration_docs.py
@@ -13,6 +13,11 @@ import pytest
 
 from esphome_device_builder.controllers.components import ComponentCatalog
 
+# Pin every test in the file onto the same xdist worker as the rest of
+# the catalog-heavy suite so they share one ``ComponentCatalog.load``
+# instead of each worker paying ~2s on Linux CI.
+pytestmark = pytest.mark.xdist_group("catalog")
+
 
 @pytest.fixture
 def catalog(session_component_catalog: ComponentCatalog) -> ComponentCatalog:

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -33,6 +33,13 @@ from esphome_device_builder.helpers.yaml import generate_component_yaml
 from esphome_device_builder.models import ComponentCategory
 from esphome_device_builder.models.common import FieldPreset
 
+# Pin every test in the file onto the same xdist worker as the rest of
+# the catalog-heavy suite so they share one ``ComponentCatalog.load``
+# instead of each worker paying ~2s on Linux CI. The unit tests at the
+# top of the file don't touch the catalog but it's not worth splitting
+# the file for the savings.
+pytestmark = pytest.mark.xdist_group("catalog")
+
 # ---------------------------------------------------------------------------
 # Loader-level (pure unit tests, no catalog)
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_featured.py
+++ b/tests/test_validate_featured.py
@@ -16,6 +16,10 @@ from script.validate_definitions import (  # type: ignore[import-not-found]
     _validate_field_preset,
 )
 
+# Co-locate with the rest of the catalog-heavy suite so we don't burn a
+# second xdist worker re-reading ``components.json``.
+pytestmark = pytest.mark.xdist_group("catalog")
+
 
 @pytest.fixture(scope="module")
 def _index() -> dict | None:


### PR DESCRIPTION
## Summary
- Switch the pytest-xdist scheduler to `--dist=loadgroup` (no behavioural change for unmarked tests — they keep round-robin).
- Tag `tests/test_featured_components.py`, `tests/test_components_integration_docs.py`, and `tests/test_validate_featured.py` with `pytest.mark.xdist_group(\"catalog\")` so they all land on a single worker.

Session-scoped fixtures only live within one xdist worker, so each worker that happened to pick up any catalog test was paying its own ~2s `ComponentCatalog.load`. After this change the catalog parses exactly once per run instead of once per worker, and the slow setups disappear from \`--durations\` (only one worker still shows the cost, as `@catalog`-suffixed entries).

## Test plan
- [x] \`uv run pytest -n auto --durations=10 -q\` — single \`@catalog\` setup on the chosen worker, full suite green
- [ ] CI green on Linux