### PR TITLE
Add StreamEvent StrEnum for streaming-frame names

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -45,6 +45,7 @@ from ...models import (
     EventType,
     JobStatus,
     JobType,
+    StreamEvent,
     UpdateDeviceResponse,
     WizardResponse,
 )
@@ -1877,7 +1878,7 @@ class DevicesController:
                 payload = line.rstrip("\n\r")
                 if line_transform is not None:
                     payload = line_transform(payload)
-                await client.send_event(message_id, "output", payload)
+                await client.send_event(message_id, StreamEvent.OUTPUT, payload)
             exit_code = await proc.wait()
         except asyncio.CancelledError:
             # Synchronous kill only — no awaits in the cancel path. The

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -508,9 +508,10 @@ class FirmwareController:
         def _handle_event(event: Event, controls: StreamControls) -> None:
             if event.event_type == EventType.JOB_OUTPUT:
                 # Forward the bus event name through verbatim — the
-                # all-jobs follower's wire protocol uses the EventType
-                # value directly for job-* events (see push_priority
-                # branch below).
+                # all-jobs follower's wire protocol matches the
+                # ``EventType`` value byte-for-byte for these high-
+                # rate events. Pass the StrEnum member directly;
+                # ``StreamControls.push`` accepts any str.
                 controls.push(EventType.JOB_OUTPUT, event.data)
             elif event.event_type == EventType.JOB_PROGRESS:
                 controls.push(EventType.JOB_PROGRESS, event.data)

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -34,7 +34,7 @@ from ...helpers.api import CommandError, api_command
 from ...helpers.event_bus import StreamControls, stream_events
 from ...helpers.process import terminate_subtree_with_grace
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
-from ...models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType
+from ...models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType, StreamEvent
 from ..config import _load_metadata, metadata_transaction
 from .constants import (
     _ERROR_PATTERNS,
@@ -406,11 +406,11 @@ class FirmwareController:
 
         async def _send_initial(controls: StreamControls) -> None:
             for line in snapshot:
-                await client.send_event(message_id, "output", line)
+                await client.send_event(message_id, StreamEvent.OUTPUT, line)
             if is_terminal:
                 await client.send_event(
                     message_id,
-                    "result",
+                    StreamEvent.RESULT,
                     {"status": terminal_status, "exit_code": terminal_exit_code},
                 )
                 # No live drain — already-terminal job has nothing
@@ -421,14 +421,14 @@ class FirmwareController:
         def _handle_event(event: Event, controls: StreamControls) -> None:
             if event.event_type == EventType.JOB_OUTPUT:
                 if event.data.get("job_id") == job_id:
-                    controls.push("output", event.data["line"])
+                    controls.push(StreamEvent.OUTPUT, event.data["line"])
             elif event.event_type in _JOB_TERMINAL_EVENTS:
                 ev_job = event.data.get("job")
                 if ev_job and getattr(ev_job, "job_id", None) == job_id:
                     status = getattr(ev_job, "status", "unknown")
                     status_val = status.value if hasattr(status, "value") else str(status)
                     controls.push_priority(
-                        "result",
+                        StreamEvent.RESULT,
                         {
                             "status": status_val,
                             "exit_code": getattr(ev_job, "exit_code", None),
@@ -503,13 +503,17 @@ class FirmwareController:
 
         async def _send_initial(_controls: StreamControls) -> None:
             for payload in snapshot_payloads:
-                await client.send_event(message_id, "snapshot", payload)
+                await client.send_event(message_id, StreamEvent.SNAPSHOT, payload)
 
         def _handle_event(event: Event, controls: StreamControls) -> None:
             if event.event_type == EventType.JOB_OUTPUT:
-                controls.push("job_output", event.data)
+                # Forward the bus event name through verbatim — the
+                # all-jobs follower's wire protocol uses the EventType
+                # value directly for job-* events (see push_priority
+                # branch below).
+                controls.push(EventType.JOB_OUTPUT, event.data)
             elif event.event_type == EventType.JOB_PROGRESS:
-                controls.push("job_progress", event.data)
+                controls.push(EventType.JOB_PROGRESS, event.data)
             else:
                 # Lifecycle event (queued/started/completed/failed/
                 # cancelled). Use ``push_priority`` so a backlog of

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -58,6 +58,39 @@ class EventType(StrEnum):
     JOB_CANCELLED = "job_cancelled"
 
 
+class StreamEvent(StrEnum):
+    """Per-stream frame names sent via ``WebSocketClient.send_event``.
+
+    Distinct from :class:`EventType` (the global event-bus channel
+    name): a ``StreamEvent`` is the ``event`` field of a single
+    streaming command's response frames (``follow_job``,
+    ``stream_logs``, ``validate_config``, ``follow_jobs``'s initial
+    snapshot). Two-tier model — bus events get fanned out to per-
+    connection streams, where the controller may relabel them
+    (e.g. ``EventType.JOB_OUTPUT`` becomes ``StreamEvent.OUTPUT``
+    inside a ``follow_job`` stream that's already scoped to a
+    specific job_id).
+
+    The wire bytes coincide with some ``EventType`` values
+    (``"job_output"``, ``"job_progress"``) for the all-jobs
+    follower path, where the stream simply forwards the bus event
+    name through. Those call sites use ``EventType.X.value``
+    directly rather than redeclaring the constant here.
+    """
+
+    # Per-line subprocess output (``follow_job`` / ``stream_logs`` /
+    # ``validate_config``).
+    OUTPUT = "output"
+    # Terminal frame — final status / exit code, ends a streaming
+    # command. Sent priority so a backlog of output frames can't
+    # drop the close signal.
+    RESULT = "result"
+    # Initial replay of buffered state at the start of a stream
+    # (``follow_jobs`` snapshots the job table; ``follow_job``
+    # replays the job's output ring before live tail).
+    SNAPSHOT = "snapshot"
+
+
 # ---------------------------------------------------------------------------
 # Hardware enums (shared between board metadata and config-entry constraints)
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -74,8 +74,9 @@ class StreamEvent(StrEnum):
     The wire bytes coincide with some ``EventType`` values
     (``"job_output"``, ``"job_progress"``) for the all-jobs
     follower path, where the stream simply forwards the bus event
-    name through. Those call sites use ``EventType.X.value``
-    directly rather than redeclaring the constant here.
+    name through. Those call sites pass the ``EventType`` member
+    directly (it's a ``StrEnum``, so it serialises to the same
+    string) rather than redeclaring the constant here.
     """
 
     # Per-line subprocess output (``follow_job`` / ``stream_logs`` /

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,6 +179,27 @@ class FakeWebSocketClient:
         """
         return [data for (_mid, event, data) in self.events if event == name]
 
+    def indices_for(self, name: str) -> list[int]:
+        """Return the positional indices where ``send_event`` was called with ``event=name``.
+
+        Pair with :meth:`events_for` when a test needs to assert
+        relative ordering between events of different names —
+        e.g. "the snapshot frame landed before the first
+        ``job_queued`` event" — without re-doing the (_mid, event,
+        data) unpack at every call site.
+        """
+        return [i for i, (_mid, event, _data) in enumerate(self.events) if event == name]
+
+    def first_index_for(self, name: str) -> int:
+        """Return the first index where ``send_event`` was called with ``event=name``.
+
+        Raises ``StopIteration`` if no match — the contract mirrors
+        ``next(iter(...))`` so a missing event produces a clear
+        traceback at the assertion site rather than a confusing
+        ``IndexError`` later.
+        """
+        return next(i for i, (_mid, event, _data) in enumerate(self.events) if event == name)
+
 
 # ---------------------------------------------------------------------------
 # DashboardSettings factory

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware.constants import _MAX_OUTPUT_LINES_INFLIGHT
 from esphome_device_builder.helpers.event_bus import EventBus
-from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
+from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType, StreamEvent
 
 from ...conftest import FakeWebSocketClient
 
@@ -60,8 +60,8 @@ async def test_terminal_job_replays_full_history_and_returns() -> None:
 
     await controller.follow_job(job_id="abc", client=client, message_id="m1")
 
-    output_events = [("output", d) for d in client.events_for("output")]
-    result_events = [("result", d) for d in client.events_for("result")]
+    output_events = [(StreamEvent.OUTPUT, d) for d in client.events_for(StreamEvent.OUTPUT)]
+    result_events = [(StreamEvent.RESULT, d) for d in client.events_for(StreamEvent.RESULT)]
     assert [d for _e, d in output_events] == ["line a\n", "line b\n", "line c\n"]
     assert len(result_events) == 1
     assert result_events[0][1] == {"status": "completed", "exit_code": 0}
@@ -109,7 +109,7 @@ async def test_history_lines_arrive_before_live_lines_in_order() -> None:
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_lines = client.events_for("output")
+    output_lines = client.events_for(StreamEvent.OUTPUT)
     # Strict ordering: every history line strictly precedes every
     # live line, and within each group the original order is
     # preserved.
@@ -150,7 +150,7 @@ async def test_live_events_for_other_jobs_are_filtered_out() -> None:
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_lines = client.events_for("output")
+    output_lines = client.events_for(StreamEvent.OUTPUT)
     assert output_lines == ["from us\n"]
 
 
@@ -197,7 +197,7 @@ async def test_streaming_loop_cannot_append_between_snapshot_and_subscribe() -> 
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_lines = client.events_for("output")
+    output_lines = client.events_for(StreamEvent.OUTPUT)
     # Exactly one of each — no duplication of pre-snapshot, no
     # missing post-snapshot.
     assert output_lines == ["pre-snapshot\n", "post-snapshot\n"]
@@ -246,7 +246,7 @@ async def test_slow_follower_drops_lines_above_queue_cap() -> None:
     # in the queue.
     bus.fire(EventType.JOB_OUTPUT, {"job_id": "abc", "line": "first\n"})
     await asyncio.sleep(0)
-    assert received == [("output", "first\n")]
+    assert received == [(StreamEvent.OUTPUT, "first\n")]
 
     # Fire well past the cap. Without the bound this would grow the
     # queue unboundedly; with it the queue caps at maxsize and the
@@ -263,12 +263,12 @@ async def test_slow_follower_drops_lines_above_queue_cap() -> None:
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_count = sum(1 for (e, _) in received if e == "output")
+    output_count = sum(1 for (e, _) in received if e == StreamEvent.OUTPUT)
     # The follower must have lost some lines — the bound was the
     # whole point. The first line + at most the queue cap delivered.
     assert output_count <= 1 + _MAX_OUTPUT_LINES_INFLIGHT
     # And a result still arrives even with output dropped.
-    result_events = [d for (e, d) in received if e == "result"]
+    result_events = [d for (e, d) in received if e == StreamEvent.RESULT]
     assert len(result_events) == 1
 
 
@@ -300,7 +300,7 @@ async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full() -> No
             received.append((event, data))
             # Only block on output; let result/sentinel through so
             # the test can observe completion.
-            if event == "output":
+            if event == StreamEvent.OUTPUT:
                 await block.wait()
 
     follow_task = asyncio.create_task(
@@ -329,7 +329,7 @@ async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full() -> No
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    result_events = [d for (e, d) in received if e == "result"]
+    result_events = [d for (e, d) in received if e == StreamEvent.RESULT]
     assert len(result_events) == 1
     assert result_events[0]["status"] == "completed"
 
@@ -366,8 +366,8 @@ async def test_cancelled_terminal_event_returns_with_status() -> None:
 
     await asyncio.wait_for(follow_task, timeout=2.0)
 
-    output_lines = client.events_for("output")
-    result_events = client.events_for("result")
+    output_lines = client.events_for(StreamEvent.OUTPUT)
+    result_events = client.events_for(StreamEvent.RESULT)
     assert output_lines == ["pre-cancel\n"]
     assert len(result_events) == 1
     assert result_events[0]["status"] == "cancelled"

--- a/tests/controllers/firmware/test_follow_jobs_race.py
+++ b/tests/controllers/firmware/test_follow_jobs_race.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock
 
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.event_bus import EventBus
-from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
+from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType, StreamEvent
 
 from ...conftest import FakeWebSocketClient
 
@@ -79,23 +79,23 @@ async def test_follow_jobs_replays_snapshot_then_live_events_in_order() -> None:
     # Yield enough that the snapshot + the live event get drained.
     for _ in range(20):
         await asyncio.sleep(0)
-        if any(e == "job_queued" for (_mid, e, _d) in client.events):
+        if any(e == EventType.JOB_QUEUED for (_mid, e, _d) in client.events):
             break
 
     follow_task.cancel()
     with suppress(asyncio.CancelledError):
         await follow_task
 
-    snapshot_events = client.events_for("snapshot")
-    queued_events = client.events_for("job_queued")
+    snapshot_events = client.events_for(StreamEvent.SNAPSHOT)
+    queued_events = client.events_for(EventType.JOB_QUEUED)
     # Both jobs are in the snapshot (sorted by created_at).
     assert {s["job_id"] for s in snapshot_events} == {"a", "b"}
     # The live JOB_QUEUED arrives after the snapshot.
     assert len(queued_events) == 1
     assert queued_events[0]["job_id"] == "c"
     # Strict ordering: every snapshot event precedes the live event.
-    snapshot_indices = [i for i, (_mid, e, _d) in enumerate(client.events) if e == "snapshot"]
-    queued_index = next(i for i, (_mid, e, _d) in enumerate(client.events) if e == "job_queued")
+    snapshot_indices = client.indices_for(StreamEvent.SNAPSHOT)
+    queued_index = client.first_index_for(EventType.JOB_QUEUED)
     assert max(snapshot_indices) < queued_index
 
 
@@ -146,7 +146,7 @@ async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation(
             received.append((event, data))
             # Park after delivering snapshot[0] so the test can
             # mutate job_b before the helper iterates to it.
-            if event == "snapshot" and data["job_id"] == "a":
+            if event == StreamEvent.SNAPSHOT and data["job_id"] == "a":
                 await block.wait()
 
     follow_task = asyncio.create_task(controller.follow_jobs(client=GatedClient(), message_id="m1"))
@@ -156,7 +156,7 @@ async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation(
         await asyncio.sleep(0)
         if received:
             break
-    assert received[0][0] == "snapshot"
+    assert received[0][0] == StreamEvent.SNAPSHOT
     assert received[0][1]["job_id"] == "a"
 
     # Mutate job_b AND fire the matching JOB_OUTPUT — the same
@@ -169,15 +169,15 @@ async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation(
     block.set()
     for _ in range(20):
         await asyncio.sleep(0)
-        if any(e == "job_output" for (e, _d) in received):
+        if any(e == EventType.JOB_OUTPUT for (e, _d) in received):
             break
 
     follow_task.cancel()
     with suppress(asyncio.CancelledError):
         await follow_task
 
-    snapshots = {d["job_id"]: d for (e, d) in received if e == "snapshot"}
-    job_outputs = [d for (e, d) in received if e == "job_output"]
+    snapshots = {d["job_id"]: d for (e, d) in received if e == StreamEvent.SNAPSHOT}
+    job_outputs = [d for (e, d) in received if e == EventType.JOB_OUTPUT]
 
     # snapshot[b] was frozen synchronously up front (before any
     # await), so the mid-snapshot mutation isn't reflected.


### PR DESCRIPTION
## Summary
Streaming-command paths (\`follow_job\`, \`follow_jobs\`, \`stream_logs\`, \`validate_config\`) used bare strings (\`"output"\`, \`"result"\`, \`"snapshot"\`) for the WS frame's \`event\` field. Typos would surface only as silent test failures or wrong frontend behaviour.

Adds a \`StreamEvent\` StrEnum in \`models/common.py\` alongside \`EventType\`. The two are intentionally distinct:
- **\`EventType\`** — global event-bus channel name.
- **\`StreamEvent\`** — per-stream frame name (\`OUTPUT\` / \`RESULT\` / \`SNAPSHOT\`).

The wire bytes coincide for the all-jobs follower's \`job_output\` / \`job_progress\` push (it forwards the bus event name through), which now uses \`EventType.JOB_OUTPUT\` / \`EventType.JOB_PROGRESS\` directly rather than redeclaring the constant.

### Replaced call sites
- \`firmware/controller.py\` (follow_job): \`"output"\` / \`"result"\` → \`StreamEvent.OUTPUT\` / \`StreamEvent.RESULT\`.
- \`firmware/controller.py\` (follow_jobs): \`"snapshot"\` → \`StreamEvent.SNAPSHOT\`; \`"job_output"\` / \`"job_progress"\` → \`EventType.JOB_OUTPUT\` / \`EventType.JOB_PROGRESS\`.
- \`devices/controller.py\` (_stream_subprocess): \`"output"\` → \`StreamEvent.OUTPUT\`.

### Wire protocol
Unchanged — \`StrEnum\` members compare equal to their string values, so existing tests that match against bare strings (\`events_for("output")\`) continue to work and the frontend sees the same JSON.

## Test plan
- [x] \`uv run pytest tests/ -q\` — 1155/1155 passing locally.