### PR TITLE
Drop dead WSMsgType.ERROR/CLOSE branch in ws.py

### DIFF
--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -285,6 +285,7 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     await client.send(info.to_dict())
 
     try:
+        # CLOSE/ERROR exit via aiohttp's __anext__ → StopAsyncIteration; no explicit branch needed.
         async for msg in ws:
             if msg.type in (WSMsgType.TEXT, WSMsgType.BINARY):
                 try:
@@ -293,8 +294,6 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
                     await client.send_error("", ErrorCode.INVALID_MESSAGE, "Invalid JSON")
                     continue
                 client.create_task(client._handle_command(raw))
-            elif msg.type in (WSMsgType.ERROR, WSMsgType.CLOSE):
-                break
     finally:
         await client.cleanup()
         _LOGGER.debug("WebSocket client disconnected")


### PR DESCRIPTION
## Summary
The `elif msg.type in (WSMsgType.ERROR, WSMsgType.CLOSE): break` branch in the WS message loop was unreachable:

- aiohttp's `WebSocketResponse.__anext__` filters `CLOSE` / `CLOSING` / `CLOSED` itself by raising `StopAsyncIteration` — those frames never reach the handler's elif.
- An `ERROR` message implicitly closes the underlying socket, so the very next `__anext__` call raises `StopAsyncIteration` on `CLOSED` anyway.

The branch was therefore dead code that pegged `api/ws.py` at 99% coverage. Drop it and lean on the iter's `StopAsyncIteration` to exit cleanly into the `finally` block (which runs `client.cleanup()` either way).

Brings `esphome_device_builder/api/ws.py` from 99% → 100%.

## Test plan
- [x] `pytest tests/` — 1230 passed, 3 skipped.
- [x] `pytest --cov=esphome_device_builder.api.ws` — 100%.
- [x] `pre-commit run` on changed file — clean.