### PR TITLE
Pin count + payload on IMPORTABLE_DEVICE_REMOVED capture (PR #227 follow-up)

### DIFF
--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -383,5 +383,9 @@ async def test_import_device_drops_matching_import_result_entry(
 
     assert "apollo-plt-1-983300" not in ctrl.import_result
     # Removal is broadcast so subscribed frontends drop the card.
-    assert captured, "expected IMPORTABLE_DEVICE_REMOVED to fire"
-    assert captured[0].data == {"name": "apollo-plt-1-983300"}
+    # Pin both count and payload so a future double-fire / regression
+    # surfaces here — there's exactly one matching import_result entry,
+    # so exactly one event should land on the bus.
+    assert [(e.event_type, e.data) for e in captured] == [
+        (EventType.IMPORTABLE_DEVICE_REMOVED, {"name": "apollo-plt-1-983300"})
+    ]


### PR DESCRIPTION
## Summary
Address copilot inline comment on #227 ([discussion_r3178663027](https://github.com/esphome/device-builder/pull/227#discussion_r3178663027)).

The post-#227 assertion in `test_import_device_drops_matching_import_result_entry` was `assert captured` + `captured[0].data == {...}`, which lets a future double-fire slip through silently (the test seeds exactly one matching `import_result` entry, so exactly one event should land). Replace with a single equality on the full captured list — pins both count and payload, so a regression that fires the event twice or with a wrong payload breaks the test here.

## Test plan
- [x] `uv run pytest tests/controllers/devices/test_import.py`