### PR TITLE
Add capture_devices_events helper and use it for bus.fire assertions

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -25,6 +25,7 @@ import pytest
 
 from esphome_device_builder.controllers.config import set_device_metadata
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.models import EventType
 
 
@@ -373,6 +374,33 @@ def make_controller() -> MakeControllerFactory:
         return controller
 
     return _make
+
+
+def capture_devices_events(
+    controller: DevicesController,
+    *event_types: EventType,
+) -> list[Event]:
+    """Swap the controller's bus for a real ``EventBus`` and return the capture list.
+
+    Devices-side sibling of ``capture_firmware_events`` from the
+    firmware conftest. The ``make_controller`` factory wires
+    ``self._db`` as a ``MagicMock`` so ``_db.bus.fire`` is a
+    ``MagicMock`` auto-attribute; assertions on it have to walk
+    ``mock_calls`` or use ``assert_called_with``. Replacing with a
+    real bus + listener gives a flat ``[Event, …]`` log that
+    captures both event type and payload, with no coupling to the
+    handler's internal call shape.
+
+    Pass the ``EventType`` values to subscribe to. The returned list
+    is appended to as events fire — assertion code can read it after
+    the call under test resolves.
+    """
+    bus = EventBus()
+    captured: list[Event] = []
+    for event_type in event_types:
+        bus.add_listener(event_type, captured.append)
+    controller._db.bus = bus
+    return captured
 
 
 @pytest.fixture

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -25,7 +25,7 @@ from esphome_device_builder.controllers.devices import controller as devices_mod
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import AdoptableDevice, DeviceState, ErrorCode, EventType
 
-from .conftest import MakeControllerFactory
+from .conftest import MakeControllerFactory, capture_devices_events
 
 
 def _seed_import_state(controller: DevicesController) -> None:
@@ -362,6 +362,7 @@ async def test_import_device_drops_matching_import_result_entry(
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
+    captured = capture_devices_events(ctrl, EventType.IMPORTABLE_DEVICE_REMOVED)
     discovered = AdoptableDevice(
         name="apollo-plt-1-983300",
         friendly_name="Apollo PLT-1",
@@ -382,9 +383,5 @@ async def test_import_device_drops_matching_import_result_entry(
 
     assert "apollo-plt-1-983300" not in ctrl.import_result
     # Removal is broadcast so subscribed frontends drop the card.
-    fired = list(ctrl._db.bus.fire.mock_calls)
-    removed_events = [
-        c for c in fired if c.args and c.args[0] == EventType.IMPORTABLE_DEVICE_REMOVED
-    ]
-    assert removed_events, "expected IMPORTABLE_DEVICE_REMOVED to fire"
-    assert removed_events[0].args[1] == {"name": "apollo-plt-1-983300"}
+    assert captured, "expected IMPORTABLE_DEVICE_REMOVED to fire"
+    assert captured[0].data == {"name": "apollo-plt-1-983300"}

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -21,6 +21,8 @@ from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, EventType
 
+from .conftest import capture_devices_events
+
 
 def _make_controller(monkeypatch: Any, board_id: str = "esp32-c3-devkitm-1") -> Any:
     """Build a controller with the YAML-parsing path stubbed out.
@@ -214,6 +216,7 @@ def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None
     controller._state_monitor = MagicMock()
     schedule = MagicMock()
     monkeypatch.setattr(controller, "_schedule_storage_regenerate", schedule, raising=False)
+    captured = capture_devices_events(controller, EventType.DEVICE_ADDED)
 
     device = Device(
         name="apollo",
@@ -227,7 +230,9 @@ def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None
     schedule.assert_called_once_with("apollo-r-pro-1.yaml")
     # Sanity: the bus fire still happens — the trigger is additive,
     # not a replacement.
-    controller._db.bus.fire.assert_called_with(EventType.DEVICE_ADDED, {"device": device})
+    assert [(e.event_type, e.data) for e in captured] == [
+        (EventType.DEVICE_ADDED, {"device": device})
+    ]
     # Probe fires too — the eager mDNS probe on ADDED is what catches
     # YAMLs dropped on disk outside the API path.
     controller._state_monitor.probe_device.assert_called_once_with("apollo")

--- a/tests/controllers/devices/test_toggle_ignore.py
+++ b/tests/controllers/devices/test_toggle_ignore.py
@@ -28,15 +28,14 @@ from pathlib import Path
 import pytest
 
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.event_bus import Event
 from esphome_device_builder.models import AdoptableDevice, EventType
 
-from .conftest import MakeControllerFactory
+from .conftest import MakeControllerFactory, capture_devices_events
 
 
-def _seed_for_toggle(
-    controller: DevicesController, tmp_path: Path
-) -> tuple[list[tuple[EventType, dict[str, object]]], Path]:
-    """Wire ``import_result`` + a recording bus stub for the toggle path.
+def _seed_for_toggle(controller: DevicesController, tmp_path: Path) -> tuple[list[Event], Path]:
+    """Wire ``import_result`` + the events capture for the toggle path.
 
     Returns ``(events, ignored_path)`` so the test can assert
     against fired events and the on-disk state of the ignored
@@ -45,13 +44,12 @@ def _seed_for_toggle(
     monkeypatching it onto a known location under ``tmp_path``
     is what lets the test inspect what landed on disk without
     spinning up a full ``DashboardSettings``.
+
+    The events list is the live capture from
+    ``capture_devices_events`` — only ``IMPORTABLE_DEVICE_ADDED``
+    is subscribed since that's the toggle path's only broadcast.
     """
-    fired: list[tuple[EventType, dict[str, object]]] = []
-
-    def _fire(event_type: EventType, data: dict[str, object]) -> None:
-        fired.append((event_type, data))
-
-    controller._db.bus.fire = _fire  # type: ignore[method-assign]
+    fired = capture_devices_events(controller, EventType.IMPORTABLE_DEVICE_ADDED)
     controller.import_result = {}
     controller.ignored_devices = set()
     return fired, tmp_path / "ignored-devices.json"
@@ -155,9 +153,8 @@ async def test_toggle_ignore_mirrors_flag_onto_cached_adoptable_and_fires(
 
     # Exactly one IMPORTABLE_DEVICE_ADDED event fired with the updated model.
     assert len(fired) == 1
-    event_type, payload = fired[0]
-    assert event_type == EventType.IMPORTABLE_DEVICE_ADDED
-    assert payload == {"device": cached}
+    assert fired[0].event_type == EventType.IMPORTABLE_DEVICE_ADDED
+    assert fired[0].data == {"device": cached}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Devices-side sibling of `capture_firmware_events` from #221. The `make_controller` factory wires `controller._db` as a `MagicMock`, so `_db.bus.fire` was a `MagicMock` auto-attribute — assertions on it had to walk `mock_calls` or use `assert_called_with`, the same internals coupling the firmware-side PRs cleared up.
- Add `capture_devices_events(controller, *event_types)` to `tests/controllers/devices/conftest.py`. Same shape as the firmware helper: subscribe a real `EventBus` listener, return the captured list.
- Sweep three call sites:
  - `test_metadata_resolver.py:230` (`assert_called_with`) → flat list assertion on the captured event.
  - `test_import.py:385-390` (`mock_calls` walk filtered by event type) → capture only the targeted event.
  - `test_toggle_ignore.py`: replaces a hand-rolled `_fire` recorder with the shared helper for consistency, so all four devices-side bus assertions go through the same shape.

## Test plan
- [x] `uv run pytest tests/controllers/devices/test_metadata_resolver.py tests/controllers/devices/test_import.py tests/controllers/devices/test_toggle_ignore.py`
- [x] `uv run pytest tests/controllers/devices/` (full suite — 158 pass)