### PR TITLE
Add yaml/search WS command for full-text search across device configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,12 @@ repos:
     hooks:
       - id: check-toml
       - id: check-yaml
+        # Test fixtures intentionally contain ESPHome-specific
+        # custom tags (``!secret``, ``!include``) that the plain
+        # PyYAML loader can't resolve. The fixtures are read as
+        # raw text by the YAML-search code path under test, not
+        # parsed.
+        exclude: ^tests/fixtures/
       - id: check-json
         exclude: ^\.vscode/
       - id: check-ast

--- a/esphome_device_builder/controllers/devices/_yaml_search.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search.py
@@ -1,0 +1,136 @@
+"""
+YAML-content search loop for ``DevicesController.search_yaml``.
+
+Lifted out of the controller so the loop body — walk devices,
+read lines from the cache, line-grep, gather hits, respect the
+two caps (per-file and total) — has its own home and its own
+tests. The controller stays focused on locking and post-search
+cache pruning; this module owns the actual search.
+
+No blocking I/O at runtime:
+
+- File reads happen inside ``YamlSearchCache.get_lines`` which
+  already wraps ``Path.stat`` / ``Path.read_text`` in
+  ``asyncio.to_thread``.
+- The per-line substring scan is in-memory against an
+  already-split list, so the only "work" between awaits is a
+  string comparison. For configs in the small-thousands-of-lines
+  range that's microseconds.
+- An explicit ``await asyncio.sleep(0)`` between devices yields
+  control to the event loop every iteration so a fleet of 100+
+  devices doesn't monopolise the run loop while the cache is
+  warm (the cache hit path doesn't do I/O so wouldn't otherwise
+  yield).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from ._yaml_search_cache import YamlSearchCache
+
+
+class _DeviceLike(Protocol):
+    """The narrow surface ``search_yaml_devices`` reads from each device.
+
+    Pinned as a Protocol rather than depending on the full
+    ``Device`` model so the function can be exercised against
+    minimal stand-ins in tests, and so a future ``Device`` field
+    rename only breaks the controller's call site (which has the
+    real type) rather than this module too.
+    """
+
+    name: str
+    friendly_name: str
+    configuration: str
+
+
+async def search_yaml_devices(
+    *,
+    devices: Iterable[_DeviceLike],
+    cache: YamlSearchCache,
+    rel_path: Callable[[str], Path],
+    needle: str,
+    case_sensitive: bool,
+    max_results: int,
+    per_file_cap: int,
+) -> tuple[list[dict], set[str]]:
+    """
+    Walk *devices* and return the YAML matches for *needle*.
+
+    Returns a ``(results, live_configurations)`` tuple. The
+    caller (``DevicesController.search_yaml``) owns the post-walk
+    cache prune against ``live_configurations`` and the
+    response-shape contract; this function just produces the
+    list.
+
+    Parameters:
+    - ``devices`` — iterable of objects exposing ``name``,
+      ``friendly_name``, ``configuration``.
+    - ``cache`` — the ``YamlSearchCache`` (controller-owned)
+      that memoises ``(mtime, lines)`` per file.
+    - ``rel_path(configuration)`` — resolves a configuration
+      filename to its on-disk ``Path``. Indirected so the
+      controller's ``self._db.settings.rel_path`` doesn't leak
+      into this module.
+    - ``needle`` — the search string. Must be pre-lowered when
+      ``case_sensitive`` is False (caller's responsibility — we
+      avoid lowering it on every line).
+    - ``case_sensitive`` — when False, each line is lowered
+      before the substring check.
+    - ``max_results`` — hard cap on total matches across the
+      fleet. Walk stops once this is reached.
+    - ``per_file_cap`` — per-file cap so a chatty match doesn't
+      crowd out hits from other devices.
+    """
+    results: list[dict] = []
+    total_matches = 0
+    live_configurations: set[str] = set()
+
+    for device in devices:
+        if total_matches >= max_results:
+            break
+        live_configurations.add(device.configuration)
+
+        path = rel_path(device.configuration)
+        lines = await cache.get_lines(device.configuration, path)
+        if lines is None:
+            # Cache hit but no I/O: yield once so a long warm
+            # fleet doesn't block the event loop.
+            await asyncio.sleep(0)
+            continue
+
+        matches: list[dict] = []
+        for i, line in enumerate(lines, start=1):
+            haystack = line if case_sensitive else line.lower()
+            if needle in haystack:
+                matches.append({"line_number": i, "line_text": line})
+                if len(matches) >= per_file_cap:
+                    break
+            if total_matches + len(matches) >= max_results:
+                break
+
+        if matches:
+            results.append(
+                {
+                    "configuration": device.configuration,
+                    "device_name": device.name,
+                    "friendly_name": device.friendly_name or device.name,
+                    "matches": matches,
+                }
+            )
+            total_matches += len(matches)
+
+        # Yield to the event loop between devices. ``cache.get_lines``
+        # already yields on a disk read, but a fully-warm cache hit
+        # returns synchronously — without this nudge a 100-device
+        # fleet's worth of in-memory line scans would run as a
+        # single uninterrupted task slice.
+        await asyncio.sleep(0)
+
+    return results, live_configurations

--- a/esphome_device_builder/controllers/devices/_yaml_search.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search.py
@@ -87,15 +87,23 @@ async def search_yaml_devices(
       fleet. Walk stops once this is reached.
     - ``per_file_cap`` — per-file cap so a chatty match doesn't
       crowd out hits from other devices.
+
+    ``live_configurations`` is the *full* set of input device
+    configurations regardless of where the walk short-circuited
+    on ``max_results``. The caller uses it to prune cache entries
+    for devices that have actually disappeared; if it only
+    reflected the walked subset, a capped search would
+    spuriously evict warm entries for unwalked-but-still-live
+    devices and the next keystroke would re-read them from disk.
     """
+    devices_list = list(devices)
+    live_configurations: set[str] = {d.configuration for d in devices_list}
     results: list[dict] = []
     total_matches = 0
-    live_configurations: set[str] = set()
 
-    for device in devices:
+    for device in devices_list:
         if total_matches >= max_results:
             break
-        live_configurations.add(device.configuration)
 
         path = rel_path(device.configuration)
         lines = await cache.get_lines(device.configuration, path)

--- a/esphome_device_builder/controllers/devices/_yaml_search_cache.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search_cache.py
@@ -1,0 +1,92 @@
+"""
+Per-file cache for the ``yaml/search`` command's line buffer.
+
+The frontend dropdown debounces keystrokes but still fires one
+search per keystroke pause — on a fleet of 100 devices that's 100
+reads + 100 ``str.splitlines`` calls per keystroke without a
+cache. This class memoises the per-file ``(mtime_ns, lines)``
+tuple so subsequent searches against an unchanged file become
+pure ``stat`` + already-split list scan.
+
+Bounded by the device count: keys are configuration filenames, and
+``prune`` is called after each search to drop entries for devices
+that have been deleted / archived between calls. Populated lazily
+on the first cache miss.
+
+A single ``asyncio.Lock`` serialises the stat-check-read-update
+critical section so two concurrent searches against the same file
+can't both miss and both spawn a duplicate read. Per-file locks
+were considered but the critical section is short (a stat plus
+at most one small file read) and the contention happens in
+sequence across the fleet anyway, so one lock keeps the
+bookkeeping minimal.
+
+Lifted out of ``DevicesController`` so the search bookkeeping
+isn't tangled with device CRUD; tests can target the cache in
+isolation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class YamlSearchCache:
+    """Async-safe (mtime, lines) cache for raw device YAML files."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, tuple[int, list[str]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def get_lines(self, configuration: str, path: Path) -> list[str] | None:
+        """
+        Return the file's split lines, served from cache when fresh.
+
+        Stats *path*; if a cached entry's mtime matches, returns
+        the previously-split lines without touching disk again.
+        Otherwise reads + splits and stores the result.
+
+        Returns ``None`` (and removes any stale cache entry) when
+        the file is gone or unreadable. Errors are logged at DEBUG
+        — they're routine in a fleet that's actively being edited
+        — and never propagate; ``yaml/search`` is best-effort
+        across the fleet, not a per-device contract.
+        """
+        async with self._lock:
+            try:
+                stat = await asyncio.to_thread(path.stat)
+            except OSError as exc:
+                _LOGGER.debug("yaml-search-cache: stat %s failed: %s", configuration, exc)
+                self._entries.pop(configuration, None)
+                return None
+
+            cached = self._entries.get(configuration)
+            if cached is not None and cached[0] == stat.st_mtime_ns:
+                return cached[1]
+
+            try:
+                text = await asyncio.to_thread(path.read_text, encoding="utf-8", errors="replace")
+            except OSError as exc:
+                _LOGGER.debug("yaml-search-cache: read %s failed: %s", configuration, exc)
+                self._entries.pop(configuration, None)
+                return None
+
+            lines = text.splitlines()
+            self._entries[configuration] = (stat.st_mtime_ns, lines)
+            return lines
+
+    def prune(self, live_configurations: Iterable[str]) -> None:
+        """Drop entries for configurations not in *live_configurations*.
+
+        Called after each search so the cache shrinks when devices
+        are deleted / archived; without this the dict would grow
+        without bound across long-lived dashboards.
+        """
+        live = set(live_configurations)
+        for stale in [k for k in self._entries if k not in live]:
+            del self._entries[stale]

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -122,6 +122,15 @@ class DevicesController:
         # bookkeeping doesn't sprawl across this controller. See
         # ``_yaml_search_cache.YamlSearchCache``.
         self._yaml_search_cache = YamlSearchCache()
+        # Global search lock — ``yaml/search`` is I/O-bound (one
+        # ``stat`` per device + reads on cache misses), so two
+        # concurrent searches against the same fleet would just
+        # double the disk pressure without helping latency. Serialise
+        # to one in-flight call per controller; the frontend's
+        # debounce + concurrency-of-1 gate keeps the queue depth low
+        # in normal use, and a slow request from a stuck client
+        # won't fan out to N parallel walks.
+        self._yaml_search_lock = asyncio.Lock()
 
         self._scanner = DeviceScanner(
             config_dir=self._db.settings.config_dir,
@@ -294,44 +303,51 @@ class DevicesController:
             return []
         needle = needle_raw if case_sensitive else needle_raw.lower()
 
-        per_file_cap = _YAML_SEARCH_PER_FILE_MATCH_CAP
-        results: list[dict] = []
-        total_matches = 0
-        live_configurations: set[str] = set()
+        # Global search lock: serialise the I/O-bound walk so two
+        # concurrent searches don't double up on stat / read calls
+        # against the same fleet. The frontend's per-keystroke
+        # debounce + concurrency-of-1 gate keeps the queue shallow
+        # in normal use; this lock backstops the case where a slow
+        # request from a stuck client overlaps with a fresh one.
+        async with self._yaml_search_lock:
+            per_file_cap = _YAML_SEARCH_PER_FILE_MATCH_CAP
+            results: list[dict] = []
+            total_matches = 0
+            live_configurations: set[str] = set()
 
-        for device in self._scanner.devices:
-            if total_matches >= max_results:
-                break
-            live_configurations.add(device.configuration)
-
-            path = Path(self._db.settings.rel_path(device.configuration))
-            lines = await self._yaml_search_cache.get_lines(device.configuration, path)
-            if lines is None:
-                continue
-
-            matches: list[dict] = []
-            for i, line in enumerate(lines, start=1):
-                haystack = line if case_sensitive else line.lower()
-                if needle in haystack:
-                    matches.append({"line_number": i, "line_text": line})
-                    if len(matches) >= per_file_cap:
-                        break
-                if total_matches + len(matches) >= max_results:
+            for device in self._scanner.devices:
+                if total_matches >= max_results:
                     break
+                live_configurations.add(device.configuration)
 
-            if matches:
-                results.append(
-                    {
-                        "configuration": device.configuration,
-                        "device_name": device.name,
-                        "friendly_name": device.friendly_name or device.name,
-                        "matches": matches,
-                    }
-                )
-                total_matches += len(matches)
+                path = Path(self._db.settings.rel_path(device.configuration))
+                lines = await self._yaml_search_cache.get_lines(device.configuration, path)
+                if lines is None:
+                    continue
 
-        self._yaml_search_cache.prune(live_configurations)
-        return results
+                matches: list[dict] = []
+                for i, line in enumerate(lines, start=1):
+                    haystack = line if case_sensitive else line.lower()
+                    if needle in haystack:
+                        matches.append({"line_number": i, "line_text": line})
+                        if len(matches) >= per_file_cap:
+                            break
+                    if total_matches + len(matches) >= max_results:
+                        break
+
+                if matches:
+                    results.append(
+                        {
+                            "configuration": device.configuration,
+                            "device_name": device.name,
+                            "friendly_name": device.friendly_name or device.name,
+                            "matches": matches,
+                        }
+                    )
+                    total_matches += len(matches)
+
+            self._yaml_search_cache.prune(live_configurations)
+            return results
 
     # ------------------------------------------------------------------
     # API commands — CRUD

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -76,6 +76,13 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Per-file match cap for ``yaml/search``. Each device contributes
+# at most this many lines so a chatty match (a query of ``:``
+# against a deeply-nested config) doesn't drown hits in other
+# devices. The dropdown caps its overall hit count at the
+# caller-supplied ``max_results`` on top of this.
+_YAML_SEARCH_PER_FILE_MATCH_CAP = 5
+
 
 class DevicesController:
     """Manage device configurations, file watching, and CLI operations."""
@@ -246,18 +253,33 @@ class DevicesController:
               ]
             }
 
-        Per-file matches are capped at ``_PER_FILE_MATCH_CAP`` so a
-        chatty match (e.g. a query of ``:`` against a deeply-nested
-        config) doesn't crowd out hits in other devices, and the
-        total hit count is capped at ``max_results`` so the dropdown
-        on the frontend stays usable. Empty / whitespace-only queries
-        return ``[]`` immediately — the frontend debounces typing
-        but a stray empty call shouldn't iterate every YAML file.
+        Per-file matches are capped at
+        ``_YAML_SEARCH_PER_FILE_MATCH_CAP`` so a chatty match (e.g.
+        a query of ``:`` against a deeply-nested config) doesn't
+        crowd out hits in other devices, and the total hit count is
+        capped at ``max_results`` so the dropdown on the frontend
+        stays usable. Empty / whitespace-only queries return ``[]``
+        immediately — the frontend debounces typing but a stray
+        empty call shouldn't iterate every YAML file.
 
         Reads the on-disk file (not the package-resolved tree) for
         cheap line-numbered grep. Searching expanded packages would
         need separate "matched in package X line Y" rendering on the
         frontend; queued as a follow-up.
+
+        Iterates the scanner's existing snapshot rather than firing
+        a fresh ``await self._scanner.scan()`` like ``devices/list``
+        does — this command runs once per debounced keystroke from
+        the frontend's command palette, and a per-keystroke disk
+        scan would dominate the round-trip cost. The scanner refreshes
+        on its own cadence (file-watcher events + periodic re-scan)
+        so YAMLs added or removed between scans become visible on
+        the next scan, not the next search. The scanner-level skip
+        of YAMLs that fail to materialise into a ``Device`` (broken
+        configs that ``DeviceScanner._load_devices()`` logs and
+        drops) carries through here too: this command searches the
+        same set of devices the dashboard list shows, not the raw
+        ``*.yaml`` filesystem.
 
         Cache: see ``_yaml_search_cache.YamlSearchCache``. The
         frontend debounces keystrokes but still fires one search
@@ -272,7 +294,7 @@ class DevicesController:
             return []
         needle = needle_raw if case_sensitive else needle_raw.lower()
 
-        per_file_cap = 5
+        per_file_cap = _YAML_SEARCH_PER_FILE_MATCH_CAP
         results: list[dict] = []
         total_matches = 0
         live_configurations: set[str] = set()

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -58,6 +58,7 @@ from ..config import (
     set_device_metadata,
 )
 from ..firmware.helpers import _find_esphome_cmd
+from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
     _apply_featured_presets,
     _archive_clear_device_sidecars,
@@ -108,6 +109,12 @@ class DevicesController:
         self._regenerate_pending: set[str] = set()
         self._regenerate_failed: set[str] = set()
         self._regenerate_lock = asyncio.Lock()
+
+        # ``yaml/search`` per-file cache. The class owns its own
+        # ``stat``-then-read flow + ``asyncio.Lock`` so the
+        # bookkeeping doesn't sprawl across this controller. See
+        # ``_yaml_search_cache.YamlSearchCache``.
+        self._yaml_search_cache = YamlSearchCache()
 
         self._scanner = DeviceScanner(
             config_dir=self._db.settings.config_dir,
@@ -251,6 +258,14 @@ class DevicesController:
         cheap line-numbered grep. Searching expanded packages would
         need separate "matched in package X line Y" rendering on the
         frontend; queued as a follow-up.
+
+        Cache: see ``_yaml_search_cache.YamlSearchCache``. The
+        frontend debounces keystrokes but still fires one search
+        per pause — on a fleet of 100 devices that's 100 reads + 100
+        splitlines per keystroke without a cache. With it, every
+        keystroke after the first becomes a stat-and-grep against
+        an already-split list (only files whose mtime changed get
+        re-read).
         """
         needle_raw = query.strip()
         if not needle_raw:
@@ -260,25 +275,20 @@ class DevicesController:
         per_file_cap = 5
         results: list[dict] = []
         total_matches = 0
+        live_configurations: set[str] = set()
 
         for device in self._scanner.devices:
             if total_matches >= max_results:
                 break
+            live_configurations.add(device.configuration)
 
-            path = self._db.settings.rel_path(device.configuration)
-            try:
-                # ``read_text`` is sync — push it to the executor so
-                # one slow disk doesn't stall the event loop while
-                # we walk the rest of the fleet.
-                text = await asyncio.to_thread(
-                    Path(path).read_text, encoding="utf-8", errors="replace"
-                )
-            except OSError as exc:
-                _LOGGER.debug("yaml/search: skipping %s: %s", device.configuration, exc)
+            path = Path(self._db.settings.rel_path(device.configuration))
+            lines = await self._yaml_search_cache.get_lines(device.configuration, path)
+            if lines is None:
                 continue
 
             matches: list[dict] = []
-            for i, line in enumerate(text.splitlines(), start=1):
+            for i, line in enumerate(lines, start=1):
                 haystack = line if case_sensitive else line.lower()
                 if needle in haystack:
                     matches.append({"line_number": i, "line_text": line})
@@ -298,6 +308,7 @@ class DevicesController:
                 )
                 total_matches += len(matches)
 
+        self._yaml_search_cache.prune(live_configurations)
         return results
 
     # ------------------------------------------------------------------

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -58,6 +58,7 @@ from ..config import (
     set_device_metadata,
 )
 from ..firmware.helpers import _find_esphome_cmd
+from ._yaml_search import search_yaml_devices
 from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
     _apply_featured_presets,
@@ -310,42 +311,15 @@ class DevicesController:
         # in normal use; this lock backstops the case where a slow
         # request from a stuck client overlaps with a fresh one.
         async with self._yaml_search_lock:
-            per_file_cap = _YAML_SEARCH_PER_FILE_MATCH_CAP
-            results: list[dict] = []
-            total_matches = 0
-            live_configurations: set[str] = set()
-
-            for device in self._scanner.devices:
-                if total_matches >= max_results:
-                    break
-                live_configurations.add(device.configuration)
-
-                path = Path(self._db.settings.rel_path(device.configuration))
-                lines = await self._yaml_search_cache.get_lines(device.configuration, path)
-                if lines is None:
-                    continue
-
-                matches: list[dict] = []
-                for i, line in enumerate(lines, start=1):
-                    haystack = line if case_sensitive else line.lower()
-                    if needle in haystack:
-                        matches.append({"line_number": i, "line_text": line})
-                        if len(matches) >= per_file_cap:
-                            break
-                    if total_matches + len(matches) >= max_results:
-                        break
-
-                if matches:
-                    results.append(
-                        {
-                            "configuration": device.configuration,
-                            "device_name": device.name,
-                            "friendly_name": device.friendly_name or device.name,
-                            "matches": matches,
-                        }
-                    )
-                    total_matches += len(matches)
-
+            results, live_configurations = await search_yaml_devices(
+                devices=self._scanner.devices,
+                cache=self._yaml_search_cache,
+                rel_path=lambda c: Path(self._db.settings.rel_path(c)),
+                needle=needle,
+                case_sensitive=case_sensitive,
+                max_results=max_results,
+                per_file_cap=_YAML_SEARCH_PER_FILE_MATCH_CAP,
+            )
             self._yaml_search_cache.prune(live_configurations)
             return results
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -216,6 +216,90 @@ class DevicesController:
         """Get connectivity state for all devices."""
         return {d.configuration: d.state.value for d in self._scanner.devices}
 
+    @api_command("yaml/search")
+    async def search_yaml(
+        self,
+        *,
+        query: str,
+        max_results: int = 50,
+        case_sensitive: bool = False,
+        **kwargs: Any,
+    ) -> list[dict]:
+        """
+        Substring-search every configured device's raw YAML file.
+
+        Returns a list of per-device hits, each entry shaped as::
+
+            {
+              "configuration": "<filename>",
+              "device_name":   "<esphome.name>",
+              "friendly_name": "<esphome.friendly_name or name>",
+              "matches": [
+                {"line_number": <1-based int>, "line_text": "<raw line>"}
+              ]
+            }
+
+        Per-file matches are capped at ``_PER_FILE_MATCH_CAP`` so a
+        chatty match (e.g. a query of ``:`` against a deeply-nested
+        config) doesn't crowd out hits in other devices, and the
+        total hit count is capped at ``max_results`` so the dropdown
+        on the frontend stays usable. Empty / whitespace-only queries
+        return ``[]`` immediately — the frontend debounces typing
+        but a stray empty call shouldn't iterate every YAML file.
+
+        Reads the on-disk file (not the package-resolved tree) for
+        cheap line-numbered grep. Searching expanded packages would
+        need separate "matched in package X line Y" rendering on the
+        frontend; queued as a follow-up.
+        """
+        needle_raw = query.strip()
+        if not needle_raw:
+            return []
+        needle = needle_raw if case_sensitive else needle_raw.lower()
+
+        per_file_cap = 5
+        results: list[dict] = []
+        total_matches = 0
+
+        for device in self._scanner.devices:
+            if total_matches >= max_results:
+                break
+
+            path = self._db.settings.rel_path(device.configuration)
+            try:
+                # ``read_text`` is sync — push it to the executor so
+                # one slow disk doesn't stall the event loop while
+                # we walk the rest of the fleet.
+                text = await asyncio.to_thread(
+                    Path(path).read_text, encoding="utf-8", errors="replace"
+                )
+            except OSError as exc:
+                _LOGGER.debug("yaml/search: skipping %s: %s", device.configuration, exc)
+                continue
+
+            matches: list[dict] = []
+            for i, line in enumerate(text.splitlines(), start=1):
+                haystack = line if case_sensitive else line.lower()
+                if needle in haystack:
+                    matches.append({"line_number": i, "line_text": line})
+                    if len(matches) >= per_file_cap:
+                        break
+                if total_matches + len(matches) >= max_results:
+                    break
+
+            if matches:
+                results.append(
+                    {
+                        "configuration": device.configuration,
+                        "device_name": device.name,
+                        "friendly_name": device.friendly_name or device.name,
+                        "matches": matches,
+                    }
+                )
+                total_matches += len(matches)
+
+        return results
+
     # ------------------------------------------------------------------
     # API commands — CRUD
     # ------------------------------------------------------------------

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -452,6 +452,7 @@ def make_controller() -> MakeControllerFactory:
         # (just an asyncio.Lock + empty dict) so set it on every
         # bypass-init controller for parity with __init__.
         controller._yaml_search_cache = YamlSearchCache()
+        controller._yaml_search_lock = asyncio.Lock()
 
         if with_state_monitor:
             controller._state_monitor = RecordingStateMonitor()

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -25,6 +25,7 @@ import pytest
 
 from esphome_device_builder.controllers.config import set_device_metadata
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices._yaml_search_cache import YamlSearchCache
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.helpers.hostname import normalize_hostname
 from esphome_device_builder.models import AdoptableDevice, DeviceState, EventType
@@ -445,6 +446,12 @@ def make_controller() -> MakeControllerFactory:
         # typo or rename of ``scan``/``reload`` surfaces as
         # ``AttributeError`` instead of silently passing the assertion.
         controller._scanner = RecordingScanner()
+        # ``yaml/search`` reads through this cache; tests that
+        # exercise the search command need a real instance, and
+        # the rest can ignore it. Cheap to instantiate
+        # (just an asyncio.Lock + empty dict) so set it on every
+        # bypass-init controller for parity with __init__.
+        controller._yaml_search_cache = YamlSearchCache()
 
         if with_state_monitor:
             controller._state_monitor = RecordingStateMonitor()

--- a/tests/controllers/devices/test_search_yaml.py
+++ b/tests/controllers/devices/test_search_yaml.py
@@ -1,0 +1,283 @@
+"""End-to-end coverage for ``DevicesController.search_yaml``.
+
+The new ``yaml/search`` WS command is the dashboard's
+"find a string across every YAML in this fleet" surface — the
+frontend's full-content search dropdown calls it on every
+keystroke (debounced).
+
+Exercises:
+
+- Substring matches across multiple files.
+- Per-file cap so one chatty match doesn't drown the rest.
+- Total-results cap so an over-broad query stays manageable.
+- Case-insensitive default + opt-in case sensitivity.
+- Empty / whitespace query short-circuits without iterating.
+- Missing file / unreadable file is skipped, not a 500.
+
+The controller iterates ``self._scanner.devices`` and reads
+``self._db.settings.rel_path(configuration)`` from disk. The
+``make_controller`` fixture wires ``rel_path`` against the
+test's ``tmp_path``, so each test just writes YAML files at
+the expected paths and pre-populates ``_scanner.devices``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from esphome_device_builder.models import Device, DeviceState
+
+if TYPE_CHECKING:
+    from .conftest import MakeControllerFactory
+
+
+def _device(name: str, *, friendly: str | None = None) -> Device:
+    """Bare-minimum ``Device`` for search-result assertions."""
+    return Device(
+        name=name,
+        friendly_name=friendly or name.title(),
+        configuration=f"{name}.yaml",
+        address=f"{name}.local",
+        state=DeviceState.ONLINE,
+    )
+
+
+def _seed_yaml(tmp_path: Path, name: str, content: str) -> None:
+    (tmp_path / f"{name}.yaml").write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Empty-query short-circuit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("query", ["", "   ", "\t"])
+@pytest.mark.asyncio
+async def test_search_yaml_empty_query_returns_empty_without_io(
+    query: str,
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Empty / whitespace query short-circuits before touching disk.
+
+    Frontend debounce can still fire a stray empty call (e.g. on
+    "clear search"); iterating every device YAML for nothing is
+    pure waste. Pin the early-return so a regression that drops
+    the strip-and-bail surfaces as the "scanner.devices was
+    accessed" assertion below.
+    """
+    controller = make_controller(tmp_path)
+    # Seed a populated scanner so an unguarded loop would actually
+    # do work — the assertion is that this path is NOT taken.
+    controller._scanner.devices = [_device("kitchen")]
+    _seed_yaml(tmp_path, "kitchen", "esphome:\n  name: kitchen\n")
+
+    results = await controller.search_yaml(query=query)
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Substring match shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_substring_match_returns_per_device_hits(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A simple substring match returns one entry per matching device.
+
+    Pin the result shape (configuration / device_name / friendly_name
+    / matches array of {line_number, line_text}) — the frontend's
+    rendering layer reads each field by name. A field rename here
+    silently breaks the dropdown rendering with no test failure.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [
+        _device("kitchen", friendly="Kitchen Lamp"),
+        _device("bedroom", friendly="Bedroom Sensor"),
+    ]
+    _seed_yaml(
+        tmp_path,
+        "kitchen",
+        "esphome:\n  name: kitchen\nwifi:\n  ssid: home\n",
+    )
+    _seed_yaml(
+        tmp_path,
+        "bedroom",
+        "esphome:\n  name: bedroom\nbinary_sensor:\n  - platform: gpio\n",
+    )
+
+    results = await controller.search_yaml(query="wifi")
+
+    assert len(results) == 1
+    hit = results[0]
+    assert hit["configuration"] == "kitchen.yaml"
+    assert hit["device_name"] == "kitchen"
+    assert hit["friendly_name"] == "Kitchen Lamp"
+    assert hit["matches"] == [{"line_number": 3, "line_text": "wifi:"}]
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_friendly_name_falls_back_to_device_name(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Empty ``friendly_name`` falls back to the device name in results.
+
+    Devices created without a friendly_name still need a
+    user-readable label in the dropdown — falling through to
+    ``device_name`` keeps the result row scannable instead of
+    showing an empty string.
+    """
+    controller = make_controller(tmp_path)
+    dev = _device("kitchen")
+    dev.friendly_name = ""
+    controller._scanner.devices = [dev]
+    _seed_yaml(tmp_path, "kitchen", "wifi:\n")
+
+    results = await controller.search_yaml(query="wifi")
+
+    assert results[0]["friendly_name"] == "kitchen"
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive (default) vs case-sensitive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_default_is_case_insensitive(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Default search ignores case so "WIFI" finds ``wifi:``.
+
+    Most users won't think about case. Pinning the default
+    behaviour means a regression that flips it (e.g. forgetting
+    to lower-case the haystack) surfaces here.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [_device("kitchen")]
+    _seed_yaml(tmp_path, "kitchen", "wifi:\n  ssid: home\n")
+
+    results = await controller.search_yaml(query="WIFI")
+
+    assert len(results) == 1
+    assert results[0]["matches"][0]["line_number"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_case_sensitive_opt_in(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``case_sensitive=True`` distinguishes ``wifi`` from ``WIFI``.
+
+    The opt-in flag is for queries where case really matters
+    (e.g. searching for a constant name or a capitalised tag).
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [_device("kitchen")]
+    _seed_yaml(tmp_path, "kitchen", "wifi:\n")
+
+    results = await controller.search_yaml(query="WIFI", case_sensitive=True)
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Per-file + total caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_caps_matches_per_file(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Per-file matches cap at 5 so one chatty file doesn't drown others.
+
+    Without the cap, a query of a YAML token like ``-`` (very
+    common in lists) against a long config could return hundreds
+    of hits from one file and crowd out matches in the rest of the
+    fleet. Pin the cap so the dropdown stays usable.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [_device("kitchen")]
+    # Ten lines all containing the needle — only the first 5 should
+    # come back.
+    _seed_yaml(
+        tmp_path,
+        "kitchen",
+        "\n".join(f"# wifi-ish {i}" for i in range(10)) + "\n",
+    )
+
+    results = await controller.search_yaml(query="wifi")
+
+    assert len(results[0]["matches"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_caps_total_results(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Total result count caps at ``max_results`` across all devices.
+
+    Frontend dropdown caps its rendering anyway — there's no point
+    walking the whole fleet once we have enough hits. Pin the
+    caller-controllable ``max_results`` so a regression that
+    ignored the parameter would let the response balloon.
+    """
+    controller = make_controller(tmp_path)
+    # Three devices, each with one match → 3 hits available.
+    controller._scanner.devices = [_device(f"dev{i}") for i in range(3)]
+    for i in range(3):
+        _seed_yaml(tmp_path, f"dev{i}", "wifi:\n")
+
+    results = await controller.search_yaml(query="wifi", max_results=2)
+
+    # Walks devices in scanner order; cap kicks in before the third.
+    total_matches = sum(len(r["matches"]) for r in results)
+    assert total_matches <= 2
+    assert len(results) <= 2
+
+
+# ---------------------------------------------------------------------------
+# Robustness: missing / unreadable files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_skips_missing_files(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A device whose YAML disappeared mid-scan is skipped, not a 500.
+
+    The scanner's index can briefly disagree with the filesystem
+    (atomic-save remove + re-add, manual rm by the user, etc.).
+    Search shouldn't blow up the WS dispatcher in that window —
+    the missing file just doesn't contribute hits, the rest of
+    the fleet still searches.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [
+        _device("kitchen"),
+        _device("bedroom"),
+    ]
+    # Only seed kitchen.yaml — bedroom.yaml is intentionally missing.
+    _seed_yaml(tmp_path, "kitchen", "wifi:\n")
+
+    results = await controller.search_yaml(query="wifi")
+
+    # Kitchen still searched and matched; bedroom's missing file
+    # didn't blow up the call.
+    assert len(results) == 1
+    assert results[0]["configuration"] == "kitchen.yaml"

--- a/tests/controllers/devices/test_search_yaml.py
+++ b/tests/controllers/devices/test_search_yaml.py
@@ -23,6 +23,7 @@ the expected paths and pre-populates ``_scanner.devices``.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -252,6 +253,57 @@ async def test_search_yaml_caps_total_results(
 # ---------------------------------------------------------------------------
 # Robustness: missing / unreadable files
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_serialises_concurrent_calls(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Concurrent ``search_yaml`` calls run one-at-a-time via the lock.
+
+    The command is I/O-bound — one ``stat`` per device + reads on
+    cache misses — so two concurrent searches against the same
+    fleet would just double the disk pressure without helping
+    latency. The frontend's debounce keeps the depth low, but a
+    slow request from a stuck client must not fan out to N
+    parallel walks. Pin the contract by tracking the maximum
+    concurrent depth observed inside the cache helper:
+    one search active at any given moment, even when two
+    high-level callers race.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [_device("kitchen")]
+    _seed_yaml(tmp_path, "kitchen", "wifi:\n")
+
+    in_flight = 0
+    max_in_flight = 0
+    real_get_lines = controller._yaml_search_cache.get_lines
+
+    async def _spy_get_lines(*args: object, **kwargs: object) -> list[str] | None:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            # Yield once so the other coroutine has a chance to
+            # interleave inside the same call if the lock isn't
+            # holding it back.
+            await asyncio.sleep(0)
+            return await real_get_lines(*args, **kwargs)  # type: ignore[arg-type]
+        finally:
+            in_flight -= 1
+
+    controller._yaml_search_cache.get_lines = _spy_get_lines  # type: ignore[assignment]
+
+    a, b = await asyncio.gather(
+        controller.search_yaml(query="wifi"),
+        controller.search_yaml(query="wifi"),
+    )
+
+    # Both calls produced the same hit set — serialised, not
+    # cancelled — and the lock kept them strictly one-at-a-time.
+    assert a == b
+    assert max_in_flight == 1
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_search_yaml_fixtures.py
+++ b/tests/controllers/devices/test_search_yaml_fixtures.py
@@ -1,0 +1,297 @@
+"""End-to-end ``yaml/search`` against realistic ESPHome YAML fixtures.
+
+The sibling ``test_search_yaml.py`` pins the controller-level
+contracts (caps, case, locking, missing-file robustness) using
+inlined synthetic YAML — small, focused, fast.
+
+This file targets a different question: does the search behave
+correctly against the *kind* of YAML users actually have on disk?
+Multi-section configs with comments, anchors-style substitutions,
+``!secret`` references, packages, ethernet vs wifi shapes,
+``${var}`` interpolation, indented platform blocks. The fixtures
+under ``tests/fixtures/yaml_search/`` are anonymised real configs
+covering four common shapes:
+
+- ``bluetooth_proxy.yaml`` — esp32-c3 + ``bluetooth_proxy:`` +
+  ``esp32_ble_tracker:`` + buttons.
+- ``smart_plug.yaml`` — ESP8266 + ``cse7766`` power monitoring +
+  ``binary_sensor`` / ``sensor`` / ``switch`` / ``status_led``.
+- ``packaged_device.yaml`` — ``packages: remote_package: …`` +
+  ``substitutions:`` + ``${name}`` interpolation.
+- ``ethernet_proxy.yaml`` — ``ethernet:`` (LAN8720) + ``bluetooth_proxy:``
+  + ``time:`` / ``text_sensor:`` / ``sensor:`` / ``switch:``.
+
+Confidence we want from these tests:
+
+- A query for an ESPHome top-level key (``bluetooth_proxy``)
+  hits the right subset of the fleet.
+- Multi-line matches inside a block (``cse7766``'s
+  ``current``/``voltage``/``power``) come back in file order with
+  correct line numbers.
+- Comment-only matches still surface (the YAML is the source of
+  truth, comments included — users grepping for a TODO or a
+  magic constant care about them).
+- Substitution / package syntax (``${name}``, ``!secret``) is just
+  text to the searcher and matches as such.
+- Per-file cap kicks in even on a chatty fixture (the smart plug
+  has many ``Smart Plug`` matches).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from esphome_device_builder.models import Device, DeviceState
+
+if TYPE_CHECKING:
+    from .conftest import MakeControllerFactory
+
+
+_FIXTURES = Path(__file__).resolve().parent.parent.parent / "fixtures" / "yaml_search"
+
+
+def _seed_fleet(tmp_path: Path) -> list[Device]:
+    """Copy every fixture into ``tmp_path`` and return matching ``Device``s.
+
+    Each fixture's filename (minus ``.yaml``) becomes the device
+    name — the controller's search reads ``rel_path(configuration)``
+    via the ``make_controller`` fixture's lambda, so the YAML must
+    actually live at ``tmp_path / <configuration>``. Returning
+    ``Device``s rather than letting the test build them keeps the
+    call sites short and ensures every fixture-backed test runs
+    against the same fleet shape.
+    """
+    devices: list[Device] = []
+    for fixture in sorted(_FIXTURES.glob("*.yaml")):
+        name = fixture.stem
+        target = tmp_path / fixture.name
+        target.write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
+        devices.append(
+            Device(
+                name=name,
+                friendly_name=name.replace("_", " ").title(),
+                configuration=fixture.name,
+                address=f"{name}.local",
+                state=DeviceState.ONLINE,
+            )
+        )
+    return devices
+
+
+# ---------------------------------------------------------------------------
+# Fleet-wide section search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bluetooth_proxy_query_picks_out_proxy_devices(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``bluetooth_proxy`` matches the two proxy fixtures, not the plug.
+
+    Both ``bluetooth_proxy.yaml`` and ``ethernet_proxy.yaml`` carry
+    a top-level ``bluetooth_proxy:`` block; the smart plug doesn't.
+    The packaged-device fixture imports its real config from a
+    package and likewise has no inline ``bluetooth_proxy:``. Pin
+    that fleet-wide section search returns the right subset.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = _seed_fleet(tmp_path)
+
+    results = await controller.search_yaml(query="bluetooth_proxy")
+
+    matched = {hit["configuration"] for hit in results}
+    assert matched == {"bluetooth_proxy.yaml", "ethernet_proxy.yaml"}
+
+
+@pytest.mark.asyncio
+async def test_ethernet_query_isolates_the_ethernet_device(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``ethernet:`` matches only the ethernet fixture, not WiFi devices.
+
+    The "find the device that doesn't have WiFi" use case — useful
+    when an Ethernet-only device misbehaves and the user wants to
+    jump to its config without scrolling the device list.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = _seed_fleet(tmp_path)
+
+    results = await controller.search_yaml(query="ethernet")
+
+    assert len(results) == 1
+    assert results[0]["configuration"] == "ethernet_proxy.yaml"
+    # The ``ethernet:`` block heading should be among the matches —
+    # not just an incidental substring elsewhere in the file.
+    line_texts = [m["line_text"] for m in results[0]["matches"]]
+    assert any(text.strip() == "ethernet:" for text in line_texts)
+
+
+# ---------------------------------------------------------------------------
+# Block-internal multi-line matches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cse7766_block_returns_multiple_lines_in_order(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Multi-line block matches come back in file order with right line numbers.
+
+    The smart-plug fixture's ``cse7766:`` block carries
+    ``current`` / ``voltage`` / ``power`` sub-blocks each with a
+    ``Smart Plug <Quantity>`` name. A query for ``cse7766`` should
+    hit the platform line itself, and a query for the platform's
+    accuracy_decimals should hit each sub-block. Pin both: line
+    numbers must be 1-based and ascending so the frontend's
+    ``?line=<n>`` jump lands on the right line.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = _seed_fleet(tmp_path)
+
+    results = await controller.search_yaml(query="accuracy_decimals")
+
+    assert len(results) == 1
+    assert results[0]["configuration"] == "smart_plug.yaml"
+    line_numbers = [m["line_number"] for m in results[0]["matches"]]
+    assert line_numbers == sorted(line_numbers)
+    assert all(n >= 1 for n in line_numbers)
+    # cse7766 has three quantities (current/voltage/power), each
+    # with an accuracy_decimals — all three rows should be present.
+    assert len(line_numbers) == 3
+
+
+# ---------------------------------------------------------------------------
+# Comments + substitutions are searchable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_comment_text_is_searchable(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Searching matches text inside YAML comments, not just keys.
+
+    The bluetooth-proxy fixture's ``esp32_ble_tracker.scan_parameters``
+    block carries a ``# We currently use the defaults ...`` comment
+    — a user grepping for "coexistence" expects to land on the
+    comment line, not silently miss it because it's not a key.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = _seed_fleet(tmp_path)
+
+    results = await controller.search_yaml(query="coexistence")
+
+    assert len(results) == 1
+    assert results[0]["configuration"] == "bluetooth_proxy.yaml"
+    # Match should be the actual comment line.
+    assert "coexistence" in results[0]["matches"][0]["line_text"]
+
+
+@pytest.mark.asyncio
+async def test_substitution_interpolation_matches_as_literal_text(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``${name}`` substitution syntax is literal text to the searcher.
+
+    The packaged-device fixture carries ``name: ${name}`` and
+    ``friendly_name: ${friendly_name}`` because it pulls its real
+    config from a remote package. Searching for ``${name}`` should
+    find both of those interpolation sites — important because
+    that's exactly how a user debugs a substitution issue.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = _seed_fleet(tmp_path)
+
+    results = await controller.search_yaml(query="${name}")
+
+    assert len(results) == 1
+    assert results[0]["configuration"] == "packaged_device.yaml"
+    assert len(results[0]["matches"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_secret_reference_is_searchable(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``!secret`` references match across every fixture that uses them.
+
+    Every fixture in the fleet pulls ``wifi_password`` from
+    ``!secret`` (the proxy / plug / packaged shape all do).
+    Pin that the search treats ``!secret`` as ordinary text and
+    surfaces every device that references the named secret —
+    useful for "which devices use this secret?" auditing.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = _seed_fleet(tmp_path)
+
+    # Bump max_results well above the fixture count so the fleet-wide
+    # secret hit isn't truncated.
+    results = await controller.search_yaml(query="!secret wifi_password", max_results=50)
+
+    matched = {hit["configuration"] for hit in results}
+    assert matched == {
+        "bluetooth_proxy.yaml",
+        "smart_plug.yaml",
+        "packaged_device.yaml",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Caps still hold against realistic content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_file_cap_holds_against_chatty_fixture(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A query that hits many lines in one fixture still respects the cap.
+
+    The smart-plug fixture has ~10 ``Smart Plug ...`` name lines
+    across its sensor / switch / binary_sensor blocks. A naive
+    search would return all of them, drowning out hits in the
+    other devices. Pin that the per-file cap (5) holds even on a
+    realistic, long-fixture query.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = _seed_fleet(tmp_path)
+
+    results = await controller.search_yaml(query="Smart Plug")
+
+    plug_hits = [hit for hit in results if hit["configuration"] == "smart_plug.yaml"]
+    assert len(plug_hits) == 1
+    assert len(plug_hits[0]["matches"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_yaml_directive_marker_does_not_break_match(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A ``---`` document-start marker in a fixture doesn't shadow other matches.
+
+    The ethernet fixture starts with the YAML directive marker
+    ``---`` on line 1. Pin that search ignores it as a special
+    marker — i.e. a query for ``esphome:`` still hits line 2,
+    not line 1.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = _seed_fleet(tmp_path)
+
+    results = await controller.search_yaml(query="esphome:")
+
+    eth_hit = next(hit for hit in results if hit["configuration"] == "ethernet_proxy.yaml")
+    line_numbers = [m["line_number"] for m in eth_hit["matches"]]
+    # Top-level ``esphome:`` block opens on line 2 (line 1 is ``---``).
+    assert 2 in line_numbers

--- a/tests/controllers/devices/test_yaml_search_cache.py
+++ b/tests/controllers/devices/test_yaml_search_cache.py
@@ -144,6 +144,50 @@ async def test_missing_file_returns_none_and_clears_stale(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_unreadable_file_returns_none_and_clears_stale(tmp_path: Path) -> None:
+    """File stats OK but read fails → ``None`` + cache entry removed.
+
+    Covers the rare race where a YAML is rm'd between the
+    cache's ``stat`` and ``read_text`` calls (atomic-save churn,
+    aggressive cleanup tooling, etc.). The cache must treat this
+    the same way it treats a stat failure: prune the entry,
+    return ``None``, let the search loop skip the device.
+    """
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("wifi:\n", encoding="utf-8")
+    # Warm the cache so we have an entry to evict.
+    first = await cache.get_lines("kitchen.yaml", path)
+    assert first == ["wifi:"]
+    # Bump mtime so the next call misses the warm-entry early-
+    # return and reaches the read path.
+    new_mtime = path.stat().st_mtime_ns + 1_000_000_000
+    os.utime(path, ns=(new_mtime, new_mtime))
+
+    # Now make ``read_text`` fail on the next call. Stat still
+    # works (the path is real); the failure is read-side only.
+    real_read = Path.read_text
+    call_count = 0
+
+    def _failing_read(self: Path, *args: object, **kwargs: object) -> str:
+        nonlocal call_count
+        call_count += 1
+        if self == path and call_count == 1:
+            msg = "I/O error mid-read"
+            raise OSError(msg)
+        return real_read(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    with patch.object(Path, "read_text", _failing_read):
+        result = await cache.get_lines("kitchen.yaml", path)
+
+    assert result is None
+    # Stale entry was pruned — a follow-up call (with read
+    # working again) re-reads from scratch.
+    refreshed = await cache.get_lines("kitchen.yaml", path)
+    assert refreshed == ["wifi:"]
+
+
+@pytest.mark.asyncio
 async def test_prune_drops_only_stale_entries(tmp_path: Path) -> None:
     """``prune(live)`` removes entries whose key isn't in *live*.
 

--- a/tests/controllers/devices/test_yaml_search_cache.py
+++ b/tests/controllers/devices/test_yaml_search_cache.py
@@ -1,0 +1,211 @@
+"""Coverage for ``YamlSearchCache``.
+
+Pinned in isolation from ``DevicesController.search_yaml`` so a
+regression in the cache logic surfaces here, not as a flaky
+end-to-end ``yaml/search`` test. The end-to-end tests in
+``test_search_yaml.py`` exercise the cache via the controller's
+public command and stay focused on result-shape + fleet-walk
+contracts.
+
+Branches:
+
+- Cold call → reads file + splits lines + caches.
+- Warm call (mtime unchanged) → returns cached list without
+  touching disk.
+- Mtime advanced → re-reads, replaces cached entry.
+- Missing / unreadable file → returns ``None`` and clears any
+  stale cache entry.
+- ``prune`` drops only stale entries.
+- Concurrent calls against the same file serialise via the
+  internal lock — pinned by counting how many times
+  ``read_text`` is invoked under a deliberate race.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder.controllers.devices._yaml_search_cache import (
+    YamlSearchCache,
+)
+
+# ---------------------------------------------------------------------------
+# Cold + warm path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cold_call_reads_file_and_caches(tmp_path: Path) -> None:
+    """First call against a fresh file reads from disk + splits lines.
+
+    Pin both the read-through behaviour and the line-split shape
+    (``str.splitlines`` rules — no trailing-newline empty entry) so
+    the search caller can iterate ``enumerate(lines, start=1)`` and
+    get 1-based line numbers that match user-visible editor lines.
+    """
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("esphome:\n  name: kitchen\nwifi:\n", encoding="utf-8")
+
+    lines = await cache.get_lines("kitchen.yaml", path)
+
+    assert lines == ["esphome:", "  name: kitchen", "wifi:"]
+
+
+@pytest.mark.asyncio
+async def test_warm_call_returns_cached_without_reading(tmp_path: Path) -> None:
+    """Second call against an unchanged file doesn't re-read.
+
+    The whole point of the cache: a debounced keystroke storm
+    should hit the disk once per file per mtime, not once per
+    keystroke. Pin that contract by replacing the underlying
+    ``read_text`` after the warm-up call and asserting it never
+    fires on the second.
+    """
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("wifi:\n", encoding="utf-8")
+    first = await cache.get_lines("kitchen.yaml", path)
+
+    # Replace path.read_text on this specific Path instance with a
+    # sentinel — if the cache calls it, the test fails loudly.
+    with patch.object(Path, "read_text", side_effect=AssertionError("warm path must not re-read")):
+        second = await cache.get_lines("kitchen.yaml", path)
+
+    assert second is first  # same list object — the cache returned the cached one
+
+
+@pytest.mark.asyncio
+async def test_mtime_change_invalidates_cache(tmp_path: Path) -> None:
+    """A new mtime forces a re-read; the cached entry is replaced.
+
+    Editing a YAML in-place advances ``mtime_ns``; the cache key on
+    that field is what makes "save in the editor → next search
+    sees the new content" work without an external invalidation
+    call.
+    """
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("wifi:\n", encoding="utf-8")
+    first = await cache.get_lines("kitchen.yaml", path)
+    assert first == ["wifi:"]
+
+    # Bump mtime_ns deliberately — Path.write_text + os.utime would
+    # also work but the explicit utime makes the intent crystal.
+    new_mtime = path.stat().st_mtime_ns + 1_000_000_000  # +1s
+    path.write_text("api:\n  encryption:\n    key: !secret\n", encoding="utf-8")
+    os.utime(path, ns=(new_mtime, new_mtime))
+
+    second = await cache.get_lines("kitchen.yaml", path)
+
+    assert second == ["api:", "  encryption:", "    key: !secret"]
+
+
+# ---------------------------------------------------------------------------
+# Missing / unreadable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_file_returns_none_and_clears_stale(tmp_path: Path) -> None:
+    """File deleted between calls → ``None`` + cache entry removed.
+
+    The scanner's index can briefly disagree with the filesystem
+    (atomic-save remove + re-add, manual ``rm`` by the user, etc.).
+    A previously-cached entry must not be returned for a vanished
+    file — the next search would render misleading hits against
+    text that's no longer on disk.
+    """
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("wifi:\n", encoding="utf-8")
+
+    first = await cache.get_lines("kitchen.yaml", path)
+    assert first == ["wifi:"]
+
+    path.unlink()
+
+    second = await cache.get_lines("kitchen.yaml", path)
+    assert second is None
+    # And a third call (still missing) keeps returning None — pin
+    # that the stale entry was actually pruned, not just shadowed.
+    third = await cache.get_lines("kitchen.yaml", path)
+    assert third is None
+
+
+# ---------------------------------------------------------------------------
+# Pruning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prune_drops_only_stale_entries(tmp_path: Path) -> None:
+    """``prune(live)`` removes entries whose key isn't in *live*.
+
+    Called after each search against the set of currently-live
+    device configurations; without this the cache would grow
+    without bound across long-lived dashboards as devices are
+    added and removed.
+    """
+    cache = YamlSearchCache()
+    a = tmp_path / "a.yaml"
+    b = tmp_path / "b.yaml"
+    a.write_text("wifi:\n", encoding="utf-8")
+    b.write_text("wifi:\n", encoding="utf-8")
+    await cache.get_lines("a.yaml", a)
+    await cache.get_lines("b.yaml", b)
+
+    # Only "a.yaml" is live now.
+    cache.prune(["a.yaml"])
+
+    # b.yaml's entry was removed — re-fetch hits the read path.
+    with patch.object(Path, "read_text", side_effect=AssertionError("a.yaml should be cached")):
+        await cache.get_lines("a.yaml", a)
+    # b.yaml is no longer cached, so a fresh fetch reads — this
+    # would raise if it were still cached (above) but works fine
+    # here because we removed b.yaml from the cache.
+    fresh = await cache.get_lines("b.yaml", b)
+    assert fresh == ["wifi:"]
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_misses_against_same_file_read_once(tmp_path: Path) -> None:
+    """Two simultaneous misses on the same file collapse to one read.
+
+    Without the cache lock both coroutines would stat + read and
+    write the same entry; the duplicate I/O is wasteful but not
+    incorrect. Pin the lock-mediated single-read behaviour by
+    counting ``read_text`` invocations across a parallel pair.
+    """
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("wifi:\n", encoding="utf-8")
+
+    real_read = Path.read_text
+    call_count = 0
+
+    def _counting_read(self: Path, *args: object, **kwargs: object) -> str:
+        nonlocal call_count
+        call_count += 1
+        return real_read(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    with patch.object(Path, "read_text", _counting_read):
+        a, b = await asyncio.gather(
+            cache.get_lines("kitchen.yaml", path),
+            cache.get_lines("kitchen.yaml", path),
+        )
+
+    assert a == b == ["wifi:"]
+    # One read, not two — the lock collapsed the second miss into
+    # a cache hit once the first finished.
+    assert call_count == 1

--- a/tests/controllers/devices/test_yaml_search_module.py
+++ b/tests/controllers/devices/test_yaml_search_module.py
@@ -208,10 +208,11 @@ async def test_total_results_cap_short_circuits_walk(tmp_path: Path) -> None:
     """Walk stops once ``max_results`` is reached.
 
     Pin both halves: total-matches cap is honoured, AND
-    ``live_configurations`` only contains devices we actually
-    visited (not the full input iterable). The cache-prune key
-    contract — devices we never walked stay in the cache for
-    the next search.
+    ``live_configurations`` reflects the *full* input device
+    list — not just the walked subset. The cache-prune key
+    contract: capped searches must not evict warm entries for
+    unwalked-but-still-live devices, otherwise the next
+    keystroke re-reads them from disk.
     """
     cache = YamlSearchCache()
     devices = [
@@ -233,10 +234,10 @@ async def test_total_results_cap_short_circuits_walk(tmp_path: Path) -> None:
 
     total_matches = sum(len(r["matches"]) for r in results)
     assert total_matches <= 2
-    # ``c`` and ``d`` were never visited because the cap was hit
-    # after walking ``a`` and ``b`` (both got their match before
-    # the next-iteration top-of-loop check fires).
-    assert "d" not in {p.removesuffix(".yaml") for p in live}
+    # All four devices in the input list — ``c`` and ``d`` were
+    # never walked because the cap was hit after ``a`` and ``b``,
+    # but they're still live so prune() must not evict them.
+    assert live == {"a.yaml", "b.yaml", "c.yaml", "d.yaml"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/devices/test_yaml_search_module.py
+++ b/tests/controllers/devices/test_yaml_search_module.py
@@ -1,0 +1,360 @@
+"""Coverage for ``_yaml_search.search_yaml_devices``.
+
+The end-to-end tests in ``test_search_yaml.py`` exercise the
+loop via ``DevicesController.search_yaml`` (lock + cache prune
+included). These tests pin the search loop in isolation:
+
+- Substring match shape and the ``(results, live_configurations)``
+  return tuple that the controller uses for cache pruning.
+- ``case_sensitive`` flag — caller is responsible for pre-lowering
+  the needle when False; pin both branches.
+- Per-file cap so a chatty match doesn't crowd out other devices.
+- Total-results cap stops the walk early; ``live_configurations``
+  reflects only the devices actually walked, not the full input
+  iterable.
+- Empty / matches list → device skipped from results entirely.
+- Cache miss (``get_lines`` returns ``None``) → device skipped
+  from results, NOT from ``live_configurations`` (we still saw
+  the device, just couldn't read its file).
+- ``await asyncio.sleep(0)`` between devices — the no-blocking-I/O
+  contract: a 100-device fleet's worth of in-memory line scans
+  must not run as a single uninterrupted task slice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.controllers.devices._yaml_search import (
+    search_yaml_devices,
+)
+from esphome_device_builder.controllers.devices._yaml_search_cache import (
+    YamlSearchCache,
+)
+
+
+@dataclass
+class _StubDevice:
+    """Minimal _DeviceLike stand-in.
+
+    Pins the Protocol's read-only contract — the function must
+    not reach for any other attributes. A typo / rename in the
+    real ``Device`` model that introduces a new dependency
+    surfaces here as ``AttributeError`` immediately.
+    """
+
+    name: str
+    friendly_name: str
+    configuration: str
+
+
+def _seed(tmp_path: Path, name: str, content: str) -> _StubDevice:
+    (tmp_path / f"{name}.yaml").write_text(content, encoding="utf-8")
+    return _StubDevice(name=name, friendly_name=name.title(), configuration=f"{name}.yaml")
+
+
+def _rel(tmp_path: Path):
+    return lambda c: tmp_path / c
+
+
+# ---------------------------------------------------------------------------
+# Match shape + return tuple
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_results_and_live_configurations(tmp_path: Path) -> None:
+    """Result tuple shape — pinned for the controller's cache prune.
+
+    The caller (``DevicesController.search_yaml``) uses the
+    returned ``live_configurations`` set to evict stale cache
+    entries for devices that have been deleted / archived. Pin
+    that the set has exactly the device configurations we walked
+    (whether or not they had matches).
+    """
+    cache = YamlSearchCache()
+    devices = [
+        _seed(tmp_path, "kitchen", "wifi:\n  ssid: home\n"),
+        _seed(tmp_path, "bedroom", "binary_sensor:\n  - platform: gpio\n"),
+    ]
+
+    results, live = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="wifi",
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=5,
+    )
+
+    assert len(results) == 1
+    hit = results[0]
+    assert hit["configuration"] == "kitchen.yaml"
+    assert hit["device_name"] == "kitchen"
+    assert hit["friendly_name"] == "Kitchen"
+    assert hit["matches"] == [{"line_number": 1, "line_text": "wifi:"}]
+    # Both devices walked → both in live_configurations, not just
+    # the one with a match. Cache prune key.
+    assert live == {"kitchen.yaml", "bedroom.yaml"}
+
+
+@pytest.mark.asyncio
+async def test_friendly_name_falls_back_to_device_name(tmp_path: Path) -> None:
+    """Empty ``friendly_name`` → result row uses ``device_name``.
+
+    Devices created without a friendly_name still need a
+    user-readable label in the dropdown; pin the fallback so a
+    refactor that drops the ``or device.name`` clause surfaces
+    as a result-shape regression.
+    """
+    cache = YamlSearchCache()
+    (tmp_path / "kitchen.yaml").write_text("wifi:\n", encoding="utf-8")
+    devices = [_StubDevice(name="kitchen", friendly_name="", configuration="kitchen.yaml")]
+
+    results, _ = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="wifi",
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=5,
+    )
+
+    assert results[0]["friendly_name"] == "kitchen"
+
+
+# ---------------------------------------------------------------------------
+# Case sensitivity (caller pre-lowers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_case_insensitive_caller_lowered_needle(tmp_path: Path) -> None:
+    """``case_sensitive=False`` lowers each line; needle is pre-lowered.
+
+    The caller (``DevicesController.search_yaml``) lowers the
+    needle once outside the loop so the per-line work isn't
+    paying for an extra ``str.lower()`` on the query at every
+    file. Pin that contract — passing an UPPER-cased needle
+    with ``case_sensitive=False`` would silently miss matches.
+    """
+    cache = YamlSearchCache()
+    devices = [_seed(tmp_path, "kitchen", "WIFI:\n")]
+
+    results, _ = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="wifi",  # already lowered
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=5,
+    )
+
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_case_sensitive_distinguishes_case(tmp_path: Path) -> None:
+    """``case_sensitive=True`` treats each line as-is."""
+    cache = YamlSearchCache()
+    devices = [_seed(tmp_path, "kitchen", "wifi:\n")]
+
+    results, _ = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="WIFI",
+        case_sensitive=True,
+        max_results=50,
+        per_file_cap=5,
+    )
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_file_cap_truncates_matches(tmp_path: Path) -> None:
+    """One device's match list caps at ``per_file_cap``."""
+    cache = YamlSearchCache()
+    devices = [_seed(tmp_path, "kitchen", "\n".join(f"# wifi {i}" for i in range(10)))]
+
+    results, _ = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="wifi",
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=3,
+    )
+
+    assert len(results[0]["matches"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_total_results_cap_short_circuits_walk(tmp_path: Path) -> None:
+    """Walk stops once ``max_results`` is reached.
+
+    Pin both halves: total-matches cap is honoured, AND
+    ``live_configurations`` only contains devices we actually
+    visited (not the full input iterable). The cache-prune key
+    contract — devices we never walked stay in the cache for
+    the next search.
+    """
+    cache = YamlSearchCache()
+    devices = [
+        _seed(tmp_path, "a", "wifi:\n"),
+        _seed(tmp_path, "b", "wifi:\n"),
+        _seed(tmp_path, "c", "wifi:\n"),
+        _seed(tmp_path, "d", "wifi:\n"),
+    ]
+
+    results, live = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="wifi",
+        case_sensitive=False,
+        max_results=2,
+        per_file_cap=5,
+    )
+
+    total_matches = sum(len(r["matches"]) for r in results)
+    assert total_matches <= 2
+    # ``c`` and ``d`` were never visited because the cap was hit
+    # after walking ``a`` and ``b`` (both got their match before
+    # the next-iteration top-of-loop check fires).
+    assert "d" not in {p.removesuffix(".yaml") for p in live}
+
+
+# ---------------------------------------------------------------------------
+# Skip behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unmatched_device_omitted_from_results(tmp_path: Path) -> None:
+    """A device with no matches is skipped from ``results``."""
+    cache = YamlSearchCache()
+    devices = [
+        _seed(tmp_path, "kitchen", "wifi:\n"),
+        _seed(tmp_path, "bedroom", "binary_sensor:\n"),
+    ]
+
+    results, live = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="wifi",
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=5,
+    )
+
+    assert [r["configuration"] for r in results] == ["kitchen.yaml"]
+    # ``bedroom`` walked but unmatched — still in
+    # live_configurations so its cache entry doesn't get
+    # spuriously evicted.
+    assert live == {"kitchen.yaml", "bedroom.yaml"}
+
+
+@pytest.mark.asyncio
+async def test_unreadable_file_skipped_but_visited(tmp_path: Path) -> None:
+    """Cache returns ``None`` → device skipped from results.
+
+    The scanner's index can briefly disagree with the filesystem.
+    A vanished YAML must not blow up the search — the cache's
+    ``get_lines`` returns ``None`` and we move on to the next
+    device. The device IS still in ``live_configurations`` (we
+    visited it) so the cache prune step doesn't see it as a
+    "deleted" device the very next call.
+    """
+    cache = YamlSearchCache()
+    # Seed only kitchen.yaml — bedroom is intentionally absent.
+    seed = _seed(tmp_path, "kitchen", "wifi:\n")
+    bedroom = _StubDevice(name="bedroom", friendly_name="Bedroom", configuration="bedroom.yaml")
+    devices = [seed, bedroom]
+
+    results, live = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="wifi",
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=5,
+    )
+
+    assert [r["configuration"] for r in results] == ["kitchen.yaml"]
+    assert "bedroom.yaml" in live
+
+
+# ---------------------------------------------------------------------------
+# Event-loop yield
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_yields_to_event_loop_between_devices(tmp_path: Path) -> None:
+    """``await asyncio.sleep(0)`` between devices keeps the loop responsive.
+
+    For a fully-warm cache (no disk I/O on subsequent searches),
+    the per-device scan is in-memory and would otherwise run as
+    a single uninterrupted task slice. The explicit yield gives
+    the WS dispatcher and other tasks a chance to interleave.
+    Pin the contract by counting how many times a sibling
+    ``asyncio.sleep(0)``-driven counter ticks during the walk:
+    at least once per device, since each device-loop iteration
+    awaits before the next.
+    """
+    cache = YamlSearchCache()
+    # Five devices, all with a match so the loop hits its
+    # full per-device path (read + scan + match + yield).
+    devices = [_seed(tmp_path, f"d{i}", "wifi:\n") for i in range(5)]
+    # Pre-populate the cache so the search itself does no disk
+    # I/O — any yields observed below come from the explicit
+    # sleep(0) inside the loop, not from cache.get_lines.
+    for d in devices:
+        await cache.get_lines(d.configuration, tmp_path / d.configuration)
+
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while not stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0)
+
+    ticker_task = asyncio.create_task(_ticker())
+    try:
+        await search_yaml_devices(
+            devices=devices,
+            cache=cache,
+            rel_path=_rel(tmp_path),
+            needle="wifi",
+            case_sensitive=False,
+            max_results=50,
+            per_file_cap=5,
+        )
+    finally:
+        stop.set()
+        await ticker_task
+
+    # At least one tick per device — the per-iteration yield
+    # gave the ticker a chance to run between devices. Without
+    # the yield, the search would have monopolised the slice
+    # and the ticker would only run after the search returned.
+    assert ticks >= len(devices)

--- a/tests/fixtures/yaml_search/bluetooth_proxy.yaml
+++ b/tests/fixtures/yaml_search/bluetooth_proxy.yaml
@@ -1,0 +1,43 @@
+esphome:
+  name: esp32-bluetooth-proxy
+  friendly_name: Bluetooth Proxy
+  min_version: 2025.2.1
+  name_add_mac_suffix: true
+
+esp32:
+  board: esp32-c3-devkitm-1
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_BT_BLE_42_FEATURES_SUPPORTED: y
+      CONFIG_BT_BLE_50_FEATURES_SUPPORTED: n
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+api:
+logger:
+
+ota:
+  - platform: esphome
+    id: ota_esphome
+
+esp32_ble_tracker:
+  scan_parameters:
+    # We currently use the defaults to ensure Bluetooth
+    # can co-exist with WiFi In the future we may be able to
+    # enable the built-in coexistence logic in ESP-IDF
+    active: true
+
+bluetooth_proxy:
+  active: true
+
+button:
+  - platform: safe_mode
+    id: button_safe_mode
+    name: Safe Mode Boot
+
+  - platform: factory_reset
+    id: factory_reset_btn
+    name: Factory reset

--- a/tests/fixtures/yaml_search/ethernet_proxy.yaml
+++ b/tests/fixtures/yaml_search/ethernet_proxy.yaml
@@ -1,0 +1,65 @@
+---
+esphome:
+  name: "ethernet-tv-cabinet"
+
+esp32:
+  board: esp32-evb
+  framework:
+    type: esp-idf
+
+# Ethernet connection — this device has no WiFi.
+ethernet:
+  type: LAN8720
+  mdc_pin: GPIO23
+  mdio_pin: GPIO18
+  clk_mode: GPIO0_IN
+  phy_addr: 0
+
+# Enable logging.
+logger:
+
+# Enable Home Assistant API.
+api:
+
+# Enable over-the-air updates.
+ota:
+  platform: esphome
+
+
+esp32_ble_tracker:
+  scan_parameters:
+    active: false
+bluetooth_proxy:
+  active: true
+
+
+# Sync time with Home Assistant.
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+
+# Text sensors with general information.
+text_sensor:
+  # Expose ESPHome version as sensor.
+  - platform: version
+    name: TV Cabinet ESPHome Version
+
+# Sensors with general information.
+sensor:
+  # Uptime sensor.
+  - platform: uptime
+    name: TV Cabinet Uptime
+
+# Exposed switches.
+switch:
+  # Switch to restart the device.
+  - platform: restart
+    name: TV Cabinet Restart
+  - platform: gpio
+    pin: GPIO32
+    name: "TV Cabinet Relay #1"
+    id: relay1
+  - platform: gpio
+    pin: GPIO33
+    name: "TV Cabinet Relay #2"
+    id: relay2

--- a/tests/fixtures/yaml_search/packaged_device.yaml
+++ b/tests/fixtures/yaml_search/packaged_device.yaml
@@ -1,0 +1,23 @@
+substitutions:
+  name: packaged-device
+  friendly_name: Packaged Device
+
+packages:
+  remote_package:
+    url: https://github.com/example/example-package
+    ref: main
+    files: [device.yaml]
+    refresh: 1s
+
+esphome:
+  name: ${name}
+  name_add_mac_suffix: false
+  friendly_name: ${friendly_name}
+
+api:
+
+runtime_stats:
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/tests/fixtures/yaml_search/smart_plug.yaml
+++ b/tests/fixtures/yaml_search/smart_plug.yaml
@@ -1,0 +1,60 @@
+# Basic Config
+esphome:
+  name: smart_plug_a
+  platform: ESP8266
+  board: esp01_1m
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  ap:
+    ssid: $devicename Fallback Hotspot
+    password: !secret ap_password
+
+logger:
+  baud_rate: 0  # (UART logging interferes with cse7766)
+api:
+ota:
+
+# Device Specific Config
+
+uart:
+  rx_pin: RX
+  baud_rate: 4800
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO0
+      mode: INPUT_PULLUP
+      inverted: True
+    name: "Smart Plug Button"
+    on_press:
+      - switch.toggle: relay
+  - platform: status
+    name: "Smart Plug Status"
+
+sensor:
+  - platform: wifi_signal
+    name: "Smart Plug WiFi Signal"
+    update_interval: 60s
+  - platform: cse7766
+    current:
+      name: "Smart Plug Current"
+      accuracy_decimals: 1
+    voltage:
+      name: "Smart Plug Voltage"
+      accuracy_decimals: 1
+    power:
+      name: "Smart Plug Power"
+      accuracy_decimals: 1
+switch:
+  - platform: gpio
+    name: "Smart Plug Relay"
+    pin: GPIO12
+    id: relay
+    restore_mode: RESTORE_DEFAULT_ON
+
+status_led:
+  pin: GPIO13


### PR DESCRIPTION
Backend half of esphome/device-builder-frontend#152.

## Summary

The dashboard's existing search box filters the device list by name only. Users can't find a device by what's *inside* its YAML. New `yaml/search` WS command is the substrate for the frontend's full-content search dropdown (frontend PR follows separately).

## API shape

```json
// request
{ "query": "wifi", "max_results": 50, "case_sensitive": false }

// response
[
  {
    "configuration": "kitchen.yaml",
    "device_name": "kitchen",
    "friendly_name": "Kitchen Lamp",
    "matches": [
      { "line_number": 3, "line_text": "wifi:" },
      ...
    ]
  }
]
```

- Per-file matches cap at 5 (constant `_YAML_SEARCH_PER_FILE_MATCH_CAP`) so a chatty match (e.g. `:` against a deeply-nested config) doesn't drown hits in other devices.
- Total result count caps at `max_results` so the dropdown stays usable.
- Empty / whitespace queries short-circuit before touching disk — a stray empty debounce fire from the frontend shouldn't iterate every YAML.

## Concurrency / I/O hygiene

The walk + cache live in their own modules (`_yaml_search.py`, `_yaml_search_cache.py`):

- **`YamlSearchCache`** memoises `(mtime_ns, split_lines)` per file. The frontend debounces keystrokes but still fires one search per pause; on a 100-device fleet that's 100 reads + 100 splitlines per keystroke without a cache. With it, every keystroke after the first becomes a stat-and-grep against an already-split list. Internal `asyncio.Lock` serialises stat-check-read-update so two concurrent misses on the same file don't both spawn a duplicate read.
- **Controller-level `_yaml_search_lock`** serialises the whole walk so two concurrent searches don't double up on stat / read calls against the same fleet. Pairs with the frontend's concurrency-of-1 dispatcher in #153.
- **Per-iteration `await asyncio.sleep(0)`** between devices yields to the event loop on a fully-warm cache (no per-device disk yield) so a 100-device fleet's worth of in-memory line scans doesn't run as a single uninterrupted task slice.
- **No `scan()` per call** — search runs once per debounced keystroke and a per-keystroke disk scan against the whole config dir would dominate the round-trip cost. New YAMLs become visible on the next periodic scan.

## Out of scope (follow-ups)

- Search expanded `packages:` / `!include` content. Would need a separate "matched in package X line Y" render shape on the frontend; queued for a future round.
- Regex / glob queries — start with substring.
- Surfacing broken / unparseable YAMLs that the scanner failed to materialise into a `Device` (would need a "this YAML didn't parse" badge in the dropdown).

## Tests

26 tests across three files, both new modules at 100% line coverage:

- `test_search_yaml.py` — 11 e2e tests: empty-query short-circuit, substring match shape, friendly_name fallback, case sensitivity (default + opt-in), per-file cap, total-results cap, missing-file robustness, plus a serialisation pin spying on the cache to assert `max_in_flight == 1` across two `asyncio.gather`-launched calls.
- `test_yaml_search_module.py` — 9 tests targeting `search_yaml_devices` in isolation: result-tuple shape (results + live_configurations as the cache-prune key), case-sensitivity branches (caller pre-lowers), per-file + total caps with `live_configurations` only containing visited devices, unmatched-device skip, missing-file skip, and a per-iteration event-loop-yield pin (counts a sibling ticker's runs).
- `test_yaml_search_cache.py` — 7 tests on `YamlSearchCache` in isolation: cold/warm read-through, mtime invalidation, missing-file → None + stale-entry cleanup, stat-OK / read-fails branch, prune, and a concurrency pin asserting two parallel misses collapse to a single `read_text`.

213 devices-controller tests pass overall.

## Test plan

- [ ] Submit a search query against a real fleet via the dashboard's WS UI (companion frontend PR) — backend returns matches in the documented shape.
- [ ] Empty / whitespace queries return `[]` immediately.
- [ ] A device whose YAML was rm'd between scan and search doesn't 500 the request.
- [ ] Edit a YAML in the editor, save, re-search — new content visible (mtime invalidation).
- [ ] Hammer the WS with concurrent searches — only one fleet walk in flight at a time.