### PR TITLE
Use get_job() instead of poking _jobs dict in firmware tests

### DIFF
--- a/tests/controllers/firmware/test_clean.py
+++ b/tests/controllers/firmware/test_clean.py
@@ -118,7 +118,7 @@ async def test_clean_registers_job_in_jobs_map(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """The new job lands in ``self._jobs`` keyed by ``job_id``.
+    """The new job is registered so ``get_job`` finds it by ``job_id``.
 
     Subsequent ``firmware/get_jobs`` / ``firmware/cancel`` /
     ``firmware/follow_job`` calls all look the job up by id;
@@ -130,4 +130,4 @@ async def test_clean_registers_job_in_jobs_map(
 
     job = await controller.clean(configuration="kitchen.yaml")
 
-    assert controller._jobs[job.job_id] is job
+    assert await controller.get_job(job_id=job.job_id) is job

--- a/tests/controllers/firmware/test_compile.py
+++ b/tests/controllers/firmware/test_compile.py
@@ -114,7 +114,7 @@ async def test_compile_enqueues_before_firing_job_queued(
 async def test_compile_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """The new job lands in ``self._jobs`` keyed by ``job_id``.
+    """The new job is registered so ``get_job`` finds it by ``job_id``.
 
     Subsequent ``firmware/get_jobs`` / ``firmware/cancel`` /
     ``firmware/follow_job`` calls all look the job up by id;
@@ -126,4 +126,4 @@ async def test_compile_registers_job_in_jobs_map(
 
     job = await controller.compile(configuration="kitchen.yaml")
 
-    assert controller._jobs[job.job_id] is job
+    assert await controller.get_job(job_id=job.job_id) is job

--- a/tests/controllers/firmware/test_get_jobs.py
+++ b/tests/controllers/firmware/test_get_jobs.py
@@ -218,7 +218,7 @@ async def test_get_job_returns_none_for_unknown_id(
 async def test_get_job_does_not_mutate_state(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """Pure read — the call doesn't mutate ``self._jobs`` or persist anything.
+    """Pure read — the call doesn't add/remove jobs or persist anything.
 
     Belt-and-braces: a future refactor that, say, lazy-removes
     terminal jobs on read would silently change the contract for
@@ -227,9 +227,9 @@ async def test_get_job_does_not_mutate_state(
     """
     target = _job("target")
     controller = firmware_controller_factory(target, with_settings=False)
-    before = dict(controller._jobs)
+    before = await controller.get_jobs()
 
     await controller.get_job(job_id="target")
 
-    assert controller._jobs == before
+    assert await controller.get_jobs() == before
     controller._persist_jobs.assert_not_awaited()

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -195,7 +195,7 @@ async def test_install_enqueues_before_firing_job_queued(
 async def test_install_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """The new job lands in ``self._jobs`` keyed by ``job_id``.
+    """The new job is registered so ``get_job`` finds it by ``job_id``.
 
     Subsequent ``firmware/get_jobs`` / ``firmware/cancel`` /
     ``firmware/follow_job`` calls all look the job up by id;
@@ -207,4 +207,4 @@ async def test_install_registers_job_in_jobs_map(
 
     job = await controller.install(configuration="kitchen.yaml")
 
-    assert controller._jobs[job.job_id] is job
+    assert await controller.get_job(job_id=job.job_id) is job

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -81,12 +81,12 @@ async def test_reset_build_env_uses_empty_configuration(
 async def test_reset_build_env_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """The new job lands in ``self._jobs`` so ``cancel`` / ``follow_job`` can find it."""
+    """The new job is registered so ``cancel`` / ``follow_job`` can find it by id."""
     controller = firmware_controller_factory(with_queue=True, with_terminate=True)
 
     job = await controller.reset_build_env()
 
-    assert controller._jobs[job.job_id] is job
+    assert await controller.get_job(job_id=job.job_id) is job
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_upload.py
+++ b/tests/controllers/firmware/test_upload.py
@@ -194,7 +194,7 @@ async def test_upload_enqueues_before_firing_job_queued(
 async def test_upload_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """The new job lands in ``self._jobs`` keyed by ``job_id``.
+    """The new job is registered so ``get_job`` finds it by ``job_id``.
 
     Subsequent ``firmware/get_jobs`` / ``firmware/cancel`` /
     ``firmware/follow_job`` calls all look the job up by id;
@@ -206,4 +206,4 @@ async def test_upload_registers_job_in_jobs_map(
 
     job = await controller.upload(configuration="kitchen.yaml")
 
-    assert controller._jobs[job.job_id] is job
+    assert await controller.get_job(job_id=job.job_id) is job


### PR DESCRIPTION
## Summary
- Six firmware handler tests (`test_compile.py`, `test_upload.py`, `test_install.py`, `test_clean.py`, `test_reset_build_env.py`, `test_get_jobs.py`) reached into `controller._jobs[job.job_id]` to verify a freshly queued job is registered.
- Replace with `await controller.get_job(job_id=...)` — same identity check (the public API returns the same object), same guarantee, no coupling to the internal dict shape.
- Independent of #219; touches different files.

## Test plan
- [x] `uv run pytest tests/controllers/firmware/test_compile.py tests/controllers/firmware/test_reset_build_env.py tests/controllers/firmware/test_upload.py tests/controllers/firmware/test_clean.py tests/controllers/firmware/test_install.py tests/controllers/firmware/test_get_jobs.py`