### PR TITLE
Restrict pr-labels workflow to minimum permissions

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -17,6 +17,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   pr_labels:
     name: Verify


### PR DESCRIPTION
# What does this implement/fix?

Add an explicit `permissions: {}` block to the pr-labels workflow.
The `ludeeus/action-require-labels` action only inspects labels from
the event payload and makes no GitHub API calls, so dropping the
inherited `GITHUB_TOKEN` scopes to none removes a needless attack
surface without affecting behaviour.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.