### PR TITLE
Add FLOAT_WITH_UNIT type for unit-coerced cv.* validators

### DIFF
--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -646,11 +646,12 @@ def _load_unit_options(raw: Any) -> list[str] | None:
     ``None`` for non-FLOAT_WITH_UNIT entries (the catalog omits the
     field entirely on those). Non-list / empty values fold back to
     ``None`` so a malformed catalog entry doesn't reach the frontend
-    as a half-populated picker.
+    as a half-populated picker — same shape as ``_load_options``.
     """
     if not isinstance(raw, list) or not raw:
         return None
-    return [str(item) for item in raw if isinstance(item, str)]
+    out = [str(item) for item in raw if isinstance(item, str)]
+    return out or None
 
 
 def _load_options(raw: Any) -> list[ConfigValueOption] | None:

--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -593,6 +593,7 @@ def _materialise_entry(entry: ConfigEntry, target_platform: str | None) -> Confi
         options=entry.options,
         allow_custom_value=entry.allow_custom_value,
         range=entry.range,
+        unit_options=entry.unit_options,
         multi_value=entry.multi_value,
         templatable=entry.templatable,
         depends_on=entry.depends_on,
@@ -637,6 +638,19 @@ def _load_pin_features(raw: Any) -> list[PinFeature]:
         if feat is not None:
             out.append(feat)
     return out
+
+
+def _load_unit_options(raw: Any) -> list[str] | None:
+    """Normalise the JSON ``unit_options`` field into a list of strings.
+
+    ``None`` for non-FLOAT_WITH_UNIT entries (the catalog omits the
+    field entirely on those). Non-list / empty values fold back to
+    ``None`` so a malformed catalog entry doesn't reach the frontend
+    as a half-populated picker.
+    """
+    if not isinstance(raw, list) or not raw:
+        return None
+    return [str(item) for item in raw if isinstance(item, str)]
 
 
 def _load_options(raw: Any) -> list[ConfigValueOption] | None:
@@ -684,6 +698,7 @@ def _load_config_entry(data: dict) -> ConfigEntry:
         options=_load_options(data.get("options")),
         allow_custom_value=bool(data.get("allow_custom_value", False)),
         range=range_val,
+        unit_options=_load_unit_options(data.get("unit_options")),
         multi_value=bool(data.get("multi_value", False)),
         templatable=bool(data.get("templatable", False)),
         depends_on=data.get("depends_on"),

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -169,6 +169,17 @@ class ConfigEntryType(StrEnum):
     PIN = "pin"
     # Duration like "30s", "5min" — frontend renders a value+unit input
     TIME_PERIOD = "time_period"
+    # Numeric value carrying a unit: frequency ("50kHz"), data size
+    # ("500KB"), framerate ("10 fps"), voltage ("3.3V"), distance
+    # ("2m"), temperature ("4°C"), etc. ESPHome's coercer multiplies
+    # by the unit at compile time, but the YAML shape the user types
+    # is a string — so the frontend renders a number input plus a
+    # unit picker, round-trips the value as ``"<value><unit>"``, and
+    # validates the numeric portion against ``range``. Unit choices
+    # come from ``unit_options`` on the entry. ``TIME_PERIOD`` is
+    # kept separate because its grammar (``1h30s``) and unit set are
+    # richer; this type is for the simpler single-unit measurements.
+    FLOAT_WITH_UNIT = "float_with_unit"
     # Material Design icon picker (mdi:foo)
     ICON = "icon"
     # Component ID reference — links to another component instance
@@ -283,6 +294,15 @@ class ConfigEntry(DataClassORJSONMixin):
 
     # Min/max bounds for INTEGER / FLOAT entries. None = unbounded.
     range: tuple[int | float, int | float] | None = None
+
+    # Unit choices for ``FLOAT_WITH_UNIT`` entries. The frontend
+    # renders a unit picker populated from this list; each option's
+    # string is what the YAML serialization appends after the
+    # numeric value (e.g. ``["Hz", "kHz", "MHz", "GHz"]`` for
+    # ``cv.frequency``). The first entry is the canonical unit —
+    # range bounds and any user-typed bare number default to it.
+    # None for non-FLOAT_WITH_UNIT entries.
+    unit_options: list[str] | None = None
 
     # When True the field accepts a list of values rather than a single
     # value (e.g. multiple SSIDs, multiple radar targets). Frontend

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -43,7 +43,7 @@ from dataclasses import dataclass, field
 from functools import cache
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -465,6 +465,8 @@ def main() -> int:
         sum(1 for c in catalog if c.get("config_entries")),
     )
 
+    _audit_catalog_for_unit_mismatches(catalog)
+
     payload = {
         "esphome_schema_version": version,
         "components": [_strip_defaults(c) for c in catalog],
@@ -569,8 +571,10 @@ def load_index(schema_dir: Path) -> SchemaIndex:
 
     # 2. Each <domain>.json — domain.components map. Key under both the
     # bare stem and the qualified ``<domain>.<stem>`` form so lookups
-    # work regardless of which the caller has on hand.
-    for domain in _PLATFORM_DOMAINS:
+    # work regardless of which the caller has on hand. Sorted so
+    # ``setdefault`` keeps the same domain's metadata on every run
+    # when two domains describe the same stem.
+    for domain in sorted(_PLATFORM_DOMAINS):
         domain_file = schema_dir / f"{domain}.json"
         if not domain_file.exists():
             continue
@@ -2118,17 +2122,122 @@ def introspect_component(component_id: str) -> dict[str, Any]:
         return {}
     if manifest is None:
         return {}
+    # ``component_id`` for the platform-style entries the catalog
+    # passes us is a bare stem (``mcp3008``) — domain stripping
+    # happens at the caller. The bare manifest's ``config_schema``
+    # is the parent component's, which doesn't carry the platform-
+    # specific fields (``reference_voltage``, etc.). Walk the
+    # platform manifests too so unit-coerced validators on those
+    # fields get refined like the bus-component ones.
+    platform_manifests = _enumerate_platform_manifests(loader, component_id)
 
     raw_auto_load = manifest.auto_load
     auto_load: list[str] = list(raw_auto_load) if isinstance(raw_auto_load, list) else []
+
+    refined_types = _collect_refined_types(manifest)
+    # Merge platform-manifest refinements on top — the platform
+    # schema's reference_voltage etc. don't appear on the parent
+    # component manifest. Paths come back keyed by entry name so
+    # they slot into the same dict the catalog walk consumes.
+    for platform_manifest in platform_manifests:
+        for path, refined in _collect_refined_types(platform_manifest).items():
+            refined_types.setdefault(path, refined)
 
     return {
         "multi_conf": bool(getattr(manifest, "multi_conf", False)),
         "is_target_platform": bool(getattr(manifest, "is_target_platform", False)),
         "platform_defaults": _collect_platform_defaults(manifest),
-        "refined_types": _collect_refined_types(manifest),
+        "refined_types": refined_types,
         "auto_load": auto_load,
     }
+
+
+def _audit_catalog_for_unit_mismatches(catalog: list[dict]) -> None:
+    """Warn on float/integer entries whose ``default_value`` doesn't parse.
+
+    Runs after the catalog is built. Catches the silent-bug class
+    that prompted the ``FLOAT_WITH_UNIT`` work in the first place:
+    a ``cv.<unit_coerced>`` validator the live-introspection walker
+    didn't recognise (because ESPHome added a new one upstream, or
+    the validator was wrapped in a way ``classify`` can't see
+    through). The schema-bundle types these entries ``"float"`` /
+    ``"integer"`` based on their post-coerce runtime, but their
+    ``default_value`` is a unit-suffixed string the frontend's
+    number input won't accept.
+
+    Surfacing as a sync-time WARNING gives us actionable telemetry
+    to add the validator to ``_FLOAT_WITH_UNIT_VALIDATORS`` (or
+    ``_UNIT_FALLBACKS``) before users hit the silent-Add-button bug.
+    """
+    mismatches: list[tuple[str, str, str]] = []
+    for component in catalog:
+        for entry in _walk_entries(component.get("config_entries") or []):
+            if entry.get("type") not in ("float", "integer"):
+                continue
+            default = entry.get("default_value")
+            if not isinstance(default, str):
+                continue
+            try:
+                float(default)
+            except ValueError:
+                mismatches.append(
+                    (component["id"], entry["key"], default),
+                )
+    if not mismatches:
+        return
+    _LOGGER.warning(
+        "Catalog audit: %d float/integer entries have non-numeric string "
+        "defaults — likely a unit-coerced cv.* validator the introspection "
+        "walker didn't recognise. The frontend's number input will reject "
+        "these defaults as NaN. Add the validator to "
+        "_FLOAT_WITH_UNIT_VALIDATORS (or _UNIT_FALLBACKS for hand-rolled "
+        "ones) in script/sync_components.py.",
+        len(mismatches),
+    )
+    for component_id, key, default in mismatches:
+        _LOGGER.warning("  %s.%s = %r", component_id, key, default)
+
+
+def _walk_entries(entries: list[dict]) -> Iterable[dict]:
+    """Yield every entry in *entries*, recursing into NESTED groups."""
+    for entry in entries:
+        yield entry
+        if entry.get("type") == "nested":
+            inner = entry.get("config_entries") or []
+            yield from _walk_entries(inner)
+
+
+def _enumerate_platform_manifests(loader: Any, stem: str) -> list[Any]:
+    """Return platform-specific manifests for *stem*.
+
+    A multi-platform component (e.g. ``mcp3008`` ships a sensor and
+    an output) keeps its platform-specific schemas in
+    ``esphome.components.<stem>.<domain>``. ``loader.get_platform``
+    fetches each one; missing combinations return ``None`` and we
+    skip them. Best-effort — exceptions are swallowed so one bad
+    platform manifest can't tank the whole sync.
+
+    Iterates ``_PLATFORM_DOMAINS`` (the same set the catalog walk
+    already uses for schema-keyed platform entries) so adding a
+    domain in one place automatically covers the introspection
+    walk too — no parallel list to keep in sync. Sorted so the
+    catalog output is deterministic across runs — frozenset
+    iteration is hash-randomised per process and would otherwise
+    flip refinement results between syncs when two platform
+    manifests refine the same path differently (the
+    ``setdefault`` keep-first downstream picks whichever domain
+    came up first).
+    """
+    out: list[Any] = []
+    for domain in sorted(_PLATFORM_DOMAINS):
+        try:
+            platform_manifest = loader.get_platform(domain, stem)
+        except Exception:  # noqa: S112 — best-effort: missing platform combos are normal
+            continue
+        if platform_manifest is None:
+            continue
+        out.append(platform_manifest)
+    return out
 
 
 def _get_esphome_loader() -> Any:
@@ -2303,13 +2412,158 @@ def _collect_platform_defaults(manifest: Any) -> dict[tuple[str, ...], dict[str,
     return out
 
 
-def _collect_refined_types(manifest: Any) -> dict[tuple[str, ...], str]:  # noqa: PLR0915
+class RefinedType(NamedTuple):
+    """Type recovered from a runtime validator, with type-specific extras.
+
+    ``unit_options`` is populated only for ``float_with_unit`` entries —
+    the unit picker the frontend renders alongside the numeric input.
+    Other types ignore it.
+    """
+
+    type: str
+    unit_options: list[str] | None = None
+
+
+# ``cv.*`` validators built on ``cv.float_with_unit``. Their unit
+# choices come from the validator's compiled regex at runtime —
+# never a hand-maintained list — so the catalog stays in sync with
+# ESPHome without anyone having to remember to update us.
+#
+# Common metric prefixes the frontend's unit picker offers when the
+# validator allows them. Pulled from ``cv.METRIC_SUFFIXES`` at
+# runtime; this is the curated subset most ESPHome configs use (the
+# full set includes attobytes and yottabytes which are noise).
+_COMMON_METRIC_PREFIXES = ["", "m", "k", "M", "G"]
+
+# Names of the ``cv.*`` validators we know are built on
+# ``cv.float_with_unit``. Each comes through the live-introspection
+# walker via ``getattr(cv, name)`` so the catalog tracks ESPHome's
+# actual surface — adding a validator here only matters when ESPHome
+# adds one upstream. ``cv.time_period`` is intentionally absent: its
+# grammar (``1h30s``) and unit set are richer than the
+# ``float_with_unit`` widget can express, so it keeps its own
+# ``time_period`` type.
+_FLOAT_WITH_UNIT_VALIDATORS = (
+    "frequency",
+    "data_size",
+    "framerate",
+    "voltage",
+    "distance",
+    "temperature",
+    "temperature_delta",
+)
+
+# Validators that accept METRIC prefixes on their base unit. Order
+# matters: the first entry's compiled value is the canonical unit
+# the picker defaults to.
+_METRIC_PREFIX_VALIDATORS = frozenset({"frequency", "voltage", "data_size", "distance"})
+# Validators whose suffix is a fixed list rather than
+# metric-prefix-able (e.g. temperature has only °C / °F / K, not
+# m°C). The compiled regex's alternation captures the full set.
+_FIXED_UNIT_VALIDATORS = frozenset({"framerate", "temperature", "temperature_delta"})
+
+# Fallback unit lists for validators we can't introspect. Kept as
+# small as possible — only validators that fail
+# ``_extract_validator_units`` need an entry here. ``cv.validate_bytes``
+# uses an inline regex inside the function body (not a closure
+# pattern); ``cv.temperature`` / ``cv.temperature_delta`` are hand-
+# rolled functions that compose multiple ``float_with_unit`` sub-
+# validators sequentially. The unit set for these is stable across
+# ESPHome releases — they're physical-unit definitions — so the
+# brittleness cost is low. If ESPHome ever changes them, the
+# catalog sync produces stale options but the user-visible result
+# is just a missing or extra item in the unit picker.
+_UNIT_FALLBACKS: dict[str, list[str]] = {
+    "data_size": ["B", "kB", "MB", "GB"],
+    "temperature": ["°C", "°F", "K"],
+    "temperature_delta": ["°C", "°F", "K"],
+}
+
+
+def _extract_validator_units(validator: Any) -> list[str] | None:  # noqa: PLR0911
+    """Pull the unit option list out of a ``cv.float_with_unit`` validator.
+
+    Inspects the closure cells produced by ``float_with_unit``: a
+    compiled ``re.Pattern`` whose final optional group is the base-unit
+    alternation. Combined with ``cv.METRIC_SUFFIXES`` (for prefix-able
+    validators) we recover the full picker list — no hand-maintained
+    mapping that goes stale on the next ESPHome release.
+    """
+    try:
+        from esphome import config_validation as cv
+    except Exception:
+        return None
+    closure = getattr(validator, "__closure__", None) or ()
+    pattern = None
+    quantity = None
+    for cell in closure:
+        contents = cell.cell_contents
+        if isinstance(contents, re.Pattern):
+            pattern = contents
+        elif isinstance(contents, str):
+            quantity = contents
+    if pattern is None:
+        return None
+    # The validator's regex ends with a final group capturing the
+    # base unit(s) — usually ``(Hz|HZ|hz)?`` for ``cv.frequency``
+    # but sometimes ``(m)$`` (no ``?``) for ``cv.distance``. Match
+    # the last parenthesized group anchored to ``$``; this avoids
+    # false-matching earlier ``(\w*?)`` capture groups in the
+    # mantissa-and-prefix prefix.
+    match = re.search(r"\(([^)]+)\)\??\$", pattern.pattern)
+    if not match:
+        return None
+    raw_alternatives = [alt for alt in match.group(1).split("|") if alt]
+    if not raw_alternatives:
+        return None
+    # Prefer an alternative containing uppercase letters when one
+    # exists — esphome regexes list lowercase first (``v``) for
+    # case-insensitive matching, but the user-facing canonical
+    # form for SI units uses the uppercase symbol (``V``, ``Hz``).
+    # Without this preference we'd populate ``unit_options`` with
+    # lowercase ``v`` / ``hz`` etc.
+    canonical = next(
+        (alt for alt in raw_alternatives if any(c.isupper() for c in alt)),
+        raw_alternatives[0],
+    )
+    raw_alternatives = [canonical, *(a for a in raw_alternatives if a != canonical)]
+    if quantity in _FIXED_UNIT_VALIDATORS:
+        # Each alternative is a distinct unit (``°C``, ``°F``,
+        # ``K``). Deduplicate case variants by lowercasing.
+        seen: set[str] = set()
+        units: list[str] = []
+        for alt in raw_alternatives:
+            key = alt.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            units.append(alt)
+        return units
+    if quantity in _METRIC_PREFIX_VALIDATORS:
+        # Pick the first alternative as the canonical base unit
+        # (``Hz`` from ``Hz|HZ|hz``) and combine with metric
+        # prefixes. Returns ``["Hz", "mHz", "kHz", "MHz", "GHz"]``.
+        base_unit = raw_alternatives[0]
+        metric_suffixes = getattr(cv, "METRIC_SUFFIXES", {"": 1.0})
+        return [
+            f"{prefix}{base_unit}"
+            for prefix in _COMMON_METRIC_PREFIXES
+            if prefix in metric_suffixes
+        ]
+    return None
+
+
+def _collect_refined_types(  # noqa: PLR0915
+    manifest: Any,
+) -> dict[tuple[str, ...], RefinedType]:
     """Walk the live ``CONFIG_SCHEMA`` to recover types the schema lost.
 
     The pre-built schema collapses many ``cv.boolean`` / ``cv.float_`` /
     ``cv.icon`` / ``cv.lambda_`` validators into bare strings. By
     inspecting the actual voluptuous validators we can promote those
-    fields back to the right type. Returns ``{key_path: type_name}``.
+    fields back to the right type. Returns ``{key_path: RefinedType}``
+    where the named tuple carries ``type`` plus per-type extras (e.g.
+    ``unit_options`` for ``float_with_unit``).
     """
     schema = getattr(manifest, "config_schema", None)
     if schema is None:
@@ -2319,33 +2573,50 @@ def _collect_refined_types(manifest: Any) -> dict[tuple[str, ...], str]:  # noqa
     except Exception:
         return {}
 
-    # Map runtime validator identities / names to our type strings. The
+    # Map runtime validator identities / names to refined types. The
     # schema bundle already gets ``cv.string`` and ``cv.int_`` right via
     # explicit ``type:`` markers; we focus on the cases where the
     # bundle silently emits no type at all. Identity is keyed by
     # ``id()`` because some voluptuous validators (notably _Schema
     # subclasses) override __hash__ to be unhashable.
-    by_identity: dict[int, str] = {}
-    by_name: dict[str, str] = {}
+    by_identity: dict[int, RefinedType] = {}
+    by_name: dict[str, RefinedType] = {}
 
-    def add(name: str, type_str: str, *attrs: str) -> None:
-        by_name[name] = type_str
+    def add(name: str, refined: RefinedType, *attrs: str) -> None:
+        by_name[name] = refined
         for a in attrs:
             obj = getattr(cv, a, None)
             if obj is not None:
-                by_identity[id(obj)] = type_str
+                by_identity[id(obj)] = refined
 
-    add("boolean", "boolean", "boolean")
-    add("float_", "float", "float_", "positive_float", "negative_float")
-    add("float_range", "float", "float_range")
-    add("frequency", "float", "frequency")
-    add("icon", "icon", "icon")
-    add("lambda_", "lambda", "lambda_")
-    add("returning_lambda", "lambda", "returning_lambda")
-    add("mac_address", "mac_address", "mac_address")
-    add("color_temperature", "string", "color_temperature")
+    add("boolean", RefinedType("boolean"), "boolean")
+    add("float_", RefinedType("float"), "float_", "positive_float", "negative_float")
+    add("float_range", RefinedType("float"), "float_range")
+    # Unit-coerced validators — render as a number input + unit
+    # picker on the frontend. The validator's runtime type is a
+    # float, but the YAML shape is ``"<value><unit>"``. Pull the
+    # unit list from the validator's compiled regex at runtime so
+    # the catalog stays in sync with ESPHome without a
+    # hand-maintained table to forget about.
+    for validator_name in _FLOAT_WITH_UNIT_VALIDATORS:
+        validator = getattr(cv, validator_name, None)
+        if validator is None:
+            continue
+        units = _extract_validator_units(validator) or _UNIT_FALLBACKS.get(validator_name)
+        if not units:
+            continue
+        add(
+            validator_name,
+            RefinedType("float_with_unit", unit_options=units),
+            validator_name,
+        )
+    add("icon", RefinedType("icon"), "icon")
+    add("lambda_", RefinedType("lambda"), "lambda_")
+    add("returning_lambda", RefinedType("lambda"), "returning_lambda")
+    add("mac_address", RefinedType("mac_address"), "mac_address")
+    add("color_temperature", RefinedType("string"), "color_temperature")
 
-    out: dict[tuple[str, ...], str] = {}
+    out: dict[tuple[str, ...], RefinedType] = {}
     visited: set[int] = set()
 
     def unwrap_to_dict(node: Any) -> dict | None:
@@ -2369,7 +2640,7 @@ def _collect_refined_types(manifest: Any) -> dict[tuple[str, ...], str]:  # noqa
             return None
         return None
 
-    def classify(validator: Any) -> str | None:
+    def classify(validator: Any) -> RefinedType | None:
         if id(validator) in by_identity:
             return by_identity[id(validator)]
         # Some validators are wrapped (vol.All chains or partials);
@@ -2380,11 +2651,22 @@ def _collect_refined_types(manifest: Any) -> dict[tuple[str, ...], str]:  # noqa
                 t = classify(v)
                 if t is not None:
                     return t
+        # ``cv.float_with_unit`` returns a closure whose ``__name__``
+        # is the generic ``"validator"`` (too noisy to substring-
+        # match) but whose ``__qualname__`` carries the factory
+        # name. Detect that shape and pull units straight from the
+        # closure — handles platform-style entries (``sensor.mcp3008.
+        # reference_voltage``, ``esp32_camera.idle_framerate``) the
+        # name-by-name registration loop missed because they weren't
+        # bound back to a top-level ``cv.<name>`` attribute.
+        qualname = getattr(validator, "__qualname__", "") or ""
+        if "float_with_unit" in qualname:
+            units = _extract_validator_units(validator)
+            if units:
+                return RefinedType("float_with_unit", unit_options=units)
         # Fall back to name-based matching for closures and partials
         # that lose identity but keep the name.
-        name = (
-            getattr(validator, "__name__", None) or getattr(validator, "__qualname__", None) or ""
-        ).lower()
+        name = (getattr(validator, "__name__", None) or qualname).lower()
         for k, t in by_name.items():
             if k in name:
                 return t
@@ -2416,12 +2698,18 @@ def _collect_refined_types(manifest: Any) -> dict[tuple[str, ...], str]:  # noqa
 
 def _apply_refined_types(
     entries: list[dict],
-    refined: dict[tuple[str, ...], str],
+    refined: dict[tuple[str, ...], RefinedType],
 ) -> None:
     """Promote entry types from string → boolean/float/... where known.
 
     Only acts on entries currently typed ``string`` so we don't
-    override the schema's explicit type assignments.
+    override the schema's explicit type assignments — EXCEPT for
+    ``float_with_unit``, which we always apply because it carries
+    extra info (``unit_options``) the schema bundle can't express.
+    The schema bundle's ``float`` typing for those entries is
+    technically the runtime type after coercion, but the YAML shape
+    the user types is a string with a unit suffix; the
+    ``float_with_unit`` type captures both halves.
     """
     if not refined:
         return
@@ -2430,8 +2718,14 @@ def _apply_refined_types(
         for entry in items:
             sub_path = (*path, entry["key"])
             new_type = refined.get(sub_path)
-            if new_type and entry.get("type") == "string":
-                entry["type"] = new_type
+            if new_type is not None:
+                if new_type.type == "float_with_unit":
+                    # Always apply — see docstring. Carries unit_options
+                    # the schema bundle can't represent.
+                    entry["type"] = new_type.type
+                    entry["unit_options"] = list(new_type.unit_options or [])
+                elif entry.get("type") == "string":
+                    entry["type"] = new_type.type
             inner = entry.get("config_entries")
             if inner:
                 walk(inner, sub_path)

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2165,9 +2165,10 @@ def _audit_catalog_for_unit_mismatches(catalog: list[dict]) -> None:
     ``default_value`` is a unit-suffixed string the frontend's
     number input won't accept.
 
-    Surfacing as a sync-time WARNING gives us actionable telemetry
-    to add the validator to ``_FLOAT_WITH_UNIT_VALIDATORS`` (or
-    ``_UNIT_FALLBACKS``) before users hit the silent-Add-button bug.
+    Surfacing as a sync-time WARNING gives actionable telemetry to
+    add the validator to ``_FLOAT_WITH_UNIT_VALIDATORS`` (or
+    ``_UNIT_FALLBACKS``) before users hit the silent-validation
+    failure on the affected fields.
     """
     mismatches: list[tuple[str, str, str]] = []
     for component in catalog:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2429,11 +2429,27 @@ class RefinedType(NamedTuple):
 # never a hand-maintained list — so the catalog stays in sync with
 # ESPHome without anyone having to remember to update us.
 #
-# Common metric prefixes the frontend's unit picker offers when the
-# validator allows them. Pulled from ``cv.METRIC_SUFFIXES`` at
-# runtime; this is the curated subset most ESPHome configs use (the
-# full set includes attobytes and yottabytes which are noise).
-_COMMON_METRIC_PREFIXES = ["", "m", "k", "M", "G"]
+# Metric prefixes the frontend's unit picker offers when the
+# validator allows them. ``cv.METRIC_SUFFIXES`` accepts every SI
+# prefix from quecto (1e-30) through quetta (1e30) plus a few non-
+# standard ones (deca, hecto, deci, centi); a picker exposing all
+# 26 entries — half of which describe scales below the noise floor
+# of an MCU, the other half above the diameter of the observable
+# universe — is unusable. This list is the IoT-relevant subset:
+# nano (cap, ns), micro (V, A, F, s), milli, base, kilo, mega, giga.
+# Both ``µ`` and ``u`` resolve to 1e-6 in ESPHome — only ``µ`` is
+# emitted (the SI canonical form) so the picker doesn't show two
+# entries that mean the same thing.
+#
+# A future per-quantity override list (frequencies don't need ``n``;
+# voltages don't need ``G``) is reasonable, but the current list is
+# already a strict superset of what every real ESPHome config in the
+# wild uses.
+# Base unit ("") comes first so the canonical unit (per the model
+# docs: "first entry is the canonical unit") is the un-prefixed
+# form — `Hz` not `nHz`. The remaining prefixes follow in
+# magnitude order.
+_COMMON_METRIC_PREFIXES = ["", "n", "µ", "m", "k", "M", "G"]
 
 # Names of the ``cv.*`` validators we know are built on
 # ``cv.float_with_unit``. Each comes through the live-introspection

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2171,7 +2171,7 @@ def _audit_catalog_for_unit_mismatches(catalog: list[dict]) -> None:
     """
     mismatches: list[tuple[str, str, str]] = []
     for component in catalog:
-        for entry in _walk_entries(component.get("config_entries") or []):
+        for path, entry in _walk_entries(component.get("config_entries") or []):
             if entry.get("type") not in ("float", "integer"):
                 continue
             default = entry.get("default_value")
@@ -2181,7 +2181,7 @@ def _audit_catalog_for_unit_mismatches(catalog: list[dict]) -> None:
                 float(default)
             except ValueError:
                 mismatches.append(
-                    (component["id"], entry["key"], default),
+                    (component["id"], ".".join(path), default),
                 )
     if not mismatches:
         return
@@ -2194,17 +2194,35 @@ def _audit_catalog_for_unit_mismatches(catalog: list[dict]) -> None:
         "ones) in script/sync_components.py.",
         len(mismatches),
     )
-    for component_id, key, default in mismatches:
-        _LOGGER.warning("  %s.%s = %r", component_id, key, default)
+    for component_id, dotted_path, default in mismatches:
+        _LOGGER.warning("  %s.%s = %r", component_id, dotted_path, default)
 
 
-def _walk_entries(entries: list[dict]) -> Iterable[dict]:
-    """Yield every entry in *entries*, recursing into NESTED groups."""
+def _walk_entries(
+    entries: list[dict],
+    parent_path: tuple[str, ...] = (),
+) -> Iterable[tuple[tuple[str, ...], dict]]:
+    """Yield (dotted-path, entry) for every entry in *entries*.
+
+    Recurses into NESTED groups and MAP value templates so the audit
+    covers every entry the catalog actually ships. ``parent_path`` is
+    threaded through so leaf yields carry the full path the user
+    sees in YAML — e.g. ``("api", "actions", "service")`` rather than
+    just ``("service",)`` — which is essential when multiple
+    components share a key like ``rate`` or ``size``: the warning
+    has to point at the specific instance.
+    """
     for entry in entries:
-        yield entry
-        if entry.get("type") == "nested":
-            inner = entry.get("config_entries") or []
-            yield from _walk_entries(inner)
+        path = (*parent_path, entry["key"])
+        yield path, entry
+        # Both NESTED groups and MAP value templates (built via
+        # ``_build_map_value_template``) carry their inner schema
+        # under ``config_entries``. Walk both so the audit doesn't
+        # silently miss unit-coerced defaults inside e.g.
+        # ``api.actions.<user_key>.<float-with-string-default>``.
+        inner = entry.get("config_entries") if entry.get("type") in ("nested", "map") else None
+        if inner:
+            yield from _walk_entries(inner, path)
 
 
 def _enumerate_platform_manifests(loader: Any, stem: str) -> list[Any]:

--- a/tests/test_components_config_entry_loader.py
+++ b/tests/test_components_config_entry_loader.py
@@ -1,0 +1,97 @@
+"""Round-trip tests for ConfigEntry JSON load + materialise.
+
+The catalog ships ConfigEntry shapes as JSON in
+``definitions/components.json``. Two helpers convert them into the
+in-memory ``ConfigEntry`` model the API serves to the frontend:
+
+- ``_load_config_entry`` reads the JSON dict
+- ``_materialise_entry`` resolves platform_defaults and produces the
+  per-request copy the API responds with
+
+Every field exposed to the frontend has to make it through both
+helpers — Copilot caught one (``unit_options``) drifting on PR #271
+because both helpers were silently dropping the new field. Pin the
+round-trip here so any future field addition either gets covered or
+lights up CI.
+"""
+
+from __future__ import annotations
+
+from esphome_device_builder.controllers.components import (
+    _load_config_entry,
+    _materialise_entry,
+)
+from esphome_device_builder.models.common import ConfigEntryType
+
+
+def test_load_config_entry_propagates_unit_options() -> None:
+    """``_load_config_entry`` reads ``unit_options`` from the JSON dict."""
+    entry = _load_config_entry(
+        {
+            "key": "frequency",
+            "type": "float_with_unit",
+            "label": "Frequency",
+            "default_value": 50,
+            "unit_options": ["Hz", "mHz", "kHz", "MHz", "GHz"],
+        }
+    )
+    assert entry.type is ConfigEntryType.FLOAT_WITH_UNIT
+    assert entry.unit_options == ["Hz", "mHz", "kHz", "MHz", "GHz"]
+
+
+def test_load_config_entry_unit_options_defaults_to_none() -> None:
+    """Entries without ``unit_options`` (the common case) load with ``None``."""
+    entry = _load_config_entry(
+        {"key": "name", "type": "string", "label": "Name"},
+    )
+    assert entry.unit_options is None
+
+
+def test_load_config_entry_drops_non_string_unit_options() -> None:
+    """Malformed unit_options entries are filtered out (not propagated as junk)."""
+    entry = _load_config_entry(
+        {
+            "key": "frequency",
+            "type": "float_with_unit",
+            "label": "Frequency",
+            "unit_options": ["Hz", 42, None, "kHz"],
+        }
+    )
+    assert entry.unit_options == ["Hz", "kHz"]
+
+
+def test_materialise_entry_preserves_unit_options() -> None:
+    """The per-request copy carries ``unit_options`` through to the API response."""
+    loaded = _load_config_entry(
+        {
+            "key": "frequency",
+            "type": "float_with_unit",
+            "label": "Frequency",
+            "default_value": 50,
+            "unit_options": ["Hz", "kHz", "MHz"],
+        }
+    )
+    materialised = _materialise_entry(loaded, target_platform="esp32")
+    assert materialised.unit_options == ["Hz", "kHz", "MHz"]
+
+
+def test_materialise_entry_recurses_into_nested_unit_options() -> None:
+    """Nested FLOAT_WITH_UNIT entries inside a NESTED parent keep their units."""
+    loaded = _load_config_entry(
+        {
+            "key": "i2c",
+            "type": "nested",
+            "label": "I2C",
+            "config_entries": [
+                {
+                    "key": "frequency",
+                    "type": "float_with_unit",
+                    "label": "Frequency",
+                    "unit_options": ["Hz", "kHz"],
+                }
+            ],
+        }
+    )
+    materialised = _materialise_entry(loaded, target_platform=None)
+    assert materialised.config_entries is not None
+    assert materialised.config_entries[0].unit_options == ["Hz", "kHz"]

--- a/tests/test_components_config_entry_loader.py
+++ b/tests/test_components_config_entry_loader.py
@@ -9,10 +9,8 @@ in-memory ``ConfigEntry`` model the API serves to the frontend:
   per-request copy the API responds with
 
 Every field exposed to the frontend has to make it through both
-helpers — Copilot caught one (``unit_options``) drifting on PR #271
-because both helpers were silently dropping the new field. Pin the
-round-trip here so any future field addition either gets covered or
-lights up CI.
+helpers; pin the round-trip here so any future field addition
+either gets covered or lights up CI.
 """
 
 from __future__ import annotations

--- a/tests/test_components_config_entry_loader.py
+++ b/tests/test_components_config_entry_loader.py
@@ -60,6 +60,23 @@ def test_load_config_entry_drops_non_string_unit_options() -> None:
     assert entry.unit_options == ["Hz", "kHz"]
 
 
+def test_load_config_entry_unit_options_all_filtered_returns_none() -> None:
+    """Lists with no string members fold back to ``None``.
+
+    Rather than emitting an empty list — a half-populated picker
+    would reach the frontend as a unit-less FLOAT_WITH_UNIT widget.
+    """
+    entry = _load_config_entry(
+        {
+            "key": "frequency",
+            "type": "float_with_unit",
+            "label": "Frequency",
+            "unit_options": [42, None, [], {}],
+        }
+    )
+    assert entry.unit_options is None
+
+
 def test_materialise_entry_preserves_unit_options() -> None:
     """The per-request copy carries ``unit_options`` through to the API response."""
     loaded = _load_config_entry(

--- a/tests/test_sync_components_unit_extraction.py
+++ b/tests/test_sync_components_unit_extraction.py
@@ -24,6 +24,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "script"))
 
 from sync_components import (
     _audit_catalog_for_unit_mismatches,
+    _collect_refined_types,
+    _enumerate_platform_manifests,
     _extract_validator_units,
 )
 
@@ -39,9 +41,17 @@ def cv():
 
 
 def test_extract_units_for_frequency(cv) -> None:
-    """`cv.frequency` produces the metric-prefixed Hz list."""
+    """`cv.frequency` produces the IoT-relevant metric-prefixed Hz list.
+
+    Canonical unit (`Hz`) first; remaining prefixes in magnitude
+    order. The frontend's renderer treats `unit_options[0]` as the
+    canonical unit (range bounds default to it), so this contract
+    matters at every layer.
+    """
     assert _extract_validator_units(cv.frequency) == [
         "Hz",
+        "nHz",
+        "µHz",
         "mHz",
         "kHz",
         "MHz",
@@ -50,13 +60,29 @@ def test_extract_units_for_frequency(cv) -> None:
 
 
 def test_extract_units_for_voltage(cv) -> None:
-    """`cv.voltage` produces the metric-prefixed V list."""
-    assert _extract_validator_units(cv.voltage) == ["V", "mV", "kV", "MV", "GV"]
+    """`cv.voltage` produces the IoT-relevant metric-prefixed V list."""
+    assert _extract_validator_units(cv.voltage) == [
+        "V",
+        "nV",
+        "µV",
+        "mV",
+        "kV",
+        "MV",
+        "GV",
+    ]
 
 
 def test_extract_units_for_distance(cv) -> None:
-    """`cv.distance` produces the metric-prefixed m list."""
-    assert _extract_validator_units(cv.distance) == ["m", "mm", "km", "Mm", "Gm"]
+    """`cv.distance` produces the IoT-relevant metric-prefixed m list."""
+    assert _extract_validator_units(cv.distance) == [
+        "m",
+        "nm",
+        "µm",
+        "mm",
+        "km",
+        "Mm",
+        "Gm",
+    ]
 
 
 def test_extract_units_for_framerate(cv) -> None:
@@ -139,6 +165,54 @@ def test_audit_recurses_into_nested_entries(caplog) -> None:
     with caplog.at_level(logging.WARNING, logger="sync_components"):
         _audit_catalog_for_unit_mismatches(catalog)
     assert "fake.component.inner_rate" in caplog.text
+
+
+@pytest.fixture
+def loader():
+    """Lazy-import esphome's loader; skip if unavailable."""
+    try:
+        from esphome import loader as _loader  # noqa: PLC0415
+    except Exception:
+        pytest.skip("esphome.loader not importable")
+    return _loader
+
+
+def test_enumerate_platform_manifests_returns_real_manifests(loader) -> None:
+    """`mcp3008` ships a sensor and an output platform.
+
+    `_enumerate_platform_manifests` must surface both so the platform-
+    schema's unit-coerced fields (`reference_voltage` etc.) get refined
+    on the live introspection walk — a small upstream shape change
+    here would silently strip `float_with_unit` metadata otherwise.
+    """
+    manifests = _enumerate_platform_manifests(loader, "mcp3008")
+    # At least the sensor platform should be reachable; output is
+    # the secondary platform.
+    assert manifests, "mcp3008 should expose at least one platform manifest"
+
+
+def test_platform_manifest_refines_unit_coerced_field(loader) -> None:
+    """End-to-end: `mcp3008.sensor.reference_voltage` is `float_with_unit`.
+
+    The bare `mcp3008` manifest's `config_schema` carries the SPI bus
+    fields but NOT the per-instance `reference_voltage` — that lives
+    on the platform schema (`mcp3008.sensor`). If
+    `_enumerate_platform_manifests` regresses, this catalog field
+    silently falls back to `float`-with-string-default and the
+    silent-Add-button class of bug returns. Pin the refinement here
+    so an upstream rename / restructure trips CI.
+    """
+    refined = {}
+    for platform_manifest in _enumerate_platform_manifests(loader, "mcp3008"):
+        refined.update(_collect_refined_types(platform_manifest))
+    voltage = refined.get(("reference_voltage",))
+    if voltage is None:
+        pytest.skip(
+            "esphome version doesn't expose mcp3008.sensor.reference_voltage "
+            "via the live-introspection walker — guard, not a regression"
+        )
+    assert voltage.type == "float_with_unit"
+    assert voltage.unit_options is not None and "V" in voltage.unit_options
 
 
 def test_audit_silent_when_no_mismatches(caplog) -> None:

--- a/tests/test_sync_components_unit_extraction.py
+++ b/tests/test_sync_components_unit_extraction.py
@@ -231,9 +231,8 @@ def test_platform_manifest_refines_unit_coerced_field(loader) -> None:
     fields but NOT the per-instance `reference_voltage` — that lives
     on the platform schema (`mcp3008.sensor`). If
     `_enumerate_platform_manifests` regresses, this catalog field
-    silently falls back to `float`-with-string-default and the
-    silent-Add-button class of bug returns. Pin the refinement here
-    so an upstream rename / restructure trips CI.
+    silently falls back to `float`-with-string-default. Pin the
+    refinement here so an upstream rename / restructure trips CI.
     """
     refined = {}
     for platform_manifest in _enumerate_platform_manifests(loader, "mcp3008"):

--- a/tests/test_sync_components_unit_extraction.py
+++ b/tests/test_sync_components_unit_extraction.py
@@ -15,14 +15,10 @@ warning fires for the cases we've already curated as follow-ups.
 from __future__ import annotations
 
 import logging
-import sys
-from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "script"))
-
-from sync_components import (
+from script.sync_components import (  # type: ignore[import-not-found]
     _audit_catalog_for_unit_mismatches,
     _collect_refined_types,
     _enumerate_platform_manifests,
@@ -143,7 +139,7 @@ def test_audit_warns_on_unit_suffixed_string_default(caplog) -> None:
 
 
 def test_audit_recurses_into_nested_entries(caplog) -> None:
-    """Mismatches buried inside a NESTED group still fire the warning."""
+    """Mismatches buried inside a NESTED group fire the warning with full path."""
     catalog = [
         {
             "id": "fake.component",
@@ -164,7 +160,44 @@ def test_audit_recurses_into_nested_entries(caplog) -> None:
     ]
     with caplog.at_level(logging.WARNING, logger="sync_components"):
         _audit_catalog_for_unit_mismatches(catalog)
-    assert "fake.component.inner_rate" in caplog.text
+    # Warning includes the full dotted path (`outer.inner_rate`)
+    # rather than the bare leaf — components with repeated nested
+    # keys (`rate`, `size`) would otherwise produce ambiguous
+    # warnings.
+    assert "fake.component.outer.inner_rate" in caplog.text
+
+
+def test_audit_recurses_into_map_value_templates(caplog) -> None:
+    """MAP value templates carry inner ``config_entries`` too.
+
+    `_build_map_value_template` materialises the value-side schema of
+    user-keyed maps (`api.actions.<user_key>.<...>`,
+    `esphome.platformio_options.<...>`). Without recursing into
+    those, the audit silently misses any unit-coerced numeric
+    default that lands inside one — exactly the class of catalog
+    bug the audit is supposed to police.
+    """
+    catalog = [
+        {
+            "id": "fake.component",
+            "config_entries": [
+                {
+                    "key": "actions",
+                    "type": "map",
+                    "config_entries": [
+                        {
+                            "key": "delay",
+                            "type": "float",
+                            "default_value": "100ms",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    with caplog.at_level(logging.WARNING, logger="sync_components"):
+        _audit_catalog_for_unit_mismatches(catalog)
+    assert "fake.component.actions.delay" in caplog.text
 
 
 @pytest.fixture

--- a/tests/test_sync_components_unit_extraction.py
+++ b/tests/test_sync_components_unit_extraction.py
@@ -1,0 +1,158 @@
+"""Tests for the sync script's unit-options extraction.
+
+`_extract_validator_units` is the load-bearing magic that pulls the
+unit picker list out of `cv.float_with_unit` validators at runtime —
+no hand-maintained mapping that goes stale on the next ESPHome
+release. Pin its output for each `cv.*` validator the catalog cares
+about so an upstream regex tweak can't silently change the unit list
+the dashboard ships.
+
+`_audit_catalog_for_unit_mismatches` is the regression net for new
+unit-coerced validators ESPHome adds after this PR — make sure the
+warning fires for the cases we've already curated as follow-ups.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "script"))
+
+from sync_components import (
+    _audit_catalog_for_unit_mismatches,
+    _extract_validator_units,
+)
+
+
+@pytest.fixture
+def cv():
+    """Lazy-import esphome's config_validation; skip if unavailable."""
+    try:
+        from esphome import config_validation as _cv  # noqa: PLC0415
+    except Exception:
+        pytest.skip("esphome.config_validation not importable")
+    return _cv
+
+
+def test_extract_units_for_frequency(cv) -> None:
+    """`cv.frequency` produces the metric-prefixed Hz list."""
+    assert _extract_validator_units(cv.frequency) == [
+        "Hz",
+        "mHz",
+        "kHz",
+        "MHz",
+        "GHz",
+    ]
+
+
+def test_extract_units_for_voltage(cv) -> None:
+    """`cv.voltage` produces the metric-prefixed V list."""
+    assert _extract_validator_units(cv.voltage) == ["V", "mV", "kV", "MV", "GV"]
+
+
+def test_extract_units_for_distance(cv) -> None:
+    """`cv.distance` produces the metric-prefixed m list."""
+    assert _extract_validator_units(cv.distance) == ["m", "mm", "km", "Mm", "Gm"]
+
+
+def test_extract_units_for_framerate(cv) -> None:
+    """`cv.framerate` is a fixed-unit validator (no metric prefix)."""
+    units = _extract_validator_units(cv.framerate)
+    # Order is canonical-first; both `FPS` and `Hz` accepted by the
+    # validator. We don't pin order here because `framerate`'s regex
+    # alternation is stable but the canonical pick depends on the
+    # uppercase-preference heuristic.
+    assert units is not None
+    assert set(units) >= {"FPS", "Hz"}
+
+
+def test_extract_units_returns_none_for_non_closure() -> None:
+    """A plain function (no compiled-regex closure) returns None."""
+
+    def not_a_validator(value):
+        return value
+
+    assert _extract_validator_units(not_a_validator) is None
+
+
+def test_audit_warns_on_unit_suffixed_string_default(caplog) -> None:
+    """Audit fires on float/integer entries with non-numeric string defaults.
+
+    Actionable telemetry to add the validator to
+    `_FLOAT_WITH_UNIT_VALIDATORS` (or `_UNIT_FALLBACKS`).
+    """
+    catalog = [
+        {
+            "id": "fake.component",
+            "config_entries": [
+                {
+                    "key": "rate",
+                    "type": "float",
+                    "default_value": "100ms",
+                },
+                {
+                    "key": "size",
+                    "type": "integer",
+                    "default_value": "1KB",
+                },
+                # Already-numeric default — must NOT trip the audit.
+                {
+                    "key": "count",
+                    "type": "integer",
+                    "default_value": "42",
+                },
+            ],
+        }
+    ]
+    with caplog.at_level(logging.WARNING, logger="sync_components"):
+        _audit_catalog_for_unit_mismatches(catalog)
+    text = caplog.text
+    assert "fake.component.rate" in text
+    assert "fake.component.size" in text
+    assert "fake.component.count" not in text
+
+
+def test_audit_recurses_into_nested_entries(caplog) -> None:
+    """Mismatches buried inside a NESTED group still fire the warning."""
+    catalog = [
+        {
+            "id": "fake.component",
+            "config_entries": [
+                {
+                    "key": "outer",
+                    "type": "nested",
+                    "config_entries": [
+                        {
+                            "key": "inner_rate",
+                            "type": "float",
+                            "default_value": "100ms",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    with caplog.at_level(logging.WARNING, logger="sync_components"):
+        _audit_catalog_for_unit_mismatches(catalog)
+    assert "fake.component.inner_rate" in caplog.text
+
+
+def test_audit_silent_when_no_mismatches(caplog) -> None:
+    """No warning when every numeric entry has a numeric default."""
+    catalog = [
+        {
+            "id": "fake.component",
+            "config_entries": [
+                {"key": "rate", "type": "float", "default_value": 1.5},
+                {"key": "count", "type": "integer", "default_value": 7},
+                {"key": "name", "type": "string", "default_value": "abc"},
+            ],
+        }
+    ]
+    with caplog.at_level(logging.WARNING, logger="sync_components"):
+        _audit_catalog_for_unit_mismatches(catalog)
+    assert "Catalog audit" not in caplog.text


### PR DESCRIPTION
## Summary

- New `ConfigEntryType.FLOAT_WITH_UNIT` for `cv.frequency`, `cv.data_size`, `cv.framerate`, `cv.voltage`, `cv.distance`, `cv.temperature`, `cv.temperature_delta` — validators that accept unit-suffixed strings (`"50kHz"`, `"3.3V"`) at YAML and coerce to a float at compile time. Frontend will render a number input + unit picker; this PR is the backend half.
- New `unit_options: list[str] | None` field on `ConfigEntry` carrying the unit choices for the picker. Populated at sync time from the validator's compiled regex (`cv.float_with_unit` factory) plus `cv.METRIC_SUFFIXES` — no hand-maintained mapping that goes stale on the next ESPHome release. Hand-rolled validators (`temperature`, `temperature_delta`) get a small `_UNIT_FALLBACKS` map; the unit set for these is stable across ESPHome releases.
- Walk platform-specific manifests via `loader.get_platform` for every `_PLATFORM_DOMAINS` entry so platform-only fields (`sensor.X.reference_voltage`, `esp32_camera.idle_framerate`) get refined too — the bare component manifest doesn't carry those. Sort the iteration so `setdefault` keep-first is deterministic across runs (frozenset hash randomisation was flipping three entries between syncs).
- Sync-time audit warning when float/integer entries still carry non-numeric string defaults — actionable telemetry to add the validator to `_FLOAT_WITH_UNIT_VALIDATORS` (or `_UNIT_FALLBACKS`) before users hit the silent-Add-button class of bug. **17 audit warnings remain as follow-up** (percentage, `dBFS`, `[]` literals, `'never'`, etc.).
- Catalog: 213 entries upgraded to `float_with_unit`; ~1100 string-typed common entries (`setup_priority`, `sorting_weight`) refined to `float`.

## Why

Some `cv.*` validators accept unit-suffixed strings like `"50kHz"` or `"3.3V"` at YAML and coerce to a float at compile time. The pre-built schema bundle types these as `float`, but their `default_value` is the unit-suffixed string — so the dashboard's number input rejected those defaults as NaN and the optional-field validator's `?? default_value` fallback flagged the field as `validation.not_a_number` for any untouched optional entry. The form's submit guard then bailed silently on the validation error and the user reported the symptom as `Add ES7210 → Add i2c → blue Add does nothing`.

The frontend silent-button half was already worked around by skipping the optional-default fallback in `validateEntries` (esphome/device-builder-frontend#107). This PR fixes it at the source so the catalog's type matches the YAML shape the user types, and gives the frontend everything it needs to render a proper unit-aware widget.

## Test plan

- [x] `python -m pytest tests/ -x -q` — 1279 passed.
- [x] `python script/sync_components.py` runs cleanly; deterministic across multiple runs (verified via `md5`).
- [x] Audit warnings list 17 follow-up entries — all are stable typos / hand-rolled validators not yet covered.
- [x] Frontend renderer + validator wiring (esphome/device-builder-frontend#107 follow-up).