### PR TITLE
Fail release tag check loudly on non-404 errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if gh api "repos/${{ github.repository }}/git/refs/tags/${{ inputs.version }}" --silent 2>/dev/null; then
+          # `gh api` exits 0 on 2xx and non-zero on any other outcome
+          # (HTTP error or transport failure), so a bare exit-code check
+          # can't tell "tag doesn't exist" apart from "the network ate
+          # the request". Capture stderr and require an HTTP 404 before
+          # treating the tag as absent — anything else fails loudly.
+          if err=$(gh api "repos/${{ github.repository }}/git/refs/tags/${{ inputs.version }}" --silent 2>&1); then
             echo "::error::Tag '${{ inputs.version }}' already exists. Pick a new version."
+            exit 1
+          elif ! grep -q "HTTP 404" <<<"$err"; then
+            echo "::error::Failed to check whether tag '${{ inputs.version }}' exists: $err"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,9 @@ jobs:
             echo "::error::Tag '${{ inputs.version }}' already exists. Pick a new version."
             exit 1
           elif ! grep -q "HTTP 404" <<<"$err"; then
-            echo "::error::Failed to check whether tag '${{ inputs.version }}' exists: $err"
+            echo "::error::Failed to check whether tag '${{ inputs.version }}' exists."
+            echo "gh api stderr:"
+            echo "$err"
             exit 1
           fi
 


### PR DESCRIPTION
# What does this implement/fix?

The existing existing-tag check swallowed every `gh api` failure with `2>/dev/null` and treated any non-zero exit as "tag doesn't exist". A transient network blip, auth issue, or 5xx from GitHub would silently bypass the collision guard and let the release proceed.

Capture stderr instead and only treat the tag as absent when `gh api` reports an HTTP 404 — every other failure now bubbles up with the captured stderr in the workflow log.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.