### PR TITLE
Add capture_enqueue_order helper for put-then-fire ordering tests

### DIFF
--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -22,6 +22,8 @@ silently absorbing into a stub.
 
 from __future__ import annotations
 
+import asyncio
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
@@ -32,6 +34,20 @@ from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.models import EventType, FirmwareJob
+
+
+class EnqueueStep(StrEnum):
+    """Step labels in the ``capture_enqueue_order`` log.
+
+    Same shape as ``StreamEvent`` (PR #212): a small enum keeps
+    callers from drifting on bare strings — a typo in either the
+    helper or the assertion would otherwise pass silently
+    (``log[0] == ("putt", job)`` is a valid tuple comparison that
+    never matches).
+    """
+
+    PUT = "put"
+    FIRE = "fire"
 
 
 class FirmwareControllerFactory(Protocol):
@@ -170,3 +186,41 @@ def capture_firmware_events(
         bus.add_listener(event_type, captured.append)
     controller._db.bus = bus
     return captured
+
+
+def capture_enqueue_order(
+    controller: FirmwareController,
+    *event_types: EventType,
+) -> list[tuple[EnqueueStep, Any]]:
+    """Trace ``_queue.put`` calls and ``bus.fire`` events into one ordered log.
+
+    Each ``await self._queue.put(job)`` appends ``(EnqueueStep.PUT, job)``
+    and each broadcast for a subscribed ``EventType`` appends
+    ``(EnqueueStep.FIRE, Event)``. Tests assert the put-then-fire
+    ordering by index in the returned list — the previous shape
+    spread the same contract across a parent ``MagicMock`` whose
+    ``method_calls`` log was walked with two ``.index()`` calls and
+    a ``parent.bus.fire.assert_any_call(...)`` follow-up.
+
+    The internal queue is a real ``asyncio.Queue`` so a runner can
+    still dequeue if the test exercises that path.
+    """
+    log: list[tuple[EnqueueStep, Any]] = []
+    inner_queue: asyncio.Queue[FirmwareJob] = asyncio.Queue()
+
+    async def _trace_put(item: FirmwareJob) -> None:
+        log.append((EnqueueStep.PUT, item))
+        await inner_queue.put(item)
+
+    queue_proxy = MagicMock()
+    queue_proxy.put = _trace_put
+    queue_proxy.get = inner_queue.get
+    queue_proxy.qsize = inner_queue.qsize
+    controller._queue = queue_proxy
+
+    bus = EventBus()
+    for event_type in event_types:
+        bus.add_listener(event_type, lambda event: log.append((EnqueueStep.FIRE, event)))
+    controller._db.bus = bus
+
+    return log

--- a/tests/controllers/firmware/test_clean.py
+++ b/tests/controllers/firmware/test_clean.py
@@ -19,13 +19,16 @@ test catching it.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
-from tests.controllers.firmware.conftest import FirmwareControllerFactory
+from tests.controllers.firmware.conftest import (
+    EnqueueStep,
+    FirmwareControllerFactory,
+    capture_enqueue_order,
+)
 
 
 @pytest.mark.asyncio
@@ -86,31 +89,17 @@ async def test_clean_enqueues_before_firing_job_queued(
     race the runner if the event broadcast preceded the queue
     insert — the follower could attach to a queue that hasn't
     seen the job yet, dropping the first line.
-
-    Implementation note: the factory's ``with_queue=True``
-    installs ``AsyncMock`` stubs for ``_queue`` and
-    ``_supersede_active_jobs``; we replace ``_queue`` and the
-    bus with attribute children of a parent ``MagicMock`` so
-    both calls land on a single ``method_calls`` log in their
-    actual order.
     """
-    parent = MagicMock()
-    parent.queue.put = AsyncMock()
-    parent.bus.fire = MagicMock()
-
     controller = firmware_controller_factory(with_queue=True)
-    controller._queue = parent.queue
-    controller._db.bus = parent.bus
+    log = capture_enqueue_order(controller, EventType.JOB_QUEUED)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.clean(configuration="kitchen.yaml")
 
-    method_names = [name for name, _, _ in parent.method_calls]
-    queued_idx = method_names.index("queue.put")
-    fired_idx = method_names.index("bus.fire")
-    assert queued_idx < fired_idx
-
-    parent.bus.fire.assert_any_call(EventType.JOB_QUEUED, {"job": job})
+    assert log[0] == (EnqueueStep.PUT, job)
+    assert log[1][0] is EnqueueStep.FIRE
+    assert log[1][1].event_type == EventType.JOB_QUEUED
+    assert log[1][1].data == {"job": job}
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_compile.py
+++ b/tests/controllers/firmware/test_compile.py
@@ -18,13 +18,16 @@ silently degrade the dashboard.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
-from tests.controllers.firmware.conftest import FirmwareControllerFactory
+from tests.controllers.firmware.conftest import (
+    EnqueueStep,
+    FirmwareControllerFactory,
+    capture_enqueue_order,
+)
 
 
 @pytest.mark.asyncio
@@ -83,31 +86,17 @@ async def test_compile_enqueues_before_firing_job_queued(
     event broadcast preceded the queue insert — the follower
     could attach to a queue that hasn't seen the job yet,
     dropping the first line.
-
-    Implementation: capture a single shared call log via a
-    parent ``MagicMock`` whose ``method_calls`` is updated in
-    put-then-fire order. The ``_queue`` and ``bus`` mocks
-    installed in the fixture are wired as attribute children of
-    this parent so every call (sync or async) lands on the
-    parent's call log.
     """
-    parent = MagicMock()
-    parent.queue.put = AsyncMock()
-    parent.bus.fire = MagicMock()
-
     controller = firmware_controller_factory(with_queue=True)
-    controller._queue = parent.queue
-    controller._db.bus = parent.bus
+    log = capture_enqueue_order(controller, EventType.JOB_QUEUED)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.compile(configuration="kitchen.yaml")
 
-    method_names = [name for name, _, _ in parent.method_calls]
-    queued_idx = method_names.index("queue.put")
-    fired_idx = method_names.index("bus.fire")
-    assert queued_idx < fired_idx
-
-    parent.bus.fire.assert_any_call(EventType.JOB_QUEUED, {"job": job})
+    assert log[0] == (EnqueueStep.PUT, job)
+    assert log[1][0] is EnqueueStep.FIRE
+    assert log[1][1].event_type == EventType.JOB_QUEUED
+    assert log[1][1].data == {"job": job}
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -22,13 +22,16 @@ the right defaults and order. This file pins:
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
-from tests.controllers.firmware.conftest import FirmwareControllerFactory
+from tests.controllers.firmware.conftest import (
+    EnqueueStep,
+    FirmwareControllerFactory,
+    capture_enqueue_order,
+)
 
 
 @pytest.mark.asyncio
@@ -165,30 +168,17 @@ async def test_install_enqueues_before_firing_job_queued(
     halves: the event fires with the right payload, *and* the
     queue had already received the job by the time the event
     fired.
-
-    Implementation: capture a single shared call log via a
-    ``MagicMock`` whose ``method_calls`` is updated in put-then-
-    fire order. The ``_queue`` and ``bus`` mocks installed in the
-    fixture are wired as attribute children of this parent so
-    every call (sync or async) lands on the parent's call log.
     """
-    parent = MagicMock()
-    parent.queue.put = AsyncMock()
-    parent.bus.fire = MagicMock()
-
     controller = firmware_controller_factory(with_queue=True)
-    controller._queue = parent.queue
-    controller._db.bus = parent.bus
+    log = capture_enqueue_order(controller, EventType.JOB_QUEUED)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml")
 
-    method_names = [name for name, _, _ in parent.method_calls]
-    queued_idx = method_names.index("queue.put")
-    fired_idx = method_names.index("bus.fire")
-    assert queued_idx < fired_idx
-
-    parent.bus.fire.assert_any_call(EventType.JOB_QUEUED, {"job": job})
+    assert log[0] == (EnqueueStep.PUT, job)
+    assert log[1][0] is EnqueueStep.FIRE
+    assert log[1][1].event_type == EventType.JOB_QUEUED
+    assert log[1][1].data == {"job": job}
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -25,14 +25,15 @@ shells out via ``create_subprocess_exec``).
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.controllers.firmware.constants import _RESET_BUILD_ENV_TARGETS
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
+    EnqueueStep,
     FirmwareControllerFactory,
+    capture_enqueue_order,
     capture_firmware_events,
 )
 
@@ -106,22 +107,15 @@ async def test_reset_build_env_fires_job_queued_after_enqueue(
     that immediately calls ``follow_job`` could race the runner
     and miss the first lines.
     """
-    parent = MagicMock()
-    parent.queue.put = AsyncMock()
-    parent.bus.fire = MagicMock()
-
     controller = firmware_controller_factory(with_queue=True, with_terminate=True)
-    controller._queue = parent.queue
-    controller._db.bus = parent.bus
+    log = capture_enqueue_order(controller, EventType.JOB_QUEUED)
 
     job = await controller.reset_build_env()
 
-    method_names = [name for name, _, _ in parent.method_calls]
-    queued_idx = method_names.index("queue.put")
-    fired_idx = method_names.index("bus.fire")
-    assert queued_idx < fired_idx
-
-    parent.bus.fire.assert_any_call(EventType.JOB_QUEUED, {"job": job})
+    assert log[0] == (EnqueueStep.PUT, job)
+    assert log[1][0] is EnqueueStep.FIRE
+    assert log[1][1].event_type == EventType.JOB_QUEUED
+    assert log[1][1].data == {"job": job}
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_upload.py
+++ b/tests/controllers/firmware/test_upload.py
@@ -24,13 +24,16 @@ pieces with the right defaults and order. This file pins:
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
-from tests.controllers.firmware.conftest import FirmwareControllerFactory
+from tests.controllers.firmware.conftest import (
+    EnqueueStep,
+    FirmwareControllerFactory,
+    capture_enqueue_order,
+)
 
 
 @pytest.mark.asyncio
@@ -163,31 +166,17 @@ async def test_upload_enqueues_before_firing_job_queued(
     ``JOB_QUEUED`` would race the runner if the event broadcast
     preceded the queue insert — the follower could attach to a
     queue that hasn't seen the job yet, dropping the first line.
-
-    Implementation: capture a single shared call log via a
-    parent ``MagicMock`` whose ``method_calls`` is updated in
-    put-then-fire order. The ``_queue`` and ``bus`` mocks
-    installed in the fixture are wired as attribute children
-    of this parent so every call (sync or async) lands on the
-    parent's call log.
     """
-    parent = MagicMock()
-    parent.queue.put = AsyncMock()
-    parent.bus.fire = MagicMock()
-
     controller = firmware_controller_factory(with_queue=True)
-    controller._queue = parent.queue
-    controller._db.bus = parent.bus
+    log = capture_enqueue_order(controller, EventType.JOB_QUEUED)
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.upload(configuration="kitchen.yaml")
 
-    method_names = [name for name, _, _ in parent.method_calls]
-    queued_idx = method_names.index("queue.put")
-    fired_idx = method_names.index("bus.fire")
-    assert queued_idx < fired_idx
-
-    parent.bus.fire.assert_any_call(EventType.JOB_QUEUED, {"job": job})
+    assert log[0] == (EnqueueStep.PUT, job)
+    assert log[1][0] is EnqueueStep.FIRE
+    assert log[1][1].event_type == EventType.JOB_QUEUED
+    assert log[1][1].data == {"job": job}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Five firmware submission handlers (`compile`, `upload`, `install`, `clean`, `reset_build_env`) had a "put-then-fire" ordering test that wired `_queue` and `bus` as attribute children of a parent `MagicMock`, then asserted on `parent.method_calls` indices plus a `parent.bus.fire.assert_any_call`. The contract being pinned is just "the queue saw the job before `JOB_QUEUED` fired so a follower attaching on that signal can't race the runner" — the MagicMock plumbing was incidental.
- Add `capture_enqueue_order(controller, *event_types)` to `tests/controllers/firmware/conftest.py`. It wraps `_queue.put` and `bus.fire` into a single ordered log of `(EnqueueStep, value)` tuples. The internal queue is a real `asyncio.Queue` so a runner can still dequeue.
- `EnqueueStep` is a `StrEnum` (`PUT` / `FIRE`) — same idea as PR #212's `StreamEvent`. A typo in a bare `"put"` / `"fire"` literal would otherwise pass silently because the tuple comparison `(. , .) == ("putt", job)` is just false, not an error.
- Each call site shrinks to "subscribe → assert on log indices" with no `parent.method_calls` walk and no `assert_any_call` follow-up.

## Test plan
- [x] `uv run pytest tests/controllers/firmware/test_compile.py tests/controllers/firmware/test_upload.py tests/controllers/firmware/test_install.py tests/controllers/firmware/test_clean.py tests/controllers/firmware/test_reset_build_env.py`