### PR TITLE
Resolve nested substitutions when parsing esphome metadata

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -29,6 +29,11 @@ _PLATFORM_KEYS = frozenset({"esp32", "esp8266", "rp2040", "bk72xx", "rtl87xx", "
 # matches ``$name`` or ``${name}`` where name is alphanumeric + underscore.
 _SUBSTITUTION_RE = re.compile(r"\$(\{[a-zA-Z0-9_]*\}|[a-zA-Z0-9_]+)")
 
+# Cap on recursive substitution passes — protects against circular
+# references (``a: ${b}`` / ``b: ${a}``) without bailing on legitimately
+# deep chains a user might write.
+_SUBSTITUTION_MAX_PASSES = 16
+
 # ESPHome's ``esphome.name`` accepts lowercase ASCII letters, digits,
 # and hyphens — the same character class an mDNS hostname / API
 # endpoint can carry. A parsed value with anything else (dots, spaces,
@@ -592,9 +597,12 @@ def _resolve_substitutions(value: str | None, subs: dict[str, str]) -> str | Non
     """
     Replace ``$var`` / ``${var}`` references in *value* with values from *subs*.
 
-    Unknown references are left untouched (mirrors esphome's
-    ``ignore_missing`` behaviour). Returns *value* unchanged when it
-    is ``None`` or contains no references.
+    Substitutions are expanded recursively so a substitution whose value
+    itself references another substitution (e.g. ``comment: "${area}, Well"``
+    paired with ``esphome.comment: ${comment}``) resolves to the fully
+    substituted string. Unknown references are left untouched (mirrors
+    esphome's ``ignore_missing`` behaviour). Returns *value* unchanged when
+    it is ``None`` or contains no references.
     """
     if value is None or "$" not in value:
         return value
@@ -604,4 +612,14 @@ def _resolve_substitutions(value: str | None, subs: dict[str, str]) -> str | Non
         key = token[1:-1] if token.startswith("{") else token
         return subs.get(key, match.group(0))
 
-    return _SUBSTITUTION_RE.sub(repl, value)
+    # Re-run until the string stops changing — a single ``re.sub`` pass
+    # only walks the input once, so a reference whose replacement value
+    # contains another reference would otherwise be left half-resolved.
+    # Bounded to defend against circular substitutions.
+    for _ in range(_SUBSTITUTION_MAX_PASSES):
+        previous = value
+        value = _SUBSTITUTION_RE.sub(repl, value)
+        if value == previous or "$" not in value:
+            break
+
+    return value

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -143,6 +143,54 @@ esphome:
     assert friendly_name == "$missing"
 
 
+def test_parse_meta_resolves_substitution_in_comment() -> None:
+    """Substitutions in ``esphome.comment`` resolve like the other fields."""
+    yaml_content = """
+substitutions:
+  area: Outside
+esphome:
+  name: well
+  comment: "${area} sensor"
+"""
+    _, _, comment = parse_esphome_meta(yaml_content)
+    assert comment == "Outside sensor"
+
+
+def test_parse_meta_resolves_chained_substitutions() -> None:
+    """A substitution whose value references another substitution resolves fully.
+
+    Regression test for substitutions inside ``comment:`` not being
+    expanded when the substitution's own value contained a reference
+    (e.g. ``comment: "${area}, Well"`` + ``esphome.comment: ${comment}``).
+    """
+    yaml_content = """
+substitutions:
+  area: Outside
+  comment: "${area}, Well | Irrigation A"
+esphome:
+  name: well
+  comment: ${comment}
+"""
+    _, _, comment = parse_esphome_meta(yaml_content)
+    assert comment == "Outside, Well | Irrigation A"
+
+
+def test_parse_meta_circular_substitutions_terminate() -> None:
+    """Circular substitution references bail out instead of looping forever."""
+    yaml_content = """
+substitutions:
+  a: ${b}
+  b: ${a}
+esphome:
+  name: device
+  friendly_name: ${a}
+"""
+    # Should return without hanging; the exact stuck value is irrelevant
+    # — what matters is that the resolver terminates safely.
+    _, friendly_name, _ = parse_esphome_meta(yaml_content)
+    assert friendly_name in {"${a}", "${b}"}
+
+
 # ----------------------------------------------------------------------
 # compute_has_pending_changes
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a device YAML uses substitutions whose values themselves contain
substitution references, the dashboard's device card showed the raw
`${...}` token instead of the resolved string. Example from #286:

```yaml
substitutions:
  area: Outside
  comment: "${area}, Well | Irrigation A"
esphome:
  comment: ${comment}
```

`esphome.comment` rendered as `${area}, Well | Irrigation A` instead of
`Outside, Well | Irrigation A`.

`_resolve_substitutions` in `helpers/device_yaml.py` only ran a single
`re.sub` pass — `${comment}` got replaced once, but the inner `${area}`
never got a second pass.

## Changes

- Iterate the resolver until the string stabilises so a substitution
  whose value contains another `$var` reference is fully expanded.
- Cap iterations (16) to defend against circular references like
  `a: ${b}` / `b: ${a}` instead of looping forever.
- Add regression tests for: substitutions inside `comment:`, chained
  substitutions, and the circular-reference guard.

Closes #286.