### PR TITLE
Add typed RecordingStateMonitor fake; replace MagicMock state-monitor asserts

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -26,7 +26,111 @@ import pytest
 from esphome_device_builder.controllers.config import set_device_metadata
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.event_bus import Event, EventBus
-from esphome_device_builder.models import EventType
+from esphome_device_builder.helpers.hostname import normalize_hostname
+from esphome_device_builder.models import AdoptableDevice, DeviceState, EventType
+
+
+class RecordingStateMonitor:
+    """Test fake for ``DeviceStateMonitor`` that captures every call.
+
+    Mirrors every public method on the production
+    ``DeviceStateMonitor`` (``apply`` / ``apply_ip`` /
+    ``apply_version`` / ``apply_api_encryption`` /
+    ``apply_config_hash`` / ``get_cached_addresses`` /
+    ``get_cached_dns_addresses`` / ``probe_device`` /
+    ``priority_for`` / ``revisit_importable`` /
+    ``revisit_all_importables`` / ``get_importable_devices``)
+    without any of the real monitor's I/O. Calls land in
+    ``self.calls`` as flat tuples ``(method_name, *args)`` —
+    assertion-time comparisons read like
+    ``calls == [("apply", "kitchen", ONLINE, "mdns", True), ...]``
+    instead of three scattered ``MagicMock.assert_called_*`` lines.
+
+    Why a typed fake rather than ``MagicMock``: a typo (e.g.
+    ``probe_devicee.assert_called_once``) silently passes against a
+    ``MagicMock`` because it spawns a fresh attribute on access; a
+    refactor renaming a real method (``apply_ip`` → ``set_ip``)
+    similarly breaks the contract without breaking the assertion.
+    Pinning the surface here means both classes of drift surface as
+    ``AttributeError`` immediately. Mirroring the *full* public
+    surface (rather than just what the first batch of tests
+    needed) means a controller path like ``_on_scan_change(…,
+    REMOVED)`` that calls ``revisit_importable`` won't blow up
+    against the fake just because no earlier test exercised it.
+
+    ``cached_addresses`` and ``cached_dns_addresses`` accept
+    ``hostname → [ips]`` maps. Lookup keys are normalised through
+    ``normalize_hostname`` so tests can pass production-equivalent
+    inputs like ``Kitchen.local.`` and still hit the seeded entry.
+
+    ``importable_devices`` lets tests pre-seed a list returned by
+    ``get_importable_devices``; defaults to ``[]``.
+
+    ``priority_map`` lets tests override the per-source priority
+    returned by ``priority_for``; lookup falls back to ``"unknown"``
+    for unmapped sources, matching production's default branch.
+    """
+
+    def __init__(
+        self,
+        *,
+        cached_addresses: dict[str, list[str]] | None = None,
+        cached_dns_addresses: dict[str, list[str]] | None = None,
+        importable_devices: list[AdoptableDevice] | None = None,
+        priority_map: dict[str, str] | None = None,
+    ) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self._cached = {normalize_hostname(k): v for k, v in (cached_addresses or {}).items()}
+        self._cached_dns = {
+            normalize_hostname(k): v for k, v in (cached_dns_addresses or {}).items()
+        }
+        self._importable = list(importable_devices or [])
+        self._priority = priority_map or {}
+
+    def apply(self, name: str, state: DeviceState, source: str, *, claim: bool = False) -> bool:
+        self.calls.append(("apply", name, state, source, claim))
+        return True
+
+    def apply_ip(self, name: str, ip: str) -> bool:
+        self.calls.append(("apply_ip", name, ip))
+        return True
+
+    def apply_version(self, name: str, version: str) -> bool:
+        self.calls.append(("apply_version", name, version))
+        return True
+
+    def apply_api_encryption(self, name: str, encryption: str) -> bool:
+        self.calls.append(("apply_api_encryption", name, encryption))
+        return True
+
+    def apply_config_hash(self, name: str, config_hash: str) -> bool:
+        self.calls.append(("apply_config_hash", name, config_hash))
+        return True
+
+    def get_cached_addresses(self, host_name: str) -> list[str] | None:
+        self.calls.append(("get_cached_addresses", host_name))
+        return self._cached.get(normalize_hostname(host_name))
+
+    def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
+        self.calls.append(("get_cached_dns_addresses", host_name))
+        return self._cached_dns.get(normalize_hostname(host_name))
+
+    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
+        self.calls.append(("probe_device", device_name, service_name))
+
+    def priority_for(self, name: str) -> str:
+        self.calls.append(("priority_for", name))
+        return self._priority.get(name, "unknown")
+
+    def revisit_importable(self, device_name: str) -> None:
+        self.calls.append(("revisit_importable", device_name))
+
+    def revisit_all_importables(self) -> None:
+        self.calls.append(("revisit_all_importables",))
+
+    def get_importable_devices(self) -> list[AdoptableDevice]:
+        self.calls.append(("get_importable_devices",))
+        return list(self._importable)
 
 
 def _make_board_stub(board_id: str) -> MagicMock:
@@ -318,12 +422,15 @@ def make_controller() -> MakeControllerFactory:
     ``_schedule_storage_regenerate`` doesn't short-circuit;
     leave it ``None`` for tests that don't reach that code path.
 
-    ``with_state_monitor=True`` attaches a ``MagicMock``-shaped
-    ``_state_monitor`` for tests that exercise paths reading the
-    cached-address / get_cached_addresses lookup (``import_device``,
-    ``create_device``). The monitor's ``get_cached_addresses``
-    defaults to returning ``None`` so the fast-online branch
-    short-circuits unless a test overrides it.
+    ``with_state_monitor=True`` attaches a typed
+    :class:`RecordingStateMonitor` for tests that exercise paths
+    reading the cached-address / get_cached_addresses lookup
+    (``import_device``, ``create_device``). The fake's
+    ``get_cached_addresses`` returns ``None`` for an empty cache
+    so the fast-online branch short-circuits unless a test
+    overrides it (``ctrl._state_monitor =
+    RecordingStateMonitor(cached_addresses=...)``). Tests get the
+    typo-resistant typed surface by default — no opt-in flag.
 
     ``with_boards=True`` attaches a ``MagicMock``-shaped
     ``_db.boards`` for tests that go through the
@@ -348,8 +455,7 @@ def make_controller() -> MakeControllerFactory:
         controller._scanner.reload = AsyncMock()
 
         if with_state_monitor:
-            controller._state_monitor = MagicMock()
-            controller._state_monitor.get_cached_addresses = MagicMock(return_value=None)
+            controller._state_monitor = RecordingStateMonitor()
 
         if with_boards:
             controller._db.boards = MagicMock()

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -25,7 +25,7 @@ from esphome_device_builder.controllers.devices import controller as devices_mod
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import AdoptableDevice, DeviceState, ErrorCode, EventType
 
-from .conftest import MakeControllerFactory, capture_devices_events
+from .conftest import MakeControllerFactory, RecordingStateMonitor, capture_devices_events
 
 
 def _seed_import_state(controller: DevicesController) -> None:
@@ -306,9 +306,11 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     new card has an address right away.
     """
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
-    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
-    ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=["192.168.1.42"])
+    ctrl._state_monitor = RecordingStateMonitor(
+        cached_addresses={"kitchen.local": ["192.168.1.42"]}
+    )
 
     await ctrl.import_device(
         name="kitchen",
@@ -316,11 +318,14 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
         package_import_url="github://x",
     )
 
-    ctrl._state_monitor.apply.assert_called_once_with(
-        "kitchen", DeviceState.ONLINE, "mdns", claim=True
-    )
-    ctrl._state_monitor.get_cached_addresses.assert_called_once_with("kitchen.local")
-    ctrl._state_monitor.apply_ip.assert_called_once_with("kitchen", "192.168.1.42")
+    # Full call sequence — includes the post-apply probe_device the
+    # previous MagicMock-based assertion silently let through.
+    assert ctrl._state_monitor.calls == [
+        ("apply", "kitchen", DeviceState.ONLINE, "mdns", True),
+        ("get_cached_addresses", "kitchen.local"),
+        ("apply_ip", "kitchen", "192.168.1.42"),
+        ("probe_device", "kitchen", "kitchen"),
+    ]
 
 
 async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
@@ -330,9 +335,9 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
 ) -> None:
     """No cached IP → state still flips ONLINE, just no apply_ip call."""
     monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
-    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
-    ctrl._state_monitor.get_cached_addresses = MagicMock(return_value=None)
+    ctrl._state_monitor = RecordingStateMonitor()  # no cached addresses
 
     await ctrl.import_device(
         name="kitchen",
@@ -340,10 +345,11 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
         package_import_url="github://x",
     )
 
-    ctrl._state_monitor.apply.assert_called_once_with(
-        "kitchen", DeviceState.ONLINE, "mdns", claim=True
-    )
-    ctrl._state_monitor.apply_ip.assert_not_called()
+    assert ctrl._state_monitor.calls == [
+        ("apply", "kitchen", DeviceState.ONLINE, "mdns", True),
+        ("get_cached_addresses", "kitchen.local"),
+        ("probe_device", "kitchen", "kitchen"),
+    ]
 
 
 async def test_import_device_drops_matching_import_result_entry(

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -21,7 +21,7 @@ from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, EventType
 
-from .conftest import capture_devices_events
+from .conftest import RecordingStateMonitor, capture_devices_events
 
 
 def _make_controller(monkeypatch: Any, board_id: str = "esp32-c3-devkitm-1") -> Any:
@@ -213,7 +213,7 @@ def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller._regenerate_failed = set()
-    controller._state_monitor = MagicMock()
+    controller._state_monitor = RecordingStateMonitor()
     schedule = MagicMock()
     monkeypatch.setattr(controller, "_schedule_storage_regenerate", schedule, raising=False)
     captured = capture_devices_events(controller, EventType.DEVICE_ADDED)
@@ -235,7 +235,7 @@ def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None
     ]
     # Probe fires too — the eager mDNS probe on ADDED is what catches
     # YAMLs dropped on disk outside the API path.
-    controller._state_monitor.probe_device.assert_called_once_with("apollo")
+    assert controller._state_monitor.calls == [("probe_device", "apollo", None)]
 
 
 def test_added_device_fully_populated_does_not_regenerate(


### PR DESCRIPTION
## Summary
- `test_import.py` and `test_metadata_resolver.py` asserted on a MagicMock-shaped `controller._state_monitor` with scattered `.apply.assert_called_once_with` / `.apply_ip.assert_called_once_with` / `.probe_device.assert_called_once_with` lines. Two regression risks the MagicMock didn't catch:
  - A typo (`probe_devicee.assert_called_once`) silently passes because MagicMock spawns a fresh attribute on access.
  - A refactor renaming a real method (`apply_ip` → `set_ip`) breaks the contract without breaking the assertion.
- Add `RecordingStateMonitor` to `tests/controllers/devices/conftest.py`: mirrors the public `DeviceStateMonitor` surface (`apply` / `apply_ip` / `apply_version` / `apply_api_encryption` / `apply_config_hash` / `get_cached_addresses` / `probe_device`) with no I/O, capturing each call as a flat `(method, *args)` tuple.
- Caught a previously-missed `probe_device` call in `import_device` that the MagicMock-based assertions silently let through. Both seed-online tests now pin the full call sequence.

## Test plan
- [x] `uv run pytest tests/controllers/devices/test_import.py tests/controllers/devices/test_metadata_resolver.py`
- [x] `uv run pytest tests/controllers/devices/` (full suite — 158 pass)