### PR TITLE
Stop poking _jobs dict in firmware tests

### DIFF
--- a/tests/controllers/firmware/test_clear.py
+++ b/tests/controllers/firmware/test_clear.py
@@ -54,16 +54,16 @@ async def test_clear_default_removes_all_terminal_states(
     forgets to include any one of them in ``_TERMINAL_JOB_STATUSES``
     surfaces here regardless of which state was missed.
     """
-    controller = firmware_controller_factory(with_settings=False)
-    controller._jobs = {
-        "c": _job("c", JobStatus.COMPLETED),
-        "f": _job("f", JobStatus.FAILED),
-        "x": _job("x", JobStatus.CANCELLED),
-    }
+    controller = firmware_controller_factory(
+        _job("c", JobStatus.COMPLETED),
+        _job("f", JobStatus.FAILED),
+        _job("x", JobStatus.CANCELLED),
+        with_settings=False,
+    )
 
     await controller.clear()
 
-    assert controller._jobs == {}
+    assert await controller.get_jobs() == []
 
 
 @pytest.mark.asyncio
@@ -77,16 +77,16 @@ async def test_clear_default_keeps_queued_and_running_jobs(
     that defaulted to "remove all" would silently nuke the queue
     and follow_job sessions would be left dangling.
     """
-    controller = firmware_controller_factory(with_settings=False)
-    controller._jobs = {
-        "q": _job("q", JobStatus.QUEUED),
-        "r": _job("r", JobStatus.RUNNING),
-        "c": _job("c", JobStatus.COMPLETED),
-    }
+    controller = firmware_controller_factory(
+        _job("q", JobStatus.QUEUED),
+        _job("r", JobStatus.RUNNING),
+        _job("c", JobStatus.COMPLETED),
+        with_settings=False,
+    )
 
     await controller.clear()
 
-    assert set(controller._jobs) == {"q", "r"}
+    assert {j.job_id for j in await controller.get_jobs()} == {"q", "r"}
 
 
 @pytest.mark.asyncio
@@ -100,15 +100,15 @@ async def test_clear_default_with_no_terminal_jobs_is_noop(
     was empty would leak a stale on-disk file when the user
     *did* clear something earlier in the same session.
     """
-    controller = firmware_controller_factory(with_settings=False)
-    controller._jobs = {
-        "q": _job("q", JobStatus.QUEUED),
-        "r": _job("r", JobStatus.RUNNING),
-    }
+    controller = firmware_controller_factory(
+        _job("q", JobStatus.QUEUED),
+        _job("r", JobStatus.RUNNING),
+        with_settings=False,
+    )
 
     await controller.clear()
 
-    assert set(controller._jobs) == {"q", "r"}
+    assert {j.job_id for j in await controller.get_jobs()} == {"q", "r"}
     controller._persist_jobs.assert_awaited_once()
 
 
@@ -127,17 +127,17 @@ async def test_clear_with_specific_status_removes_only_that_status(
     without exact-match filtering they'd nuke the wrong category
     and the user would lose history they wanted to keep.
     """
-    controller = firmware_controller_factory(with_settings=False)
-    controller._jobs = {
-        "c1": _job("c1", JobStatus.COMPLETED),
-        "c2": _job("c2", JobStatus.COMPLETED),
-        "f": _job("f", JobStatus.FAILED),
-        "x": _job("x", JobStatus.CANCELLED),
-    }
+    controller = firmware_controller_factory(
+        _job("c1", JobStatus.COMPLETED),
+        _job("c2", JobStatus.COMPLETED),
+        _job("f", JobStatus.FAILED),
+        _job("x", JobStatus.CANCELLED),
+        with_settings=False,
+    )
 
     await controller.clear(status=JobStatus.COMPLETED)
 
-    assert set(controller._jobs) == {"f", "x"}
+    assert {j.job_id for j in await controller.get_jobs()} == {"f", "x"}
 
 
 @pytest.mark.asyncio
@@ -153,15 +153,15 @@ async def test_clear_with_status_string_matches_enum_value(
     enum would silently make this comparison false and the
     string-status branch would no-op.
     """
-    controller = firmware_controller_factory(with_settings=False)
-    controller._jobs = {
-        "c": _job("c", JobStatus.COMPLETED),
-        "f": _job("f", JobStatus.FAILED),
-    }
+    controller = firmware_controller_factory(
+        _job("c", JobStatus.COMPLETED),
+        _job("f", JobStatus.FAILED),
+        with_settings=False,
+    )
 
     await controller.clear(status="completed")
 
-    assert set(controller._jobs) == {"f"}
+    assert {j.job_id for j in await controller.get_jobs()} == {"f"}
 
 
 @pytest.mark.asyncio
@@ -176,16 +176,16 @@ async def test_clear_with_status_can_remove_active_jobs(
     FAILED) is a real recovery scenario. Pin the contract that
     the filter is applied verbatim, not intersected with terminal.
     """
-    controller = firmware_controller_factory(with_settings=False)
-    controller._jobs = {
-        "r": _job("r", JobStatus.RUNNING),
-        "q": _job("q", JobStatus.QUEUED),
-        "c": _job("c", JobStatus.COMPLETED),
-    }
+    controller = firmware_controller_factory(
+        _job("r", JobStatus.RUNNING),
+        _job("q", JobStatus.QUEUED),
+        _job("c", JobStatus.COMPLETED),
+        with_settings=False,
+    )
 
     await controller.clear(status=JobStatus.RUNNING)
 
-    assert set(controller._jobs) == {"q", "c"}
+    assert {j.job_id for j in await controller.get_jobs()} == {"q", "c"}
 
 
 @pytest.mark.asyncio
@@ -193,14 +193,14 @@ async def test_clear_with_status_no_matches_is_noop(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """An unmatched status is a no-op (still persists the unchanged map)."""
-    controller = firmware_controller_factory(with_settings=False)
-    controller._jobs = {
-        "c": _job("c", JobStatus.COMPLETED),
-    }
+    controller = firmware_controller_factory(
+        _job("c", JobStatus.COMPLETED),
+        with_settings=False,
+    )
 
     await controller.clear(status=JobStatus.FAILED)
 
-    assert set(controller._jobs) == {"c"}
+    assert {j.job_id for j in await controller.get_jobs()} == {"c"}
     controller._persist_jobs.assert_awaited_once()
 
 
@@ -220,24 +220,24 @@ async def test_clear_persists_after_removal(
     (persist runs *after* the deletes — the map must be the
     cleared shape when persist serialises it).
     """
-    controller = firmware_controller_factory(with_settings=False)
-    seen_jobs_at_persist: dict[str, FirmwareJob] = {}
+    controller = firmware_controller_factory(
+        _job("c", JobStatus.COMPLETED),
+        _job("q", JobStatus.QUEUED),
+        with_settings=False,
+    )
+    seen_ids_at_persist: set[str] = set()
 
     async def _capture() -> None:
-        seen_jobs_at_persist.update(controller._jobs)
+        seen_ids_at_persist.update(j.job_id for j in await controller.get_jobs())
 
     controller._persist_jobs = AsyncMock(side_effect=_capture)
-    controller._jobs = {
-        "c": _job("c", JobStatus.COMPLETED),
-        "q": _job("q", JobStatus.QUEUED),
-    }
 
     await controller.clear()
 
     controller._persist_jobs.assert_awaited_once()
     # Snapshot at persist time has the queued job only — not the
     # pre-delete shape.
-    assert set(seen_jobs_at_persist) == {"q"}
+    assert seen_ids_at_persist == {"q"}
 
 
 @pytest.mark.asyncio
@@ -251,12 +251,14 @@ async def test_clear_accepts_arbitrary_kwargs(
     ``client`` / ``message_id`` / bookkeeping fields the handler
     doesn't read.
     """
-    controller = firmware_controller_factory(with_settings=False)
-    controller._jobs = {"c": _job("c", JobStatus.COMPLETED)}
+    controller = firmware_controller_factory(
+        _job("c", JobStatus.COMPLETED),
+        with_settings=False,
+    )
 
     await controller.clear(client=object(), message_id="m1", spurious=True)
 
-    assert controller._jobs == {}
+    assert await controller.get_jobs() == []
 
 
 @pytest.mark.asyncio
@@ -268,5 +270,5 @@ async def test_clear_with_empty_jobs_map_is_noop(
 
     await controller.clear()
 
-    assert controller._jobs == {}
+    assert await controller.get_jobs() == []
     controller._persist_jobs.assert_awaited_once()

--- a/tests/controllers/firmware/test_compile_bulk.py
+++ b/tests/controllers/firmware/test_compile_bulk.py
@@ -84,7 +84,7 @@ async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
     # to completion before any enqueue work, so a partial batch
     # with the valid head queued and the bad entry erroring would
     # be a regression.
-    assert controller._jobs == {}
+    assert await controller.get_jobs() == []
 
 
 @pytest.mark.asyncio
@@ -105,7 +105,7 @@ async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
     with pytest.raises(CommandError) as exc:
         await controller.compile_bulk(configurations=["kitchen.yaml", ""])
     assert exc.value.code == ErrorCode.INVALID_ARGS
-    assert controller._jobs == {}
+    assert await controller.get_jobs() == []
 
 
 @pytest.mark.asyncio
@@ -148,12 +148,13 @@ async def test_compile_bulk_skips_entries_with_enqueue_command_error(
     queued_configs = [j.configuration for j in jobs]
     assert queued_configs == ["kitchen.yaml", "office.yaml"]
     # The skipped job's ``_create_job`` call still wrote it into
-    # ``self._jobs`` (the rename-lock check fires inside
+    # the in-memory job map (the rename-lock check fires inside
     # ``_enqueue``, *after* ``_create_job`` registers the job).
     # That's the production contract — skipping the enqueue
-    # leaves a stranded ``QUEUED`` entry in the map. Pin it so a
-    # future refactor that swaps the order surfaces here.
-    assert "locked.yaml" in {j.configuration for j in controller._jobs.values()}
+    # leaves a stranded ``QUEUED`` entry visible via ``get_jobs``.
+    # Pin it so a future refactor that swaps the order surfaces
+    # here.
+    assert "locked.yaml" in {j.configuration for j in await controller.get_jobs()}
 
 
 @pytest.mark.asyncio
@@ -171,7 +172,7 @@ async def test_compile_bulk_empty_input_returns_empty_list(
     jobs = await controller.compile_bulk(configurations=[])
 
     assert jobs == []
-    assert controller._jobs == {}
+    assert await controller.get_jobs() == []
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_supersede.py
+++ b/tests/controllers/firmware/test_supersede.py
@@ -128,10 +128,13 @@ async def test_resubmit_cancels_running_predecessor(
     (tmp_path / "kitchen.yaml").write_text("")
     controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     first = await controller.compile(configuration="kitchen.yaml")
-    # Simulate the runner having picked it up.
-    in_flight = controller._jobs[first.job_id]
-    in_flight.status = JobStatus.RUNNING
-    controller._current_job = in_flight
+    # Simulate the runner having picked it up. ``status`` is set
+    # on the live job object; there's no public API for putting a
+    # job into RUNNING without spawning a real ``esphome`` (same
+    # justified seam as ``test_persistence.py``'s RUNNING-carryover
+    # test).
+    first.status = JobStatus.RUNNING
+    controller._current_job = first
 
     second = await controller.compile(configuration="kitchen.yaml")
 
@@ -142,7 +145,8 @@ async def test_resubmit_cancels_running_predecessor(
     assert first.job_id in controller._cancel_requested
     controller._terminate_current_process.assert_awaited()
     # Second submission queued normally.
-    assert controller._jobs[second.job_id].status == JobStatus.QUEUED
+    jobs = {j.job_id: j for j in await controller.get_jobs()}
+    assert jobs[second.job_id].status == JobStatus.QUEUED
 
 
 @pytest.mark.asyncio
@@ -163,22 +167,23 @@ async def test_resubmit_does_not_cancel_terminal_jobs_for_same_config(
     spawning a real ``esphome``).
     """
     (tmp_path / "kitchen.yaml").write_text("")
-    controller = firmware_controller_factory(with_queue=True)
-    # Seed historical entries directly.
-    historical: list[FirmwareJob] = []
-    for status, job_id in [
-        (JobStatus.COMPLETED, "h-completed"),
-        (JobStatus.FAILED, "h-failed"),
-        (JobStatus.CANCELLED, "h-cancelled"),
-    ]:
-        job = FirmwareJob(
+    # Seed historical entries through the factory's ``*jobs``
+    # arg — no public API to land a job in COMPLETED / FAILED /
+    # CANCELLED without spawning a real ``esphome``.
+    historical: list[FirmwareJob] = [
+        FirmwareJob(
             job_id=job_id,
             configuration="kitchen.yaml",
             job_type=JobType.COMPILE,
             status=status,
         )
-        controller._jobs[job_id] = job
-        historical.append(job)
+        for status, job_id in [
+            (JobStatus.COMPLETED, "h-completed"),
+            (JobStatus.FAILED, "h-failed"),
+            (JobStatus.CANCELLED, "h-cancelled"),
+        ]
+    ]
+    controller = firmware_controller_factory(*historical, with_queue=True)
 
     fresh = await controller.compile(configuration="kitchen.yaml")
 


### PR DESCRIPTION
## Summary
- Tests in `test_clear.py`, `test_compile_bulk.py`, and `test_supersede.py` were reaching into `controller._jobs` to seed state and assert on the post-condition. That couples the tests to the in-memory dict shape; any future swap to a different job store (sqlite, external service) would churn every assertion without a behaviour change.
- Seed jobs through the factory's `*jobs` positional arg (already supported by `firmware_controller_factory`) and read state through the public `get_jobs()` API. No new test infra; all 22 affected tests still pass.
- Justified seams (no public API for "RUNNING mid-build" / non-QUEUED seeded history) are kept and now flagged with the same in-line note as `test_persistence.py`.

## Test plan
- [x] `uv run pytest tests/controllers/firmware/test_clear.py tests/controllers/firmware/test_compile_bulk.py tests/controllers/firmware/test_supersede.py`