### PR TITLE
Drop github.token expression from action input description

### DIFF
--- a/.github/actions/resolve-release-versions/action.yml
+++ b/.github/actions/resolve-release-versions/action.yml
@@ -48,7 +48,7 @@ inputs:
   github-token:
     description: |
       Token used to call ``gh release list``. Leave empty to use the
-      implicit ``${{ github.token }}``, which has the read access
+      workflow's implicit ``github.token``, which has the read access
       needed for the release list. Callers that want to use an app
       token (e.g. for consistency with the rest of their workflow)
       can pass it explicitly.


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #326. The whole `inputs:` block of a composite action is parsed at action-load time, before the `github` context exists, so even a `${{ github.token }}` written as documentation prose inside an input description fails with `Unrecognized named-value: 'github'` and the workflow refuses to start. Refer to `github.token` as plain text in the description; the runtime fallback in the step's `env:` was already in place from #326.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.