### PR TITLE
Add More Functionality To Starter Kit

### DIFF
--- a/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
@@ -28,6 +28,8 @@ tags:
 - starter-kit
 - rgb-led
 - usb-c
+- lipo
+- battery
 docs_url: https://wiki.apolloautomation.com/products/esk1/buttongettingstarted/
 product_url: https://apolloautomation.com/products/esk-1-esphome-starter-kit
 featured: true
@@ -147,9 +149,11 @@ featured_components:
     i2c_id: i2c_bus
     update_interval: 60s
     battery_voltage:
-      name: Battery Voltage
+      value:
+        name: Battery Voltage
     battery_level:
-      name: Battery Level
+      value:
+        name: Battery Level
 - id: accessory_power
   component_id: switch.gpio
   name: Accessory Power Rail

--- a/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
@@ -56,7 +56,12 @@ pins:
   features:
   - adc
   available: true
-  notes: Available on FPC connector
+  notes: FPC connector — default pin for the bundled PIR motion module
+- gpio: 4
+  label: ACCESSORY_PWR
+  available: false
+  occupied_by: Accessory power switch (controls FPC module power rail)
+  notes: Internal GPIO switch, ALWAYS_ON with setup_priority 2000 — must latch high before FPC modules enumerate
 - gpio: 5
   label: RGB_LED
   features:
@@ -95,16 +100,14 @@ pins:
   - adc
   available: true
   notes: Available on FPC connector
-- gpio: 30
-  label: RX
-  features:
-  - uart_rx
-  available: true
-- gpio: 31
-  label: TX
+- gpio: 16
+  label: TXD0
   features:
   - uart_tx
-  available: true
+- gpio: 17
+  label: RXD0
+  features:
+  - uart_rx
 featured_components:
 - id: i2c_bus
   component_id: i2c
@@ -131,6 +134,22 @@ featured_components:
     id: aht20
     name: AHT20 Temperature & Humidity
     variant: AHT20
+- id: accessory_power
+  component_id: switch.gpio
+  name: Accessory Power Rail
+  description: |
+    Internal GPIO switch that gates power to the FPC accessory connectors.
+    Must be ALWAYS_ON with an early setup_priority so the AHT20, PIR, RGB+buzzer
+    and other plug-in modules are powered before they enumerate. Marked
+    ``internal`` so it doesn't surface as a user-controllable entity.
+  fields:
+    id: accessory_power
+    pin:
+      value: 4
+    name: Accessory Power
+    restore_mode: ALWAYS_ON
+    setup_priority: 2000
+    internal: true
 - id: pir_motion
   component_id: binary_sensor.gpio
   name: PIR Motion Module (MH-SR602)
@@ -142,6 +161,42 @@ featured_components:
     pin:
       value: 3
     device_class: motion
+- id: boot_button
+  component_id: binary_sensor.gpio
+  name: Boot Button (onboard)
+  description: |
+    Physical pushbutton on the dev board tied to GPIO9. Active-low with the
+    chip's internal pull-up, so configure with ``mode: INPUT_PULLUP`` and
+    ``inverted: true``. Doubles as the bootloader strapping pin — hold while
+    powering the board to enter download mode.
+  fields:
+    id: boot_button
+    name: Boot Button
+    pin:
+      value:
+        number: 9
+        mode:
+          input: true
+          pullup: true
+        inverted: true
+      locked: true
+- id: button_module
+  component_id: binary_sensor.gpio
+  name: Button Module (FPC accessory)
+  description: |
+    Plug-in pushbutton accessory module. Wired to GPIO6 on the FPC connector;
+    active-low with internal pull-up so the ``inverted`` flag turns "pressed"
+    into the on state.
+  fields:
+    id: button_1
+    name: Button 1
+    pin:
+      value:
+        number: 6
+        mode:
+          input: true
+          pullup: true
+        inverted: true
 - id: rgb_strip
   component_id: light.esp32_rmt_led_strip
   name: RGB LED Strip (addon module)

--- a/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
@@ -134,6 +134,22 @@ featured_components:
     id: aht20
     name: AHT20 Temperature & Humidity
     variant: AHT20
+- id: battery_monitor
+  component_id: sensor.max17043
+  name: Battery Fuel Gauge (MAX17048)
+  description: |
+    Onboard MAX17048 fuel gauge for monitoring a LiPo battery. ESPHome's
+    ``max17043`` driver speaks the same I²C protocol (fixed address
+    ``0x36``, VCELL + SOC register layout) and reads voltage and
+    state-of-charge correctly without any external component.
+  fields:
+    id: battery_monitor
+    i2c_id: i2c_bus
+    update_interval: 60s
+    battery_voltage:
+      name: Battery Voltage
+    battery_level:
+      name: Battery Level
 - id: accessory_power
   component_id: switch.gpio
   name: Accessory Power Rail


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Adds more functionality to the starter kit board. Buttons & battery

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [ ] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [ ] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
