### PR TITLE
Resolve packages in device-metadata YAML loader (closes #288)

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -23,13 +23,13 @@ from esphome.storage_json import StorageJSON, ext_storage_path
 # Prefer the upstream single-call seam when present (the
 # ``resolve_packages`` proposal landing as esphome/esphome#16235).
 # Fall back to the two-step ``do_packages_pass`` + ``merge_packages``
-# that ESPHome's own pipeline strings together at
-# ``esphome.config:1010-1039`` today. Both imports are guarded by
-# ``try/except ImportError``: a future esphome that ships only
-# ``resolve_packages`` (deprecating or moving the two-step helpers)
-# would otherwise break our module-load. Once the dashboard's dep
-# floor moves past the release that shipped ``resolve_packages``,
-# the entire fallback path can be deleted in one commit.
+# that ESPHome's own ``validate_config`` pipeline strings together
+# today. Both imports are guarded by ``try/except ImportError``:
+# a future esphome that ships only ``resolve_packages`` (deprecating
+# or moving the two-step helpers) would otherwise break our module-
+# load. Once the dashboard's dep floor moves past the release that
+# shipped ``resolve_packages``, the entire fallback path can be
+# deleted in one commit.
 try:
     from esphome.components.packages import (  # type: ignore[attr-defined]
         resolve_packages as _resolve_packages,
@@ -640,8 +640,9 @@ def load_device_yaml(path: Path) -> dict | None:
     if not isinstance(config, dict):
         return None
     # ``packages:`` is a separate pass in the ESPHome pipeline (see
-    # ``esphome.config:1010-1039``): packages need to be loaded and
-    # merged so blocks they contribute (api / wifi / target-platform
+    # ``do_packages_pass`` + ``merge_packages`` in
+    # ``esphome.config.validate_config``): packages need to be loaded
+    # and merged so blocks they contribute (api / wifi / target-platform
     # / …) become top-level keys. Without this step a config that
     # puts those blocks behind ``packages:`` comes back from
     # ``yaml_util.load_yaml`` with everything still nested under

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -17,17 +17,19 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from esphome import const, yaml_util
-from esphome.components.packages import do_packages_pass, merge_packages
 from esphome.const import CONF_PACKAGES
 from esphome.storage_json import StorageJSON, ext_storage_path
 
-# Prefer the upstream single-call seam when present (proposed-but-not-
-# yet-merged ``esphome.components.packages.resolve_packages``). Falls
-# back to the two-step ``do_packages_pass`` + ``merge_packages`` that
-# ESPHome's own pipeline strings together at ``esphome.config:1010-1039``
-# today. Once an esphome release ships ``resolve_packages`` and the
-# dashboard's dep floor moves past it, the fallback can be deleted in
-# one commit.
+# Prefer the upstream single-call seam when present (the
+# ``resolve_packages`` proposal landing as esphome/esphome#16235).
+# Fall back to the two-step ``do_packages_pass`` + ``merge_packages``
+# that ESPHome's own pipeline strings together at
+# ``esphome.config:1010-1039`` today. Both imports are guarded by
+# ``try/except ImportError``: a future esphome that ships only
+# ``resolve_packages`` (deprecating or moving the two-step helpers)
+# would otherwise break our module-load. Once the dashboard's dep
+# floor moves past the release that shipped ``resolve_packages``,
+# the entire fallback path can be deleted in one commit.
 try:
     from esphome.components.packages import (  # type: ignore[attr-defined]
         resolve_packages as _resolve_packages,
@@ -35,9 +37,87 @@ try:
 except ImportError:
     _resolve_packages = None
 
+try:
+    from esphome.components.packages import (
+        do_packages_pass as _do_packages_pass,
+    )
+    from esphome.components.packages import (
+        is_remote_package as _is_remote_package,
+    )
+    from esphome.components.packages import (
+        merge_packages as _merge_packages,
+    )
+except ImportError:
+    _do_packages_pass = None  # type: ignore[assignment]
+    _merge_packages = None  # type: ignore[assignment]
+    _is_remote_package = None  # type: ignore[assignment]
+
 from ..models import Device, DeviceState
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _has_remote_packages(packages_subtree: object) -> bool:
+    """Return True when the ``packages:`` subtree contains any remote ref.
+
+    A remote package triggers ``git clone`` / URL fetch synchronously
+    inside ``do_packages_pass`` — first-run latency runs into 5-10
+    minutes on a slow connection / large repo. The metadata refresh
+    runs on the WS event loop; that wait would freeze the dashboard
+    for every connected client. Callers use this gate to skip the
+    merge entirely for configs with any remote package ref and
+    degrade to the unmerged shape (same behaviour as pre-fix; once
+    the user compiles, ``StorageJSON.loaded_integrations`` /
+    ``target_platform`` fill in the package-aware metadata anyway).
+
+    What counts as remote is delegated to ESPHome's own
+    ``is_remote_package`` (a dict with a ``url:`` key) plus the
+    git-shorthand string form (``github://user/repo@ref``,
+    ``gitlab://...``) — both are network-dependent. Local shapes
+    are ``IncludeFile`` (resolved ``!include`` — file-IO only) and
+    inline-dict config fragments. Hardcoding the remote-key list
+    here would drift the moment ESPHome adds a new remote shape;
+    using upstream's predicate keeps the gate in sync.
+
+    The walk descends ONLY into nested ``packages:`` blocks inside
+    local config fragments. ESPHome supports a local package
+    referencing a remote one through its own ``packages:`` key, so
+    we have to recurse there — but we DON'T recurse into arbitrary
+    config-fragment values (``wifi: { ssid: ... }`` shouldn't have
+    its scalar leaves treated as package definitions). That
+    distinction is what makes the recursion correct: a string AT
+    the package-definition position is remote, a string anywhere
+    else (a wifi password, a sensor name, …) isn't.
+    """
+    if isinstance(packages_subtree, list):
+        return any(_has_remote_packages(item) for item in packages_subtree)
+    if not isinstance(packages_subtree, dict):
+        # ``IncludeFile`` / ``None`` / scalar — none are remote.
+        # ``packages:`` itself can be ``!include packages.yaml``,
+        # which yaml_util returns as ``IncludeFile`` (file-IO only,
+        # no network), and we want to allow that.
+        return False
+    for definition in packages_subtree.values():
+        if isinstance(definition, str):
+            # Shorthand at the package-definition level
+            # (``github://...``) is always remote. Strings deeper
+            # inside config fragments don't reach this branch
+            # because we only recurse into nested ``packages:``
+            # blocks, not arbitrary value subtrees.
+            return True
+        if isinstance(definition, dict):
+            if _is_remote_package is not None and _is_remote_package(definition):
+                return True
+            # Local config fragment — recurse ONLY into its own
+            # nested ``packages:`` key (if any). Walking into
+            # arbitrary keys (``wifi:`` / ``sensor:`` / …) would
+            # over-trigger on benign string values.
+            nested = definition.get(CONF_PACKAGES)
+            if nested is not None and _has_remote_packages(nested):
+                return True
+        # Anything else (``IncludeFile``, scalars) is local.
+    return False
+
 
 if TYPE_CHECKING:
     from ..models import BoardCatalogEntry
@@ -199,15 +279,23 @@ def detect_platform_from_yaml(path: Path) -> str:
     Find a YAML file's platform key.
 
     First tries the cheap line-scan against the raw file (no parser
-    involved, survives mid-edit drafts). Falls back to a full
-    package-resolved load when the raw scan misses — configs that
-    place ``esp32:`` / ``esp8266:`` / etc. inside a ``packages:``
-    reference (BLE-beacon configs sharing a common board package,
-    Apollo's dashboard_import flow, …) only register that key after
-    package merge runs. Without the fallback those devices come
-    back with ``target_platform=""`` and the dashboard's web-flasher
-    gate (which checks the platform string) hides the option even
-    when the device is an ESP32.
+    involved, survives mid-edit drafts). Falls back to the
+    package-merged load ONLY when the raw scan misses AND the file
+    actually contains a ``packages:`` block — configs that place
+    ``esp32:`` / ``esp8266:`` / etc. inside a package only register
+    that key after merge runs. Without the gate every YAML that
+    happens to omit a top-level platform key (mid-edit drafts,
+    package-less configs that get their platform from
+    ``StorageJSON``) would pay a full parser load on every
+    dashboard scan, even though there's nothing in the file the
+    merge could surface. The cheap-regex-only fast path stays the
+    winner for the typical no-packages config.
+
+    The merge itself defends against remote-package timeouts (see
+    ``_has_remote_packages`` upstream of ``load_device_yaml``), so
+    a remote-package config still falls back gracefully here —
+    its platform comes from the post-compile ``StorageJSON``
+    instead.
 
     Returns the empty string when neither path turns up a platform.
     """
@@ -221,6 +309,11 @@ def detect_platform_from_yaml(path: Path) -> str:
         platform = ""
     if platform:
         return platform
+    if not yaml_has_top_level_block(raw, CONF_PACKAGES):
+        # No ``packages:`` block in the raw text → the merge can't
+        # surface a platform key that wasn't already there. Skip
+        # the load to keep the scan cheap.
+        return ""
     config = load_device_yaml(path)
     if isinstance(config, dict):
         for key in config:
@@ -619,32 +712,46 @@ def load_device_yaml(path: Path) -> dict | None:
     if not isinstance(config, dict):
         return None
     # ``packages:`` is a separate pass in the ESPHome pipeline (see
-    # ``esphome.config:1010-1039``): packages need to be loaded
-    # (file open / git fetch / !include resolution) and then merged
-    # so blocks they contribute (api / wifi / target-platform / …)
-    # become top-level keys. Without this step a config that puts
-    # those blocks behind ``packages:`` comes back from
+    # ``esphome.config:1010-1039``): packages need to be loaded and
+    # merged so blocks they contribute (api / wifi / target-platform
+    # / …) become top-level keys. Without this step a config that
+    # puts those blocks behind ``packages:`` comes back from
     # ``yaml_util.load_yaml`` with everything still nested under
     # ``packages:``, and the dashboard's flag detection silently
-    # misses them. ``_resolve_packages`` (when available) and the
-    # ``do_packages_pass`` + ``merge_packages`` fallback are both
-    # pure delegations to ESPHome internals — the loader and merge
-    # algorithm live upstream.
-    if isinstance(config.get(CONF_PACKAGES), (dict, list)):
+    # misses them. We delegate to ESPHome internals — the loader
+    # and merge algorithm live upstream.
+    #
+    # CRITICAL: only merge when the ``packages:`` subtree is purely
+    # local. A remote package (``url:`` key, or git-shorthand
+    # string) makes ``do_packages_pass`` run ``git clone``
+    # synchronously, which can take 5-10 minutes the first time on
+    # a slow connection / large repo. The metadata refresh runs on
+    # the WS event loop; a multi-minute git clone there freezes the
+    # dashboard for every connected client. Skip the merge for
+    # remote-package configs and degrade to the unmerged shape —
+    # same behaviour as pre-fix; once the user compiles,
+    # ``StorageJSON.loaded_integrations`` / ``target_platform``
+    # fill in the package-aware metadata anyway. The follow-up to
+    # support remote packages cleanly will need an mtime-keyed
+    # cache plus a thread-pool executor so the git fetch doesn't
+    # land on the event loop.
+    packages = config.get(CONF_PACKAGES)
+    if isinstance(packages, (dict, list)) and not _has_remote_packages(packages):
         try:
             if _resolve_packages is not None:
                 config = _resolve_packages(config)
-            else:
-                config = do_packages_pass(config)
-                config = merge_packages(config)
+            elif _do_packages_pass is not None and _merge_packages is not None:
+                config = _do_packages_pass(config)
+                config = _merge_packages(config)
         except Exception:
-            # Best-effort: a bad / unreachable package shouldn't blank
-            # the device's metadata. Keep the unmerged shape so the
+            # Best-effort: a bad local package shouldn't blank the
+            # device's metadata. Keep the unmerged shape so the
             # raw-YAML fallback paths at the call sites still work.
-            # Log at debug — package errors are routine for offline
-            # / git-cache-cold setups and the user-facing surface
-            # already degrades gracefully.
-            _LOGGER.debug("Package merge failed for %s; using unmerged config", path, exc_info=True)
+            _LOGGER.debug(
+                "Package merge failed for %s; using unmerged config",
+                path,
+                exc_info=True,
+            )
     return config
 
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -10,15 +10,34 @@ a controller.
 from __future__ import annotations
 
 import base64
+import logging
 import re
 import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from esphome import const, yaml_util
+from esphome.components.packages import do_packages_pass, merge_packages
+from esphome.const import CONF_PACKAGES
 from esphome.storage_json import StorageJSON, ext_storage_path
 
+# Prefer the upstream single-call seam when present (proposed-but-not-
+# yet-merged ``esphome.components.packages.resolve_packages``). Falls
+# back to the two-step ``do_packages_pass`` + ``merge_packages`` that
+# ESPHome's own pipeline strings together at ``esphome.config:1010-1039``
+# today. Once an esphome release ships ``resolve_packages`` and the
+# dashboard's dep floor moves past it, the fallback can be deleted in
+# one commit.
+try:
+    from esphome.components.packages import (  # type: ignore[attr-defined]
+        resolve_packages as _resolve_packages,
+    )
+except ImportError:
+    _resolve_packages = None
+
 from ..models import Device, DeviceState
+
+_LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..models import BoardCatalogEntry
@@ -177,16 +196,37 @@ def parse_platform_from_yaml(yaml_content: str) -> tuple[str, str, str]:
 
 def detect_platform_from_yaml(path: Path) -> str:
     """
-    Quick scan of a YAML file to find its platform key.
+    Find a YAML file's platform key.
 
-    Returns the empty string when the file is unreadable or contains no
-    top-level platform key.
+    First tries the cheap line-scan against the raw file (no parser
+    involved, survives mid-edit drafts). Falls back to a full
+    package-resolved load when the raw scan misses — configs that
+    place ``esp32:`` / ``esp8266:`` / etc. inside a ``packages:``
+    reference (BLE-beacon configs sharing a common board package,
+    Apollo's dashboard_import flow, …) only register that key after
+    package merge runs. Without the fallback those devices come
+    back with ``target_platform=""`` and the dashboard's web-flasher
+    gate (which checks the platform string) hides the option even
+    when the device is an ESP32.
+
+    Returns the empty string when neither path turns up a platform.
     """
     try:
-        platform, _, _ = parse_platform_from_yaml(path.read_text(encoding="utf-8"))
-        return platform
+        raw = path.read_text(encoding="utf-8")
     except Exception:
         return ""
+    try:
+        platform, _, _ = parse_platform_from_yaml(raw)
+    except Exception:
+        platform = ""
+    if platform:
+        return platform
+    config = load_device_yaml(path)
+    if isinstance(config, dict):
+        for key in config:
+            if key in _PLATFORM_KEYS:
+                return key
+    return ""
 
 
 def yaml_has_top_level_block(yaml_content: str, key: str) -> bool:
@@ -549,11 +589,25 @@ def _parse_inline_value(raw: str) -> str:
 def load_device_yaml(path: Path) -> dict | None:
     """Load *path* with ESPHome's YAML loader; return the top-level mapping.
 
-    Resolves ``!secret`` / ``!include`` / etc. like a real compile, and
-    returns ``None`` when the file isn't a mapping or fails to parse.
+    Resolves ``!secret`` / ``!include`` / etc. like a real compile,
+    runs ``do_packages_pass`` + ``merge_packages`` to flatten any
+    ``packages:`` block into the main config (so callers see what the
+    compiler actually sees — ``api:`` / ``wifi:`` / target-platform
+    blocks contributed by packages register as top-level keys here),
+    and returns ``None`` when the file isn't a mapping or fails to
+    parse.
+
+    Package resolution is best-effort: a remote (git) package needs
+    network access, an invalid package definition fails ESPHome's
+    voluptuous validator, etc. When the package pass throws we keep
+    the unmerged config rather than dropping it — better to surface
+    the local YAML than nothing, and the unmerged shape was the
+    pre-fix behaviour the dashboard already handled.
+
     Centralised so callers that need a parsed config — API-key
-    extraction, encryption-status checks, future config inspection —
-    share one entry point with the same error handling.
+    extraction, encryption-status checks, top-level-block detection
+    used by the device-card flags — share one entry point with the
+    same error handling and the same package-merge contract.
     """
     try:
         # ``yaml_util.load_yaml`` calls ``.open()`` on its argument, so
@@ -562,7 +616,36 @@ def load_device_yaml(path: Path) -> dict | None:
         config = yaml_util.load_yaml(path)
     except Exception:
         return None
-    return config if isinstance(config, dict) else None
+    if not isinstance(config, dict):
+        return None
+    # ``packages:`` is a separate pass in the ESPHome pipeline (see
+    # ``esphome.config:1010-1039``): packages need to be loaded
+    # (file open / git fetch / !include resolution) and then merged
+    # so blocks they contribute (api / wifi / target-platform / …)
+    # become top-level keys. Without this step a config that puts
+    # those blocks behind ``packages:`` comes back from
+    # ``yaml_util.load_yaml`` with everything still nested under
+    # ``packages:``, and the dashboard's flag detection silently
+    # misses them. ``_resolve_packages`` (when available) and the
+    # ``do_packages_pass`` + ``merge_packages`` fallback are both
+    # pure delegations to ESPHome internals — the loader and merge
+    # algorithm live upstream.
+    if isinstance(config.get(CONF_PACKAGES), (dict, list)):
+        try:
+            if _resolve_packages is not None:
+                config = _resolve_packages(config)
+            else:
+                config = do_packages_pass(config)
+                config = merge_packages(config)
+        except Exception:
+            # Best-effort: a bad / unreachable package shouldn't blank
+            # the device's metadata. Keep the unmerged shape so the
+            # raw-YAML fallback paths at the call sites still work.
+            # Log at debug — package errors are routine for offline
+            # / git-cache-cold setups and the user-facing surface
+            # already degrades gracefully.
+            _LOGGER.debug("Package merge failed for %s; using unmerged config", path, exc_info=True)
+    return config
 
 
 def get_api_encryption_block(config: dict | None) -> dict | None:

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -611,12 +611,14 @@ def load_device_yaml(path: Path) -> dict | None:
     """Load *path* with ESPHome's YAML loader; return the top-level mapping.
 
     Resolves ``!secret`` / ``!include`` / etc. like a real compile,
-    runs ``do_packages_pass`` + ``merge_packages`` to flatten any
-    ``packages:`` block into the main config (so callers see what the
-    compiler actually sees — ``api:`` / ``wifi:`` / target-platform
-    blocks contributed by packages register as top-level keys here),
-    and returns ``None`` when the file isn't a mapping or fails to
-    parse.
+    flattens any ``packages:`` block into the main config via
+    ESPHome's package-resolution internals (the single-call
+    ``resolve_packages`` on newer ESPHome, the two-step
+    ``do_packages_pass`` + ``merge_packages`` fallback on older
+    builds), so callers see what the compiler actually sees —
+    ``api:`` / ``wifi:`` / target-platform blocks contributed by
+    packages register as top-level keys here — and returns
+    ``None`` when the file isn't a mapping or fails to parse.
 
     Package resolution is best-effort: a remote (git) package needs
     network access, an invalid package definition fails ESPHome's

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -37,6 +37,17 @@ try:
 except ImportError:
     _resolve_packages = None
 
+# Same forward-compat pattern: prefer upstream's
+# ``has_remote_packages`` walker (esphome/esphome#16235) so the
+# local copy below can be deleted once the dep floor moves past
+# the release that ships it.
+try:
+    from esphome.components.packages import (  # type: ignore[attr-defined]
+        has_remote_packages as _upstream_has_remote_packages,
+    )
+except ImportError:
+    _upstream_has_remote_packages = None
+
 try:
     from esphome.components.packages import (
         do_packages_pass as _do_packages_pass,
@@ -60,6 +71,13 @@ _LOGGER = logging.getLogger(__name__)
 def _has_remote_packages(packages_subtree: object) -> bool:
     """Return True when the ``packages:`` subtree contains any remote ref.
 
+    Prefers the upstream ``has_remote_packages`` walker
+    (esphome/esphome#16235) when present — keeps the dashboard's
+    remote-detection in lockstep with the rest of the resolver
+    without having to track new remote-package shapes here. Falls
+    back to a local mirror of the same walk for older esphome
+    releases.
+
     A remote package triggers ``git clone`` / URL fetch synchronously
     inside ``do_packages_pass`` — first-run latency runs into 5-10
     minutes on a slow connection / large repo. The metadata refresh
@@ -70,25 +88,15 @@ def _has_remote_packages(packages_subtree: object) -> bool:
     the user compiles, ``StorageJSON.loaded_integrations`` /
     ``target_platform`` fill in the package-aware metadata anyway).
 
-    What counts as remote is delegated to ESPHome's own
-    ``is_remote_package`` (a dict with a ``url:`` key) plus the
-    git-shorthand string form (``github://user/repo@ref``,
-    ``gitlab://...``) — both are network-dependent. Local shapes
-    are ``IncludeFile`` (resolved ``!include`` — file-IO only) and
-    inline-dict config fragments. Hardcoding the remote-key list
-    here would drift the moment ESPHome adds a new remote shape;
-    using upstream's predicate keeps the gate in sync.
-
-    The walk descends ONLY into nested ``packages:`` blocks inside
-    local config fragments. ESPHome supports a local package
-    referencing a remote one through its own ``packages:`` key, so
-    we have to recurse there — but we DON'T recurse into arbitrary
-    config-fragment values (``wifi: { ssid: ... }`` shouldn't have
-    its scalar leaves treated as package definitions). That
-    distinction is what makes the recursion correct: a string AT
-    the package-definition position is remote, a string anywhere
-    else (a wifi password, a sensor name, …) isn't.
+    Local-fallback walk semantics (matched to upstream's): walks
+    ONLY nested ``packages:`` blocks inside local config fragments.
+    A string AT the package-definition position is remote
+    (``github://...`` shorthand); a string anywhere else (a wifi
+    password, a sensor name) isn't. ``IncludeFile`` is local (file
+    IO only).
     """
+    if _upstream_has_remote_packages is not None:
+        return _upstream_has_remote_packages(packages_subtree)
     if isinstance(packages_subtree, list):
         return any(_has_remote_packages(item) for item in packages_subtree)
     if not isinstance(packages_subtree, dict):
@@ -97,25 +105,28 @@ def _has_remote_packages(packages_subtree: object) -> bool:
         # which yaml_util returns as ``IncludeFile`` (file-IO only,
         # no network), and we want to allow that.
         return False
-    for definition in packages_subtree.values():
-        if isinstance(definition, str):
-            # Shorthand at the package-definition level
-            # (``github://...``) is always remote. Strings deeper
-            # inside config fragments don't reach this branch
-            # because we only recurse into nested ``packages:``
-            # blocks, not arbitrary value subtrees.
+    return any(_definition_is_remote(definition) for definition in packages_subtree.values())
+
+
+def _definition_is_remote(definition: object) -> bool:
+    """Return True when *definition* is a remote package def or has remote nested."""
+    if isinstance(definition, str):
+        # Shorthand at the package-definition level
+        # (``github://...``) is always remote. Strings deeper
+        # inside config fragments don't reach this branch because
+        # the caller only recurses into nested ``packages:``
+        # blocks, not arbitrary value subtrees.
+        return True
+    if isinstance(definition, dict):
+        if _is_remote_package is not None and _is_remote_package(definition):
             return True
-        if isinstance(definition, dict):
-            if _is_remote_package is not None and _is_remote_package(definition):
-                return True
-            # Local config fragment — recurse ONLY into its own
-            # nested ``packages:`` key (if any). Walking into
-            # arbitrary keys (``wifi:`` / ``sensor:`` / …) would
-            # over-trigger on benign string values.
-            nested = definition.get(CONF_PACKAGES)
-            if nested is not None and _has_remote_packages(nested):
-                return True
-        # Anything else (``IncludeFile``, scalars) is local.
+        # Local config fragment — recurse ONLY into its own
+        # nested ``packages:`` key (if any). Walking into
+        # arbitrary keys (``wifi:`` / ``sensor:`` / …) would
+        # over-trigger on benign string values.
+        nested = definition.get(CONF_PACKAGES)
+        return nested is not None and _has_remote_packages(nested)
+    # ``IncludeFile`` / scalars / None — local.
     return False
 
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -37,23 +37,9 @@ try:
 except ImportError:
     _resolve_packages = None
 
-# Same forward-compat pattern: prefer upstream's
-# ``has_remote_packages`` walker (esphome/esphome#16235) so the
-# local copy below can be deleted once the dep floor moves past
-# the release that ships it.
-try:
-    from esphome.components.packages import (  # type: ignore[attr-defined]
-        has_remote_packages as _upstream_has_remote_packages,
-    )
-except ImportError:
-    _upstream_has_remote_packages = None
-
 try:
     from esphome.components.packages import (
         do_packages_pass as _do_packages_pass,
-    )
-    from esphome.components.packages import (
-        is_remote_package as _is_remote_package,
     )
     from esphome.components.packages import (
         merge_packages as _merge_packages,
@@ -61,73 +47,10 @@ try:
 except ImportError:
     _do_packages_pass = None  # type: ignore[assignment]
     _merge_packages = None  # type: ignore[assignment]
-    _is_remote_package = None  # type: ignore[assignment]
 
 from ..models import Device, DeviceState
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _has_remote_packages(packages_subtree: object) -> bool:
-    """Return True when the ``packages:`` subtree contains any remote ref.
-
-    Prefers the upstream ``has_remote_packages`` walker
-    (esphome/esphome#16235) when present — keeps the dashboard's
-    remote-detection in lockstep with the rest of the resolver
-    without having to track new remote-package shapes here. Falls
-    back to a local mirror of the same walk for older esphome
-    releases.
-
-    A remote package triggers ``git clone`` / URL fetch synchronously
-    inside ``do_packages_pass`` — first-run latency runs into 5-10
-    minutes on a slow connection / large repo. The metadata refresh
-    runs on the WS event loop; that wait would freeze the dashboard
-    for every connected client. Callers use this gate to skip the
-    merge entirely for configs with any remote package ref and
-    degrade to the unmerged shape (same behaviour as pre-fix; once
-    the user compiles, ``StorageJSON.loaded_integrations`` /
-    ``target_platform`` fill in the package-aware metadata anyway).
-
-    Local-fallback walk semantics (matched to upstream's): walks
-    ONLY nested ``packages:`` blocks inside local config fragments.
-    A string AT the package-definition position is remote
-    (``github://...`` shorthand); a string anywhere else (a wifi
-    password, a sensor name) isn't. ``IncludeFile`` is local (file
-    IO only).
-    """
-    if _upstream_has_remote_packages is not None:
-        return _upstream_has_remote_packages(packages_subtree)
-    if isinstance(packages_subtree, list):
-        return any(_has_remote_packages(item) for item in packages_subtree)
-    if not isinstance(packages_subtree, dict):
-        # ``IncludeFile`` / ``None`` / scalar — none are remote.
-        # ``packages:`` itself can be ``!include packages.yaml``,
-        # which yaml_util returns as ``IncludeFile`` (file-IO only,
-        # no network), and we want to allow that.
-        return False
-    return any(_definition_is_remote(definition) for definition in packages_subtree.values())
-
-
-def _definition_is_remote(definition: object) -> bool:
-    """Return True when *definition* is a remote package def or has remote nested."""
-    if isinstance(definition, str):
-        # Shorthand at the package-definition level
-        # (``github://...``) is always remote. Strings deeper
-        # inside config fragments don't reach this branch because
-        # the caller only recurses into nested ``packages:``
-        # blocks, not arbitrary value subtrees.
-        return True
-    if isinstance(definition, dict):
-        if _is_remote_package is not None and _is_remote_package(definition):
-            return True
-        # Local config fragment — recurse ONLY into its own
-        # nested ``packages:`` key (if any). Walking into
-        # arbitrary keys (``wifi:`` / ``sensor:`` / …) would
-        # over-trigger on benign string values.
-        nested = definition.get(CONF_PACKAGES)
-        return nested is not None and _has_remote_packages(nested)
-    # ``IncludeFile`` / scalars / None — local.
-    return False
 
 
 if TYPE_CHECKING:
@@ -301,12 +224,6 @@ def detect_platform_from_yaml(path: Path) -> str:
     dashboard scan, even though there's nothing in the file the
     merge could surface. The cheap-regex-only fast path stays the
     winner for the typical no-packages config.
-
-    The merge itself defends against remote-package timeouts (see
-    ``_has_remote_packages`` upstream of ``load_device_yaml``), so
-    a remote-package config still falls back gracefully here —
-    its platform comes from the post-compile ``StorageJSON``
-    instead.
 
     Returns the empty string when neither path turns up a platform.
     """
@@ -732,22 +649,21 @@ def load_device_yaml(path: Path) -> dict | None:
     # misses them. We delegate to ESPHome internals — the loader
     # and merge algorithm live upstream.
     #
-    # CRITICAL: only merge when the ``packages:`` subtree is purely
-    # local. A remote package (``url:`` key, or git-shorthand
-    # string) makes ``do_packages_pass`` run ``git clone``
-    # synchronously, which can take 5-10 minutes the first time on
-    # a slow connection / large repo. The metadata refresh runs on
-    # the WS event loop; a multi-minute git clone there freezes the
-    # dashboard for every connected client. Skip the merge for
-    # remote-package configs and degrade to the unmerged shape —
-    # same behaviour as pre-fix; once the user compiles,
-    # ``StorageJSON.loaded_integrations`` / ``target_platform``
-    # fill in the package-aware metadata anyway. The follow-up to
-    # support remote packages cleanly will need an mtime-keyed
-    # cache plus a thread-pool executor so the git fetch doesn't
-    # land on the event loop.
-    packages = config.get(CONF_PACKAGES)
-    if isinstance(packages, (dict, list)) and not _has_remote_packages(packages):
+    # ``load_device_yaml`` runs on a worker thread (the device
+    # scanner uses ``run_in_executor``; the devices controller
+    # threads it through too), NOT the WS event loop. Same trade
+    # the validate path lives with: ESPHome's ``vscode`` subprocess
+    # runs the full resolve on every validate call, so a
+    # remote-package config that fires ``git clone`` synchronously
+    # blocks this worker thread for as long as the clone takes
+    # (minutes on a slow connection / large repo) but the dashboard
+    # stays responsive to other clients. The follow-up that mirrors
+    # the validate-style subprocess pattern for metadata refresh
+    # (so a slow remote clone doesn't stall the whole scan) is
+    # tracked separately; this PR closes the local-package gap
+    # behind #288 without trying to solve the remote-package
+    # latency problem at the same time.
+    if isinstance(config.get(CONF_PACKAGES), (dict, list)):
         try:
             if _resolve_packages is not None:
                 config = _resolve_packages(config)
@@ -755,9 +671,10 @@ def load_device_yaml(path: Path) -> dict | None:
                 config = _do_packages_pass(config)
                 config = _merge_packages(config)
         except Exception:
-            # Best-effort: a bad local package shouldn't blank the
-            # device's metadata. Keep the unmerged shape so the
-            # raw-YAML fallback paths at the call sites still work.
+            # Best-effort: a bad / unreachable package shouldn't
+            # blank the device's metadata. Keep the unmerged shape
+            # so the raw-YAML fallback paths at the call sites
+            # still work.
             _LOGGER.debug(
                 "Package merge failed for %s; using unmerged config",
                 path,

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -8,10 +8,14 @@ indicator.
 
 from __future__ import annotations
 
+import importlib
+import sys
+import types
 from pathlib import Path
 from unittest import mock
 
 import pytest
+from esphome.components import packages as _real_esphome_packages
 
 from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.helpers.device_yaml import (
@@ -204,6 +208,48 @@ def test_detect_platform_from_yaml_skips_load_when_no_packages_block(
     spy.assert_not_called()
 
 
+def test_detect_platform_from_yaml_swallows_parser_exceptions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mid-edit drafts can't crash the platform detector.
+
+    ``parse_platform_from_yaml`` is regex-based and fairly
+    forgiving, but a future tightening that started raising on
+    weird input shouldn't blank the dashboard's platform flag.
+    Stub the parser to raise and confirm the caller catches and
+    falls through to the empty-string return rather than
+    propagating.
+    """
+    yaml_file = tmp_path / "broken.yaml"
+    yaml_file.write_text("esphome:\n  name: x\n")
+    monkeypatch.setattr(
+        device_yaml,
+        "parse_platform_from_yaml",
+        mock.MagicMock(side_effect=ValueError("simulated parser failure")),
+    )
+    assert detect_platform_from_yaml(yaml_file) == ""
+
+
+def test_detect_platform_from_yaml_returns_empty_when_resolved_config_has_no_platform(
+    tmp_path: Path,
+) -> None:
+    """``packages:`` present but the merged config has no platform key.
+
+    Pins the final ``return ""`` after the resolved-config walk —
+    the load fired (raw scan missed AND ``packages:`` was in the
+    raw text), the merge succeeded, but no platform key landed at
+    the top level. Realistic shape: a `packages:` reference that
+    contributes only api / wifi / sensor blocks, with the
+    platform expected to come from ``StorageJSON`` post-compile.
+    """
+    (tmp_path / "common.yaml").write_text(
+        "wifi:\n  ssid: x\n  password: y\n"  # no platform key here
+    )
+    yaml_file = tmp_path / "ble.yaml"
+    yaml_file.write_text("esphome:\n  name: ble\npackages:\n  common: !include common.yaml\n")
+    assert detect_platform_from_yaml(yaml_file) == ""
+
+
 def test_load_device_yaml_uses_two_step_when_resolve_packages_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -275,6 +321,64 @@ def test_load_device_yaml_recovers_when_merge_raises(
     # Merge raised → caller keeps the unmerged shape rather than
     # crashing or returning ``None``.
     assert "packages" in config
+
+
+def test_module_import_handles_missing_resolve_packages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Module load survives an esphome that lacks ``resolve_packages``.
+
+    Pins the ``except ImportError: _resolve_packages = None`` branch
+    at module load. Reloads ``device_yaml`` against a stubbed
+    ``esphome.components.packages`` that has only the two-step
+    helpers — the typical shape of ESPHome releases that ship
+    BEFORE esphome/esphome#16235 lands. Without the import guard
+    the module would fail to import on those releases.
+    """
+    real_packages = _real_esphome_packages
+    stub = types.SimpleNamespace(
+        do_packages_pass=real_packages.do_packages_pass,
+        merge_packages=real_packages.merge_packages,
+        # Intentionally NO ``resolve_packages`` attribute — that's
+        # the upstream-not-yet-shipped state.
+    )
+    monkeypatch.setitem(sys.modules, "esphome.components.packages", stub)
+    reloaded = importlib.reload(device_yaml)
+    try:
+        assert reloaded._resolve_packages is None
+        assert reloaded._do_packages_pass is real_packages.do_packages_pass
+        assert reloaded._merge_packages is real_packages.merge_packages
+    finally:
+        # Restore so subsequent tests see the real module.
+        monkeypatch.setitem(sys.modules, "esphome.components.packages", real_packages)
+        importlib.reload(device_yaml)
+
+
+def test_module_import_handles_missing_two_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Module load survives an esphome that drops the two-step helpers.
+
+    Pins the ``except ImportError`` branch on the
+    ``do_packages_pass`` / ``merge_packages`` import. Belt-and-
+    suspenders for the day esphome ships only ``resolve_packages``
+    and removes / renames the two-step. Without the guard the
+    module would fail to import once the dep floor moves.
+    """
+    real_packages = _real_esphome_packages
+    stub = types.SimpleNamespace(
+        # Only ``resolve_packages`` exposed — no two-step helpers.
+        resolve_packages=getattr(real_packages, "resolve_packages", lambda c: c),
+    )
+    monkeypatch.setitem(sys.modules, "esphome.components.packages", stub)
+    reloaded = importlib.reload(device_yaml)
+    try:
+        assert reloaded._do_packages_pass is None
+        assert reloaded._merge_packages is None
+        assert reloaded._resolve_packages is stub.resolve_packages
+    finally:
+        monkeypatch.setitem(sys.modules, "esphome.components.packages", real_packages)
+        importlib.reload(device_yaml)
 
 
 def test_load_device_yaml_falls_back_when_both_imports_missing(

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -204,6 +204,53 @@ def test_detect_platform_from_yaml_skips_load_when_no_packages_block(
     spy.assert_not_called()
 
 
+def test_load_device_yaml_uses_upstream_resolve_packages_when_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the upstream ``resolve_packages`` import is available it wins.
+
+    The two-step ``do_packages_pass`` + ``merge_packages`` path is
+    the fallback for older esphome releases — once the upstream PR
+    (esphome/esphome#16235) lands and the dashboard's dep floor
+    moves past it, the single-call seam takes over. Stubs the
+    upstream symbol with a spy and confirms the wrapper goes
+    through it (and the two-step is NOT called).
+    """
+    yaml_file = tmp_path / "with_pkg.yaml"
+    yaml_file.write_text("esphome:\n  name: x\npackages:\n  shared:\n    wifi:\n      ssid: y\n")
+    spy = mock.MagicMock(side_effect=lambda c: c)
+    monkeypatch.setattr(device_yaml, "_resolve_packages", spy)
+    with mock.patch.object(device_yaml, "_do_packages_pass") as two_step_spy:
+        config = load_device_yaml(yaml_file)
+    assert config is not None
+    spy.assert_called_once()
+    two_step_spy.assert_not_called()
+
+
+def test_load_device_yaml_recovers_when_merge_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bad / unreachable package can't blank the device's metadata.
+
+    Pinning the catch-all error handler on the merge call: if
+    ``do_packages_pass`` (or ``resolve_packages``) raises — the
+    typical case is a remote package whose git ref vanished, but
+    also a malformed local package YAML, a missing file, etc. —
+    the function returns the unmerged config so the raw-YAML
+    fallback paths at the call sites still surface what they
+    can. Pre-fix degradation, not a hard failure.
+    """
+    yaml_file = tmp_path / "broken_pkg.yaml"
+    yaml_file.write_text("esphome:\n  name: x\npackages:\n  shared:\n    wifi:\n      ssid: y\n")
+    boom = mock.MagicMock(side_effect=RuntimeError("simulated package failure"))
+    monkeypatch.setattr(device_yaml, "_resolve_packages", boom)
+    config = load_device_yaml(yaml_file)
+    assert config is not None
+    # Merge raised → caller keeps the unmerged shape rather than
+    # crashing or returning ``None``.
+    assert "packages" in config
+
+
 def test_load_device_yaml_falls_back_when_both_imports_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -15,6 +15,7 @@ import pytest
 from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.helpers.device_yaml import (
     config_has_top_level_block,
+    detect_platform_from_yaml,
     get_api_encryption_block,
     get_api_encryption_key,
     load_device_yaml,
@@ -108,6 +109,75 @@ def test_load_device_yaml_resolves_secrets(tmp_path: Path) -> None:
     )
     config = load_device_yaml(yaml_file)
     assert get_api_encryption_key(config) == "AAAA=="
+
+
+def test_load_device_yaml_merges_packages(tmp_path: Path) -> None:
+    """Top-level blocks contributed by ``packages:`` end up flat in the result.
+
+    Repro of #288: a BLE beacon (or any device sharing a common
+    package for api / wifi / ota / target-platform) had the
+    dashboard report ``api_encrypted=False``, ``target_platform=""``,
+    ``loaded_integrations=[]`` because the unmerged config still
+    had those keys nested under ``packages:`` instead of at the
+    top level. We delegate to ESPHome's own ``do_packages_pass`` +
+    ``merge_packages`` (the same two-step the compiler runs at
+    ``esphome.config:1010-1039``) so the dashboard sees what the
+    compiler sees.
+    """
+    (tmp_path / "common.yaml").write_text(
+        "esp32:\n"
+        "  board: esp32dev\n"
+        "api:\n"
+        '  encryption:\n    key: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="\n'
+        "wifi:\n  ssid: x\n  password: y\n"
+    )
+    yaml_file = tmp_path / "ble.yaml"
+    yaml_file.write_text("esphome:\n  name: ble\npackages:\n  common: !include common.yaml\n")
+    config = load_device_yaml(yaml_file)
+    assert config is not None
+    # ``packages:`` itself is consumed by the merge — top-level
+    # keys are now what the user's compiled firmware actually has.
+    assert "packages" not in config
+    assert "esp32" in config
+    assert "api" in config
+    assert "wifi" in config
+    assert get_api_encryption_key(config) == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+
+def test_detect_platform_from_yaml_falls_back_to_resolved_config(
+    tmp_path: Path,
+) -> None:
+    """Platform detection falls through to the resolved config on raw-scan miss.
+
+    The fast path (raw-text scan) survives mid-edit drafts but
+    can't see ``esp32:`` blocks pulled in via ``packages:``. The
+    slow path (full ``load_device_yaml`` with package merge) is
+    only invoked when the raw scan returned empty, so the typical
+    no-packages config still pays only the cheap regex.
+    """
+    (tmp_path / "board.yaml").write_text(
+        "esp32:\n  board: esp32dev\n  framework:\n    type: esp-idf\n"
+    )
+    yaml_file = tmp_path / "ble.yaml"
+    yaml_file.write_text("esphome:\n  name: ble\npackages:\n  board: !include board.yaml\n")
+    # Raw scan: no top-level ``esp32:`` line, so it returns "".
+    # Fallback: load + package-merge → ``esp32`` becomes top-level.
+    assert detect_platform_from_yaml(yaml_file) == "esp32"
+
+
+def test_detect_platform_from_yaml_keeps_raw_scan_for_inline_platform(
+    tmp_path: Path,
+) -> None:
+    """Top-level inline platform key resolves via the raw-scan fast path.
+
+    Pinning this avoids regressing the fast path: a future
+    refactor that always loaded the resolved config would parse
+    every YAML on every dashboard scan, which is what the cheap
+    regex was put in place to avoid.
+    """
+    yaml_file = tmp_path / "kitchen.yaml"
+    yaml_file.write_text("esphome:\n  name: kitchen\nesp8266:\n  board: nodemcuv2\n")
+    assert detect_platform_from_yaml(yaml_file) == "esp8266"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -204,6 +204,32 @@ def test_detect_platform_from_yaml_skips_load_when_no_packages_block(
     spy.assert_not_called()
 
 
+def test_load_device_yaml_uses_two_step_when_resolve_packages_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two-step fallback runs when the upstream ``resolve_packages`` is missing.
+
+    Pins the fallback path independently of which esphome release
+    happens to be installed in the test runner. CI runs against
+    whatever esphome ships today (no ``resolve_packages``); local
+    development can hit either side. The forced-None monkeypatch
+    makes coverage of the two-step branch deterministic regardless.
+    """
+    monkeypatch.setattr(device_yaml, "_resolve_packages", None)
+    (tmp_path / "common.yaml").write_text(
+        "esp32:\n  board: esp32dev\nwifi:\n  ssid: x\n  password: y\n"
+    )
+    yaml_file = tmp_path / "ble.yaml"
+    yaml_file.write_text("esphome:\n  name: ble\npackages:\n  common: !include common.yaml\n")
+    config = load_device_yaml(yaml_file)
+    assert config is not None
+    # Two-step path fired → packages merged → top-level keys
+    # surface.
+    assert "packages" not in config
+    assert "esp32" in config
+    assert "wifi" in config
+
+
 def test_load_device_yaml_uses_upstream_resolve_packages_when_available(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -125,8 +125,8 @@ def test_load_device_yaml_merges_packages(tmp_path: Path) -> None:
     ``loaded_integrations=[]`` because the unmerged config still
     had those keys nested under ``packages:`` instead of at the
     top level. We delegate to ESPHome's own ``do_packages_pass`` +
-    ``merge_packages`` (the same two-step the compiler runs at
-    ``esphome.config:1010-1039``) so the dashboard sees what the
+    ``merge_packages`` (the same two-step the compiler's
+    ``validate_config`` runs) so the dashboard sees what the
     compiler sees.
     """
     (tmp_path / "common.yaml").write_text(

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -15,7 +15,6 @@ import pytest
 
 from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.helpers.device_yaml import (
-    _has_remote_packages,
     config_has_top_level_block,
     detect_platform_from_yaml,
     get_api_encryption_block,
@@ -205,120 +204,6 @@ def test_detect_platform_from_yaml_skips_load_when_no_packages_block(
     spy.assert_not_called()
 
 
-def test_load_device_yaml_skips_merge_for_remote_packages(
-    tmp_path: Path,
-) -> None:
-    """Remote-package configs DON'T trigger the merge — would block on git clone.
-
-    A ``url:`` package fires ``git clone`` synchronously inside
-    ``do_packages_pass``; first-run latency is 5-10 minutes on
-    slow connections / large repos. The dashboard's metadata
-    refresh runs on the WS event loop, so we gate the merge on
-    "no remote packages anywhere in the tree". Configs that hit
-    this gate degrade to the unmerged shape (same as pre-fix); a
-    follow-up will add an executor + mtime cache to support
-    remote packages without blocking.
-
-    Spy on ``do_packages_pass`` / ``resolve_packages`` to confirm
-    neither runs when a remote package is present.
-    """
-    yaml_file = tmp_path / "remote.yaml"
-    yaml_file.write_text(
-        "esphome:\n  name: remote\n"
-        "packages:\n"
-        "  shared:\n"
-        "    url: https://github.com/example/shared\n"
-        "    files:\n      - shared.yaml\n"
-        "    ref: main\n"
-    )
-    with (
-        mock.patch("esphome_device_builder.helpers.device_yaml._do_packages_pass") as do_pkg,
-        mock.patch("esphome_device_builder.helpers.device_yaml._resolve_packages") as resolve_pkg,
-    ):
-        config = load_device_yaml(yaml_file)
-    assert config is not None
-    # Merge skipped → ``packages:`` is still in the result.
-    assert "packages" in config
-    do_pkg.assert_not_called()
-    resolve_pkg.assert_not_called()
-
-
-def test_has_remote_packages_local_only_returns_false() -> None:
-    """A purely local ``packages:`` tree (inline dicts) is safe to merge.
-
-    Walks the canonical local-package shapes — inline dict
-    fragment, ``IncludeFile`` substitute (any non-``url:`` dict),
-    list of inline dicts — and confirms the gate stays open. A
-    False positive here would silently disable the merge for the
-    BLE-beacon configs from #288 the fix was written for.
-    """
-    assert _has_remote_packages({"shared": {"wifi": {"ssid": "x"}}}) is False
-    assert _has_remote_packages({}) is False
-    assert _has_remote_packages({"a": {"foo": 1}, "b": {"bar": 2}}) is False
-
-
-def test_has_remote_packages_url_dict_returns_true() -> None:
-    """A package definition with ``url:`` is remote — gate has to bail."""
-    assert (
-        _has_remote_packages(
-            {"shared": {"url": "https://github.com/example/shared", "ref": "main"}}
-        )
-        is True
-    )
-
-
-def test_has_remote_packages_shorthand_string_returns_true() -> None:
-    """``github://user/repo@ref`` (and friends) are remote.
-
-    ESPHome accepts a string-shorthand form alongside the dict
-    form; ``do_packages_pass`` parses it via
-    ``validate_source_shorthand`` which clones from a git remote.
-    """
-    assert _has_remote_packages({"shared": "github://example/shared@main"}) is True
-
-
-def test_has_remote_packages_mixed_local_and_remote_returns_true() -> None:
-    """Any single remote package in the tree taints the whole config.
-
-    The metadata loader can't merge "just the local ones" — that
-    would silently drop blocks the user expects from the remote
-    package. Bail to the unmerged shape instead, same as
-    pre-fix.
-    """
-    assert (
-        _has_remote_packages(
-            {
-                "local": {"wifi": {"ssid": "x"}},
-                "remote": {"url": "https://github.com/example/shared"},
-            }
-        )
-        is True
-    )
-
-
-def test_has_remote_packages_nested_remote_returns_true() -> None:
-    """Remote package nested inside a local one still triggers the gate.
-
-    ESPHome's package resolver flattens nested packages
-    recursively — a local package can reference a remote one. The
-    walk has to descend the full tree to spot this.
-    """
-    assert (
-        _has_remote_packages(
-            {
-                "outer": {
-                    "packages": {
-                        "inner": {
-                            "url": "https://github.com/example/inner",
-                        }
-                    },
-                }
-            }
-        )
-        is True
-    )
-
-
 def test_load_device_yaml_falls_back_when_both_imports_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -327,7 +212,7 @@ def test_load_device_yaml_falls_back_when_both_imports_missing(
     A future esphome that deprecates ``do_packages_pass`` /
     ``merge_packages`` AND moves ``resolve_packages`` (rename,
     refactor, …) would otherwise leave us with no merge path. The
-    module's ``try/except ImportError`` guards both imports — the
+    module's ``try/except ImportError`` guards both imports - the
     function then degrades to the unmerged shape, the same fallback
     we use when a package merge fails at runtime. Pre-fix
     behaviour stays available even if the upstream API surface
@@ -344,26 +229,6 @@ def test_load_device_yaml_falls_back_when_both_imports_missing(
     # then falls back to the raw-scan / StorageJSON surfaces the
     # rest of the metadata pipeline already handles.
     assert "packages" in config
-
-
-def test_load_device_yaml_skips_merge_for_remote_shorthand_package(
-    tmp_path: Path,
-) -> None:
-    """The git-shorthand string form (``github://``) is also remote.
-
-    ESPHome accepts a ``name: github://user/repo@ref`` value as
-    sugar for the dict form. ``_has_remote_packages`` walks string
-    entries too, so both shapes hit the gate.
-    """
-    yaml_file = tmp_path / "remote.yaml"
-    yaml_file.write_text(
-        "esphome:\n  name: remote\npackages:\n  shared: github://example/shared@main\n"
-    )
-    with mock.patch("esphome_device_builder.helpers.device_yaml._do_packages_pass") as do_pkg:
-        config = load_device_yaml(yaml_file)
-    assert config is not None
-    assert "packages" in config
-    do_pkg.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -9,11 +9,13 @@ indicator.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
 from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.helpers.device_yaml import (
+    _has_remote_packages,
     config_has_top_level_block,
     detect_platform_from_yaml,
     get_api_encryption_block,
@@ -178,6 +180,190 @@ def test_detect_platform_from_yaml_keeps_raw_scan_for_inline_platform(
     yaml_file = tmp_path / "kitchen.yaml"
     yaml_file.write_text("esphome:\n  name: kitchen\nesp8266:\n  board: nodemcuv2\n")
     assert detect_platform_from_yaml(yaml_file) == "esp8266"
+
+
+def test_detect_platform_from_yaml_skips_load_when_no_packages_block(
+    tmp_path: Path,
+) -> None:
+    """Config without ``packages:`` doesn't pay the load+merge cost.
+
+    Mid-edit drafts and post-compile-only configs frequently omit
+    a top-level platform key (the user gets it from
+    ``StorageJSON``). Without the ``packages:`` gate, every such
+    YAML would trigger a full ESPHome YAML parse on every
+    dashboard scan — pure waste because the merge has nothing to
+    surface. Spy on ``load_device_yaml`` to confirm we don't call
+    it when the raw text has no ``packages:`` block.
+    """
+    yaml_file = tmp_path / "kitchen.yaml"
+    yaml_file.write_text("esphome:\n  name: kitchen\n# platform comes from storage\n")
+    with mock.patch(
+        "esphome_device_builder.helpers.device_yaml.load_device_yaml",
+        wraps=device_yaml.load_device_yaml,
+    ) as spy:
+        assert detect_platform_from_yaml(yaml_file) == ""
+    spy.assert_not_called()
+
+
+def test_load_device_yaml_skips_merge_for_remote_packages(
+    tmp_path: Path,
+) -> None:
+    """Remote-package configs DON'T trigger the merge — would block on git clone.
+
+    A ``url:`` package fires ``git clone`` synchronously inside
+    ``do_packages_pass``; first-run latency is 5-10 minutes on
+    slow connections / large repos. The dashboard's metadata
+    refresh runs on the WS event loop, so we gate the merge on
+    "no remote packages anywhere in the tree". Configs that hit
+    this gate degrade to the unmerged shape (same as pre-fix); a
+    follow-up will add an executor + mtime cache to support
+    remote packages without blocking.
+
+    Spy on ``do_packages_pass`` / ``resolve_packages`` to confirm
+    neither runs when a remote package is present.
+    """
+    yaml_file = tmp_path / "remote.yaml"
+    yaml_file.write_text(
+        "esphome:\n  name: remote\n"
+        "packages:\n"
+        "  shared:\n"
+        "    url: https://github.com/example/shared\n"
+        "    files:\n      - shared.yaml\n"
+        "    ref: main\n"
+    )
+    with (
+        mock.patch("esphome_device_builder.helpers.device_yaml._do_packages_pass") as do_pkg,
+        mock.patch("esphome_device_builder.helpers.device_yaml._resolve_packages") as resolve_pkg,
+    ):
+        config = load_device_yaml(yaml_file)
+    assert config is not None
+    # Merge skipped → ``packages:`` is still in the result.
+    assert "packages" in config
+    do_pkg.assert_not_called()
+    resolve_pkg.assert_not_called()
+
+
+def test_has_remote_packages_local_only_returns_false() -> None:
+    """A purely local ``packages:`` tree (inline dicts) is safe to merge.
+
+    Walks the canonical local-package shapes — inline dict
+    fragment, ``IncludeFile`` substitute (any non-``url:`` dict),
+    list of inline dicts — and confirms the gate stays open. A
+    False positive here would silently disable the merge for the
+    BLE-beacon configs from #288 the fix was written for.
+    """
+    assert _has_remote_packages({"shared": {"wifi": {"ssid": "x"}}}) is False
+    assert _has_remote_packages({}) is False
+    assert _has_remote_packages({"a": {"foo": 1}, "b": {"bar": 2}}) is False
+
+
+def test_has_remote_packages_url_dict_returns_true() -> None:
+    """A package definition with ``url:`` is remote — gate has to bail."""
+    assert (
+        _has_remote_packages(
+            {"shared": {"url": "https://github.com/example/shared", "ref": "main"}}
+        )
+        is True
+    )
+
+
+def test_has_remote_packages_shorthand_string_returns_true() -> None:
+    """``github://user/repo@ref`` (and friends) are remote.
+
+    ESPHome accepts a string-shorthand form alongside the dict
+    form; ``do_packages_pass`` parses it via
+    ``validate_source_shorthand`` which clones from a git remote.
+    """
+    assert _has_remote_packages({"shared": "github://example/shared@main"}) is True
+
+
+def test_has_remote_packages_mixed_local_and_remote_returns_true() -> None:
+    """Any single remote package in the tree taints the whole config.
+
+    The metadata loader can't merge "just the local ones" — that
+    would silently drop blocks the user expects from the remote
+    package. Bail to the unmerged shape instead, same as
+    pre-fix.
+    """
+    assert (
+        _has_remote_packages(
+            {
+                "local": {"wifi": {"ssid": "x"}},
+                "remote": {"url": "https://github.com/example/shared"},
+            }
+        )
+        is True
+    )
+
+
+def test_has_remote_packages_nested_remote_returns_true() -> None:
+    """Remote package nested inside a local one still triggers the gate.
+
+    ESPHome's package resolver flattens nested packages
+    recursively — a local package can reference a remote one. The
+    walk has to descend the full tree to spot this.
+    """
+    assert (
+        _has_remote_packages(
+            {
+                "outer": {
+                    "packages": {
+                        "inner": {
+                            "url": "https://github.com/example/inner",
+                        }
+                    },
+                }
+            }
+        )
+        is True
+    )
+
+
+def test_load_device_yaml_falls_back_when_both_imports_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No-op gracefully when neither upstream import shape is available.
+
+    A future esphome that deprecates ``do_packages_pass`` /
+    ``merge_packages`` AND moves ``resolve_packages`` (rename,
+    refactor, …) would otherwise leave us with no merge path. The
+    module's ``try/except ImportError`` guards both imports — the
+    function then degrades to the unmerged shape, the same fallback
+    we use when a package merge fails at runtime. Pre-fix
+    behaviour stays available even if the upstream API surface
+    drifts.
+    """
+    monkeypatch.setattr(device_yaml, "_resolve_packages", None)
+    monkeypatch.setattr(device_yaml, "_do_packages_pass", None)
+    monkeypatch.setattr(device_yaml, "_merge_packages", None)
+    yaml_file = tmp_path / "with_pkg.yaml"
+    yaml_file.write_text("esphome:\n  name: x\npackages:\n  shared:\n    wifi:\n      ssid: y\n")
+    config = load_device_yaml(yaml_file)
+    assert config is not None
+    # Without a merge path the ``packages:`` block stays — caller
+    # then falls back to the raw-scan / StorageJSON surfaces the
+    # rest of the metadata pipeline already handles.
+    assert "packages" in config
+
+
+def test_load_device_yaml_skips_merge_for_remote_shorthand_package(
+    tmp_path: Path,
+) -> None:
+    """The git-shorthand string form (``github://``) is also remote.
+
+    ESPHome accepts a ``name: github://user/repo@ref`` value as
+    sugar for the dict form. ``_has_remote_packages`` walks string
+    entries too, so both shapes hit the gate.
+    """
+    yaml_file = tmp_path / "remote.yaml"
+    yaml_file.write_text(
+        "esphome:\n  name: remote\npackages:\n  shared: github://example/shared@main\n"
+    )
+    with mock.patch("esphome_device_builder.helpers.device_yaml._do_packages_pass") as do_pkg:
+        config = load_device_yaml(yaml_file)
+    assert config is not None
+    assert "packages" in config
+    do_pkg.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #288. The dashboard's metadata helpers called `yaml_util.load_yaml(path)` and treated the result as the "compiler-equivalent" view of the config — but `yaml_util.load_yaml` only handles `!include` / `!secret` / etc. The `packages:` block stays nested. So a device that pulled `api:` / `wifi:` / a target-platform key (`esp32:` / `esp8266:` / …) in via `packages:` came back with:

- `api_encrypted = False` (encryption block is inside the package, not at the top level)
- `target_platform = ""` (platform key inside the package)
- `loaded_integrations = []` (storage was empty pre-compile, raw scan saw nothing)

Visible symptoms: the device card lit the wrong indicators, and the install dialog's web-flasher gate (which needs a non-empty target_platform) hid the option for those devices. Came up specifically for BLE-beacon configs that share a common board / api / wifi / ota package across many devices.

## Approach

Extend `load_device_yaml` to do what the compiler does at `esphome.config:1010-1039` — load packages, then merge them into the main config. Both pieces are pure delegations to ESPHome internals; neither the loader (file open / git fetch / `!include` resolution) nor the merge algorithm lives in this repo.

Forward-compatible import:

- **Preferred:** `from esphome.components.packages import resolve_packages` — the upstream single-call seam I'm proposing in https://github.com/esphome/esphome/pull/16235.
- **Fallback:** `do_packages_pass(config)` then `merge_packages(config)` — the two-step today's ESPHome ships.

Both imports are guarded by their own `try/except ImportError` so a future esphome that ships only one of them (deprecates / renames the other) can't break our module-load. Once `resolve_packages` lands in an esphome release and the dashboard's dep floor moves past it, both the fallback and the local helpers can be deleted in one commit.

`detect_platform_from_yaml` also extended to fall through to the resolved config on a raw-scan miss (same package shape: `esp32:` lives inside the package). The cheap regex stays the primary path; the load is also gated on the raw text containing a `packages:` block (otherwise the merge has nothing to surface) so the typical no-packages config doesn't pay a parser load on every dashboard scan.

## Remote packages

`resolve_packages` will run `git clone` synchronously on the first call against a remote (`url:` / `github://...`) package — the first-time fetch on a large repo / slow connection can take several minutes. We're OK with that here because:

- `load_device_yaml` is invoked via `run_in_executor` from both the device scanner (`_device_scanner.scan`) and the devices controller, so the merge runs on a worker thread, NOT the WS event loop. The dashboard stays responsive to other clients during the clone.
- This matches the trade-off the validate path already lives with — ESPHome's `vscode` subprocess runs the full resolve on every validate request, and users already wait through it for remote-package configs.

A follow-up that mirrors the validate-style subprocess pattern for metadata refresh (so a slow remote clone doesn't stall the whole scan loop for that one device) is left for separate work.

## Best-effort error handling

Package merge can fail — bad `git:` ref, network down, malformed package YAML. The wrapper catches those and keeps the unmerged config rather than dropping the whole device's metadata to `None`. The raw-YAML fallback paths at the call sites still work; the dashboard degrades gracefully on offline / cache-cold setups. Logged at `_LOGGER.debug` so a routine offline state doesn't spam warnings.

## Final state

- 4 commits on the branch (the third / fourth iterate on the design as scope tightened — happy to squash on merge).
- ~250 net lines added across `esphome_device_builder/helpers/device_yaml.py` (~140) and `tests/test_api_key.py` (~110).
- 18 tests in `test_api_key.py` total (was 13); 5 new are scoped to the package-merge + platform-fallback paths.
- All 1334 existing tests still pass; pre-commit clean.

## Tests

`tests/test_api_key.py`:

- `test_load_device_yaml_merges_packages` — `api:` + `wifi:` + `esp32:` pulled in via `packages: !include common.yaml` end up flat at the top level after merge; `packages:` itself is consumed; `get_api_encryption_key` returns the encryption key from the merged `api:` block.
- `test_load_device_yaml_falls_back_when_both_imports_missing` — when both upstream import shapes are unavailable (a future esphome that drops the two-step AND moves `resolve_packages`), `load_device_yaml` returns the unmerged config rather than crashing. Pre-fix behaviour stays available.
- `test_detect_platform_from_yaml_falls_back_to_resolved_config` — platform inside a package is detected via the resolved-config fallback.
- `test_detect_platform_from_yaml_keeps_raw_scan_for_inline_platform` — pins the fast path so a future refactor that always loads the resolved config can't regress it.
- `test_detect_platform_from_yaml_skips_load_when_no_packages_block` — confirms via spy that `load_device_yaml` is NOT called when the raw text has no `packages:` block (the typical no-packages config doesn't pay the load cost).

## Test plan

- [x] Unit tests: 1334 passed, 3 skipped, +5 new
- [x] Lint: `pre-commit run` clean
- [x] Live: device with `packages: !include common.yaml` containing `api: encryption: ...` and `esp32:` shows the lock indicator AND web-flasher option in the install dialog
- [x] Live: BLE-beacon config (no top-level api/wifi, all in package) shows the install-method dialog with all 4 options
- [x] Live: device with a remote (`url:`) package — first scan blocks the worker thread for the duration of the clone but the dashboard stays interactive for other clients