### PR TITLE
Fix runner-shutdown test flake under xdist

### DIFF
--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -405,14 +405,22 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
     cancelling, otherwise we'd race the subprocess spawn and either
     leak the process or hit the cancel before the try-block had
     entered.
+
+    Subprocess-keepalive: use ``time.sleep`` rather than
+    ``sys.stdin.read``. Under xdist the worker's stdin is ``/dev/null``
+    so ``stdin.read()`` returns immediately, the subprocess exits on
+    its own, and the cancel races the natural completion path —
+    ``terminate()`` then raises ``ProcessLookupError`` against a
+    dead transport. A long sleep keeps the process alive until the
+    test cancels.
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
     _fake_esphome(
         controller,
         # Print one line so the runner enters the line-reading loop,
-        # then block forever on stdin so the test controls the exit.
-        "import sys\nprint('starting...', flush=True)\nsys.stdin.read()\n",
+        # then sleep so the subprocess is still alive when we cancel.
+        "import sys, time\nprint('starting...', flush=True)\ntime.sleep(60)\n",
     )
     _seed_yaml(tmp_path)
 


### PR DESCRIPTION
## Summary
\`test_execute_job_runner_shutdown_terminates_and_marks_cancelled\` (added in #214) flaked on the macOS xdist matrix with:

\`\`\`
self._current_process.terminate()
...
ProcessLookupError
\`\`\`

The fake-esphome script kept the subprocess alive with \`sys.stdin.read()\`. Under \`pytest -n auto\` the worker's stdin is \`/dev/null\`, so \`stdin.read()\` returns immediately and the subprocess exits between the test seeing JOB_OUTPUT and \`runner_task.cancel()\` reaching the \`except asyncio.CancelledError\` branch. The branch then calls \`terminate()\` on a closed transport and crashes.

Switch the keepalive to \`time.sleep(60)\` so the subprocess can't exit on its own — the \`except CancelledError\` branch is the only path that ends it.

## Notes
There's a real production race underneath this: the \`except asyncio.CancelledError\` arm in \`_execute_job\` calls \`self._current_process.terminate()\` without a \`ProcessLookupError\` guard, so a real shutdown that happens to race a clean subprocess exit will skip the \`_mark_job_terminal\` / \`bus.fire(JOB_CANCELLED)\` cleanup. Worth tightening in a separate PR — flagged for follow-up.

## Test plan
- [x] \`uv run pytest tests/controllers/firmware/test_execute_job_e2e.py -k runner_shutdown -v\` (interactive stdin)
- [x] \`uv run pytest tests/controllers/firmware/test_execute_job_e2e.py -k runner_shutdown -v < /dev/null\` (mimics xdist worker)