### PR TITLE
Convert last MagicMock-based test in test_state_fanout_duplicate_names.py

### DIFF
--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -16,10 +16,9 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.models import Device, DeviceState
 
-from .conftest import make_devices_controller_with_bus
+from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
 
 
 def _device(configuration: str, **overrides: Any) -> Device:
@@ -177,24 +176,9 @@ def test_apply_state_repairs_stale_sibling_when_first_match_is_in_sync() -> None
     primary = _device("kitchen.yaml")
     primary.state = DeviceState.ONLINE  # already in-sync
     sibling = _device("kitchen (1).yaml")  # state=UNKNOWN — was rebuilt
-
-    on_state = MagicMock()
-
-    def _flip(name: str, state: DeviceState, _source: str) -> None:
-        for d in (primary, sibling):
-            if d.name == name:
-                d.state = state
-
-    on_state.side_effect = _flip
-
-    monitor = DeviceStateMonitor(
-        get_devices=lambda: [primary, sibling],
-        get_devices_by_name=lambda name: [d for d in (primary, sibling) if d.name == name],
-        on_state_change=on_state,
-        on_ip_change=MagicMock(),
-    )
+    monitor, callbacks = make_state_monitor_with_callbacks([primary, sibling])
 
     assert monitor.apply("kitchen", DeviceState.ONLINE, "mdns", claim=True) is True
     assert primary.state == DeviceState.ONLINE
     assert sibling.state == DeviceState.ONLINE
-    on_state.assert_called_once_with("kitchen", DeviceState.ONLINE, "mdns")
+    assert callbacks.calls == [("on_state_change", "kitchen", DeviceState.ONLINE, "mdns")]


### PR DESCRIPTION
## Summary
The `apply_state_repairs_stale_sibling_when_first_match_is_in_sync` test still wired its `DeviceStateMonitor` with a hand-rolled `MagicMock(side_effect=_flip)` callback and asserted via `on_state.assert_called_once_with(...)`. Same shape `make_state_monitor_with_callbacks` (#249) replaces.

Lift through the helper. Drops the local `_flip` closure (the recorder mirrors the same per-device state write) and the explicit `get_devices_by_name` lambda (`DeviceStateMonitor`'s default filters `get_devices()` by name — equivalent semantics, the explicit form was just an O(1) micro-optimisation). Drops the now-unused `DeviceStateMonitor` import.

## Test plan
- [x] `uv run pytest tests/test_state_fanout_duplicate_names.py` (7 pass)