### PR TITLE
draft-next-releases: skip stable preview without a prior stable

### DIFF
--- a/.github/actions/resolve-release-versions/action.yml
+++ b/.github/actions/resolve-release-versions/action.yml
@@ -9,13 +9,16 @@ description: |
 
   Diff-base rules (applied to ``inputs.version``, or to the computed
   next prerelease when none is supplied):
-    - stable ``X.Y.Z``       → most recent stable; fall back to last beta
+    - stable ``X.Y.Z``       → most recent stable; **empty** when none exists
     - first beta ``X.Y.Zb1`` → most recent stable; fall back to last beta
     - later beta ``X.Y.ZbN`` → most recent beta;   fall back to last stable
 
-  The two beta cases differ because ``b1`` opens a new version cycle —
-  reviewers want to see everything that accumulated since the previous
-  shipped version, not an empty diff against a missing predecessor.
+  Stable cuts deliberately do *not* fall back to a beta: the very first
+  stable should diff against the project's whole history (or be skipped
+  entirely by the caller), not against the last beta — beta tags don't
+  represent a stable shipping baseline. The two beta cases differ
+  because ``b1`` opens a new version cycle and wants to show everything
+  that's accumulated since the previous shipped version.
 
   Next-version bump (used when ``inputs.version`` is empty), keyed on
   ``inputs.mode``:
@@ -159,7 +162,8 @@ runs:
 
         # Resolve the diff base by channel.
         if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          previous="${latest_stable:-$latest_beta}"
+          # No fallback to beta — see the action description.
+          previous="$latest_stable"
         elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+b([0-9]+)$ ]]; then
           if [ "${BASH_REMATCH[1]}" -eq 1 ]; then
             previous="${latest_stable:-$latest_beta}"

--- a/.github/workflows/draft-next-releases.yml
+++ b/.github/workflows/draft-next-releases.yml
@@ -75,8 +75,16 @@ jobs:
           mode: ${{ matrix.kind }}
           github-token: ${{ steps.app-token.outputs.token }}
 
+      # The next three steps are skipped for the stable matrix entry
+      # when no prior stable exists — there's no meaningful preview to
+      # render against an empty diff base, and we'd rather show nothing
+      # than fall back to "since last beta" (which doesn't represent a
+      # stable shipping baseline). The prerelease entry is unaffected;
+      # ``previous-tag`` can be empty there only on a never-released
+      # project, where the generator's "first release" path is fine.
       - name: Generate release notes
         id: notes
+        if: matrix.kind != 'stable' || steps.versions.outputs.previous-tag != ''
         uses: ./.github/actions/generate-release-notes
         with:
           version: ${{ steps.versions.outputs.version }}
@@ -89,7 +97,9 @@ jobs:
         # click into the draft from the releases list — it's the
         # signal that this draft is a preview, not something to hit
         # the publish button on. The ``kind`` controls which workflow
-        # the header points the maintainer to.
+        # the header points the maintainer to. Prose lines are left
+        # unwrapped and GitHub re-flows them on render.
+        if: matrix.kind != 'stable' || steps.versions.outputs.previous-tag != ''
         shell: python
         env:
           NOTES_FILE: ${{ steps.notes.outputs.release-notes-file }}
@@ -103,27 +113,32 @@ jobs:
           kind = os.environ["KIND"]
           notes = Path(os.environ["NOTES_FILE"])
 
+          # Source lines wrap to keep the file readable; the rendered
+          # output stays a single paragraph per ``>`` line because adjacent
+          # string literals concatenate and only the explicit ``\n``s
+          # introduce line breaks. Trailing spaces on continued fragments
+          # matter — without them, words would run together at the joins.
           if kind == "stable":
               instr = (
-                  "Stable releases are cut by manually running the\n"
-                  f"> [Release workflow]({repo}/actions/workflows/release.yml),\n"
-                  "> which creates and publishes its own version-tagged draft."
+                  "Stable releases are cut by manually running the "
+                  f"[Release workflow]({repo}/actions/workflows/release.yml), "
+                  "which creates and publishes its own version-tagged draft."
               )
           else:
               instr = (
-                  "Prereleases are cut by the\n"
-                  f"> [Auto Release workflow]({repo}/actions/workflows/auto-release.yml)\n"
-                  "> nightly (or manually from the same workflow), which creates\n"
-                  "> and publishes its own version-tagged draft."
+                  "Prereleases are cut by the "
+                  f"[Auto Release workflow]({repo}/actions/workflows/auto-release.yml) "
+                  "nightly (or manually from the same workflow), which creates "
+                  "and publishes its own version-tagged draft."
               )
 
           header = (
               "> ⚠️ **Maintainer note — do not publish this draft.**\n"
               ">\n"
-              f"> This is a rolling preview of the next {kind}. {instr}\n"
-              "> Publishing this draft is rejected by a repository ruleset\n"
-              "> anyway — only that workflow can create release tags — so\n"
-              "> the rolling preview is purely a read-only changelog view.\n"
+              f"> This is a rolling preview of the next {kind}. {instr} "
+              "Publishing this draft is rejected by a repository ruleset "
+              "anyway — only that workflow can create release tags — so "
+              "the rolling preview is purely a read-only changelog view.\n"
               "\n"
               "---\n"
               "\n"
@@ -131,6 +146,7 @@ jobs:
           notes.write_text(header + notes.read_text())
 
       - name: Create or update the rolling draft
+        if: matrix.kind != 'stable' || steps.versions.outputs.previous-tag != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NOTES_FILE: ${{ steps.notes.outputs.release-notes-file }}


### PR DESCRIPTION
# What does this implement/fix?

The rolling stable draft was diffing against the last beta when no prior stable existed, which produces a misleading "since last beta" preview rather than the cumulative-since-last-stable view a stable release should show. This PR drops the stable-cut fallback in `resolve-release-versions` (stable now returns an empty `previous-tag` until a stable has shipped) and gates the stable matrix entry's downstream steps on a non-empty `previous-tag`, so no `next-stable` draft is created or refreshed for the very first stable. Existing stale drafts can be deleted manually — the workflow will leave them alone. Beta-cut diff-base rules are unchanged.

The maintainer-note Python is also unwrapped: adjacent string literals concatenate without inserting `\n`, so the source wraps at sensible widths while the rendered blockquote stays a single long line that GitHub re-flows on render. No ragged hard wraps in either source or output.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.