### PR TITLE
ci(pr-labels): apply label from filled checkbox, fail when none

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,32 +1,90 @@
 ---
 name: PR Labels
 
-# Every PR must carry exactly one of the labels release-drafter
-# knows how to slot into a release-notes section. Without this
-# guard a contributor can quietly skip labelling and their PR
-# disappears from the next changelog.
+# Each PR must carry exactly one of the labels release-drafter knows
+# how to slot into a release-notes section. We derive that label from
+# the "Types of changes" checkbox in the PR template and apply it
+# automatically — most external contributors can't label their own
+# PRs. The job only fails when no checkbox is ticked.
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
+      - edited
       - synchronize
       - labeled
       - unlabeled
     branches:
       - main
 
-permissions: {}
+permissions:
+  pull-requests: write
 
 jobs:
-  pr_labels:
-    name: Verify
+  apply_label:
+    name: Apply
     runs-on: ubuntu-latest
     steps:
-      - name: 🏷 Verify PR has a valid label
-        uses: ludeeus/action-require-labels@7ef0dba93830452589680da7cdea2e2c4c0f8dff  # 1.1.0
+      - name: 🏷 Apply label from PR description checkbox
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
-          labels: >-
-            breaking-change, bugfix, refactor, new-feature, enhancement,
-            maintenance, ci, dependencies, docs
+          script: |
+            const known = [
+              'breaking-change', 'bugfix', 'refactor',
+              'new-feature', 'enhancement', 'maintenance',
+              'ci', 'dependencies', 'docs',
+            ];
+
+            // Match `- [x] ... `<label>`` lines in the PR body. The
+            // PR template puts the canonical label name in backticks
+            // at the end of each "Types of changes" bullet.
+            const body = context.payload.pull_request.body || '';
+            const re = /^\s*-\s*\[x\][^`\n]*`([^`]+)`/gim;
+            const ticked = [];
+            for (const m of body.matchAll(re)) {
+              const name = m[1];
+              if (known.includes(name) && !ticked.includes(name)) {
+                ticked.push(name);
+              }
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            if (ticked.length === 0) {
+              core.setFailed(
+                'No "Types of changes" checkbox is ticked in the PR ' +
+                'description. Edit the description and tick exactly ' +
+                'one box so this PR can be release-noted.'
+              );
+              return;
+            }
+            if (ticked.length > 1) {
+              core.setFailed(
+                `Multiple "Types of changes" checkboxes are ticked ` +
+                `(${ticked.join(', ')}). Tick exactly one.`
+              );
+              return;
+            }
+
+            const desired = ticked[0];
+            const current = (context.payload.pull_request.labels || [])
+              .map(l => l.name);
+
+            // Strip any stale labels from the known set so a
+            // contributor changing their mind in the description
+            // doesn't leave the previous label behind.
+            for (const name of current) {
+              if (known.includes(name) && name !== desired) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number, name,
+                }).catch(() => {});
+              }
+            }
+            if (!current.includes(desired)) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number, labels: [desired],
+              });
+            }


### PR DESCRIPTION
# What does this implement/fix?

External contributors can't label their own PRs, so the existing `require-labels` guard blocks every fork PR until a maintainer manually labels it. This rewrites the workflow to derive the label from the ticked "Types of changes" checkbox in the PR body and apply it automatically, so the contributor's checkbox selection is the source of truth. The job only fails when zero (or more than one) box is ticked.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [ ] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.