### PR TITLE
Add typed RecordingScanner fake; replace MagicMock _scanner asserts

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -29,6 +29,60 @@ from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.models import EventType
 
 
+class RecordingScanner:
+    """Test fake for ``DeviceScanner`` capturing scan/reload calls.
+
+    Mirrors every public method on the production ``DeviceScanner``
+    (``scan`` / ``reload`` / ``get_by_name`` / ``devices`` /
+    ``by_path``). Calls to ``scan`` / ``reload`` / ``get_by_name``
+    land in ``self.calls`` as ``(method_name, *args)``; tests
+    assert on the list directly instead of scattering
+    ``MagicMock.assert_awaited_*`` lines.
+
+    Why a typed fake rather than ``MagicMock``: a typo
+    (``scann.assert_awaited_once``) silently passes against a
+    ``MagicMock`` because it spawns a fresh attribute on access; a
+    refactor renaming a real method (``reload`` → ``refresh_one``)
+    similarly breaks the contract without breaking the assertion.
+    Mirroring the *full* public surface (rather than just
+    ``scan`` + ``reload``) means a controller path that touches
+    ``get_by_name`` or ``by_path`` won't blow up against the fake
+    just because no earlier test exercised it.
+
+    ``reload_returns`` controls the truthy return — production's
+    ``reload`` returns ``False`` when the file isn't tracked, which
+    a few tests exercise. ``devices_by_name`` lets tests pre-seed
+    the name index that ``get_by_name`` reads from.
+    """
+
+    def __init__(
+        self,
+        *,
+        reload_returns: bool = True,
+        devices_by_name: dict[str, list[object]] | None = None,
+    ) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self._reload_returns = reload_returns
+        self._devices_by_name = devices_by_name or {}
+        # Mirrors ``DeviceScanner.devices`` / ``by_path`` — empty by
+        # default; tests that need a populated catalog can assign.
+        self.devices: list[object] = []
+        self.by_path: dict[Path, object] = {}
+
+    async def scan(self) -> None:
+        self.calls.append(("scan",))
+
+    async def reload(self, filename: str) -> bool:
+        self.calls.append(("reload", filename))
+        return self._reload_returns
+
+    def get_by_name(self, name: str) -> list[object]:
+        self.calls.append(("get_by_name", name))
+        # Fresh list snapshot — mirrors production semantics so
+        # callers can iterate / mutate without poisoning the index.
+        return list(self._devices_by_name.get(name, []))
+
+
 def _make_board_stub(board_id: str) -> MagicMock:
     """Build a catalog-result stub with the right ``id`` shape.
 
@@ -343,9 +397,10 @@ def make_controller() -> MakeControllerFactory:
         controller._db = MagicMock()
         controller._db.settings.config_dir = config_dir
         controller._db.settings.rel_path = lambda configuration: config_dir / configuration
-        controller._scanner = MagicMock()
-        controller._scanner.scan = AsyncMock()
-        controller._scanner.reload = AsyncMock()
+        # ``RecordingScanner`` rather than a MagicMock-shaped scanner so a
+        # typo or rename of ``scan``/``reload`` surfaces as
+        # ``AttributeError`` instead of silently passing the assertion.
+        controller._scanner = RecordingScanner()
 
         if with_state_monitor:
             controller._state_monitor = MagicMock()

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -321,7 +321,7 @@ async def test_archive_device_full_flow_calls_scanner(
 
     assert not yaml_path.exists()
     assert (tmp_path / "archive" / "kitchen.yaml").exists()
-    controller._scanner.scan.assert_awaited_once()
+    assert controller._scanner.calls == [("scan",)]
 
 
 @pytest.mark.asyncio
@@ -342,7 +342,7 @@ async def test_unarchive_device_full_flow_calls_scanner(
 
     assert not (archive_dir / "kitchen.yaml").exists()
     assert (tmp_path / "kitchen.yaml").exists()
-    controller._scanner.scan.assert_awaited_once()
+    assert controller._scanner.calls == [("scan",)]
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -46,7 +46,7 @@ async def test_create_device_translates_file_exists_to_command_error(
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "kitchen.yaml already exists" in excinfo.value.message
     # Nothing should hit the scanner when the pre-flight check fails.
-    ctrl._scanner.scan.assert_not_called()
+    assert ctrl._scanner.calls == []
 
 
 async def test_create_device_rejects_empty_name(
@@ -60,7 +60,7 @@ async def test_create_device_rejects_empty_name(
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "name is required" in excinfo.value.message
-    ctrl._scanner.scan.assert_not_called()
+    assert ctrl._scanner.calls == []
 
 
 async def test_create_device_rejects_unknown_board_id(
@@ -75,7 +75,7 @@ async def test_create_device_rejects_unknown_board_id(
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "bogus-board" in excinfo.value.message
-    ctrl._scanner.scan.assert_not_called()
+    assert ctrl._scanner.calls == []
 
 
 async def test_create_device_writes_stub_yaml_and_scans(
@@ -102,7 +102,7 @@ async def test_create_device_writes_stub_yaml_and_scans(
     yaml_path = tmp_path / "kitchen.yaml"
     assert yaml_path.read_text("utf-8").startswith("esphome:\n  name: kitchen\n")
     assert storage_path.exists()
-    ctrl._scanner.scan.assert_awaited_once()
+    assert ctrl._scanner.calls == [("scan",)]
 
 
 async def test_create_device_clears_residual_metadata_from_archived_same_name(

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -196,7 +196,7 @@ async def test_update_config_triggers_scan(
 
     await controller.update_config(configuration="new.yaml", content="esphome:\n  name: new\n")
 
-    controller._scanner.scan.assert_awaited_once()
+    assert controller._scanner.calls == [("scan",)]
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -87,7 +87,7 @@ async def test_import_device_invokes_import_config_and_returns_path(
     # No matching importable cache entry → fall back to wifi (legacy behaviour).
     assert args[5] == "wifi"
     assert args[6] == "true"  # encryption flag forwarded
-    ctrl._scanner.scan.assert_awaited_once()
+    assert ("scan",) in ctrl._scanner.calls
 
 
 async def test_import_device_passes_ethernet_network_through_to_import_config(
@@ -262,7 +262,7 @@ async def test_import_device_translates_file_exists_to_command_error(
     assert "kitchen.yaml already exists" in excinfo.value.message
     # Scan must NOT run when the YAML write failed — otherwise we'd
     # falsely advertise a successful adoption to subscribers.
-    ctrl._scanner.scan.assert_not_called()
+    assert ctrl._scanner.calls == []
 
 
 async def test_import_device_returns_even_when_post_scan_fails(

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -144,7 +144,7 @@ async def test_rename_invalid_yaml_uses_manual_path(
 
     assert result == {"configuration": "livingroom.yaml", "job": None}
     assert calls == [("kitchen.yaml", "livingroom")]
-    controller._scanner.scan.assert_awaited_once()
+    assert controller._scanner.calls == [("scan",)]
 
 
 @pytest.mark.asyncio
@@ -207,7 +207,7 @@ async def test_rename_valid_yaml_queues_firmware_job(
     assert result["job"]["job_type"] == JobType.RENAME
     # Manual rename must NOT have run — old YAML stays untouched
     # while the queued job owns the rollback semantics.
-    controller._scanner.scan.assert_not_called()
+    assert controller._scanner.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_rename_inline_e2e.py
+++ b/tests/controllers/devices/test_rename_inline_e2e.py
@@ -83,7 +83,7 @@ async def test_manual_rename_writes_new_yaml_with_rewritten_name(
     # Old YAML is gone.
     assert not (tmp_path / "kitchen.yaml").exists()
     # Scanner was kicked so the device list refreshes.
-    controller._scanner.scan.assert_awaited_once()
+    assert controller._scanner.calls == [("scan",)]
 
 
 @pytest.mark.asyncio
@@ -489,4 +489,4 @@ async def test_manual_rename_full_round_trip(
     assert await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml") == {}
     assert await asyncio.to_thread(get_device_metadata, tmp_path, "livingroom.yaml") != {}
     # Scanner kicked.
-    controller._scanner.scan.assert_awaited_once()
+    assert controller._scanner.calls == [("scan",)]

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -117,7 +117,8 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
         ]
     ]
     assert persist_calls == ["kitchen.yaml"]
-    controller._scanner.reload.assert_awaited_once_with("kitchen.yaml")
+    reload_calls = [c for c in controller._scanner.calls if c[0] == "reload"]
+    assert reload_calls == [("reload", "kitchen.yaml")]
     # Pending guard cleared in the ``finally``.
     assert controller._regenerate_pending == set()
     # Success → not in failed set.
@@ -219,7 +220,7 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     await _drain(controller)
 
     # Failure → reload skipped, persist skipped, failed marker set.
-    controller._scanner.reload.assert_not_called()
+    assert not any(c[0] == "reload" for c in controller._scanner.calls)
     assert persist_calls == []
     assert controller._regenerate_failed == {"kitchen.yaml"}
     # Pending cleared via the ``finally``.
@@ -260,7 +261,7 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     )
     await _drain(controller)
 
-    controller._scanner.reload.assert_not_called()
+    assert not any(c[0] == "reload" for c in controller._scanner.calls)
     assert controller._regenerate_failed == {"kitchen.yaml"}
     assert controller._regenerate_pending == set()
 


### PR DESCRIPTION
## Summary
- Sibling of #229. Tests across the devices controller used a MagicMock-shaped `controller._scanner` with `.scan.assert_awaited_once()` / `.reload.assert_not_called()` assertions. Same regression risks the typed fake addresses:
  - A typo (`scann.assert_awaited_once`) silently passes against a `MagicMock`.
  - A refactor renaming a real method (`reload` → `refresh_one`) breaks the contract without breaking the assertion.
- Add `RecordingScanner` to `tests/controllers/devices/conftest.py` — mirrors the full public `DeviceScanner` surface (`scan` / `reload` / `get_by_name` / `devices` / `by_path`) so a controller path that touches anything beyond `scan`+`reload` doesn't blow up against the fake. Reflects the lesson from Copilot's review on #229.
- The `make_controller` factory now wires `RecordingScanner` by default — no opt-in flag, future tests inherit the typed surface.
- 7 test files swept (`test_archive`, `test_create`, `test_get_update_config`, `test_import`, `test_rename`, `test_rename_inline_e2e`, `test_storage_regenerate_e2e`) — assertions move from MagicMock-style `assert_awaited_once` / `assert_not_called` to direct comparisons on `_scanner.calls`.
- Deferred: `test_lifecycle_e2e.py` and `test_refresh.py` construct their controllers without the `make_controller` factory and use parent-MagicMock `attach_mock` for cross-collaborator ordering — a different shape that needs its own follow-up.

## Test plan
- [x] `uv run pytest tests/controllers/devices/` (full suite — 158 pass)