### PR TITLE
Surface MAC + derived ethernet/bluetooth MACs from mDNS

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -34,6 +34,7 @@ class DeviceFileMetadata(NamedTuple):
     board_id: str
     ip: str
     expected_config_hash: str = ""
+    mac_address: str = ""
 
 
 class ScanChange(StrEnum):
@@ -379,6 +380,7 @@ class DeviceScanner:
                     metadata.board_id,
                     metadata.ip,
                     metadata.expected_config_hash,
+                    metadata.mac_address,
                     previous=self._index.by_path.get(path),
                 )
             except Exception:

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -102,6 +102,34 @@ _SOURCE_PRIORITY: dict[str, int] = {
     ReachabilitySource.MDNS: 3,
 }
 
+
+# Allowed separators between the six octets of a MAC. ``:`` is the
+# canonical wire format ESPHome firmware broadcasts today, but we
+# normalize away ``-`` (Windows-style) and ``.`` (Cisco) too so a
+# future firmware change or vendored tool can't slip a non-canonical
+# form into the dedupe path or the sidecar.
+_MAC_SEPARATORS = str.maketrans("", "", ":-.")
+
+
+def _normalize_mac(value: str) -> str:
+    """Canonicalise a broadcast MAC to lowercase 12-hex-char form.
+
+    Returns ``""`` when the input doesn't shape into a 48-bit hex MAC
+    after stripping ``:`` / ``-`` / ``.`` separators — callers treat
+    that the same as "TXT absent" and skip the apply path. Done at
+    ingest so the dedupe + sidecar stay canonical regardless of which
+    case / separator style the firmware happens to broadcast.
+    """
+    stripped = value.translate(_MAC_SEPARATORS)
+    if len(stripped) != 12:
+        return ""
+    try:
+        int(stripped, 16)
+    except ValueError:
+        return ""
+    return stripped.lower()
+
+
 # Callback signature used by DeviceStateMonitor to push state changes
 # back to its owner. The owner decides what to do with the new state
 # (e.g. fire a bus event, mutate the device model).
@@ -137,6 +165,14 @@ ConfigHashChangeCallback = Callable[[str, str], None]
 # callback at all, so the device controller can keep that state as
 # ``None`` to mean "trust whatever the YAML says".
 ApiEncryptionChangeCallback = Callable[[str, str], None]
+
+# Callback fired when the mDNS ``mac`` TXT record reports a different
+# MAC than last seen for a device. The value is the lowercase
+# 12-hex-char form ESPHome firmware broadcasts (no colons); the
+# frontend pretty-prints at display time. Empty / missing TXT skips
+# the callback — devices on firmware predating the ``mac`` broadcast
+# stay with whatever value they already had.
+MacAddressChangeCallback = Callable[[str, str], None]
 
 # Callback fired when zeroconf turns up a previously-unseen device that
 # advertises ``package_import_url`` / ``project_name`` /
@@ -200,6 +236,7 @@ class DeviceStateMonitor:
         on_version_change: VersionChangeCallback | None = None,
         on_config_hash_change: ConfigHashChangeCallback | None = None,
         on_api_encryption_change: ApiEncryptionChangeCallback | None = None,
+        on_mac_address_change: MacAddressChangeCallback | None = None,
         on_importable_added: ImportableAddedCallback | None = None,
         on_importable_removed: ImportableRemovedCallback | None = None,
         reachability: ReachabilityTracker | None = None,
@@ -224,6 +261,7 @@ class DeviceStateMonitor:
         self._on_version_change = on_version_change
         self._on_config_hash_change = on_config_hash_change
         self._on_api_encryption_change = on_api_encryption_change
+        self._on_mac_address_change = on_mac_address_change
         self._on_importable_added = on_importable_added
         self._on_importable_removed = on_importable_removed
         self._is_ignored = is_ignored or (lambda _name: False)
@@ -657,6 +695,29 @@ class DeviceStateMonitor:
         self._on_config_hash_change(name, config_hash)
         return True
 
+    def apply_mac_address(self, name: str, mac: str) -> bool:
+        """
+        Record a MAC-address observation from the device's mDNS TXT.
+
+        Returns True when the MAC actually changed and the change was
+        forwarded to the callback. The broadcast value is normalized
+        via :func:`_normalize_mac` (lowercase, separators stripped) so
+        the dedupe + persisted sidecar stay canonical even if a
+        future firmware switches case or separator style. Empty / non-
+        hex inputs are dropped so a broadcast that happens to omit the
+        ``mac`` TXT (older firmware, non-ESPHome services that share
+        the type) doesn't blank out an already-known MAC.
+        """
+        if self._on_mac_address_change is None:
+            return False
+        normalized = _normalize_mac(mac)
+        if not normalized:
+            return False
+        if not self._any_matching_device_differs(name, "mac_address", normalized):
+            return False
+        self._on_mac_address_change(name, normalized)
+        return True
+
     def _any_matching_device_differs(self, name: str, attr: str, value: Any) -> bool:
         """Return True iff some configured device named *name* has ``attr != value``.
 
@@ -1087,6 +1148,8 @@ class DeviceStateMonitor:
             self.apply_version(device_name, version)
         if config_hash := props.get("config_hash"):
             self.apply_config_hash(device_name, config_hash)
+        if mac := props.get("mac"):
+            self.apply_mac_address(device_name, mac)
         # Always apply api_encryption — empty / missing TXT is itself
         # a meaningful signal (device is broadcasting plaintext) and
         # apply_api_encryption distinguishes it from "never seen".

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -103,11 +103,13 @@ _SOURCE_PRIORITY: dict[str, int] = {
 }
 
 
-# Allowed separators between the six octets of a MAC. ``:`` is the
-# canonical wire format ESPHome firmware broadcasts today, but we
-# normalize away ``-`` (Windows-style) and ``.`` (Cisco) too so a
-# future firmware change or vendored tool can't slip a non-canonical
-# form into the dedupe path or the sidecar.
+# Allowed separators between the six octets of a MAC.
+# ESPHome firmware today broadcasts the compact 12-hex-char form
+# (no separators); the dashboard's *canonical* form
+# (``XX:XX:XX:XX:XX:XX``, applied at ingest by ``_normalize_mac``)
+# uses ``:``. We normalize away ``-`` (Windows-style) and ``.``
+# (Cisco) too so a future firmware change or vendored tool can't
+# slip a non-canonical form into the dedupe path or the sidecar.
 _MAC_SEPARATORS = str.maketrans("", "", ":-.")
 
 
@@ -170,11 +172,12 @@ ConfigHashChangeCallback = Callable[[str, str], None]
 ApiEncryptionChangeCallback = Callable[[str, str], None]
 
 # Callback fired when the mDNS ``mac`` TXT record reports a different
-# MAC than last seen for a device. The value is the lowercase
-# 12-hex-char form ESPHome firmware broadcasts (no colons); the
-# frontend pretty-prints at display time. Empty / missing TXT skips
-# the callback — devices on firmware predating the ``mac`` broadcast
-# stay with whatever value they already had.
+# MAC than last seen for a device. The value passed has already been
+# normalized by :func:`_normalize_mac` to the canonical
+# ``XX:XX:XX:XX:XX:XX`` form (uppercase, colon-separated); the
+# frontend renders it directly with no per-display formatter. Empty /
+# missing TXT skips the callback — devices on firmware predating the
+# ``mac`` broadcast stay with whatever value they already had.
 MacAddressChangeCallback = Callable[[str, str], None]
 
 # Callback fired when zeroconf turns up a previously-unseen device that
@@ -704,12 +707,13 @@ class DeviceStateMonitor:
 
         Returns True when the MAC actually changed and the change was
         forwarded to the callback. The broadcast value is normalized
-        via :func:`_normalize_mac` (lowercase, separators stripped) so
-        the dedupe + persisted sidecar stay canonical even if a
-        future firmware switches case or separator style. Empty / non-
-        hex inputs are dropped so a broadcast that happens to omit the
-        ``mac`` TXT (older firmware, non-ESPHome services that share
-        the type) doesn't blank out an already-known MAC.
+        via :func:`_normalize_mac` (uppercased, separators stripped,
+        re-inserted as ``XX:XX:XX:XX:XX:XX``) so the dedupe +
+        persisted sidecar + frontend wire all stay canonical even if
+        a future firmware switches case or separator style. Empty /
+        non-hex inputs are dropped so a broadcast that happens to
+        omit the ``mac`` TXT (older firmware, non-ESPHome services
+        that share the type) doesn't blank out an already-known MAC.
         """
         if self._on_mac_address_change is None:
             return False
@@ -1266,11 +1270,22 @@ class DeviceStateMonitor:
             for device, addresses in zip(batch, resolved, strict=True):
                 if isinstance(addresses, list) and addresses:
                     target = addresses[0]
-                    # mDNS owns IP tracking for ``.local`` hosts; only
-                    # backfill from DNS for non-mDNS hosts so a stale
-                    # DNS result can't clobber the live mDNS value.
-                    if not is_local_hostname(device.address):
-                        self.apply_ip(device.name, target)
+                    # Apply the resolved target so the drawer / table
+                    # have an IP to show. ``apply_ip`` already
+                    # preserves an existing multi-IP set when the
+                    # incoming target is already in it (the typical
+                    # case for a ``.local`` host with an active
+                    # ``_esphomelib._tcp`` broadcast — the ping
+                    # target is the IPv4 primary the browser
+                    # callback already populated). For ``.local``
+                    # hosts that don't broadcast ``_esphomelib._tcp``
+                    # (non-API ESPHome devices, the
+                    # zwave-proxy-seeedw5500 case) this is the only
+                    # path that ever populates ``device.ip``, so a
+                    # ping-source-only device would otherwise show
+                    # an em-dash in the drawer's IP row even after
+                    # successful pings.
+                    self.apply_ip(device.name, target)
                     ping_targets.append((device, target))
                 else:
                     # DNS cache says we can't resolve this hostname

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -112,22 +112,25 @@ _MAC_SEPARATORS = str.maketrans("", "", ":-.")
 
 
 def _normalize_mac(value: str) -> str:
-    """Canonicalise a broadcast MAC to lowercase 12-hex-char form.
+    """Canonicalise a broadcast MAC to ``XX:XX:XX:XX:XX:XX`` form.
 
-    Returns ``""`` when the input doesn't shape into a 48-bit hex MAC
-    after stripping ``:`` / ``-`` / ``.`` separators — callers treat
-    that the same as "TXT absent" and skip the apply path. Done at
-    ingest so the dedupe + sidecar stay canonical regardless of which
-    case / separator style the firmware happens to broadcast.
+    Strips ``:`` / ``-`` / ``.`` separators, uppercases, validates
+    the result is 12 hex chars, then re-inserts ``:`` between every
+    octet. Returns ``""`` when the input doesn't shape into a
+    48-bit hex MAC — callers treat that the same as "TXT absent"
+    and skip the apply path. Done at ingest so the dedupe, sidecar,
+    in-memory model, and frontend wire all carry one canonical form
+    regardless of which case / separator style the firmware happens
+    to broadcast.
     """
-    stripped = value.translate(_MAC_SEPARATORS)
+    stripped = value.translate(_MAC_SEPARATORS).upper()
     if len(stripped) != 12:
         return ""
     try:
         int(stripped, 16)
     except ValueError:
         return ""
-    return stripped.lower()
+    return ":".join(stripped[i : i + 2] for i in range(0, 12, 2))
 
 
 # Callback signature used by DeviceStateMonitor to push state changes

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -285,10 +285,11 @@ def set_device_metadata(
     string clears it (e.g. after a YAML edit invalidates the prior
     compile).
 
-    ``mac_address`` is the lowercase 12-hex-char MAC from the mDNS
-    ``mac`` TXT record. Persisted so the dashboard renders the
-    address immediately on startup, before the first mDNS probe
-    response. Passing an empty string clears it.
+    ``mac_address`` is the canonical ``XX:XX:XX:XX:XX:XX`` MAC
+    from the mDNS ``mac`` TXT record (normalized at ingest).
+    Persisted so the dashboard renders the address immediately on
+    startup, before the first mDNS probe response. Passing an
+    empty string clears it.
     """
     with metadata_transaction(config_dir) as data:
         entry = data.setdefault(filename, {})

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -268,6 +268,7 @@ def set_device_metadata(
     comment: str | None = None,
     ip: str | None = None,
     expected_config_hash: str | None = None,
+    mac_address: str | None = None,
 ) -> None:
     """
     Set metadata fields for a device.
@@ -283,6 +284,11 @@ def set_device_metadata(
     the running firmware matches the compiled config. Passing an empty
     string clears it (e.g. after a YAML edit invalidates the prior
     compile).
+
+    ``mac_address`` is the lowercase 12-hex-char MAC from the mDNS
+    ``mac`` TXT record. Persisted so the dashboard renders the
+    address immediately on startup, before the first mDNS probe
+    response. Passing an empty string clears it.
     """
     with metadata_transaction(config_dir) as data:
         entry = data.setdefault(filename, {})
@@ -299,6 +305,11 @@ def set_device_metadata(
                 entry["expected_config_hash"] = expected_config_hash
             else:
                 entry.pop("expected_config_hash", None)
+        if mac_address is not None:
+            if mac_address:
+                entry["mac_address"] = mac_address
+            else:
+                entry.pop("mac_address", None)
 
 
 def get_device_metadata(config_dir: Path, filename: str) -> dict[str, Any]:
@@ -337,6 +348,12 @@ _VOLATILE_DEVICE_METADATA_FIELDS: frozenset[str] = frozenset(
         # available artifact and would be misleading on the next
         # compile.
         "expected_config_hash",
+        # Last MAC observed via mDNS. Stable per device but tied
+        # to the running firmware — on archive the YAML may later
+        # be redeployed to a different physical board, and a
+        # stale persisted MAC would render until the next mDNS
+        # announce overwrote it.
+        "mac_address",
     }
 )
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1351,7 +1351,7 @@ class DevicesController:
 
     def _resolve_device_metadata(self, config_dir: Path, filename: str) -> DeviceFileMetadata:
         """
-        Resolve a device's persisted ``board_id``, ``ip``, and config hash.
+        Resolve a device's persisted ``board_id`` / ``ip`` / config hash / MAC.
 
         ``board_id`` priority:
           1. The metadata sidecar — set explicitly when the user
@@ -1384,6 +1384,17 @@ class DevicesController:
         wrote a wrong hash (e.g. the pre-codegen subprocess hash
         the dashboard used to compute) — the next scan after this
         change picks up the canonical value automatically.
+
+        ``mac_address`` is the canonical ``XX:XX:XX:XX:XX:XX`` form
+        last observed on the device's mDNS ``mac`` TXT, persisted
+        to the sidecar so the dashboard renders the value
+        immediately on restart (ESPHome devices are mDNS-silent
+        until probed). Empty when the device hasn't been seen yet
+        — the next mDNS announcement repopulates via
+        :meth:`_on_mac_address_change`. The derived
+        ``ethernet_mac`` / ``bluetooth_mac`` are recomputed by
+        :func:`derive_interface_macs` at ``Device`` construction
+        time, not stored in the sidecar.
         """
         md = get_device_metadata(config_dir, filename)
         ip = str(md.get("ip", ""))

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -33,6 +33,7 @@ from ...helpers.device_yaml import (
 )
 from ...helpers.event_bus import Event, StreamControls, stream_events
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
+from ...helpers.mac_addresses import derive_interface_macs
 from ...helpers.process import kill_quietly
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ...helpers.yaml import merge_component_yaml, rewrite_esphome_name
@@ -157,6 +158,7 @@ class DevicesController:
             on_version_change=self._on_version_change,
             on_config_hash_change=self._on_config_hash_change,
             on_api_encryption_change=self._on_api_encryption_change,
+            on_mac_address_change=self._on_mac_address_change,
             on_importable_added=self._on_importable_added,
             on_importable_removed=self._on_importable_removed,
             is_ignored=self.ignored_devices.__contains__,
@@ -1392,8 +1394,12 @@ class DevicesController:
         board_id = str(md.get("board_id", ""))
         if not board_id:
             board_id = self._derive_board_id_from_yaml(config_dir, filename)
+        mac_address = str(md.get("mac_address", ""))
         return DeviceFileMetadata(
-            board_id=board_id, ip=ip, expected_config_hash=expected_config_hash
+            board_id=board_id,
+            ip=ip,
+            expected_config_hash=expected_config_hash,
+            mac_address=mac_address,
         )
 
     def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:
@@ -1667,6 +1673,41 @@ class DevicesController:
                 device.configuration,
                 old_version or "?",
                 version,
+            )
+            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+
+    def _on_mac_address_change(self, name: str, mac: str) -> None:
+        """
+        Apply a MAC address observed via mDNS and derive interface MACs.
+
+        The mDNS broadcast is always the device's primary MAC (Wi-Fi
+        STA / eFuse base on ESP32, the single MAC on RP2040). When
+        the YAML loads ``ethernet`` or any ``esp32_ble*`` /
+        ``bluetooth_*`` integration we compute the corresponding
+        interface MAC via :func:`derive_interface_macs` so the drawer
+        can show every MAC the device owns without forcing the
+        firmware to broadcast all of them.
+
+        Persists ``mac_address`` to the per-device metadata sidecar
+        so the dashboard shows the value immediately on restart —
+        ESPHome devices stay mDNS-silent until probed. The derived
+        MACs aren't persisted: they're deterministic from primary +
+        ``loaded_integrations``, so a YAML edit that toggles
+        bluetooth picks up the new derived MAC on the next reload
+        without going through a stale-cache window. The early-return
+        on equality skips both the in-memory write and the sidecar
+        I/O on a steady-state announcement, keeping the typical
+        "same value re-broadcast every 60s" cycle off-disk.
+        """
+        for device in self._devices_by_name(name):
+            if device.mac_address == mac:
+                continue
+            device.mac_address = mac
+            device.ethernet_mac, device.bluetooth_mac = derive_interface_macs(
+                mac, device.target_platform, device.loaded_integrations
+            )
+            self._db.create_background_task(
+                self._persist_device_metadata_async(device.configuration, mac_address=mac)
             )
             self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -49,6 +49,7 @@ except ImportError:
     _merge_packages = None  # type: ignore[assignment]
 
 from ..models import Device, DeviceState
+from .mac_addresses import derive_interface_macs
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -387,6 +388,7 @@ def load_device_from_storage(
     board_id: str = "",
     ip: str = "",
     expected_config_hash: str = "",
+    mac_address: str = "",
     *,
     previous: Device | None = None,
 ) -> Device:
@@ -407,6 +409,13 @@ def load_device_from_storage(
     apart from "device has older firmware"; empty when the device
     hasn't been compiled yet, in which case ``has_pending_changes``
     falls back to the mtime check.
+
+    *mac_address* is the lowercase 12-hex-char MAC observed in the
+    device's mDNS ``mac`` TXT, persisted to the sidecar so the
+    drawer / table render the address immediately on startup —
+    ESPHome devices stay mDNS-silent until probed, and the sidecar
+    bridges the gap until the discovery sweep prompts a fresh
+    announcement.
 
     *previous* is the prior in-memory Device for this path, when one
     exists. Runtime-only fields populated by monitors (``state``,
@@ -526,6 +535,14 @@ def load_device_from_storage(
         or config_has_top_level_block(resolved_config, "api")
         or yaml_has_top_level_block(yaml_content, "api")
     )
+    # Derived interface MACs: deterministic from
+    # ``mac_address`` + ``target_platform`` + ``loaded_integrations``,
+    # so we recompute on construction rather than persisting in the
+    # sidecar — a YAML edit that toggles bluetooth picks up the new
+    # derived MAC on the next reload, no stale-cache window.
+    ethernet_mac, bluetooth_mac = derive_interface_macs(
+        mac_address, target_platform, loaded_integrations
+    )
     api_encrypted = get_api_encryption_block(
         resolved_config
     ) is not None or yaml_has_api_encryption(yaml_content)
@@ -571,6 +588,9 @@ def load_device_from_storage(
         ),
         api_enabled=api_enabled,
         api_encrypted=api_encrypted,
+        mac_address=mac_address,
+        ethernet_mac=ethernet_mac,
+        bluetooth_mac=bluetooth_mac,
     )
 
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -410,12 +410,12 @@ def load_device_from_storage(
     hasn't been compiled yet, in which case ``has_pending_changes``
     falls back to the mtime check.
 
-    *mac_address* is the lowercase 12-hex-char MAC observed in the
-    device's mDNS ``mac`` TXT, persisted to the sidecar so the
-    drawer / table render the address immediately on startup —
-    ESPHome devices stay mDNS-silent until probed, and the sidecar
-    bridges the gap until the discovery sweep prompts a fresh
-    announcement.
+    *mac_address* is the canonical ``XX:XX:XX:XX:XX:XX`` MAC
+    observed in the device's mDNS ``mac`` TXT (normalized at
+    ingest), persisted to the sidecar so the drawer / table
+    render the address immediately on startup — ESPHome devices
+    stay mDNS-silent until probed, and the sidecar bridges the gap
+    until the discovery sweep prompts a fresh announcement.
 
     *previous* is the prior in-memory Device for this path, when one
     exists. Runtime-only fields populated by monitors (``state``,

--- a/esphome_device_builder/helpers/mac_addresses.py
+++ b/esphome_device_builder/helpers/mac_addresses.py
@@ -83,8 +83,9 @@ def derive_interface_macs(
     ethernet just renders one row.
 
     *primary* must be in the canonical ``XX:XX:XX:XX:XX:XX`` form
-    that :func:`_normalize_mac` produces; all output MACs match
-    that shape so the wire surface is uniform.
+    that :func:`controllers._device_state_monitor._normalize_mac`
+    produces; all output MACs match that shape so the wire
+    surface is uniform.
 
     The derivation is deterministic and side-effect-free; we recompute
     on every primary-MAC observation rather than persisting the

--- a/esphome_device_builder/helpers/mac_addresses.py
+++ b/esphome_device_builder/helpers/mac_addresses.py
@@ -57,15 +57,15 @@ def _has_bluetooth(loaded_integrations: list[str]) -> bool:
 def _offset_last_octet(primary: str, offset: int) -> str:
     """Return *primary* with the last octet incremented by *offset* (mod 256).
 
-    *primary* is the lowercase 12-hex-char form
+    *primary* is the canonical ``XX:XX:XX:XX:XX:XX`` form
     :func:`controllers._device_state_monitor._normalize_mac` produces.
     The last two hex chars cover the trailing octet; we wrap modulo
     256 to mirror the ESP-IDF behaviour where the offset addition
-    can roll a high-byte value (``0xff`` + 3 → ``0x02``) without
+    can roll a high-byte value (``0xFF`` + 3 → ``0x02``) without
     touching the upper octets.
     """
     last = int(primary[-2:], 16)
-    return f"{primary[:-2]}{(last + offset) % 256:02x}"
+    return f"{primary[:-2]}{(last + offset) % 256:02X}"
 
 
 def derive_interface_macs(
@@ -82,12 +82,17 @@ def derive_interface_macs(
     ``mac_address``, so a single-MAC platform like RP2040 with
     ethernet just renders one row.
 
+    *primary* must be in the canonical ``XX:XX:XX:XX:XX:XX`` form
+    that :func:`_normalize_mac` produces; all output MACs match
+    that shape so the wire surface is uniform.
+
     The derivation is deterministic and side-effect-free; we recompute
     on every primary-MAC observation rather than persisting the
     derived values, so a YAML edit that toggles bluetooth picks up
     the new derived MAC on the very next reload.
     """
-    if not primary or len(primary) != 12:
+    # 17 = ``XX:XX:XX:XX:XX:XX`` — six octets joined by five colons.
+    if not primary or len(primary) != 17:
         return "", ""
 
     has_ethernet = _has_ethernet(loaded_integrations)

--- a/esphome_device_builder/helpers/mac_addresses.py
+++ b/esphome_device_builder/helpers/mac_addresses.py
@@ -91,8 +91,16 @@ def derive_interface_macs(
     derived values, so a YAML edit that toggles bluetooth picks up
     the new derived MAC on the very next reload.
     """
-    # 17 = ``XX:XX:XX:XX:XX:XX`` — six octets joined by five colons.
+    # 17 = ``XX:XX:XX:XX:XX:XX`` — six octets joined by five
+    # colons. Validate hex on the trailing octet too: a corrupt /
+    # hand-edited sidecar entry of the right length but bad chars
+    # would otherwise raise ``ValueError`` deep inside
+    # ``_offset_last_octet`` rather than returning empty here.
     if not primary or len(primary) != 17:
+        return "", ""
+    try:
+        int(primary[-2:], 16)
+    except ValueError:
         return "", ""
 
     has_ethernet = _has_ethernet(loaded_integrations)

--- a/esphome_device_builder/helpers/mac_addresses.py
+++ b/esphome_device_builder/helpers/mac_addresses.py
@@ -1,0 +1,111 @@
+"""Derive interface MAC addresses from a device's primary (broadcast) MAC.
+
+The mDNS ``mac`` TXT record on ``_esphomelib._tcp.local.`` always
+carries the device's *primary* MAC: on ESP32 / ESP32-S2 / ESP32-S3 /
+ESP32-C3 / ESP32-C6 etc. that's the eFuse base MAC (also used as the
+Wi-Fi STA MAC); on RP2040 / RP2350 there's only one MAC across
+interfaces, and that's it.
+
+ESP32-family devices that *also* enable Ethernet or Bluetooth derive
+those interfaces' MACs from the same base via fixed offsets per
+Espressif's allocation table[^1] — Ethernet is base + 3 to the last
+octet, Bluetooth is base + 2. This module computes those derivations
+so the dashboard can show every interface MAC the device owns,
+without forcing the firmware to broadcast all of them.
+
+[^1]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/misc_system_api.html#mac-address-allocation
+"""
+
+from __future__ import annotations
+
+# Platform keys (``Device.target_platform``) that follow Espressif's
+# 4-MAC offset scheme. Anything outside this set falls through the
+# derivation paths as "no derived MACs" — explicit allowlist beats
+# guessing on chips we haven't validated against the eFuse layout.
+_ESP32_PLATFORMS: frozenset[str] = frozenset(
+    {"esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6", "esp32h2", "esp32p4"}
+)
+
+# Platform keys that share a single MAC across every interface — the
+# RP2040 / RP2350 family. When ethernet is enabled the ethernet MAC
+# equals the primary; bluetooth on the Pico W routes through a
+# separate radio chip with its own allocation scheme so we don't
+# derive there.
+_SINGLE_MAC_PLATFORMS: frozenset[str] = frozenset({"rp2040", "rp2350"})
+
+
+def _has_ethernet(loaded_integrations: list[str]) -> bool:
+    """Return whether the resolved YAML loads the ``ethernet`` component."""
+    return "ethernet" in loaded_integrations
+
+
+def _has_bluetooth(loaded_integrations: list[str]) -> bool:
+    """Return whether any ``esp32_ble*`` / ``bluetooth_*`` integration is loaded.
+
+    ESPHome's bluetooth support spans several integrations
+    (``esp32_ble``, ``esp32_ble_tracker``, ``esp32_ble_server``,
+    ``esp32_ble_beacon``, ``bluetooth_proxy``…). Match by prefix so a
+    new bluetooth-related integration name added upstream Just Works
+    without a parallel update here.
+    """
+    return any(
+        name.startswith("esp32_ble") or name.startswith("bluetooth_")
+        for name in loaded_integrations
+    )
+
+
+def _offset_last_octet(primary: str, offset: int) -> str:
+    """Return *primary* with the last octet incremented by *offset* (mod 256).
+
+    *primary* is the lowercase 12-hex-char form
+    :func:`controllers._device_state_monitor._normalize_mac` produces.
+    The last two hex chars cover the trailing octet; we wrap modulo
+    256 to mirror the ESP-IDF behaviour where the offset addition
+    can roll a high-byte value (``0xff`` + 3 → ``0x02``) without
+    touching the upper octets.
+    """
+    last = int(primary[-2:], 16)
+    return f"{primary[:-2]}{(last + offset) % 256:02x}"
+
+
+def derive_interface_macs(
+    primary: str,
+    target_platform: str,
+    loaded_integrations: list[str],
+) -> tuple[str, str]:
+    """
+    Derive ``(ethernet_mac, bluetooth_mac)`` from the broadcast primary MAC.
+
+    Empty primary or unknown platform → ``("", "")``. Each derived
+    MAC is empty when the relevant integration isn't loaded — the
+    drawer hides any row whose value is blank or equal to
+    ``mac_address``, so a single-MAC platform like RP2040 with
+    ethernet just renders one row.
+
+    The derivation is deterministic and side-effect-free; we recompute
+    on every primary-MAC observation rather than persisting the
+    derived values, so a YAML edit that toggles bluetooth picks up
+    the new derived MAC on the very next reload.
+    """
+    if not primary or len(primary) != 12:
+        return "", ""
+
+    has_ethernet = _has_ethernet(loaded_integrations)
+    has_bluetooth = _has_bluetooth(loaded_integrations)
+
+    if target_platform in _ESP32_PLATFORMS:
+        ethernet = _offset_last_octet(primary, 3) if has_ethernet else ""
+        bluetooth = _offset_last_octet(primary, 2) if has_bluetooth else ""
+        return ethernet, bluetooth
+
+    if target_platform in _SINGLE_MAC_PLATFORMS:
+        # Ethernet on RP2040 / RP2350 reuses the primary MAC; we
+        # surface it as a separate field so the frontend can decide
+        # whether to render a redundant row (it doesn't — equality
+        # with the primary is the hide signal). Bluetooth on the
+        # Pico W lives on a CYW43439 radio chip with its own MAC
+        # that we can't derive from the RP-side base.
+        ethernet = primary if has_ethernet else ""
+        return ethernet, ""
+
+    return "", ""

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -100,16 +100,20 @@ class Device(DataClassORJSONMixin):
     # Drives the four-state lock indicator on the device card / table:
     # active, pending-flash, mismatch, plaintext.
     api_encryption_active: str | None = None
-    # Lowercase 12-hex-char MAC observed in the device's
+    # Canonical ``XX:XX:XX:XX:XX:XX`` MAC observed in the device's
     # ``_esphomelib._tcp.local.`` ``mac`` TXT record (e.g.
-    # ``"94c9601f8cf1"``). Empty string when mDNS hasn't surfaced
-    # one yet — the broadcast is reliable for ESPHome firmware so a
-    # blank typically means "device hasn't been seen this session".
-    # Wire format stays raw; the frontend pretty-prints to
-    # ``94:c9:60:1f:8c:f1`` at display time. On ESP32 this is the
-    # Wi-Fi STA MAC (which equals the eFuse base MAC for the
-    # 4-universally-administered default); on RP2040 / RP2350
-    # there's only one MAC across interfaces and this is it.
+    # ``"94:C9:60:1F:8C:F1"``). Empty string when mDNS hasn't
+    # surfaced one yet — the broadcast is reliable for ESPHome
+    # firmware so a blank typically means "device hasn't been
+    # seen this session". The wire form ESPHome currently
+    # broadcasts is lowercase 12-hex-char with no separators; we
+    # normalize at ingest (``_normalize_mac``) so the in-memory
+    # model, sidecar, and frontend wire all carry one canonical
+    # form regardless of what the firmware happens to send. On
+    # ESP32 this is the Wi-Fi STA MAC (which equals the eFuse
+    # base MAC for the 4-universally-administered default); on
+    # RP2040 / RP2350 there's only one MAC across interfaces and
+    # that's it.
     mac_address: str = ""
     # Derived ethernet MAC for devices whose YAML loads the
     # ``ethernet`` integration. Empty string when the device has no

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -100,6 +100,34 @@ class Device(DataClassORJSONMixin):
     # Drives the four-state lock indicator on the device card / table:
     # active, pending-flash, mismatch, plaintext.
     api_encryption_active: str | None = None
+    # Lowercase 12-hex-char MAC observed in the device's
+    # ``_esphomelib._tcp.local.`` ``mac`` TXT record (e.g.
+    # ``"94c9601f8cf1"``). Empty string when mDNS hasn't surfaced
+    # one yet — the broadcast is reliable for ESPHome firmware so a
+    # blank typically means "device hasn't been seen this session".
+    # Wire format stays raw; the frontend pretty-prints to
+    # ``94:c9:60:1f:8c:f1`` at display time. On ESP32 this is the
+    # Wi-Fi STA MAC (which equals the eFuse base MAC for the
+    # 4-universally-administered default); on RP2040 / RP2350
+    # there's only one MAC across interfaces and this is it.
+    mac_address: str = ""
+    # Derived ethernet MAC for devices whose YAML loads the
+    # ``ethernet`` integration. Empty string when the device has no
+    # ethernet integration or no primary MAC has been observed yet.
+    # On ESP32 this is the base MAC + 3 to the last octet, per
+    # Espressif's MAC allocation table; on RP2040 / RP2350 it
+    # equals ``mac_address`` (single-MAC platforms). The drawer
+    # renders this row only when present and distinct from
+    # ``mac_address``.
+    ethernet_mac: str = ""
+    # Derived Bluetooth MAC for devices whose YAML loads any
+    # ``esp32_ble*`` / ``bluetooth_*`` integration. Empty string
+    # when no bluetooth integration is loaded or no primary MAC
+    # has been observed yet. ESP32 only — RP2040 bluetooth
+    # support routes through a separate radio chip with its own
+    # allocation scheme, so we don't derive there. Per
+    # Espressif's table this is base + 2 to the last octet.
+    bluetooth_mac: str = ""
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -395,6 +395,10 @@ class RecordingMonitorCallbacks:
         self.calls.append(("on_api_encryption_change", name, encryption))
         self._flip(name, "api_encryption_active", encryption)
 
+    def on_mac_address_change(self, name: str, mac: str) -> None:
+        self.calls.append(("on_mac_address_change", name, mac))
+        self._flip(name, "mac_address", mac)
+
     def on_importable_added(self, device: AdoptableDevice) -> None:
         self.calls.append(("on_importable_added", device))
 
@@ -422,5 +426,6 @@ def make_state_monitor_with_callbacks(
         on_version_change=callbacks.on_version_change,
         on_config_hash_change=callbacks.on_config_hash_change,
         on_api_encryption_change=callbacks.on_api_encryption_change,
+        on_mac_address_change=callbacks.on_mac_address_change,
     )
     return monitor, callbacks

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -169,19 +169,24 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
         comment="By the toaster",
         ip="192.168.1.42",
         expected_config_hash="deadbeef",
+        mac_address="94c9601f8cf1",
     )
     pre = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
     # Sanity that the seeding above wrote everything we expect.
     assert pre["board_id"] == "esp32-c3-devkitm-1"
     assert pre["ip"] == "192.168.1.42"
     assert pre["expected_config_hash"] == "deadbeef"
+    assert pre["mac_address"] == "94c9601f8cf1"
 
     await controller._archive_single("kitchen.yaml")
 
     post = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
     # Identity fields survive — that's the whole point of this
     # behaviour. A future regression that wipes the entire entry
-    # (the previous shape) fails here.
+    # (the previous shape) fails here. The MAC counts as volatile
+    # (the YAML may later be redeployed to a different physical
+    # board on unarchive) and must be scrubbed alongside ``ip`` /
+    # ``expected_config_hash``.
     assert post == {
         "board_id": "esp32-c3-devkitm-1",
         "friendly_name": "Kitchen Sensor",

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -169,14 +169,14 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
         comment="By the toaster",
         ip="192.168.1.42",
         expected_config_hash="deadbeef",
-        mac_address="94c9601f8cf1",
+        mac_address="94:C9:60:1F:8C:F1",
     )
     pre = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
     # Sanity that the seeding above wrote everything we expect.
     assert pre["board_id"] == "esp32-c3-devkitm-1"
     assert pre["ip"] == "192.168.1.42"
     assert pre["expected_config_hash"] == "deadbeef"
-    assert pre["mac_address"] == "94c9601f8cf1"
+    assert pre["mac_address"] == "94:C9:60:1F:8C:F1"
 
     await controller._archive_single("kitchen.yaml")
 

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -214,6 +214,33 @@ def test_set_device_metadata_clears_expected_config_hash_on_empty(
     assert "expected_config_hash" not in get_device_metadata(tmp_path, "kitchen.yaml")
 
 
+def test_set_device_metadata_persists_mac_address(tmp_path: Path) -> None:
+    """``mac_address=...`` round-trips through ``get_device_metadata``.
+
+    Persisted so the dashboard surfaces the MAC immediately on
+    backend restart — ESPHome devices are mDNS-silent until probed,
+    so a runtime-only field renders blank for the discovery sweep's
+    bootstrap window.
+    """
+    set_device_metadata(tmp_path, "kitchen.yaml", mac_address="94c9601f8cf1")
+
+    assert get_device_metadata(tmp_path, "kitchen.yaml") == {"mac_address": "94c9601f8cf1"}
+
+
+def test_set_device_metadata_clears_mac_on_empty(tmp_path: Path) -> None:
+    """``mac_address=""`` actively clears the persisted MAC.
+
+    Mirrors ``expected_config_hash``'s tri-state (``None`` →
+    no-change, ``""`` → clear, value → set) — a deleted device's
+    archive flow uses the empty-string path to wipe the volatile
+    fields.
+    """
+    set_device_metadata(tmp_path, "kitchen.yaml", mac_address="94c9601f8cf1")
+    set_device_metadata(tmp_path, "kitchen.yaml", mac_address="")
+
+    assert "mac_address" not in get_device_metadata(tmp_path, "kitchen.yaml")
+
+
 def test_remove_device_metadata_clears_only_target(tmp_path: Path) -> None:
     """Removing one device's entry leaves siblings intact."""
     set_device_metadata(tmp_path, "a.yaml", board_id="esp32")

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -222,9 +222,9 @@ def test_set_device_metadata_persists_mac_address(tmp_path: Path) -> None:
     so a runtime-only field renders blank for the discovery sweep's
     bootstrap window.
     """
-    set_device_metadata(tmp_path, "kitchen.yaml", mac_address="94c9601f8cf1")
+    set_device_metadata(tmp_path, "kitchen.yaml", mac_address="94:C9:60:1F:8C:F1")
 
-    assert get_device_metadata(tmp_path, "kitchen.yaml") == {"mac_address": "94c9601f8cf1"}
+    assert get_device_metadata(tmp_path, "kitchen.yaml") == {"mac_address": "94:C9:60:1F:8C:F1"}
 
 
 def test_set_device_metadata_clears_mac_on_empty(tmp_path: Path) -> None:
@@ -235,7 +235,7 @@ def test_set_device_metadata_clears_mac_on_empty(tmp_path: Path) -> None:
     archive flow uses the empty-string path to wipe the volatile
     fields.
     """
-    set_device_metadata(tmp_path, "kitchen.yaml", mac_address="94c9601f8cf1")
+    set_device_metadata(tmp_path, "kitchen.yaml", mac_address="94:C9:60:1F:8C:F1")
     set_device_metadata(tmp_path, "kitchen.yaml", mac_address="")
 
     assert "mac_address" not in get_device_metadata(tmp_path, "kitchen.yaml")

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -264,8 +264,19 @@ async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
     assert monitor.get_cached_dns_addresses("esp.example.com") == ["10.0.0.1"]
 
 
-async def test_ping_sweep_does_not_apply_ip_for_local_hosts(fake_resolver) -> None:
-    """``.local`` devices keep their mDNS-owned IP — DNS doesn't write."""
+async def test_ping_sweep_applies_ip_for_local_hosts(fake_resolver) -> None:
+    """``.local`` devices reachable only via ping get their resolved IP applied.
+
+    Non-API ESPHome devices (no ``_esphomelib._tcp`` broadcast)
+    only surface in the ping sweep. Without applying the
+    DNS/mDNS-resolved address to ``device.ip`` the drawer / table
+    would show an em-dash for the IP row even after successful
+    pings — the
+    ``zwave-proxy-seeedw5500.local``-shows-no-IP-while-ping-active
+    bug. ``apply_ip``'s "preserve existing list when target is in
+    it" branch keeps a richer multi-IP set populated by mDNS
+    safe; this test pins the empty-existing case.
+    """
     devices = [_device(address="kitchen.local")]
     ip_changes: list[tuple[str, str, list[str]]] = []
     monitor = DeviceStateMonitor(
@@ -288,7 +299,7 @@ async def test_ping_sweep_does_not_apply_ip_for_local_hosts(fake_resolver) -> No
     ):
         await monitor._ping_sweep()
 
-    assert ip_changes == []
+    assert ip_changes == [("kitchen", "192.168.1.50", ["192.168.1.50"])]
 
 
 async def test_ping_sweep_rescues_local_device_from_zeroconf_cache() -> None:

--- a/tests/test_mac_address_derivation.py
+++ b/tests/test_mac_address_derivation.py
@@ -131,6 +131,21 @@ def test_short_primary_yields_empty() -> None:
     assert derive_interface_macs("94:C9:60", "esp32", ["ethernet"]) == ("", "")
 
 
+def test_correct_length_non_hex_primary_yields_empty() -> None:
+    """A 17-char value with non-hex chars in the last octet is rejected.
+
+    A corrupt or hand-edited sidecar entry could end up the right
+    length but carry junk in the trailing octet ``ZZ``. Without an
+    explicit hex check the offset math would raise ``ValueError``
+    deep inside ``_offset_last_octet``; the helper instead returns
+    empty so the caller treats the device as "no derived MACs".
+    """
+    assert derive_interface_macs("94:C9:60:1F:8C:ZZ", "esp32", ["ethernet"]) == (
+        "",
+        "",
+    )
+
+
 def test_uncanonical_primary_yields_empty() -> None:
     """Compact 12-hex-char input (the broadcast form) is rejected.
 

--- a/tests/test_mac_address_derivation.py
+++ b/tests/test_mac_address_derivation.py
@@ -20,122 +20,137 @@ import pytest
 
 from esphome_device_builder.helpers.mac_addresses import derive_interface_macs
 
+# ----------------------------------------------------------------------
+# ESP32 family — base + offset per Espressif's table
+# ----------------------------------------------------------------------
 
-class TestEsp32:
-    """ESP32 family follows base + offset per Espressif's table."""
 
-    def test_ethernet_offsets_last_octet_by_three(self) -> None:
-        """``ethernet`` integration → base + 3 to last octet."""
-        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "esp32", ["ethernet"])
-        assert ethernet == "94:C9:60:1F:8C:F3"
-        assert bluetooth == ""
+def test_esp32_ethernet_offsets_last_octet_by_three() -> None:
+    """``ethernet`` integration → base + 3 to last octet."""
+    ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "esp32", ["ethernet"])
+    assert ethernet == "94:C9:60:1F:8C:F3"
+    assert bluetooth == ""
 
-    def test_bluetooth_offsets_last_octet_by_two(self) -> None:
-        """Any ``esp32_ble*`` integration → base + 2 to last octet."""
-        ethernet, bluetooth = derive_interface_macs(
-            "94:C9:60:1F:8C:F0", "esp32", ["esp32_ble_tracker"]
-        )
-        assert ethernet == ""
-        assert bluetooth == "94:C9:60:1F:8C:F2"
 
-    def test_bluetooth_matches_bluetooth_proxy_prefix(self) -> None:
-        """``bluetooth_proxy`` (no ``esp32_`` prefix) still flips the bit."""
-        ethernet, bluetooth = derive_interface_macs(
-            "94:C9:60:1F:8C:F0", "esp32", ["bluetooth_proxy"]
-        )
-        assert ethernet == ""
-        assert bluetooth == "94:C9:60:1F:8C:F2"
+def test_esp32_bluetooth_offsets_last_octet_by_two() -> None:
+    """Any ``esp32_ble*`` integration → base + 2 to last octet."""
+    ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "esp32", ["esp32_ble_tracker"])
+    assert ethernet == ""
+    assert bluetooth == "94:C9:60:1F:8C:F2"
 
-    def test_both_integrations_derive_both(self) -> None:
-        """A device with ethernet + bluetooth surfaces both derived MACs."""
-        ethernet, bluetooth = derive_interface_macs(
-            "94:C9:60:1F:8C:F0",
-            "esp32",
-            ["api", "ethernet", "esp32_ble_tracker", "wifi"],
-        )
-        assert ethernet == "94:C9:60:1F:8C:F3"
-        assert bluetooth == "94:C9:60:1F:8C:F2"
 
-    def test_no_integrations_yields_empty(self) -> None:
-        """A pure Wi-Fi device with no extras has no derived MACs."""
-        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "esp32", ["api", "wifi"])
-        assert ethernet == ""
-        assert bluetooth == ""
+def test_esp32_bluetooth_matches_bluetooth_proxy_prefix() -> None:
+    """``bluetooth_proxy`` (no ``esp32_`` prefix) still flips the bit."""
+    ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "esp32", ["bluetooth_proxy"])
+    assert ethernet == ""
+    assert bluetooth == "94:C9:60:1F:8C:F2"
 
-    def test_last_octet_overflow_wraps_modulo_256(self) -> None:
-        """``0xFF`` + 3 → ``0x02``; the upper octets stay put.
 
-        Mirrors ESP-IDF behaviour where the offset is added with
-        modular wrapping rather than carrying into the next byte.
-        """
-        ethernet, _ = derive_interface_macs("94:C9:60:1F:8C:FF", "esp32", ["ethernet"])
-        assert ethernet == "94:C9:60:1F:8C:02"
-
-    @pytest.mark.parametrize(
-        "platform",
-        ["esp32s2", "esp32s3", "esp32c3", "esp32c6", "esp32h2", "esp32p4"],
+def test_esp32_both_integrations_derive_both() -> None:
+    """A device with ethernet + bluetooth surfaces both derived MACs."""
+    ethernet, bluetooth = derive_interface_macs(
+        "94:C9:60:1F:8C:F0",
+        "esp32",
+        ["api", "ethernet", "esp32_ble_tracker", "wifi"],
     )
-    def test_other_esp32_variants_use_same_offsets(self, platform: str) -> None:
-        """ESP32 variants share the eFuse layout and offset table."""
-        ethernet, bluetooth = derive_interface_macs(
-            "94:C9:60:1F:8C:F0", platform, ["ethernet", "esp32_ble"]
-        )
-        assert ethernet == "94:C9:60:1F:8C:F3"
-        assert bluetooth == "94:C9:60:1F:8C:F2"
+    assert ethernet == "94:C9:60:1F:8C:F3"
+    assert bluetooth == "94:C9:60:1F:8C:F2"
 
 
-class TestSingleMacPlatforms:
-    """RP2040 / RP2350 share one MAC across interfaces."""
-
-    def test_rp2040_ethernet_equals_primary(self) -> None:
-        """W5500-on-RP2040 reuses the single platform MAC."""
-        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2040", ["ethernet"])
-        assert ethernet == "94:C9:60:1F:8C:F0"
-        # No bluetooth derivation: Pico W's BT lives on the CYW43439
-        # with its own MAC the dashboard can't compute from RP-side
-        # data.
-        assert bluetooth == ""
-
-    def test_rp2350_ethernet_equals_primary(self) -> None:
-        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2350", ["ethernet"])
-        assert ethernet == "94:C9:60:1F:8C:F0"
-        assert bluetooth == ""
-
-    def test_rp2040_no_ethernet_yields_empty(self) -> None:
-        """Without the ``ethernet`` integration the row stays hidden."""
-        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2040", ["api", "wifi"])
-        assert ethernet == ""
-        assert bluetooth == ""
+def test_esp32_no_integrations_yields_empty() -> None:
+    """A pure Wi-Fi device with no extras has no derived MACs."""
+    ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "esp32", ["api", "wifi"])
+    assert ethernet == ""
+    assert bluetooth == ""
 
 
-class TestEdgeCases:
-    """Empty / malformed / unknown inputs return empty derivations."""
+def test_esp32_last_octet_overflow_wraps_modulo_256() -> None:
+    """``0xFF`` + 3 → ``0x02``; the upper octets stay put.
 
-    def test_empty_primary_yields_empty(self) -> None:
-        assert derive_interface_macs("", "esp32", ["ethernet"]) == ("", "")
+    Mirrors ESP-IDF behaviour where the offset is added with
+    modular wrapping rather than carrying into the next byte.
+    """
+    ethernet, _ = derive_interface_macs("94:C9:60:1F:8C:FF", "esp32", ["ethernet"])
+    assert ethernet == "94:C9:60:1F:8C:02"
 
-    def test_short_primary_yields_empty(self) -> None:
-        """A primary that's not the canonical 17-char form short-circuits before any math."""
-        assert derive_interface_macs("94:C9:60", "esp32", ["ethernet"]) == ("", "")
 
-    def test_uncanonical_primary_yields_empty(self) -> None:
-        """Compact 12-hex-char input (the broadcast form) is rejected.
+@pytest.mark.parametrize(
+    "platform",
+    ["esp32s2", "esp32s3", "esp32c3", "esp32c6", "esp32h2", "esp32p4"],
+)
+def test_esp32_variants_use_same_offsets(platform: str) -> None:
+    """ESP32 variants share the eFuse layout and offset table."""
+    ethernet, bluetooth = derive_interface_macs(
+        "94:C9:60:1F:8C:F0", platform, ["ethernet", "esp32_ble"]
+    )
+    assert ethernet == "94:C9:60:1F:8C:F3"
+    assert bluetooth == "94:C9:60:1F:8C:F2"
 
-        ``derive_interface_macs`` is wired downstream of
-        ``_normalize_mac``; a non-canonical input here means a caller
-        skipped the normalization step. Returning empty rather than
-        guessing keeps the offset math from operating on
-        unvalidated bytes.
-        """
-        assert derive_interface_macs("94c9601f8cf0", "esp32", ["ethernet"]) == ("", "")
 
-    def test_unknown_platform_yields_empty(self) -> None:
-        """A platform we haven't validated (e.g. ``bk72xx``) → no derivation."""
-        assert derive_interface_macs("94:C9:60:1F:8C:F0", "bk72xx", ["ethernet", "esp32_ble"]) == (
-            "",
-            "",
-        )
+# ----------------------------------------------------------------------
+# Single-MAC platforms — RP2040 / RP2350 share one MAC across interfaces
+# ----------------------------------------------------------------------
 
-    def test_empty_platform_yields_empty(self) -> None:
-        """``target_platform`` blank (never compiled) → no derivation."""
-        assert derive_interface_macs("94:C9:60:1F:8C:F0", "", ["ethernet"]) == ("", "")
+
+def test_rp2040_ethernet_equals_primary() -> None:
+    """W5500-on-RP2040 reuses the single platform MAC."""
+    ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2040", ["ethernet"])
+    assert ethernet == "94:C9:60:1F:8C:F0"
+    # No bluetooth derivation: Pico W's BT lives on the CYW43439
+    # with its own MAC the dashboard can't compute from RP-side
+    # data.
+    assert bluetooth == ""
+
+
+def test_rp2350_ethernet_equals_primary() -> None:
+    """RP2350 follows the same single-MAC scheme as RP2040."""
+    ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2350", ["ethernet"])
+    assert ethernet == "94:C9:60:1F:8C:F0"
+    assert bluetooth == ""
+
+
+def test_rp2040_no_ethernet_yields_empty() -> None:
+    """Without the ``ethernet`` integration the row stays hidden."""
+    ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2040", ["api", "wifi"])
+    assert ethernet == ""
+    assert bluetooth == ""
+
+
+# ----------------------------------------------------------------------
+# Edge cases — empty / malformed / unknown inputs
+# ----------------------------------------------------------------------
+
+
+def test_empty_primary_yields_empty() -> None:
+    """No primary MAC observed yet → no derivation."""
+    assert derive_interface_macs("", "esp32", ["ethernet"]) == ("", "")
+
+
+def test_short_primary_yields_empty() -> None:
+    """A primary that's not the canonical 17-char form short-circuits before any math."""
+    assert derive_interface_macs("94:C9:60", "esp32", ["ethernet"]) == ("", "")
+
+
+def test_uncanonical_primary_yields_empty() -> None:
+    """Compact 12-hex-char input (the broadcast form) is rejected.
+
+    ``derive_interface_macs`` is wired downstream of
+    ``_normalize_mac``; a non-canonical input here means a caller
+    skipped the normalization step. Returning empty rather than
+    guessing keeps the offset math from operating on
+    unvalidated bytes.
+    """
+    assert derive_interface_macs("94c9601f8cf0", "esp32", ["ethernet"]) == ("", "")
+
+
+def test_unknown_platform_yields_empty() -> None:
+    """A platform we haven't validated (e.g. ``bk72xx``) → no derivation."""
+    assert derive_interface_macs("94:C9:60:1F:8C:F0", "bk72xx", ["ethernet", "esp32_ble"]) == (
+        "",
+        "",
+    )
+
+
+def test_empty_platform_yields_empty() -> None:
+    """``target_platform`` blank (never compiled) → no derivation."""
+    assert derive_interface_macs("94:C9:60:1F:8C:F0", "", ["ethernet"]) == ("", "")

--- a/tests/test_mac_address_derivation.py
+++ b/tests/test_mac_address_derivation.py
@@ -1,0 +1,122 @@
+"""Tests for the per-interface MAC derivation helper.
+
+The mDNS ``mac`` TXT carries the device's primary MAC. ESP32-family
+devices that also enable Ethernet / Bluetooth derive those
+interfaces' MACs from the same base via fixed offsets per
+Espressif's allocation table; RP2040 / RP2350 share a single MAC
+across interfaces. The dashboard renders every derived MAC in the
+device drawer so users can match a device to its router-side
+ethernet MAC, BLE scanner readings, etc. without forcing the
+firmware to broadcast each one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.helpers.mac_addresses import derive_interface_macs
+
+
+class TestEsp32:
+    """ESP32 family follows base + offset per Espressif's table."""
+
+    def test_ethernet_offsets_last_octet_by_three(self) -> None:
+        """``ethernet`` integration → base + 3 to last octet."""
+        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "esp32", ["ethernet"])
+        assert ethernet == "94c9601f8cf3"
+        assert bluetooth == ""
+
+    def test_bluetooth_offsets_last_octet_by_two(self) -> None:
+        """Any ``esp32_ble*`` integration → base + 2 to last octet."""
+        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "esp32", ["esp32_ble_tracker"])
+        assert ethernet == ""
+        assert bluetooth == "94c9601f8cf2"
+
+    def test_bluetooth_matches_bluetooth_proxy_prefix(self) -> None:
+        """``bluetooth_proxy`` (no ``esp32_`` prefix) still flips the bit."""
+        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "esp32", ["bluetooth_proxy"])
+        assert ethernet == ""
+        assert bluetooth == "94c9601f8cf2"
+
+    def test_both_integrations_derive_both(self) -> None:
+        """A device with ethernet + bluetooth surfaces both derived MACs."""
+        ethernet, bluetooth = derive_interface_macs(
+            "94c9601f8cf0",
+            "esp32",
+            ["api", "ethernet", "esp32_ble_tracker", "wifi"],
+        )
+        assert ethernet == "94c9601f8cf3"
+        assert bluetooth == "94c9601f8cf2"
+
+    def test_no_integrations_yields_empty(self) -> None:
+        """A pure Wi-Fi device with no extras has no derived MACs."""
+        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "esp32", ["api", "wifi"])
+        assert ethernet == ""
+        assert bluetooth == ""
+
+    def test_last_octet_overflow_wraps_modulo_256(self) -> None:
+        """``0xff`` + 3 → ``0x02``; the upper octets stay put.
+
+        Mirrors ESP-IDF behaviour where the offset is added with
+        modular wrapping rather than carrying into the next byte.
+        """
+        ethernet, _ = derive_interface_macs("94c9601f8cff", "esp32", ["ethernet"])
+        assert ethernet == "94c9601f8c02"
+
+    @pytest.mark.parametrize(
+        "platform",
+        ["esp32s2", "esp32s3", "esp32c3", "esp32c6", "esp32h2", "esp32p4"],
+    )
+    def test_other_esp32_variants_use_same_offsets(self, platform: str) -> None:
+        """ESP32 variants share the eFuse layout and offset table."""
+        ethernet, bluetooth = derive_interface_macs(
+            "94c9601f8cf0", platform, ["ethernet", "esp32_ble"]
+        )
+        assert ethernet == "94c9601f8cf3"
+        assert bluetooth == "94c9601f8cf2"
+
+
+class TestSingleMacPlatforms:
+    """RP2040 / RP2350 share one MAC across interfaces."""
+
+    def test_rp2040_ethernet_equals_primary(self) -> None:
+        """W5500-on-RP2040 reuses the single platform MAC."""
+        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "rp2040", ["ethernet"])
+        assert ethernet == "94c9601f8cf0"
+        # No bluetooth derivation: Pico W's BT lives on the CYW43439
+        # with its own MAC the dashboard can't compute from RP-side
+        # data.
+        assert bluetooth == ""
+
+    def test_rp2350_ethernet_equals_primary(self) -> None:
+        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "rp2350", ["ethernet"])
+        assert ethernet == "94c9601f8cf0"
+        assert bluetooth == ""
+
+    def test_rp2040_no_ethernet_yields_empty(self) -> None:
+        """Without the ``ethernet`` integration the row stays hidden."""
+        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "rp2040", ["api", "wifi"])
+        assert ethernet == ""
+        assert bluetooth == ""
+
+
+class TestEdgeCases:
+    """Empty / malformed / unknown inputs return empty derivations."""
+
+    def test_empty_primary_yields_empty(self) -> None:
+        assert derive_interface_macs("", "esp32", ["ethernet"]) == ("", "")
+
+    def test_short_primary_yields_empty(self) -> None:
+        """A primary that's not 12 chars short-circuits before any math."""
+        assert derive_interface_macs("94c960", "esp32", ["ethernet"]) == ("", "")
+
+    def test_unknown_platform_yields_empty(self) -> None:
+        """A platform we haven't validated (e.g. ``bk72xx``) → no derivation."""
+        assert derive_interface_macs("94c9601f8cf0", "bk72xx", ["ethernet", "esp32_ble"]) == (
+            "",
+            "",
+        )
+
+    def test_empty_platform_yields_empty(self) -> None:
+        """``target_platform`` blank (never compiled) → no derivation."""
+        assert derive_interface_macs("94c9601f8cf0", "", ["ethernet"]) == ("", "")

--- a/tests/test_mac_address_derivation.py
+++ b/tests/test_mac_address_derivation.py
@@ -8,6 +8,10 @@ across interfaces. The dashboard renders every derived MAC in the
 device drawer so users can match a device to its router-side
 ethernet MAC, BLE scanner readings, etc. without forcing the
 firmware to broadcast each one.
+
+All MACs in / out of :func:`derive_interface_macs` are in the
+canonical ``XX:XX:XX:XX:XX:XX`` form that
+:func:`controllers._device_state_monitor._normalize_mac` produces.
 """
 
 from __future__ import annotations
@@ -22,46 +26,50 @@ class TestEsp32:
 
     def test_ethernet_offsets_last_octet_by_three(self) -> None:
         """``ethernet`` integration → base + 3 to last octet."""
-        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "esp32", ["ethernet"])
-        assert ethernet == "94c9601f8cf3"
+        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "esp32", ["ethernet"])
+        assert ethernet == "94:C9:60:1F:8C:F3"
         assert bluetooth == ""
 
     def test_bluetooth_offsets_last_octet_by_two(self) -> None:
         """Any ``esp32_ble*`` integration → base + 2 to last octet."""
-        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "esp32", ["esp32_ble_tracker"])
+        ethernet, bluetooth = derive_interface_macs(
+            "94:C9:60:1F:8C:F0", "esp32", ["esp32_ble_tracker"]
+        )
         assert ethernet == ""
-        assert bluetooth == "94c9601f8cf2"
+        assert bluetooth == "94:C9:60:1F:8C:F2"
 
     def test_bluetooth_matches_bluetooth_proxy_prefix(self) -> None:
         """``bluetooth_proxy`` (no ``esp32_`` prefix) still flips the bit."""
-        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "esp32", ["bluetooth_proxy"])
+        ethernet, bluetooth = derive_interface_macs(
+            "94:C9:60:1F:8C:F0", "esp32", ["bluetooth_proxy"]
+        )
         assert ethernet == ""
-        assert bluetooth == "94c9601f8cf2"
+        assert bluetooth == "94:C9:60:1F:8C:F2"
 
     def test_both_integrations_derive_both(self) -> None:
         """A device with ethernet + bluetooth surfaces both derived MACs."""
         ethernet, bluetooth = derive_interface_macs(
-            "94c9601f8cf0",
+            "94:C9:60:1F:8C:F0",
             "esp32",
             ["api", "ethernet", "esp32_ble_tracker", "wifi"],
         )
-        assert ethernet == "94c9601f8cf3"
-        assert bluetooth == "94c9601f8cf2"
+        assert ethernet == "94:C9:60:1F:8C:F3"
+        assert bluetooth == "94:C9:60:1F:8C:F2"
 
     def test_no_integrations_yields_empty(self) -> None:
         """A pure Wi-Fi device with no extras has no derived MACs."""
-        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "esp32", ["api", "wifi"])
+        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "esp32", ["api", "wifi"])
         assert ethernet == ""
         assert bluetooth == ""
 
     def test_last_octet_overflow_wraps_modulo_256(self) -> None:
-        """``0xff`` + 3 → ``0x02``; the upper octets stay put.
+        """``0xFF`` + 3 → ``0x02``; the upper octets stay put.
 
         Mirrors ESP-IDF behaviour where the offset is added with
         modular wrapping rather than carrying into the next byte.
         """
-        ethernet, _ = derive_interface_macs("94c9601f8cff", "esp32", ["ethernet"])
-        assert ethernet == "94c9601f8c02"
+        ethernet, _ = derive_interface_macs("94:C9:60:1F:8C:FF", "esp32", ["ethernet"])
+        assert ethernet == "94:C9:60:1F:8C:02"
 
     @pytest.mark.parametrize(
         "platform",
@@ -70,10 +78,10 @@ class TestEsp32:
     def test_other_esp32_variants_use_same_offsets(self, platform: str) -> None:
         """ESP32 variants share the eFuse layout and offset table."""
         ethernet, bluetooth = derive_interface_macs(
-            "94c9601f8cf0", platform, ["ethernet", "esp32_ble"]
+            "94:C9:60:1F:8C:F0", platform, ["ethernet", "esp32_ble"]
         )
-        assert ethernet == "94c9601f8cf3"
-        assert bluetooth == "94c9601f8cf2"
+        assert ethernet == "94:C9:60:1F:8C:F3"
+        assert bluetooth == "94:C9:60:1F:8C:F2"
 
 
 class TestSingleMacPlatforms:
@@ -81,21 +89,21 @@ class TestSingleMacPlatforms:
 
     def test_rp2040_ethernet_equals_primary(self) -> None:
         """W5500-on-RP2040 reuses the single platform MAC."""
-        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "rp2040", ["ethernet"])
-        assert ethernet == "94c9601f8cf0"
+        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2040", ["ethernet"])
+        assert ethernet == "94:C9:60:1F:8C:F0"
         # No bluetooth derivation: Pico W's BT lives on the CYW43439
         # with its own MAC the dashboard can't compute from RP-side
         # data.
         assert bluetooth == ""
 
     def test_rp2350_ethernet_equals_primary(self) -> None:
-        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "rp2350", ["ethernet"])
-        assert ethernet == "94c9601f8cf0"
+        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2350", ["ethernet"])
+        assert ethernet == "94:C9:60:1F:8C:F0"
         assert bluetooth == ""
 
     def test_rp2040_no_ethernet_yields_empty(self) -> None:
         """Without the ``ethernet`` integration the row stays hidden."""
-        ethernet, bluetooth = derive_interface_macs("94c9601f8cf0", "rp2040", ["api", "wifi"])
+        ethernet, bluetooth = derive_interface_macs("94:C9:60:1F:8C:F0", "rp2040", ["api", "wifi"])
         assert ethernet == ""
         assert bluetooth == ""
 
@@ -107,16 +115,27 @@ class TestEdgeCases:
         assert derive_interface_macs("", "esp32", ["ethernet"]) == ("", "")
 
     def test_short_primary_yields_empty(self) -> None:
-        """A primary that's not 12 chars short-circuits before any math."""
-        assert derive_interface_macs("94c960", "esp32", ["ethernet"]) == ("", "")
+        """A primary that's not the canonical 17-char form short-circuits before any math."""
+        assert derive_interface_macs("94:C9:60", "esp32", ["ethernet"]) == ("", "")
+
+    def test_uncanonical_primary_yields_empty(self) -> None:
+        """Compact 12-hex-char input (the broadcast form) is rejected.
+
+        ``derive_interface_macs`` is wired downstream of
+        ``_normalize_mac``; a non-canonical input here means a caller
+        skipped the normalization step. Returning empty rather than
+        guessing keeps the offset math from operating on
+        unvalidated bytes.
+        """
+        assert derive_interface_macs("94c9601f8cf0", "esp32", ["ethernet"]) == ("", "")
 
     def test_unknown_platform_yields_empty(self) -> None:
         """A platform we haven't validated (e.g. ``bk72xx``) → no derivation."""
-        assert derive_interface_macs("94c9601f8cf0", "bk72xx", ["ethernet", "esp32_ble"]) == (
+        assert derive_interface_macs("94:C9:60:1F:8C:F0", "bk72xx", ["ethernet", "esp32_ble"]) == (
             "",
             "",
         )
 
     def test_empty_platform_yields_empty(self) -> None:
         """``target_platform`` blank (never compiled) → no derivation."""
-        assert derive_interface_macs("94c9601f8cf0", "", ["ethernet"]) == ("", "")
+        assert derive_interface_macs("94:C9:60:1F:8C:F0", "", ["ethernet"]) == ("", "")

--- a/tests/test_mdns_mac_address.py
+++ b/tests/test_mdns_mac_address.py
@@ -3,9 +3,12 @@
 ESPHome firmware broadcasts a ``mac`` TXT record on the
 ``_esphomelib._tcp`` mDNS service so dashboards can show the
 hardware address without a separate query. The TXT value is the
-lowercase 12-hex-char form (no colons); the frontend pretty-prints
-to ``94:c9:60:1f:8c:f1`` at display time. Same monitor → controller
-shape as the other TXT pipelines in ``test_mdns_version.py`` and
+lowercase 12-hex-char form (no colons); the dashboard normalizes
+at ingest to the canonical ``XX:XX:XX:XX:XX:XX`` form so the
+in-memory model, sidecar, and frontend wire all carry one shape
+regardless of which case / separator style the firmware happens
+to broadcast. Same monitor → controller pipeline as the other TXT
+records covered by ``test_mdns_version.py`` /
 ``test_mdns_config_hash.py``.
 
 The MAC is persisted to the per-device metadata sidecar so it
@@ -22,7 +25,10 @@ from typing import Any
 
 from esphome_device_builder.models import Device, DeviceState, EventType
 
-from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
+from .conftest import (
+    make_devices_controller_with_bus,
+    make_state_monitor_with_callbacks,
+)
 
 
 def _device(**overrides: Any) -> Device:
@@ -38,10 +44,10 @@ def _device(**overrides: Any) -> Device:
 
 
 def test_apply_mac_address_first_observation_fires_callback() -> None:
-    """A MAC we haven't seen before reaches the controller."""
+    """A MAC we haven't seen before reaches the controller in canonical form."""
     monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_mac_address("kitchen", "94c9601f8cf1") is True
-    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_dedupes_same_value() -> None:
@@ -53,7 +59,7 @@ def test_apply_mac_address_dedupes_same_value() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
-    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_fires_on_change() -> None:
@@ -66,8 +72,8 @@ def test_apply_mac_address_fires_on_change() -> None:
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
     monitor.apply_mac_address("kitchen", "aabbccddeeff")
     assert callbacks.calls == [
-        ("on_mac_address_change", "kitchen", "94c9601f8cf1"),
-        ("on_mac_address_change", "kitchen", "aabbccddeeff"),
+        ("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1"),
+        ("on_mac_address_change", "kitchen", "AA:BB:CC:DD:EE:FF"),
     ]
 
 
@@ -96,52 +102,74 @@ def test_apply_mac_address_unknown_device_is_no_op() -> None:
 # Normalization at ingest
 #
 # ESPHome firmware broadcasts a lowercase 12-hex-char MAC today, but
-# the dashboard normalizes at ingest so the dedupe + persisted sidecar
-# stay canonical even if a future firmware switches case or
-# separator style. The wire is not the source of truth — the
-# normalized form is.
+# the dashboard normalizes at ingest to ``XX:XX:XX:XX:XX:XX`` so the
+# dedupe + persisted sidecar + frontend wire all carry one canonical
+# form even if a future firmware switches case or separator style.
 # ----------------------------------------------------------------------
 
 
-def test_apply_mac_address_normalizes_uppercase() -> None:
-    """Uppercase MACs collapse to lowercase before storage."""
+def test_apply_mac_address_normalizes_lowercase_to_canonical() -> None:
+    """Lowercase 12-hex-char wire form (today's broadcast shape) → uppercase colon-form."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor.apply_mac_address("kitchen", "94c9601f8cf1")
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
+
+
+def test_apply_mac_address_normalizes_uppercase_compact() -> None:
+    """Uppercase 12-hex-char input also lands as canonical."""
     monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_mac_address("kitchen", "94C9601F8CF1")
-    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
-def test_apply_mac_address_strips_colon_separators() -> None:
-    """Colon-separated MACs land as 12 contiguous hex chars."""
+def test_apply_mac_address_already_canonical_is_idempotent() -> None:
+    """Already-canonical input passes through unchanged.
+
+    A MAC normalized once shouldn't shift form on the second
+    pass — important because the controller stores canonical form
+    on the device, and a re-broadcast feeds back through the same
+    normalize path.
+    """
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor.apply_mac_address("kitchen", "94:C9:60:1F:8C:F1")
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
+
+
+def test_apply_mac_address_strips_lowercase_colon_separators() -> None:
+    """Lowercase colon-separated MAC normalizes to uppercase canonical."""
     monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_mac_address("kitchen", "94:c9:60:1f:8c:f1")
-    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_strips_dash_separators() -> None:
-    """Windows-style ``94-c9-60-...`` normalizes the same way."""
+    """Windows-style ``94-C9-60-...`` normalizes the same way."""
     monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_mac_address("kitchen", "94-C9-60-1F-8C-F1")
-    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_strips_dot_separators() -> None:
     """Cisco-style ``94c9.601f.8cf1`` normalizes the same way."""
     monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     monitor.apply_mac_address("kitchen", "94c9.601f.8cf1")
-    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_normalized_dedupes_against_stored() -> None:
-    """An uppercase re-broadcast of a stored lowercase MAC dedupes.
+    """A non-canonical re-broadcast of a stored canonical MAC dedupes.
 
     The whole point of normalizing at ingest: the dashboard
     shouldn't write a sidecar entry every time the firmware happens
-    to switch case style. The dedupe is keyed off the normalized
+    to switch case style. The dedupe is keyed off the canonical
     form so equivalence holds across surface formats.
     """
-    devices = [_device(mac_address="94c9601f8cf1")]
+    devices = [_device(mac_address="94:C9:60:1F:8C:F1")]
     monitor, callbacks = make_state_monitor_with_callbacks(devices)
-    assert monitor.apply_mac_address("kitchen", "94:C9:60:1F:8C:F1") is False
+    # Wire form (lowercase 12-hex) — what the firmware actually broadcasts.
+    assert monitor.apply_mac_address("kitchen", "94c9601f8cf1") is False
+    # Dash-separated — what some vendored tools might use.
+    assert monitor.apply_mac_address("kitchen", "94-C9-60-1F-8C-F1") is False
     assert callbacks.calls == []
 
 
@@ -171,24 +199,29 @@ def test_apply_mac_address_refires_after_device_rebuild() -> None:
     the device's own field, so the next mDNS announcement should
     repopulate without short-circuiting on a stale cache.
     """
-    devices = [_device(mac_address="94c9601f8cf1")]
+    devices = [_device(mac_address="94:C9:60:1F:8C:F1")]
     monitor, callbacks = make_state_monitor_with_callbacks(devices)
 
-    # Steady state: the device already has the MAC, so a repeat
-    # announcement is a no-op.
+    # Steady state: the device already has the canonical MAC, so a
+    # repeat broadcast (in the wire form) is a no-op.
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
     assert callbacks.calls == []
 
     # Atomic-save churn rebuilds the Device with empty fields. The
     # next mDNS announcement should write the MAC back through the
-    # callback.
+    # callback, in canonical form.
     devices[0].mac_address = ""
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
-    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 # ----------------------------------------------------------------------
 # DevicesController._on_mac_address_change — full pipe + persistence
+#
+# The controller-level callback receives the *already normalized*
+# MAC (the monitor's ``apply_mac_address`` does the normalization
+# before invoking the change callback), so these tests pass the
+# canonical form directly.
 # ----------------------------------------------------------------------
 
 
@@ -229,9 +262,9 @@ def test_on_mac_address_change_updates_device_and_fires_event() -> None:
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_mac_address_change("kitchen", "94c9601f8cf1")
+    controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F1")
 
-    assert device.mac_address == "94c9601f8cf1"
+    assert device.mac_address == "94:C9:60:1F:8C:F1"
     assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
 
 
@@ -243,7 +276,7 @@ def test_on_mac_address_change_persists_to_sidecar() -> None:
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_mac_address_change("kitchen", "94c9601f8cf1")
+    controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F1")
 
     assert len(scheduled) == 1
 
@@ -257,13 +290,13 @@ def test_on_mac_address_change_skips_persist_when_unchanged() -> None:
     broadcast short-circuits before either the in-memory write or
     the executor-bound ``set_device_metadata`` call.
     """
-    device = _device_kitchen(mac_address="94c9601f8cf1")
+    device = _device_kitchen(mac_address="94:C9:60:1F:8C:F1")
     scheduled: list[object] = []
     controller, captured = make_devices_controller_with_bus(
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_mac_address_change("kitchen", "94c9601f8cf1")
+    controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F1")
 
     assert scheduled == []
     assert captured == []
@@ -276,7 +309,7 @@ def test_on_mac_address_change_unknown_device_is_noop() -> None:
         [], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_mac_address_change("ghost", "94c9601f8cf1")
+    controller._on_mac_address_change("ghost", "94:C9:60:1F:8C:F1")
 
     assert scheduled == []
     assert captured == []
@@ -298,10 +331,10 @@ def test_on_mac_address_change_derives_ethernet_mac_on_esp32() -> None:
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_mac_address_change("kitchen", "94c9601f8cf0")
+    controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
 
-    assert device.mac_address == "94c9601f8cf0"
-    assert device.ethernet_mac == "94c9601f8cf3"
+    assert device.mac_address == "94:C9:60:1F:8C:F0"
+    assert device.ethernet_mac == "94:C9:60:1F:8C:F3"
     assert device.bluetooth_mac == ""
 
 
@@ -316,11 +349,11 @@ def test_on_mac_address_change_derives_bluetooth_mac_on_esp32() -> None:
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_mac_address_change("kitchen", "94c9601f8cf0")
+    controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
 
-    assert device.mac_address == "94c9601f8cf0"
+    assert device.mac_address == "94:C9:60:1F:8C:F0"
     assert device.ethernet_mac == ""
-    assert device.bluetooth_mac == "94c9601f8cf2"
+    assert device.bluetooth_mac == "94:C9:60:1F:8C:F2"
 
 
 def test_on_mac_address_change_derives_ethernet_equal_primary_on_rp2040() -> None:
@@ -339,10 +372,10 @@ def test_on_mac_address_change_derives_ethernet_equal_primary_on_rp2040() -> Non
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_mac_address_change("kitchen", "94c9601f8cf0")
+    controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
 
-    assert device.mac_address == "94c9601f8cf0"
-    assert device.ethernet_mac == "94c9601f8cf0"
+    assert device.mac_address == "94:C9:60:1F:8C:F0"
+    assert device.ethernet_mac == "94:C9:60:1F:8C:F0"
     assert device.bluetooth_mac == ""
 
 
@@ -362,8 +395,35 @@ def test_on_mac_address_change_clears_derived_on_unknown_platform() -> None:
         [device], create_background_task=_record_scheduled(scheduled)
     )
 
-    controller._on_mac_address_change("kitchen", "94c9601f8cf0")
+    controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
 
-    assert device.mac_address == "94c9601f8cf0"
+    assert device.mac_address == "94:C9:60:1F:8C:F0"
+    assert device.ethernet_mac == ""
+    assert device.bluetooth_mac == ""
+
+
+def test_on_mac_address_change_clears_stale_derived_macs_on_change() -> None:
+    """A new primary MAC overwrites previously-derived ethernet/bluetooth.
+
+    A device whose YAML drops the ``ethernet`` integration after
+    a re-flash would otherwise carry a stale ``ethernet_mac`` until
+    the next reload. Recomputing on every change ensures the
+    derived fields can never lag behind the integration loadout.
+    """
+    device = _device_kitchen(
+        target_platform="esp32",
+        loaded_integrations=["api", "wifi"],  # no ethernet, no bluetooth
+        mac_address="94:C9:60:1F:8C:00",
+        ethernet_mac="94:C9:60:1F:8C:03",  # stale from a prior loadout
+        bluetooth_mac="94:C9:60:1F:8C:02",
+    )
+    scheduled: list[object] = []
+    controller, _captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
+
+    assert device.mac_address == "94:C9:60:1F:8C:F0"
     assert device.ethernet_mac == ""
     assert device.bluetooth_mac == ""

--- a/tests/test_mdns_mac_address.py
+++ b/tests/test_mdns_mac_address.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.models import Device, DeviceState, EventType
 
 from .conftest import (
@@ -96,6 +97,22 @@ def test_apply_mac_address_unknown_device_is_no_op() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([_device()])
     assert monitor.apply_mac_address("not-configured", "94c9601f8cf1") is False
     assert callbacks.calls == []
+
+
+def test_apply_mac_address_no_op_when_callback_unwired() -> None:
+    """A monitor built without ``on_mac_address_change`` is a no-op.
+
+    The callback is optional in :class:`DeviceStateMonitor`'s
+    constructor — older callers (in-process usages, smaller test
+    fixtures) skip it. ``apply_mac_address`` must short-circuit
+    cleanly without dereferencing the ``None`` callback.
+    """
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: [_device()],
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+    assert monitor.apply_mac_address("kitchen", "94c9601f8cf1") is False
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_mdns_mac_address.py
+++ b/tests/test_mdns_mac_address.py
@@ -1,0 +1,369 @@
+"""Tests for mDNS-driven MAC-address sync.
+
+ESPHome firmware broadcasts a ``mac`` TXT record on the
+``_esphomelib._tcp`` mDNS service so dashboards can show the
+hardware address without a separate query. The TXT value is the
+lowercase 12-hex-char form (no colons); the frontend pretty-prints
+to ``94:c9:60:1f:8c:f1`` at display time. Same monitor → controller
+shape as the other TXT pipelines in ``test_mdns_version.py`` and
+``test_mdns_config_hash.py``.
+
+The MAC is persisted to the per-device metadata sidecar so it
+renders immediately on backend restart — ESPHome devices stay
+mDNS-silent until probed, which would otherwise leave the column
+blank for several seconds. Persistence is gated on a real change
+to keep the steady-state "same MAC every announce" cycle off-disk.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from esphome_device_builder.models import Device, DeviceState, EventType
+
+from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
+
+
+def _device(**overrides: Any) -> Device:
+    base: dict[str, Any] = {
+        "name": "kitchen",
+        "friendly_name": "Kitchen",
+        "configuration": "kitchen.yaml",
+        "address": "kitchen.local",
+        "state": DeviceState.UNKNOWN,
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+def test_apply_mac_address_first_observation_fires_callback() -> None:
+    """A MAC we haven't seen before reaches the controller."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    assert monitor.apply_mac_address("kitchen", "94c9601f8cf1") is True
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+
+
+def test_apply_mac_address_dedupes_same_value() -> None:
+    """Same MAC twice → callback fires once.
+
+    Devices broadcast the same TXT every announce; the dedupe keeps
+    DEVICE_UPDATED quiet on a healthy fleet.
+    """
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor.apply_mac_address("kitchen", "94c9601f8cf1")
+    monitor.apply_mac_address("kitchen", "94c9601f8cf1")
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+
+
+def test_apply_mac_address_fires_on_change() -> None:
+    """A different MAC than the last observation re-fires the callback.
+
+    Realistic when an unflashed YAML gets pointed at a different
+    physical board mid-test.
+    """
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor.apply_mac_address("kitchen", "94c9601f8cf1")
+    monitor.apply_mac_address("kitchen", "aabbccddeeff")
+    assert callbacks.calls == [
+        ("on_mac_address_change", "kitchen", "94c9601f8cf1"),
+        ("on_mac_address_change", "kitchen", "aabbccddeeff"),
+    ]
+
+
+def test_apply_mac_address_ignores_empty_string() -> None:
+    """Older firmware doesn't broadcast the TXT → empty-string is a no-op.
+
+    The TXT extraction site (``_apply_service_info_to_device``)
+    skips ``apply_mac_address`` entirely when the TXT is missing,
+    but the apply method still has to drop empty strings on its own
+    so callers that read the dict via ``.get("mac") or ""`` don't
+    blank out a previously-known MAC.
+    """
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    assert monitor.apply_mac_address("kitchen", "") is False
+    assert callbacks.calls == []
+
+
+def test_apply_mac_address_unknown_device_is_no_op() -> None:
+    """A stray announcement for an unconfigured name does nothing."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    assert monitor.apply_mac_address("not-configured", "94c9601f8cf1") is False
+    assert callbacks.calls == []
+
+
+# ----------------------------------------------------------------------
+# Normalization at ingest
+#
+# ESPHome firmware broadcasts a lowercase 12-hex-char MAC today, but
+# the dashboard normalizes at ingest so the dedupe + persisted sidecar
+# stay canonical even if a future firmware switches case or
+# separator style. The wire is not the source of truth — the
+# normalized form is.
+# ----------------------------------------------------------------------
+
+
+def test_apply_mac_address_normalizes_uppercase() -> None:
+    """Uppercase MACs collapse to lowercase before storage."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor.apply_mac_address("kitchen", "94C9601F8CF1")
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+
+
+def test_apply_mac_address_strips_colon_separators() -> None:
+    """Colon-separated MACs land as 12 contiguous hex chars."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor.apply_mac_address("kitchen", "94:c9:60:1f:8c:f1")
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+
+
+def test_apply_mac_address_strips_dash_separators() -> None:
+    """Windows-style ``94-c9-60-...`` normalizes the same way."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor.apply_mac_address("kitchen", "94-C9-60-1F-8C-F1")
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+
+
+def test_apply_mac_address_strips_dot_separators() -> None:
+    """Cisco-style ``94c9.601f.8cf1`` normalizes the same way."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor.apply_mac_address("kitchen", "94c9.601f.8cf1")
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+
+
+def test_apply_mac_address_normalized_dedupes_against_stored() -> None:
+    """An uppercase re-broadcast of a stored lowercase MAC dedupes.
+
+    The whole point of normalizing at ingest: the dashboard
+    shouldn't write a sidecar entry every time the firmware happens
+    to switch case style. The dedupe is keyed off the normalized
+    form so equivalence holds across surface formats.
+    """
+    devices = [_device(mac_address="94c9601f8cf1")]
+    monitor, callbacks = make_state_monitor_with_callbacks(devices)
+    assert monitor.apply_mac_address("kitchen", "94:C9:60:1F:8C:F1") is False
+    assert callbacks.calls == []
+
+
+def test_apply_mac_address_rejects_non_hex_input() -> None:
+    """Garbage TXT content is dropped, not stored."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    assert monitor.apply_mac_address("kitchen", "not-a-mac") is False
+    assert callbacks.calls == []
+
+
+def test_apply_mac_address_rejects_wrong_length() -> None:
+    """Too-short / too-long values are dropped (not silently truncated)."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    # 11 chars
+    assert monitor.apply_mac_address("kitchen", "94c9601f8cf") is False
+    # 13 chars
+    assert monitor.apply_mac_address("kitchen", "94c9601f8cf1a") is False
+    assert callbacks.calls == []
+
+
+def test_apply_mac_address_refires_after_device_rebuild() -> None:
+    """A rebuilt Device with empty MAC gets repopulated by the next mDNS event.
+
+    Atomic-write editor races (vscode-on-macOS et al.) can briefly
+    REMOVE+re-ADD a device with ``previous=None``, leaving the new
+    Device with ``mac_address=""``. The monitor's dedupe is keyed off
+    the device's own field, so the next mDNS announcement should
+    repopulate without short-circuiting on a stale cache.
+    """
+    devices = [_device(mac_address="94c9601f8cf1")]
+    monitor, callbacks = make_state_monitor_with_callbacks(devices)
+
+    # Steady state: the device already has the MAC, so a repeat
+    # announcement is a no-op.
+    monitor.apply_mac_address("kitchen", "94c9601f8cf1")
+    assert callbacks.calls == []
+
+    # Atomic-save churn rebuilds the Device with empty fields. The
+    # next mDNS announcement should write the MAC back through the
+    # callback.
+    devices[0].mac_address = ""
+    monitor.apply_mac_address("kitchen", "94c9601f8cf1")
+    assert callbacks.calls == [("on_mac_address_change", "kitchen", "94c9601f8cf1")]
+
+
+# ----------------------------------------------------------------------
+# DevicesController._on_mac_address_change — full pipe + persistence
+# ----------------------------------------------------------------------
+
+
+def _record_scheduled(coros: list[object]) -> Callable[[object], object]:
+    """Capture + close coroutines handed to ``create_background_task``.
+
+    The persist-async branches use ``create_background_task`` to push
+    the blocking sidecar write off the event-loop thread. The tests
+    don't have a running loop, so we just record the coroutine and
+    close it to avoid the "coroutine was never awaited" warning —
+    the call count is what verifies whether the I/O was scheduled.
+    """
+
+    def _impl(coro: object) -> object:
+        coros.append(coro)
+        if hasattr(coro, "close"):
+            coro.close()
+        return coro
+
+    return _impl
+
+
+def _device_kitchen(**overrides: Any) -> Device:
+    base: dict[str, Any] = {
+        "name": "kitchen",
+        "friendly_name": "Kitchen",
+        "configuration": "kitchen.yaml",
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+def test_on_mac_address_change_updates_device_and_fires_event() -> None:
+    """Full pipe: callback writes the MAC + fires DEVICE_UPDATED."""
+    device = _device_kitchen()
+    scheduled: list[object] = []
+    controller, captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "94c9601f8cf1")
+
+    assert device.mac_address == "94c9601f8cf1"
+    assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
+
+
+def test_on_mac_address_change_persists_to_sidecar() -> None:
+    """First observation schedules exactly one sidecar write."""
+    device = _device_kitchen()
+    scheduled: list[object] = []
+    controller, _captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "94c9601f8cf1")
+
+    assert len(scheduled) == 1
+
+
+def test_on_mac_address_change_skips_persist_when_unchanged() -> None:
+    """Repeat observation of the same MAC must not schedule any I/O.
+
+    mDNS announces the same TXT every cycle on a healthy fleet; a
+    naive write-through would hammer the sidecar on every announce.
+    The dedupe is keyed off ``device.mac_address`` so a steady-state
+    broadcast short-circuits before either the in-memory write or
+    the executor-bound ``set_device_metadata`` call.
+    """
+    device = _device_kitchen(mac_address="94c9601f8cf1")
+    scheduled: list[object] = []
+    controller, captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "94c9601f8cf1")
+
+    assert scheduled == []
+    assert captured == []
+
+
+def test_on_mac_address_change_unknown_device_is_noop() -> None:
+    """Stray callback for an unconfigured name doesn't raise or fire events."""
+    scheduled: list[object] = []
+    controller, captured = make_devices_controller_with_bus(
+        [], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("ghost", "94c9601f8cf1")
+
+    assert scheduled == []
+    assert captured == []
+
+
+def test_on_mac_address_change_derives_ethernet_mac_on_esp32() -> None:
+    """ESP32 + ethernet integration → ``ethernet_mac`` = primary + 3.
+
+    The primary stays at the broadcast value; the derived MAC is
+    written to ``device.ethernet_mac`` so the drawer can render the
+    second row without the firmware having to broadcast it.
+    """
+    device = _device_kitchen(
+        target_platform="esp32",
+        loaded_integrations=["api", "wifi", "ethernet"],
+    )
+    scheduled: list[object] = []
+    controller, _captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "94c9601f8cf0")
+
+    assert device.mac_address == "94c9601f8cf0"
+    assert device.ethernet_mac == "94c9601f8cf3"
+    assert device.bluetooth_mac == ""
+
+
+def test_on_mac_address_change_derives_bluetooth_mac_on_esp32() -> None:
+    """ESP32 + bluetooth integration → ``bluetooth_mac`` = primary + 2."""
+    device = _device_kitchen(
+        target_platform="esp32",
+        loaded_integrations=["api", "wifi", "esp32_ble_tracker"],
+    )
+    scheduled: list[object] = []
+    controller, _captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "94c9601f8cf0")
+
+    assert device.mac_address == "94c9601f8cf0"
+    assert device.ethernet_mac == ""
+    assert device.bluetooth_mac == "94c9601f8cf2"
+
+
+def test_on_mac_address_change_derives_ethernet_equal_primary_on_rp2040() -> None:
+    """RP2040 + ethernet → derived ethernet equals the primary MAC.
+
+    Single-MAC platform: the dashboard exposes the field for shape
+    consistency with ESP32 but the frontend hides any row whose
+    derived value equals the primary so the row doesn't render twice.
+    """
+    device = _device_kitchen(
+        target_platform="rp2040",
+        loaded_integrations=["api", "wifi", "ethernet"],
+    )
+    scheduled: list[object] = []
+    controller, _captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "94c9601f8cf0")
+
+    assert device.mac_address == "94c9601f8cf0"
+    assert device.ethernet_mac == "94c9601f8cf0"
+    assert device.bluetooth_mac == ""
+
+
+def test_on_mac_address_change_clears_derived_on_unknown_platform() -> None:
+    """A platform we haven't validated against the eFuse layout → empty derivations.
+
+    Belt-and-braces: even if a future ESPHome adds a platform key
+    ahead of the dashboard's allowlist update, we'd rather show a
+    single primary MAC than a wrong derived one.
+    """
+    device = _device_kitchen(
+        target_platform="bk72xx",
+        loaded_integrations=["api", "ethernet"],
+    )
+    scheduled: list[object] = []
+    controller, _captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "94c9601f8cf0")
+
+    assert device.mac_address == "94c9601f8cf0"
+    assert device.ethernet_mac == ""
+    assert device.bluetooth_mac == ""

--- a/tests/test_mdns_mac_address.py
+++ b/tests/test_mdns_mac_address.py
@@ -190,6 +190,20 @@ def test_apply_mac_address_rejects_wrong_length() -> None:
     assert callbacks.calls == []
 
 
+def test_apply_mac_address_rejects_correct_length_non_hex() -> None:
+    """A 12-char-after-stripping value with non-hex chars is dropped.
+
+    The length check passes (12 chars) but ``int(_, 16)`` raises
+    ``ValueError``; ``_normalize_mac`` catches and returns empty so
+    a corrupt TXT can't pollute the sidecar with a value that
+    looks the right shape but doesn't decode to a real MAC.
+    """
+    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    # 12 chars, but the 'Z' isn't valid hex.
+    assert monitor.apply_mac_address("kitchen", "94c9601f8cZZ") is False
+    assert callbacks.calls == []
+
+
 def test_apply_mac_address_refires_after_device_rebuild() -> None:
     """A rebuilt Device with empty MAC gets repopulated by the next mDNS event.
 
@@ -427,3 +441,31 @@ def test_on_mac_address_change_clears_stale_derived_macs_on_change() -> None:
     assert device.mac_address == "94:C9:60:1F:8C:F0"
     assert device.ethernet_mac == ""
     assert device.bluetooth_mac == ""
+
+
+def test_on_mac_address_change_rederives_ethernet_and_bluetooth_when_primary_changes() -> None:
+    """A new primary on an ESP32 with ethernet + bluetooth re-derives both.
+
+    Pins the inverse of the "clears stale" case: when the
+    integrations *are* still loaded, the derived MACs must shift
+    to track the new base. A factory replacement (same YAML, new
+    physical board) is the realistic trigger — the broadcast MAC
+    changes and every interface MAC has to follow.
+    """
+    device = _device_kitchen(
+        target_platform="esp32",
+        loaded_integrations=["api", "wifi", "ethernet", "esp32_ble_tracker"],
+        mac_address="94:C9:60:1F:8C:00",
+        ethernet_mac="94:C9:60:1F:8C:03",  # base + 3 from the old primary
+        bluetooth_mac="94:C9:60:1F:8C:02",  # base + 2 from the old primary
+    )
+    scheduled: list[object] = []
+    controller, _captured = make_devices_controller_with_bus(
+        [device], create_background_task=_record_scheduled(scheduled)
+    )
+
+    controller._on_mac_address_change("kitchen", "AA:BB:CC:DD:EE:F0")
+
+    assert device.mac_address == "AA:BB:CC:DD:EE:F0"
+    assert device.ethernet_mac == "AA:BB:CC:DD:EE:F3"
+    assert device.bluetooth_mac == "AA:BB:CC:DD:EE:F2"

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -190,3 +190,48 @@ async def test_apply_service_info_claims_online() -> None:
     assert callbacks.calls_for("on_state_change") == [
         ("on_state_change", "kitchen", DeviceState.ONLINE, "mdns")
     ]
+
+
+@pytest.mark.asyncio
+async def test_apply_service_info_routes_mac_txt_to_apply_mac_address() -> None:
+    """A populated ``mac`` TXT lands at ``apply_mac_address``.
+
+    Pins the wiring at the TXT-extraction site
+    (``_apply_service_info_to_device``) where the broadcast value
+    is plucked out of ``decoded_properties`` alongside ``version`` /
+    ``config_hash``. Without this hop the canonical-form
+    normalization + dedupe never runs and the drawer / sidecar
+    don't get populated from the broadcast.
+    """
+    monitor = _make_monitor()
+    monitor._state_source = {}
+    device = Device(
+        name="kitchen",
+        friendly_name="Kitchen",
+        configuration="kitchen.yaml",
+        address="kitchen.local",
+        state=DeviceState.UNKNOWN,
+    )
+    monitor._get_devices = lambda: [device]
+    monitor._get_devices_by_name = lambda name: [device] if device.name == name else []
+    callbacks = RecordingMonitorCallbacks([device])
+    monitor._on_state_change = callbacks.on_state_change
+    monitor._on_ip_change = callbacks.on_ip_change
+    monitor._on_version_change = callbacks.on_version_change
+    monitor._on_config_hash_change = callbacks.on_config_hash_change
+    monitor._on_api_encryption_change = callbacks.on_api_encryption_change
+    monitor._on_mac_address_change = callbacks.on_mac_address_change
+    monitor._reachability = None
+
+    fake_info = MagicMock()
+    fake_info.parsed_scoped_addresses.return_value = []
+    # Wire-form value (lowercase 12-hex-char, no separators) — what
+    # ESPHome firmware actually broadcasts. The callback receives
+    # the canonical form because ``apply_mac_address`` normalizes
+    # before invoking the change callback.
+    fake_info.decoded_properties = {"mac": "94c9601f8cf1"}
+    monitor._apply_service_info("kitchen", fake_info)
+
+    assert callbacks.calls_for("on_mac_address_change") == [
+        ("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")
+    ]


### PR DESCRIPTION
# What does this implement/fix?

Adds MAC-address surfacing to `DevicesController` / `DeviceStateMonitor`: the broadcast `mac` TXT on `_esphomelib._tcp.local.` lands on `Device.mac_address` (canonical `XX:XX:XX:XX:XX:XX` form, normalized at ingest), and devices with the `ethernet` or `esp32_ble*` / `bluetooth_*` integrations loaded also get a derived `ethernet_mac` / `bluetooth_mac` per Espressif's MAC allocation table (Ethernet = base + 3, Bluetooth = base + 2). RP2040 / RP2350 share a single MAC across interfaces, so `ethernet_mac == mac_address` there.

Same monitor → controller pipeline as the existing `version` / `config_hash` / `api_encryption` TXT records. The primary MAC is persisted to the per-device metadata sidecar (`ip` / `expected_config_hash` neighbour) so a freshly-restarted dashboard renders the value immediately — ESPHome devices stay mDNS-silent until probed, otherwise the column renders blank for the discovery sweep's bootstrap window. Persistence is gated on a real change (the existing `device.mac_address == mac` early-return covers both the in-memory write and the executor-bound `set_device_metadata` call) so the steady-state "same MAC every announce" cycle stays off-disk. `mac_address` joins `ip` / `expected_config_hash` in `_VOLATILE_DEVICE_METADATA_FIELDS` so archive scrubs it (the YAML may be redeployed to a different physical board on unarchive).

The derived MACs are deterministic from primary + `loaded_integrations`, so we recompute on every primary-MAC observation and on every `load_device_from_storage` rather than persisting — a YAML edit that toggles bluetooth picks up the new derived MAC on the next reload, no stale-cache window. `_normalize_mac` strips `:` / `-` / `.` separators, validates 12 hex chars, then re-inserts `:` between each octet so the form is idempotent regardless of which case / separator style the firmware happens to broadcast.

Espressif allocation reference: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/misc_system_api.html#mac-address-allocation

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#170

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
