### PR TITLE
Convert capture_*_events / capture_enqueue_order helpers to pytest fixtures

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -16,6 +16,7 @@ wraps it in ``asyncio.to_thread`` so callers don't have to remember.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
@@ -522,11 +523,12 @@ def make_controller() -> MakeControllerFactory:
     return _make
 
 
-def capture_devices_events(
-    controller: DevicesController,
-    *event_types: EventType,
-) -> list[Event]:
-    """Swap the controller's bus for a real ``EventBus`` and return the capture list.
+CaptureDevicesEventsFactory = Callable[..., list[Event]]
+
+
+@pytest.fixture
+def capture_devices_events() -> Iterator[CaptureDevicesEventsFactory]:
+    """Yield a factory that swaps a controller's bus for a real ``EventBus``.
 
     Devices-side sibling of ``capture_firmware_events`` from the
     firmware conftest. The ``make_controller`` factory wires
@@ -537,16 +539,32 @@ def capture_devices_events(
     captures both event type and payload, with no coupling to the
     handler's internal call shape.
 
-    Pass the ``EventType`` values to subscribe to. The returned list
-    is appended to as events fire — assertion code can read it after
-    the call under test resolves.
+    Tests pull the fixture in by adding ``capture_devices_events``
+    to their signature and call it as a factory:
+    ``captured = capture_devices_events(controller, EventType.X, ...)``.
+    The fixture wrapper tracks every swap and restores
+    ``controller._db.bus`` to its original value on teardown so a
+    test that holds a controller reference past the assertion sees
+    the original bus, not a stale fake.
     """
-    bus = EventBus()
-    captured: list[Event] = []
-    for event_type in event_types:
-        bus.add_listener(event_type, captured.append)
-    controller._db.bus = bus
-    return captured
+    swaps: list[tuple[DevicesController, Any]] = []
+
+    def _factory(
+        controller: DevicesController,
+        *event_types: EventType,
+    ) -> list[Event]:
+        bus = EventBus()
+        captured: list[Event] = []
+        for event_type in event_types:
+            bus.add_listener(event_type, captured.append)
+        swaps.append((controller, controller._db.bus))
+        controller._db.bus = bus
+        return captured
+
+    yield _factory
+
+    for controller, original_bus in swaps:
+        controller._db.bus = original_bus
 
 
 @pytest.fixture

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -48,9 +48,9 @@ from esphome_device_builder.models import (
 from tests._storage_fixtures import write_storage_json
 
 from .conftest import (
+    CaptureDevicesEventsFactory,
     MakeControllerFactory,
     SeedDeviceFactory,
-    capture_devices_events,
 )
 
 
@@ -324,7 +324,9 @@ async def test_add_component_missing_required_field_raises(
 
 
 def test_on_ip_change_skips_when_ip_unchanged(
-    tmp_path: Path, make_controller: MakeControllerFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """A duplicate IP broadcast is a no-op — no event, no persist task.
 

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -25,7 +25,11 @@ from esphome_device_builder.controllers.devices import controller as devices_mod
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import AdoptableDevice, DeviceState, ErrorCode, EventType
 
-from .conftest import MakeControllerFactory, RecordingStateMonitor, capture_devices_events
+from .conftest import (
+    CaptureDevicesEventsFactory,
+    MakeControllerFactory,
+    RecordingStateMonitor,
+)
 
 
 def _seed_import_state(controller: DevicesController) -> None:
@@ -360,6 +364,7 @@ async def test_import_device_drops_matching_import_result_entry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """The discovery banner entry disappears the moment adoption finishes.
 

--- a/tests/controllers/devices/test_listing_api.py
+++ b/tests/controllers/devices/test_listing_api.py
@@ -37,7 +37,7 @@ from esphome_device_builder.models import (
     EventType,
 )
 
-from .conftest import MakeControllerFactory, capture_devices_events
+from .conftest import CaptureDevicesEventsFactory, MakeControllerFactory
 
 
 def _device(name: str, *, state: DeviceState = DeviceState.ONLINE) -> Device:
@@ -163,7 +163,9 @@ async def test_list_devices_filters_importable_already_configured(
 
 
 def test_on_importable_added_stashes_and_fires_event(
-    tmp_path: Path, make_controller: MakeControllerFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """``import_result`` is keyed by ``device.name`` and fires DEVICE_ADDED.
 
@@ -188,7 +190,9 @@ def test_on_importable_added_stashes_and_fires_event(
 
 
 def test_on_importable_removed_drops_entry_and_fires_event(
-    tmp_path: Path, make_controller: MakeControllerFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """``IMPORTABLE_DEVICE_REMOVED`` carries just the name, not the full record.
 
@@ -209,7 +213,9 @@ def test_on_importable_removed_drops_entry_and_fires_event(
 
 
 def test_on_importable_removed_ignores_unknown_name(
-    tmp_path: Path, make_controller: MakeControllerFactory
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """An unknown name is a no-op — no cache pop, no event.
 

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -22,7 +22,7 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, EventType
 from tests._storage_fixtures import write_storage_json
 
-from .conftest import RecordingStateMonitor, capture_devices_events
+from .conftest import CaptureDevicesEventsFactory, RecordingStateMonitor
 
 
 def _make_controller(monkeypatch: Any, board_id: str = "esp32-c3-devkitm-1") -> Any:
@@ -180,7 +180,9 @@ def test_build_info_hash_used_even_when_sidecar_empty(tmp_path: Path, monkeypatc
     assert metadata.expected_config_hash == "12345678"
 
 
-def test_added_device_without_hash_triggers_regenerate(monkeypatch: Any) -> None:
+def test_added_device_without_hash_triggers_regenerate(
+    monkeypatch: Any, capture_devices_events: CaptureDevicesEventsFactory
+) -> None:
     """An imported device with integrations but no hash gets its hash backfilled.
 
     Symptom from the field: an Apollo R_PRO-1 added before

--- a/tests/controllers/devices/test_toggle_ignore.py
+++ b/tests/controllers/devices/test_toggle_ignore.py
@@ -31,10 +31,14 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.event_bus import Event
 from esphome_device_builder.models import AdoptableDevice, EventType
 
-from .conftest import MakeControllerFactory, capture_devices_events
+from .conftest import CaptureDevicesEventsFactory, MakeControllerFactory
 
 
-def _seed_for_toggle(controller: DevicesController, tmp_path: Path) -> tuple[list[Event], Path]:
+def _seed_for_toggle(
+    controller: DevicesController,
+    tmp_path: Path,
+    capture_devices_events: CaptureDevicesEventsFactory,
+) -> tuple[list[Event], Path]:
     """Wire ``import_result`` + the events capture for the toggle path.
 
     Returns ``(events, ignored_path)`` so the test can assert
@@ -76,10 +80,11 @@ async def test_toggle_ignore_true_adds_to_set_and_persists(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
     _patch_ignored_path: None,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """``ignore=True`` adds the name and writes the updated list to disk."""
     controller = make_controller(tmp_path)
-    _fired, ignored_path = _seed_for_toggle(controller, tmp_path)
+    _fired, ignored_path = _seed_for_toggle(controller, tmp_path, capture_devices_events)
 
     await controller.toggle_ignore(name="kitchen-1a2b3c")
 
@@ -95,6 +100,7 @@ async def test_toggle_ignore_false_removes_and_persists(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
     _patch_ignored_path: None,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """``ignore=False`` discards the name and writes the trimmed list.
 
@@ -104,7 +110,7 @@ async def test_toggle_ignore_false_removes_and_persists(
     up.
     """
     controller = make_controller(tmp_path)
-    _fired, ignored_path = _seed_for_toggle(controller, tmp_path)
+    _fired, ignored_path = _seed_for_toggle(controller, tmp_path, capture_devices_events)
     controller.ignored_devices.add("kitchen-1a2b3c")
 
     await controller.toggle_ignore(name="kitchen-1a2b3c", ignore=False)
@@ -122,6 +128,7 @@ async def test_toggle_ignore_mirrors_flag_onto_cached_adoptable_and_fires(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
     _patch_ignored_path: None,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """When an ``AdoptableDevice`` is cached, its ``ignored`` flag is mirrored.
 
@@ -132,7 +139,7 @@ async def test_toggle_ignore_mirrors_flag_onto_cached_adoptable_and_fires(
     ``IMPORTABLE_DEVICE_ADDED`` re-fire.
     """
     controller = make_controller(tmp_path)
-    fired, _ignored_path = _seed_for_toggle(controller, tmp_path)
+    fired, _ignored_path = _seed_for_toggle(controller, tmp_path, capture_devices_events)
     controller.import_result["kitchen-1a2b3c"] = AdoptableDevice(
         name="kitchen-1a2b3c",
         friendly_name="Kitchen",
@@ -162,6 +169,7 @@ async def test_toggle_ignore_does_not_fire_when_state_unchanged(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
     _patch_ignored_path: None,
+    capture_devices_events: CaptureDevicesEventsFactory,
 ) -> None:
     """Re-asserting an already-set flag doesn't fire a duplicate event.
 
@@ -171,7 +179,7 @@ async def test_toggle_ignore_does_not_fire_when_state_unchanged(
     and a wasted round-trip for every connected frontend.
     """
     controller = make_controller(tmp_path)
-    fired, _ignored_path = _seed_for_toggle(controller, tmp_path)
+    fired, _ignored_path = _seed_for_toggle(controller, tmp_path, capture_devices_events)
     controller.import_result["kitchen-1a2b3c"] = AdoptableDevice(
         name="kitchen-1a2b3c",
         friendly_name="Kitchen",

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -23,6 +23,7 @@ silently absorbing into a stub.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Iterator
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Protocol
@@ -176,36 +177,47 @@ def firmware_controller_factory(
     return _make
 
 
-def capture_firmware_events(
-    controller: FirmwareController,
-    *event_types: EventType,
-) -> list[Event]:
-    """Swap the controller's bus for a real ``EventBus`` and return the capture list.
+CaptureEventsFactory = Callable[..., list[Event]]
+CaptureEnqueueOrderFactory = Callable[..., list[tuple[EnqueueStep, Any]]]
 
-    The conftest factory wires ``self._db.bus`` as a ``MagicMock``;
-    that's fine for tests that ignore events but means assertions on
-    event firing have to walk ``call_args_list``. Replacing with a
-    real bus + listener gives a flat ``[Event, …]`` log that captures
-    both the event type and payload, with no coupling to the
-    handler's internal call shape.
 
-    Pass the ``EventType`` values to subscribe to. The returned list
-    is appended to as events fire — assertion code can read it after
-    the call under test resolves.
+@pytest.fixture
+def capture_firmware_events() -> Iterator[CaptureEventsFactory]:
+    """Yield a factory that swaps a controller's bus for a real ``EventBus``.
+
+    Same shape as the previous function-style helper — tests call
+    ``capture_firmware_events(controller, EventType.X, ...)`` and
+    get a live ``list[Event]``. The fixture wrapper tracks every
+    swap and restores ``controller._db.bus`` to its original value
+    on teardown so a test that holds a controller reference past
+    the assertion sees the original bus, not a stale fake.
+
+    Tests pull the fixture in by adding ``capture_firmware_events``
+    to their signature; no ``with`` block needed.
     """
-    bus = EventBus()
-    captured: list[Event] = []
-    for event_type in event_types:
-        bus.add_listener(event_type, captured.append)
-    controller._db.bus = bus
-    return captured
+    swaps: list[tuple[FirmwareController, Any]] = []
+
+    def _factory(
+        controller: FirmwareController,
+        *event_types: EventType,
+    ) -> list[Event]:
+        bus = EventBus()
+        captured: list[Event] = []
+        for event_type in event_types:
+            bus.add_listener(event_type, captured.append)
+        swaps.append((controller, controller._db.bus))
+        controller._db.bus = bus
+        return captured
+
+    yield _factory
+
+    for controller, original_bus in swaps:
+        controller._db.bus = original_bus
 
 
-def capture_enqueue_order(
-    controller: FirmwareController,
-    *event_types: EventType,
-) -> list[tuple[EnqueueStep, Any]]:
-    """Trace ``_queue.put`` calls and ``bus.fire`` events into one ordered log.
+@pytest.fixture
+def capture_enqueue_order() -> Iterator[CaptureEnqueueOrderFactory]:
+    """Yield a factory that traces ``_queue.put`` + ``bus.fire`` into one ordered log.
 
     Each ``await self._queue.put(job)`` appends ``(EnqueueStep.PUT, job)``
     and each broadcast for a subscribed ``EventType`` appends
@@ -216,24 +228,39 @@ def capture_enqueue_order(
     a ``parent.bus.fire.assert_any_call(...)`` follow-up.
 
     The internal queue is a real ``asyncio.Queue`` so a runner can
-    still dequeue if the test exercises that path.
+    still dequeue if the test exercises that path. Auto-restore on
+    teardown reinstates the original ``_queue`` and ``_db.bus`` so
+    sibling tests in the same xdist worker don't see leaked stubs.
     """
-    log: list[tuple[EnqueueStep, Any]] = []
-    inner_queue: asyncio.Queue[FirmwareJob] = asyncio.Queue()
+    swaps: list[tuple[FirmwareController, Any, Any]] = []
 
-    async def _trace_put(item: FirmwareJob) -> None:
-        log.append((EnqueueStep.PUT, item))
-        await inner_queue.put(item)
+    def _factory(
+        controller: FirmwareController,
+        *event_types: EventType,
+    ) -> list[tuple[EnqueueStep, Any]]:
+        log: list[tuple[EnqueueStep, Any]] = []
+        inner_queue: asyncio.Queue[FirmwareJob] = asyncio.Queue()
 
-    queue_proxy = MagicMock()
-    queue_proxy.put = _trace_put
-    queue_proxy.get = inner_queue.get
-    queue_proxy.qsize = inner_queue.qsize
-    controller._queue = queue_proxy
+        async def _trace_put(item: FirmwareJob) -> None:
+            log.append((EnqueueStep.PUT, item))
+            await inner_queue.put(item)
 
-    bus = EventBus()
-    for event_type in event_types:
-        bus.add_listener(event_type, lambda event: log.append((EnqueueStep.FIRE, event)))
-    controller._db.bus = bus
+        queue_proxy = MagicMock()
+        queue_proxy.put = _trace_put
+        queue_proxy.get = inner_queue.get
+        queue_proxy.qsize = inner_queue.qsize
 
-    return log
+        bus = EventBus()
+        for event_type in event_types:
+            bus.add_listener(event_type, lambda event: log.append((EnqueueStep.FIRE, event)))
+
+        swaps.append((controller, controller._queue, controller._db.bus))
+        controller._queue = queue_proxy
+        controller._db.bus = bus
+        return log
+
+    yield _factory
+
+    for controller, original_queue, original_bus in swaps:
+        controller._queue = original_queue
+        controller._db.bus = original_bus

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -36,8 +36,8 @@ from esphome_device_builder.models import (
     JobType,
 )
 from tests.controllers.firmware.conftest import (
+    CaptureEventsFactory,
     FirmwareControllerFactory,
-    capture_firmware_events,
 )
 
 
@@ -91,6 +91,7 @@ async def test_cancel_raises_not_found_for_unknown_job_id(
 @pytest.mark.asyncio
 async def test_cancel_queued_job_marks_terminal_and_fires_event(
     firmware_controller_factory: FirmwareControllerFactory,
+    capture_firmware_events: CaptureEventsFactory,
 ) -> None:
     """A queued job flips to ``CANCELLED`` immediately and broadcasts.
 
@@ -197,6 +198,7 @@ async def test_cancel_running_job_records_intent_and_terminates(
 @pytest.mark.asyncio
 async def test_cancel_running_job_does_not_fire_event_directly(
     firmware_controller_factory: FirmwareControllerFactory,
+    capture_firmware_events: CaptureEventsFactory,
 ) -> None:
     """``JOB_CANCELLED`` is fired by the *runner*, not by ``cancel``.
 
@@ -270,7 +272,9 @@ async def test_cancel_running_job_with_mismatched_current_job_raises(
 )
 @pytest.mark.asyncio
 async def test_cancel_terminal_job_raises_invalid_args(
-    status: JobStatus, firmware_controller_factory: FirmwareControllerFactory
+    status: JobStatus,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_firmware_events: CaptureEventsFactory,
 ) -> None:
     """A job in any terminal status rejects with ``CommandError(INVALID_ARGS)``.
 

--- a/tests/controllers/firmware/test_clean.py
+++ b/tests/controllers/firmware/test_clean.py
@@ -25,9 +25,9 @@ import pytest
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
+    CaptureEnqueueOrderFactory,
     EnqueueStep,
     FirmwareControllerFactory,
-    capture_enqueue_order,
 )
 
 
@@ -80,6 +80,7 @@ async def test_clean_rejects_traversal_configuration(
 async def test_clean_enqueues_before_firing_job_queued(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
+    capture_enqueue_order: CaptureEnqueueOrderFactory,
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 

--- a/tests/controllers/firmware/test_compile.py
+++ b/tests/controllers/firmware/test_compile.py
@@ -24,9 +24,9 @@ import pytest
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
+    CaptureEnqueueOrderFactory,
     EnqueueStep,
     FirmwareControllerFactory,
-    capture_enqueue_order,
 )
 
 
@@ -76,7 +76,9 @@ async def test_compile_rejects_traversal_configuration(
 
 @pytest.mark.asyncio
 async def test_compile_enqueues_before_firing_job_queued(
-    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+    tmp_path: Path,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_enqueue_order: CaptureEnqueueOrderFactory,
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 

--- a/tests/controllers/firmware/test_compile_bulk.py
+++ b/tests/controllers/firmware/test_compile_bulk.py
@@ -32,8 +32,8 @@ import pytest
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
+    CaptureEventsFactory,
     FirmwareControllerFactory,
-    capture_firmware_events,
 )
 
 
@@ -180,7 +180,9 @@ async def test_compile_bulk_empty_input_returns_empty_list(
 
 @pytest.mark.asyncio
 async def test_compile_bulk_fires_job_queued_per_successful_entry(
-    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+    tmp_path: Path,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_firmware_events: CaptureEventsFactory,
 ) -> None:
     """``JOB_QUEUED`` fires exactly once per queued job — no double-fire, no skip.
 

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -28,9 +28,9 @@ import pytest
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
+    CaptureEnqueueOrderFactory,
     EnqueueStep,
     FirmwareControllerFactory,
-    capture_enqueue_order,
 )
 
 
@@ -150,7 +150,9 @@ async def test_install_rejects_traversal_configuration(
 
 @pytest.mark.asyncio
 async def test_install_enqueues_before_firing_job_queued(
-    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+    tmp_path: Path,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_enqueue_order: CaptureEnqueueOrderFactory,
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -31,10 +31,10 @@ import pytest
 from esphome_device_builder.controllers.firmware.constants import _RESET_BUILD_ENV_TARGETS
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
+    CaptureEnqueueOrderFactory,
+    CaptureEventsFactory,
     EnqueueStep,
     FirmwareControllerFactory,
-    capture_enqueue_order,
-    capture_firmware_events,
 )
 
 # ---------------------------------------------------------------------------
@@ -95,7 +95,9 @@ async def test_reset_build_env_registers_job_in_jobs_map(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_fires_job_queued_after_enqueue(
-    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+    tmp_path: Path,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_enqueue_order: CaptureEnqueueOrderFactory,
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 
@@ -214,7 +216,9 @@ async def test_reset_build_env_runner_marks_job_completed(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_fires_job_completed(
-    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+    tmp_path: Path,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_firmware_events: CaptureEventsFactory,
 ) -> None:
     """``JOB_COMPLETED`` fires with the finished job in its payload.
 
@@ -235,7 +239,9 @@ async def test_reset_build_env_runner_fires_job_completed(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_streams_output_lines(
-    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+    tmp_path: Path,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_firmware_events: CaptureEventsFactory,
 ) -> None:
     """Progress lines hit both ``job.output`` and the bus.
 
@@ -319,7 +325,9 @@ async def test_reset_build_env_runner_no_op_when_esphome_absent(
 
 @pytest.mark.asyncio
 async def test_reset_build_env_runner_honours_cancel_between_targets(
-    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+    tmp_path: Path,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_firmware_events: CaptureEventsFactory,
 ) -> None:
     """Cancellation requested mid-run stops before the next target.
 

--- a/tests/controllers/firmware/test_upload.py
+++ b/tests/controllers/firmware/test_upload.py
@@ -30,9 +30,9 @@ import pytest
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
+    CaptureEnqueueOrderFactory,
     EnqueueStep,
     FirmwareControllerFactory,
-    capture_enqueue_order,
 )
 
 
@@ -157,7 +157,9 @@ async def test_upload_rejects_traversal_configuration(
 
 @pytest.mark.asyncio
 async def test_upload_enqueues_before_firing_job_queued(
-    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+    tmp_path: Path,
+    firmware_controller_factory: FirmwareControllerFactory,
+    capture_enqueue_order: CaptureEnqueueOrderFactory,
 ) -> None:
     """``_queue.put`` runs *before* the ``JOB_QUEUED`` broadcast.
 


### PR DESCRIPTION
## Summary
- The three function-style capture helpers (`capture_firmware_events`, `capture_enqueue_order`, `capture_devices_events`) all swapped `controller._db.bus` (and `capture_enqueue_order` also `_queue`) and never restored the originals. Fine in practice because the factory builds a fresh controller per test, but a latent footgun if a future test held a controller reference past the assertion.
- Convert each to a `@pytest.fixture` that yields a factory callable. Call sites stay identical (`captured = capture_X(controller, EventType.Y, ...)`); each test signature picks up the fixture by name. Auto-restore via fixture teardown reinstates the originals so sibling tests can't see a leaked stub.
- Add `CaptureEventsFactory` / `CaptureEnqueueOrderFactory` / `CaptureDevicesEventsFactory` type aliases so test signatures get a clean type for the fixture parameter.
- Drops the `from .conftest import capture_*` imports across 8 firmware test files and 5 devices test files.

## Test plan
- [x] `uv run pytest tests/controllers/` (509 pass, 2 skip)