### PR TITLE
Use make_devices_controller_with_bus in mDNS controller-side tests

### DIFF
--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -18,14 +18,12 @@ Three states matter for the apply path:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, DeviceState, EventType
 
-from .conftest import make_state_monitor_with_callbacks
+from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
 
 
 def _device(**overrides: Any) -> Device:
@@ -111,21 +109,12 @@ def test_apply_api_encryption_dedupes_repeated_empty() -> None:
 async def test_on_api_encryption_change_updates_device_and_fires_event() -> None:
     """Callback writes the value onto the in-memory device + fires DEVICE_UPDATED."""
     device = _device(api_encryption_active=None)
-
-    db = MagicMock()
-    fired_events: list[tuple[EventType, dict]] = []
-    db.bus.fire.side_effect = lambda event_type, data: fired_events.append((event_type, data))
-
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
 
     assert device.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
-    assert any(et == EventType.DEVICE_UPDATED for et, _ in fired_events)
+    assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
 
 
 @pytest.mark.asyncio
@@ -139,47 +128,30 @@ async def test_on_api_encryption_change_records_empty_string() -> None:
     plaintext device).
     """
     device = _device(api_encryption_active=None)
-
-    db = MagicMock()
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_api_encryption_change("kitchen", "")
 
     assert device.api_encryption_active == ""
-    db.bus.fire.assert_called_once()
+    assert len(captured) == 1
 
 
 @pytest.mark.asyncio
 async def test_on_api_encryption_change_skips_when_same() -> None:
     """No-op when the in-memory device already has the announced value."""
     device = _device(api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256")
-
-    db = MagicMock()
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
 
-    db.bus.fire.assert_not_called()
+    assert captured == []
 
 
 @pytest.mark.asyncio
 async def test_on_api_encryption_change_unknown_device_is_noop() -> None:
     """A stray callback for a name we don't track must not raise or fire."""
-    db = MagicMock()
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = []
-    controller._scanner.get_by_name = lambda name, _d=[]: [d for d in _d if d.name == name]
+    controller, captured = make_devices_controller_with_bus([])
 
     controller._on_api_encryption_change("ghost", "anything")
 
-    db.bus.fire.assert_not_called()
+    assert captured == []

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -17,10 +17,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, DeviceState, EventType
 
-from .conftest import make_state_monitor_with_callbacks
+from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
 
 
 def _device(**overrides: Any) -> Device:
@@ -144,53 +143,33 @@ def test_apply_config_hash_no_callback_silently_drops() -> None:
 async def test_on_config_hash_change_updates_device_and_fires_event() -> None:
     """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
     device = _device(deployed_config_hash="")
-
-    db = MagicMock()
-    fired_events: list[tuple[EventType, dict]] = []
-    db.bus.fire.side_effect = lambda event_type, data: fired_events.append((event_type, data))
-
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_config_hash_change("kitchen", "1a2b3c4d")
 
     assert device.deployed_config_hash == "1a2b3c4d"
-    assert any(et == EventType.DEVICE_UPDATED for et, _ in fired_events)
+    assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
 
 
 @pytest.mark.asyncio
 async def test_on_config_hash_change_skips_when_same() -> None:
     """No-op when in-memory device already has the announced hash."""
     device = _device(deployed_config_hash="1a2b3c4d")
-
-    db = MagicMock()
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_config_hash_change("kitchen", "1a2b3c4d")
 
-    db.bus.fire.assert_not_called()
+    assert captured == []
 
 
 @pytest.mark.asyncio
 async def test_on_config_hash_change_unknown_device_is_noop() -> None:
     """A stray callback for an unknown device must not raise or fire events."""
-    db = MagicMock()
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = []
-    controller._scanner.get_by_name = lambda name, _d=[]: [d for d in _d if d.name == name]
+    controller, captured = make_devices_controller_with_bus([])
 
     controller._on_config_hash_change("ghost", "1a2b3c4d")
 
-    db.bus.fire.assert_not_called()
+    assert captured == []
 
 
 @pytest.mark.asyncio
@@ -201,13 +180,7 @@ async def test_on_config_hash_change_flips_pending_when_hashes_diverge() -> None
         deployed_config_hash="",
         has_pending_changes=False,
     )
-
-    db = MagicMock()
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, _captured = make_devices_controller_with_bus([device])
 
     controller._on_config_hash_change("kitchen", "deadbeef")
 
@@ -223,13 +196,7 @@ async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
         deployed_config_hash="",
         has_pending_changes=True,
     )
-
-    db = MagicMock()
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, _captured = make_devices_controller_with_bus([device])
 
     controller._on_config_hash_change("kitchen", "abc12345")
 
@@ -245,13 +212,7 @@ async def test_on_config_hash_change_leaves_pending_alone_without_expected_hash(
         deployed_config_hash="",
         has_pending_changes=True,
     )
-
-    db = MagicMock()
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, _captured = make_devices_controller_with_bus([device])
 
     controller._on_config_hash_change("kitchen", "deadbeef")
 

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -20,7 +20,7 @@ from esphome_device_builder.controllers._device_state_monitor import DeviceState
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, DeviceState, EventType
 
-from .conftest import make_state_monitor_with_callbacks
+from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
 
 
 def _device(**overrides: Any) -> Device:
@@ -161,28 +161,26 @@ def test_persist_storage_version_handles_missing_storage(monkeypatch: Any, tmp_p
 # ----------------------------------------------------------------------
 
 
+def _close_coro(coro: object) -> object:
+    """Close any scheduled coroutine to silence the un-awaited warning."""
+    if hasattr(coro, "close"):
+        coro.close()
+    return coro
+
+
 @pytest.mark.asyncio
 async def test_on_version_change_updates_device_and_fires_event(monkeypatch: Any) -> None:
     """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
     device = _device(deployed_version="2026.4.0")
-
-    db = MagicMock()
-
-    fired_events: list[tuple[EventType, dict]] = []
-    db.bus.fire.side_effect = lambda event_type, data: fired_events.append((event_type, data))
+    controller, captured = make_devices_controller_with_bus(
+        [device], create_background_task=_close_coro
+    )
 
     persisted: list[tuple[str, str]] = []
 
     async def _fake_persist(configuration: str, version: str) -> None:
         persisted.append((configuration, version))
 
-    db.create_background_task.side_effect = lambda coro: coro.close() or MagicMock()
-
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
     monkeypatch.setattr(controller, "_persist_storage_version_async", _fake_persist, raising=False)
 
     controller._on_version_change("kitchen", "2026.5.0")
@@ -190,41 +188,36 @@ async def test_on_version_change_updates_device_and_fires_event(monkeypatch: Any
     assert device.deployed_version == "2026.5.0"
     # current_version is "2026.5.0" too, so update_available should be False.
     assert device.update_available is False
-    assert any(et == EventType.DEVICE_UPDATED for et, _ in fired_events)
+    assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
 
 
 @pytest.mark.asyncio
-async def test_on_version_change_skips_when_same(monkeypatch: Any) -> None:
+async def test_on_version_change_skips_when_same() -> None:
     """No-op when in-memory device already has the announced version."""
     device = _device(deployed_version="2026.5.0")
+    scheduled: list[object] = []
 
-    db = MagicMock()
+    def _record(coro: object) -> object:
+        scheduled.append(coro)
+        return _close_coro(coro)
 
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record
+    )
 
     controller._on_version_change("kitchen", "2026.5.0")
 
-    db.bus.fire.assert_not_called()
-    db.create_background_task.assert_not_called()
+    assert captured == []
+    assert scheduled == []
 
 
 @pytest.mark.asyncio
 async def test_on_version_change_marks_update_available_when_behind() -> None:
     """A device on an older version than the dashboard → ``update_available`` flips on."""
     device = _device(current_version="2026.5.0", deployed_version="2026.4.0")
-
-    db = MagicMock()
-    db.create_background_task.side_effect = lambda coro: coro.close() or MagicMock()
-
-    controller = DevicesController.__new__(DevicesController)
-    controller._db = db
-    controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
-    controller._scanner.get_by_name = lambda name, _d=[device]: [d for d in _d if d.name == name]
+    controller, _captured = make_devices_controller_with_bus(
+        [device], create_background_task=_close_coro
+    )
 
     # Simulate mDNS reporting an even older version than the previous
     # deployed_version — the dashboard's installed esphome is newer


### PR DESCRIPTION
## Summary
- Three mDNS test files (`test_mdns_api_encryption.py`, `test_mdns_config_hash.py`, `test_mdns_version.py`) had a second tier of tests under `# DevicesController._on_X_change` that rebuilt the controller bypass-init shape inline (`db = MagicMock(); fired_events = []; db.bus.fire.side_effect = ...; controller = DevicesController.__new__(...); controller._scanner = MagicMock(); ...`) and asserted via `db.bus.fire.assert_not_called` / `assert_called_once`. Same shape `make_devices_controller_with_bus` (#238) already builds.
- Lift through `make_devices_controller_with_bus(devices)`. Bus assertions move to the helper's captured event list (`assert any(e.event_type == X for e in captured)` for positive, `assert captured == []` for negative). Drops three identical inline `DevicesController.__new__` + `_scanner` setup blocks per file.
- `test_mdns_version.py` keeps a small `_close_coro` helper for the `create_background_task` side-effect (one of the three tests records scheduled coroutines).

## Test plan
- [x] `uv run pytest tests/test_mdns_api_encryption.py tests/test_mdns_config_hash.py tests/test_mdns_version.py` (35 pass)