### PR TITLE
Address copilot wording nits on PR #198 + PR #209

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,9 +142,10 @@ warn_unused_configs = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-# ``loadgroup`` keeps the round-robin scheduler for unmarked tests but
-# pins anything tagged ``@pytest.mark.xdist_group("<name>")`` to a
-# single worker. The catalog-heavy modules use that to share one
+# ``loadgroup`` is xdist's default ``load`` scheduler (each test goes
+# to whichever worker is free) plus an extra rule: tests tagged
+# ``@pytest.mark.xdist_group("<name>")`` are pinned to a single
+# worker. The catalog-heavy modules use that to share one
 # ``ComponentCatalog.load`` (~2s on Linux CI) per run instead of
 # paying it on every xdist worker.
 addopts = "--dist=loadgroup"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,8 +116,9 @@ def session_board_catalog() -> BoardCatalog:
 def session_component_catalog(session_board_catalog: BoardCatalog) -> ComponentCatalog:
     """Real ``ComponentCatalog`` (with featured registry built) loaded once per worker.
 
-    Tests that mutate the catalog must restore it before yielding back —
-    the instance is shared across every test in the session.
+    The fixture returns a single shared instance for every test in
+    the session, so tests that mutate the catalog must restore it
+    before the test finishes (typically via ``try / finally``).
     """
     container = _CatalogContainer()
     container.boards = session_board_catalog


### PR DESCRIPTION
## Summary
Two doc-only fixes flagged by copilot on already-merged PRs:

- **PR #198 follow-up** (\`tests/conftest.py:115\`): the \`session_component_catalog\` fixture \`return\`s a value, it doesn't \`yield\`, so the existing \"restore before yielding back\" docstring was misleading. Reword to \"restore before the test finishes\".
- **PR #209 follow-up** (\`pyproject.toml:145\`): pytest-xdist's \`load*\` schedulers are load-based (each test to whichever worker is free), not round-robin. Clarify the inline comment for \`--dist=loadgroup\` so the comment matches xdist's actual behaviour.

## Test plan
- [x] No code change — pre-commit (ruff, codespell, toml-check) passes