### PR TITLE
Surface every announced device IP, not just the IPv4 primary

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -84,10 +84,11 @@ StateChangeCallback = Callable[[str, DeviceState, str], None]
 # Callback fired when mDNS resolves (or clears) a device's IP address.
 # ``primary`` is the IPv4 we lock onto for ICMP / OTA cache args (or
 # the first scoped IPv6 when a host has no V4); ``addresses`` is the
-# full announced list — IPv4 first, then any scoped IPv6 entries —
-# so the dashboard can surface every IP a multi-homed device claims.
-# Empty primary + empty list signals the device went offline / was
-# removed from mDNS.
+# announced set — order is whatever zeroconf's
+# ``parsed_scoped_addresses(IPVersion.All)`` returned (in practice
+# IPv4 first, then any scoped IPv6 entries). Single-IP sources (MQTT,
+# DNS fallback) carry just the one address they know. Empty primary +
+# empty list signals the device went offline / was removed from mDNS.
 IPChangeCallback = Callable[[str, str, list[str]], None]
 
 # Callback fired when the mDNS ``version`` TXT record reports a
@@ -318,8 +319,24 @@ class DeviceStateMonitor:
         callers with the full announced set should reach for
         :meth:`apply_ip_addresses` instead so the multi-IP view stays
         accurate.
+
+        When *ip* is already present in the device's ``ip_addresses``
+        list, only the primary slot is touched — a narrower MQTT /
+        DNS observation must not shrink a multi-IP view that mDNS
+        already populated, otherwise we'd re-hide IPv6 the next time
+        MQTT discovery fires.
         """
-        return self._dispatch_ip(name, ip, [ip] if ip else [])
+        if not ip:
+            return self._dispatch_ip(name, "", [])
+        devices = self._get_devices_by_name(name)
+        if not devices:
+            return False
+        # Read ``ip_addresses`` off any matching device — duplicates
+        # all flow through ``_dispatch_ip``'s fan-out so they end up
+        # at the same state regardless of which we sampled here.
+        existing = devices[0].ip_addresses
+        addresses = list(existing) if ip in existing else [ip]
+        return self._dispatch_ip(name, ip, addresses)
 
     def apply_ip_addresses(self, name: str, addresses: list[str]) -> bool:
         """

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -82,8 +82,13 @@ _SOURCE_PRIORITY = {"unknown": 0, "ping": 1, "mqtt": 2, "mdns": 3}
 StateChangeCallback = Callable[[str, DeviceState, str], None]
 
 # Callback fired when mDNS resolves (or clears) a device's IP address.
-# Empty string signals the device went offline / was removed from mDNS.
-IPChangeCallback = Callable[[str, str], None]
+# ``primary`` is the IPv4 we lock onto for ICMP / OTA cache args (or
+# the first scoped IPv6 when a host has no V4); ``addresses`` is the
+# full announced list — IPv4 first, then any scoped IPv6 entries —
+# so the dashboard can surface every IP a multi-homed device claims.
+# Empty primary + empty list signals the device went offline / was
+# removed from mDNS.
+IPChangeCallback = Callable[[str, str, list[str]], None]
 
 # Callback fired when the mDNS ``version`` TXT record reports a
 # different firmware version than last seen for a device.
@@ -305,19 +310,49 @@ class DeviceStateMonitor:
 
     def apply_ip(self, name: str, ip: str) -> bool:
         """
-        Record an IP observation. Empty string clears the stored IP.
+        Record a single-IP observation. Empty string clears the stored IPs.
 
         Returns True when the IP actually changed and the change was
-        forwarded to the callback. Dedupe is done against the
-        configured devices' current ``ip`` field rather than a
-        separate monitor cache so a Device that's been rebuilt with
-        ``previous=None`` (e.g. an atomic save's brief
-        REMOVE+re-ADD scan churn) still gets repopulated by the
-        next mDNS announcement.
+        forwarded to the callback. Used by sources that only know one
+        address per device (MQTT discovery, DNS resolve fallback);
+        callers with the full announced set should reach for
+        :meth:`apply_ip_addresses` instead so the multi-IP view stays
+        accurate.
         """
-        if not self._any_matching_device_differs(name, "ip", ip):
+        return self._dispatch_ip(name, ip, [ip] if ip else [])
+
+    def apply_ip_addresses(self, name: str, addresses: list[str]) -> bool:
+        """
+        Record the full set of announced IPs for *name*.
+
+        Picks an IPv4 primary via :func:`_pick_ipv4` (falling back to
+        the first scoped IPv6 when no V4 is present) so ``device.ip``
+        keeps its "single IP we'll hand to ICMP / OTA" shape, and
+        forwards the complete list so ``device.ip_addresses`` reflects
+        what the device is broadcasting. Empty list clears both.
+        """
+        primary = _pick_ipv4(addresses) if addresses else ""
+        return self._dispatch_ip(name, primary, addresses)
+
+    def _dispatch_ip(self, name: str, primary: str, addresses: list[str]) -> bool:
+        """
+        Shared dedupe + dispatch for both apply_ip variants.
+
+        Dedupe is done against the configured devices' current ``ip``
+        and ``ip_addresses`` fields rather than a separate monitor
+        cache so a Device that's been rebuilt with ``previous=None``
+        (e.g. an atomic save's brief REMOVE+re-ADD scan churn) still
+        gets repopulated by the next mDNS announcement. Either side
+        differing is enough to fire — a host that picks up an IPv6
+        address while keeping the same IPv4 still surfaces in the
+        dashboard.
+        """
+        devices = self._get_devices_by_name(name)
+        if not devices:
             return False
-        self._on_ip_change(name, ip)
+        if all(d.ip == primary and d.ip_addresses == addresses for d in devices):
+            return False
+        self._on_ip_change(name, primary, addresses)
         return True
 
     def apply_version(self, name: str, version: str) -> bool:
@@ -784,14 +819,15 @@ class DeviceStateMonitor:
         # had already labelled the device — same shape the browser
         # callback uses on its way into this method.
         self.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
-        # Prefer V4; fall back to scoped V6 (link-local needs the
-        # ``%scope`` suffix to connect at all). Matches the upstream
-        # esphome dashboard's ``parsed_scoped_addresses`` usage.
-        addresses = info.parsed_scoped_addresses(IPVersion.V4Only) or info.parsed_scoped_addresses(
-            IPVersion.V6Only
-        )
-        if addresses:
-            self.apply_ip(device_name, addresses[0])
+        # Pull every announced address (IPv4 first, then scoped IPv6
+        # — link-local entries keep the ``%scope`` suffix that's
+        # required to connect at all). ``apply_ip_addresses`` picks
+        # the IPv4 primary for ``device.ip`` and forwards the whole
+        # list so ``device.ip_addresses`` reflects what's actually
+        # broadcast — a multi-homed dual-stack device used to surface
+        # only its V4 here.
+        if addresses := info.parsed_scoped_addresses(IPVersion.All):
+            self.apply_ip_addresses(device_name, addresses)
         # ``decoded_properties`` is a ``dict[str, str | None]`` — zeroconf
         # already handles the UTF-8 decode and None-on-bad-bytes for us.
         props = info.decoded_properties
@@ -869,7 +905,7 @@ class DeviceStateMonitor:
                 # we want mDNS to be the single source of truth for
                 # devices that respond to it.
                 self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-                self.apply_ip(device.name, _pick_ipv4(addresses))
+                self.apply_ip_addresses(device.name, addresses)
             # No OFFLINE branch — deliberate. The browser path can
             # trust mDNS in both directions because the
             # ServiceBrowser delivers a ``Removed`` event when a
@@ -957,14 +993,11 @@ class DeviceStateMonitor:
                 cached := self.get_cached_addresses(device.address)
             ):
                 self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-                # Prefer IPv4 for ``apply_ip`` (the per-device single
-                # IP) so the device-list display and any ad-hoc ICMP
-                # probe both pick the cross-subnet-friendly entry. The
-                # OTA cache args built in
-                # ``_build_address_cache_args`` consume every cached
-                # IP separately, so we don't lose V6 reachability by
-                # picking V4 here.
-                self.apply_ip(device.name, _pick_ipv4(cached))
+                # Forward every cached IP so the dashboard shows all
+                # of them; ``apply_ip_addresses`` picks an IPv4 primary
+                # for ``device.ip`` so ICMP probes and OTA cache args
+                # still hit the cross-subnet-friendly entry.
+                self.apply_ip_addresses(device.name, cached)
                 continue
             if self._dns_cache.has_cached_failure(device.address):
                 dns_skipped.append(device)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -906,7 +906,7 @@ class DevicesController:
         self._state_monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
         cached = self._state_monitor.get_cached_addresses(f"{mdns_name}.local")
         if cached:
-            self._state_monitor.apply_ip(name, cached[0])
+            self._state_monitor.apply_ip_addresses(name, cached)
         # Eagerly probe the esphomelib service so the new card lands
         # with version / config_hash / api_encryption populated, not
         # just IP. The device on the network is still broadcasting
@@ -1215,21 +1215,33 @@ class DevicesController:
                 {"configuration": device.configuration, "state": state.value},
             )
 
-    def _on_ip_change(self, name: str, ip: str) -> None:
+    def _on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:
         """
-        Forward IP updates onto the event bus and persist non-empty values.
+        Forward IP updates onto the event bus and persist the primary value.
 
-        ``ip=""`` means the device dropped off mDNS — we keep the
-        last-known IP on disk so the OTA address cache stays warm
-        across the device's offline window. The DNS pre-resolve and
-        next mDNS resolve will overwrite it on reconnect.
+        ``ip=""`` (with an empty *addresses* list) means the device
+        dropped off mDNS — we keep the last-known primary on disk so
+        the OTA address cache stays warm across the device's offline
+        window. The DNS pre-resolve and next mDNS resolve will
+        overwrite it on reconnect.
+
+        Only ``ip`` is persisted; ``addresses`` is the live mDNS view
+        and gets repopulated by the next monitor pass after a restart.
         """
+        new_addresses = list(addresses)
         for device in self._devices_by_name(name):
-            if device.ip == ip:
+            if device.ip == ip and device.ip_addresses == new_addresses:
                 continue
+            ip_changed = device.ip != ip
             device.ip = ip
-            _LOGGER.debug("Device %s (%s) IP: %s", name, device.configuration, ip or "(cleared)")
-            if ip:
+            device.ip_addresses = list(new_addresses)
+            _LOGGER.debug(
+                "Device %s (%s) IPs: %s",
+                name,
+                device.configuration,
+                ", ".join(new_addresses) or "(cleared)",
+            )
+            if ip and ip_changed:
                 self._db.create_background_task(
                     self._persist_device_ip_async(device.configuration, ip)
                 )

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -397,6 +397,11 @@ def load_device_from_storage(
 
     deployed_config_hash = previous.deployed_config_hash if previous else ""
     state = previous.state if previous else DeviceState.UNKNOWN
+    # mDNS-derived view that isn't persisted in the metadata sidecar;
+    # carry it across reloads so a re-scan triggered by an unrelated
+    # YAML edit doesn't blank the dashboard's IP list until the next
+    # mDNS broadcast lands.
+    ip_addresses = list(previous.ip_addresses) if previous else []
 
     has_pending = compute_has_pending_changes(
         yaml_mtime=yaml_mtime,
@@ -456,6 +461,7 @@ def load_device_from_storage(
         # ``esphome.address``.
         address=(storage.address if storage and storage.address else f"{fallback_name}.local"),
         ip=ip,
+        ip_addresses=ip_addresses,
         web_port=storage.web_port if storage else None,
         current_version=const.__version__,
         deployed_version=deployed,

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -27,10 +27,19 @@ class Device(DataClassORJSONMixin):
     board_id: str = ""
     target_platform: str = ""
     address: str = ""  # mDNS hostname from StorageJSON (e.g. "my_device.local")
-    # Last-known resolved IP. Populated by mDNS resolution and DNS
+    # Last-known resolved IP — primary IPv4 when available, else the
+    # first scoped IPv6. Populated by mDNS resolution and DNS
     # pre-resolve in the ping sweep, persisted through the device-builder
     # metadata sidecar so the OTA address cache survives a restart.
     ip: str = ""
+    # Every IP currently announced by the device, IPv4 first then any
+    # scoped IPv6 entries (link-local addresses keep the ``%scope``
+    # suffix). Populated from zeroconf's ``parsed_scoped_addresses``
+    # so the dashboard can surface a multi-homed device's full set —
+    # ``ip`` only holds the primary picked for OTA cache args.
+    # Runtime-only: not persisted to the metadata sidecar; the next
+    # mDNS pass repopulates after a restart.
+    ip_addresses: list[str] = field(default_factory=list)
     web_port: int | None = None
     current_version: str = ""
     deployed_version: str = ""

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -32,13 +32,14 @@ class Device(DataClassORJSONMixin):
     # pre-resolve in the ping sweep, persisted through the device-builder
     # metadata sidecar so the OTA address cache survives a restart.
     ip: str = ""
-    # Every IP currently announced by the device, IPv4 first then any
-    # scoped IPv6 entries (link-local addresses keep the ``%scope``
-    # suffix). Populated from zeroconf's ``parsed_scoped_addresses``
-    # so the dashboard can surface a multi-homed device's full set —
-    # ``ip`` only holds the primary picked for OTA cache args.
-    # Runtime-only: not persisted to the metadata sidecar; the next
-    # mDNS pass repopulates after a restart.
+    # Every IP currently known for the device. mDNS populates from
+    # zeroconf's ``parsed_scoped_addresses`` (in practice IPv4 first,
+    # then any scoped IPv6 — link-local addresses keep the ``%scope``
+    # suffix); single-IP sources (MQTT discovery, DNS fallback) carry
+    # just the one address they know. ``ip`` always holds the primary
+    # picked for OTA cache args. Runtime-only: not persisted to the
+    # metadata sidecar; the next mDNS pass repopulates after a
+    # restart.
     ip_addresses: list[str] = field(default_factory=list)
     web_port: int | None = None
     current_version: str = ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -378,9 +378,10 @@ class RecordingMonitorCallbacks:
         self.calls.append(("on_state_change", name, state, source))
         self._flip(name, "state", state)
 
-    def on_ip_change(self, name: str, ip: str) -> None:
-        self.calls.append(("on_ip_change", name, ip))
+    def on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:
+        self.calls.append(("on_ip_change", name, ip, list(addresses)))
         self._flip(name, "ip", ip)
+        self._flip(name, "ip_addresses", list(addresses))
 
     def on_version_change(self, name: str, version: str) -> None:
         self.calls.append(("on_version_change", name, version))

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -97,6 +97,10 @@ class RecordingStateMonitor:
         self.calls.append(("apply_ip", name, ip))
         return True
 
+    def apply_ip_addresses(self, name: str, addresses: list[str]) -> bool:
+        self.calls.append(("apply_ip_addresses", name, list(addresses)))
+        return True
+
     def apply_version(self, name: str, version: str) -> bool:
         self.calls.append(("apply_version", name, version))
         return True

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -55,7 +55,7 @@ from .conftest import (
 )
 
 
-def _device(name: str, *, ip: str = "") -> Device:
+def _device(name: str, *, ip: str = "", ip_addresses: list[str] | None = None) -> Device:
     return Device(
         name=name,
         friendly_name=name.title(),
@@ -63,6 +63,7 @@ def _device(name: str, *, ip: str = "") -> Device:
         address=f"{name}.local",
         state=DeviceState.ONLINE,
         ip=ip,
+        ip_addresses=list(ip_addresses) if ip_addresses else [],
     )
 
 
@@ -328,14 +329,14 @@ def test_on_ip_change_skips_when_ip_unchanged(
     benchmarks (not just a soft "feels slow" complaint).
     """
     controller = make_controller(tmp_path)
-    device = _device("kitchen", ip="192.168.1.42")
+    device = _device("kitchen", ip="192.168.1.42", ip_addresses=["192.168.1.42"])
     controller._scanner._devices_by_name = {"kitchen": [device]}  # type: ignore[attr-defined]
     captured = capture_devices_events(controller, EventType.DEVICE_UPDATED)
     spawned: list[Any] = []
     controller._db.create_background_task = spawned.append
 
-    # Same IP → no-op.
-    controller._on_ip_change("kitchen", "192.168.1.42")
+    # Same primary + same list → no-op.
+    controller._on_ip_change("kitchen", "192.168.1.42", ["192.168.1.42"])
 
     assert captured == []
     assert spawned == []

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -331,7 +331,7 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     assert ctrl._state_monitor.calls == [
         ("apply", "kitchen", DeviceState.ONLINE, "mdns", True),
         ("get_cached_addresses", "kitchen.local"),
-        ("apply_ip", "kitchen", "192.168.1.42"),
+        ("apply_ip_addresses", "kitchen", ["192.168.1.42"]),
         ("probe_device", "kitchen", "kitchen"),
     ]
 

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -233,11 +233,11 @@ async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
     """A ping sweep populates the DNS cache and pings the resolved IP."""
     devices = [_device()]
     state_changes: list[tuple[str, object, str]] = []
-    ip_changes: list[tuple[str, str]] = []
+    ip_changes: list[tuple[str, str, list[str]]] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
         on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
-        on_ip_change=lambda n, ip: ip_changes.append((n, ip)),
+        on_ip_change=lambda n, ip, addrs: ip_changes.append((n, ip, list(addrs))),
     )
 
     resolver = fake_resolver(["10.0.0.1"])
@@ -258,7 +258,7 @@ async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
         await monitor._ping_sweep()
 
     assert pinged == ["10.0.0.1"]
-    assert ip_changes == [("kitchen", "10.0.0.1")]
+    assert ip_changes == [("kitchen", "10.0.0.1", ["10.0.0.1"])]
     # DNS cache is now warm — ``get_cached_dns_addresses`` should hit
     # without triggering another resolver call.
     assert monitor.get_cached_dns_addresses("esp.example.com") == ["10.0.0.1"]
@@ -267,11 +267,11 @@ async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
 async def test_ping_sweep_does_not_apply_ip_for_local_hosts(fake_resolver) -> None:
     """``.local`` devices keep their mDNS-owned IP — DNS doesn't write."""
     devices = [_device(address="kitchen.local")]
-    ip_changes: list[tuple[str, str]] = []
+    ip_changes: list[tuple[str, str, list[str]]] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
         on_state_change=lambda *_: None,
-        on_ip_change=lambda n, ip: ip_changes.append((n, ip)),
+        on_ip_change=lambda n, ip, addrs: ip_changes.append((n, ip, list(addrs))),
     )
 
     resolver = fake_resolver(["192.168.1.50"])
@@ -304,11 +304,11 @@ async def test_ping_sweep_rescues_local_device_from_zeroconf_cache() -> None:
     """
     devices = [_device(address="winefridge.local", name="winefridge")]
     state_changes: list[tuple[str, object, str]] = []
-    ip_changes: list[tuple[str, str]] = []
+    ip_changes: list[tuple[str, str, list[str]]] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
         on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
-        on_ip_change=lambda n, ip: ip_changes.append((n, ip)),
+        on_ip_change=lambda n, ip, addrs: ip_changes.append((n, ip, list(addrs))),
     )
 
     pinged: list[str] = []
@@ -329,7 +329,7 @@ async def test_ping_sweep_rescues_local_device_from_zeroconf_cache() -> None:
 
     assert pinged == []
     assert state_changes == [("winefridge", DeviceState.ONLINE, "mdns")]
-    assert ip_changes == [("winefridge", "192.168.213.11")]
+    assert ip_changes == [("winefridge", "192.168.213.11", ["192.168.213.11"])]
     assert monitor.priority_for("winefridge") == "mdns"
 
 
@@ -615,25 +615,31 @@ def test_on_ip_change_persists_non_empty_value() -> None:
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_ip_change("kitchen", "10.0.0.1")
+    controller._on_ip_change("kitchen", "10.0.0.1", ["10.0.0.1", "fe80::1%en0"])
 
     assert device.ip == "10.0.0.1"
+    assert device.ip_addresses == ["10.0.0.1", "fe80::1%en0"]
     assert len(scheduled) == 1
 
 
 def test_on_ip_change_skips_persist_for_empty_value() -> None:
     """Empty IP (device went offline) doesn't schedule a write — keeps the cache warm."""
     device = Device(
-        name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml", ip="10.0.0.1"
+        name="kitchen",
+        friendly_name="Kitchen",
+        configuration="kitchen.yaml",
+        ip="10.0.0.1",
+        ip_addresses=["10.0.0.1"],
     )
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_ip_change("kitchen", "")
+    controller._on_ip_change("kitchen", "", [])
 
     assert device.ip == ""
+    assert device.ip_addresses == []
     assert scheduled == []
 
 

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -276,13 +276,12 @@ async def test_offline_via_ping_still_resolved() -> None:
 
 @pytest.mark.asyncio
 async def test_resolve_picks_ipv4_for_apply_ip() -> None:
-    """``apply_ip`` gets the IPv4 address even when V6 is present.
+    """Active resolve forwards every IP; primary picks IPv4 when present.
 
-    ``Device.ip`` only carries one address; cross-subnet ICMP and
-    the device-list display both prefer V4. The address-cache CLI
-    args still consume every IP via a different code path
-    (``_build_address_cache_args``), so we don't lose V6
-    reachability by picking V4 here.
+    ``Device.ip`` only carries one address — cross-subnet ICMP and
+    OTA cache args both prefer V4 — but ``Device.ip_addresses``
+    keeps the full announced set so the dashboard can surface every
+    IP a multi-homed device claims.
     """
     devices = [_device(loaded_integrations=["web_server"])]
     monitor, _ = _make_monitor(
@@ -293,6 +292,7 @@ async def test_resolve_picks_ipv4_for_apply_ip() -> None:
     await monitor._resolve_non_api_mdns_targets()
 
     assert devices[0].ip == "192.168.1.42"
+    assert devices[0].ip_addresses == ["fe80::1%en0", "192.168.1.42", "fe80::2%en0"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -77,10 +77,12 @@ def test_ip_change_fans_out_to_every_matching_device() -> None:
         create_background_task=_close_coro,
     )
 
-    controller._on_ip_change("kitchen", "10.0.0.5")
+    controller._on_ip_change("kitchen", "10.0.0.5", ["10.0.0.5"])
 
     assert a.ip == "10.0.0.5"
     assert b.ip == "10.0.0.5"
+    assert a.ip_addresses == ["10.0.0.5"]
+    assert b.ip_addresses == ["10.0.0.5"]
     assert len(captured) == 2
     assert sorted(e.data["device"].configuration for e in captured) == [
         "kitchen (1).yaml",

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1256,3 +1256,41 @@ def test_apply_ip_addresses_fires_when_list_changes_but_primary_does_not() -> No
     ]
     assert device.ip == "10.0.0.1"
     assert device.ip_addresses == ["10.0.0.1", "fe80::1%en0"]
+
+
+def test_apply_ip_preserves_multi_ip_list_when_primary_already_known() -> None:
+    """Single-IP sources don't shrink a multi-IP view they don't see.
+
+    MQTT discovery fires every ping interval against a device whose
+    mDNS bundle (V4 + V6) already populated ``ip_addresses``. Without
+    this guard, MQTT's narrower observation would collapse the list
+    back to ``[v4]`` every cycle and re-hide the V6 from the
+    dashboard until the next mDNS pass.
+    """
+    device = _device(ip="10.0.0.1", ip_addresses=["10.0.0.1", "fe80::1%en0"])
+    monitor, callbacks = _make_monitor([device])
+
+    monitor.apply_ip("kitchen", "10.0.0.1")
+
+    assert callbacks.calls_for("on_ip_change") == []
+    assert device.ip == "10.0.0.1"
+    assert device.ip_addresses == ["10.0.0.1", "fe80::1%en0"]
+
+
+def test_apply_ip_replaces_list_when_primary_is_new() -> None:
+    """A different single IP overrides the list — the device moved networks.
+
+    The previous V4 isn't in the new MQTT-reported set, so we treat
+    that as authoritative for the live IP and let the next mDNS pass
+    repopulate the V6 entries.
+    """
+    device = _device(ip="10.0.0.1", ip_addresses=["10.0.0.1", "fe80::1%en0"])
+    monitor, callbacks = _make_monitor([device])
+
+    monitor.apply_ip("kitchen", "10.0.0.99")
+
+    assert callbacks.calls_for("on_ip_change") == [
+        ("on_ip_change", "kitchen", "10.0.0.99", ["10.0.0.99"]),
+    ]
+    assert device.ip == "10.0.0.99"
+    assert device.ip_addresses == ["10.0.0.99"]

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -365,24 +365,23 @@ async def test_dispatch_removed_event_flips_offline_clears_ip(
 async def test_dispatch_added_cache_hit_propagates_full_txt_bundle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A cache-hit Added event applies IP + version + config_hash + api_encryption.
+    """A cache-hit Added event applies IPs + version + config_hash + api_encryption.
 
     Anchors the full bundle so a refactor that drops one of the
     apply-* calls (or reorders in a way that hides a missing one)
-    surfaces here. Also the V4 preference: apply_ip receives the
-    V4 address even though the info also carries V6.
+    surfaces here. Also the V4-primary preference: ``device.ip``
+    holds the IPv4 even when the info also carries V6, while
+    ``device.ip_addresses`` keeps every announced address.
     """
     device = _device()
     monitor, _callbacks = _make_monitor([device])
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = True
-
-    def _addresses(mode: Any) -> list[str]:
-        # IPVersion.V4Only first, then V6Only on the fallback call.
-        return ["10.0.0.5"] if "V4" in repr(mode) else ["fe80::1%en0"]
-
-    fake_info.parsed_scoped_addresses = _addresses
+    # ``_apply_service_info`` calls ``parsed_scoped_addresses(IPVersion.All)``
+    # — return the full announced set (V4 + V6) so we can assert the
+    # primary picks V4 and the full list lands on the device.
+    fake_info.parsed_scoped_addresses = lambda _mode: ["10.0.0.5", "fe80::1%en0"]
     fake_info.decoded_properties = {
         "version": "2026.5.0",
         "config_hash": "abcd1234",
@@ -401,6 +400,7 @@ async def test_dispatch_added_cache_hit_propagates_full_txt_bundle(
 
         assert device.state == DeviceState.ONLINE
         assert device.ip == "10.0.0.5"
+        assert device.ip_addresses == ["10.0.0.5", "fe80::1%en0"]
         assert device.deployed_version == "2026.5.0"
         assert device.deployed_config_hash == "abcd1234"
         assert device.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
@@ -413,23 +413,19 @@ async def test_dispatch_added_cache_hit_propagates_full_txt_bundle(
 async def test_dispatch_added_cache_hit_falls_back_to_v6_when_no_v4(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No V4 in the cached info → ``apply_ip`` gets the first scoped V6.
+    """V6-only announcement → primary is the first scoped V6 address.
 
-    Pin the ``parsed_scoped_addresses(V4Only) or
-    parsed_scoped_addresses(V6Only)`` short-circuit. Empty V4 list
-    falls through; if the second call also returned empty, no
-    apply_ip happens.
+    Pin the V4-preference fallback in ``_pick_ipv4``: with no IPv4
+    in the announced set, ``device.ip`` lands on the first V6 entry
+    so the OTA cache args still have a target. The full list flows
+    through to ``ip_addresses`` either way.
     """
     device = _device(state=DeviceState.UNKNOWN)
     monitor, _callbacks = _make_monitor([device])
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = True
-
-    def _addresses(mode: Any) -> list[str]:
-        return [] if "V4" in repr(mode) else ["fe80::1%en0"]
-
-    fake_info.parsed_scoped_addresses = _addresses
+    fake_info.parsed_scoped_addresses = lambda _mode: ["fe80::1%en0"]
     fake_info.decoded_properties = {}
     monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
@@ -442,6 +438,7 @@ async def test_dispatch_added_cache_hit_falls_back_to_v6_when_no_v4(
             ServiceStateChange.Added,
         )
         assert device.ip == "fe80::1%en0"
+        assert device.ip_addresses == ["fe80::1%en0"]
     finally:
         await _stop_and_drain(monitor)
 
@@ -1227,16 +1224,35 @@ async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
 
 
 def test_apply_ip_short_circuits_when_value_unchanged() -> None:
-    """``apply_ip`` is a no-op when every matching device already has *ip*.
+    """``apply_ip`` is a no-op when both primary + list already match.
 
-    Pin the dedupe so a refactor that drops the
-    ``_any_matching_device_differs`` guard surfaces here — without
-    it, every mDNS announcement would re-fire DEVICE_UPDATED for
-    the same IP and the UI would thrash.
+    Pin the dedupe so a refactor that drops the device-state
+    comparison surfaces here — without it, every mDNS announcement
+    would re-fire DEVICE_UPDATED for the same IP and the UI would
+    thrash.
     """
-    device = _device(ip="10.0.0.1")
+    device = _device(ip="10.0.0.1", ip_addresses=["10.0.0.1"])
     monitor, callbacks = _make_monitor([device])
 
     monitor.apply_ip("kitchen", "10.0.0.1")
 
     assert callbacks.calls_for("on_ip_change") == []
+
+
+def test_apply_ip_addresses_fires_when_list_changes_but_primary_does_not() -> None:
+    """A device picking up a V6 address while keeping its V4 still fires.
+
+    The dedupe has to look at both ``ip`` and ``ip_addresses`` so a
+    dual-stack device whose V4 was already known surfaces its
+    newly-announced V6 too.
+    """
+    device = _device(ip="10.0.0.1", ip_addresses=["10.0.0.1"])
+    monitor, callbacks = _make_monitor([device])
+
+    monitor.apply_ip_addresses("kitchen", ["10.0.0.1", "fe80::1%en0"])
+
+    assert callbacks.calls_for("on_ip_change") == [
+        ("on_ip_change", "kitchen", "10.0.0.1", ["10.0.0.1", "fe80::1%en0"]),
+    ]
+    assert device.ip == "10.0.0.1"
+    assert device.ip_addresses == ["10.0.0.1", "fe80::1%en0"]


### PR DESCRIPTION
## Problem

A multi-homed (dual-stack V4 + V6) device only ever surfaced its IPv4 address through the dashboard. The state monitor read `parsed_scoped_addresses(IPVersion.V4Only)` first, fell back to `V6Only`, and dropped everything but the first entry — and the `Device` model only carried a single `ip` field anyway, so there was nowhere to put the rest. Net effect: IPv6 addresses never reached the UI.

## Changes

- Add `Device.ip_addresses: list[str]` for the full announced set; `ip` stays as the IPv4 primary used by ICMP probes and the OTA address cache.
- Switch `_apply_service_info` to `IPVersion.All` and pipe every address through a new `apply_ip_addresses` on the state monitor.
- Extend the IP-change callback to `(name, primary, addresses)` so controllers update both fields atomically and fire a single `DEVICE_UPDATED` event.
- Carry `ip_addresses` across re-scans via the `previous` Device so YAML edits don't blank the live IP list until the next mDNS pass.