### PR TITLE
Adopt conftest redirect_storage_path across devices tests

### DIFF
--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -136,18 +136,8 @@ async def test_create_device_falls_back_to_platform_variant_lookup(
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def _patch_ext_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Redirect ``ext_storage_path`` so ``_delete_single`` reads tmp sidecars."""
-    fake = lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json"  # noqa: E731
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.ext_storage_path", fake
-    )
-    monkeypatch.setattr("esphome_device_builder.controllers.devices.helpers.ext_storage_path", fake)
-
-
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
+@pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_device_unlinks_yaml_then_scans(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -171,7 +161,7 @@ async def test_delete_device_unlinks_yaml_then_scans(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
+@pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_bulk_returns_per_device_success_with_mixed_outcomes(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -14,7 +14,6 @@ to retry.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -53,24 +52,8 @@ def _seed_device(
     return yaml_path, build_path
 
 
-@pytest.fixture
-def _patch_ext_storage(monkeypatch: Any, tmp_path: Path) -> None:
-    """Redirect ``ext_storage_path`` away from CORE.
-
-    ``ext_storage_path`` walks ``CORE.config_path`` which isn't set
-    in the test process; pin it to the tmp config directory so the
-    on-disk sidecar laid down by ``_seed_device`` is the one the
-    delete path reads.
-    """
-    fake = lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json"  # noqa: E731
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.ext_storage_path", fake
-    )
-    monkeypatch.setattr("esphome_device_builder.controllers.devices.helpers.ext_storage_path", fake)
-
-
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
+@pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_wipes_build_directory(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -90,7 +73,7 @@ async def test_delete_wipes_build_directory(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
+@pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_succeeds_when_never_compiled(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -105,7 +88,7 @@ async def test_delete_succeeds_when_never_compiled(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_patch_ext_storage")
+@pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_tolerates_missing_build_directory(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:


### PR DESCRIPTION
## Summary
The local `_patch_ext_storage` fixture was a strict subset of the conftest's existing `redirect_storage_path` — same two `ext_storage_path` patches (`controllers.devices.controller` + `controllers.devices.helpers`). The conftest version also rebinds `esphome.storage_json.ext_storage_path` with `raising=False`, harmless when nothing in these files calls upstream's lookup directly.

Migrates two files that were each carrying their own copy:
- `tests/controllers/devices/test_delete.py`
- `tests/controllers/devices/test_branches_coverage.py` (added in PR #240)

A future change to the redirect (extra path to patch, different module structure) now only has to update the one shared site.

## Test plan
- [x] `pytest tests/controllers/devices/test_delete.py tests/controllers/devices/test_branches_coverage.py` — 24 passed.
- [x] `pre-commit run` on changed files — clean.