### PR TITLE
Expand frontend bump PRs in release notes

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: true
   github-token:
     description: |
-      GitHub token. Needs read access to this repo *and* to the frontend repo
-      (for the release bodies). The default GITHUB_TOKEN works for public
-      repos; the release workflow passes its app token here.
+      GitHub token used to read this repo's PRs and tags. The frontend
+      repo is read anonymously (it's public) so the token only needs
+      access to the calling repo — no cross-repo install required.
     required: true
   frontend-repo:
     description: Frontend repo in OWNER/REPO form.

--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -1,0 +1,71 @@
+name: Generate release notes
+description: |
+  Build the device-builder release notes from merged PRs since the previous
+  tag. Mirrors the label-driven categorisation in release-drafter.yml and,
+  on top of that, expands every "Bump frontend to X.Y.Z" PR in place: the
+  frontend GitHub releases between the previous and current pinned versions
+  are fetched and their bullets are dropped into the matching backend
+  category. Bump PRs themselves never appear in the rendered notes.
+
+inputs:
+  version:
+    description: Version being released (used in log lines, not in the body).
+    required: true
+  previous-tag:
+    description: Previous release tag to diff against. Empty for the first release.
+    required: false
+    default: ""
+  commitish:
+    description: Branch name or commit SHA the release is being cut from.
+    required: true
+  github-token:
+    description: |
+      GitHub token. Needs read access to this repo *and* to the frontend repo
+      (for the release bodies). The default GITHUB_TOKEN works for public
+      repos; the release workflow passes its app token here.
+    required: true
+  frontend-repo:
+    description: Frontend repo in OWNER/REPO form.
+    required: false
+    default: esphome/device-builder-frontend
+  frontend-dep-name:
+    description: Frontend distribution name as it appears in pyproject.toml's `dependencies`.
+    required: false
+    default: esphome-device-builder-frontend
+
+outputs:
+  release-notes:
+    description: The rendered release-notes body.
+    value: ${{ steps.generate.outputs.release-notes }}
+  release-notes-file:
+    description: |
+      Path to a file containing the rendered notes. Prefer this over
+      `release-notes` when piping into `gh release create --notes-file`,
+      since multi-line outputs can be brittle to reinterpolate.
+    value: ${{ steps.generate.outputs.release-notes-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      with:
+        python-version: "3.13"
+
+    - name: Install Python dependencies
+      shell: bash
+      run: pip install --no-cache-dir PyGithub PyYAML
+
+    - name: Generate release notes
+      id: generate
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_SERVER_URL: ${{ github.server_url }}
+        VERSION: ${{ inputs.version }}
+        PREVIOUS_TAG: ${{ inputs.previous-tag }}
+        COMMITISH: ${{ inputs.commitish }}
+        FRONTEND_REPO: ${{ inputs.frontend-repo }}
+        FRONTEND_DEP_NAME: ${{ inputs.frontend-dep-name }}
+      run: python "${{ github.action_path }}/generate_notes.py"

--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""
+Render the device-builder release notes for a single release.
+
+Mirrors release-drafter's label-driven categorisation, then *expands*
+each frontend version pin in place: the GitHub releases between the
+previous tag's pinned version (exclusive) and the current pinned version
+(inclusive) are fetched from the frontend repo, and their bullets are
+dropped into the matching backend category. The "Bump frontend to ..."
+PRs themselves never appear in the rendered notes — readers care about
+what changed, not which sequence of bumps landed it.
+
+Bullets in the frontend's Dependencies / CI section are skipped: the
+frontend's dependabot churn is irrelevant to a device-builder release.
+Bullets under any unrecognised section heading are also dropped — the
+frontend repo enforces a labelled PR per merge, so an unknown heading
+only happens when a release body is hand-edited, in which case the
+maintainer can drop the change into the relevant section by hand.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tomllib
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from github.Repository import Repository
+
+
+# Path to the release-drafter config we share with the rolling-draft tool.
+_CONFIG_PATH = ".github/release-drafter.yml"
+
+# Frontend release-notes patterns. The frontend repo's release-drafter
+# emits one bullet per PR with the same "$TITLE (by @$AUTHOR in #$NUMBER)"
+# template, so we can pull title/author/number out cleanly. Backticks
+# around the handle are a copy that GitHub adds when one PR's body is
+# included into another via the dependency-update template, so be
+# permissive about them.
+_FRONTEND_BULLET_RE = re.compile(
+    r"^[-*•]\s+"
+    r"(?P<title>.+?)"
+    r"\s+\(by\s+`?@(?P<author>[\w-]+)`?\s+in\s+#(?P<number>\d+)\)"
+    r"\s*$"
+)
+_SECTION_HEADER_RE = re.compile(r"^##\s+(.+?)\s*$")
+_FRONTEND_BUMP_TITLE_RE = re.compile(r"^Bump frontend to ")
+
+# Versions are X.Y.Z; tuple-compare is enough for ordering. Anything
+# fancier (pre-releases, build metadata) is unlikely on the frontend
+# and would need a real packaging.version comparison.
+_VERSION_RE = re.compile(r"^\d+(?:\.\d+)+$")
+
+# Category labels whose section we never inline frontend bullets into.
+# A frontend dependency bump is just dependabot churn from the user's
+# perspective.
+_FRONTEND_SKIP_LABELS = frozenset({"dependencies", "ci"})
+
+
+def load_config(path: str = _CONFIG_PATH) -> dict[str, Any]:
+    """Load the release-drafter config that defines categories and templates."""
+    p = Path(path)
+    if not p.exists():
+        sys.exit(f"Error: {path} not found")
+    with p.open() as f:
+        return yaml.safe_load(f) or {}
+
+
+def parse_pyproject_frontend_version(text: str | None, dep_name: str) -> str | None:
+    """
+    Extract the frontend pin from a pyproject.toml string.
+
+    Returns ``None`` when the dep is missing or pinned with anything
+    other than ``==``. We deliberately don't try to resolve ``>=``
+    ranges — a release pin is always exact in this project.
+    """
+    if not text:
+        return None
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return None
+    deps = (data.get("project") or {}).get("dependencies") or []
+    prefix = f"{dep_name}=="
+    for spec in deps:
+        if isinstance(spec, str) and spec.startswith(prefix):
+            return spec[len(prefix) :].strip().strip('"').strip("'")
+    return None
+
+
+def get_pyproject_at(repo: Repository, ref: str | None) -> str | None:
+    """Fetch ``pyproject.toml`` at ``ref`` (tag, branch, or SHA)."""
+    from github import GithubException
+
+    if not ref:
+        return None
+    try:
+        contents = repo.get_contents("pyproject.toml", ref=ref)
+    except GithubException as e:  # pragma: no cover - network failure
+        print(f"Warning: cannot read pyproject.toml at {ref}: {e}", file=sys.stderr)
+        return None
+    if isinstance(contents, list):  # directory; shouldn't happen
+        return None
+    return contents.decoded_content.decode("utf-8")
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in v.split("."))
+
+
+def get_frontend_releases_in_range(
+    frontend_repo: Repository,
+    *,
+    after: str | None,
+    up_to: str,
+) -> list[Any]:
+    """
+    Yield frontend releases with ``after < tag <= up_to``, oldest-first.
+
+    ``after`` is exclusive — its body shipped with the previous backend
+    release — and ``up_to`` is inclusive. Returns an empty list if either
+    bound isn't a recognised X.Y.Z version (e.g. an experimental tag),
+    rather than guessing how to compare.
+    """
+    if not _VERSION_RE.match(up_to):
+        return []
+    up_to_t = _version_tuple(up_to)
+    after_t = _version_tuple(after) if after and _VERSION_RE.match(after) else None
+
+    selected: list[Any] = []
+    for rel in frontend_repo.get_releases():
+        tag = rel.tag_name or ""
+        if not _VERSION_RE.match(tag):
+            continue
+        t = _version_tuple(tag)
+        if after_t is not None and t <= after_t:
+            continue
+        if t > up_to_t:
+            continue
+        selected.append(rel)
+    selected.sort(key=lambda r: _version_tuple(r.tag_name))
+    return selected
+
+
+def parse_frontend_release_body(
+    body: str,
+    *,
+    category_titles: list[str],
+    skip_titles: set[str],
+    frontend_repo_full_name: str,
+    server_url: str = "https://github.com",
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Bucket a frontend release body into category -> list of changes.
+
+    Walks the body line-by-line, tracking the most recent ``## TITLE``
+    heading. Bullets emitted while the current heading matches a known
+    backend category title (and isn't a skip-list bucket like
+    Dependencies / CI) are captured into a dict the renderer can reuse.
+
+    The frontend repo writes ``#NNN`` for its own PR refs; we synthesise
+    the absolute URL here so the rendered link in the backend's release
+    notes lands on the actual frontend PR rather than auto-linking to
+    the same number in the backend repo.
+    """
+    by_category: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    title_set = set(category_titles)
+    current_title: str | None = None
+
+    for raw in body.splitlines():
+        line = raw.rstrip()
+        header_match = _SECTION_HEADER_RE.match(line)
+        if header_match:
+            heading = header_match.group(1).strip()
+            current_title = heading if heading in title_set else None
+            continue
+
+        if current_title is None or current_title in skip_titles:
+            continue
+
+        bullet = _FRONTEND_BULLET_RE.match(line.strip())
+        if not bullet:
+            continue
+
+        number = int(bullet.group("number"))
+        by_category[current_title].append(
+            {
+                "title": bullet.group("title").strip(),
+                "author": bullet.group("author"),
+                "number": number,
+                "url": f"{server_url}/{frontend_repo_full_name}/pull/{number}",
+                "is_frontend": True,
+            }
+        )
+
+    return by_category
+
+
+def render_change_line(template: str, change: dict[str, Any]) -> str:
+    """
+    Render a single bullet from a captured change dict.
+
+    For backend PRs we emit ``#NNN`` literally — GitHub auto-links to
+    the surrounding repo, which is the right destination. For frontend
+    bullets we pre-substitute ``#$NUMBER`` with an explicit markdown
+    link to the frontend PR; otherwise the same auto-link logic would
+    silently re-resolve the number against the backend repo and either
+    point at the wrong PR or render as a dead link.
+    """
+    line = template
+    if change.get("is_frontend"):
+        line = line.replace("#$NUMBER", f"[#{change['number']}]({change['url']})")
+    line = line.replace("$TITLE", str(change["title"]))
+    line = line.replace("$AUTHOR", str(change["author"]))
+    line = line.replace("$NUMBER", str(change["number"]))
+    return line.replace("$URL", str(change["url"]))
+
+
+def build_release_notes(
+    *,
+    config: dict[str, Any],
+    by_category: dict[str, list[dict[str, Any]]],
+    previous_tag: str | None,
+    repo_url: str,
+) -> str:
+    """Render the final body using the release-drafter ``template`` field."""
+    change_template = config.get("change-template", "- $TITLE (@$AUTHOR) #$NUMBER")
+    category_configs = config.get("categories", [])
+
+    section_lines: list[str] = []
+    if previous_tag:
+        section_lines.append(
+            f"_Changes since [{previous_tag}]({repo_url}/releases/tag/{previous_tag})_"
+        )
+        section_lines.append("")
+
+    for cfg in category_configs:
+        title = cfg["title"]
+        changes = by_category.get(title, [])
+        if not changes:
+            continue
+        section_lines.append(f"### {title}")
+        section_lines.append("")
+
+        collapse_after = cfg.get("collapse-after")
+        collapsed = collapse_after is not None and len(changes) > collapse_after
+        if collapsed:
+            section_lines.append("<details>")
+            section_lines.append(f"<summary>{len(changes)} changes</summary>")
+            section_lines.append("")
+
+        section_lines.extend(render_change_line(change_template, c) for c in changes)
+
+        if collapsed:
+            section_lines.append("")
+            section_lines.append("</details>")
+        section_lines.append("")
+
+    body = "\n".join(section_lines).rstrip()
+    template = config.get("template") or "## What's changed\n\n$CHANGES\n"
+    return template.replace("$CHANGES", body).rstrip() + "\n"
+
+
+def categorise_backend_pr(
+    pr_labels: set[str], category_configs: list[dict[str, Any]]
+) -> str | None:
+    """Return the first category whose labels overlap ``pr_labels``."""
+    for cfg in category_configs:
+        labels = cfg.get("labels") or []
+        if isinstance(labels, str):
+            labels = [labels]
+        if pr_labels & set(labels):
+            return cfg["title"]
+    return None
+
+
+def _extract_pr_numbers_from_commits(commits: list[Any]) -> set[int]:
+    """Pull every ``#NNN`` reference out of a list of commit messages."""
+    pr_re = re.compile(r"#(\d+)")
+    merge_re = re.compile(r"Merge pull request #(\d+)")
+    numbers: set[int] = set()
+    for commit in commits:
+        msg = commit.commit.message
+        merge_match = merge_re.search(msg)
+        if merge_match:
+            numbers.add(int(merge_match.group(1)))
+            continue
+        numbers.update(int(m.group(1)) for m in pr_re.finditer(msg))
+    return numbers
+
+
+def _get_tag_date(repo: Repository, tag: str) -> Any | None:
+    """Return the commit date that ``tag`` points to (for filtering)."""
+    from github import GithubException
+
+    try:
+        ref = repo.get_git_ref(f"tags/{tag}")
+        if ref.object.type == "tag":
+            return repo.get_git_tag(ref.object.sha).tagger.date
+        return repo.get_commit(ref.object.sha).commit.committer.date
+    except GithubException:
+        return None
+
+
+def fetch_backend_prs(
+    repo: Repository,
+    *,
+    previous_tag: str | None,
+    commitish: str,
+) -> list[Any]:
+    """
+    Fetch backend PRs merged since ``previous_tag``.
+
+    Falls back to the last 100 commits on ``commitish`` when no previous
+    tag exists (first-ever release). Mirrors release-drafter's strategy
+    of pulling PR numbers out of commit messages instead of querying the
+    PR list directly, since rebase-merged commits may not appear under
+    the tag's compare ancestry exactly the way ``gh pr list`` orders them.
+    """
+    from github import GithubException
+
+    if previous_tag:
+        try:
+            commits = list(repo.compare(previous_tag, commitish).commits)
+        except GithubException as e:
+            sys.exit(f"Error: cannot compare {previous_tag}..{commitish}: {e}")
+    else:
+        commits = list(repo.get_commits(sha=commitish)[:100])
+
+    pr_numbers = _extract_pr_numbers_from_commits(commits)
+    tag_date = _get_tag_date(repo, previous_tag) if previous_tag else None
+
+    prs: list[Any] = []
+    for num in sorted(pr_numbers):
+        try:
+            pr = repo.get_pull(num)
+        except GithubException as e:
+            print(f"Warning: cannot fetch PR #{num}: {e}", file=sys.stderr)
+            continue
+        if not pr.merged:
+            continue
+        # Squash-merged or referenced from a later commit but actually
+        # shipped in the previous tag — drop it to avoid duplicating
+        # the line across two consecutive releases.
+        if tag_date and pr.merged_at and pr.merged_at <= tag_date:
+            continue
+        prs.append(pr)
+    return prs
+
+
+def _compute_skip_titles(category_configs: list[dict[str, Any]]) -> set[str]:
+    """Categories whose labels mark them as 'machine churn' (deps / CI)."""
+    skip: set[str] = set()
+    for cfg in category_configs:
+        labels = cfg.get("labels") or []
+        if isinstance(labels, str):
+            labels = [labels]
+        if set(labels) & _FRONTEND_SKIP_LABELS:
+            skip.add(cfg["title"])
+    return skip
+
+
+def _categorise_backend_prs(
+    prs: list[Any],
+    category_configs: list[dict[str, Any]],
+) -> tuple[dict[str, list[dict[str, Any]]], list[int]]:
+    """Bucket backend PRs by category. Bump-PR numbers are returned separately."""
+    by_category: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    skipped_bumps: list[int] = []
+
+    for pr in prs:
+        if _FRONTEND_BUMP_TITLE_RE.match(pr.title):
+            skipped_bumps.append(pr.number)
+            continue
+        labels = {label.name for label in pr.labels}
+        title = categorise_backend_pr(labels, category_configs)
+        if title is None:
+            continue
+        by_category[title].append(
+            {
+                "title": pr.title,
+                "author": pr.user.login,
+                "number": pr.number,
+                "url": pr.html_url,
+                "is_frontend": False,
+            }
+        )
+
+    return by_category, skipped_bumps
+
+
+def _collect_frontend_changes(
+    *,
+    repo: Repository,
+    commitish: str,
+    previous_tag: str | None,
+    frontend_repo_name: str,
+    frontend_dep_name: str,
+    category_titles: list[str],
+    skip_titles: set[str],
+    server_url: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """Resolve the frontend version range and inline its release-notes bullets.
+
+    The version range comes straight from ``pyproject.toml`` at the
+    previous tag and the release commitish, so a backend bump that skips
+    a frontend version (e.g. 0.1.20 -> 0.1.22 in one PR) still surfaces
+    the intermediate 0.1.21 release notes.
+    """
+    from github import Github
+
+    current_fv = parse_pyproject_frontend_version(
+        get_pyproject_at(repo, commitish), frontend_dep_name
+    )
+    previous_fv = (
+        parse_pyproject_frontend_version(get_pyproject_at(repo, previous_tag), frontend_dep_name)
+        if previous_tag
+        else None
+    )
+
+    by_category: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    if not current_fv or current_fv == previous_fv:
+        return by_category
+
+    print(
+        f"Inlining frontend changes from {previous_fv or '(first release)'} -> {current_fv}",
+        file=sys.stderr,
+    )
+    # The release.yml token is a GitHub App token scoped to the backend
+    # repo; it can't read the frontend repo. Frontend releases are
+    # public, so an anonymous client works — at the cost of the
+    # 60/hour rate limit, which is plenty for a one-shot release run.
+    try:
+        frontend_repo = Github().get_repo(frontend_repo_name)
+        releases = get_frontend_releases_in_range(
+            frontend_repo, after=previous_fv, up_to=current_fv
+        )
+    except Exception as e:
+        print(
+            f"Warning: cannot fetch frontend releases ({e}); "
+            "release notes will not include frontend changes.",
+            file=sys.stderr,
+        )
+        return by_category
+
+    for release in releases:
+        if not release.body:
+            continue
+        cats = parse_frontend_release_body(
+            release.body,
+            category_titles=category_titles,
+            skip_titles=skip_titles,
+            frontend_repo_full_name=frontend_repo_name,
+            server_url=server_url,
+        )
+        for title, items in cats.items():
+            by_category[title].extend(items)
+    return by_category
+
+
+def _emit_outputs(notes: str) -> None:
+    """Write the notes to a file and to ``GITHUB_OUTPUT`` (when present)."""
+    runner_temp = os.environ.get("RUNNER_TEMP", "/tmp")
+    notes_file = Path(runner_temp) / "release-notes.md"
+    notes_file.write_text(notes, encoding="utf-8")
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        sys.stdout.write(notes)
+        return
+    with open(output_path, "a", encoding="utf-8") as f:
+        f.write(f"release-notes-file={notes_file}\n")
+        # Multi-line outputs need the heredoc form. The delimiter has to
+        # be a string we know won't appear in the rendered notes.
+        f.write("release-notes<<RELEASENOTES_EOF\n")
+        f.write(notes)
+        if not notes.endswith("\n"):
+            f.write("\n")
+        f.write("RELEASENOTES_EOF\n")
+
+
+def main() -> None:
+    """Entry point for the GitHub Action."""
+    from github import Github
+
+    token = os.environ["GITHUB_TOKEN"]
+    repo_name = os.environ["GITHUB_REPOSITORY"]
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    previous_tag = os.environ.get("PREVIOUS_TAG", "").strip() or None
+    commitish = os.environ["COMMITISH"]
+    frontend_repo_name = os.environ["FRONTEND_REPO"]
+    frontend_dep_name = os.environ["FRONTEND_DEP_NAME"]
+
+    config = load_config()
+    category_configs = config.get("categories", [])
+    category_titles = [c["title"] for c in category_configs]
+    skip_titles = _compute_skip_titles(category_configs)
+
+    repo = Github(token).get_repo(repo_name)
+
+    backend_prs = fetch_backend_prs(repo, previous_tag=previous_tag, commitish=commitish)
+    print(f"Backend PRs in range: {len(backend_prs)}", file=sys.stderr)
+
+    by_category, skipped_bumps = _categorise_backend_prs(backend_prs, category_configs)
+    if skipped_bumps:
+        print(
+            f"Skipped {len(skipped_bumps)} frontend bump PR(s): "
+            f"{', '.join(f'#{n}' for n in skipped_bumps)}",
+            file=sys.stderr,
+        )
+
+    frontend_buckets = _collect_frontend_changes(
+        repo=repo,
+        commitish=commitish,
+        previous_tag=previous_tag,
+        frontend_repo_name=frontend_repo_name,
+        frontend_dep_name=frontend_dep_name,
+        category_titles=category_titles,
+        skip_titles=skip_titles,
+        server_url=server_url,
+    )
+    for title, items in frontend_buckets.items():
+        by_category[title].extend(items)
+
+    notes = build_release_notes(
+        config=config,
+        by_category=by_category,
+        previous_tag=previous_tag,
+        repo_url=f"{server_url}/{repo_name}",
+    )
+    _emit_outputs(notes)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/generate-release-notes/test_generate_notes.py
+++ b/.github/actions/generate-release-notes/test_generate_notes.py
@@ -1,0 +1,292 @@
+"""Pure-Python unit tests for the release-notes generator.
+
+Only exercises the parser/renderer halves — anything that calls into
+PyGithub is integration-tested implicitly via a dry run from the repo
+maintainer when the action lands.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def gen():
+    """Import the script as a module despite its dotted parent path."""
+    here = Path(__file__).resolve().parent
+    sys.path.insert(0, str(here))
+    try:
+        import generate_notes
+
+        return generate_notes
+    finally:
+        sys.path.pop(0)
+
+
+def test_parse_pyproject_extracts_pinned_version(gen):
+    text = """
+[project]
+name = "esphome-device-builder"
+dependencies = [
+  "esphome-device-builder-frontend==0.1.25",
+  "aiohttp>=3.9.0",
+]
+"""
+    assert gen.parse_pyproject_frontend_version(text, "esphome-device-builder-frontend") == "0.1.25"
+
+
+def test_parse_pyproject_returns_none_for_range_pin(gen):
+    text = """
+[project]
+dependencies = [
+  "esphome-device-builder-frontend>=0.1.0",
+]
+"""
+    assert gen.parse_pyproject_frontend_version(text, "esphome-device-builder-frontend") is None
+
+
+def test_parse_pyproject_returns_none_when_dep_missing(gen):
+    text = """
+[project]
+dependencies = ["aiohttp>=3.9.0"]
+"""
+    assert gen.parse_pyproject_frontend_version(text, "esphome-device-builder-frontend") is None
+
+
+def test_parse_pyproject_handles_invalid_toml(gen):
+    assert (
+        gen.parse_pyproject_frontend_version(
+            "this is not toml [", "esphome-device-builder-frontend"
+        )
+        is None
+    )
+
+
+# A realistic frontend release body; mirrors what release-drafter emits in the
+# frontend repo, including the bare ``#NNN`` PR refs and the trailing
+# Contributors section we want to ignore.
+_FRONTEND_BODY = """\
+## 🚀 New features
+
+- Add awesome thing (by @alice in #99)
+
+## 🐛 Bug fixes
+
+- Stop the editor from eating the trailing newline (by @bob in #100)
+- Restore something else (by `@carol` in #101)
+
+## ⬆️ Dependencies / CI
+
+- Bump vue from 3.1.2 to 3.1.3 (by @dependabot[bot] in #102)
+
+## :bow: Contributors
+
+@alice, @bob, @carol
+"""
+
+
+def test_parse_frontend_release_body_buckets_known_categories(gen):
+    by_cat = gen.parse_frontend_release_body(
+        _FRONTEND_BODY,
+        category_titles=["🚀 New features", "🐛 Bug fixes", "⬆️ Dependencies / CI"],
+        skip_titles={"⬆️ Dependencies / CI"},
+        frontend_repo_full_name="esphome/device-builder-frontend",
+    )
+
+    new_features = by_cat["🚀 New features"]
+    assert [c["number"] for c in new_features] == [99]
+    assert new_features[0]["title"] == "Add awesome thing"
+    assert new_features[0]["author"] == "alice"
+    assert new_features[0]["is_frontend"] is True
+    assert new_features[0]["url"] == "https://github.com/esphome/device-builder-frontend/pull/99"
+
+    bug_fixes = by_cat["🐛 Bug fixes"]
+    assert [c["number"] for c in bug_fixes] == [100, 101]
+    # Backtick-wrapped author handles in cross-repo includes are normalised away.
+    assert bug_fixes[1]["author"] == "carol"
+
+
+def test_parse_frontend_release_body_skips_dependencies_section(gen):
+    by_cat = gen.parse_frontend_release_body(
+        _FRONTEND_BODY,
+        category_titles=["🚀 New features", "🐛 Bug fixes", "⬆️ Dependencies / CI"],
+        skip_titles={"⬆️ Dependencies / CI"},
+        frontend_repo_full_name="esphome/device-builder-frontend",
+    )
+    assert "⬆️ Dependencies / CI" not in by_cat
+
+
+def test_parse_frontend_release_body_drops_bullets_under_unknown_heading(gen):
+    body = """\
+## Some made-up heading
+
+- Untracked work (by @alice in #1)
+
+## 🐛 Bug fixes
+
+- A real fix (by @bob in #2)
+"""
+    by_cat = gen.parse_frontend_release_body(
+        body,
+        category_titles=["🐛 Bug fixes"],
+        skip_titles=set(),
+        frontend_repo_full_name="esphome/device-builder-frontend",
+    )
+    assert list(by_cat) == ["🐛 Bug fixes"]
+    assert by_cat["🐛 Bug fixes"][0]["number"] == 2
+
+
+def test_parse_frontend_release_body_drops_bullets_before_first_heading(gen):
+    body = """\
+- Stray bullet (by @alice in #1)
+
+## 🐛 Bug fixes
+
+- Categorised fix (by @bob in #2)
+"""
+    by_cat = gen.parse_frontend_release_body(
+        body,
+        category_titles=["🐛 Bug fixes"],
+        skip_titles=set(),
+        frontend_repo_full_name="esphome/device-builder-frontend",
+    )
+    assert by_cat["🐛 Bug fixes"][0]["number"] == 2
+    assert all(c["number"] != 1 for changes in by_cat.values() for c in changes)
+
+
+def test_parse_frontend_release_body_ignores_contributors_section(gen):
+    by_cat = gen.parse_frontend_release_body(
+        _FRONTEND_BODY,
+        category_titles=["🚀 New features", "🐛 Bug fixes"],
+        skip_titles=set(),
+        frontend_repo_full_name="esphome/device-builder-frontend",
+    )
+    # The contributors heading isn't a known category title, so its bullets
+    # — if any — would be dropped along with the heading itself.
+    assert ":bow:" not in str(by_cat)
+
+
+def test_render_change_line_backend_uses_bare_number(gen):
+    line = gen.render_change_line(
+        "- #$NUMBER - $TITLE (@$AUTHOR)",
+        {
+            "title": "Fix something",
+            "author": "alice",
+            "number": 42,
+            "url": "https://github.com/esphome/device-builder/pull/42",
+            "is_frontend": False,
+        },
+    )
+    # Backend lines keep ``#42`` literal — GitHub auto-links them to the
+    # surrounding repo at render time.
+    assert line == "- #42 - Fix something (@alice)"
+
+
+def test_render_change_line_frontend_emits_explicit_link(gen):
+    line = gen.render_change_line(
+        "- #$NUMBER - $TITLE (@$AUTHOR)",
+        {
+            "title": "Fix something",
+            "author": "alice",
+            "number": 42,
+            "url": "https://github.com/esphome/device-builder-frontend/pull/42",
+            "is_frontend": True,
+        },
+    )
+    # Frontend lines must hard-code the URL: the same ``#42`` would
+    # otherwise auto-resolve against the backend repo.
+    assert line == (
+        "- [#42](https://github.com/esphome/device-builder-frontend/pull/42) - "
+        "Fix something (@alice)"
+    )
+
+
+def test_build_release_notes_renders_backend_and_frontend_together(gen):
+    config = {
+        "change-template": "- #$NUMBER - $TITLE (@$AUTHOR)",
+        "template": "## What's changed\n\n$CHANGES\n",
+        "categories": [
+            {"title": "🐛 Bug fixes", "labels": ["bugfix"]},
+            {"title": "⬆️ Dependencies / CI", "labels": ["dependencies"], "collapse-after": 1},
+        ],
+    }
+    by_category = {
+        "🐛 Bug fixes": [
+            {
+                "title": "Fix backend",
+                "author": "alice",
+                "number": 1,
+                "url": "https://github.com/owner/backend/pull/1",
+                "is_frontend": False,
+            },
+            {
+                "title": "Fix frontend",
+                "author": "bob",
+                "number": 200,
+                "url": "https://github.com/owner/frontend/pull/200",
+                "is_frontend": True,
+            },
+        ],
+    }
+    notes = gen.build_release_notes(
+        config=config,
+        by_category=by_category,
+        previous_tag="0.1.24",
+        repo_url="https://github.com/owner/backend",
+    )
+    assert "## What's changed" in notes
+    assert "_Changes since [0.1.24](https://github.com/owner/backend/releases/tag/0.1.24)_" in notes
+    assert "### 🐛 Bug fixes" in notes
+    assert "- #1 - Fix backend (@alice)" in notes
+    assert "- [#200](https://github.com/owner/frontend/pull/200) - Fix frontend (@bob)" in notes
+    # Empty categories are dropped entirely — no Dependencies / CI section here.
+    assert "Dependencies" not in notes
+
+
+def test_build_release_notes_collapses_long_dependency_lists(gen):
+    config = {
+        "change-template": "- #$NUMBER - $TITLE (@$AUTHOR)",
+        "template": "## What's changed\n\n$CHANGES\n",
+        "categories": [
+            {"title": "⬆️ Dependencies / CI", "labels": ["dependencies"], "collapse-after": 1},
+        ],
+    }
+    by_category = {
+        "⬆️ Dependencies / CI": [
+            {
+                "title": f"Bump foo {i}",
+                "author": "dep",
+                "number": i,
+                "url": f"https://github.com/owner/backend/pull/{i}",
+                "is_frontend": False,
+            }
+            for i in range(3)
+        ],
+    }
+    notes = gen.build_release_notes(
+        config=config,
+        by_category=by_category,
+        previous_tag=None,
+        repo_url="https://github.com/owner/backend",
+    )
+    assert "<details>" in notes
+    assert "<summary>3 changes</summary>" in notes
+    assert "</details>" in notes
+
+
+def test_categorise_backend_pr_picks_first_match(gen):
+    cfgs = [
+        {"title": "🚀 New features", "labels": ["new-feature", "enhancement"]},
+        {"title": "🐛 Bug fixes", "labels": ["bugfix"]},
+    ]
+    assert gen.categorise_backend_pr({"bugfix"}, cfgs) == "🐛 Bug fixes"
+    assert gen.categorise_backend_pr({"enhancement"}, cfgs) == "🚀 New features"
+    assert gen.categorise_backend_pr({"unrelated"}, cfgs) is None
+
+
+def test_version_tuple_orders_lexicographically(gen):
+    assert gen._version_tuple("0.1.21") < gen._version_tuple("0.1.22")
+    assert gen._version_tuple("0.2.0") > gen._version_tuple("0.1.99")

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,9 @@
-# Release-drafter config — drives the rolling draft maintained by
-# .github/workflows/release-drafter.yml. Each merged PR's label
-# decides which section it lands in; the version bump (major/minor/
-# patch) is derived from the labels too. Mirrors matter-server's
-# convention so contributors familiar with that repo land in the
-# right place by default.
+# Release-notes config — read by .github/actions/generate-release-notes/
+# at release time. Each merged PR's label decides which section it lands
+# in; the action also expands "Bump frontend to ..." PRs by inlining the
+# matching frontend release notes under the same backend categories.
+# Mirrors matter-server's category convention so contributors familiar
+# with that repo land in the right place by default.
 
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
@@ -40,11 +40,12 @@ template: |
 
   $CHANGES
 
-# Label-driven version resolution. ``breaking-change`` bumps major,
-# ``new-feature`` / ``enhancement`` bumps minor, anything else patch.
-# The drafter doesn't pick the actual tag — the maintainer types it
-# when publishing — but ``$RESOLVED_VERSION`` shows up in the draft
-# title as a suggestion.
+# Label-to-bump mapping kept for documentation. The release workflow
+# picks the actual version itself (auto-release.yml increments the
+# beta/patch suffix; manual stable releases pass the version into
+# release.yml directly), so these fields aren't consumed by the
+# generator — they're a reference for which labels imply which kind
+# of version bump.
 version-resolver:
   major:
     labels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,23 +147,66 @@ jobs:
         with:
           # Tag doesn't exist yet — it's created when the draft release
           # is published. Build from the SHA the workflow ran on, which
-          # is also what release-drafter targets via commitish.
+          # is also what the generate-release-notes action targets via
+          # commitish.
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Generate release notes (draft)
-        uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2  # v7.2.1
-        with:
-          config-name: release-drafter.yml
-          version: ${{ inputs.version }}
-          tag: ${{ inputs.version }}
-          name: ${{ inputs.version }}
-          commitish: ${{ github.sha }}
-          publish: false
-          prerelease: ${{ needs.validate.outputs.is-prerelease }}
+      - name: Resolve previous release tag
+        id: previous
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # Latest non-draft release that isn't the one we're about to
+          # cut. ``--exclude-drafts`` already strips draft entries left
+          # over from a prior attempt; ``grep -v`` defends against the
+          # rare case where ``inputs.version`` matches a published tag
+          # that the validate job somehow let through.
+          tag=$(gh release list --exclude-drafts --limit 5 \
+            --json tagName --jq '.[].tagName' \
+            | grep -v "^${{ inputs.version }}$" | head -n 1 || true)
+          if [ -z "$tag" ]; then
+            echo "No previous release found — emitting full first-release notes."
+          else
+            echo "Previous release: $tag"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        id: notes
+        uses: ./.github/actions/generate-release-notes
+        with:
+          version: ${{ inputs.version }}
+          previous-tag: ${{ steps.previous.outputs.tag }}
+          commitish: ${{ github.sha }}
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create or update draft release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NOTES_FILE: ${{ steps.notes.outputs.release-notes-file }}
+          IS_PRERELEASE: ${{ needs.validate.outputs.is-prerelease }}
+        run: |
+          set -euo pipefail
+          # Reruns of this job may find an existing draft from the
+          # previous attempt — edit it in place rather than failing on
+          # a duplicate-tag error from ``gh release create``.
+          if gh release view "${{ inputs.version }}" >/dev/null 2>&1; then
+            gh release edit "${{ inputs.version }}" \
+              --notes-file "$NOTES_FILE" \
+              --target "${{ github.sha }}" \
+              --draft \
+              --prerelease="$IS_PRERELEASE"
+          else
+            gh release create "${{ inputs.version }}" \
+              --notes-file "$NOTES_FILE" \
+              --target "${{ github.sha }}" \
+              --title "${{ inputs.version }}" \
+              --draft \
+              --prerelease="$IS_PRERELEASE"
+          fi
 
       - name: Download dist artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,17 @@ jobs:
           set -euo pipefail
           # Reruns of this job may find an existing draft from the
           # previous attempt — edit it in place rather than failing on
-          # a duplicate-tag error from ``gh release create``.
-          if gh release view "${{ inputs.version }}" >/dev/null 2>&1; then
+          # a duplicate-tag error from ``gh release create``. If the
+          # release somehow already exists *and* has been published,
+          # bail out: the validate step rejects existing tags so this
+          # would only happen on an out-of-band publish, and silently
+          # flipping a public release back to draft would be worse
+          # than failing loudly.
+          if existing=$(gh release view "${{ inputs.version }}" --json isDraft --jq '.isDraft' 2>/dev/null); then
+            if [ "$existing" != "true" ]; then
+              echo "::error::Release ${{ inputs.version }} already exists and is not a draft; refusing to overwrite."
+              exit 1
+            fi
             gh release edit "${{ inputs.version }}" \
               --notes-file "$NOTES_FILE" \
               --target "${{ github.sha }}" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,10 @@ select = [
 # behind try/except ImportError, and several subprocess invocations are inherent.
 "script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415"]
 "tests/*" = ["S105", "S106"] # hardcoded test credentials
+# GitHub Action helpers: prints are CI-log diagnostics, lazy imports keep the
+# module importable for unit tests without PyGithub installed, and the temp
+# file path is a runner-controlled location not user input.
+".github/actions/*" = ["T20", "S108", "PLC0415", "BLE001"]
 
 [tool.codespell]
 skip = "*.json,*/definitions/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ select = [
 # GitHub Action helpers: prints are CI-log diagnostics, lazy imports keep the
 # module importable for unit tests without PyGithub installed, and the temp
 # file path is a runner-controlled location not user input.
-".github/actions/*" = ["T20", "S108", "PLC0415", "BLE001"]
+".github/actions/**" = ["T20", "S108", "PLC0415", "BLE001"]
 
 [tool.codespell]
 skip = "*.json,*/definitions/*"


### PR DESCRIPTION
## Problem

Release notes show every frontend version bump as a bare line:

> - #282 - Bump frontend to 0.1.25 (@dependabot)

That hides what actually changed in the release — users following along see version numbers, not features or fixes.

## Changes

- New composite action [.github/actions/generate-release-notes/](.github/actions/generate-release-notes/) replaces release-drafter as the release notes generator.
- It diffs the frontend pin in `pyproject.toml` between the previous tag and HEAD, fetches every frontend GitHub release in that range, and inlines each bullet under the matching backend category (`🐛 Bug fixes`, `🚀 New features`, etc. — same labels as today).
- Frontend bullets in `⬆️ Dependencies / CI` are dropped (dependabot churn isn't release-note material). `Bump frontend to ...` PRs themselves no longer appear.
- Cross-repo PR refs are rewritten to explicit links so a frontend `#121` doesn't auto-resolve against the backend repo.
- Skipped versions are handled correctly: a backend bump that goes 0.1.20 → 0.1.22 still surfaces 0.1.21's notes, since the version range comes straight from the pin diff.
- `release.yml` now drives the draft release via `gh release create/edit` after the action emits the body.