### PR TITLE
Centralise mDNS-callback recorder; convert apply_X test files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,12 +27,13 @@ import pytest
 from blockbuster import blockbuster_ctx
 from esphome.core import CORE
 
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.event_bus import Event, EventBus
-from esphome_device_builder.models import Device, EventType
+from esphome_device_builder.models import Device, DeviceState, EventType
 
 if TYPE_CHECKING:
     from blockbuster import BlockBuster
@@ -314,3 +315,98 @@ def make_devices_controller_with_bus(
         by_name.setdefault(device.name, []).append(device)
     controller._scanner.get_by_name = lambda name: by_name.get(name, [])
     return controller, captured
+
+
+# ---------------------------------------------------------------------------
+# DeviceStateMonitor callback recorder
+#
+# Every ``test_mdns_*.py`` file at the top of the tree was carrying a
+# near-identical ``_monitor()`` helper that wired ``MagicMock(side_effect=
+# _flip)`` callbacks per field, then asserted via ``cb.assert_called_with``.
+# The ``_flip`` side-effect was specifically there to mirror what the real
+# DevicesController callback does — without it, the monitor's dedupe
+# (which keys off the device's *own* field) doesn't observe the
+# post-callback state and every repeat call would re-fire.
+# ---------------------------------------------------------------------------
+
+
+class RecordingMonitorCallbacks:
+    """Capture monitor callback calls + apply production state-flip side-effects.
+
+    Mirrors the callback interface ``DeviceStateMonitor`` invokes on
+    its owning ``DevicesController`` (``on_state_change`` /
+    ``on_ip_change`` / ``on_version_change`` /
+    ``on_config_hash_change`` / ``on_api_encryption_change``). Each
+    invocation lands in ``self.calls`` as a flat tuple
+    ``(callback_name, *args)``; tests assert on the list directly
+    instead of poking ``MagicMock.assert_called_*``.
+
+    Each callback also writes the new value back onto the matching
+    ``Device`` in *devices* — the same write the production
+    ``DevicesController._on_*_change`` callback does. Without that
+    side-effect, the monitor's dedupe (keyed off the device's own
+    field) would never observe the post-callback state and every
+    repeat call would re-fire. Centralising means every mdns test
+    inherits the correct mirror without copy-pasting the
+    ``_flip``-style helper.
+
+    Type-resistant to typos: ``cb.assertt_called_once_with`` would
+    spawn a fresh ``MagicMock`` attribute and silently pass; calling
+    ``callbacks.assertt_called_once_with`` raises ``AttributeError``.
+    """
+
+    def __init__(self, devices: list[Device]) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self._devices = devices
+
+    def on_state_change(self, name: str, state: DeviceState, source: str) -> None:
+        self.calls.append(("on_state_change", name, state, source))
+        for device in self._devices:
+            if device.name == name:
+                device.state = state
+
+    def on_ip_change(self, name: str, ip: str) -> None:
+        self.calls.append(("on_ip_change", name, ip))
+        for device in self._devices:
+            if device.name == name:
+                device.ip = ip
+
+    def on_version_change(self, name: str, version: str) -> None:
+        self.calls.append(("on_version_change", name, version))
+        for device in self._devices:
+            if device.name == name:
+                device.deployed_version = version
+
+    def on_config_hash_change(self, name: str, config_hash: str) -> None:
+        self.calls.append(("on_config_hash_change", name, config_hash))
+        for device in self._devices:
+            if device.name == name:
+                device.deployed_config_hash = config_hash
+
+    def on_api_encryption_change(self, name: str, encryption: str) -> None:
+        self.calls.append(("on_api_encryption_change", name, encryption))
+        for device in self._devices:
+            if device.name == name:
+                device.api_encryption_active = encryption
+
+
+def make_state_monitor_with_callbacks(
+    devices: list[Device],
+) -> tuple[DeviceStateMonitor, RecordingMonitorCallbacks]:
+    """Build a ``DeviceStateMonitor`` + ``RecordingMonitorCallbacks`` pair.
+
+    Centralises the per-test ``_monitor()`` helper that every
+    ``test_mdns_*.py`` file was carrying. Returns the live monitor
+    plus the callbacks recorder; tests assert on
+    ``callbacks.calls``.
+    """
+    callbacks = RecordingMonitorCallbacks(devices)
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=callbacks.on_state_change,
+        on_ip_change=callbacks.on_ip_change,
+        on_version_change=callbacks.on_version_change,
+        on_config_hash_change=callbacks.on_config_hash_change,
+        on_api_encryption_change=callbacks.on_api_encryption_change,
+    )
+    return monitor, callbacks

--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -22,9 +22,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, DeviceState, EventType
+
+from .conftest import make_state_monitor_with_callbacks
 
 
 def _device(**overrides: Any) -> Device:
@@ -39,32 +40,13 @@ def _device(**overrides: Any) -> Device:
     return Device(**base)
 
 
-def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
-    # Mirror production: the controller's callback writes the value
-    # back onto the device. The monitor's dedupe is keyed off the
-    # device's ``api_encryption_active`` so without the side-effect
-    # every repeat call would re-fire (and the empty-string
-    # plaintext state in particular would never settle).
-    def _flip(name: str, encryption: str) -> None:
-        for d in devices:
-            if d.name == name:
-                d.api_encryption_active = encryption
-
-    on_enc = MagicMock(side_effect=_flip)
-    monitor = DeviceStateMonitor(
-        get_devices=lambda: devices,
-        on_state_change=MagicMock(),
-        on_ip_change=MagicMock(),
-        on_api_encryption_change=on_enc,
-    )
-    return monitor, on_enc
-
-
 def test_apply_api_encryption_first_observation_fires_callback() -> None:
     """A first encryption value reaches the controller."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256") is True
-    cb.assert_called_once_with("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+    assert callbacks.calls == [
+        ("on_api_encryption_change", "kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+    ]
 
 
 def test_apply_api_encryption_empty_string_is_a_real_observation() -> None:
@@ -74,26 +56,30 @@ def test_apply_api_encryption_empty_string_is_a_real_observation() -> None:
     callback firing at least once to know we have ground truth from
     mDNS at all.
     """
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_api_encryption("kitchen", "") is True
-    cb.assert_called_once_with("kitchen", "")
+    assert callbacks.calls == [("on_api_encryption_change", "kitchen", "")]
 
 
 def test_apply_api_encryption_dedupes_same_value() -> None:
     """Repeated identical observations don't churn the controller."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
     monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
-    cb.assert_called_once()
+    assert callbacks.calls == [
+        ("on_api_encryption_change", "kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+    ]
 
 
 def test_apply_api_encryption_fires_on_change() -> None:
     """Encrypted → plaintext (or vice versa) re-fires the callback."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
     monitor.apply_api_encryption("kitchen", "")
-    assert cb.call_count == 2
-    assert cb.call_args_list[1].args == ("kitchen", "")
+    assert callbacks.calls == [
+        ("on_api_encryption_change", "kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256"),
+        ("on_api_encryption_change", "kitchen", ""),
+    ]
 
 
 def test_apply_api_encryption_unknown_device_is_ignored() -> None:
@@ -103,17 +89,17 @@ def test_apply_api_encryption_unknown_device_is_ignored() -> None:
     trigger a DEVICE_UPDATED on a configured device that happens to
     share a similar name slot.
     """
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_api_encryption("not-a-device", "anything") is False
-    cb.assert_not_called()
+    assert callbacks.calls == []
 
 
 def test_apply_api_encryption_dedupes_repeated_empty() -> None:
     """The empty-string state is dedup'd just like a non-empty one."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_api_encryption("kitchen", "")
     monitor.apply_api_encryption("kitchen", "")
-    cb.assert_called_once()
+    assert callbacks.calls == [("on_api_encryption_change", "kitchen", "")]
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -20,6 +20,8 @@ from esphome_device_builder.controllers._device_state_monitor import DeviceState
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, DeviceState, EventType
 
+from .conftest import make_state_monitor_with_callbacks
+
 
 def _device(**overrides: Any) -> Device:
     base: dict[str, Any] = {
@@ -35,27 +37,6 @@ def _device(**overrides: Any) -> Device:
     return Device(**base)
 
 
-def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
-    # Mirror production: the controller's callback writes the value
-    # back onto the device. The monitor's dedupe is keyed off the
-    # device's ``deployed_config_hash`` so without the side-effect
-    # every repeat call would re-fire.
-    def _flip(name: str, config_hash: str) -> None:
-        for d in devices:
-            if d.name == name:
-                d.deployed_config_hash = config_hash
-
-    on_config_hash = MagicMock(side_effect=_flip)
-    monitor = DeviceStateMonitor(
-        get_devices=lambda: devices,
-        on_state_change=MagicMock(),
-        on_ip_change=MagicMock(),
-        on_version_change=MagicMock(),
-        on_config_hash_change=on_config_hash,
-    )
-    return monitor, on_config_hash
-
-
 # ----------------------------------------------------------------------
 # DeviceStateMonitor.apply_config_hash
 # ----------------------------------------------------------------------
@@ -63,9 +44,9 @@ def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
 
 def test_apply_config_hash_first_observation_fires_callback() -> None:
     """A hash we haven't seen before reaches the controller."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_config_hash("kitchen", "1a2b3c4d") is True
-    cb.assert_called_once_with("kitchen", "1a2b3c4d")
+    assert callbacks.calls == [("on_config_hash_change", "kitchen", "1a2b3c4d")]
 
 
 def test_apply_config_hash_dedupes_same_value() -> None:
@@ -74,28 +55,28 @@ def test_apply_config_hash_dedupes_same_value() -> None:
     mDNS announcements are noisy and the hash only changes when the
     user re-flashes; deduping keeps the DEVICE_UPDATED stream quiet.
     """
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_config_hash("kitchen", "1a2b3c4d")
     monitor.apply_config_hash("kitchen", "1a2b3c4d")
-    cb.assert_called_once()
+    assert callbacks.calls == [("on_config_hash_change", "kitchen", "1a2b3c4d")]
 
 
 def test_apply_config_hash_fires_on_change() -> None:
     """A different hash than the last observation fires the callback again."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_config_hash("kitchen", "1a2b3c4d")
     monitor.apply_config_hash("kitchen", "deadbeef")
-    assert cb.call_args_list == [
-        (("kitchen", "1a2b3c4d"),),
-        (("kitchen", "deadbeef"),),
+    assert callbacks.calls == [
+        ("on_config_hash_change", "kitchen", "1a2b3c4d"),
+        ("on_config_hash_change", "kitchen", "deadbeef"),
     ]
 
 
 def test_apply_config_hash_ignores_empty_string() -> None:
     """Pre-#16145 firmware doesn't broadcast the TXT → empty-string is a no-op."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_config_hash("kitchen", "") is False
-    cb.assert_not_called()
+    assert callbacks.calls == []
 
 
 def test_apply_config_hash_refires_after_device_rebuild() -> None:
@@ -114,7 +95,7 @@ def test_apply_config_hash_refires_after_device_rebuild() -> None:
     again, and the device repopulates.
     """
     devices = [_device()]
-    monitor, cb = _monitor(devices)
+    monitor, callbacks = make_state_monitor_with_callbacks(devices)
 
     # First observation: device populated.
     monitor.apply_config_hash("kitchen", "1a2b3c4d")
@@ -129,14 +110,17 @@ def test_apply_config_hash_refires_after_device_rebuild() -> None:
     # the prior observation; the rebuilt device needs the value back.
     monitor.apply_config_hash("kitchen", "1a2b3c4d")
     assert devices[0].deployed_config_hash == "1a2b3c4d"
-    assert cb.call_count == 2
+    assert [c for c in callbacks.calls if c[0] == "on_config_hash_change"] == [
+        ("on_config_hash_change", "kitchen", "1a2b3c4d"),
+        ("on_config_hash_change", "kitchen", "1a2b3c4d"),
+    ]
 
 
 def test_apply_config_hash_ignores_unknown_device() -> None:
     """Stray mDNS announcements for devices not in the catalog are dropped."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_config_hash("ghost", "1a2b3c4d") is False
-    cb.assert_not_called()
+    assert callbacks.calls == []
 
 
 def test_apply_config_hash_no_callback_silently_drops() -> None:

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -20,6 +20,8 @@ from esphome_device_builder.controllers._device_state_monitor import DeviceState
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, DeviceState, EventType
 
+from .conftest import make_state_monitor_with_callbacks
+
 
 def _device(**overrides: Any) -> Device:
     base: dict[str, Any] = {
@@ -35,27 +37,6 @@ def _device(**overrides: Any) -> Device:
     return Device(**base)
 
 
-def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
-    # Mirror production: the controller's callback writes the value
-    # back onto the device. The monitor's dedupe is keyed off the
-    # device's ``deployed_version`` so without the side-effect every
-    # repeat call would re-fire (the dedupe would never observe the
-    # post-callback state).
-    def _flip(name: str, version: str) -> None:
-        for d in devices:
-            if d.name == name:
-                d.deployed_version = version
-
-    on_version = MagicMock(side_effect=_flip)
-    monitor = DeviceStateMonitor(
-        get_devices=lambda: devices,
-        on_state_change=MagicMock(),
-        on_ip_change=MagicMock(),
-        on_version_change=on_version,
-    )
-    return monitor, on_version
-
-
 # ----------------------------------------------------------------------
 # DeviceStateMonitor.apply_version
 # ----------------------------------------------------------------------
@@ -63,9 +44,9 @@ def _monitor(devices: list[Device]) -> tuple[DeviceStateMonitor, MagicMock]:
 
 def test_apply_version_first_observation_fires_callback() -> None:
     """A version we haven't seen before reaches the controller."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_version("kitchen", "2026.5.0") is True
-    cb.assert_called_once_with("kitchen", "2026.5.0")
+    assert callbacks.calls == [("on_version_change", "kitchen", "2026.5.0")]
 
 
 def test_apply_version_dedupes_same_value() -> None:
@@ -75,35 +56,35 @@ def test_apply_version_dedupes_same_value() -> None:
     deduplication is the difference between a quiet ``DEVICE_UPDATED``
     stream and the UI thrashing.
     """
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_version("kitchen", "2026.5.0")
     monitor.apply_version("kitchen", "2026.5.0")
-    cb.assert_called_once()
+    assert callbacks.calls == [("on_version_change", "kitchen", "2026.5.0")]
 
 
 def test_apply_version_fires_on_change() -> None:
     """A different version than the last observation fires the callback again."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_version("kitchen", "2026.5.0")
     monitor.apply_version("kitchen", "2026.6.0")
-    assert cb.call_args_list == [
-        (("kitchen", "2026.5.0"),),
-        (("kitchen", "2026.6.0"),),
+    assert callbacks.calls == [
+        ("on_version_change", "kitchen", "2026.5.0"),
+        ("on_version_change", "kitchen", "2026.6.0"),
     ]
 
 
 def test_apply_version_ignores_empty_string() -> None:
     """Devices that don't announce a version → no-op (don't fire empty-string callbacks)."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_version("kitchen", "") is False
-    cb.assert_not_called()
+    assert callbacks.calls == []
 
 
 def test_apply_version_ignores_unknown_device() -> None:
     """Stray mDNS announcements for devices not in the catalog are dropped."""
-    monitor, cb = _monitor([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_version("ghost", "2026.5.0") is False
-    cb.assert_not_called()
+    assert callbacks.calls == []
 
 
 def test_apply_version_no_callback_silently_drops() -> None:


### PR DESCRIPTION
## Summary
- Three mDNS test files (`test_mdns_version.py`, `test_mdns_config_hash.py`, `test_mdns_api_encryption.py`) each carried a near-identical `_monitor()` helper that wired `MagicMock(side_effect=_flip)` callbacks. The `_flip` side-effect mirrored what the production `DevicesController` callback does — without it, the monitor's dedupe (keyed off the device's own field) would never observe the post-callback state and every repeat call would re-fire.
- Lift the helper into `tests/conftest.py`:
  - `RecordingMonitorCallbacks`: typed recorder for the `on_state_change` / `on_ip_change` / `on_version_change` / `on_config_hash_change` / `on_api_encryption_change` callback surface. Each invocation lands in `self.calls` as `(callback_name, *args)`; the matching device's field is updated to mirror production semantics.
  - `make_state_monitor_with_callbacks(devices)`: builds a `DeviceStateMonitor` with the recorder wired into all five callback slots, returns `(monitor, callbacks)`.
- Tests now assert via `callbacks.calls == [...]` instead of `MagicMock.assert_called_*`. Type-resistant: a typo on the recorder raises `AttributeError` instead of silently passing.
- The next round of mDNS files (`test_mdns_name_match.py`, `test_state_monitor_lifecycle.py`, `test_probe_device.py`, `test_non_api_mdns_resolve.py`) can adopt the same helper in follow-ups.

## Test plan
- [x] `uv run pytest tests/test_mdns_version.py tests/test_mdns_config_hash.py tests/test_mdns_api_encryption.py`
- [x] `uv run pytest tests/ --ignore=tests/benchmarks` (1226 pass, 3 skip)