### PR TITLE
Replace _stub_regenerate MagicMock with typed list-append closure

### DIFF
--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -37,17 +37,19 @@ from esphome_device_builder.controllers.devices import DevicesController
 from .conftest import MakeControllerFactory
 
 
-def _stub_regenerate(controller: DevicesController) -> MagicMock:
-    """Replace ``_schedule_storage_regenerate`` with a sync MagicMock.
+def _stub_regenerate(controller: DevicesController) -> list[str]:
+    """Replace ``_schedule_storage_regenerate`` with a list-append closure.
 
     The production helper is fire-and-forget that internally schedules
-    a background task; a ``MagicMock`` records the call site without
-    dispatching the subprocess so tests can
-    ``assert_called_once_with(...)``.
+    a background task; capturing into a typed ``list[str]`` records
+    the call site without dispatching the subprocess. Tests assert on
+    the list directly (``regenerated == ["kitchen.yaml"]``) — no
+    ``MagicMock`` attribute to misspell on the assertion side, and a
+    typo'd reference to the helper name surfaces as ``NameError``.
     """
-    stub = MagicMock()
-    controller._schedule_storage_regenerate = stub  # type: ignore[method-assign]
-    return stub
+    regenerated: list[str] = []
+    controller._schedule_storage_regenerate = regenerated.append  # type: ignore[method-assign]
+    return regenerated
 
 
 # ---------------------------------------------------------------------------
@@ -215,13 +217,13 @@ async def test_update_config_schedules_storage_regenerate(
     regression class this prevents.
     """
     controller = make_controller(tmp_path)
-    _stub_regenerate(controller)
+    regenerated = _stub_regenerate(controller)
 
     await controller.update_config(
         configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
     )
 
-    controller._schedule_storage_regenerate.assert_called_once_with("kitchen.yaml")
+    assert regenerated == ["kitchen.yaml"]
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -198,8 +198,10 @@ def test_added_device_without_hash_triggers_regenerate(
     controller._db = MagicMock()
     controller._regenerate_failed = set()
     controller._state_monitor = RecordingStateMonitor()
-    schedule = MagicMock()
-    monkeypatch.setattr(controller, "_schedule_storage_regenerate", schedule, raising=False)
+    regenerated: list[str] = []
+    monkeypatch.setattr(
+        controller, "_schedule_storage_regenerate", regenerated.append, raising=False
+    )
     captured = capture_devices_events(controller, EventType.DEVICE_ADDED)
 
     device = Device(
@@ -211,7 +213,7 @@ def test_added_device_without_hash_triggers_regenerate(
     )
     controller._on_scan_change(ScanChange.ADDED, device)
 
-    schedule.assert_called_once_with("apollo-r-pro-1.yaml")
+    assert regenerated == ["apollo-r-pro-1.yaml"]
     # Sanity: the bus fire still happens — the trigger is additive,
     # not a replacement.
     assert [(e.event_type, e.data) for e in captured] == [
@@ -235,8 +237,10 @@ def test_added_device_fully_populated_does_not_regenerate(
     controller._db = MagicMock()
     controller._regenerate_failed = set()
     controller._state_monitor = MagicMock()
-    schedule = MagicMock()
-    monkeypatch.setattr(controller, "_schedule_storage_regenerate", schedule, raising=False)
+    regenerated: list[str] = []
+    monkeypatch.setattr(
+        controller, "_schedule_storage_regenerate", regenerated.append, raising=False
+    )
 
     device = Device(
         name="apollo",
@@ -247,7 +251,7 @@ def test_added_device_fully_populated_does_not_regenerate(
     )
     controller._on_scan_change(ScanChange.ADDED, device)
 
-    schedule.assert_not_called()
+    assert regenerated == []
 
 
 def test_board_id_from_sidecar_takes_priority_over_yaml(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary
- Three sites across two devices test files stubbed `_schedule_storage_regenerate` with a `MagicMock` and asserted via `.assert_called_once_with` / `.assert_not_called`. Same shape #254's `_capture_apply` replaced for `test_probe_device.py` — list-append closure, equality assertion, no `MagicMock` attribute to misspell.
- **`test_get_update_config.py`:** rework `_stub_regenerate` (used in 9 tests as a "just stub the method" helper) to return a `list[str]` log instead of a `MagicMock`. Only one test (`test_update_config_schedules_storage_regenerate`) actually asserts on the call — moves to `assert regenerated == ["kitchen.yaml"]`.
- **`test_metadata_resolver.py`:** two sites, inline list-append closure pattern (no shared helper since these are `__new__`-bypass tests not using the `make_controller` factory).

## Test plan
- [x] `uv run pytest tests/controllers/devices/test_get_update_config.py tests/controllers/devices/test_metadata_resolver.py` (17 pass)