### PR TITLE
Add StubBoardLookups helper to devices conftest

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -28,6 +28,60 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import EventType
 
 
+def _make_board_stub(board_id: str) -> MagicMock:
+    """Build a catalog-result stub with the right ``id`` shape.
+
+    The catalog lookup methods (``find_by_pio_board`` /
+    ``find_by_platform_variant`` / ``get_board``) return
+    ``BoardCatalogEntry``-shaped objects; tests only ever read
+    ``.id`` off the result, so a ``MagicMock`` with that one attr
+    set is enough.
+    """
+    matched = MagicMock()
+    matched.id = board_id
+    return matched
+
+
+class StubBoardLookups:
+    """Stub the ``controller._db.boards`` lookup methods without poking the mock directly.
+
+    Centralises the ``MagicMock(return_value=...)`` /
+    ``AsyncMock(return_value=...)`` boilerplate that
+    ``test_derive_board_id``, ``test_create``, and any future
+    catalog-driven test would otherwise repeat. Each ``*_returns``
+    method takes a board id (string → return a
+    ``BoardCatalogEntry``-shaped stub with that id) or ``None``
+    (the lookup misses), and returns the underlying mock so a
+    test can later ``assert_called_once_with(...)`` on it.
+
+    For tests that need a specific catalog entry passed back
+    (e.g. with custom platform/template fields), assign directly
+    to ``controller._db.boards.<method>``; this helper is for the
+    common id-only shape that 90% of catalog-driven tests want.
+    """
+
+    def __init__(self, controller: DevicesController) -> None:
+        self._boards = controller._db.boards
+
+    def find_by_pio_board_returns(self, board_id: str | None) -> MagicMock:
+        """Stub the PIO-board lookup. ``None`` → miss; ``str`` → match with that id."""
+        mock = MagicMock(return_value=_make_board_stub(board_id) if board_id else None)
+        self._boards.find_by_pio_board = mock
+        return mock
+
+    def find_by_platform_variant_returns(self, board_id: str | None) -> MagicMock:
+        """Stub the platform-variant fallback lookup."""
+        mock = MagicMock(return_value=_make_board_stub(board_id) if board_id else None)
+        self._boards.find_by_platform_variant = mock
+        return mock
+
+    def get_board_returns(self, board_id: str | None) -> AsyncMock:
+        """Stub the async ``get_board(board_id)`` lookup the create path uses."""
+        mock = AsyncMock(return_value=_make_board_stub(board_id) if board_id else None)
+        self._boards.get_board = mock
+        return mock
+
+
 class StubBus:
     """Minimal event-bus stand-in for tests that exercise the listener wiring.
 

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -24,7 +24,7 @@ from esphome_device_builder.controllers.devices import controller as devices_mod
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
-from .conftest import MakeControllerFactory
+from .conftest import MakeControllerFactory, StubBoardLookups
 
 
 async def test_create_device_translates_file_exists_to_command_error(
@@ -68,7 +68,7 @@ async def test_create_device_rejects_unknown_board_id(
 ) -> None:
     """An unknown ``board_id`` produces ``INVALID_ARGS`` and names the bad id."""
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
-    ctrl._db.boards.get_board = AsyncMock(return_value=None)
+    StubBoardLookups(ctrl).get_board_returns(None)
 
     with pytest.raises(CommandError) as excinfo:
         await ctrl.create_device(name="kitchen", board_id="bogus-board")
@@ -92,8 +92,9 @@ async def test_create_device_writes_stub_yaml_and_scans(
     # Catalog lookups must return ``None`` so the derive-from-yaml
     # branch leaves ``board`` unset; otherwise ``StorageJSON``'s
     # ``target_platform`` would receive a ``MagicMock``.
-    ctrl._db.boards.find_by_pio_board = MagicMock(return_value=None)
-    ctrl._db.boards.find_by_platform_variant = MagicMock(return_value=None)
+    boards = StubBoardLookups(ctrl)
+    boards.find_by_pio_board_returns(None)
+    boards.find_by_platform_variant_returns(None)
 
     result = await ctrl.create_device(name="kitchen")
 
@@ -140,8 +141,9 @@ async def test_create_device_clears_residual_metadata_from_archived_same_name(
 
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     ctrl._db.settings.config_dir = config_dir
-    ctrl._db.boards.find_by_pio_board = MagicMock(return_value=None)
-    ctrl._db.boards.find_by_platform_variant = MagicMock(return_value=None)
+    boards = StubBoardLookups(ctrl)
+    boards.find_by_pio_board_returns(None)
+    boards.find_by_platform_variant_returns(None)
 
     await ctrl.create_device(name="kitchen")
 

--- a/tests/controllers/devices/test_derive_board_id.py
+++ b/tests/controllers/devices/test_derive_board_id.py
@@ -25,13 +25,12 @@ Six branches to pin:
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
 from esphome_device_builder.controllers.config import get_device_metadata
 
-from .conftest import MakeControllerFactory
+from .conftest import MakeControllerFactory, StubBoardLookups
 
 
 def _write_yaml(tmp_path: Path, filename: str, *, platform: str, board: str = "") -> Path:
@@ -42,13 +41,6 @@ def _write_yaml(tmp_path: Path, filename: str, *, platform: str, board: str = ""
     path = tmp_path / filename
     path.write_text(body, encoding="utf-8")
     return path
-
-
-def _stub_match(board_id: str) -> MagicMock:
-    """Build a catalog-result stub with the right ``id`` shape."""
-    matched = MagicMock()
-    matched.id = board_id
-    return matched
 
 
 def test_derive_returns_empty_when_boards_catalog_unloaded(
@@ -98,17 +90,18 @@ def test_derive_uses_pio_board_match_first(
     the persist-to-sidecar step.
     """
     controller = make_controller(tmp_path, with_boards=True)
-    controller._db.boards.find_by_pio_board = MagicMock(return_value=_stub_match("generic-esp32c3"))
-    controller._db.boards.find_by_platform_variant = MagicMock()
+    boards = StubBoardLookups(controller)
+    pio_lookup = boards.find_by_pio_board_returns("generic-esp32c3")
+    platform_lookup = boards.find_by_platform_variant_returns(None)
     _write_yaml(tmp_path, "kitchen.yaml", platform="esp32", board="esp32-c3-devkitm-1")
 
     result = controller._derive_board_id_from_yaml(tmp_path, "kitchen.yaml")
 
     assert result == "generic-esp32c3"
     # PlatformIO match was tried.
-    controller._db.boards.find_by_pio_board.assert_called_once_with("esp32-c3-devkitm-1", "")
+    pio_lookup.assert_called_once_with("esp32-c3-devkitm-1", "")
     # Platform fallback wasn't reached.
-    controller._db.boards.find_by_platform_variant.assert_not_called()
+    platform_lookup.assert_not_called()
     # Sidecar got backfilled so the next scan skips the YAML parse.
     meta = get_device_metadata(tmp_path, "kitchen.yaml")
     assert meta == {"board_id": "generic-esp32c3"}
@@ -129,18 +122,17 @@ def test_derive_falls_back_to_platform_when_pio_board_misses(
     about.
     """
     controller = make_controller(tmp_path, with_boards=True)
-    controller._db.boards.find_by_pio_board = MagicMock(return_value=None)
-    controller._db.boards.find_by_platform_variant = MagicMock(
-        return_value=_stub_match("generic-esp32")
-    )
+    boards = StubBoardLookups(controller)
+    pio_lookup = boards.find_by_pio_board_returns(None)
+    platform_lookup = boards.find_by_platform_variant_returns("generic-esp32")
     _write_yaml(tmp_path, "kitchen.yaml", platform="esp32", board="unknown-board")
 
     result = controller._derive_board_id_from_yaml(tmp_path, "kitchen.yaml")
 
     assert result == "generic-esp32"
     # Both lookups ran in order: PIO first, then platform fallback.
-    controller._db.boards.find_by_pio_board.assert_called_once_with("unknown-board", "")
-    controller._db.boards.find_by_platform_variant.assert_called_once_with("esp32", "")
+    pio_lookup.assert_called_once_with("unknown-board", "")
+    platform_lookup.assert_called_once_with("esp32", "")
     meta = get_device_metadata(tmp_path, "kitchen.yaml")
     assert meta == {"board_id": "generic-esp32"}
 
@@ -156,18 +148,17 @@ def test_derive_skips_pio_board_when_yaml_omits_board_field(
     straight to the platform fallback.
     """
     controller = make_controller(tmp_path, with_boards=True)
-    controller._db.boards.find_by_pio_board = MagicMock(return_value=None)
-    controller._db.boards.find_by_platform_variant = MagicMock(
-        return_value=_stub_match("generic-esp32")
-    )
+    boards = StubBoardLookups(controller)
+    pio_lookup = boards.find_by_pio_board_returns(None)
+    platform_lookup = boards.find_by_platform_variant_returns("generic-esp32")
     _write_yaml(tmp_path, "kitchen.yaml", platform="esp32")
 
     result = controller._derive_board_id_from_yaml(tmp_path, "kitchen.yaml")
 
     assert result == "generic-esp32"
     # PIO lookup was skipped — pio_board was empty.
-    controller._db.boards.find_by_pio_board.assert_not_called()
-    controller._db.boards.find_by_platform_variant.assert_called_once_with("esp32", "")
+    pio_lookup.assert_not_called()
+    platform_lookup.assert_called_once_with("esp32", "")
 
 
 def test_derive_returns_empty_when_no_catalog_entry_matches(
@@ -180,8 +171,9 @@ def test_derive_returns_empty_when_no_catalog_entry_matches(
     catalog was reloaded with new entries in the meantime).
     """
     controller = make_controller(tmp_path, with_boards=True)
-    controller._db.boards.find_by_pio_board = MagicMock(return_value=None)
-    controller._db.boards.find_by_platform_variant = MagicMock(return_value=None)
+    boards = StubBoardLookups(controller)
+    boards.find_by_pio_board_returns(None)
+    boards.find_by_platform_variant_returns(None)
     _write_yaml(tmp_path, "kitchen.yaml", platform="esp32", board="nonexistent-board")
 
     result = controller._derive_board_id_from_yaml(tmp_path, "kitchen.yaml")
@@ -213,7 +205,7 @@ def test_derive_swallows_persist_failure_and_still_returns_id(
     sync I/O even though production is fine.
     """
     controller = make_controller(tmp_path, with_boards=True)
-    controller._db.boards.find_by_pio_board = MagicMock(return_value=_stub_match("generic-esp32c3"))
+    StubBoardLookups(controller).find_by_pio_board_returns("generic-esp32c3")
     _write_yaml(tmp_path, "kitchen.yaml", platform="esp32", board="esp32-c3-devkitm-1")
 
     def _boom(*args: object, **kwargs: object) -> None:


### PR DESCRIPTION
## Summary
Tests in \`tests/controllers/devices/\` poked \`controller._db.boards.find_by_pio_board\` / \`find_by_platform_variant\` / \`get_board\` directly with \`MagicMock(return_value=...)\` boilerplate, and \`test_derive_board_id\` carried its own \`_stub_match\` helper for wrapping the catalog-result shape. Centralise both into the devices conftest:

- \`_make_board_stub(board_id)\` builds the \`BoardCatalogEntry\`-shaped \`MagicMock\` (only \`.id\` is read by tests).
- \`StubBoardLookups(controller)\` wraps the three lookup-method stubs:
  - \`find_by_pio_board_returns(id_or_none)\` → sync mock returning the stub or \`None\`.
  - \`find_by_platform_variant_returns(...)\` → same.
  - \`get_board_returns(...)\` → async-mock variant for the create path.
  Each method returns the underlying mock so callers can \`assert_called_once_with(...)\` on it.

Refactors \`test_derive_board_id\` and the three id-only call sites in \`test_create\`. The fourth site in \`test_create\` (\`test_create_device_with_board_id_overwrites_archived_board_id\`) keeps its hand-rolled \`MagicMock\` because it sets custom \`esphome.platform\` / \`template\` fields the helper doesn't cover.

## Test plan
- [x] \`uv run pytest tests/controllers/devices/test_create.py tests/controllers/devices/test_derive_board_id.py -v\` — 13/13 passing.