### PR TITLE
Add --version CLI flag

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -6,10 +6,12 @@ import argparse
 import logging
 import os
 from logging.handlers import RotatingFileHandler
+from typing import TYPE_CHECKING
 
 from .constants import DEFAULT_HOST, DEFAULT_INGRESS_PORT, DEFAULT_PORT, __version__
-from .controllers.config import DashboardSettings
-from .device_builder import DeviceBuilder
+
+if TYPE_CHECKING:
+    from .controllers.config import DashboardSettings
 
 _FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
 _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -139,6 +141,12 @@ def main() -> None:
 
     _setup_logging(args.log_level, args.log_file)
 
+    # Deferred so ``--version`` / ``--help`` keep working in installs
+    # that omit the optional ``[esphome]`` extra — both modules below
+    # transitively import ``esphome`` at module load time.
+    from .controllers.config import DashboardSettings  # noqa: PLC0415
+    from .device_builder import DeviceBuilder  # noqa: PLC0415
+
     settings = DashboardSettings()
     settings.parse_args(args)
 
@@ -146,6 +154,15 @@ def main() -> None:
 
     device_builder = DeviceBuilder(settings)
     device_builder.run()
+
+
+def _esphome_version() -> str | None:
+    """Return the bundled ESPHome version, or ``None`` if the optional extra is missing."""
+    try:
+        from esphome.const import __version__ as version  # noqa: PLC0415
+    except ImportError:
+        return None
+    return version
 
 
 def _format_version() -> str:
@@ -159,11 +176,10 @@ def _format_version() -> str:
     that's the matching pair an operator pastes into a bug report.
     """
     base = f"esphome-device-builder {__version__}"
-    try:
-        from esphome.const import __version__ as esphome_version  # noqa: PLC0415
-    except ImportError:
+    esphome = _esphome_version()
+    if esphome is None:
         return base
-    return f"{base} (esphome {esphome_version})"
+    return f"{base} (esphome {esphome})"
 
 
 def _validate_credentials(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -7,7 +7,7 @@ import logging
 import os
 from logging.handlers import RotatingFileHandler
 
-from .constants import DEFAULT_HOST, DEFAULT_INGRESS_PORT, DEFAULT_PORT
+from .constants import DEFAULT_HOST, DEFAULT_INGRESS_PORT, DEFAULT_PORT, __version__
 from .controllers.config import DashboardSettings
 from .device_builder import DeviceBuilder
 
@@ -48,6 +48,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="ESPHome Device Builder",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=_format_version(),
+        help="Print version information and exit",
     )
     parser.add_argument(
         "configuration",
@@ -140,6 +146,24 @@ def main() -> None:
 
     device_builder = DeviceBuilder(settings)
     device_builder.run()
+
+
+def _format_version() -> str:
+    """
+    Build the string shown by ``--version``.
+
+    Always reports the device builder package version (read from the
+    installed wheel's metadata, which the release workflow stamps via
+    ``pyproject.toml``). Appends the bundled ESPHome version in
+    parentheses when the optional ``[esphome]`` extra is importable —
+    that's the matching pair an operator pastes into a bug report.
+    """
+    base = f"esphome-device-builder {__version__}"
+    try:
+        from esphome.const import __version__ as esphome_version  # noqa: PLC0415
+    except ImportError:
+        return base
+    return f"{base} (esphome {esphome_version})"
 
 
 def _validate_credentials(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:

--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-try:
-    __version__ = version("esphome-device-builder")
-except PackageNotFoundError:
-    # Source checkout without an editable install — keep imports
-    # working with a placeholder. Real builds get the version
-    # stamped into ``pyproject.toml`` by the release workflow.
-    __version__ = "0.0.0"
+
+def _resolve_version() -> str:
+    """
+    Read the installed package version from wheel metadata.
+
+    Real builds get the version stamped into ``pyproject.toml`` by the
+    release workflow, which propagates to the installed distribution
+    metadata. Source checkouts without an editable install fall back
+    to ``0.0.0`` so imports keep working.
+    """
+    try:
+        return version("esphome-device-builder")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+__version__ = _resolve_version()
 
 DEFAULT_PORT = 6052
 DEFAULT_HOST = "0.0.0.0"

--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -1,6 +1,16 @@
 """Constants for the ESPHome Device Builder."""
 
-__version__ = "0.0.0"
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("esphome-device-builder")
+except PackageNotFoundError:
+    # Source checkout without an editable install — keep imports
+    # working with a placeholder. Real builds get the version
+    # stamped into ``pyproject.toml`` by the release workflow.
+    __version__ = "0.0.0"
 
 DEFAULT_PORT = 6052
 DEFAULT_HOST = "0.0.0.0"

--- a/script/setup
+++ b/script/setup
@@ -34,4 +34,4 @@ fi
 echo ""
 echo "Development environment ready!"
 echo "Activate with: source $VENV_DIR/bin/activate"
-echo "Run with:      esphome-device-builder ./configs --verbose"
+echo "Run with:      esphome-device-builder ./configs --log-level debug"

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,132 @@
+"""Tests for the ``--version`` CLI flag and its supporting helpers.
+
+Two layers exercise the version path:
+
+* ``_resolve_version`` (constants) — reads the installed package
+  version from wheel metadata, falling back to ``0.0.0`` when the
+  package isn't installed (source checkouts).
+* ``_esphome_version`` / ``_format_version`` (``__main__``) — build
+  the string ``--version`` prints. The bundled ESPHome version is
+  optional; the formatter must degrade cleanly when the
+  ``[esphome]`` extra is absent.
+
+The end-to-end test pins the ``argparse action="version"`` exit
+behaviour (stdout + ``SystemExit(0)``) so a future swap to a custom
+action doesn't silently break the CLI shape that the bug-report
+template relies on.
+"""
+
+from __future__ import annotations
+
+import builtins
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder import __main__ as main_module
+from esphome_device_builder import constants
+
+# ---------------------------------------------------------------------------
+# constants._resolve_version
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_version_returns_metadata_version() -> None:
+    """Real installs return the version stamped into ``pyproject.toml``."""
+    with patch("esphome_device_builder.constants.version", return_value="2026.5.0"):
+        assert constants._resolve_version() == "2026.5.0"
+
+
+def test_resolve_version_falls_back_when_package_missing() -> None:
+    """Source checkouts without an editable install fall back to ``0.0.0``."""
+    with patch(
+        "esphome_device_builder.constants.version",
+        side_effect=PackageNotFoundError("esphome-device-builder"),
+    ):
+        assert constants._resolve_version() == "0.0.0"
+
+
+# ---------------------------------------------------------------------------
+# __main__._esphome_version
+# ---------------------------------------------------------------------------
+
+
+def test_esphome_version_returns_string_when_installed() -> None:
+    """With the ``[esphome]`` extra installed the function returns the version."""
+    # The test environment installs ``esphome``, so the helper resolves
+    # to whatever ``esphome.const.__version__`` is. Pin only the shape
+    # (a non-empty string) so the test doesn't break on every esphome
+    # bump.
+    result = main_module._esphome_version()
+    assert isinstance(result, str)
+    assert result
+
+
+def test_esphome_version_returns_none_when_import_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the ``[esphome]`` extra the function returns ``None``.
+
+    Simulated by replacing ``__import__`` with one that raises for
+    ``esphome`` / ``esphome.const``. The function-level import inside
+    ``_esphome_version`` re-runs each call, so the patch fully
+    controls which branch fires.
+    """
+    real_import = builtins.__import__
+
+    def _block_esphome(
+        name: str,
+        globals: object = None,  # noqa: A002 — matches ``__import__`` signature
+        locals: object = None,  # noqa: A002
+        fromlist: object = (),
+        level: int = 0,
+    ) -> object:
+        if name == "esphome" or name.startswith("esphome."):
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _block_esphome)
+
+    assert main_module._esphome_version() is None
+
+
+# ---------------------------------------------------------------------------
+# __main__._format_version
+# ---------------------------------------------------------------------------
+
+
+def test_format_version_includes_esphome_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both versions are present → ``... X.Y.Z (esphome A.B.C)``."""
+    monkeypatch.setattr(main_module, "__version__", "2026.5.0")
+    monkeypatch.setattr(main_module, "_esphome_version", lambda: "2026.3.1")
+    assert main_module._format_version() == "esphome-device-builder 2026.5.0 (esphome 2026.3.1)"
+
+
+def test_format_version_omits_esphome_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ``[esphome]`` extra → the parenthetical is dropped entirely."""
+    monkeypatch.setattr(main_module, "__version__", "2026.5.0")
+    monkeypatch.setattr(main_module, "_esphome_version", lambda: None)
+    assert main_module._format_version() == "esphome-device-builder 2026.5.0"
+
+
+# ---------------------------------------------------------------------------
+# end-to-end ``main(['--version'])``
+# ---------------------------------------------------------------------------
+
+
+def test_main_version_flag_prints_and_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--version`` writes the formatted string to stdout and exits ``0``."""
+    monkeypatch.setattr("sys.argv", ["esphome-device-builder", "--version"])
+    monkeypatch.setattr(main_module, "__version__", "2026.5.0")
+    monkeypatch.setattr(main_module, "_esphome_version", lambda: "2026.3.1")
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_module.main()
+
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert "esphome-device-builder 2026.5.0 (esphome 2026.3.1)" in captured.out


### PR DESCRIPTION
The bug report template tells operators to paste the output of `esphome-device-builder --version`, but the flag was never wired up (#287). The existing `config/version` WS endpoint also always returned `0.0.0` because `constants.__version__` was a hardcoded string the release workflow never stamped.

Changes:
- Add `--version` to the CLI; reports `esphome-device-builder X.Y.Z (esphome A.B.C)` when the optional `[esphome]` extra is installed, falls back to the device builder version alone otherwise.
- Source `constants.__version__` from the installed wheel's metadata via `importlib.metadata`, so `pyproject.toml` (stamped by the release workflow) is the single source of truth — fixes the WS endpoint regression as a side effect.
- Drop the outdated `--verbose` example from `script/setup`; it was superseded by `--log-level`.

Closes #287.