### PR TITLE
Use RecordingScanner for _scanner.reload assertions in test_refresh.py

### DIFF
--- a/tests/_recording_scanner.py
+++ b/tests/_recording_scanner.py
@@ -1,0 +1,68 @@
+"""
+Shared typed fake for ``DeviceScanner`` — captures scan / reload / get_by_name calls.
+
+Lives in ``tests/`` (not in any ``conftest.py``) so cross-suite
+imports — devices tests and firmware tests both reach for it —
+don't create a hidden cross-conftest dependency. Future fixture
+or pytest-plugin changes in either suite's ``conftest.py`` won't
+break the other suite at import time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class RecordingScanner:
+    """Test fake for ``DeviceScanner`` capturing scan/reload calls.
+
+    Mirrors every public method on the production ``DeviceScanner``
+    (``scan`` / ``reload`` / ``get_by_name`` / ``devices`` /
+    ``by_path``). Calls to ``scan`` / ``reload`` / ``get_by_name``
+    land in ``self.calls`` as ``(method_name, *args)``; tests
+    assert on the list directly instead of scattering
+    ``MagicMock.assert_awaited_*`` lines.
+
+    Why a typed fake rather than ``MagicMock``: a typo
+    (``scann.assert_awaited_once``) silently passes against a
+    ``MagicMock`` because it spawns a fresh attribute on access; a
+    refactor renaming a real method (``reload`` → ``refresh_one``)
+    similarly breaks the contract without breaking the assertion.
+    Mirroring the *full* public surface (rather than just
+    ``scan`` + ``reload``) means a controller path that touches
+    ``get_by_name`` or ``by_path`` won't blow up against the fake
+    just because no earlier test exercised it.
+
+    ``reload_returns`` controls the truthy return — production's
+    ``reload`` returns ``False`` when the file isn't tracked, which
+    a few tests exercise. ``devices_by_name`` lets tests pre-seed
+    the name index that ``get_by_name`` reads from.
+    """
+
+    def __init__(
+        self,
+        *,
+        reload_returns: bool = True,
+        devices_by_name: dict[str, list[object]] | None = None,
+    ) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self._reload_returns = reload_returns
+        self._devices_by_name = devices_by_name or {}
+        # Mirrors ``DeviceScanner.devices`` / ``by_path`` — empty by
+        # default; tests that need a populated catalog can assign.
+        self.devices: list[object] = []
+        self.by_path: dict[Path, object] = {}
+
+    async def scan(self) -> None:
+        self.calls.append(("scan",))
+
+    async def reload(self, filename: str) -> bool:
+        self.calls.append(("reload", filename))
+        return self._reload_returns
+
+    def get_by_name(self, name: str) -> list[object]:
+        self.calls.append(("get_by_name", name))
+        # Fresh list snapshot — mirrors production semantics so
+        # callers can iterate / mutate without poisoning the index.
+        return list(self._devices_by_name.get(name, []))

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -28,6 +28,7 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.helpers.hostname import normalize_hostname
 from esphome_device_builder.models import AdoptableDevice, DeviceState, EventType
+from tests._recording_scanner import RecordingScanner
 from tests._storage_fixtures import write_storage_json
 
 
@@ -132,60 +133,6 @@ class RecordingStateMonitor:
     def get_importable_devices(self) -> list[AdoptableDevice]:
         self.calls.append(("get_importable_devices",))
         return list(self._importable)
-
-
-class RecordingScanner:
-    """Test fake for ``DeviceScanner`` capturing scan/reload calls.
-
-    Mirrors every public method on the production ``DeviceScanner``
-    (``scan`` / ``reload`` / ``get_by_name`` / ``devices`` /
-    ``by_path``). Calls to ``scan`` / ``reload`` / ``get_by_name``
-    land in ``self.calls`` as ``(method_name, *args)``; tests
-    assert on the list directly instead of scattering
-    ``MagicMock.assert_awaited_*`` lines.
-
-    Why a typed fake rather than ``MagicMock``: a typo
-    (``scann.assert_awaited_once``) silently passes against a
-    ``MagicMock`` because it spawns a fresh attribute on access; a
-    refactor renaming a real method (``reload`` → ``refresh_one``)
-    similarly breaks the contract without breaking the assertion.
-    Mirroring the *full* public surface (rather than just
-    ``scan`` + ``reload``) means a controller path that touches
-    ``get_by_name`` or ``by_path`` won't blow up against the fake
-    just because no earlier test exercised it.
-
-    ``reload_returns`` controls the truthy return — production's
-    ``reload`` returns ``False`` when the file isn't tracked, which
-    a few tests exercise. ``devices_by_name`` lets tests pre-seed
-    the name index that ``get_by_name`` reads from.
-    """
-
-    def __init__(
-        self,
-        *,
-        reload_returns: bool = True,
-        devices_by_name: dict[str, list[object]] | None = None,
-    ) -> None:
-        self.calls: list[tuple[Any, ...]] = []
-        self._reload_returns = reload_returns
-        self._devices_by_name = devices_by_name or {}
-        # Mirrors ``DeviceScanner.devices`` / ``by_path`` — empty by
-        # default; tests that need a populated catalog can assign.
-        self.devices: list[object] = []
-        self.by_path: dict[Path, object] = {}
-
-    async def scan(self) -> None:
-        self.calls.append(("scan",))
-
-    async def reload(self, filename: str) -> bool:
-        self.calls.append(("reload", filename))
-        return self._reload_returns
-
-    def get_by_name(self, name: str) -> list[object]:
-        self.calls.append(("get_by_name", name))
-        # Fresh list snapshot — mirrors production semantics so
-        # callers can iterate / mutate without poisoning the index.
-        return list(self._devices_by_name.get(name, []))
 
 
 def _make_board_stub(board_id: str) -> MagicMock:

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -45,7 +45,7 @@ from esphome_device_builder.models import (
     JobStatus,
     JobType,
 )
-from tests.controllers.devices.conftest import RecordingScanner
+from tests._recording_scanner import RecordingScanner
 
 
 def _device(name: str = "kitchen", **overrides: Any) -> Device:

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -45,6 +45,7 @@ from esphome_device_builder.models import (
     JobStatus,
     JobType,
 )
+from tests.controllers.devices.conftest import RecordingScanner
 
 
 def _device(name: str = "kitchen", **overrides: Any) -> Device:
@@ -269,13 +270,12 @@ async def test_refresh_after_compile_persists_hash_and_reloads(
 
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.reload = AsyncMock(return_value=True)
+    controller._scanner = RecordingScanner()
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=True, flashed=False)
 
     assert persisted == [{"filename": "kitchen.yaml", "expected_config_hash": "1a2b3c4d"}]
-    controller._scanner.reload.assert_awaited_once_with("kitchen.yaml")
+    assert controller._scanner.calls == [("reload", "kitchen.yaml")]
 
 
 @pytest.mark.asyncio
@@ -306,13 +306,12 @@ async def test_refresh_after_compile_skips_persist_on_hash_failure(
 
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.reload = AsyncMock(return_value=True)
+    controller._scanner = RecordingScanner()
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=True, flashed=False)
 
     assert persisted == []  # don't overwrite with garbage
-    controller._scanner.reload.assert_awaited_once_with("kitchen.yaml")  # reload still happens
+    assert controller._scanner.calls == [("reload", "kitchen.yaml")]  # reload still happens
 
 
 @pytest.mark.asyncio
@@ -335,13 +334,12 @@ async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypat
 
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.reload = AsyncMock(return_value=True)
+    controller._scanner = RecordingScanner()
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=False, flashed=True)
 
     assert compute_calls == []
-    controller._scanner.reload.assert_awaited_once_with("kitchen.yaml")
+    assert controller._scanner.calls == [("reload", "kitchen.yaml")]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Three tests in `test_refresh.py` wired up `controller._scanner = MagicMock(); _scanner.reload = AsyncMock(return_value=True)`, then asserted via `_scanner.reload.assert_awaited_once_with("kitchen.yaml")`. Same MagicMock-coupling issue addressed for the devices side in #233 — a typo (`scanner.relod.assert_awaited_once_with`) silently passes because MagicMock spawns a fresh attribute on access.
- Cross-import `RecordingScanner` from `tests/controllers/devices/conftest.py` (its natural home — the production target lives in the devices controller). The three tests build their controller via `DevicesController.__new__`, so the factory wiring doesn't help; they assign `_scanner = RecordingScanner()` directly. The reload assertion drops to `assert controller._scanner.calls == [("reload", "kitchen.yaml")]` — equality over the full call list pins both fact-of-call and exact arg.
- Drops the now-unused `AsyncMock` import.

## Test plan
- [x] `uv run pytest tests/controllers/firmware/test_refresh.py`