### PR TITLE
Convert remaining mDNS test files to RecordingMonitorCallbacks

### DIFF
--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -25,6 +25,8 @@ import pytest
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.models import Device, DeviceState
 
+from .conftest import make_state_monitor_with_callbacks
+
 
 def _device(
     name: str = "kitchen",
@@ -48,6 +50,12 @@ def _make_monitor(
 ) -> tuple[DeviceStateMonitor, AsyncMock]:
     """Build a monitor with a mocked ``AsyncEsphomeZeroconf``.
 
+    Wires the production-mirroring state/IP write-back via the
+    shared :class:`RecordingMonitorCallbacks` (the recorder's
+    ``calls`` list isn't read by these tests — they assert on the
+    device's own ``state`` / ``ip`` after the side-effect runs —
+    but it's the canonical way to get the write-back for free).
+
     ``resolved`` maps a hostname to either a list of IPs (resolve
     succeeded), an empty list / ``None`` (resolve failed). The
     mock's ``async_resolve_host`` looks up the host in the dict
@@ -57,26 +65,7 @@ def _make_monitor(
     ``test_resolve_exception_does_not_propagate`` /
     ``test_multiple_devices_resolve_in_parallel``).
     """
-    captured_state: list[tuple[str, DeviceState, str]] = []
-    captured_ip: list[tuple[str, str]] = []
-
-    def _flip_state(name: str, state: DeviceState, source: str) -> None:
-        captured_state.append((name, state, source))
-        for d in devices:
-            if d.name == name:
-                d.state = state
-
-    def _flip_ip(name: str, ip: str) -> None:
-        captured_ip.append((name, ip))
-        for d in devices:
-            if d.name == name:
-                d.ip = ip
-
-    monitor = DeviceStateMonitor(
-        get_devices=lambda: devices,
-        on_state_change=_flip_state,
-        on_ip_change=_flip_ip,
-    )
+    monitor, _callbacks = make_state_monitor_with_callbacks(devices)
 
     fake_zc = MagicMock()
     resolve_map = resolved or {}

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -22,6 +22,8 @@ from esphome_device_builder.controllers._device_state_monitor import (
 )
 from esphome_device_builder.models import Device, DeviceState
 
+from .conftest import RecordingMonitorCallbacks
+
 
 def _make_monitor() -> DeviceStateMonitor:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
@@ -31,12 +33,34 @@ def _make_monitor() -> DeviceStateMonitor:
     return monitor
 
 
+def _capture_apply(
+    monitor: DeviceStateMonitor, monkeypatch: pytest.MonkeyPatch
+) -> list[tuple[str, Any]]:
+    """Swap ``_apply_service_info`` for a list-append closure and return the log.
+
+    A typed substitute for the previous ``apply = MagicMock();
+    apply.assert_called_once_with(...)`` shape. The win is on the
+    *assertion-method* side: against a ``MagicMock`` a typo'd
+    method name (``apply.assertt_called_once_with``) silently
+    passes because ``MagicMock`` spawns a fresh attribute on
+    access. Comparing the returned list with ``==`` has no
+    ``assert_*`` method to misspell — the failure mode is a clear
+    diff at the comparison instead of a vacuous green.
+    """
+    calls: list[tuple[str, Any]] = []
+
+    def _apply(name: str, info: Any) -> None:
+        calls.append((name, info))
+
+    monkeypatch.setattr(monitor, "_apply_service_info", _apply)
+    return calls
+
+
 @pytest.mark.asyncio
 async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None:
     """A cached service info applies inline; no task is spawned."""
     monitor = _make_monitor()
-    apply = MagicMock()
-    monkeypatch.setattr(monitor, "_apply_service_info", apply)
+    apply_calls = _capture_apply(monitor, monkeypatch)
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = True
@@ -47,7 +71,7 @@ async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None
 
     monitor.probe_device("kitchen")
 
-    apply.assert_called_once_with("kitchen", fake_info)
+    assert apply_calls == [("kitchen", fake_info)]
     assert not monitor._tasks
 
 
@@ -62,8 +86,7 @@ async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None
     the configured device under its NEW name.
     """
     monitor = _make_monitor()
-    apply = MagicMock()
-    monkeypatch.setattr(monitor, "_apply_service_info", apply)
+    apply_calls = _capture_apply(monitor, monkeypatch)
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = True
@@ -85,15 +108,14 @@ async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None
         ("_esphomelib._tcp.local.", "apollo-r-pro-1-eth-5938e0._esphomelib._tcp.local.")
     ]
     # …but applied under the NEW configured name.
-    apply.assert_called_once_with("my-living-room", fake_info)
+    assert apply_calls == [("my-living-room", fake_info)]
 
 
 @pytest.mark.asyncio
 async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
     """Cache miss → fire-and-forget resolve task tracked in ``_tasks``."""
     monitor = _make_monitor()
-    apply = MagicMock()
-    monkeypatch.setattr(monitor, "_apply_service_info", apply)
+    apply_calls = _capture_apply(monitor, monkeypatch)
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
@@ -109,7 +131,7 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
 
     monitor.probe_device("kitchen")
 
-    apply.assert_not_called()
+    assert apply_calls == []
     # One task was registered for tracking. Wait it out so the
     # done-callback can run and prune the set; otherwise pending
     # tasks would leak into the next test's event loop.
@@ -138,11 +160,6 @@ async def test_apply_service_info_claims_online() -> None:
     until the next ping sweep.
     """
     monitor = _make_monitor()
-    monitor._on_state_change = MagicMock()
-    monitor._on_ip_change = MagicMock()
-    monitor._on_version_change = MagicMock()
-    monitor._on_config_hash_change = MagicMock()
-    monitor._on_api_encryption_change = MagicMock()
     monitor._state_source = {}
     # ``apply()`` validates against the configured-devices catalog.
     device = Device(
@@ -154,6 +171,12 @@ async def test_apply_service_info_claims_online() -> None:
     )
     monitor._get_devices = lambda: [device]
     monitor._get_devices_by_name = lambda name: [device] if device.name == name else []
+    callbacks = RecordingMonitorCallbacks([device])
+    monitor._on_state_change = callbacks.on_state_change
+    monitor._on_ip_change = callbacks.on_ip_change
+    monitor._on_version_change = callbacks.on_version_change
+    monitor._on_config_hash_change = callbacks.on_config_hash_change
+    monitor._on_api_encryption_change = callbacks.on_api_encryption_change
 
     fake_info = MagicMock()
     fake_info.parsed_scoped_addresses.return_value = []
@@ -162,4 +185,6 @@ async def test_apply_service_info_claims_online() -> None:
 
     # ``_on_state_change`` is the bridge our owner registered for
     # state transitions; the call carries (name, state, source).
-    monitor._on_state_change.assert_called_once_with("kitchen", DeviceState.ONLINE, "mdns")
+    assert callbacks.calls_for("on_state_change") == [
+        ("on_state_change", "kitchen", DeviceState.ONLINE, "mdns")
+    ]


### PR DESCRIPTION
## Summary
Two more mDNS files brought onto the shared `RecordingMonitorCallbacks` recorder added in #249/#252 — completes the cluster after #249, #252, and #253.

- **`test_probe_device.py`** (3 top tests + 1 bottom): replace the per-test `apply = MagicMock(); monkeypatch.setattr(monitor, "_apply_service_info", apply); apply.assert_called_once_with(...)` triplet with a small `_capture_apply(monitor, monkeypatch)` helper that returns a list-append closure log. Type-resistant — a typo on the recorder name `NameError`s instead of silently passing against a fresh MagicMock attribute. The bottom test (`test_apply_service_info_claims_online`) drops its 5 MagicMock-shaped `_on_X.assert_called` assertions for `RecordingMonitorCallbacks`.
- **`test_non_api_mdns_resolve.py`**: drop the local `_flip_state` / `_flip_ip` closures + the dead `captured_state` / `captured_ip` lists they populated (no test reads them), and route through `make_state_monitor_with_callbacks`. The recorder's per-device write-back gives these tests the same production-mirror they were hand-rolling.

## Test plan
- [x] `uv run pytest tests/test_probe_device.py tests/test_non_api_mdns_resolve.py` (18 pass)