### PR TITLE
Normalise target_platform casing for the frontend device list

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1063,9 +1063,19 @@ class FirmwareController:
         Verify the chip on the serial port matches the device config.
 
         Runs ``esptool chip-id`` to detect the actual chip, then
-        compares against the target platform in the device config.
+        compares against the chip variant recorded in StorageJSON.
         Raises ValueError on mismatch so the job fails early with a
         clear error message.
+
+        Reads from ``StorageJSON.target_platform`` (the upstream-
+        canonical chip variant — ``ESP32S3`` / ``ESP32C3`` / plain
+        ``ESP8266``) rather than ``Device.target_platform`` (which
+        carries the lowercase platform *key*, e.g. ``esp32`` for
+        every ESP32 family member, and would false-positive on a
+        chip-vs-variant mismatch). Skipped when StorageJSON is
+        absent — pre-compile installs have no compile-time truth
+        to compare against, and esphome's own flash error covers
+        the wrong-chip case there.
 
         The verify subprocess is registered as ``_current_process``
         for the duration of its run so an early ``firmware/cancel``
@@ -1080,19 +1090,14 @@ class FirmwareController:
         if not job.port or job.port.upper() == "OTA" or not job.port.startswith("/dev"):
             return  # only check serial ports
 
-        device = None
-        if self._db.devices:
-            target_name = job.configuration.removesuffix(".yaml").removesuffix(".yml")
-            device = next(
-                (d for d in self._db.devices.get_devices() if d.name == target_name),
-                None,
-            )
+        loop = asyncio.get_running_loop()
+        storage = await loop.run_in_executor(
+            None, lambda: StorageJSON.load(ext_storage_path(job.configuration))
+        )
+        if storage is None or not storage.target_platform:
+            return  # never compiled or no platform recorded — nothing to verify
 
-        expected_platform = ""
-        if device and device.target_platform:
-            expected_platform = device.target_platform.lower()
-        if not expected_platform:
-            return  # can't verify without knowing expected platform
+        expected_platform = storage.target_platform.lower()
 
         async with self._tracked_subprocess(
             sys.executable,

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -474,10 +474,38 @@ def load_device_from_storage(
     deployed = storage.esphome_version or "" if storage else ""
     update_available = bool(deployed and deployed != const.__version__)
 
+    # ``Device.target_platform`` is the lowercase platform *key*
+    # (``esp32``, ``esp8266``, ``rp2040``, …) — the value the
+    # frontend's PLATFORM column renders. Source order:
+    #
+    # 1. ``storage.core_platform`` — post-codegen ground truth
+    #    written by upstream's ``StorageJSON.from_esphome_core``
+    #    (esphome#9028, 2025.6+). Always the lowercase platform
+    #    key, never the chip variant. ``getattr`` with a default
+    #    keeps this working on older ``esphome`` installs where
+    #    ``StorageJSON`` doesn't carry the attribute at all —
+    #    pyproject's floor is ``esphome>=2024.1.0`` so the
+    #    pre-#9028 path is reachable.
+    # 2. ``detect_platform_from_yaml(path)`` — the YAML's top-level
+    #    platform key, also lowercase. Picks up never-compiled
+    #    devices and pre-2025.6 ``StorageJSON`` files that don't
+    #    carry ``core_platform`` yet.
+    #
+    # ``storage.target_platform`` is deliberately NOT a fallback:
+    # upstream uppercases it AND resolves it to the chip variant
+    # for ESP32 boards (``ESP32S3``, ``ESP32C3``), so a fleet with
+    # mixed compile states would otherwise show ``esp32s3`` next
+    # to ``esp32`` for the same family — the inconsistency
+    # frontend issue #137 was opened against. Chip-variant info
+    # for ``_verify_chip`` is read from StorageJSON directly at
+    # the call site, where the variant *is* the right level of
+    # detail.
     target_platform = ""
-    if storage and storage.target_platform:
-        target_platform = storage.target_platform
-    else:
+    if storage:
+        core_platform = getattr(storage, "core_platform", None)
+        if core_platform:
+            target_platform = core_platform.lower()
+    if not target_platform:
         target_platform = detect_platform_from_yaml(path)
 
     loaded_integrations = sorted(storage.loaded_integrations) if storage else []

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -18,6 +18,15 @@ output can be controlled while the real subsequent build still
 runs through the same wrapper (substitute returns a no-op
 success-exit script for non-esptool calls).
 
+The expected chip variant comes from a real StorageJSON sidecar
+seeded via ``write_storage_json`` — ``_verify_chip`` reads
+``StorageJSON.target_platform`` directly (the upstream-canonical
+chip variant) rather than ``Device.target_platform`` (which now
+carries the platform *key*, not the variant). Tests redirect
+``ext_storage_path`` in the firmware controller's namespace so
+``StorageJSON.load`` finds the sidecar at
+``tmp_path/.esphome/storage/<configuration>.json``.
+
 Branches the runner depends on:
 
 - Chip matches → no error, build proceeds, status COMPLETED.
@@ -32,9 +41,10 @@ Branches the runner depends on:
 - Non-serial port shapes (``OTA``, IPv4, hostname, Windows
   ``COMx``) → no esptool call (the helper only probes
   ``/dev/*`` paths).
-- ``self._db.devices`` returns no matching device → skip the
-  chip check, build still runs.
-- Device matched but ``target_platform`` empty → skip the chip
+- StorageJSON missing → skip the chip check, build still runs
+  (pre-compile install has no compile-time truth to verify
+  against; esphome's own flash error catches a wrong-chip case).
+- StorageJSON with empty ``target_platform`` → skip the chip
   check, build still runs.
 
 Without these the chip-id pre-flight (~54 lines, the longest
@@ -56,6 +66,7 @@ import pytest
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware import controller as controller_module
 from esphome_device_builder.models import EventType, JobStatus
+from tests._storage_fixtures import write_storage_json
 
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
@@ -82,6 +93,27 @@ def _seed_yaml(tmp_path: Path, name: str = "kitchen.yaml") -> None:
     (tmp_path / name).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
 
+def _seed_storage(
+    tmp_path: Path,
+    *,
+    configuration: str = "kitchen.yaml",
+    target_platform: str = "ESP32C3",
+) -> Path:
+    """Write a StorageJSON sidecar so ``_verify_chip`` can read the chip variant.
+
+    Defaults to ``ESP32C3`` to match upstream's wire format —
+    ``StorageJSON.from_esphome_core`` resolves ESP32 variants to
+    their uppercase short name (no hyphen). Pass another value
+    (``ESP32S3``, ``ESP8266``, …) to drive the mismatch and
+    no-detection branches.
+    """
+    return write_storage_json(
+        tmp_path,
+        configuration,
+        overrides={"esp_platform": target_platform, "target_platform": target_platform},
+    )
+
+
 # A no-op script for the actual build subprocess. Exit 0 produces
 # a clean COMPLETED job once chip-id has passed.
 _BUILD_SCRIPT_OK = "import sys\nsys.exit(0)\n"
@@ -93,54 +125,47 @@ _BUILD_SCRIPT_OK = "import sys\nsys.exit(0)\n"
 
 
 @dataclass
-class _StubDevice:
-    """Narrow stand-in for ``Device`` — only the attributes ``_verify_chip`` reads.
-
-    Mirrors the conftest's "minimal test doubles fail fast on
-    unexpected attribute access" pattern. A regression that
-    teaches ``_verify_chip`` to read a new field (e.g. ``board``
-    or ``platform``) crashes with ``AttributeError`` here
-    instead of silently conjuring a ``MagicMock`` value.
-    """
-
-    name: str
-    target_platform: str
-
-
-@dataclass
 class _StubDevices:
     """Narrow ``DevicesController`` stand-in.
 
-    Exposes only the surface ``_verify_chip`` and
-    ``_build_cache_args`` actually read:
-
-    - ``get_devices()`` — for the chip lookup by YAML name.
-    - ``get_address_cache_args(configuration)`` — for the OTA
-      address-cache CLI flags ``_build_cache_args`` adds to
-      install/upload commands when ``port == "OTA"``.
-
+    ``_verify_chip`` no longer reads from the devices controller —
+    chip variant comes from ``StorageJSON`` directly — but the
+    runner's ``_build_cache_args`` still calls
+    ``get_address_cache_args`` on the install/upload paths.
     Returning ``[]`` for the address-cache args keeps the build
     command shape minimal (``--mdns-address-cache`` / ``--dns-
     address-cache`` skipped) — orthogonal to the chip-id branches
     these tests exercise.
     """
 
-    devices: list[_StubDevice]
-
-    def get_devices(self) -> list[_StubDevice]:
-        return self.devices
-
     def get_address_cache_args(self, _configuration: str) -> list[str]:
         return []
 
 
-def _wire_devices(
-    controller: FirmwareController, *, name: str = "kitchen", target_platform: str = "esp32-c3"
-) -> None:
-    """Attach a fake ``DevicesController`` whose ``get_devices`` returns one entry."""
-    controller._db.devices = _StubDevices(  # type: ignore[attr-defined]
-        devices=[_StubDevice(name=name, target_platform=target_platform)]
-    )
+def _wire_devices(controller: FirmwareController) -> None:
+    """Attach a no-op ``DevicesController`` stub for ``_build_cache_args``."""
+    controller._db.devices = _StubDevices()  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def _redirect_ext_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Redirect ``ext_storage_path`` to ``tmp_path/.esphome/storage/``.
+
+    The production helper resolves through ``CORE.config_path``
+    which isn't set in isolated tests; the redirect makes
+    ``StorageJSON.load(ext_storage_path(filename))`` (called from
+    ``_verify_chip``) read the sidecar ``_seed_storage`` lays
+    down. Same pattern as ``test_download.py``'s redirect — the
+    fixture is autouse so every test in this module is covered
+    without a per-test ``@pytest.mark.usefixtures`` decoration.
+    """
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def _ext(configuration: str) -> Path:
+        return storage_dir / f"{configuration}.json"
+
+    monkeypatch.setattr(controller_module, "ext_storage_path", _ext)
 
 
 def _patch_subprocess(
@@ -252,20 +277,21 @@ async def test_install_serial_chip_match_proceeds_to_completed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Detected chip matches device's ``target_platform`` → build runs to COMPLETED.
+    """Detected chip matches StorageJSON's chip variant → build runs to COMPLETED.
 
     The happy path through the chip-id pre-flight: the runner
-    sees a serial port, looks up the device, spawns esptool,
-    parses ``Detecting chip type... ESP32-C3``, normalises both
-    sides (``esp32-c3`` → ``esp32c3``), confirms equality, and
+    sees a serial port, loads StorageJSON, spawns esptool, parses
+    ``Detecting chip type... ESP32-C3``, normalises both sides
+    (``esp32c3`` matches ``esp32c3``), confirms equality, and
     returns without raising. ``_execute_job`` then proceeds to
     the actual build subprocess.
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    _seed_storage(tmp_path, target_platform="ESP32C3")
 
     record = _patch_subprocess(
         monkeypatch,
@@ -293,7 +319,7 @@ async def test_serial_chip_mismatch_marks_failed_with_message(
 ) -> None:
     """Mismatch raises → status FAILED, error message names both sides.
 
-    Device YAML says ``esp32-c3``, esptool detects ``ESP32-S3`` —
+    StorageJSON records ``ESP32C3``, esptool detects ``ESP32-S3`` —
     a wrong-board misconfiguration that would otherwise let the
     user flash a build for a different chip and brick the device.
     The ``ValueError`` thrown by the chip check propagates into
@@ -308,9 +334,10 @@ async def test_serial_chip_mismatch_marks_failed_with_message(
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    _seed_storage(tmp_path, target_platform="ESP32C3")
 
     record = _patch_subprocess(
         monkeypatch,
@@ -326,7 +353,7 @@ async def test_serial_chip_mismatch_marks_failed_with_message(
     assert record["build_calls"] == []
     assert job.status == JobStatus.FAILED
     assert job.error is not None
-    assert "esp32-c3" in job.error.lower()
+    assert "esp32c3" in job.error.lower().replace("-", "")
     assert "esp32s3" in job.error.lower().replace("-", "")
     assert "wrong board" in job.error.lower()
     assert captured["job_failed"]
@@ -355,9 +382,10 @@ async def test_install_serial_no_chip_detected_proceeds_to_completed(
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    _seed_storage(tmp_path, target_platform="ESP32C3")
 
     record = _patch_subprocess(
         monkeypatch,
@@ -380,7 +408,7 @@ async def test_install_serial_no_chip_detected_proceeds_to_completed(
 
 
 # ---------------------------------------------------------------------------
-# Skip branches: OTA, missing device, missing target_platform
+# Skip branches: non-serial port, missing StorageJSON, empty target_platform
 # ---------------------------------------------------------------------------
 
 
@@ -425,9 +453,10 @@ async def test_install_non_dev_port_skips_chip_check(
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    _seed_storage(tmp_path, target_platform="ESP32C3")
 
     record = _patch_subprocess(
         monkeypatch,
@@ -443,19 +472,20 @@ async def test_install_non_dev_port_skips_chip_check(
 
 
 @pytest.mark.asyncio
-async def test_install_serial_no_matching_device_skips_check(
+async def test_install_serial_no_storage_skips_check(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No device in the scanner's list with this YAML's name → skip check.
+    """No StorageJSON sidecar for this YAML → skip check.
 
-    A serial install for a YAML the scanner hasn't seen yet
-    (e.g. just-created file the periodic scan hasn't picked up)
-    has no ``target_platform`` to compare against. Skipping is
+    A serial install for a YAML that's never been compiled (or
+    whose ``.esphome/storage/`` cache was wiped) has no
+    compile-time ground truth to compare against. Skipping is
     the safer default — the user explicitly chose the port and
-    we'd rather let the build proceed than fail on a check we
-    can't run.
+    esphome's own flash error covers the wrong-chip case below
+    us. Failing the install here would block first-time flashes
+    for any new YAML.
 
     Pin both halves of the contract: esptool must NOT spawn
     (would block forever) AND the build subprocess must STILL
@@ -465,20 +495,20 @@ async def test_install_serial_no_matching_device_skips_check(
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    # Devices controller is present but has no matching device.
-    controller._db.devices = _StubDevices(devices=[])  # type: ignore[attr-defined]
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    # No ``_seed_storage`` — sidecar absent.
 
     record = _patch_subprocess(monkeypatch, chip_id_output=b"never invoked")
 
     job = await controller.install(configuration="kitchen.yaml", port="/dev/ttyUSB0")
     await _run_until_terminal(controller)
 
-    # No device match → no platform → early return before esptool spawn.
+    # No StorageJSON → no platform → early return before esptool spawn.
     assert record["esptool_calls"] == []
     # The build subprocess MUST still run — a regression that
-    # short-circuited the job entirely on missing-device would
+    # short-circuited the job entirely on missing-storage would
     # also leave esptool_calls empty + status COMPLETED, but
     # silently no-op the install.
     assert record["build_calls"], "build subprocess should still have run"
@@ -486,30 +516,28 @@ async def test_install_serial_no_matching_device_skips_check(
 
 
 @pytest.mark.asyncio
-async def test_install_serial_device_without_target_platform_skips_check(
+async def test_install_serial_storage_without_target_platform_skips_check(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Device matched but ``target_platform`` empty → skip.
+    """StorageJSON present but ``target_platform`` empty → skip.
 
-    ``Device.target_platform`` carries the chip family
-    (``esp32-c3`` / ``esp8266`` / ...). It can come from a few
-    sources — the StorageJSON sidecar after a successful compile,
-    YAML detection on first scan, or restored monitor state —
-    so empty is uncommon but possible (e.g. a YAML the parser
-    couldn't extract a platform from). Without something to
-    compare against the chip-id check has nothing to act on;
-    skip and let the build proceed for the real reason.
+    ``StorageJSON.target_platform`` is normally populated by
+    ``from_esphome_core`` after a successful compile, but a
+    partially-written or hand-edited sidecar can carry an empty
+    string. Without a chip variant there's nothing to compare
+    against; skip and let the build proceed for the real reason.
 
     Pin both halves: esptool skipped AND build still runs (same
-    contract as the no-matching-device case).
+    contract as the no-storage case).
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    _wire_devices(controller, name="kitchen", target_platform="")
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    _seed_storage(tmp_path, target_platform="")
 
     record = _patch_subprocess(monkeypatch, chip_id_output=b"never invoked")
 
@@ -553,9 +581,10 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    _seed_storage(tmp_path, target_platform="ESP32C3")
 
     real = controller_module.create_subprocess_exec
     verify_spawned = asyncio.Event()
@@ -637,9 +666,10 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    _seed_storage(tmp_path, target_platform="ESP32C3")
 
     real = controller_module.create_subprocess_exec
     cancel_armed = False
@@ -842,9 +872,13 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
-    _wire_devices(controller, name="kitchen", target_platform="esp32-c3")
+    _wire_devices(controller)
     _set_esphome_cmd(controller)
     _seed_yaml(tmp_path)
+    # Port is OTA so ``_verify_chip`` returns before reading storage,
+    # but seed it anyway to keep the test independent of skip-branch
+    # ordering — the post-spawn cancel check is what's under test.
+    _seed_storage(tmp_path, target_platform="ESP32C3")
 
     real = controller_module.create_subprocess_exec
     terminate_calls: list[asyncio.subprocess.Process | None] = []

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -7,7 +7,7 @@ hand-rolled text scanning makes regression risk meaningful.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -687,16 +687,24 @@ def test_load_device_records_firmware_bin_mtime_when_present(tmp_path: Path) -> 
 
 
 @pytest.mark.usefixtures("_redirect_ext_storage")
-def test_load_device_uses_storage_target_platform_over_yaml(tmp_path: Path) -> None:
-    """When StorageJSON carries ``target_platform``, it wins over YAML detection.
+def test_load_device_uses_storage_core_platform_over_yaml(tmp_path: Path) -> None:
+    """When StorageJSON carries ``core_platform``, it wins over YAML detection.
 
-    StorageJSON's ``target_platform`` is post-codegen — what
+    ``core_platform`` is the post-codegen platform key — what
     actually compiled. The YAML's ``esp32:`` / ``esp8266:`` block
     is what the user typed, which can drift from reality if
     ESPHome remapped it during validation. Pin the
     StorageJSON-wins precedence so a regression that
     short-circuited to ``detect_platform_from_yaml`` would
     surface here as the YAML-derived value leaking through.
+
+    Frontend issue #137: the column rendered uppercase
+    ``ESP32`` straight from ``StorageJSON.target_platform``
+    while uncompiled devices pulled lowercase ``esp32`` from the
+    YAML scan. ``core_platform`` is upstream's lowercase platform
+    key (added in esphome#9028), always canonical regardless of
+    chip variant — so a fleet of mixed compile states now shows
+    ``esp32`` end-to-end.
     """
     yaml_path = tmp_path / "kitchen.yaml"
     # YAML says esp32 …
@@ -705,15 +713,134 @@ def test_load_device_uses_storage_target_platform_over_yaml(tmp_path: Path) -> N
         encoding="utf-8",
     )
     # … but StorageJSON records rp2040 (post-codegen truth).
-    # ``StorageJSON.load`` reads ``target_platform`` from the
-    # JSON's ``esp_platform`` key (upstream's wire-name); override
-    # both to keep the on-disk shape consistent.
+    # ``core_platform`` is the lowercase platform key upstream
+    # writes alongside the uppercase ``target_platform`` chip
+    # variant; override both to keep the on-disk shape consistent.
     write_storage_json(
         tmp_path,
         "kitchen.yaml",
-        overrides={"esp_platform": "rp2040", "target_platform": "rp2040"},
+        overrides={
+            "core_platform": "rp2040",
+            "esp_platform": "RP2040",
+            "target_platform": "RP2040",
+        },
     )
 
     device = load_device_from_storage(yaml_path)
 
     assert device.target_platform == "rp2040"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_uses_core_platform_for_esp32_variants(tmp_path: Path) -> None:
+    """ESP32 variants land as ``esp32`` (the platform key), not the chip variant.
+
+    ``StorageJSON.target_platform`` is the upstream-canonical
+    chip variant (``ESP32S3`` here) — the right level of detail
+    for chip-mismatch verification but the wrong level for the
+    frontend's PLATFORM column, where the user expects the
+    family name (``esp32``) to match the YAML key. The loader
+    pulls from ``core_platform`` (lowercase platform key, always
+    ``esp32`` for any ESP32 variant) so a heterogeneous ESP32-
+    S3/C3 fleet renders consistently against plain ``esp32``
+    boards. Variant-level info is still available to chip
+    verification, which reads ``StorageJSON.target_platform``
+    directly at the firmware-controller call site.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text(
+        "esphome:\n  name: kitchen\nesp32:\n  variant: esp32s3\n",
+        encoding="utf-8",
+    )
+    write_storage_json(
+        tmp_path,
+        "kitchen.yaml",
+        overrides={
+            "core_platform": "esp32",
+            "esp_platform": "ESP32S3",
+            "target_platform": "ESP32S3",
+        },
+    )
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.target_platform == "esp32"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_falls_back_to_yaml_when_core_platform_missing(tmp_path: Path) -> None:
+    """Pre-2025.6 ``StorageJSON`` (no ``core_platform``) falls back to YAML scan.
+
+    ``core_platform`` was added in esphome#9028 (2025.6+). A
+    StorageJSON written by an older esphome carries
+    ``target_platform`` (uppercase variant) but no
+    ``core_platform``. Rather than lowercase the variant
+    (which would surface ``esp32s3`` in the column for ESP32-S3
+    boards — re-introducing the inconsistency #137 closed), the
+    loader falls back to ``detect_platform_from_yaml``, which
+    returns the lowercase platform key from the YAML's top-level
+    ``esp32:`` / ``esp8266:`` block. Same end value either way.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text(
+        "esphome:\n  name: kitchen\nesp32:\n  variant: esp32s3\n",
+        encoding="utf-8",
+    )
+    write_storage_json(
+        tmp_path,
+        "kitchen.yaml",
+        # Pre-2025.6 shape: ``core_platform`` absent, only the
+        # uppercase variant in ``target_platform``.
+        overrides={
+            "core_platform": None,
+            "esp_platform": "ESP32S3",
+            "target_platform": "ESP32S3",
+        },
+    )
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.target_platform == "esp32"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_handles_storage_without_core_platform_attr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``StorageJSON`` from older esphome (< 2025.6) lacks ``core_platform`` entirely.
+
+    pyproject's floor is ``esphome>=2024.1.0`` so the attribute
+    can be missing on the loaded object — not just ``None``.
+    Direct attribute access would raise ``AttributeError`` and
+    blow up the device scan. ``getattr`` with a default keeps
+    the loader compatible while we wait for the dep floor to
+    move past 2025.6.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text(
+        "esphome:\n  name: kitchen\nesp32:\n  board: esp32-c3-devkitm-1\n",
+        encoding="utf-8",
+    )
+
+    class _LegacyStorage:
+        # Pre-#9028 ``StorageJSON`` shape — no ``core_platform``
+        # attribute at all. Carries the upstream-canonical chip
+        # variant uppercase as ``target_platform``.
+        name = "kitchen"
+        friendly_name = None
+        comment = None
+        address = ""
+        web_port = None
+        target_platform = "ESP32C3"
+        firmware_bin_path = None
+        esphome_version = ""
+        loaded_integrations: ClassVar[list[str]] = []
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.device_yaml.StorageJSON.load",
+        staticmethod(lambda _p: _LegacyStorage()),
+    )
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.target_platform == "esp32"

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -577,6 +577,7 @@ def test_load_device_from_storage_address_uses_storage_when_set(  # type: ignore
         address = "kitchen.lan"
         web_port = None
         target_platform = ""
+        core_platform = None
         firmware_bin_path = None
         esphome_version = ""
         loaded_integrations: ClassVar[list[str]] = []


### PR DESCRIPTION
## Problem

The PLATFORM column on the frontend device list shows a mix of `ESP32` and `esp32` for the same fleet. `Device.target_platform` is sourced from `StorageJSON` after a successful compile (upstream uppercases the chip variant — `ESP32`, `ESP32S3`, `ESP8266`, …) and falls back to a YAML scan for never-compiled devices (returns the lowercase platform key — `esp32`, `esp8266`, …). Same fleet, two casings.

Reported in esphome/device-builder-frontend#137.

## Changes

- Source `Device.target_platform` from `storage.core_platform` (upstream's lowercase platform key, added in esphome#9028) instead of the uppercase chip variant. Falls back to `detect_platform_from_yaml` when storage is missing or pre-2025.6.
- Read the chip variant straight from `StorageJSON.target_platform` in `FirmwareController._verify_chip` — the variant is the right level of detail for chip-mismatch verification (so an ESP32-S3 board on an ESP32-C3 chip still raises). `Device.target_platform`'s new platform-key shape would have false-positived here.
- Skip chip verification when StorageJSON is absent (first-time install before any compile) — esphome's own flash error covers the wrong-chip case there.
- Update tests to seed StorageJSON sidecars (matching upstream's wire format: uppercase variant in `target_platform`, lowercase platform key in `core_platform`) instead of stubbing `Device.target_platform`.