### PR TITLE
Pin exact scan-call list on import happy path (PR #233 follow-up)

### DIFF
--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -87,7 +87,11 @@ async def test_import_device_invokes_import_config_and_returns_path(
     # No matching importable cache entry → fall back to wifi (legacy behaviour).
     assert args[5] == "wifi"
     assert args[6] == "true"  # encryption flag forwarded
-    assert ("scan",) in ctrl._scanner.calls
+    # ``import_device`` calls ``scan()`` exactly once on the happy
+    # path; pin the full call list so a regression that double-scans
+    # (or sneaks in a stray ``reload``) breaks here instead of
+    # silently passing the membership check.
+    assert ctrl._scanner.calls == [("scan",)]
 
 
 async def test_import_device_passes_ethernet_network_through_to_import_config(


### PR DESCRIPTION
## Summary
Address copilot inline comment on #233 ([discussion_r3178689696](https://github.com/esphome/device-builder/pull/233#discussion_r3178689696)).

The post-#233 assertion `assert ("scan",) in ctrl._scanner.calls` was a membership check that still passes if `scan()` ran twice or an unexpected call (e.g. `reload`) snuck in. Replace with a full-list equality (`ctrl._scanner.calls == [("scan",)]`) so the original "exactly once on the happy path" guarantee is preserved.

## Test plan
- [x] `uv run pytest tests/controllers/devices/test_import.py`