### PR TITLE
Document PyPI install in README and add version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome Device Builder Dashboard
 
-[![codecov](https://codecov.io/gh/esphome/device-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/esphome/device-builder) [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/esphome/device-builder)
+[![PyPI version](https://img.shields.io/pypi/v/esphome-device-builder.svg)](https://pypi.org/project/esphome-device-builder/) [![codecov](https://codecov.io/gh/esphome/device-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/esphome/device-builder) [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/esphome/device-builder)
 
 > **Status:** in active development. Roughly alpha, closing on beta. Issues
 > and feedback welcome — please check existing issues / the
@@ -17,7 +17,27 @@ managing automations, and pushing firmware updates.
 The dashboard isn't yet wired into the ESPHome container or the Home Assistant
 add-on as an opt-in preview — that's coming soon. In the meantime:
 
-**Install from a [GitHub release](https://github.com/esphome/device-builder/releases):**
+**Install from [PyPI](https://pypi.org/project/esphome-device-builder/):**
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install esphome-device-builder
+
+esphome-device-builder ~/esphome-configs
+```
+
+To try a pre-release (beta), pass `--pre` to `pip install`.
+
+The server starts on `http://localhost:6052`. Run with `--help` for the
+full flag set.
+
+<details>
+<summary>Install from a GitHub release</summary>
+
+Every build is published to PyPI, so the install above is the
+preferred path. The same wheels are mirrored on the
+[GitHub releases page](https://github.com/esphome/device-builder/releases) —
+handy as a fallback if PyPI is unreachable.
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
@@ -28,8 +48,7 @@ pip install "https://github.com/esphome/device-builder/releases/download/<versio
 esphome-device-builder ~/esphome-configs
 ```
 
-The server starts on `http://localhost:6052`. Run with `--help` for the
-full flag set. A PyPI release is on the way.
+</details>
 
 **From source** (requires [uv](https://docs.astral.sh/uv/)):
 


### PR DESCRIPTION
# What does this implement/fix?

The package is now published to PyPI on every release, so the README should point users there by default. Adds a PyPI version badge alongside the existing codecov / CodSpeed ones, replaces the hand-pinned GitHub-release wheel URL with a plain `pip install esphome-device-builder`, and tucks the GitHub-release install away in a collapsed `<details>` block as a fallback for when PyPI is unreachable.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.