### PR TITLE
Assert on real EventBus in cancel tests via shared helper

### DIFF
--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -30,7 +30,8 @@ import pytest
 
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.models import FirmwareJob
+from esphome_device_builder.helpers.event_bus import Event, EventBus
+from esphome_device_builder.models import EventType, FirmwareJob
 
 
 class FirmwareControllerFactory(Protocol):
@@ -144,3 +145,28 @@ def firmware_controller_factory(
         return controller
 
     return _make
+
+
+def capture_firmware_events(
+    controller: FirmwareController,
+    *event_types: EventType,
+) -> list[Event]:
+    """Swap the controller's bus for a real ``EventBus`` and return the capture list.
+
+    The conftest factory wires ``self._db.bus`` as a ``MagicMock``;
+    that's fine for tests that ignore events but means assertions on
+    event firing have to walk ``call_args_list``. Replacing with a
+    real bus + listener gives a flat ``[Event, …]`` log that captures
+    both the event type and payload, with no coupling to the
+    handler's internal call shape.
+
+    Pass the ``EventType`` values to subscribe to. The returned list
+    is appended to as events fire — assertion code can read it after
+    the call under test resolves.
+    """
+    bus = EventBus()
+    captured: list[Event] = []
+    for event_type in event_types:
+        bus.add_listener(event_type, captured.append)
+    controller._db.bus = bus
+    return captured

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -35,7 +35,10 @@ from esphome_device_builder.models import (
     JobStatus,
     JobType,
 )
-from tests.controllers.firmware.conftest import FirmwareControllerFactory
+from tests.controllers.firmware.conftest import (
+    FirmwareControllerFactory,
+    capture_firmware_events,
+)
 
 
 def _job(
@@ -99,12 +102,13 @@ async def test_cancel_queued_job_marks_terminal_and_fires_event(
     job = _job("j-q", status=JobStatus.QUEUED)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
     controller._prune_history = MagicMock()
+    captured = capture_firmware_events(controller, EventType.JOB_CANCELLED)
 
     await controller.cancel(job_id="j-q")
 
     assert job.status == JobStatus.CANCELLED
     assert job.completed_at is not None
-    controller._db.bus.fire.assert_called_once_with(EventType.JOB_CANCELLED, {"job": job})
+    assert [(e.event_type, e.data) for e in captured] == [(EventType.JOB_CANCELLED, {"job": job})]
 
 
 @pytest.mark.asyncio
@@ -205,10 +209,11 @@ async def test_cancel_running_job_does_not_fire_event_directly(
     job = _job("j-r", status=JobStatus.RUNNING)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
     controller._current_job = job
+    captured = capture_firmware_events(controller, EventType.JOB_CANCELLED)
 
     await controller.cancel(job_id="j-r")
 
-    controller._db.bus.fire.assert_not_called()
+    assert captured == []
     # Status stays RUNNING — the runner is what flips it CANCELLED.
     assert job.status == JobStatus.RUNNING
 
@@ -278,10 +283,11 @@ async def test_cancel_terminal_job_raises_invalid_args(
     """
     job = _job("j-t", status=status)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
+    captured = capture_firmware_events(controller, EventType.JOB_CANCELLED)
 
     with pytest.raises(CommandError) as exc:
         await controller.cancel(job_id="j-t")
     assert exc.value.code == ErrorCode.INVALID_ARGS
     assert f"Cannot cancel a {status.value} job" in exc.value.message
     controller._terminate_current_process.assert_not_called()
-    controller._db.bus.fire.assert_not_called()
+    assert captured == []


### PR DESCRIPTION
## Summary
- `test_cancel.py` asserted on a MagicMock-shaped `controller._db.bus.fire` across three tests (`assert_called_once_with` for the QUEUED branch, `assert_not_called` for RUNNING and terminal-status branches). That couples the assertions to the controller's internal call shape — a refactor that batched two events into one call would silently break the assertion, while the user-visible contract is just "this set of events fired with these payloads."
- Add `capture_firmware_events(controller, *event_types)` to `tests/controllers/firmware/conftest.py`. It swaps the controller's bus for a real `EventBus` and subscribes a flat listener for the requested types. Other firmware tests can import it from the same conftest as the next round of bus-mock cleanups lands.
- Independent of #219 and #220; touches different files.

## Test plan
- [x] `uv run pytest tests/controllers/firmware/test_cancel.py`
- [x] `uv run pytest tests/controllers/firmware/` (full suite — 290 pass, 2 skip)