### PR TITLE
Treat empty-string board_id as a hit in StubBoardLookups (PR #211 follow-up)

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -65,19 +65,19 @@ class StubBoardLookups:
 
     def find_by_pio_board_returns(self, board_id: str | None) -> MagicMock:
         """Stub the PIO-board lookup. ``None`` → miss; ``str`` → match with that id."""
-        mock = MagicMock(return_value=_make_board_stub(board_id) if board_id else None)
+        mock = MagicMock(return_value=_make_board_stub(board_id) if board_id is not None else None)
         self._boards.find_by_pio_board = mock
         return mock
 
     def find_by_platform_variant_returns(self, board_id: str | None) -> MagicMock:
         """Stub the platform-variant fallback lookup."""
-        mock = MagicMock(return_value=_make_board_stub(board_id) if board_id else None)
+        mock = MagicMock(return_value=_make_board_stub(board_id) if board_id is not None else None)
         self._boards.find_by_platform_variant = mock
         return mock
 
     def get_board_returns(self, board_id: str | None) -> AsyncMock:
         """Stub the async ``get_board(board_id)`` lookup the create path uses."""
-        mock = AsyncMock(return_value=_make_board_stub(board_id) if board_id else None)
+        mock = AsyncMock(return_value=_make_board_stub(board_id) if board_id is not None else None)
         self._boards.get_board = mock
         return mock
 


### PR DESCRIPTION
## Summary
Copilot flagged on PR #211 that the \`*_returns\` helpers used \`if board_id else None\`, which collapsed an empty string into the miss branch even though the type annotation (\`str | None\`) says any \`str\` is a hit. Switch to \`is not None\` so an empty-string id round-trips as a stub with \`.id == ""\` instead of silently degrading to a miss.

Tiny follow-up — three lines in \`tests/controllers/devices/conftest.py\`. No production change.

## Test plan
- [x] \`uv run pytest tests/controllers/devices/test_create.py tests/controllers/devices/test_derive_board_id.py -q\` — 13/13 passing.