### PR TITLE
Capture serial install progress from new esptool output

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -55,19 +55,23 @@ _NO_ESPHOME_MODULE_MARKER = "No module named 'esphome'"
 #     output uses parens around a bare percentage.
 #   * esptool serial flash (current): ``Writing at 0x10000 [bar]  84.8% NNN/NNN bytes...``
 #     Newer esptool releases dropped the parens and added an ASCII
-#     progress bar plus a decimal percentage. Anchored to the
+#     progress bar plus a decimal percentage. Pinned to the
 #     ``Writing at`` prefix so the wider ``\d{1,3}(?:\.\d+)?%``
 #     match doesn't fire on memory-usage / unpacking / stray-percent
-#     lines elsewhere in the build output. We capture the integer
-#     part and discard the decimal — the dashboard's progress bar
-#     is a single coarse 0-100 indicator, sub-percent precision is
-#     wasted resolution.
+#     lines elsewhere in the build output. The runner sets
+#     ``FORCE_COLOR=1`` / ``CLICOLOR_FORCE=1`` so esptool emits ANSI
+#     escape sequences (e.g. ``\x1b[2K`` clear-line) that prefix the
+#     output — DO NOT anchor with ``^\s*`` here, those escapes
+#     aren't whitespace and the anchor would silently fail in
+#     production while passing in plain-text tests. Capture the
+#     integer part and discard the decimal — the dashboard's
+#     progress bar is a single coarse 0-100 indicator.
 #   * ESPHome OTA upload:            ``Uploading: [====] 100% Done...``
 #     Anchored to the ``Uploading:`` prefix.
 _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*\[\s*(\d{1,3})\s*%\s*\]"),
     re.compile(r"\(\s*(\d{1,3})\s*%\s*\)"),
-    re.compile(r"^\s*Writing at\b.*?(\d{1,3})(?:\.\d+)?\s*%"),
+    re.compile(r"Writing at\b.*?(\d{1,3})(?:\.\d+)?\s*%"),
     re.compile(r"^\s*Uploading:.*?\b(\d{1,3})\s*%"),
 )
 

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -48,16 +48,26 @@ _NO_ESPHOME_MODULE_MARKER = "No module named 'esphome'"
 #     brackets so PIO's ESP-IDF builds (which don't emit a per-file
 #     percent at all) and the package-extract bar (no ``[NN%]`` shape)
 #     never trip it.
-#   * esptool serial flash:          ``Writing at 0x10000... (45 %)``
+#   * esptool serial flash (legacy):  ``Writing at 0x10000... (45 %)``
 #     We match a bare parenthesized percentage anywhere in the line:
-#     ``(\s*\d{1,3}\s*%\s*\)``. In practice that is enough for esptool
-#     progress, and no other expected PIO/ESPHome output uses parens
-#     around a bare percentage.
+#     ``(\s*\d{1,3}\s*%\s*\)``. In practice that is enough for the
+#     older esptool output shape, and no other expected PIO/ESPHome
+#     output uses parens around a bare percentage.
+#   * esptool serial flash (current): ``Writing at 0x10000 [bar]  84.8% NNN/NNN bytes...``
+#     Newer esptool releases dropped the parens and added an ASCII
+#     progress bar plus a decimal percentage. Anchored to the
+#     ``Writing at`` prefix so the wider ``\d{1,3}(?:\.\d+)?%``
+#     match doesn't fire on memory-usage / unpacking / stray-percent
+#     lines elsewhere in the build output. We capture the integer
+#     part and discard the decimal — the dashboard's progress bar
+#     is a single coarse 0-100 indicator, sub-percent precision is
+#     wasted resolution.
 #   * ESPHome OTA upload:            ``Uploading: [====] 100% Done...``
 #     Anchored to the ``Uploading:`` prefix.
 _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*\[\s*(\d{1,3})\s*%\s*\]"),
     re.compile(r"\(\s*(\d{1,3})\s*%\s*\)"),
+    re.compile(r"^\s*Writing at\b.*?(\d{1,3})(?:\.\d+)?\s*%"),
     re.compile(r"^\s*Uploading:.*?\b(\d{1,3})\s*%"),
 )
 

--- a/tests/controllers/firmware/test_progress.py
+++ b/tests/controllers/firmware/test_progress.py
@@ -49,7 +49,38 @@ class TestRealProgressLines:
             ("Writing at 0x00050000... (45%)", 45),
         ],
     )
-    def test_esptool_writing_marker(self, line: str, expected: int) -> None:
+    def test_esptool_writing_marker_legacy(self, line: str, expected: int) -> None:
+        assert _parse_progress(line) == expected
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            # Issue #140: newer esptool dropped the parens around the
+            # percent and added an ASCII progress bar + bytes counter.
+            # The percentage is now decimal — we capture the integer
+            # part since the dashboard's progress bar is a coarse 0-100.
+            (
+                "Writing at 0x000cf943 [========================>     ]  84.8% "
+                "491520/579918 bytes...",
+                84,
+            ),
+            ("Writing at 0x00010000 [                              ]  0.0% 0/579918 bytes...", 0),
+            (
+                "Writing at 0x000a1234 [==============================] 100.0% "
+                "579918/579918 bytes...",
+                100,
+            ),
+            # Carriage-return-terminated chunk: ``iter_lines_with_progress``
+            # splits on ``\r`` so esptool's in-place line refreshes survive
+            # the pipe. The trailing ``\r`` is part of the chunk handed to
+            # ``_parse_progress``; it must not break the match.
+            (
+                "Writing at 0x000cf943 [=>     ]  42.5% 200000/579918 bytes...\r",
+                42,
+            ),
+        ],
+    )
+    def test_esptool_writing_marker_new(self, line: str, expected: int) -> None:
         assert _parse_progress(line) == expected
 
     @pytest.mark.parametrize(

--- a/tests/controllers/firmware/test_progress.py
+++ b/tests/controllers/firmware/test_progress.py
@@ -78,6 +78,19 @@ class TestRealProgressLines:
                 "Writing at 0x000cf943 [=>     ]  42.5% 200000/579918 bytes...\r",
                 42,
             ),
+            # ANSI-prefixed line — the runner sets ``FORCE_COLOR=1`` /
+            # ``CLICOLOR_FORCE=1`` so esptool emits ``\x1b[2K`` clear-line
+            # escapes before each refresh. An anchored ``^\s*`` regex
+            # would silently fail in production (the escapes aren't
+            # whitespace) while passing in plain-text tests. Pinning
+            # this case prevents a future "tighten the regex" refactor
+            # from re-introducing the anchor and breaking serial install
+            # progress capture again — that's exactly the regression
+            # this PR fixes (issue #140).
+            (
+                "\x1b[2KWriting at 0x000cf943 [=>     ]  42.5% 200000/579918 bytes...",
+                42,
+            ),
         ],
     )
     def test_esptool_writing_marker_new(self, line: str, expected: int) -> None:


### PR DESCRIPTION
Closes esphome/device-builder-frontend#140.

## Summary

Newer esptool releases changed their progress output shape from `Writing at 0x... (45 %)` to `Writing at 0x... [bar]  84.8% NNN/NNN bytes...` — parens dropped, ASCII progress bar added, percent now decimal. The existing `_PROGRESS_PATTERNS` whitelist only matched the legacy parenthesized shape, so serial installs fell through and `job.progress` stayed at 0 for the whole flash. The dashboard's device card showed "Installing…" with no live percentage. OTA uploads were unaffected (different prefix).

Reported by user observing:

```
Stub flasher running.
Changing baud rate to 460800...
Changed.
Configuring flash size...
Auto-detected flash size: 4MB
Flash will be erased from 0x00010000 to 0x000effff...
Writing at 0x000cf943 [========================>     ]  84.8% 491520/579918 bytes...
```

## Fix

Add a fourth pattern in `_PROGRESS_PATTERNS`:

```python
re.compile(r"^\s*Writing at\b.*?(\d{1,3})(?:\.\d+)?\s*%"),
```

Anchored to the `Writing at` prefix so the wider `\d{1,3}(?:\.\d+)?%` doesn't fire on memory-usage reports (`RAM: ... 19.3%`), unpacking bars (`Unpacking [###] 100%`), or stray-percent narrative text — the same noise the existing whitelist already filters out. Captures the integer part of either an integer or decimal percent (the dashboard's progress bar is a coarse 0-100 indicator, sub-percent precision is wasted resolution).

The legacy `(45 %)` regex stays in place; both shapes are matched.

## Tests

`tests/controllers/firmware/test_progress.py`:

- New parametrised case `test_esptool_writing_marker_new` covers the new shape: decimal percent, 0%, 100%, and a `\r`-terminated chunk (since `iter_lines_with_progress` splits on `\r` so esptool's in-place line refreshes survive the pipe).
- Existing `test_esptool_writing_marker_legacy` still passes — both shapes are now covered.
- Existing noise cases (memory-usage, unpacking, stray percentages) still resolve to `None`.

321 firmware tests pass.

## Test plan

- [ ] Server-serial install with a current-version esptool — the device card transitions through 0% → 100% as the flash progresses, instead of staying at 0.
- [ ] OTA install — progress still updates as before (no regression).
- [ ] Web Serial install path is browser-side (esptool-js, not the backend regex) so this PR doesn't touch that flow.