### PR TITLE
Gitignore coverage artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ configs/
 /__pycache__
 *.lock
 /.claude
+
+# Coverage artefacts (left behind by ``uv run pytest --cov``)
+.coverage
+.coverage.*
+htmlcov/


### PR DESCRIPTION
## Summary

``uv run pytest --cov`` leaves a ``.coverage`` SQLite file (plus optional ``.coverage.*`` parallel-mode shards and ``htmlcov/`` output) in the working tree. Untracked, but easy to ``git add -A`` accidentally — I did exactly that twice while iterating on PR #268.

Adding the standard coverage.py artefact patterns to ``.gitignore`` keeps them out of every contributor's ``git status``.

## Test plan
No code change — pure gitignore addition. ``git status`` after a ``uv run pytest --cov`` invocation now shows a clean working tree.