### PR TITLE
Centralise DevicesController + EventBus helper in top-level conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
+from unittest.mock import MagicMock
 
 import pytest
 from blockbuster import blockbuster_ctx
@@ -27,11 +30,11 @@ from esphome.core import CORE
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.event_bus import Event, EventBus
+from esphome_device_builder.models import Device, EventType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from pathlib import Path
-
     from blockbuster import BlockBuster
 
 # Call sites known to do bounded blocking I/O during one-time server
@@ -249,3 +252,60 @@ def make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MakeSettin
         return settings
 
     return _make
+
+
+# ---------------------------------------------------------------------------
+# Bypass-init DevicesController + real EventBus + captured listener
+#
+# The handler-test-style ``make_controller`` factory in
+# ``tests/controllers/devices/conftest.py`` is the right tool for handler-
+# level coverage. The shape this helper builds is for the *callback* tests
+# at the top of the tree (``test_device_state_event.py`` /
+# ``test_state_fanout_duplicate_names.py``) — they exercise
+# ``_on_state_change`` / ``_on_ip_change`` etc. against a minimal scanner +
+# real EventBus, and were each carrying a near-identical ``_make_controller``
+# helper before this lived in one place.
+# ---------------------------------------------------------------------------
+
+
+def make_devices_controller_with_bus(
+    devices: list[Device],
+    *,
+    capture_event_types: tuple[EventType, ...] = (EventType.DEVICE_STATE_CHANGED,),
+    create_background_task: Callable[[Any], Any] | None = None,
+) -> tuple[DevicesController, list[Event]]:
+    """Bypass-init a ``DevicesController`` wired to a real ``EventBus``.
+
+    Returns the controller and a live ``list[Event]`` capture for
+    every subscribed ``EventType``. Tests assert on the flat list
+    instead of poking ``MagicMock.assert_called_once_with`` /
+    ``call_args_list`` — the contract being tested is "what fanned
+    out to the bus", not the call shape of the mock that recorded
+    it.
+
+    The scanner is a ``MagicMock`` exposing ``devices`` and a
+    ``get_by_name(name)`` lambda derived from *devices*; mirrors
+    the production ``DeviceScanner``'s name-keyed grouping closely
+    enough for the callback paths these tests exercise.
+
+    ``create_background_task`` lets callers wire a side-effect
+    function (e.g. closing the coroutine to avoid
+    ``RuntimeWarning: coroutine was never awaited``) for the
+    persist-async branches.
+    """
+    bus = EventBus()
+    captured: list[Event] = []
+    for event_type in capture_event_types:
+        bus.add_listener(event_type, captured.append)
+    controller = DevicesController.__new__(DevicesController)
+    controller._db = MagicMock()
+    if create_background_task is not None:
+        controller._db.create_background_task = MagicMock(side_effect=create_background_task)
+    controller._db.bus = bus
+    controller._scanner = MagicMock()
+    controller._scanner.devices = devices
+    by_name: dict[str, list[Device]] = {}
+    for device in devices:
+        by_name.setdefault(device.name, []).append(device)
+    controller._scanner.get_by_name = lambda name: by_name.get(name, [])
+    return controller, captured

--- a/tests/test_device_state_event.py
+++ b/tests/test_device_state_event.py
@@ -10,22 +10,9 @@ other source) flipped a device online — exactly the bug from the
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, DeviceState, EventType
 
-
-def _make_controller(devices: list[Device]) -> tuple[DevicesController, MagicMock]:
-    """Stand up enough of a controller to exercise ``_on_state_change``."""
-    db = MagicMock()
-    db.bus.fire = MagicMock()
-    ctrl = DevicesController.__new__(DevicesController)
-    ctrl._db = db  # type: ignore[attr-defined]
-    ctrl._scanner = MagicMock()
-    ctrl._scanner.devices = devices
-    ctrl._scanner.get_by_name = lambda name, _d=devices: [d for d in _d if d.name == name]
-    return ctrl, db
+from .conftest import make_devices_controller_with_bus
 
 
 def test_state_change_event_uses_flat_configuration_state_payload() -> None:
@@ -36,14 +23,13 @@ def test_state_change_event_uses_flat_configuration_state_payload() -> None:
     that swaps them back makes every state transition no-op the UI.
     """
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
-    ctrl, db = _make_controller([device])
+    ctrl, captured = make_devices_controller_with_bus([device])
 
     ctrl._on_state_change("kitchen", DeviceState.ONLINE, "ping")
 
-    db.bus.fire.assert_called_once_with(
-        EventType.DEVICE_STATE_CHANGED,
-        {"configuration": "kitchen.yaml", "state": "online"},
-    )
+    assert [(e.event_type, e.data) for e in captured] == [
+        (EventType.DEVICE_STATE_CHANGED, {"configuration": "kitchen.yaml", "state": "online"})
+    ]
 
 
 def test_state_change_state_value_is_serialised_string() -> None:
@@ -56,19 +42,19 @@ def test_state_change_state_value_is_serialised_string() -> None:
     plain string.
     """
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
-    ctrl, db = _make_controller([device])
+    ctrl, captured = make_devices_controller_with_bus([device])
 
     ctrl._on_state_change("kitchen", DeviceState.OFFLINE, "ping")
 
-    payload = db.bus.fire.call_args.args[1]
-    assert payload["state"] == "offline"
-    assert isinstance(payload["state"], str)
+    assert len(captured) == 1
+    assert captured[0].data["state"] == "offline"
+    assert isinstance(captured[0].data["state"], str)
 
 
 def test_state_change_unknown_device_does_not_fire() -> None:
     """A name not in the catalog is dropped — no spurious event."""
-    ctrl, db = _make_controller([])
+    ctrl, captured = make_devices_controller_with_bus([])
 
     ctrl._on_state_change("ghost", DeviceState.ONLINE, "mdns")
 
-    db.bus.fire.assert_not_called()
+    assert captured == []

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -17,8 +17,9 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.controllers.devices import DevicesController
-from esphome_device_builder.models import Device, DeviceState
+from esphome_device_builder.models import Device, DeviceState, EventType
+
+from .conftest import make_devices_controller_with_bus
 
 
 def _device(configuration: str, **overrides: Any) -> Device:
@@ -46,25 +47,7 @@ def _close_coro(coro: Any) -> Any:
     return MagicMock()
 
 
-def _make_controller(devices: list[Device]) -> DevicesController:
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = MagicMock()
-    controller._db.create_background_task = MagicMock(side_effect=_close_coro)
-    controller._db.bus = MagicMock()
-    controller._scanner = MagicMock()
-    controller._scanner.devices = devices
-    # ``_devices_by_name`` now reads the scanner's name index. Mirror
-    # the same name-keyed grouping the real scanner maintains.
-    by_name: dict[str, list[Device]] = {}
-    for device in devices:
-        by_name.setdefault(device.name, []).append(device)
-    controller._scanner.get_by_name = lambda name: by_name.get(name, [])
-    return controller
-
-
-def _fired_events(controller: DevicesController) -> list[tuple[Any, dict[str, Any]]]:
-    """All ``(event_type, data)`` pairs forwarded to the event bus."""
-    return [call.args for call in controller._db.bus.fire.call_args_list]
+_FANOUT_EVENT_TYPES = (EventType.DEVICE_STATE_CHANGED, EventType.DEVICE_UPDATED)
 
 
 def test_state_change_fans_out_to_every_matching_device() -> None:
@@ -76,30 +59,36 @@ def test_state_change_fans_out_to_every_matching_device() -> None:
     """
     a = _device("kitchen.yaml")
     b = _device("kitchen (1).yaml")
-    controller = _make_controller([a, b])
+    controller, captured = make_devices_controller_with_bus(
+        [a, b],
+        capture_event_types=_FANOUT_EVENT_TYPES,
+        create_background_task=_close_coro,
+    )
 
     controller._on_state_change("kitchen", DeviceState.ONLINE, "mdns")
 
     assert a.state == DeviceState.ONLINE
     assert b.state == DeviceState.ONLINE
-    fired = _fired_events(controller)
-    assert len(fired) == 2
-    targeted = sorted(data["configuration"] for _et, data in fired)
+    assert len(captured) == 2
+    targeted = sorted(e.data["configuration"] for e in captured)
     assert targeted == ["kitchen (1).yaml", "kitchen.yaml"]
 
 
 def test_ip_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", ip="")
     b = _device("kitchen (1).yaml", ip="")
-    controller = _make_controller([a, b])
+    controller, captured = make_devices_controller_with_bus(
+        [a, b],
+        capture_event_types=_FANOUT_EVENT_TYPES,
+        create_background_task=_close_coro,
+    )
 
     controller._on_ip_change("kitchen", "10.0.0.5")
 
     assert a.ip == "10.0.0.5"
     assert b.ip == "10.0.0.5"
-    fired = _fired_events(controller)
-    assert len(fired) == 2
-    assert sorted(data["device"].configuration for _et, data in fired) == [
+    assert len(captured) == 2
+    assert sorted(e.data["device"].configuration for e in captured) == [
         "kitchen (1).yaml",
         "kitchen.yaml",
     ]
@@ -108,15 +97,18 @@ def test_ip_change_fans_out_to_every_matching_device() -> None:
 def test_version_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", current_version="2026.5.0", deployed_version="")
     b = _device("kitchen (1).yaml", current_version="2026.5.0", deployed_version="")
-    controller = _make_controller([a, b])
+    controller, captured = make_devices_controller_with_bus(
+        [a, b],
+        capture_event_types=_FANOUT_EVENT_TYPES,
+        create_background_task=_close_coro,
+    )
 
     controller._on_version_change("kitchen", "2026.5.0")
 
     assert a.deployed_version == "2026.5.0"
     assert b.deployed_version == "2026.5.0"
-    fired = _fired_events(controller)
-    assert len(fired) == 2
-    assert sorted(data["device"].configuration for _et, data in fired) == [
+    assert len(captured) == 2
+    assert sorted(e.data["device"].configuration for e in captured) == [
         "kitchen (1).yaml",
         "kitchen.yaml",
     ]
@@ -129,7 +121,11 @@ def test_config_hash_change_fans_out_to_every_matching_device() -> None:
         expected_config_hash="abcd1234",
         deployed_config_hash="",
     )
-    controller = _make_controller([a, b])
+    controller, captured = make_devices_controller_with_bus(
+        [a, b],
+        capture_event_types=_FANOUT_EVENT_TYPES,
+        create_background_task=_close_coro,
+    )
 
     controller._on_config_hash_change("kitchen", "abcd1234")
 
@@ -138,36 +134,41 @@ def test_config_hash_change_fans_out_to_every_matching_device() -> None:
     # Both devices' has_pending_changes should reflect the match.
     assert a.has_pending_changes is False
     assert b.has_pending_changes is False
-    fired = _fired_events(controller)
-    assert len(fired) == 2
+    assert len(captured) == 2
 
 
 def test_api_encryption_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", api_encryption_active=None)
     b = _device("kitchen (1).yaml", api_encryption_active=None)
-    controller = _make_controller([a, b])
+    controller, captured = make_devices_controller_with_bus(
+        [a, b],
+        capture_event_types=_FANOUT_EVENT_TYPES,
+        create_background_task=_close_coro,
+    )
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
 
     assert a.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
     assert b.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
-    fired = _fired_events(controller)
-    assert len(fired) == 2
+    assert len(captured) == 2
 
 
 def test_unrelated_devices_are_not_touched() -> None:
     """Devices with a different ``name`` field stay UNKNOWN."""
     kitchen = _device("kitchen.yaml")
     garage = _device("garage.yaml", name="garage", address="garage.local")
-    controller = _make_controller([kitchen, garage])
+    controller, captured = make_devices_controller_with_bus(
+        [kitchen, garage],
+        capture_event_types=_FANOUT_EVENT_TYPES,
+        create_background_task=_close_coro,
+    )
 
     controller._on_state_change("kitchen", DeviceState.ONLINE, "mdns")
 
     assert kitchen.state == DeviceState.ONLINE
     assert garage.state == DeviceState.UNKNOWN
-    fired = _fired_events(controller)
-    assert len(fired) == 1
-    assert fired[0][1]["configuration"] == "kitchen.yaml"
+    assert len(captured) == 1
+    assert captured[0].data["configuration"] == "kitchen.yaml"
 
 
 def test_apply_state_repairs_stale_sibling_when_first_match_is_in_sync() -> None:


### PR DESCRIPTION
## Summary
- `tests/test_device_state_event.py` and `tests/test_state_fanout_duplicate_names.py` each carried a near-identical `_make_controller` helper that bypass-init'd a `DevicesController`, wired `_scanner.devices` + a `get_by_name` lambda, and either left `_db.bus` as a `MagicMock` (silent `assert_called_once_with` coupling) or built up an `EventBus` by hand.
- Lift `make_devices_controller_with_bus` into `tests/conftest.py`: builds the bypass-init controller, attaches a real `EventBus` with a captured listener for the requested event types, exposes the same scanner mirror. Both test files now import it instead of carrying their own copy.
- Behaviour preserved: assertions read the flat captured-event list directly, no `MagicMock` indirection. Drops the dead `_fired_events` walker that re-derived `(event_type, data)` tuples from `MagicMock.call_args_list`.
- Also lifts the imports out of `TYPE_CHECKING` for clarity at the top level (`Callable` / `Iterator` / `Path`).

## Test plan
- [x] `uv run pytest tests/test_device_state_event.py tests/test_state_fanout_duplicate_names.py`
- [x] `uv run pytest tests/ --ignore=tests/controllers` (top-level — 703 pass)