### PR TITLE
yaml/search: cap per-file scan to 5000 lines AND load to 8 MiB

### DIFF
--- a/esphome_device_builder/controllers/devices/_yaml_search.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search.py
@@ -35,6 +35,19 @@ if TYPE_CHECKING:
     from ._yaml_search_cache import YamlSearchCache
 
 
+# Largest line index that can ever appear in a search hit. Files
+# longer than this are still cached in full, but the search loop
+# scans only the first ``MAX_LINES_PER_FILE`` lines — a defence
+# against pathological configs (machine-generated YAML, runaway
+# lambda blocks, accidentally-checked-in build output) tying up
+# the per-keystroke search loop while we walk tens of thousands
+# of lines for a no-match needle. Set high enough that no
+# realistic packaged ESPHome config (hundreds of sensors) hits
+# it, but low enough that the worst case stays sub-millisecond
+# warm-cache.
+MAX_LINES_PER_FILE = 5000
+
+
 def scan_lines(
     lines: list[str],
     needle: str,
@@ -54,7 +67,9 @@ def scan_lines(
     Returns up to *max_take* matches. The caller folds two
     upstream caps (``per_file_cap``, the remaining
     ``max_results`` budget across the fleet) into a single
-    ``max_take`` value before calling.
+    ``max_take`` value before calling. The
+    ``MAX_LINES_PER_FILE`` pathological-file cap is also applied
+    by the caller via a pre-slice on *lines*.
 
     *needle* must be pre-lowered when ``case_sensitive`` is
     ``False`` — the caller lowers it once outside the per-file
@@ -148,6 +163,17 @@ async def search_yaml_devices(
             await asyncio.sleep(0)
             continue
 
+        # Pathologically-large files (machine-generated configs,
+        # accidentally-checked-in build output, runaway lambda
+        # blocks) would otherwise tie up the per-keystroke search
+        # for tens of milliseconds while we scan tens of thousands
+        # of lines for a no-match needle. Cap the scan window to
+        # ``MAX_LINES_PER_FILE``; substring matches past that line
+        # silently drop out of search results. The cache still
+        # holds the full file (so the editor's other code paths
+        # see the real content) — only the search loop is bounded.
+        scannable = lines if len(lines) <= MAX_LINES_PER_FILE else lines[:MAX_LINES_PER_FILE]
+
         # Fold per-file + remaining-budget caps into a single
         # ``max_take`` and hand off to the synchronous scan
         # helper. The previous inline loop had two break paths
@@ -155,7 +181,7 @@ async def search_yaml_devices(
         # max_results); both collapse cleanly into
         # ``min(per_file_cap, remaining)``.
         max_take = min(per_file_cap, max_results - total_matches)
-        matches = scan_lines(lines, needle, case_sensitive=case_sensitive, max_take=max_take)
+        matches = scan_lines(scannable, needle, case_sensitive=case_sensitive, max_take=max_take)
 
         if matches:
             results.append(

--- a/esphome_device_builder/controllers/devices/_yaml_search_cache.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search_cache.py
@@ -36,6 +36,25 @@ from pathlib import Path
 _LOGGER = logging.getLogger(__name__)
 
 
+# Hard byte ceiling on any single file the search cache will
+# load into memory. Files past this size are *not* loaded — the
+# cache returns ``None`` and the search loop skips them.
+#
+# 8 MiB comfortably holds every realistic ESPHome config (the
+# largest packaged ratgdo / Apollo configs land around 100 KiB
+# even with hundreds of binary_sensor blocks). The cap exists
+# to defend against pathological cases — machine-generated
+# YAML, accidentally-checked-in build output, runaway lambda
+# blocks producing megabytes of source — that would otherwise
+# pin tens or hundreds of megabytes per device into the cache
+# for a feature that's only meant to surface line-grep matches.
+#
+# Pairs with ``_yaml_search.MAX_LINES_PER_FILE``: the line cap
+# bounds *scan* time, this byte cap bounds *memory*. Both are
+# sized so realistic configs are unaffected.
+MAX_FILE_BYTES = 8 * 1024 * 1024
+
+
 class YamlSearchCache:
     """Async-safe (mtime, lines) cache for raw device YAML files."""
 
@@ -51,17 +70,37 @@ class YamlSearchCache:
         the previously-split lines without touching disk again.
         Otherwise reads + splits and stores the result.
 
-        Returns ``None`` (and removes any stale cache entry) when
-        the file is gone or unreadable. Errors are logged at DEBUG
-        — they're routine in a fleet that's actively being edited
-        — and never propagate; ``yaml/search`` is best-effort
-        across the fleet, not a per-device contract.
+        Returns ``None`` (and removes any stale cache entry) when:
+
+        - the file is gone or unreadable (errors logged at DEBUG —
+          they're routine in a fleet that's actively being edited
+          — and never propagate; ``yaml/search`` is best-effort
+          across the fleet, not a per-device contract);
+        - the file's on-disk size exceeds ``MAX_FILE_BYTES``. The
+          byte ceiling is checked from ``stat.st_size`` *before*
+          ``read_text``, so a pathological multi-megabyte YAML
+          never gets loaded into Python memory in the first place
+          — the cache stays bounded regardless of what the
+          filesystem holds.
         """
         async with self._lock:
             try:
                 stat = await asyncio.to_thread(path.stat)
             except OSError as exc:
                 _LOGGER.debug("yaml-search-cache: stat %s failed: %s", configuration, exc)
+                self._entries.pop(configuration, None)
+                return None
+
+            if stat.st_size > MAX_FILE_BYTES:
+                _LOGGER.debug(
+                    "yaml-search-cache: %s is %d bytes, over %d-byte cap — skipped",
+                    configuration,
+                    stat.st_size,
+                    MAX_FILE_BYTES,
+                )
+                # Drop any stale entry from a previous call when
+                # the file was smaller — the search loop should
+                # treat the device as unreadable now.
                 self._entries.pop(configuration, None)
                 return None
 

--- a/tests/benchmarks/test_yaml_search.py
+++ b/tests/benchmarks/test_yaml_search.py
@@ -37,9 +37,16 @@ from __future__ import annotations
 
 from pytest_codspeed import BenchmarkFixture
 
-from esphome_device_builder.controllers.devices._yaml_search import scan_lines
+from esphome_device_builder.controllers.devices._yaml_search import (
+    MAX_LINES_PER_FILE,
+    scan_lines,
+)
 
-_TARGET_LINES = 5000
+# Pin the benchmark fixture's line count to the production
+# pathological-file cap so the two stay in sync — if the cap
+# moves, the benchmark moves with it and we keep measuring
+# "the largest file the search loop actually scans".
+_TARGET_LINES = MAX_LINES_PER_FILE
 
 
 def _generate_yaml(target_lines: int) -> list[str]:

--- a/tests/controllers/devices/test_yaml_search_cache.py
+++ b/tests/controllers/devices/test_yaml_search_cache.py
@@ -31,6 +31,7 @@ from unittest.mock import patch
 import pytest
 
 from esphome_device_builder.controllers.devices._yaml_search_cache import (
+    MAX_FILE_BYTES,
     YamlSearchCache,
 )
 
@@ -253,3 +254,77 @@ async def test_concurrent_misses_against_same_file_read_once(tmp_path: Path) -> 
     # One read, not two — the lock collapsed the second miss into
     # a cache hit once the first finished.
     assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Byte-size cap (pathological-file defence)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oversize_file_returns_none_without_loading(tmp_path: Path) -> None:
+    """Files past ``MAX_FILE_BYTES`` are skipped *before* read_text fires.
+
+    Defends the cache's memory footprint against pathological
+    files (machine-generated YAML, accidentally-checked-in build
+    output). The on-disk size is checked from ``stat.st_size``;
+    if the file is over the cap, ``read_text`` is never called
+    and no entry lands in the cache.
+
+    Pin both halves: returns ``None``, AND ``read_text`` was not
+    invoked (i.e. we didn't pay the megabyte read cost just to
+    immediately drop it).
+    """
+    cache = YamlSearchCache()
+    path = tmp_path / "huge.yaml"
+    # One byte past the cap — minimum to exercise the >cap branch.
+    path.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
+
+    real_read = Path.read_text
+    read_calls = 0
+
+    def _counting_read(self: Path, *args: object, **kwargs: object) -> str:
+        nonlocal read_calls
+        read_calls += 1
+        return real_read(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    with patch.object(Path, "read_text", _counting_read):
+        result = await cache.get_lines("huge.yaml", path)
+
+    assert result is None
+    assert read_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_oversize_file_drops_stale_cache_entry(tmp_path: Path) -> None:
+    """A previously-cached small file is evicted if it grows past the cap.
+
+    The byte cap is checked on every call (not just on the first
+    cold one), so a file that lived in the cache while small and
+    then grew past the cap drops out cleanly — the next call
+    returns ``None`` and the entry is removed. Pin via a third
+    call confirming the entry isn't merely shadowed.
+    """
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("wifi:\n", encoding="utf-8")
+    first = await cache.get_lines("kitchen.yaml", path)
+    assert first == ["wifi:"]
+
+    # Grow past the cap and bump mtime so the cache would
+    # otherwise miss + re-read.
+    path.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
+    new_mtime = path.stat().st_mtime_ns + 1_000_000_000
+    os.utime(path, ns=(new_mtime, new_mtime))
+
+    second = await cache.get_lines("kitchen.yaml", path)
+    assert second is None
+
+    # Shrink back below the cap; the next call should re-populate
+    # from scratch (the previous oversize call must have dropped
+    # the entry, otherwise we'd see a stale empty / shadow result).
+    path.write_text("api:\n", encoding="utf-8")
+    new_mtime += 1_000_000_000
+    os.utime(path, ns=(new_mtime, new_mtime))
+    third = await cache.get_lines("kitchen.yaml", path)
+    assert third == ["api:"]

--- a/tests/controllers/devices/test_yaml_search_module.py
+++ b/tests/controllers/devices/test_yaml_search_module.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import pytest
 
 from esphome_device_builder.controllers.devices._yaml_search import (
+    MAX_LINES_PER_FILE,
     search_yaml_devices,
 )
 from esphome_device_builder.controllers.devices._yaml_search_cache import (
@@ -182,6 +183,61 @@ async def test_case_sensitive_distinguishes_case(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Caps
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_max_lines_per_file_caps_pathological_files(tmp_path: Path) -> None:
+    """Files past ``MAX_LINES_PER_FILE`` lines are scanned only up to the cap.
+
+    Pathological configs (machine-generated YAML, runaway lambda
+    blocks) would otherwise tie up the per-keystroke search loop
+    while we walk tens of thousands of lines for a no-match
+    needle. The cap defends the worst case — substring matches
+    past line ``MAX_LINES_PER_FILE`` silently drop out, so the
+    loop's hot path stays bounded.
+
+    Pin the contract:
+    - a match at the cap boundary IS returned (last in-range line);
+    - a match past the cap is NOT returned (first out-of-range
+      line should be invisible to search);
+    - the line numbers in the result remain 1-indexed against the
+      scanned slice (which is the same as the file line number,
+      since we slice from line 1).
+    """
+    cache = YamlSearchCache()
+    # ``MAX_LINES_PER_FILE`` lines of filler then two unique-needle
+    # lines: the first lands exactly AT the cap (last scanned line),
+    # the second lands past the cap (must be invisible).
+    filler = "\n".join("# noise" for _ in range(MAX_LINES_PER_FILE - 1))
+    content = f"{filler}\n# tag-at-cap\n# tag-past-cap\n"
+    devices = [_seed(tmp_path, "huge", content)]
+
+    results, _ = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="tag-at-cap",
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=10,
+    )
+    assert results[0]["matches"] == [
+        {"line_number": MAX_LINES_PER_FILE, "line_text": "# tag-at-cap"}
+    ]
+
+    # Same file, different needle that only appears past the cap.
+    # ``cache`` is reused; the in-memory line list still holds the
+    # full file (we cap the search, not the cache).
+    results, _ = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="tag-past-cap",
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=10,
+    )
+    assert results == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Defend the YAML-search hot path against pathologically-large configs with two paired caps:

- **`MAX_LINES_PER_FILE = 5000`** (in `_yaml_search.py`) — bounds *scan time* per file. Substring matches past line 5000 silently drop out of search results. The cache still holds the full file (so the editor's other code paths see real content); only the per-keystroke search loop is bounded.

- **`MAX_FILE_BYTES = 8 * 1024 * 1024`** (in `_yaml_search_cache.py`) — bounds *memory*. Checked from `stat.st_size` *before* `read_text`, so a multi-megabyte YAML never gets loaded into Python memory in the first place. Files past this size are skipped entirely (cache returns `None`; the search loop already handles that as "device unreadable").

The two go together: capping scan without capping load lets a single 100 MB YAML pin 100 MB per fleet member; capping load without capping scan still ties up the keystroke loop on a 4 MB file. Both are sized so realistic configs are unaffected — the largest packaged ESPHome configs (full ratgdo / Apollo packages, hundreds of binary_sensors) land around 100 KB and a few hundred lines.

Targets the worst-case shape that the codspeed benchmarks (#315) measure.

Frontend impact: none. Search results past line 5000 simply stop appearing for the (very rare) files past that size, and over-8-MiB files become invisible to search. The `?line=N` deep-link path on the device editor and the editor itself are unaffected — both load via different code paths.

## Test plan

- [x] `uv run pytest tests/controllers/devices/test_yaml_search_module.py tests/controllers/devices/test_yaml_search_cache.py -v` — 38/38 green, including:
  - `test_max_lines_per_file_caps_pathological_files` — match at the cap boundary IS returned, match past the cap is NOT, line numbers stay 1-indexed.
  - `test_oversize_file_returns_none_without_loading` — `read_text` is never called for an over-cap file (defends the "we don't pay the megabyte read cost" promise).
  - `test_oversize_file_drops_stale_cache_entry` — a file that grows past the cap evicts its previous in-cache version, and shrinking back below repopulates from scratch rather than serving a stale shadow.
- [x] `tests/benchmarks/test_yaml_search.py --codspeed` numbers unchanged for in-cap files (the benchmark fixture is exactly `MAX_LINES_PER_FILE` lines so the slice is a no-op on the benchmarked path).
- [ ] CI green on the regular test matrix.