### PR TITLE
editor: include configuration in vscode-spawn log

### DIFF
--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -31,6 +31,7 @@ _VALIDATE_TIMEOUT = 30.0
 class _EditorSession:
     """Per-configuration validator state: one warm subprocess plus a serialization lock."""
 
+    configuration: str
     proc: asyncio.subprocess.Process | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
@@ -75,7 +76,16 @@ class EditorController:
 
         config_dir = str(self._db.settings.config_dir)
         cmd = [*self._esphome_cmd, "vscode", config_dir, "--ace"]
-        _LOGGER.info("Spawning vscode subprocess: %s", " ".join(cmd))
+        # Include the session's configuration so a fleet-wide log
+        # can distinguish "two different files opened" (expected:
+        # one warm subprocess per config) from "same file
+        # respawned after a timeout / crash". The cmd line itself
+        # only carries the config-dir, not the specific file.
+        _LOGGER.info(
+            "Spawning vscode subprocess for %s: %s",
+            session.configuration,
+            " ".join(cmd),
+        )
         session.proc = await create_subprocess_exec(
             *cmd,
             stdin=asyncio.subprocess.PIPE,
@@ -163,7 +173,9 @@ class EditorController:
         ``message`` and (for validation errors) a ``range`` with
         ``{start_line, start_col, end_line, end_col}`` (0-indexed).
         """
-        session = self._sessions.setdefault(configuration, _EditorSession())
+        session = self._sessions.setdefault(
+            configuration, _EditorSession(configuration=configuration)
+        )
         async with session.lock:
             try:
                 return await asyncio.wait_for(

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -180,7 +180,7 @@ async def test_validate_locked_returns_result_payload(tmp_path: Path) -> None:
     the dashboard's editor renders both inline.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, _reader, stdin_capture = _make_fake_proc(
         [
             dumps(
@@ -217,7 +217,7 @@ async def test_validate_locked_handles_read_file_round_trip(tmp_path: Path) -> N
     is reading.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, reader, stdin_capture = _make_fake_proc(
         [
             dumps({"type": "read_file", "path": "kitchen.yaml"}) + b"\n",
@@ -272,7 +272,7 @@ async def test_validate_locked_raises_when_subprocess_closes_stdout(
     process.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, reader, _ = _make_fake_proc([])
     reader.feed_eof()
     session.proc = proc
@@ -296,8 +296,8 @@ async def test_stop_terminates_all_sessions(tmp_path: Path) -> None:
     previous config dir.
     """
     controller = _make_controller(tmp_path)
-    session_a = _EditorSession()
-    session_b = _EditorSession()
+    session_a = _EditorSession(configuration="a.yaml")
+    session_b = _EditorSession(configuration="b.yaml")
     controller._sessions = {"a.yaml": session_a, "b.yaml": session_b}
     controller._terminate_subprocess = AsyncMock()  # type: ignore[method-assign]
 
@@ -362,7 +362,7 @@ async def test_ensure_subprocess_no_op_when_proc_already_running(
     every validation's wall-clock cost.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, *_ = _make_fake_proc([])
     session.proc = proc
     spawned = False
@@ -398,7 +398,7 @@ async def test_ensure_subprocess_spawns_and_drains_version_line(
     this branch protects against a refactor that drops the readline.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, reader, _ = _make_fake_proc([dumps({"type": "version", "version": "1.0"}) + b"\n"])
 
     async def _fake_spawn(*_args: Any, **_kwargs: Any) -> Any:
@@ -431,7 +431,7 @@ async def test_ensure_subprocess_terminates_session_and_raises_on_startup_timeou
     runs.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, _reader, _ = _make_fake_proc([])  # no lines → readline blocks
 
     async def _fake_spawn(*_args: Any, **_kwargs: Any) -> Any:
@@ -474,7 +474,7 @@ async def test_terminate_subprocess_no_op_when_session_proc_is_none(
 ) -> None:
     """No proc → return immediately, no surprise calls."""
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     session.proc = None
     await controller._terminate_subprocess(session)
 
@@ -485,7 +485,7 @@ async def test_terminate_subprocess_no_op_when_proc_already_exited(
 ) -> None:
     """Already-exited proc skips the exit/terminate/kill ladder."""
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, *_ = _make_fake_proc([])
     proc.returncode = 0
     session.proc = proc
@@ -500,7 +500,7 @@ async def test_terminate_subprocess_no_op_when_proc_already_exited(
 async def test_terminate_subprocess_sends_exit_and_waits(tmp_path: Path) -> None:
     """Happy path: write ``{"type": "exit"}``, drain, close stdin, wait."""
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, _reader, stdin_capture = _make_fake_proc([])
     session.proc = proc
 
@@ -527,7 +527,7 @@ async def test_terminate_subprocess_escalates_through_terminate_then_kill(
     keeps shutdown from hanging.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, _reader, _ = _make_fake_proc([])
     session.proc = proc
 
@@ -574,7 +574,7 @@ async def test_terminate_subprocess_swallows_stdin_write_failure(
     what makes that work.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, _reader, _ = _make_fake_proc([])
 
     def _broken_write(_data: bytes) -> None:
@@ -642,7 +642,7 @@ async def test_validate_locked_skips_unparseable_lines(tmp_path: Path) -> None:
     try/except surfaces here.
     """
     controller = _make_controller(tmp_path)
-    session = _EditorSession()
+    session = _EditorSession(configuration="kitchen.yaml")
     proc, _reader, _ = _make_fake_proc(
         [
             b"this is not json\n",


### PR DESCRIPTION
## Summary

The vscode-subprocess spawn log printed only the cmd (`esphome vscode <config-dir> --ace`), which is identical across all sessions because the subprocess takes the config-dir not the specific file. With `EditorController` keeping one warm subprocess per configuration (so concurrent edits on different devices don't block each other), the log left users guessing whether two consecutive spawns were:

- Expected: two different files opened, each spinning up its own warm subprocess.
- Unexpected: same file's subprocess respawned after a timeout / crash.

Add a `configuration` field to `_EditorSession` and include it in the spawn-log line:

```
INFO  Spawning vscode subprocess for kitchen.yaml: …esphome vscode … --ace
```

Diagnostic-only change. No behaviour difference; just better logging.

## Test plan

- [x] `uv run pytest tests/test_editor_controller.py` — 23/23 green (existing tests updated to pass the new required field).
- [ ] CI green on the regular test matrix.