### PR TITLE
Capture every EventType in make_devices_controller_with_bus (PR #238 follow-up)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,17 +271,22 @@ def make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MakeSettin
 def make_devices_controller_with_bus(
     devices: list[Device],
     *,
-    capture_event_types: tuple[EventType, ...] = (EventType.DEVICE_STATE_CHANGED,),
     create_background_task: Callable[[Any], Any] | None = None,
 ) -> tuple[DevicesController, list[Event]]:
     """Bypass-init a ``DevicesController`` wired to a real ``EventBus``.
 
     Returns the controller and a live ``list[Event]`` capture for
-    every subscribed ``EventType``. Tests assert on the flat list
-    instead of poking ``MagicMock.assert_called_once_with`` /
-    ``call_args_list`` — the contract being tested is "what fanned
-    out to the bus", not the call shape of the mock that recorded
-    it.
+    *every* ``EventType`` fired on the bus. Tests assert on the
+    flat list instead of poking ``MagicMock.assert_called_once_with``
+    / ``call_args_list`` — the contract being tested is "what
+    fanned out to the bus", not the call shape of the mock that
+    recorded it.
+
+    Captures every event type by default (rather than an explicit
+    subset) so a refactor that fires an unexpected event surfaces
+    in the test instead of silently passing through. Tests that
+    only care about a subset filter the list themselves
+    (``[e for e in captured if e.event_type == X]``).
 
     The scanner is a ``MagicMock`` exposing ``devices`` and a
     ``get_by_name(name)`` lambda derived from *devices*; mirrors
@@ -295,7 +300,7 @@ def make_devices_controller_with_bus(
     """
     bus = EventBus()
     captured: list[Event] = []
-    for event_type in capture_event_types:
+    for event_type in EventType:
         bus.add_listener(event_type, captured.append)
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -17,7 +17,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.models import Device, DeviceState, EventType
+from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import make_devices_controller_with_bus
 
@@ -47,9 +47,6 @@ def _close_coro(coro: Any) -> Any:
     return MagicMock()
 
 
-_FANOUT_EVENT_TYPES = (EventType.DEVICE_STATE_CHANGED, EventType.DEVICE_UPDATED)
-
-
 def test_state_change_fans_out_to_every_matching_device() -> None:
     """Fans the state update + bus event out to every matching device.
 
@@ -61,7 +58,6 @@ def test_state_change_fans_out_to_every_matching_device() -> None:
     b = _device("kitchen (1).yaml")
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        capture_event_types=_FANOUT_EVENT_TYPES,
         create_background_task=_close_coro,
     )
 
@@ -79,7 +75,6 @@ def test_ip_change_fans_out_to_every_matching_device() -> None:
     b = _device("kitchen (1).yaml", ip="")
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        capture_event_types=_FANOUT_EVENT_TYPES,
         create_background_task=_close_coro,
     )
 
@@ -99,7 +94,6 @@ def test_version_change_fans_out_to_every_matching_device() -> None:
     b = _device("kitchen (1).yaml", current_version="2026.5.0", deployed_version="")
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        capture_event_types=_FANOUT_EVENT_TYPES,
         create_background_task=_close_coro,
     )
 
@@ -123,7 +117,6 @@ def test_config_hash_change_fans_out_to_every_matching_device() -> None:
     )
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        capture_event_types=_FANOUT_EVENT_TYPES,
         create_background_task=_close_coro,
     )
 
@@ -142,7 +135,6 @@ def test_api_encryption_change_fans_out_to_every_matching_device() -> None:
     b = _device("kitchen (1).yaml", api_encryption_active=None)
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        capture_event_types=_FANOUT_EVENT_TYPES,
         create_background_task=_close_coro,
     )
 
@@ -159,7 +151,6 @@ def test_unrelated_devices_are_not_touched() -> None:
     garage = _device("garage.yaml", name="garage", address="garage.local")
     controller, captured = make_devices_controller_with_bus(
         [kitchen, garage],
-        capture_event_types=_FANOUT_EVENT_TYPES,
         create_background_task=_close_coro,
     )
 


### PR DESCRIPTION
## Summary
Address copilot inline comment on #238 ([discussion_r3178704309](https://github.com/esphome/device-builder/pull/238#discussion_r3178704309)).

The post-#238 helper subscribed only to `capture_event_types` (default `(DEVICE_STATE_CHANGED,)`), so a refactor that fired an unexpected event type would slip past the captured list silently — weaker than the pre-#238 MagicMock-based helpers that captured every `bus.fire(...)` call.

Drop the `capture_event_types` arg and subscribe to every member of `EventType`. Tests that only care about a subset filter the list themselves (one-line list-comp). Drops the now-unused `_FANOUT_EVENT_TYPES` constant + the `EventType` import in `test_state_fanout_duplicate_names.py`.

## Test plan
- [x] `uv run pytest tests/test_device_state_event.py tests/test_state_fanout_duplicate_names.py`