### PR TITLE
Correct capture_inner_lifecycle docstring rationale (PR #242 follow-up)

### DIFF
--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -87,9 +87,12 @@ def _capture_inner_lifecycle(controller: DevicesController) -> Iterator[list[str
     contract; the inner controllers have their own dedicated test
     files.
 
-    Context-manager shape so the originals restore on exit (success
-    *or* failure) — sibling tests in the same xdist worker don't
-    see leaked stubs on the shared inner-controller instances.
+    Context-manager shape so the patches restore on exit (success
+    *or* failure). Each test in this module builds its own fresh
+    ``DevicesController``, so there are no shared instances to leak
+    onto — the auto-restore is for *intra-test* hygiene: the
+    captured stubs only intercept calls inside the ``with`` block,
+    which makes the scope of the capture explicit at the call site.
 
     Each stub appends a single label string to the yielded list so
     tests assert on the call sequence in one comparison instead of


### PR DESCRIPTION
## Summary
Address copilot inline comment on #242 ([discussion_r3178713487](https://github.com/esphome/device-builder/pull/242#discussion_r3178713487)).

The original docstring claimed the contextmanager prevents leaks onto "shared inner-controller instances", but every test in this module builds its own fresh `DevicesController` via `DevicesController(db)` — there are no shared instances to leak onto. The "auto-restore on context exit" benefit is real, but the rationale was wrong.

Rewrite to explain the actual benefit: intra-test scope hygiene (stubs only intercept calls inside the `with` block, which makes the scope of the capture explicit at the call site).

## Test plan
- [x] `uv run pytest tests/controllers/devices/test_lifecycle_e2e.py`