### PR TITLE
Close early-cancel race for serial install pre-flight checks

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -18,7 +18,8 @@ import logging
 import os
 import shutil
 import sys
-from contextlib import suppress
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any
@@ -785,6 +786,15 @@ class FirmwareController:
             )
             self._current_process = proc
 
+            # Honour a cancel that landed in the gap between
+            # ``_verify_chip`` finishing and ``create_subprocess_exec``
+            # returning — without this, an early Stop click during
+            # the brief async window where ``_current_process`` was
+            # ``None`` lets the install run to completion before the
+            # post-``proc.wait()`` cancel check sees the flag.
+            if job.job_id in self._cancel_requested:
+                await self._terminate_current_process()
+
             has_error_in_output = False
             # Captured at append time because the in-flight trim can
             # elide the offending line before the post-exit handler
@@ -896,10 +906,22 @@ class FirmwareController:
             _LOGGER.info("Job %s cancelled (runner shutdown)", job.job_id)
             raise
         except Exception as exc:
-            job.error = str(exc)
-            _mark_job_terminal(job, JobStatus.FAILED)
-            self._db.bus.fire(EventType.JOB_FAILED, {"job": job})
-            _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
+            # If a cancel was requested before this exception escaped,
+            # honour it as CANCELLED instead of FAILED. The
+            # ``_verify_chip`` early-cancel path raises ``ValueError``
+            # to short-circuit the install — without this branch
+            # that error would be reported as a generic failure
+            # rather than the user-driven cancel it actually is.
+            if job.job_id in self._cancel_requested:
+                self._cancel_requested.discard(job.job_id)
+                _mark_job_terminal(job, JobStatus.CANCELLED)
+                self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
+                _LOGGER.info("Job %s cancelled before subprocess wait: %s", job.job_id, exc)
+            else:
+                job.error = str(exc)
+                _mark_job_terminal(job, JobStatus.FAILED)
+                self._db.bus.fire(EventType.JOB_FAILED, {"job": job})
+                _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
         finally:
             self._current_job = None
             self._current_process = None
@@ -911,6 +933,56 @@ class FirmwareController:
                 _trim_job_output(job)
                 self._prune_history()
             await self._persist_jobs()
+
+    @asynccontextmanager
+    async def _tracked_subprocess(
+        self, *args: Any, **kwargs: Any
+    ) -> AsyncIterator[asyncio.subprocess.Process]:
+        """
+        Spawn a subprocess that's visible to ``firmware/cancel``.
+
+        Use this for **every** subprocess invocation in the runner
+        path — pre-flight checks (``_verify_chip``-style) AND any
+        future probe that the runner adds. Setting
+        ``_current_process`` is what lets a concurrent
+        ``firmware/cancel`` actually land SIGTERM on the running
+        spawn; a direct ``create_subprocess_exec`` call without
+        this registration silently regresses the issue-#136 fix —
+        the cancel handler walks ``_current_process`` and no-ops on
+        ``None``, the user clicks Stop, nothing visible happens,
+        and the orphaned subprocess runs to completion in the
+        background.
+
+        Restores the prior ``_current_process`` value on exit so
+        the wrapper composes safely if a future caller nests them.
+
+        Pairs with ``_raise_if_cancelled`` — wrap each spawn, then
+        call the helper after to short-circuit if the cancel landed
+        between this subprocess and the next one.
+        """
+        proc = await create_subprocess_exec(*args, **kwargs)
+        prev = self._current_process
+        self._current_process = proc
+        try:
+            yield proc
+        finally:
+            self._current_process = prev
+
+    def _raise_if_cancelled(self, job: FirmwareJob, phase: str) -> None:
+        """
+        Short-circuit a runner phase if a cancel landed mid-phase.
+
+        Called between subprocess spawns so a cancel that came in
+        while one pre-flight was running stops the next one from
+        starting. Raises ``ValueError`` so ``_execute_job``'s
+        cancel-aware ``except Exception`` branch finalises the job
+        as ``CANCELLED`` (vs. the bare ``FAILED`` path used for
+        unrelated exceptions). ``phase`` shows up in the error
+        message to make the cause clear in the log.
+        """
+        if job.job_id in self._cancel_requested:
+            msg = f"Cancelled during {phase}"
+            raise ValueError(msg)
 
     async def _terminate_current_process(self) -> None:
         """Signal the running subprocess (and its children); escalate if it lingers.
@@ -1018,6 +1090,16 @@ class FirmwareController:
         compares against the target platform in the device config.
         Raises ValueError on mismatch so the job fails early with a
         clear error message.
+
+        The verify subprocess is registered as ``_current_process``
+        for the duration of its run so an early ``firmware/cancel``
+        — typical when the user picked the wrong serial port and
+        esptool is hanging waiting for a device that won't answer
+        — actually lands on the spawned esptool process, instead
+        of no-op'ing because the main install hadn't been spawned
+        yet. ``start_new_session=True`` puts the process in its
+        own group so the SIGTERM signal walks the whole tree the
+        same way the main install spawn site does.
         """
         if not job.port or job.port.upper() == "OTA" or not job.port.startswith("/dev"):
             return  # only check serial ports
@@ -1036,7 +1118,7 @@ class FirmwareController:
         if not expected_platform:
             return  # can't verify without knowing expected platform
 
-        proc = await create_subprocess_exec(
+        async with self._tracked_subprocess(
             sys.executable,
             "-m",
             "esptool",
@@ -1045,10 +1127,19 @@ class FirmwareController:
             "chip-id",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
-        )
-        assert proc.stdout is not None  # type narrowing
-        output = (await proc.stdout.read()).decode("utf-8", errors="replace")
-        await proc.wait()
+            start_new_session=True,
+        ) as proc:
+            assert proc.stdout is not None  # type narrowing
+            output = (await proc.stdout.read()).decode("utf-8", errors="replace")
+            await proc.wait()
+
+        # Honour an early cancel that arrived during chip detection
+        # (the main install hasn't spawned yet, so the post-wait
+        # check below in ``_execute_job`` would otherwise let the
+        # full install run before reporting CANCELLED). Reusing
+        # the ``ValueError`` shape keeps the error path identical
+        # to a chip mismatch.
+        self._raise_if_cancelled(job, "chip verification")
 
         # Parse "Detecting chip type... ESP32-C3"
         detected = ""

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -869,9 +869,7 @@ class FirmwareController:
             # exits non-zero (terminated by signal). Honour that
             # intent rather than reporting it as a generic failure.
             if job.job_id in self._cancel_requested:
-                self._cancel_requested.discard(job.job_id)
-                _mark_job_terminal(job, JobStatus.CANCELLED)
-                self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
+                self._finalize_cancelled(job)
                 _LOGGER.info("Job %s cancelled mid-run (exit %s)", job.job_id, exit_code)
             else:
                 success = exit_code == 0 and not has_error_in_output
@@ -902,9 +900,7 @@ class FirmwareController:
             # ``_tracked_subprocess`` already terminated the spawn
             # on its way out; this branch only needs to finalise
             # the job model and fire the event.
-            _mark_job_terminal(job, JobStatus.CANCELLED)
-            self._cancel_requested.discard(job.job_id)
-            self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
+            self._finalize_cancelled(job)
             _LOGGER.info("Job %s cancelled (runner shutdown)", job.job_id)
             raise
         except Exception as exc:
@@ -915,9 +911,7 @@ class FirmwareController:
             # that error would be reported as a generic failure
             # rather than the user-driven cancel it actually is.
             if job.job_id in self._cancel_requested:
-                self._cancel_requested.discard(job.job_id)
-                _mark_job_terminal(job, JobStatus.CANCELLED)
-                self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
+                self._finalize_cancelled(job)
                 _LOGGER.info("Job %s cancelled before subprocess wait: %s", job.job_id, exc)
             else:
                 job.error = str(exc)
@@ -994,6 +988,29 @@ class FirmwareController:
             raise
         finally:
             self._current_process = prev
+
+    def _finalize_cancelled(self, job: FirmwareJob) -> None:
+        """
+        Run the runtime-cancel finalisation: discard, mark, fire.
+
+        Centralises the three-line sequence every "user cancelled
+        an in-flight job" code path needs: drop the id from
+        ``_cancel_requested`` (so a subsequent re-queue starts
+        clean), stamp ``CANCELLED`` + ``completed_at`` via the
+        shared ``_mark_job_terminal`` helper, and broadcast
+        ``JOB_CANCELLED`` so frontends following the all-jobs
+        stream stay consistent. Each call site adds its own log
+        line so the message can name the phase that was cancelled.
+
+        Doesn't cover the QUEUED-cancel path in ``cancel`` itself —
+        that one also runs ``_prune_history`` + ``_persist_jobs``
+        because the runner never sees the job, and inlining those
+        here would couple the runtime-cancel sites to disk I/O
+        they don't otherwise need.
+        """
+        self._cancel_requested.discard(job.job_id)
+        _mark_job_terminal(job, JobStatus.CANCELLED)
+        self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
 
     def _raise_if_cancelled(self, job: FirmwareJob, phase: str) -> None:
         """
@@ -1086,10 +1103,8 @@ class FirmwareController:
                 # rmtree isn't interruptible from another coroutine,
                 # so we can only stop before starting the next target.
                 if job.job_id in self._cancel_requested:
-                    self._cancel_requested.discard(job.job_id)
                     _emit("Reset cancelled by user.")
-                    _mark_job_terminal(job, JobStatus.CANCELLED)
-                    self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
+                    self._finalize_cancelled(job)
                     return
 
                 if not target_exists[name]:

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -770,31 +770,6 @@ class FirmwareController:
                 "CLICOLOR_FORCE": "1",
                 "PYTHONUNBUFFERED": "1",
             }
-            proc = await create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                env=env,
-                # Put the whole esphome → platformio → gcc tree in its
-                # own process group so ``_terminate_current_process``
-                # can signal the entire chain, not just the python
-                # parent. Without this, killing the parent leaves the
-                # compiler children orphaned and the build keeps
-                # running until they finish on their own — exactly the
-                # "stop compile doesn't work" symptom.
-                start_new_session=True,
-            )
-            self._current_process = proc
-
-            # Honour a cancel that landed in the gap between
-            # ``_verify_chip`` finishing and ``create_subprocess_exec``
-            # returning — without this, an early Stop click during
-            # the brief async window where ``_current_process`` was
-            # ``None`` lets the install run to completion before the
-            # post-``proc.wait()`` cancel check sees the flag.
-            if job.job_id in self._cancel_requested:
-                await self._terminate_current_process()
-
             has_error_in_output = False
             # Captured at append time because the in-flight trim can
             # elide the offending line before the post-exit handler
@@ -803,7 +778,6 @@ class FirmwareController:
             # handler render a specific actionable message even
             # after a long noisy build trims the head.
             saw_no_esphome_module = False
-            assert proc.stdout is not None  # type narrowing
 
             def _check_error(text: str) -> None:
                 nonlocal has_error_in_output, saw_no_esphome_module
@@ -832,37 +806,64 @@ class FirmwareController:
                         {"job_id": job.job_id, "progress": progress},
                     )
 
-            # ``iter_lines_with_progress`` splits on `\n` _or_ `\r` so
-            # carriage-return-based in-place updates (esptool's
-            # `Writing at 0x... (5%)\r`, PlatformIO's progress bars)
-            # survive the pipe instead of getting buffered until the
-            # next newline. Each chunk keeps its trailing terminator
-            # so the frontend can decide whether to append a new line
-            # or overwrite the last one.
-            async for line in iter_lines_with_progress(proc.stdout):
-                job.output.append(line)
-                # Bound mid-run memory growth. Without this, a build
-                # that streams gigabytes of stderr (chatty
-                # external_components fetch loop, esptool stuck on a
-                # repeating error) holds every line in memory until
-                # the subprocess exits — only the post-completion
-                # ``_trim_job_output`` in the ``finally`` block ever
-                # ran. Trim down to a smaller keep size than the
-                # trigger so the next ``cap - keep`` appends don't
-                # each pay an O(cap) slice copy. Concretely with the
-                # current constants: cap=4000, keep=2000, so 2000
-                # lines fit between trims.
-                if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
-                    _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
-                self._db.bus.fire(
-                    EventType.JOB_OUTPUT,
-                    {"job_id": job.job_id, "line": line},
-                )
-                _check_error(line)
-                _check_progress(line)
+            async with self._tracked_subprocess(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=env,
+                # Put the whole esphome → platformio → gcc tree in its
+                # own process group so ``_terminate_current_process``
+                # can signal the entire chain, not just the python
+                # parent. Without this, killing the parent leaves the
+                # compiler children orphaned and the build keeps
+                # running until they finish on their own — exactly the
+                # "stop compile doesn't work" symptom.
+                start_new_session=True,
+            ) as proc:
+                # Honour a cancel that landed in the gap between
+                # ``_verify_chip`` finishing and ``create_subprocess_exec``
+                # returning — without this, an early Stop click during
+                # the brief async window where ``_current_process`` was
+                # ``None`` lets the install run to completion before the
+                # post-``proc.wait()`` cancel check sees the flag.
+                if job.job_id in self._cancel_requested:
+                    await self._terminate_current_process()
 
-            exit_code = await proc.wait()
-            job.exit_code = exit_code
+                assert proc.stdout is not None  # type narrowing
+
+                # ``iter_lines_with_progress`` splits on `\n` _or_ `\r`
+                # so carriage-return-based in-place updates (esptool's
+                # `Writing at 0x... (5%)\r`, PlatformIO's progress
+                # bars) survive the pipe instead of getting buffered
+                # until the next newline. Each chunk keeps its
+                # trailing terminator so the frontend can decide
+                # whether to append a new line or overwrite the last
+                # one.
+                async for line in iter_lines_with_progress(proc.stdout):
+                    job.output.append(line)
+                    # Bound mid-run memory growth. Without this, a
+                    # build that streams gigabytes of stderr (chatty
+                    # external_components fetch loop, esptool stuck on
+                    # a repeating error) holds every line in memory
+                    # until the subprocess exits — only the post-
+                    # completion ``_trim_job_output`` in the
+                    # ``finally`` block ever ran. Trim down to a
+                    # smaller keep size than the trigger so the next
+                    # ``cap - keep`` appends don't each pay an O(cap)
+                    # slice copy. Concretely with the current
+                    # constants: cap=4000, keep=2000, so 2000 lines
+                    # fit between trims.
+                    if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
+                        _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
+                    self._db.bus.fire(
+                        EventType.JOB_OUTPUT,
+                        {"job_id": job.job_id, "line": line},
+                    )
+                    _check_error(line)
+                    _check_progress(line)
+
+                exit_code = await proc.wait()
+                job.exit_code = exit_code
 
             # If the user cancelled this job mid-run, the subprocess
             # exits non-zero (terminated by signal). Honour that
@@ -898,8 +899,9 @@ class FirmwareController:
                 )
 
         except asyncio.CancelledError:
-            if self._current_process:
-                self._current_process.terminate()
+            # ``_tracked_subprocess`` already terminated the spawn
+            # on its way out; this branch only needs to finalise
+            # the job model and fire the event.
             _mark_job_terminal(job, JobStatus.CANCELLED)
             self._cancel_requested.discard(job.job_id)
             self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
@@ -941,20 +943,30 @@ class FirmwareController:
         """
         Spawn a subprocess that's visible to ``firmware/cancel``.
 
-        Use this for **every** subprocess invocation in the runner
-        path — pre-flight checks (``_verify_chip``-style) AND any
-        future probe that the runner adds. Setting
-        ``_current_process`` is what lets a concurrent
-        ``firmware/cancel`` actually land SIGTERM on the running
-        spawn; a direct ``create_subprocess_exec`` call without
-        this registration silently regresses the issue-#136 fix —
-        the cancel handler walks ``_current_process`` and no-ops on
-        ``None``, the user clicks Stop, nothing visible happens,
-        and the orphaned subprocess runs to completion in the
-        background.
+        Required for every ``create_subprocess_exec`` call in the
+        runner path — both the main install/upload spawn in
+        ``_execute_job`` and pre-flight probes like
+        ``_verify_chip``. Setting ``_current_process`` is what lets
+        a concurrent ``firmware/cancel`` actually land SIGTERM on
+        the running spawn; a direct ``create_subprocess_exec`` call
+        without this registration silently regresses the
+        issue-#136 fix — the cancel handler walks
+        ``_current_process``, no-ops on ``None``, the user clicks
+        Stop, nothing visible happens, and the orphaned subprocess
+        runs to completion in the background.
 
-        Restores the prior ``_current_process`` value on exit so
-        the wrapper composes safely if a future caller nests them.
+        Two cleanup contracts on exit:
+
+        - Normal exit / non-cancellation exception: restore the
+          prior ``_current_process`` value so nested usage (a
+          future spawn site that itself wraps another) doesn't
+          accidentally null out an outer registration.
+        - ``asyncio.CancelledError`` (runner-task shutdown):
+          terminate the spawn before propagating, so the build
+          can't outlive the runner that started it. The outer
+          ``except asyncio.CancelledError`` in ``_execute_job``
+          handles the job-finalisation half and relies on this
+          helper for the terminate.
 
         Pairs with ``_raise_if_cancelled`` — wrap each spawn, then
         call the helper after to short-circuit if the cancel landed
@@ -965,6 +977,21 @@ class FirmwareController:
         self._current_process = proc
         try:
             yield proc
+        except asyncio.CancelledError:
+            # Runner-shutdown cancellation: the runner task itself
+            # was cancelled (vs. a user-driven ``firmware/cancel``,
+            # which goes through ``_terminate_current_process``
+            # explicitly). Nudge the spawn before the
+            # ``CancelledError`` propagates so the build doesn't
+            # outlive the runner that started it. Pre-refactor the
+            # outer ``except asyncio.CancelledError`` in
+            # ``_execute_job`` did this; that branch now sees
+            # ``_current_process`` already restored to ``prev`` (the
+            # finally below) so the helper has to be the one that
+            # signals.
+            with suppress(ProcessLookupError):
+                proc.terminate()
+            raise
         finally:
             self._current_process = prev
 

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -974,17 +974,15 @@ class FirmwareController:
         except asyncio.CancelledError:
             # Runner-shutdown cancellation: the runner task itself
             # was cancelled (vs. a user-driven ``firmware/cancel``,
-            # which goes through ``_terminate_current_process``
-            # explicitly). Nudge the spawn before the
-            # ``CancelledError`` propagates so the build doesn't
-            # outlive the runner that started it. Pre-refactor the
-            # outer ``except asyncio.CancelledError`` in
-            # ``_execute_job`` did this; that branch now sees
-            # ``_current_process`` already restored to ``prev`` (the
-            # finally below) so the helper has to be the one that
-            # signals.
-            with suppress(ProcessLookupError):
-                proc.terminate()
+            # which calls ``_terminate_current_process`` from the
+            # cancel handler directly). Reuse the same group-aware
+            # termination helper here so SIGTERM walks the whole
+            # process group (esphome → platformio → gcc / esptool).
+            # ``proc.terminate()`` would only signal the python
+            # parent — on POSIX with ``start_new_session=True``
+            # that orphans the child tree and the build keeps
+            # running until the children finish on their own.
+            await self._terminate_current_process()
             raise
         finally:
             self._current_process = prev

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -27,6 +27,7 @@ every dashboard build with no test failure.
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from contextlib import suppress
 from pathlib import Path
@@ -475,6 +476,100 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
     # The discard is unconditional — it's a no-op when the id wasn't
     # in the set, which is exactly the shutdown case.
     assert job.job_id not in controller._cancel_requested
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group semantics")
+@pytest.mark.asyncio
+async def test_execute_job_runner_shutdown_kills_subprocess_group(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    """Runner-shutdown cancellation walks the whole process group.
+
+    Pre-refactor regression hazard: an earlier draft used
+    ``proc.terminate()`` (signals only the python parent) inside
+    the helper's ``CancelledError`` branch instead of
+    ``_terminate_current_process`` (which uses
+    ``terminate_subtree_with_grace`` →
+    ``os.killpg(getpgid(pid), SIGTERM)`` to walk the group).
+    With ``start_new_session=True`` the build's children
+    (esphome → platformio → gcc / esptool) share a process group
+    with the parent; the parent dies but children get orphaned
+    and keep running. The previous runner-shutdown test would
+    have passed with that buggy variant because it only asserts
+    on ``proc.returncode`` of the python parent — by the time
+    the test re-checks, the parent is dead, no child involved.
+
+    Pin the group-walk by forking a real child. The parent
+    spawns a long-running ``time.sleep`` subprocess, prints the
+    child PID, then sleeps itself. After we cancel the runner,
+    poll ``os.kill(child_pid, 0)`` — it raises
+    ``ProcessLookupError`` only when the kernel has reaped the
+    child, which only happens if the child got SIGTERM too.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _fake_esphome(
+        controller,
+        # Parent fork pattern: spawn a child sleeper that's NOT a
+        # direct ``await proc.wait`` target — the runner only
+        # tracks the python parent's pid. The cancel must walk
+        # the process group to reach this child. ``start_new_session``
+        # is False here so the child inherits the parent's group.
+        # ``flush=True`` keeps the runner's line reader from
+        # buffering the PID line past the cancel.
+        "import os, subprocess, sys, time\n"
+        "child = subprocess.Popen("
+        "[sys.executable, '-c', 'import time; time.sleep(60)'])\n"
+        "print(f'CHILD_PID={child.pid}', flush=True)\n"
+        "time.sleep(60)\n",
+    )
+    _seed_yaml(tmp_path)
+
+    await controller.compile(configuration="kitchen.yaml")
+
+    child_seen = asyncio.Event()
+    child_pid: list[int] = []
+    real_fire = controller._db.bus.fire
+
+    def _watch(event_type: EventType, data: dict) -> None:
+        if event_type == EventType.JOB_OUTPUT:
+            line = data.get("line", "")
+            if "CHILD_PID=" in line:
+                child_pid.append(int(line.split("=", 1)[1].strip()))
+                child_seen.set()
+        real_fire(event_type, data)
+
+    controller._db.bus.fire = _watch
+
+    runner_task = asyncio.create_task(controller._run_queue())
+    try:
+        await asyncio.wait_for(child_seen.wait(), timeout=10.0)
+        assert child_pid, "test bug: never read CHILD_PID line"
+        runner_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await runner_task
+    finally:
+        if not runner_task.done():
+            runner_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await runner_task
+
+    # Poll until the child is reaped — group SIGTERM has a brief
+    # propagation window, then the kernel cleans up the zombie
+    # once the parent (also dead) is reaped.
+    cpid = child_pid[0]
+    deadline = asyncio.get_running_loop().time() + 5.0
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            os.kill(cpid, 0)
+        except ProcessLookupError:
+            break  # child gone — group SIGTERM landed
+        await asyncio.sleep(0.05)
+    else:
+        # Best-effort cleanup so we don't leak a runaway sleeper.
+        with suppress(ProcessLookupError):
+            os.kill(cpid, 9)
+        pytest.fail(f"child {cpid} survived runner-shutdown cancel — group SIGTERM didn't reach it")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -519,3 +519,284 @@ async def test_install_serial_device_without_target_platform_skips_check(
     assert record["esptool_calls"] == []
     assert record["build_calls"], "build subprocess should still have run"
     assert job.status == JobStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Early-cancel race: cancel arrives while ``_verify_chip`` is running
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel during a hanging verify-chip terminates the spawn quickly.
+
+    The user-visible regression from issue #136: pick the wrong
+    serial port, esptool hangs talking to a non-ESP device for
+    ~30s, user clicks Stop, **nothing happens** — the cancel
+    flag was set but ``_current_process`` was ``None`` (the main
+    install hadn't spawned yet) so ``_terminate_current_process``
+    no-op'd. The verify subprocess kept running until esptool
+    gave up on its own.
+
+    Drive that path: stub ``create_subprocess_exec`` so the
+    "esptool" call sleeps ~30s. Submit the install, wait for the
+    runner to enter ``_execute_job``, fire the public ``cancel``
+    handler, and assert the job reaches CANCELLED in well under
+    the sleep duration. The only way that's possible is if the
+    SIGTERM actually landed on the verify subprocess — which
+    requires the spawn to have been registered as
+    ``_current_process``.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _set_esphome_cmd(controller)
+    _seed_yaml(tmp_path)
+
+    real = controller_module.create_subprocess_exec
+    verify_spawned = asyncio.Event()
+
+    async def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        if (
+            len(args) >= 3
+            and args[0] == sys.executable
+            and args[1] == "-m"
+            and args[2] == "esptool"
+        ):
+            verify_spawned.set()
+            # Sleep long enough that any non-cancelled run would
+            # blow the test timeout — the assertion that the test
+            # finishes in seconds is the proof that SIGTERM landed.
+            return await real(
+                sys.executable,
+                "-c",
+                "import time\ntime.sleep(30)\n",
+                **kwargs,
+            )
+        # Build subprocess must not run — verify raises before it.
+        msg = "build subprocess spawned despite mid-verify cancel"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(controller_module, "create_subprocess_exec", _wrapper)
+
+    job = await controller.install(configuration="kitchen.yaml", port="/dev/ttyUSB0")
+
+    # Run the queue and, in parallel, fire the cancel as soon as
+    # the verify subprocess has spawned. ``_run_until_terminal``
+    # finishes when JOB_CANCELLED lands.
+    async def _cancel_when_verify_starts() -> None:
+        await verify_spawned.wait()
+        # Wait until the runner has assigned the verify subprocess
+        # to ``_current_process``. The wrapper's ``verify_spawned``
+        # fires INSIDE the ``await create_subprocess_exec`` call —
+        # ``_verify_chip`` hasn't received the proc back yet, so
+        # firing the cancel right here would hit the very race we're
+        # trying to guard against (``_current_process`` still None,
+        # ``_terminate_current_process`` no-ops). The poll proves the
+        # registration happens BEFORE the runner waits on the proc,
+        # which is the contract that makes mid-verify cancel work.
+        while controller._current_process is None:
+            await asyncio.sleep(0.01)
+        await controller.cancel(job_id=job.job_id)
+
+    canceller = asyncio.create_task(_cancel_when_verify_starts())
+    try:
+        captured = await _run_until_terminal(controller, timeout=5.0)
+    finally:
+        canceller.cancel()
+        with suppress(asyncio.CancelledError):
+            await canceller
+
+    assert job.status == JobStatus.CANCELLED
+    assert captured["job_cancelled"]
+    assert captured["job_failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_verify_chip_marks_job_cancelled(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancel during chip verify ends the job as CANCELLED, not FAILED.
+
+    Repros issue #136: the user picks a serial port, the runner
+    enters ``_verify_chip`` and spawns esptool against it, the
+    user clicks Stop, the WS handler sets ``_cancel_requested``
+    and terminates ``_current_process`` (the esptool spawn
+    courtesy of the registration covered by the previous test).
+    Once esptool is gone, ``_verify_chip`` raises ValueError to
+    short-circuit the main install spawn, and ``_execute_job``'s
+    generic ``except Exception`` honours the cancel flag and
+    marks the job CANCELLED + fires JOB_CANCELLED — instead of
+    surfacing the synthetic ValueError as a generic FAILED.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _set_esphome_cmd(controller)
+    _seed_yaml(tmp_path)
+
+    real = controller_module.create_subprocess_exec
+    cancel_armed = False
+
+    async def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        nonlocal cancel_armed
+        if (
+            len(args) >= 3
+            and args[0] == sys.executable
+            and args[1] == "-m"
+            and args[2] == "esptool"
+        ):
+            # Simulate the in-flight cancel: queue the flag set
+            # before the verify subprocess returns. The fake exits
+            # quickly (no real hang) so the runner reaches the post-
+            # wait cancel check inside ``_verify_chip`` and raises.
+            if controller._current_job is not None:
+                controller._cancel_requested.add(controller._current_job.job_id)
+                cancel_armed = True
+            return await real(
+                sys.executable,
+                "-c",
+                'import sys\nsys.stdout.buffer.write(b"Detecting chip type... ESP32-C3\\n")\n',
+                **kwargs,
+            )
+        # The build subprocess MUST NOT run — the cancel-during-verify
+        # path raises before the spawn site. Fail loudly if it does.
+        msg = "build subprocess spawned despite mid-verify cancel"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(controller_module, "create_subprocess_exec", _wrapper)
+
+    job = await controller.install(configuration="kitchen.yaml", port="/dev/ttyUSB0")
+    captured = await _run_until_terminal(controller)
+
+    assert cancel_armed, "test bug: cancel flag was never set"
+    assert job.status == JobStatus.CANCELLED
+    assert captured["job_cancelled"]
+    assert captured["job_cancelled"][0]["job"] is job
+    assert captured["job_failed"] == []
+    # The cancel flag is consumed by the except-branch finalisation —
+    # not strictly required (no other path reads it after) but pin it
+    # so a future refactor that forgets the discard surfaces here.
+    assert job.job_id not in controller._cancel_requested
+
+
+# ---------------------------------------------------------------------------
+# Hardening: the ``_tracked_subprocess`` helper itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tracked_subprocess_registers_and_clears_current_process(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """``_tracked_subprocess`` parks the spawned process on the controller.
+
+    This is the helper that future pre-flight checks
+    (``_verify_chip``-style) MUST go through to keep
+    ``firmware/cancel`` working — a fresh probe that calls
+    ``create_subprocess_exec`` directly would silently regress
+    the issue-#136 fix because the cancel handler walks
+    ``_current_process`` and no-ops on ``None``.
+
+    Pin the contract:
+
+    1. Inside the ``async with`` block, ``_current_process`` IS
+       the spawned proc (so SIGTERM via ``cancel`` lands on it).
+    2. After the block exits cleanly, the field returns to its
+       prior value (``None`` here, but the helper restores
+       whatever was there to compose safely with future nested
+       use).
+    """
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    # ``with_terminate`` mocks ``_terminate_current_process`` (which
+    # we don't exercise here), but it also initialises
+    # ``_current_process = None``. Strip the mock so the helper's
+    # real assignment stays observable.
+    assert controller._current_process is None
+
+    async with controller._tracked_subprocess(
+        sys.executable,
+        "-c",
+        "import sys\nsys.exit(0)\n",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    ) as proc:
+        assert controller._current_process is proc
+        await proc.wait()
+
+    # Restored on exit.
+    assert controller._current_process is None
+
+
+@pytest.mark.asyncio
+async def test_tracked_subprocess_restores_prior_value_on_exit(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """``_tracked_subprocess`` restores the prior ``_current_process``.
+
+    The helper saves whatever was registered before it spawned
+    and restores it on exit, so a future caller that uses the
+    helper inside an outer one (or just after another spawn site
+    that's already populated the field) doesn't accidentally
+    null out the active process reference. ``None`` is the
+    common case but the contract is "restore the prior value".
+    """
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    # ``with_terminate`` mocks ``_terminate_current_process`` (which
+    # we don't exercise here), but it also initialises
+    # ``_current_process = None``. Strip the mock so the helper's
+    # real assignment stays observable.
+    sentinel = object()
+    controller._current_process = sentinel  # type: ignore[assignment]
+
+    async with controller._tracked_subprocess(
+        sys.executable,
+        "-c",
+        "import sys\nsys.exit(0)\n",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    ) as proc:
+        assert controller._current_process is proc  # registered for the duration
+        await proc.wait()
+
+    assert controller._current_process is sentinel  # restored
+
+
+@pytest.mark.asyncio
+async def test_tracked_subprocess_restores_prior_value_on_exception(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """The restore happens even when the body raises.
+
+    Without the ``try/finally`` shape inside the helper, an
+    exception thrown inside the ``async with`` body would leave
+    the controller pointing at a defunct process — the next
+    ``firmware/cancel`` would either no-op (if the field went
+    back to ``None``) or signal the wrong process (if it stayed
+    pointing at the dead one). Pin both halves.
+    """
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    # ``with_terminate`` mocks ``_terminate_current_process`` (which
+    # we don't exercise here), but it also initialises
+    # ``_current_process = None``. Strip the mock so the helper's
+    # real assignment stays observable.
+    assert controller._current_process is None
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async with controller._tracked_subprocess(
+            sys.executable,
+            "-c",
+            "import sys\nsys.exit(0)\n",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        ):
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    assert controller._current_process is None

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -800,3 +800,84 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
             raise RuntimeError(msg)
 
     assert controller._current_process is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancel landed during the verify→main-spawn gap → terminate fires.
+
+    The runner's tracked-subprocess block clears
+    ``_current_process`` on ``_verify_chip`` exit, then assigns the
+    main install subprocess to ``_current_process`` a moment later.
+    A ``firmware/cancel`` that arrived in that gap sets
+    ``_cancel_requested`` but ``_terminate_current_process`` walked
+    a ``None`` field and no-op'd. Without the post-spawn flag check
+    inside ``_execute_job`` (the ``if job.job_id in
+    self._cancel_requested: await self._terminate_current_process()``
+    branch right after the main spawn), the install would run to
+    completion before the post-``proc.wait()`` cancel handler saw
+    the flag — the issue-#136 symptom for the "cancel arrived
+    after verify but before main-spawn returned" sub-case.
+
+    Drive that path: pre-load the cancel flag from inside the
+    ``create_subprocess_exec`` substitute so by the time the
+    runner re-enters ``_execute_job`` and assigns
+    ``_current_process``, the flag is set. The immediate post-
+    spawn check should fire ``_terminate_current_process`` on the
+    (test fake) build subprocess. Spy on the terminate call to
+    pin both halves of the contract:
+
+    1. ``_terminate_current_process`` runs at the gap-check
+       site (counter increments).
+    2. It runs against a non-``None`` ``_current_process`` —
+       i.e. the post-spawn assignment happened first, so the
+       SIGTERM has somewhere to land.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _set_esphome_cmd(controller)
+    _seed_yaml(tmp_path)
+
+    real = controller_module.create_subprocess_exec
+    terminate_calls: list[asyncio.subprocess.Process | None] = []
+    real_terminate = controller._terminate_current_process
+
+    async def _spy_terminate() -> None:
+        terminate_calls.append(controller._current_process)
+        await real_terminate()
+
+    monkeypatch.setattr(controller, "_terminate_current_process", _spy_terminate)
+
+    async def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        # OTA port → ``_verify_chip`` returns before any spawn,
+        # so the only ``create_subprocess_exec`` call here is the
+        # build subprocess. Pre-load the cancel flag right before
+        # returning the proc — this is the "cancel arrived in
+        # the verify→main-spawn gap" scenario the post-spawn
+        # check guards.
+        if controller._current_job is not None:
+            controller._cancel_requested.add(controller._current_job.job_id)
+        return await real(sys.executable, "-c", _BUILD_SCRIPT_OK, **kwargs)
+
+    monkeypatch.setattr(controller_module, "create_subprocess_exec", _wrapper)
+
+    job = await controller.install(configuration="kitchen.yaml", port="OTA")
+    captured = await _run_until_terminal(controller)
+
+    # The post-spawn flag check fired terminate exactly once,
+    # against the just-assigned build subprocess (not ``None``).
+    assert len(terminate_calls) == 1, "post-spawn cancel check should fire terminate once"
+    assert terminate_calls[0] is not None, (
+        "_current_process must be set when terminate fires — that's the whole point of "
+        "the post-spawn check (vs. the no-op None path)"
+    )
+    # Job finalises as CANCELLED via the post-``proc.wait()`` cancel
+    # handler, not FAILED.
+    assert job.status == JobStatus.CANCELLED
+    assert captured["job_cancelled"]
+    assert captured["job_failed"] == []

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -713,11 +713,12 @@ async def test_tracked_subprocess_registers_and_clears_current_process(
        whatever was there to compose safely with future nested
        use).
     """
+    # ``with_terminate=True`` initialises ``_current_process = None``
+    # and ``_cancel_requested = set()`` so the helper has a clean
+    # slate to assign onto. The mocked ``_terminate_current_process``
+    # is unused by this test (we never trip the CancelledError or
+    # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    # ``with_terminate`` mocks ``_terminate_current_process`` (which
-    # we don't exercise here), but it also initialises
-    # ``_current_process = None``. Strip the mock so the helper's
-    # real assignment stays observable.
     assert controller._current_process is None
 
     async with controller._tracked_subprocess(
@@ -747,11 +748,12 @@ async def test_tracked_subprocess_restores_prior_value_on_exit(
     null out the active process reference. ``None`` is the
     common case but the contract is "restore the prior value".
     """
+    # ``with_terminate=True`` initialises ``_current_process = None``
+    # and ``_cancel_requested = set()`` so the helper has a clean
+    # slate to assign onto. The mocked ``_terminate_current_process``
+    # is unused by this test (we never trip the CancelledError or
+    # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    # ``with_terminate`` mocks ``_terminate_current_process`` (which
-    # we don't exercise here), but it also initialises
-    # ``_current_process = None``. Strip the mock so the helper's
-    # real assignment stays observable.
     sentinel = object()
     controller._current_process = sentinel  # type: ignore[assignment]
 
@@ -781,11 +783,12 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
     back to ``None``) or signal the wrong process (if it stayed
     pointing at the dead one). Pin both halves.
     """
+    # ``with_terminate=True`` initialises ``_current_process = None``
+    # and ``_cancel_requested = set()`` so the helper has a clean
+    # slate to assign onto. The mocked ``_terminate_current_process``
+    # is unused by this test (we never trip the CancelledError or
+    # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    # ``with_terminate`` mocks ``_terminate_current_process`` (which
-    # we don't exercise here), but it also initialises
-    # ``_current_process = None``. Strip the mock so the helper's
-    # real assignment stays observable.
     assert controller._current_process is None
 
     with pytest.raises(RuntimeError, match="boom"):


### PR DESCRIPTION
## Summary

Closes esphome/device-builder-frontend#136. Fix the early-cancel race: ``firmware/cancel`` no-ops on serial installs until the main install subprocess starts producing output, because ``_verify_chip``'s esptool spawn isn't registered as ``_current_process``. The user picks the wrong serial port, esptool hangs talking to a non-ESP device for tens of seconds, they hit Stop — flag set, terminate walks ``None``, nothing happens, install runs to completion, dashboard card stuck on "Installing…".

## What changed

Three coordinated cancel-path fixes:

- ``_verify_chip`` registers its spawn as ``_current_process`` (with ``start_new_session=True`` so SIGTERM walks the group) and raises ``ValueError`` post-wait if a cancel landed mid-verify.
- The main spawn site rechecks ``_cancel_requested`` immediately after ``_current_process`` is assigned, covering the brief async gap between verify-return and main-spawn.
- ``_execute_job``'s ``except Exception`` honours the cancel flag — the synthetic ``ValueError`` from ``_verify_chip`` now surfaces as ``CANCELLED`` rather than a generic ``FAILED``.

## Hardening

To stop the same race resurfacing the next time we add a pre-flight check (chip version probe, dependency check, etc.):

- New ``_tracked_subprocess`` async context manager: ``async with self._tracked_subprocess(...) as proc:`` registers / restores ``_current_process`` automatically. Future probes get cancel-awareness for free.
- New ``_raise_if_cancelled(job, phase)`` helper for the inter-subprocess gap so each phase's cancel-check is one line and the message names the phase.
- ``_verify_chip`` is the first caller; the contract is documented on the helpers.

## Tests

3 new tests in ``test_verify_chip_e2e.py``:

- ``test_cancel_during_hanging_verify_chip_terminates_subprocess`` — drives the user-visible repro: hanging fake esptool subprocess, fire ``cancel`` once it's spawned, assert the job reaches ``CANCELLED`` in seconds (not 30s+).
- ``test_cancel_during_verify_chip_marks_job_cancelled`` — pre-loads the flag, asserts ``except Exception`` branch routes to ``CANCELLED`` instead of ``FAILED``.
- Three ``_tracked_subprocess`` unit tests pinning register-on-enter / restore-on-exit / restore-on-exception.

All 315 firmware controller tests pass locally.

## Test plan

- [ ] Pick a wrong serial port, kick off install, click Stop early — dashboard card should leave "Installing…" within seconds, not minutes.
- [ ] Pick the right serial port, click Stop after output starts — still works (no regression).
- [ ] OTA install Stop — still works (no regression).
- [ ] Server-serial install where the device responds normally — Stop works at any phase.