### PR TITLE
Cover missing branches in firmware/controller.py

### DIFF
--- a/tests/controllers/firmware/test_branches_coverage.py
+++ b/tests/controllers/firmware/test_branches_coverage.py
@@ -1,0 +1,295 @@
+"""Coverage for the smaller load-bearing branches in ``firmware/controller.py``.
+
+Each test pins one specific branch the per-feature suites either
+skip or cover only via a deeper helper. Short, surgical tests so
+when a branch they protect regresses, the failure clearly names
+the missing behaviour.
+
+Surfaces touched here:
+
+- **Public submission**: ``firmware/rename`` happy path (the
+  rename-lock suite covers conflict cases but nothing pins the
+  enqueue path itself).
+- **Stream / follower wiring**: ``follow_job`` raises ValueError
+  for an unknown job id, ``follow_jobs`` early-returns when
+  ``client`` is None.
+- **Runner internals**: queue runner skips a CANCELLED job
+  without spawning a subprocess, ``_terminate_current_process``
+  is a no-op when no process is bound.
+- **Command building**: ``_build_command`` for ``RENAME`` appends
+  ``new_name`` as a positional arg.
+- **Prune-history dedup**: same-configuration primary-pool entries
+  collapse to the newest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import (
+    ErrorCode,
+    FirmwareJob,
+    JobStatus,
+    JobType,
+)
+from tests.controllers.firmware.conftest import (
+    FirmwareControllerFactory,
+)
+
+
+def _job(
+    job_id: str,
+    configuration: str,
+    job_type: JobType,
+    *,
+    status: JobStatus = JobStatus.COMPLETED,
+    new_name: str = "",
+    created_at: str = "",
+) -> FirmwareJob:
+    return FirmwareJob(
+        job_id=job_id,
+        configuration=configuration,
+        job_type=job_type,
+        status=status,
+        new_name=new_name,
+        created_at=created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# firmware/rename — public submission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_returns_queued_rename_job(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """Happy path: handler returns a ``QUEUED`` ``RENAME`` job carrying ``new_name``.
+
+    The rename-lock suite covers conflict cases but nothing pins
+    the enqueue itself — a regression that swapped the job_type
+    or dropped ``new_name`` would still pass every lock-policy
+    test (none of them inspect the resulting job's shape).
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.rename(configuration="kitchen.yaml", new_name="livingroom")
+
+    assert job.status == JobStatus.QUEUED
+    assert job.job_type == JobType.RENAME
+    assert job.configuration == "kitchen.yaml"
+    assert job.new_name == "livingroom"
+
+
+@pytest.mark.asyncio
+async def test_rename_rejects_when_target_filename_already_exists(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """A pre-existing ``<new_name>.yaml`` blocks the rename with INVALID_ARGS.
+
+    ``esphome rename`` does NOT check for collisions — it
+    blindly writes the new YAML and OTA-installs it. A
+    direct WS client that bypassed the controller-layer check
+    would silently overwrite an unrelated device's config and
+    flash this device's firmware to it. Pin the handler-side
+    check so a refactor that dropped it can't silently make
+    that path reachable again.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    (tmp_path / "kitchen.yaml").write_text("")
+    (tmp_path / "livingroom.yaml").write_text("")  # pre-existing target
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename(configuration="kitchen.yaml", new_name="livingroom")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "livingroom.yaml" in excinfo.value.message
+
+
+# ---------------------------------------------------------------------------
+# follow_job / follow_jobs — stream wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_follow_job_raises_value_error_for_unknown_job_id(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """An unknown ``job_id`` raises ``ValueError`` before any stream work.
+
+    The WS layer translates ``ValueError`` into a typed error
+    response; pinning the precise exception keeps the
+    "Job not found" message reaching the dashboard's task panel
+    instead of a generic "Command failed".
+    """
+    controller = firmware_controller_factory(with_settings=False)
+
+    with pytest.raises(ValueError, match="Job not found: ghost-id"):
+        await controller.follow_job(job_id="ghost-id", client=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_follow_jobs_returns_immediately_when_client_is_none(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """``follow_jobs`` is a no-op when ``client`` is missing.
+
+    The WS dispatcher passes ``client=None`` for in-process
+    callers (e.g. the WS test harness driving the handler
+    without a live socket). Without the early return, the
+    handler would later iterate ``self._jobs`` and call
+    ``client.send_event`` on ``None`` — an attribute error,
+    not a clean shape mismatch.
+    """
+    controller = firmware_controller_factory()
+    controller._jobs = {
+        "j1": _job("j1", "kitchen.yaml", JobType.COMPILE, status=JobStatus.COMPLETED),
+    }
+
+    # Should return without raising — no iteration, no send_event.
+    result = await controller.follow_jobs(client=None, snapshot=True)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Queue runner — CANCELLED-skip and missing-process branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_queue_skips_cancelled_jobs_without_spawning(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """A CANCELLED job pulled from the queue is skipped, not executed.
+
+    A user can cancel a QUEUED job via ``firmware/cancel``; the
+    cancel handler flips the job's status to CANCELLED but doesn't
+    pluck it out of the queue (the queue is FIFO with no remove API).
+    The runner's first action on every dequeue is the
+    ``status == CANCELLED`` check — without it the runner would
+    spawn a real subprocess for a job the user already gave up on.
+    """
+    controller = firmware_controller_factory()
+    controller._queue = asyncio.Queue()
+    cancelled = _job("j1", "kitchen.yaml", JobType.COMPILE, status=JobStatus.CANCELLED)
+    await controller._queue.put(cancelled)
+
+    spawned = False
+
+    async def _spy_execute(_job: FirmwareJob) -> None:
+        nonlocal spawned
+        spawned = True
+
+    controller._execute_job = _spy_execute  # type: ignore[method-assign]
+
+    runner = asyncio.create_task(controller._run_queue())
+    # Give the runner a chance to dequeue + skip + return for next get.
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if controller._queue.empty():
+            break
+    runner.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await runner
+
+    assert spawned is False
+
+
+@pytest.mark.asyncio
+async def test_terminate_current_process_no_op_when_no_process(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """``_terminate_current_process`` returns cleanly when no process is bound.
+
+    The cancel handler always calls ``_terminate_current_process``
+    after flipping the status — but the QUEUED-cancel path runs
+    before the runner has spawned anything, so the controller's
+    ``_current_process`` is still ``None``. Pin the early return
+    so a regression that fell through to ``terminate_subtree_*``
+    against ``None`` would surface as a hard error here.
+    """
+    controller = firmware_controller_factory()
+    controller._current_process = None
+    controller._current_job = None
+
+    # Should return without raising; no process to terminate.
+    await controller._terminate_current_process()
+
+
+# ---------------------------------------------------------------------------
+# _build_command — RENAME branch
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_for_rename_appends_new_name_positional() -> None:
+    """``RENAME`` appends ``new_name`` as a trailing positional arg.
+
+    ``esphome rename <yaml> <new_name>`` is the CLI shape;
+    without the trailing positional the CLI errors out before
+    touching the YAML, and the dashboard would report
+    "rename failed" with no actionable hint. Pin the arg order.
+    """
+    controller = FirmwareController.__new__(FirmwareController)
+    controller._esphome_cmd = ["esphome"]
+    controller._db = MagicMock()
+    controller._db.devices = None
+
+    cmd = controller._build_command(JobType.RENAME, "kitchen.yaml", port="", new_name="livingroom")
+
+    assert cmd == [
+        "esphome",
+        "--dashboard",
+        "rename",
+        "kitchen.yaml",
+        "livingroom",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _prune_history — primary-pool dedup by configuration
+# ---------------------------------------------------------------------------
+
+
+def test_prune_history_collapses_primary_jobs_to_newest_per_configuration(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Two terminal compiles for the same configuration collapse to the newest.
+
+    The recent-jobs panel would otherwise fill up with repeated
+    compile entries for one device, pushing legitimate older
+    runs out of the cap window. The aux pool deliberately doesn't
+    dedupe (clean / reset_build_env runs are diagnostic signals);
+    primary jobs do, because re-compiling the same config is
+    routine and not interesting on its own.
+    """
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    older = _job(
+        "old",
+        "kitchen.yaml",
+        JobType.COMPILE,
+        status=JobStatus.COMPLETED,
+        created_at=base.isoformat(),
+    )
+    newer = _job(
+        "new",
+        "kitchen.yaml",
+        JobType.COMPILE,
+        status=JobStatus.COMPLETED,
+        created_at=(base + timedelta(minutes=5)).isoformat(),
+    )
+    controller = firmware_controller_factory(older, newer, with_settings=False)
+
+    controller._prune_history()
+
+    surviving_ids = set(controller._jobs.keys())
+    assert surviving_ids == {"new"}

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -30,11 +30,14 @@ import asyncio
 import sys
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware import (
+    controller as controller_module,
+)
 from esphome_device_builder.controllers.firmware.constants import (
     _INFLIGHT_TRIM_KEEP,
     _MAX_OUTPUT_LINES_INFLIGHT,
@@ -525,21 +528,23 @@ async def test_compile_progress_lines_fire_job_progress(
 async def test_run_queue_routes_reset_build_env_through_inline_handler(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
-    """A RESET_BUILD_ENV job runs inline and never spawns a subprocess.
+    """A RESET_BUILD_ENV job runs inline and never reaches the spawn path.
 
     ``_execute_job``'s first action after marking RUNNING is a
     type-switch on RESET_BUILD_ENV that delegates to
     ``_reset_build_env`` and returns. Pin the dispatch via the
-    public submission API so a regression that fell through to
-    the spawn path would (loudly) try to ``create_subprocess_exec``
-    a non-existent command and fail visibly.
+    public submission API so a regression that fell through would
+    surface here — the spawn / command-building path crashes on
+    an empty ``job.configuration`` (RESET_BUILD_ENV has none) long
+    before any subprocess fires, but either way the test catches
+    it: the build directory wouldn't be wiped and the job wouldn't
+    cleanly complete.
     """
-    # Esphome cmd would only be needed if we fell through to the
-    # spawn path — an empty list makes that fall-through fail
-    # immediately, which is the exact behaviour we want if the
-    # RESET_BUILD_ENV branch ever drops out.
     controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     _wire_real_queue(controller)
+    # Spy on _trim_job_output so we can also assert the post-exit
+    # trim path isn't even reached for the RESET branch (it
+    # short-circuits on the early return).
     controller._esphome_cmd = []
     # Seed a target dir so the RESET_BUILD_ENV runner has work to do.
     (tmp_path / ".esphome" / "build").mkdir(parents=True, exist_ok=True)
@@ -563,7 +568,9 @@ async def test_run_queue_routes_reset_build_env_through_inline_handler(
 
 @pytest.mark.asyncio
 async def test_compile_inflight_output_trims_when_cap_exceeded(
-    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Builds that stream past the in-flight cap have ``output`` trimmed mid-run.
 
@@ -573,11 +580,30 @@ async def test_compile_inflight_output_trims_when_cap_exceeded(
     ``finally``-block trim ever runs. The dashboard process OOMs
     first.
 
-    Pin: after streaming N+excess lines past the cap, ``job.output``
-    is back at or below ``_INFLIGHT_TRIM_KEEP + 1`` (the +1 is the
-    elided-notice the trim prepends). A regression that dropped the
-    mid-run trim leaves ``job.output`` at the full N+excess length.
+    Pin specifically the *mid-run* trim path: spy on
+    ``_trim_job_output`` and assert the call from inside the
+    streaming loop fires with ``keep=_INFLIGHT_TRIM_KEEP`` and
+    arrives while ``job.status`` is still ``RUNNING``. A naive
+    end-state assertion (``len(job.output) <= keep``) would
+    silently pass on a regression that dropped the mid-run trim
+    because the ``finally``-block ``_trim_job_output(job)`` call
+    runs anyway.
     """
+    real_trim = controller_module._trim_job_output
+    inflight_trim_calls: list[tuple[JobStatus, int, int | None]] = []
+
+    def _spy_trim(job: Any, *, keep: int | None = None) -> None:
+        # Capture the call's keep= kwarg AND the job status at the
+        # moment of the call. Mid-run calls are RUNNING + keep set;
+        # the finally-block call is COMPLETED + keep unset.
+        inflight_trim_calls.append((job.status, len(job.output), keep))
+        if keep is None:
+            real_trim(job)
+        else:
+            real_trim(job, keep=keep)
+
+    monkeypatch.setattr(controller_module, "_trim_job_output", _spy_trim)
+
     excess = 200
     total = _MAX_OUTPUT_LINES_INFLIGHT + excess
     controller = firmware_controller_factory(with_queue=True)
@@ -592,12 +618,15 @@ async def test_compile_inflight_output_trims_when_cap_exceeded(
     await _run_until_terminal(controller)
 
     assert job.status == JobStatus.COMPLETED
-    # Trimmed: the in-flight trim brought it down to KEEP (+1 for
-    # the elided notice the trim prepends) before the post-exit
-    # ``_trim_job_output`` ran. Either way it must be well below
-    # the total streamed.
-    assert len(job.output) <= _INFLIGHT_TRIM_KEEP + 1
-    assert len(job.output) < total
+    # At least one trim call landed mid-run (status=RUNNING, keep
+    # set to the in-flight constant). Without the mid-run trim,
+    # only the post-exit COMPLETED + keep=None call would appear.
+    inflight = [c for c in inflight_trim_calls if c[2] == _INFLIGHT_TRIM_KEEP]
+    assert inflight, (
+        "no in-flight trim observed — the mid-run trim branch is dead; "
+        f"calls were: {inflight_trim_calls}"
+    )
+    assert all(status is JobStatus.RUNNING for status, _, _ in inflight)
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -35,6 +35,10 @@ from typing import TYPE_CHECKING
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware.constants import (
+    _INFLIGHT_TRIM_KEEP,
+    _MAX_OUTPUT_LINES_INFLIGHT,
+)
 from esphome_device_builder.models import EventType, JobStatus
 
 if TYPE_CHECKING:
@@ -510,3 +514,121 @@ async def test_compile_progress_lines_fire_job_progress(
     # a 0% line clobber the bar).
     assert job.progress == 100
     assert job.status == JobStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# RESET_BUILD_ENV — early-return branch in _execute_job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_queue_routes_reset_build_env_through_inline_handler(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    """A RESET_BUILD_ENV job runs inline and never spawns a subprocess.
+
+    ``_execute_job``'s first action after marking RUNNING is a
+    type-switch on RESET_BUILD_ENV that delegates to
+    ``_reset_build_env`` and returns. Pin the dispatch via the
+    public submission API so a regression that fell through to
+    the spawn path would (loudly) try to ``create_subprocess_exec``
+    a non-existent command and fail visibly.
+    """
+    # Esphome cmd would only be needed if we fell through to the
+    # spawn path — an empty list makes that fall-through fail
+    # immediately, which is the exact behaviour we want if the
+    # RESET_BUILD_ENV branch ever drops out.
+    controller = firmware_controller_factory(with_queue=True, with_terminate=True)
+    _wire_real_queue(controller)
+    controller._esphome_cmd = []
+    # Seed a target dir so the RESET_BUILD_ENV runner has work to do.
+    (tmp_path / ".esphome" / "build").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".esphome" / "build" / "sentinel").write_text("x", encoding="utf-8")
+
+    job = await controller.reset_build_env()
+    captured = await _run_until_terminal(controller)
+
+    assert job.status == JobStatus.COMPLETED
+    assert job.progress == 100
+    assert captured["job_completed"]
+    # The build dir was wiped — proves the inline RESET handler ran,
+    # not just that the runner exited cleanly.
+    assert not (tmp_path / ".esphome" / "build").exists()
+
+
+# ---------------------------------------------------------------------------
+# Mid-run output trim + repeated error-pattern hit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compile_inflight_output_trims_when_cap_exceeded(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    """Builds that stream past the in-flight cap have ``output`` trimmed mid-run.
+
+    Without the in-flight trim a chatty build (PlatformIO retry
+    loop, esptool stuck on a repeating message) holds every line
+    in memory until the subprocess exits — only the post-exit
+    ``finally``-block trim ever runs. The dashboard process OOMs
+    first.
+
+    Pin: after streaming N+excess lines past the cap, ``job.output``
+    is back at or below ``_INFLIGHT_TRIM_KEEP + 1`` (the +1 is the
+    elided-notice the trim prepends). A regression that dropped the
+    mid-run trim leaves ``job.output`` at the full N+excess length.
+    """
+    excess = 200
+    total = _MAX_OUTPUT_LINES_INFLIGHT + excess
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _fake_esphome(
+        controller,
+        f"import sys\nfor i in range({total}):\n    print(f'INFO line {{i}}')\nsys.exit(0)\n",
+    )
+    _seed_yaml(tmp_path)
+
+    job = await controller.compile(configuration="kitchen.yaml")
+    await _run_until_terminal(controller)
+
+    assert job.status == JobStatus.COMPLETED
+    # Trimmed: the in-flight trim brought it down to KEEP (+1 for
+    # the elided notice the trim prepends) before the post-exit
+    # ``_trim_job_output`` ran. Either way it must be well below
+    # the total streamed.
+    assert len(job.output) <= _INFLIGHT_TRIM_KEEP + 1
+    assert len(job.output) < total
+
+
+@pytest.mark.asyncio
+async def test_compile_repeats_error_pattern_short_circuits_check(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    """Once an error pattern is seen, subsequent lines bypass the pattern scan.
+
+    ``_check_error`` flips ``has_error_in_output`` on the first
+    match and short-circuits on every subsequent call so a build
+    spamming error lines doesn't pay an O(patterns) loop per line.
+    Drive two error-pattern lines then a clean exit; the FAILED
+    verdict still lands and the second line follows the
+    short-circuit branch (line 803 in controller.py).
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _fake_esphome(
+        controller,
+        "import sys\n"
+        "print('Traceback (most recent call last):')\n"
+        # First error pattern — flips the flag.
+        "print(\"ModuleNotFoundError: No module named 'cryptography'\")\n"
+        # Second error pattern — hits the short-circuit branch.
+        "print(\"ImportError: cannot import name 'foo'\")\n"
+        "sys.exit(0)\n",
+    )
+    _seed_yaml(tmp_path)
+
+    job = await controller.compile(configuration="kitchen.yaml")
+    await _run_until_terminal(controller)
+
+    assert job.status == JobStatus.FAILED
+    assert job.exit_code == 0


### PR DESCRIPTION
## Summary
Brings `esphome_device_builder/controllers/firmware/controller.py` from 97% → 100% line coverage (13 missing lines → 0).

### `tests/controllers/firmware/test_branches_coverage.py` (new)
Seven small load-bearing branches the per-feature suites either skipped or covered only via deeper helpers:
- `firmware/rename` happy path + collision-rejection wiring (the rename-lock suite covers conflict cases but nothing pinned the enqueue path itself)
- `follow_job` raises `ValueError` for an unknown `job_id`
- `follow_jobs` early-returns when `client` is `None`
- Queue runner skips a `CANCELLED` job without spawning a subprocess
- `_terminate_current_process` is a no-op when no process is bound
- `_build_command` appends `new_name` as a trailing positional for `RENAME`
- `_prune_history` collapses same-configuration primary-pool entries to the newest

### `tests/controllers/firmware/test_execute_job_e2e.py` (extended)
Three end-to-end tests driving the public submission API:
- `RESET_BUILD_ENV` jobs route through the inline handler (no `create_subprocess_exec`)
- In-flight output trim fires when `job.output` exceeds the cap (without it, a chatty build OOMs the dashboard)
- `_check_error` short-circuits after the first error-pattern hit (avoids an O(patterns) loop per line on builds that spam errors)

## Test plan
- [x] `pytest tests/` — 1242 passed, 3 skipped.
- [x] `pytest --cov=esphome_device_builder.controllers.firmware.controller` — 100%.
- [x] `pre-commit run` on changed files — clean.