### PR TITLE
Replace per-file _make_controller helpers with with_real_bus factory flag

### DIFF
--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -68,6 +68,7 @@ class FirmwareControllerFactory(Protocol):
         with_queue: bool = ...,
         with_terminate: bool = ...,
         with_real_persistence: bool = ...,
+        with_real_bus: bool = ...,
     ) -> FirmwareController: ...
 
 
@@ -116,10 +117,21 @@ def firmware_controller_factory(
       against ``tmp_path/.device-builder.json`` and survives
       implementation rewrites of the on-disk shape.
 
+    - ``with_real_bus=False`` (default): ``_db.bus`` is a
+      ``MagicMock`` — fine for tests that ignore the bus or use
+      ``capture_firmware_events`` to replace it. Pass ``True`` for
+      tests that drive the bus directly (subscribe a real listener
+      to observe streamed events, fire events from another task)
+      so the existing ``EventBus`` semantics — synchronous
+      delivery, dedupe by listener identity — match production.
+      Replaces the per-test ``_make_controller`` helpers in
+      ``test_follow_job_race.py`` / ``test_follow_jobs_race.py``.
+
     Always present: ``_jobs`` (populated from positional
-    arguments), ``_db.bus`` (``MagicMock``), and
-    ``_db.create_background_task`` (no-op stub so ``start()``
-    can compose against it without spawning a runner).
+    arguments), ``_db.bus`` (``MagicMock`` or ``EventBus`` per
+    ``with_real_bus``), and ``_db.create_background_task`` (no-op
+    stub so ``start()`` can compose against it without spawning a
+    runner).
     """
 
     def _make(
@@ -128,13 +140,14 @@ def firmware_controller_factory(
         with_queue: bool = False,
         with_terminate: bool = False,
         with_real_persistence: bool = False,
+        with_real_bus: bool = False,
     ) -> FirmwareController:
         controller = FirmwareController.__new__(FirmwareController)
         controller._jobs = {j.job_id: j for j in jobs}
         if not with_real_persistence:
             controller._persist_jobs = AsyncMock()
 
-        bus = MagicMock()
+        bus: EventBus | MagicMock = EventBus() if with_real_bus else MagicMock()
         db_attrs: dict[str, Any] = {"bus": bus}
         if with_settings:
             settings = DashboardSettings()

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -20,32 +20,32 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import MagicMock
 
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware.constants import _MAX_OUTPUT_LINES_INFLIGHT
-from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType, StreamEvent
 
 from ...conftest import FakeWebSocketClient
+from .conftest import FirmwareControllerFactory
 
 
-def _make_controller_with_job(job: FirmwareJob) -> FirmwareController:
+def _make_controller_with_job(
+    factory: FirmwareControllerFactory, job: FirmwareJob
+) -> FirmwareController:
     """Build a controller shell that ``follow_job`` can drive end-to-end.
 
     ``follow_job`` reads ``self._jobs`` and ``self._db.bus`` only —
-    everything else is unused for this path, so a real ``EventBus``
-    plus the in-memory job map is enough.
+    everything else is unused for this path. ``with_real_bus=True``
+    swaps in the real ``EventBus`` so the listener-attach + fire
+    semantics match production; ``with_settings=False`` skips the
+    config-dir wiring this path doesn't read.
     """
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {job.job_id: job}
-    db = MagicMock()
-    db.bus = EventBus()
-    controller._db = db
-    return controller
+    return factory(job, with_real_bus=True, with_settings=False)
 
 
-async def test_terminal_job_replays_full_history_and_returns() -> None:
+async def test_terminal_job_replays_full_history_and_returns(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """A finished job's history is sent verbatim, followed by ``result``."""
     job = FirmwareJob(
         job_id="abc",
@@ -55,7 +55,7 @@ async def test_terminal_job_replays_full_history_and_returns() -> None:
         output=["line a\n", "line b\n", "line c\n"],
         exit_code=0,
     )
-    controller = _make_controller_with_job(job)
+    controller = _make_controller_with_job(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
 
     await controller.follow_job(job_id="abc", client=client, message_id="m1")
@@ -67,7 +67,9 @@ async def test_terminal_job_replays_full_history_and_returns() -> None:
     assert result_events[0][1] == {"status": "completed", "exit_code": 0}
 
 
-async def test_history_lines_arrive_before_live_lines_in_order() -> None:
+async def test_history_lines_arrive_before_live_lines_in_order(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Live events fired during the history send arrive after history.
 
     Drives the streaming loop concurrently with the follow_job
@@ -83,7 +85,7 @@ async def test_history_lines_arrive_before_live_lines_in_order() -> None:
         status=JobStatus.RUNNING,
         output=["history-1\n", "history-2\n"],
     )
-    controller = _make_controller_with_job(job)
+    controller = _make_controller_with_job(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -116,7 +118,9 @@ async def test_history_lines_arrive_before_live_lines_in_order() -> None:
     assert output_lines == ["history-1\n", "history-2\n", "live-1\n", "live-2\n"]
 
 
-async def test_live_events_for_other_jobs_are_filtered_out() -> None:
+async def test_live_events_for_other_jobs_are_filtered_out(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Listener ignores events for other ``job_id``s.
 
     Multiple jobs share the same bus; without filtering, the queue
@@ -130,7 +134,7 @@ async def test_live_events_for_other_jobs_are_filtered_out() -> None:
         status=JobStatus.RUNNING,
         output=[],
     )
-    controller = _make_controller_with_job(job)
+    controller = _make_controller_with_job(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -159,7 +163,9 @@ def _async_run(coro: Any) -> None:
     asyncio.run(coro)
 
 
-async def test_streaming_loop_cannot_append_between_snapshot_and_subscribe() -> None:
+async def test_streaming_loop_cannot_append_between_snapshot_and_subscribe(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Lines appended after follow_job starts appear via subscription, not history.
 
     Locks the contract that follow_job's history send and live drain
@@ -177,7 +183,7 @@ async def test_streaming_loop_cannot_append_between_snapshot_and_subscribe() -> 
         status=JobStatus.RUNNING,
         output=["pre-snapshot\n"],
     )
-    controller = _make_controller_with_job(job)
+    controller = _make_controller_with_job(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -203,7 +209,9 @@ async def test_streaming_loop_cannot_append_between_snapshot_and_subscribe() -> 
     assert output_lines == ["pre-snapshot\n", "post-snapshot\n"]
 
 
-async def test_slow_follower_drops_lines_above_queue_cap() -> None:
+async def test_slow_follower_drops_lines_above_queue_cap(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Bounded queue caps memory: lines past the cap are dropped.
 
     Without this bound, a follower that stops draining (closed WS,
@@ -222,7 +230,7 @@ async def test_slow_follower_drops_lines_above_queue_cap() -> None:
         status=JobStatus.RUNNING,
         output=[],
     )
-    controller = _make_controller_with_job(job)
+    controller = _make_controller_with_job(firmware_controller_factory, job)
     bus = controller._db.bus
 
     # Park send_event so the drain stays blocked on the very first
@@ -272,7 +280,9 @@ async def test_slow_follower_drops_lines_above_queue_cap() -> None:
     assert len(result_events) == 1
 
 
-async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full() -> None:
+async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Terminal result + sentinel still land when the queue is full.
 
     The output put_nowait drops on full, but the result + sentinel
@@ -289,7 +299,7 @@ async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full() -> No
         status=JobStatus.RUNNING,
         output=[],
     )
-    controller = _make_controller_with_job(job)
+    controller = _make_controller_with_job(firmware_controller_factory, job)
     bus = controller._db.bus
 
     block = asyncio.Event()
@@ -334,7 +344,9 @@ async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full() -> No
     assert result_events[0]["status"] == "completed"
 
 
-async def test_cancelled_terminal_event_returns_with_status() -> None:
+async def test_cancelled_terminal_event_returns_with_status(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """``JOB_CANCELLED`` ends the follow with a ``cancelled`` result.
 
     Mirrors the completed/failed paths but exercises the third
@@ -351,7 +363,7 @@ async def test_cancelled_terminal_event_returns_with_status() -> None:
         status=JobStatus.RUNNING,
         output=["pre-cancel\n"],
     )
-    controller = _make_controller_with_job(job)
+    controller = _make_controller_with_job(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 

--- a/tests/controllers/firmware/test_follow_jobs_race.py
+++ b/tests/controllers/firmware/test_follow_jobs_race.py
@@ -14,25 +14,31 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 from typing import Any
-from unittest.mock import MagicMock
 
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType, StreamEvent
 
 from ...conftest import FakeWebSocketClient
+from .conftest import FirmwareControllerFactory
 
 
-def _make_controller(jobs: list[FirmwareJob]) -> FirmwareController:
-    controller = FirmwareController.__new__(FirmwareController)
-    controller._jobs = {job.job_id: job for job in jobs}
-    db = MagicMock()
-    db.bus = EventBus()
-    controller._db = db
-    return controller
+def _make_controller(
+    factory: FirmwareControllerFactory, jobs: list[FirmwareJob]
+) -> FirmwareController:
+    """Build a ``follow_jobs``-shaped controller via the shared factory.
+
+    ``follow_jobs`` reads ``self._jobs`` and ``self._db.bus`` only;
+    ``with_real_bus=True`` swaps in the real ``EventBus`` so the
+    listener-attach + fire semantics match production, and
+    ``with_settings=False`` skips the config-dir wiring this path
+    doesn't read.
+    """
+    return factory(*jobs, with_real_bus=True, with_settings=False)
 
 
-async def test_follow_jobs_replays_snapshot_then_live_events_in_order() -> None:
+async def test_follow_jobs_replays_snapshot_then_live_events_in_order(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """A ``JOB_*`` event during the snapshot replay still reaches the client.
 
     Without the fix the snapshot loop awaited each ``send_event``,
@@ -55,7 +61,7 @@ async def test_follow_jobs_replays_snapshot_then_live_events_in_order() -> None:
         status=JobStatus.RUNNING,
         output=[],
     )
-    controller = _make_controller([job_a, job_b])
+    controller = _make_controller(firmware_controller_factory, [job_a, job_b])
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -99,7 +105,9 @@ async def test_follow_jobs_replays_snapshot_then_live_events_in_order() -> None:
     assert max(snapshot_indices) < queued_index
 
 
-async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation() -> None:
+async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """A running job mutating mid-snapshot doesn't appear twice.
 
     The earlier shape captured ``FirmwareJob`` objects synchronously
@@ -135,7 +143,7 @@ async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation(
         status=JobStatus.RUNNING,
         output=["b-pre-snapshot\n"],
     )
-    controller = _make_controller([job_a, job_b])
+    controller = _make_controller(firmware_controller_factory, [job_a, job_b])
     bus = controller._db.bus
 
     block = asyncio.Event()
@@ -187,14 +195,16 @@ async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation(
     assert job_outputs == [{"job_id": "b", "line": "b-mid-snapshot\n"}]
 
 
-async def test_follow_jobs_unsubscribes_on_cancellation() -> None:
+async def test_follow_jobs_unsubscribes_on_cancellation(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """Cancelling the WS task releases every listener.
 
     Three event types are subscribed (lifecycle, output, progress);
     a leak here would silently grow the listener set on every
     reconnect.
     """
-    controller = _make_controller([])
+    controller = _make_controller(firmware_controller_factory, [])
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
@@ -225,9 +235,11 @@ async def _drain_until(client: FakeWebSocketClient, predicate: Any, attempts: in
             return
 
 
-async def test_follow_jobs_forwards_job_progress_events() -> None:
+async def test_follow_jobs_forwards_job_progress_events(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """A ``JOB_PROGRESS`` event lands as a ``job_progress`` push (not a lifecycle)."""
-    controller = _make_controller([])
+    controller = _make_controller(firmware_controller_factory, [])
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
@@ -247,14 +259,16 @@ async def test_follow_jobs_forwards_job_progress_events() -> None:
     assert progress_events == [progress]
 
 
-async def test_follow_jobs_drops_lifecycle_event_with_no_job_payload() -> None:
+async def test_follow_jobs_drops_lifecycle_event_with_no_job_payload(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """A lifecycle event missing the ``job`` key is silently ignored.
 
     The runner always tags lifecycle bus events with ``{"job": <FirmwareJob>}``,
     but the handler defends against a malformed payload by skipping it
     instead of crashing the stream — guard the early-return path here.
     """
-    controller = _make_controller([])
+    controller = _make_controller(firmware_controller_factory, [])
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
@@ -279,7 +293,9 @@ async def test_follow_jobs_drops_lifecycle_event_with_no_job_payload() -> None:
     assert client.events_for("job_progress") == [{"job_id": "a"}]
 
 
-async def test_follow_jobs_lifecycle_payload_passthrough_for_dict_job() -> None:
+async def test_follow_jobs_lifecycle_payload_passthrough_for_dict_job(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
     """A ``job`` payload that's already a dict is forwarded verbatim.
 
     Production firmware events carry a ``FirmwareJob`` instance and the
@@ -287,7 +303,7 @@ async def test_follow_jobs_lifecycle_payload_passthrough_for_dict_job() -> None:
     however, can hand back a plain dict — the handler's ``hasattr``
     check falls through and uses the dict as-is.
     """
-    controller = _make_controller([])
+    controller = _make_controller(firmware_controller_factory, [])
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 


### PR DESCRIPTION
## Summary
- `tests/controllers/firmware/test_follow_job_race.py` and `test_follow_jobs_race.py` each carried a near-identical `_make_controller` helper that bypass-init'd a `FirmwareController` via `__new__`, attached `_jobs` and `_db.bus = EventBus()`, and skipped everything else. The shape was duplicated and would need to be re-synced every time `FirmwareController` grew a new attribute the factory already wires up.
- Add `with_real_bus=False` (default) to `firmware_controller_factory`: when `True`, `_db.bus` is a real `EventBus` instead of a `MagicMock`. The two `follow_*_race` files now build their controllers through the shared factory with `with_real_bus=True` + `with_settings=False`, so the bypass-init shape lives in one place.
- Behaviour identical: 299 firmware tests still pass.

## Test plan
- [x] `uv run pytest tests/controllers/firmware/test_follow_job_race.py tests/controllers/firmware/test_follow_jobs_race.py`
- [x] `uv run pytest tests/controllers/firmware/` (full suite — 299 pass, 2 skip)