### PR TITLE
Move PyPI to top of bug report install-method dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,9 +51,9 @@ body:
       label: How did you install it?
       multiple: false
       options:
+        - PyPI
         - Wheel from a GitHub release
         - From source (script/setup)
-        - PyPI (once available)
         - ESPHome container (preview toggle)
         - Home Assistant add-on (preview toggle)
         - Other / not sure


### PR DESCRIPTION
# What does this implement/fix?

PyPI publishing landed in #283, so this updates the bug report
issue template: drops the "(once available)" qualifier on the PyPI
option and moves it to the top of the install-method dropdown
since `pip install` is now the recommended path.

**Related issue or feature (if applicable):**

- follow-up to #283

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.