### PR TITLE
Add rolling-draft previews and centralise release-version logic

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -7,6 +7,10 @@ description: |
   are fetched and their bullets are dropped into the matching backend
   category. Bump PRs themselves never appear in the rendered notes.
 
+  When ``initial-release`` is ``true`` the action skips PR fetching entirely
+  and emits a short "Initial release" placeholder. Intended for the very
+  first release of the project.
+
 inputs:
   version:
     description: Version being released (used in log lines, not in the body).
@@ -32,32 +36,43 @@ inputs:
     description: Frontend distribution name as it appears in pyproject.toml's `dependencies`.
     required: false
     default: esphome-device-builder-frontend
+  initial-release:
+    description: |
+      When ``true``, skip PR fetching and emit a short "Initial release"
+      placeholder body instead. Intended for the very first release of
+      the project, where a full PR dump would be noisy. The exact
+      placeholder wording is a deliberate stub — refine in a follow-up.
+    required: false
+    default: "false"
 
 outputs:
   release-notes:
     description: The rendered release-notes body.
-    value: ${{ steps.generate.outputs.release-notes }}
+    value: ${{ steps.generate.outputs.release-notes || steps.initial.outputs.release-notes }}
   release-notes-file:
     description: |
       Path to a file containing the rendered notes. Prefer this over
       `release-notes` when piping into `gh release create --notes-file`,
       since multi-line outputs can be brittle to reinterpolate.
-    value: ${{ steps.generate.outputs.release-notes-file }}
+    value: ${{ steps.generate.outputs.release-notes-file || steps.initial.outputs.release-notes-file }}
 
 runs:
   using: composite
   steps:
     - name: Set up Python
+      if: inputs.initial-release != 'true'
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: "3.13"
 
     - name: Install Python dependencies
+      if: inputs.initial-release != 'true'
       shell: bash
       run: pip install --no-cache-dir PyGithub PyYAML
 
     - name: Generate release notes
       id: generate
+      if: inputs.initial-release != 'true'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
@@ -69,3 +84,21 @@ runs:
         FRONTEND_REPO: ${{ inputs.frontend-repo }}
         FRONTEND_DEP_NAME: ${{ inputs.frontend-dep-name }}
       run: python "${{ github.action_path }}/generate_notes.py"
+
+    - name: Emit initial-release placeholder
+      id: initial
+      if: inputs.initial-release == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Placeholder body for the very first release. The exact
+        # wording is a stub — a follow-up PR will replace this with
+        # something more substantive.
+        notes_file="${RUNNER_TEMP:-/tmp}/release-notes.md"
+        printf 'Initial release.\n' > "$notes_file"
+        {
+          echo "release-notes-file=$notes_file"
+          echo "release-notes<<RELEASENOTES_EOF"
+          echo "Initial release."
+          echo "RELEASENOTES_EOF"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/resolve-release-versions/action.yml
+++ b/.github/actions/resolve-release-versions/action.yml
@@ -1,0 +1,165 @@
+name: Resolve release versions
+description: |
+  Inspect recent published GitHub releases and answer two questions:
+  what tag should the release notes diff against, and (when no
+  ``version`` is supplied) what's the next prerelease version?
+
+  Both answers come from a single ``gh release list`` call so callers
+  that need both don't pay the API round-trip twice.
+
+  Diff-base rules (applied to ``inputs.version``, or to the computed
+  next prerelease when none is supplied):
+    - stable ``X.Y.Z``       → most recent stable; fall back to last beta
+    - first beta ``X.Y.Zb1`` → most recent stable; fall back to last beta
+    - later beta ``X.Y.ZbN`` → most recent beta;   fall back to last stable
+
+  The two beta cases differ because ``b1`` opens a new version cycle —
+  reviewers want to see everything that accumulated since the previous
+  shipped version, not an empty diff against a missing predecessor.
+
+  Next-version bump (used when ``inputs.version`` is empty), keyed on
+  ``inputs.mode``:
+    - ``mode: prerelease`` (default)
+        - latest is ``X.Y.ZbN``  → ``X.Y.Zb(N+1)``
+        - latest is ``X.Y.Z``    → ``X.Y.(Z+1)b1``
+        - no prior releases      → ``0.1.0b1``
+    - ``mode: stable``
+        - latest is ``X.Y.ZbN``  → ``X.Y.Z`` (the cycle's stable target)
+        - latest is ``X.Y.Z``    → ``X.Y.(Z+1)`` (placeholder patch bump)
+        - no prior releases      → ``0.1.0``
+
+inputs:
+  version:
+    description: |
+      Version about to be cut, e.g. ``0.1.5b3``. When provided, the
+      ``version`` output echoes it and the diff base is resolved for
+      this exact version. When omitted, the action computes the next
+      version per ``mode`` and resolves the diff base for that.
+    required: false
+    default: ""
+  mode:
+    description: |
+      ``prerelease`` (default) or ``stable``. Selects the next-version
+      computation when ``inputs.version`` is empty. Ignored when
+      ``inputs.version`` is set — there the diff-base rules key off
+      the input version's shape directly.
+    required: false
+    default: prerelease
+  github-token:
+    description: |
+      Token used to call ``gh release list``. Defaults to the
+      implicit ``${{ github.token }}``, which has the read access
+      needed for the release list. Callers that want to use an app
+      token (e.g. for consistency with the rest of their workflow)
+      can pass it explicitly.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  version:
+    description: |
+      The resolved version — echoes ``inputs.version`` when provided,
+      otherwise the computed next prerelease.
+    value: ${{ steps.resolve.outputs.version }}
+  previous-tag:
+    description: |
+      The tag the release notes should diff against, per the
+      channel-aware rules above. Empty when this is the first-ever
+      release.
+    value: ${{ steps.resolve.outputs.previous-tag }}
+  latest-overall:
+    description: |
+      The most recent published release of any channel (or empty
+      when nothing has shipped yet). Exposed for callers like
+      ``auto-release.yml`` that need a single baseline for commit
+      counting and don't care about the channel split.
+    value: ${{ steps.resolve.outputs.latest-overall }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve versions
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        VERSION_INPUT: ${{ inputs.version }}
+        MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+        if [ "$MODE" != "prerelease" ] && [ "$MODE" != "stable" ]; then
+          echo "::error::mode must be 'prerelease' or 'stable' (got '$MODE')."
+          exit 1
+        fi
+
+        # One pass over the recent published releases populates the
+        # buckets we need. ``--exclude-drafts`` strips any draft (the
+        # rolling previews, or a leftover from a failed release attempt).
+        mapfile -t tags < <(gh release list --exclude-drafts --limit 50 \
+          --json tagName --jq '.[].tagName')
+
+        latest_stable=""
+        latest_beta=""
+        latest_overall=""
+        for t in "${tags[@]}"; do
+          # Skip ``inputs.version`` if it somehow appears as a
+          # published tag (release.yml's pre-existing defensive check
+          # against a tag the validate job let through).
+          [ -n "$VERSION_INPUT" ] && [ "$t" = "$VERSION_INPUT" ] && continue
+          [ -z "$latest_overall" ] && latest_overall="$t"
+          if [[ "$t" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            [ -z "$latest_stable" ] && latest_stable="$t"
+          elif [[ "$t" =~ ^[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$ ]]; then
+            [ -z "$latest_beta" ] && latest_beta="$t"
+          fi
+        done
+
+        # Resolve the version: echo the input if given, else bump the
+        # most recent release per the requested mode.
+        if [ -n "$VERSION_INPUT" ]; then
+          version="$VERSION_INPUT"
+        elif [ -z "$latest_overall" ]; then
+          if [ "$MODE" = "stable" ]; then
+            version="0.1.0"
+          else
+            version="0.1.0b1"
+          fi
+        elif [[ "$latest_overall" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)b([0-9]+)$ ]]; then
+          if [ "$MODE" = "stable" ]; then
+            version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+          else
+            version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}b$((BASH_REMATCH[4] + 1))"
+          fi
+        elif [[ "$latest_overall" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+          if [ "$MODE" = "stable" ]; then
+            version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
+          else
+            version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))b1"
+          fi
+        else
+          echo "::error::Cannot parse latest tag '$latest_overall' (expected X.Y.Z or X.Y.ZbN)."
+          exit 1
+        fi
+
+        # Resolve the diff base by channel.
+        if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          previous="${latest_stable:-$latest_beta}"
+        elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+b([0-9]+)$ ]]; then
+          if [ "${BASH_REMATCH[1]}" -eq 1 ]; then
+            previous="${latest_stable:-$latest_beta}"
+          else
+            previous="${latest_beta:-$latest_stable}"
+          fi
+        else
+          echo "::error::Cannot parse version '$version' (expected X.Y.Z or X.Y.ZbN)."
+          exit 1
+        fi
+
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "previous-tag=$previous" >> "$GITHUB_OUTPUT"
+        echo "latest-overall=$latest_overall" >> "$GITHUB_OUTPUT"
+        echo "Latest stable:    ${latest_stable:-(none)}"
+        echo "Latest beta:      ${latest_beta:-(none)}"
+        echo "Latest overall:   ${latest_overall:-(none)}"
+        echo "Resolved version: $version"
+        echo "Diff base:        ${previous:-(none — first release)}"

--- a/.github/actions/resolve-release-versions/action.yml
+++ b/.github/actions/resolve-release-versions/action.yml
@@ -95,8 +95,24 @@ runs:
         # One pass over the recent published releases populates the
         # buckets we need. ``--exclude-drafts`` strips any draft (the
         # rolling previews, or a leftover from a failed release attempt).
-        mapfile -t tags < <(gh release list --exclude-drafts --limit 50 \
-          --json tagName --jq '.[].tagName')
+        #
+        # Capture into a variable first rather than ``mapfile < <(gh ...)``:
+        # process substitution swallows the inner command's exit status, so
+        # an auth/network failure on ``gh`` would silently produce an empty
+        # array and the resolver would happily compute "no prior releases"
+        # version numbers.
+        if ! tags_raw=$(gh release list --exclude-drafts --limit 50 \
+            --json tagName --jq '.[].tagName'); then
+          echo "::error::gh release list failed."
+          exit 1
+        fi
+        tags=()
+        if [ -n "$tags_raw" ]; then
+          # ``mapfile <<< ""`` produces a one-element array containing the
+          # empty string; the guard keeps a "no releases yet" run distinct
+          # from a "got one empty tag" run.
+          mapfile -t tags <<< "$tags_raw"
+        fi
 
         latest_stable=""
         latest_beta=""

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check commits and compute next version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.next.outputs.version }}
+      version: ${{ steps.resolve.outputs.version }}
       should-release: ${{ steps.commits.outputs.go }}
     steps:
       - name: Check out code from GitHub
@@ -26,19 +26,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve next prerelease version
+        id: resolve
+        uses: ./.github/actions/resolve-release-versions
+
       - name: Count commits since last release
         id: commits
         env:
-          GH_TOKEN: ${{ github.token }}
+          LATEST_TAG: ${{ steps.resolve.outputs.latest-overall }}
         run: |
           set -euo pipefail
-          LATEST_TAG=$(gh release list --exclude-drafts --limit 1 \
-            --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
-
-          if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+          if [ -z "$LATEST_TAG" ]; then
             echo "No previous release; will cut initial prerelease."
             echo "go=true" >> "$GITHUB_OUTPUT"
-            echo "last-tag=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -50,7 +50,6 @@ jobs:
 
           echo "Latest release: $LATEST_TAG"
           echo "Commits since: $COUNT"
-          echo "last-tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
           if [ "$COUNT" -ge 2 ]; then
             echo "go=true" >> "$GITHUB_OUTPUT"
@@ -58,29 +57,6 @@ jobs:
             echo "go=false" >> "$GITHUB_OUTPUT"
             echo "Only $COUNT commit(s) since last release — skipping."
           fi
-
-      - name: Compute next prerelease version
-        id: next
-        if: steps.commits.outputs.go == 'true'
-        env:
-          LAST_TAG: ${{ steps.commits.outputs.last-tag }}
-        run: |
-          set -euo pipefail
-          # X.Y.ZbN → X.Y.Zb(N+1); X.Y.Z → X.Y.(Z+1)b1; nothing → 0.1.0b1.
-          if [ -z "$LAST_TAG" ]; then
-            NEW="0.1.0b1"
-          elif [[ "$LAST_TAG" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)b([0-9]+)$ ]]; then
-            NEW="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}b$((BASH_REMATCH[4] + 1))"
-          elif [[ "$LAST_TAG" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            NEW="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))b1"
-          else
-            echo "::error::Cannot parse previous tag '$LAST_TAG'."
-            echo "::error::Expected X.Y.Z or X.Y.ZbN."
-            exit 1
-          fi
-
-          echo "version=$NEW" >> "$GITHUB_OUTPUT"
-          echo "Next prerelease version: $NEW"
 
   trigger-release:
     name: Trigger release workflow

--- a/.github/workflows/draft-next-releases.yml
+++ b/.github/workflows/draft-next-releases.yml
@@ -1,0 +1,167 @@
+name: Draft next releases
+
+# Keeps two draft GitHub releases open with rolled-up notes:
+#   - ``next-prerelease`` — what the next nightly auto-release would
+#                           publish.
+#   - ``next-stable``     — what a manually-cut stable release would
+#                           ship today.
+# Maintainers use both as a live preview — landing a labelled PR
+# refreshes them within a minute. The actual cut is still done by
+# ``release.yml``; these drafts never publish.
+#
+# Each draft uses a stable tag-name placeholder (``next-prerelease`` /
+# ``next-stable``) rather than a version-shaped one, so a real
+# ``release.yml`` run (which keys its own draft on the version)
+# doesn't collide with the rolling previews. The computed next-version
+# is shown in the release title so it's still visible at a glance.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Multiple pushes to main collapse onto the latest one — an older
+# computation is always superseded by the newer commitish, so
+# cancelling mid-run is correct here (unlike release.yml where
+# a half-finished publish must not be interrupted).
+concurrency:
+  group: draft-next-releases
+  cancel-in-progress: true
+
+jobs:
+  draft:
+    name: Update ${{ matrix.kind }} draft
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - kind: prerelease
+            tag: next-prerelease
+            title-prefix: "Next prerelease"
+            is-prerelease: "true"
+          - kind: stable
+            tag: next-stable
+            title-prefix: "Next stable"
+            is-prerelease: "false"
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: read
+
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Resolve previous tag and next version
+        id: versions
+        uses: ./.github/actions/resolve-release-versions
+        with:
+          # No ``version`` input — the action computes the next
+          # version per the matrix's ``mode`` and resolves the diff
+          # base to match.
+          mode: ${{ matrix.kind }}
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Generate release notes
+        id: notes
+        uses: ./.github/actions/generate-release-notes
+        with:
+          version: ${{ steps.versions.outputs.version }}
+          previous-tag: ${{ steps.versions.outputs.previous-tag }}
+          commitish: ${{ github.sha }}
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Prepend maintainer header to notes
+        # The header is the first thing a maintainer sees when they
+        # click into the draft from the releases list — it's the
+        # signal that this draft is a preview, not something to hit
+        # the publish button on. The ``kind`` controls which workflow
+        # the header points the maintainer to.
+        shell: python
+        env:
+          NOTES_FILE: ${{ steps.notes.outputs.release-notes-file }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          KIND: ${{ matrix.kind }}
+        run: |
+          import os
+          from pathlib import Path
+
+          repo = os.environ["REPO_URL"]
+          kind = os.environ["KIND"]
+          notes = Path(os.environ["NOTES_FILE"])
+
+          if kind == "stable":
+              instr = (
+                  "Stable releases are cut by manually running the\n"
+                  f"> [Release workflow]({repo}/actions/workflows/release.yml),\n"
+                  "> which creates and publishes its own version-tagged draft."
+              )
+          else:
+              instr = (
+                  "Prereleases are cut by the\n"
+                  f"> [Auto Release workflow]({repo}/actions/workflows/auto-release.yml)\n"
+                  "> nightly (or manually from the same workflow), which creates\n"
+                  "> and publishes its own version-tagged draft."
+              )
+
+          header = (
+              "> ⚠️ **Maintainer note — do not publish this draft.**\n"
+              ">\n"
+              f"> This is a rolling preview of the next {kind}. {instr}\n"
+              "> Publishing this draft is rejected by a repository ruleset\n"
+              "> anyway — only that workflow can create release tags — so\n"
+              "> the rolling preview is purely a read-only changelog view.\n"
+              "\n"
+              "---\n"
+              "\n"
+          )
+          notes.write_text(header + notes.read_text())
+
+      - name: Create or update the rolling draft
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NOTES_FILE: ${{ steps.notes.outputs.release-notes-file }}
+          VERSION: ${{ steps.versions.outputs.version }}
+          TAG: ${{ matrix.tag }}
+          TITLE_PREFIX: ${{ matrix.title-prefix }}
+          IS_PRERELEASE: ${{ matrix.is-prerelease }}
+        run: |
+          set -euo pipefail
+          # The placeholder tag-names ``next-prerelease`` / ``next-stable``
+          # are never published — they exist only as the stable keys for
+          # these previews. If a future change ever flips one to non-draft,
+          # fail loudly rather than silently turning the preview into a
+          # real release.
+          title="$TITLE_PREFIX: $VERSION"
+          if existing=$(gh release view "$TAG" --json isDraft --jq '.isDraft' 2>/dev/null); then
+            if [ "$existing" != "true" ]; then
+              echo "::error::Release '$TAG' exists and is not a draft; refusing to overwrite."
+              exit 1
+            fi
+            gh release edit "$TAG" \
+              --notes-file "$NOTES_FILE" \
+              --target "${{ github.sha }}" \
+              --title "$title" \
+              --draft \
+              --prerelease="$IS_PRERELEASE"
+          else
+            gh release create "$TAG" \
+              --notes-file "$NOTES_FILE" \
+              --target "${{ github.sha }}" \
+              --title "$title" \
+              --draft \
+              --prerelease="$IS_PRERELEASE"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         description: "Version number (e.g. 2026.5.0 or 2026.5.0b1)"
         required: true
         type: string
+      initial-release:
+        description: "Replace the release notes with an 'Initial release' placeholder. Intended for the very first release."
+        required: false
+        type: boolean
+        default: false
 
 env:
   PYTHON_VERSION: "3.13"
@@ -155,33 +160,20 @@ jobs:
 
       - name: Resolve previous release tag
         id: previous
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          # Latest non-draft release that isn't the one we're about to
-          # cut. ``--exclude-drafts`` already strips draft entries left
-          # over from a prior attempt; ``grep -v`` defends against the
-          # rare case where ``inputs.version`` matches a published tag
-          # that the validate job somehow let through.
-          tag=$(gh release list --exclude-drafts --limit 5 \
-            --json tagName --jq '.[].tagName' \
-            | grep -v "^${{ inputs.version }}$" | head -n 1 || true)
-          if [ -z "$tag" ]; then
-            echo "No previous release found — emitting full first-release notes."
-          else
-            echo "Previous release: $tag"
-          fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/resolve-release-versions
+        with:
+          version: ${{ inputs.version }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate release notes
         id: notes
         uses: ./.github/actions/generate-release-notes
         with:
           version: ${{ inputs.version }}
-          previous-tag: ${{ steps.previous.outputs.tag }}
+          previous-tag: ${{ steps.previous.outputs.previous-tag }}
           commitish: ${{ github.sha }}
           github-token: ${{ steps.app-token.outputs.token }}
+          initial-release: ${{ inputs.initial-release }}
 
       - name: Create or update draft release
         env:


### PR DESCRIPTION
# What does this implement/fix?

Adds two rolling draft GitHub releases — `next-prerelease` and `next-stable` — that maintainers can use as a live changelog preview for whatever ships next. Each draft auto-refreshes on push to `main`, shows the channel-aware diff (per the rules established earlier: beta vs. first-of-cycle vs. stable), and carries a maintainer note pointing at the workflow that should actually cut the release. Tag rulesets reject a direct publish on these placeholder tag names, so the drafts are read-only by construction.

While in there: pulled the duplicated next-version + diff-base logic out of `release.yml` and `auto-release.yml` into a new `resolve-release-versions` composite action with a `mode` input (`prerelease` / `stable`). All three workflows now share the same channel-aware rules in one place. Also added an `initial-release` toggle to `release.yml` and the `generate-release-notes` action that swaps the body for an "Initial release" placeholder; the wording is a deliberate stub for a follow-up PR to refine.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.