### PR TITLE
Adopt write_storage_json helper across remaining tests

### DIFF
--- a/tests/_storage_fixtures.py
+++ b/tests/_storage_fixtures.py
@@ -4,15 +4,10 @@ Shared StorageJSON sidecar fixtures for tests that touch the build-output cache.
 Several tests stand up a fake ``<config_dir>/.esphome/storage/<configuration>.json``
 sidecar to exercise paths that read it (``firmware/download``,
 ``DevicesController._delete_single`` / ``_archive_single``, the
-metadata resolver). They were each writing the same JSON shape
-inline; centralising the layout here keeps them in sync when
-upstream esphome bumps ``StorageJSON``'s schema.
-
-Currently consumed by ``tests/controllers/firmware/test_download.py``.
-The duplicates in ``tests/test_archive_device.py`` and
-``tests/test_delete_device.py`` will migrate over once
-``device-builder#132`` lands (those files are renamed by that PR
-and editing them in parallel would conflict).
+metadata resolver, the config-hash helpers, and the device archive
+listing). They were each writing the same JSON shape inline;
+centralising the layout here keeps them in sync when upstream
+esphome bumps ``StorageJSON``'s schema.
 """
 
 from __future__ import annotations
@@ -29,6 +24,7 @@ from typing import Any
 _STORAGE_DEFAULTS: dict[str, Any] = {
     "storage_version": 1,
     "name": None,  # filled from ``configuration`` stem when omitted
+    "friendly_name": None,  # filled from stem when omitted
     "comment": None,
     "esphome_version": "2026.5.0-dev",
     "src_version": 1,
@@ -43,6 +39,7 @@ _STORAGE_DEFAULTS: dict[str, Any] = {
     "no_mdns": False,
     "framework": "esp-idf",
     "core_platform": "esp32",
+    "target_platform": "esp32",
 }
 
 
@@ -79,6 +76,7 @@ def write_storage_json(
     stem = Path(configuration).stem
     payload = dict(_STORAGE_DEFAULTS)
     payload["name"] = stem
+    payload["friendly_name"] = stem
     payload["build_path"] = str(build_path or (tmp_path / ".esphome" / "build" / stem))
     payload["firmware_bin_path"] = str(firmware_bin_path) if firmware_bin_path else None
     if overrides:

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -16,7 +16,6 @@ wraps it in ``asyncio.to_thread`` so callers don't have to remember.
 from __future__ import annotations
 
 import asyncio
-import json
 from pathlib import Path
 from typing import Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
@@ -28,6 +27,7 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.helpers.hostname import normalize_hostname
 from esphome_device_builder.models import AdoptableDevice, DeviceState, EventType
+from tests._storage_fixtures import write_storage_json
 
 
 class RecordingStateMonitor:
@@ -324,34 +324,19 @@ def seed_device() -> SeedDeviceFactory:
             (build_path / "src").mkdir()
             (build_path / "src" / "main.cpp").write_text("// fake\n", encoding="utf-8")
 
-        storage_dir = config_dir / ".esphome" / "storage"
-        storage_dir.mkdir(parents=True, exist_ok=True)
-        (storage_dir / f"{configuration}.json").write_text(
-            json.dumps(
-                {
-                    "storage_version": 1,
-                    "name": name,
-                    "friendly_name": (storage_friendly if storage_friendly is not None else name),
-                    "comment": None,
-                    "esphome_version": "2026.5.0-dev",
-                    "src_version": 1,
-                    "address": address if address is not None else f"{name}.local",
-                    "web_port": None,
-                    "esp_platform": "esp32",
-                    "board": "esp32-c3-devkitm-1",
-                    "build_path": str(build_path),
-                    "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
-                    "loaded_integrations": loaded_integrations
-                    if loaded_integrations is not None
-                    else ["api"],
-                    "loaded_platforms": ["esp32"],
-                    "no_mdns": False,
-                    "framework": "esp-idf",
-                    "core_platform": "esp32",
-                    "target_platform": "esp32",
-                }
-            ),
-            encoding="utf-8",
+        write_storage_json(
+            config_dir,
+            configuration,
+            firmware_bin_path=build_path / ".pioenvs" / "firmware.bin",
+            build_path=build_path,
+            overrides={
+                "friendly_name": (storage_friendly if storage_friendly is not None else name),
+                "address": address if address is not None else f"{name}.local",
+                "loaded_integrations": (
+                    loaded_integrations if loaded_integrations is not None else ["api"]
+                ),
+                "loaded_platforms": ["esp32"],
+            },
         )
 
         # ``metadata_transaction`` reaches into ``tempfile.mkstemp``

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -17,7 +17,6 @@ Mirrors the legacy dashboard's ``ArchiveRequestHandler`` /
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -38,6 +37,7 @@ from esphome_device_builder.controllers.devices.helpers import (
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
+from tests._storage_fixtures import write_storage_json
 
 from .conftest import MakeControllerFactory, SeedDeviceFactory
 
@@ -849,31 +849,17 @@ def test_list_archived_falls_back_to_storage_json_when_yaml_meta_sparse(
         "esphome:\n  name: kitchen\n",
         encoding="utf-8",
     )
-    storage_dir = tmp_path / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-    (storage_dir / "kitchen.yaml.json").write_text(
-        json.dumps(
-            {
-                "storage_version": 1,
-                "name": "kitchen",
-                "friendly_name": "Kitchen Sensor",
-                "comment": "by the sink",
-                "esphome_version": "2026.5.0-dev",
-                "src_version": 1,
-                "address": "",
-                "web_port": None,
-                "esp_platform": "esp32",
-                "board": "esp32-c3-devkitm-1",
-                "build_path": None,
-                "firmware_bin_path": None,
-                "loaded_integrations": [],
-                "loaded_platforms": [],
-                "no_mdns": False,
-                "framework": "esp-idf",
-                "core_platform": "esp32",
-            }
-        ),
-        encoding="utf-8",
+    # Storage build_path explicitly None — the device has never been
+    # compiled, so the archive lister falls back to YAML + sidecar
+    # alone for friendly_name / comment.
+    write_storage_json(
+        tmp_path,
+        "kitchen.yaml",
+        overrides={
+            "friendly_name": "Kitchen Sensor",
+            "comment": "by the sink",
+            "build_path": None,
+        },
     )
 
     rows = make_controller(tmp_path)._list_archived_sync()

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -13,11 +13,12 @@ to retry.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
 import pytest
+
+from tests._storage_fixtures import write_storage_json
 
 from .conftest import MakeControllerFactory
 
@@ -43,30 +44,11 @@ def _seed_device(
         (build_path / "src").mkdir()
         (build_path / "src" / "main.cpp").write_text("// fake\n", encoding="utf-8")
 
-    storage_dir = config_dir / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-    (storage_dir / f"{configuration}.json").write_text(
-        json.dumps(
-            {
-                "storage_version": 1,
-                "name": Path(configuration).stem,
-                "comment": None,
-                "esphome_version": "2026.5.0-dev",
-                "src_version": 1,
-                "address": "",
-                "web_port": None,
-                "esp_platform": "esp32",
-                "board": "esp32-c3-devkitm-1",
-                "build_path": str(build_path),
-                "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
-                "loaded_integrations": [],
-                "loaded_platforms": [],
-                "no_mdns": False,
-                "framework": "esp-idf",
-                "core_platform": "esp32",
-            }
-        ),
-        encoding="utf-8",
+    write_storage_json(
+        config_dir,
+        configuration,
+        firmware_bin_path=build_path / ".pioenvs" / "firmware.bin",
+        build_path=build_path,
     )
     return yaml_path, build_path
 

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock
 from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, EventType
+from tests._storage_fixtures import write_storage_json
 
 from .conftest import RecordingStateMonitor, capture_devices_events
 
@@ -58,30 +59,11 @@ def _write_storage_pointer(config_dir: Path, filename: str, build_path: Path) ->
     write a real sidecar (instead of mocking) so the resolver
     exercises the same disk path it does in production.
     """
-    storage_dir = config_dir / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-    (storage_dir / f"{filename}.json").write_text(
-        json.dumps(
-            {
-                "storage_version": 1,
-                "name": filename.removesuffix(".yaml"),
-                "comment": None,
-                "esphome_version": "2026.5.0-dev",
-                "src_version": 1,
-                "address": "",
-                "web_port": None,
-                "esp_platform": "esp32",
-                "board": "esp32-c3-devkitm-1",
-                "build_path": str(build_path),
-                "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
-                "loaded_integrations": [],
-                "loaded_platforms": [],
-                "no_mdns": False,
-                "framework": "esp-idf",
-                "core_platform": "esp32",
-            }
-        ),
-        encoding="utf-8",
+    write_storage_json(
+        config_dir,
+        filename,
+        firmware_bin_path=build_path / ".pioenvs" / "firmware.bin",
+        build_path=build_path,
     )
 
 

--- a/tests/test_config_hash.py
+++ b/tests/test_config_hash.py
@@ -23,6 +23,7 @@ from esphome_device_builder.helpers.config_hash import (
     compute_yaml_config_hash,
     read_build_info_hash,
 )
+from tests._storage_fixtures import write_storage_json
 
 
 def _write_storage_pointer(yaml_path: Path, build_path: Path | None) -> None:
@@ -34,30 +35,11 @@ def _write_storage_pointer(yaml_path: Path, build_path: Path | None) -> None:
     """
     if build_path is None:
         return
-    storage_dir = yaml_path.parent / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-    (storage_dir / f"{yaml_path.name}.json").write_text(
-        json.dumps(
-            {
-                "storage_version": 1,
-                "name": yaml_path.stem,
-                "comment": None,
-                "esphome_version": "2026.5.0-dev",
-                "src_version": 1,
-                "address": "",
-                "web_port": None,
-                "esp_platform": "esp32",
-                "board": "esp32-c3-devkitm-1",
-                "build_path": str(build_path),
-                "firmware_bin_path": str(build_path / ".pioenvs" / "firmware.bin"),
-                "loaded_integrations": [],
-                "loaded_platforms": [],
-                "no_mdns": False,
-                "framework": "esp-idf",
-                "core_platform": "esp32",
-            }
-        ),
-        encoding="utf-8",
+    write_storage_json(
+        yaml_path.parent,
+        yaml_path.name,
+        firmware_bin_path=build_path / ".pioenvs" / "firmware.bin",
+        build_path=build_path,
     )
 
 


### PR DESCRIPTION
## Summary
- Migrates five remaining sites that were inlining the `StorageJSON` schema to the shared `write_storage_json` helper in `tests/_storage_fixtures.py`.
- Adds `friendly_name` and `target_platform` to the helper's defaults so the `tests/controllers/devices/conftest.py` `seed_device` fixture and `tests/controllers/devices/test_archive.py`'s sparse-YAML fallback test can stop hand-rolling them.
- Net `52 insertions(+), 137 deletions(-)`.

The helper's original docstring noted the duplicates would migrate "once `device-builder#132` lands"; that's done, so they migrate now.

Sites migrated:
- `tests/test_config_hash.py:_write_storage_pointer`
- `tests/controllers/devices/test_metadata_resolver.py:_write_storage_pointer`
- `tests/controllers/devices/test_delete.py:_seed_device`
- `tests/controllers/devices/conftest.py::seed_device`
- `tests/controllers/devices/test_archive.py::test_list_archived_falls_back_to_storage_json_when_yaml_meta_sparse`

## Test plan
- [x] `pytest tests/` — 1189 passed, 3 skipped.
- [x] `pre-commit run` on changed files — clean.