### PR TITLE
Fix resolve-release-versions failing to load on hosted runners

### DIFF
--- a/.github/actions/resolve-release-versions/action.yml
+++ b/.github/actions/resolve-release-versions/action.yml
@@ -47,13 +47,13 @@ inputs:
     default: prerelease
   github-token:
     description: |
-      Token used to call ``gh release list``. Defaults to the
+      Token used to call ``gh release list``. Leave empty to use the
       implicit ``${{ github.token }}``, which has the read access
       needed for the release list. Callers that want to use an app
       token (e.g. for consistency with the rest of their workflow)
       can pass it explicitly.
     required: false
-    default: ${{ github.token }}
+    default: ""
 
 outputs:
   version:
@@ -82,7 +82,7 @@ runs:
       id: resolve
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
         VERSION_INPUT: ${{ inputs.version }}
         MODE: ${{ inputs.mode }}
       run: |


### PR DESCRIPTION
# What does this implement/fix?

Composite-action input defaults are evaluated at action-load time, before the `github` context exists, so `default: ${{ github.token }}` on the `github-token` input failed with `Unrecognized named-value: 'github'` and prevented every consuming workflow from starting (`auto-release.yml`, `draft-next-releases.yml`, `release.yml`). The action now defaults the input to an empty string and resolves the fallback inside the step's `env:` via `${{ inputs.github-token || github.token }}` — an empty string is falsy in `||`, so callers that don't pass a token cleanly fall through to the implicit `github.token` at run time.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.