### PR TITLE
Cover the missing branches in follow_jobs' _handle_event

### DIFF
--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -387,6 +387,81 @@ async def test_compile_mid_run_cancel_marks_cancelled(
     assert job.job_id not in controller._cancel_requested
 
 
+@pytest.mark.asyncio
+async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    """Cancelling the runner task mid-run hits the ``CancelledError`` branch.
+
+    Distinct from the user-cancel path above: here nothing populates
+    ``_cancel_requested``. The runner is awaiting on the subprocess's
+    stdout when the task is cancelled (e.g. dashboard shutdown), so
+    ``_execute_job``'s ``except asyncio.CancelledError`` is what fires
+    JOB_CANCELLED, terminates the live process, and re-raises so the
+    surrounding runner loop unwinds.
+
+    Sequencing: wait for the first JOB_OUTPUT (proves the subprocess
+    is up *and* ``_current_process`` has been assigned) before
+    cancelling, otherwise we'd race the subprocess spawn and either
+    leak the process or hit the cancel before the try-block had
+    entered.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _fake_esphome(
+        controller,
+        # Print one line so the runner enters the line-reading loop,
+        # then block forever on stdin so the test controls the exit.
+        "import sys\nprint('starting...', flush=True)\nsys.stdin.read()\n",
+    )
+    _seed_yaml(tmp_path)
+
+    job = await controller.compile(configuration="kitchen.yaml")
+
+    proc_alive = asyncio.Event()
+    captured: list[dict] = []
+    real_fire = controller._db.bus.fire
+
+    def _watch(event_type: EventType, data: dict) -> None:
+        captured.append({"type": event_type, "data": data})
+        if event_type == EventType.JOB_OUTPUT:
+            proc_alive.set()
+        real_fire(event_type, data)
+
+    controller._db.bus.fire = _watch
+
+    runner_task = asyncio.create_task(controller._run_queue())
+    try:
+        await asyncio.wait_for(proc_alive.wait(), timeout=10.0)
+        assert controller._current_process is not None
+        proc = controller._current_process
+
+        # Cancel the runner task itself — this is the shutdown shape,
+        # not the user-cancel one. Nothing is added to
+        # ``_cancel_requested`` so the post-``proc.wait()`` branch
+        # can't be the one that finalises the job.
+        runner_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await runner_task
+    finally:
+        # Defensive cleanup if the assertion path above bailed early.
+        if not runner_task.done():
+            runner_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await runner_task
+
+    assert job.status == JobStatus.CANCELLED
+    assert any(c["type"] == EventType.JOB_CANCELLED for c in captured)
+    # ``proc.terminate()`` on POSIX puts the subprocess on a path to
+    # exit; wait briefly so the assertion below isn't racy.
+    with suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(proc.wait(), timeout=5.0)
+    assert proc.returncode is not None, "runner-shutdown branch should have terminated the proc"
+    # The discard is unconditional — it's a no-op when the id wasn't
+    # in the set, which is exactly the shutdown case.
+    assert job.job_id not in controller._cancel_requested
+
+
 # ---------------------------------------------------------------------------
 # Progress parsing
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_follow_jobs_race.py
+++ b/tests/controllers/firmware/test_follow_jobs_race.py
@@ -210,3 +210,97 @@ async def test_follow_jobs_unsubscribes_on_cancellation() -> None:
 
     listener_count_after = sum(len(bus._listeners.get(et, ())) for et in EventType)
     assert listener_count_after == 0
+
+
+# ---------------------------------------------------------------------------
+# _handle_event branch coverage
+# ---------------------------------------------------------------------------
+
+
+async def _drain_until(client: FakeWebSocketClient, predicate: Any, attempts: int = 20) -> None:
+    """Yield the event loop until *predicate(client)* is truthy or *attempts* runs out."""
+    for _ in range(attempts):
+        await asyncio.sleep(0)
+        if predicate(client):
+            return
+
+
+async def test_follow_jobs_forwards_job_progress_events() -> None:
+    """A ``JOB_PROGRESS`` event lands as a ``job_progress`` push (not a lifecycle)."""
+    controller = _make_controller([])
+    bus = controller._db.bus
+    client = FakeWebSocketClient(yield_per_event=True)
+
+    follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
+    await asyncio.sleep(0)
+
+    progress = {"job_id": "a", "stage": "compile", "percent": 42}
+    bus.fire(EventType.JOB_PROGRESS, progress)
+
+    await _drain_until(client, lambda c: any(e == "job_progress" for (_m, e, _d) in c.events))
+
+    follow_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await follow_task
+
+    progress_events = client.events_for("job_progress")
+    assert progress_events == [progress]
+
+
+async def test_follow_jobs_drops_lifecycle_event_with_no_job_payload() -> None:
+    """A lifecycle event missing the ``job`` key is silently ignored.
+
+    The runner always tags lifecycle bus events with ``{"job": <FirmwareJob>}``,
+    but the handler defends against a malformed payload by skipping it
+    instead of crashing the stream — guard the early-return path here.
+    """
+    controller = _make_controller([])
+    bus = controller._db.bus
+    client = FakeWebSocketClient(yield_per_event=True)
+
+    follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
+    await asyncio.sleep(0)
+
+    # Bare payload — no ``job`` key. The handler must early-return
+    # without raising and without pushing anything.
+    bus.fire(EventType.JOB_QUEUED, {"unrelated": "noise"})
+
+    # And then a normal event so we have a synchronisation point —
+    # if the handler had crashed, the listener would be torn down
+    # and this second event would never reach the client.
+    bus.fire(EventType.JOB_PROGRESS, {"job_id": "a"})
+    await _drain_until(client, lambda c: any(e == "job_progress" for (_m, e, _d) in c.events))
+
+    follow_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await follow_task
+
+    assert client.events_for("job_queued") == []
+    assert client.events_for("job_progress") == [{"job_id": "a"}]
+
+
+async def test_follow_jobs_lifecycle_payload_passthrough_for_dict_job() -> None:
+    """A ``job`` payload that's already a dict is forwarded verbatim.
+
+    Production firmware events carry a ``FirmwareJob`` instance and the
+    handler calls ``to_dict()`` on it. Replays from persisted history,
+    however, can hand back a plain dict — the handler's ``hasattr``
+    check falls through and uses the dict as-is.
+    """
+    controller = _make_controller([])
+    bus = controller._db.bus
+    client = FakeWebSocketClient(yield_per_event=True)
+
+    follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
+    await asyncio.sleep(0)
+
+    raw = {"job_id": "z", "status": "completed"}
+    bus.fire(EventType.JOB_COMPLETED, {"job": raw})
+    await _drain_until(client, lambda c: any(e == "job_completed" for (_m, e, _d) in c.events))
+
+    follow_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await follow_task
+
+    completed = client.events_for("job_completed")
+    assert completed == [raw]


### PR DESCRIPTION
## Summary
Adds three targeted tests against the inline handler in \`FirmwareController.follow_jobs\` to close coverage gaps:

- \`JOB_PROGRESS\` events route through \`controls.push(\"job_progress\", ...)\` (line 512 — previously uncovered).
- A lifecycle event missing the \`job\` key returns early without crashing the stream (line 524 — previously uncovered). Verified by firing a follow-up event that must still arrive.
- A lifecycle event whose \`job\` payload is already a dict (replay / persisted history shape) bypasses \`to_dict\` and is forwarded verbatim, exercising the \`hasattr\` else-branch on line 525.

## Test plan
- [x] \`uv run pytest --cov=esphome_device_builder.controllers.firmware.controller tests/controllers/firmware/test_follow_jobs_race.py\` — lines 512 and 524 are gone from the \"Missing\" report.
- [ ] CI green