### PR TITLE
Collapse repeat MQTT-unreachable log spam to DEBUG

### DIFF
--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -88,6 +88,13 @@ class DeviceMqttMonitor:
         self._task: asyncio.Task[None] | None = None
         # device name → monotonic timestamp of the last MQTT response
         self._last_seen: dict[str, float] = {}
+        # Set by ``_connect_and_listen`` the moment CONNACK succeeds.
+        # Read+cleared in ``_run``'s except branches so the loud-log
+        # gates re-arm only when we actually managed to connect this
+        # session — not when ``_connect_and_listen`` returns cleanly
+        # (which production rarely does, since the inner TaskGroup
+        # parks until cancelled or raises).
+        self._connected_this_session = False
 
     @staticmethod
     def is_available() -> bool:
@@ -130,19 +137,29 @@ class DeviceMqttMonitor:
         _LOGGER.info("MQTT discovery starting — broker=%s:%s", self._broker.host, self._broker.port)
 
         delay = int(_RECONNECT_DELAY)
-        # Track whether the *previous* attempt failed with an expected
-        # connection error. While a broker stays down we'd otherwise
-        # log a full ERROR + traceback every ``_RECONNECT_DELAY`` seconds
-        # — bug #324. Log the first failure and the recovery loudly,
-        # collapse the in-between repeats to DEBUG.
-        previous_failed = False
+        # Per-category log gates. Each flips True after a loud log
+        # and back to False on the next iteration that observed a
+        # successful CONNACK (signalled via
+        # ``self._connected_this_session``). Tracked separately so a
+        # TimeoutError loop doesn't suppress the first appearance of
+        # a *different* unexpected exception. Bug #324.
+        connect_error_logged = False
+        unexpected_error_logged = False
         while True:
             try:
                 await self._connect_and_listen(client_id)
             except asyncio.CancelledError:
                 raise
             except (TimeoutError, OSError, ConnectionError) as err:
-                if previous_failed:
+                if self._connected_this_session:
+                    # The session reached CONNACK before raising — the
+                    # broker recovered between the last failure and
+                    # this one. Re-arm both gates so this fresh outage
+                    # logs loudly again.
+                    connect_error_logged = False
+                    unexpected_error_logged = False
+                    self._connected_this_session = False
+                if connect_error_logged:
                     _LOGGER.debug(
                         "MQTT broker %s:%s still unreachable (%s) — reconnecting in %ss",
                         self._broker.host,
@@ -158,20 +175,30 @@ class DeviceMqttMonitor:
                         err,
                         delay,
                     )
-                    previous_failed = True
+                    connect_error_logged = True
                 # Drop last-seen but leave device state alone so a brief
                 # broker blip doesn't trigger an offline storm.
                 self._last_seen.clear()
                 await asyncio.sleep(_RECONNECT_DELAY)
-            except Exception:
+            except Exception as err:
                 # Unexpected exception class — keep the loud ERROR with
                 # traceback so genuine bugs are visible, but still gate
                 # repeats so a tight failure loop doesn't flood logs.
-                if previous_failed:
+                if self._connected_this_session:
+                    connect_error_logged = False
+                    unexpected_error_logged = False
+                    self._connected_this_session = False
+                if unexpected_error_logged:
+                    # Include the exception class + message even with
+                    # the traceback gated so the operator can still
+                    # tell what's repeating.
                     _LOGGER.debug(
-                        "MQTT broker %s:%s error (suppressed traceback) — reconnecting in %ss",
+                        "MQTT broker %s:%s error %s: %s "
+                        "(suppressed traceback) — reconnecting in %ss",
                         self._broker.host,
                         self._broker.port,
+                        type(err).__name__,
+                        err,
                         delay,
                     )
                 else:
@@ -181,14 +208,9 @@ class DeviceMqttMonitor:
                         self._broker.port,
                         delay,
                     )
-                    previous_failed = True
+                    unexpected_error_logged = True
                 self._last_seen.clear()
                 await asyncio.sleep(_RECONNECT_DELAY)
-            else:
-                # ``_connect_and_listen`` returned cleanly (broker closed
-                # us, ``stop()`` triggered shutdown, etc.). Reset the
-                # gate so the next failure logs loudly again.
-                previous_failed = False
 
     async def _connect_and_listen(self, client_id: str) -> None:
         assert paho_mqtt is not None  # type narrowing — checked in start()
@@ -223,6 +245,14 @@ class DeviceMqttMonitor:
                 raise ConnectionError(msg)
 
             _LOGGER.info("MQTT connected to %s:%s", self._broker.host, self._broker.port)
+            # Signal to ``_run`` that this iteration achieved a real
+            # connection — read+cleared in its except branches to
+            # re-arm the loud-log gates. Set here rather than relying
+            # on a clean ``_connect_and_listen`` return because the
+            # inner TaskGroup parks until cancelled or raises, so the
+            # ``else`` branch on the caller's ``try`` rarely runs in
+            # production.
+            self._connected_this_session = True
             client.subscribe(_DISCOVER_TOPIC)
             client.publish(_DISCOVER_PUBLISH_TOPIC, payload=None, retain=False)
 

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -130,22 +130,65 @@ class DeviceMqttMonitor:
         _LOGGER.info("MQTT discovery starting — broker=%s:%s", self._broker.host, self._broker.port)
 
         delay = int(_RECONNECT_DELAY)
+        # Track whether the *previous* attempt failed with an expected
+        # connection error. While a broker stays down we'd otherwise
+        # log a full ERROR + traceback every ``_RECONNECT_DELAY`` seconds
+        # — bug #324. Log the first failure and the recovery loudly,
+        # collapse the in-between repeats to DEBUG.
+        previous_failed = False
         while True:
             try:
                 await self._connect_and_listen(client_id)
             except asyncio.CancelledError:
                 raise
-            except Exception:
-                _LOGGER.exception(
-                    "MQTT broker %s:%s error — reconnecting in %ss",
-                    self._broker.host,
-                    self._broker.port,
-                    delay,
-                )
+            except (TimeoutError, OSError, ConnectionError) as err:
+                if previous_failed:
+                    _LOGGER.debug(
+                        "MQTT broker %s:%s still unreachable (%s) — reconnecting in %ss",
+                        self._broker.host,
+                        self._broker.port,
+                        err,
+                        delay,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "MQTT broker %s:%s unreachable (%s) — reconnecting in %ss",
+                        self._broker.host,
+                        self._broker.port,
+                        err,
+                        delay,
+                    )
+                    previous_failed = True
                 # Drop last-seen but leave device state alone so a brief
                 # broker blip doesn't trigger an offline storm.
                 self._last_seen.clear()
                 await asyncio.sleep(_RECONNECT_DELAY)
+            except Exception:
+                # Unexpected exception class — keep the loud ERROR with
+                # traceback so genuine bugs are visible, but still gate
+                # repeats so a tight failure loop doesn't flood logs.
+                if previous_failed:
+                    _LOGGER.debug(
+                        "MQTT broker %s:%s error (suppressed traceback) — reconnecting in %ss",
+                        self._broker.host,
+                        self._broker.port,
+                        delay,
+                    )
+                else:
+                    _LOGGER.exception(
+                        "MQTT broker %s:%s error — reconnecting in %ss",
+                        self._broker.host,
+                        self._broker.port,
+                        delay,
+                    )
+                    previous_failed = True
+                self._last_seen.clear()
+                await asyncio.sleep(_RECONNECT_DELAY)
+            else:
+                # ``_connect_and_listen`` returned cleanly (broker closed
+                # us, ``stop()`` triggered shutdown, etc.). Reset the
+                # gate so the next failure logs loudly again.
+                previous_failed = False
 
     async def _connect_and_listen(self, client_id: str) -> None:
         assert paho_mqtt is not None  # type narrowing — checked in start()

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -89,12 +89,19 @@ class DeviceMqttMonitor:
         # device name → monotonic timestamp of the last MQTT response
         self._last_seen: dict[str, float] = {}
         # Set by ``_connect_and_listen`` the moment CONNACK succeeds.
-        # Read+cleared in ``_run``'s except branches so the loud-log
-        # gates re-arm only when we actually managed to connect this
-        # session — not when ``_connect_and_listen`` returns cleanly
-        # (which production rarely does, since the inner TaskGroup
-        # parks until cancelled or raises).
+        # Read+cleared in ``_log_reconnect_failure`` so the loud-log
+        # gates below re-arm only when we actually managed to connect
+        # this session — not when ``_connect_and_listen`` returns
+        # cleanly (which production rarely does, since the inner
+        # TaskGroup parks until cancelled or raises). Bug #324.
         self._connected_this_session = False
+        # Per-category log gates. Each flips True after a loud log
+        # and back to False on the next failure that observed a
+        # successful CONNACK. Tracked separately so a TimeoutError
+        # loop doesn't suppress the first appearance of a different
+        # unexpected exception class.
+        self._connect_error_logged = False
+        self._unexpected_error_logged = False
 
     @staticmethod
     def is_available() -> bool:
@@ -136,81 +143,79 @@ class DeviceMqttMonitor:
         client_id = f"esphome-dashboard-{secrets.token_hex(6)}"
         _LOGGER.info("MQTT discovery starting — broker=%s:%s", self._broker.host, self._broker.port)
 
-        delay = int(_RECONNECT_DELAY)
-        # Per-category log gates. Each flips True after a loud log
-        # and back to False on the next iteration that observed a
-        # successful CONNACK (signalled via
-        # ``self._connected_this_session``). Tracked separately so a
-        # TimeoutError loop doesn't suppress the first appearance of
-        # a *different* unexpected exception. Bug #324.
-        connect_error_logged = False
-        unexpected_error_logged = False
         while True:
             try:
                 await self._connect_and_listen(client_id)
             except asyncio.CancelledError:
                 raise
             except (TimeoutError, OSError, ConnectionError) as err:
-                if self._connected_this_session:
-                    # The session reached CONNACK before raising — the
-                    # broker recovered between the last failure and
-                    # this one. Re-arm both gates so this fresh outage
-                    # logs loudly again.
-                    connect_error_logged = False
-                    unexpected_error_logged = False
-                    self._connected_this_session = False
-                if connect_error_logged:
-                    _LOGGER.debug(
-                        "MQTT broker %s:%s still unreachable (%s) — reconnecting in %ss",
-                        self._broker.host,
-                        self._broker.port,
-                        err,
-                        delay,
-                    )
-                else:
-                    _LOGGER.warning(
-                        "MQTT broker %s:%s unreachable (%s) — reconnecting in %ss",
-                        self._broker.host,
-                        self._broker.port,
-                        err,
-                        delay,
-                    )
-                    connect_error_logged = True
-                # Drop last-seen but leave device state alone so a brief
-                # broker blip doesn't trigger an offline storm.
-                self._last_seen.clear()
-                await asyncio.sleep(_RECONNECT_DELAY)
+                self._log_reconnect_failure(err, expected=True)
             except Exception as err:
-                # Unexpected exception class — keep the loud ERROR with
-                # traceback so genuine bugs are visible, but still gate
-                # repeats so a tight failure loop doesn't flood logs.
-                if self._connected_this_session:
-                    connect_error_logged = False
-                    unexpected_error_logged = False
-                    self._connected_this_session = False
-                if unexpected_error_logged:
-                    # Include the exception class + message even with
-                    # the traceback gated so the operator can still
-                    # tell what's repeating.
-                    _LOGGER.debug(
-                        "MQTT broker %s:%s error %s: %s "
-                        "(suppressed traceback) — reconnecting in %ss",
-                        self._broker.host,
-                        self._broker.port,
-                        type(err).__name__,
-                        err,
-                        delay,
-                    )
-                else:
-                    _LOGGER.exception(
-                        "MQTT broker %s:%s error — reconnecting in %ss",
-                        self._broker.host,
-                        self._broker.port,
-                        delay,
-                    )
-                    unexpected_error_logged = True
-                self._last_seen.clear()
-                await asyncio.sleep(_RECONNECT_DELAY)
+                self._log_reconnect_failure(err, expected=False)
+            # Drop last-seen on any failure but leave device state
+            # alone so a brief broker blip doesn't trigger an offline
+            # storm.
+            self._last_seen.clear()
+            await asyncio.sleep(_RECONNECT_DELAY)
+
+    def _log_reconnect_failure(self, err: BaseException, *, expected: bool) -> None:
+        """Log a reconnect failure, collapsing repeats while gates are tripped.
+
+        ``expected`` (TimeoutError / OSError / ConnectionError) and
+        unexpected exceptions track separate gates so a TimeoutError
+        loop doesn't suppress the first appearance of a different
+        exception class. A successful CONNACK during the failed
+        iteration re-arms both gates so the next outage logs loudly
+        again — tracked via ``self._connected_this_session``.
+        """
+        delay = int(_RECONNECT_DELAY)
+        if self._connected_this_session:
+            self._connect_error_logged = False
+            self._unexpected_error_logged = False
+            self._connected_this_session = False
+
+        if expected:
+            if self._connect_error_logged:
+                _LOGGER.debug(
+                    "MQTT broker %s:%s still unreachable (%s) — reconnecting in %ss",
+                    self._broker.host,
+                    self._broker.port,
+                    err,
+                    delay,
+                )
+            else:
+                _LOGGER.warning(
+                    "MQTT broker %s:%s unreachable (%s) — reconnecting in %ss",
+                    self._broker.host,
+                    self._broker.port,
+                    err,
+                    delay,
+                )
+                self._connect_error_logged = True
+            return
+
+        # Unexpected exception class — keep the loud ERROR with
+        # traceback the first time round so genuine bugs are visible.
+        # Repeats fall back to a DEBUG line that still includes the
+        # class + message so the operator can tell what's looping
+        # without flipping the log level.
+        if self._unexpected_error_logged:
+            _LOGGER.debug(
+                "MQTT broker %s:%s error %s: %s (suppressed traceback) — reconnecting in %ss",
+                self._broker.host,
+                self._broker.port,
+                type(err).__name__,
+                err,
+                delay,
+            )
+            return
+        _LOGGER.exception(
+            "MQTT broker %s:%s error — reconnecting in %ss",
+            self._broker.host,
+            self._broker.port,
+            delay,
+        )
+        self._unexpected_error_logged = True
 
     async def _connect_and_listen(self, client_id: str) -> None:
         assert paho_mqtt is not None  # type narrowing — checked in start()

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -1187,18 +1187,20 @@ async def test_run_collapses_repeat_unreachable_errors_to_debug(
 
 
 @pytest.mark.asyncio
-async def test_run_resets_log_gate_after_successful_session(
+async def test_run_resets_log_gate_after_successful_connect(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A successful broker session re-arms the loud-warning gate.
+    """A successful CONNACK re-arms the loud-warning gate.
 
     Without the reset, a broker that goes down → up → down again
     would only WARN once (on the very first failure) and silently
     DEBUG every subsequent outage forever, defeating the point of
-    surfacing it in the operator's log. Pin: after
-    ``_connect_and_listen`` returns cleanly, the next failure logs
-    WARNING again.
+    surfacing it in the operator's log. The reset trigger is
+    ``self._connected_this_session = True`` (set inside
+    ``_connect_and_listen`` right after CONNACK), not a clean
+    return — production almost never sees a clean return because
+    the inner TaskGroup parks until cancelled or raises.
     """
     monkeypatch.setattr(monitor_module, "_RECONNECT_DELAY", 0)
 
@@ -1210,9 +1212,13 @@ async def test_run_resets_log_gate_after_successful_session(
 
     # Sequence of behaviours per ``_connect_and_listen`` call:
     # 1. fail (TimeoutError) — first WARNING
-    # 2. succeed (return cleanly) — gate reset
+    # 2. simulate a session that reached CONNACK and then was
+    #    closed by the broker (sets the in-session flag, then
+    #    raises an expected error). Production's equivalent is a
+    #    broker that accepted the connection, ran for a while, and
+    #    then dropped us — the gate must re-arm.
     # 3. fail (TimeoutError) — should be a *second* WARNING, not DEBUG
-    behaviours = ["fail", "succeed", "fail"]
+    behaviours = ["fail", "connect-then-drop", "fail"]
     third_failure = asyncio.Event()
 
     async def _scripted(_client_id: str) -> None:
@@ -1220,12 +1226,14 @@ async def test_run_resets_log_gate_after_successful_session(
             third_failure.set()
             await asyncio.Event().wait()
         action = behaviours.pop(0)
+        if not behaviours:
+            third_failure.set()
         if action == "fail":
-            if not behaviours:
-                third_failure.set()
             raise TimeoutError("timed out")
-        # ``succeed`` — return cleanly, simulating a session that
-        # ran for a while and then closed.
+        # ``connect-then-drop``: signal CONNACK success, then
+        # raise as if the broker dropped the session.
+        monitor._connected_this_session = True
+        raise ConnectionError("broker dropped session")
 
     monkeypatch.setattr(monitor, "_connect_and_listen", _scripted)
 
@@ -1249,7 +1257,87 @@ async def test_run_resets_log_gate_after_successful_session(
         and r.levelname == "WARNING"
         and "unreachable" in r.message
     ]
+    # Two WARNINGs: the first failure (start of outage A) and the
+    # connect-then-drop (start of outage B — gate re-armed by the
+    # CONNACK in between). The third failure is a continuation of
+    # outage B with no successful connect between them, so it
+    # collapses to DEBUG. Pinning this also catches the inverse
+    # regression: dropping the gate-reset entirely would only emit
+    # one WARNING here instead of two.
     assert len(warnings) == 2, [r.message for r in warnings]
+    debugs = [
+        r
+        for r in caplog.records
+        if r.name == monitor_module.__name__
+        and r.levelname == "DEBUG"
+        and "unreachable" in r.message
+    ]
+    assert len(debugs) == 1, [r.message for r in debugs]
+
+
+@pytest.mark.asyncio
+async def test_run_loud_logs_unexpected_after_expected_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A new unexpected exception after a connect-error loop still logs ERROR+traceback.
+
+    The two log gates (expected vs unexpected) are tracked
+    separately so a long ``TimeoutError`` outage can't suppress
+    the first appearance of an *unexpected* exception class —
+    that would hide a genuine bug behind the offline-broker
+    spam-suppression. Pin: after a TimeoutError WARNING, a
+    subsequent ``RuntimeError`` (unrelated category) logs at
+    ERROR level with traceback (``exc_info``) attached.
+    """
+    monkeypatch.setattr(monitor_module, "_RECONNECT_DELAY", 0)
+
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    # First call raises TimeoutError (expected, WARNING),
+    # second call raises RuntimeError (unexpected, must be loud).
+    behaviours: list[str] = ["timeout", "unexpected"]
+    second_call = asyncio.Event()
+
+    async def _scripted(_client_id: str) -> None:
+        if not behaviours:
+            second_call.set()
+            await asyncio.Event().wait()
+        action = behaviours.pop(0)
+        if not behaviours:
+            second_call.set()
+        if action == "timeout":
+            raise TimeoutError("timed out")
+        msg = "kaboom"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(monitor, "_connect_and_listen", _scripted)
+
+    caplog.set_level("DEBUG", logger=monitor_module.__name__)
+
+    run_task = asyncio.create_task(monitor._run())
+    try:
+        await asyncio.wait_for(second_call.wait(), timeout=2.0)
+        await asyncio.sleep(0.05)
+    finally:
+        run_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await run_task
+
+    errors = [
+        r
+        for r in caplog.records
+        if r.name == monitor_module.__name__ and r.levelname == "ERROR" and "error" in r.message
+    ]
+    assert len(errors) == 1, [(r.levelname, r.message) for r in errors]
+    # ``logger.exception`` attaches exc_info — pin the traceback is
+    # actually present so a regression that drops the exception
+    # context (or routes through DEBUG) surfaces here.
+    assert errors[0].exc_info is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -1340,6 +1340,84 @@ async def test_run_loud_logs_unexpected_after_expected_failure(
     assert errors[0].exc_info is not None
 
 
+@pytest.mark.asyncio
+async def test_run_collapses_repeat_unexpected_errors_to_debug(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Repeat unexpected exceptions log DEBUG with class+message, no traceback.
+
+    Covers the suppressed-traceback DEBUG branch in
+    ``_log_reconnect_failure``'s unexpected-error path. The first
+    occurrence still emits one ERROR with traceback (proven in
+    ``test_run_loud_logs_unexpected_after_expected_failure``);
+    every subsequent occurrence with the gate already tripped
+    falls back to DEBUG so a tight failure loop doesn't dump the
+    same trace into the log every ``_RECONNECT_DELAY``. Pin: the
+    DEBUG line still includes the exception class name and message
+    so the operator can tell what's repeating without raising the
+    log level back to ERROR.
+    """
+    monkeypatch.setattr(monitor_module, "_RECONNECT_DELAY", 0)
+
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    call_count = 0
+    third_call = asyncio.Event()
+
+    async def _always_runtime_error(_client_id: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 3:
+            third_call.set()
+        msg = "kaboom"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(monitor, "_connect_and_listen", _always_runtime_error)
+
+    caplog.set_level("DEBUG", logger=monitor_module.__name__)
+
+    run_task = asyncio.create_task(monitor._run())
+    try:
+        await asyncio.wait_for(third_call.wait(), timeout=2.0)
+    finally:
+        run_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await run_task
+
+    errors = [
+        r
+        for r in caplog.records
+        if r.name == monitor_module.__name__ and r.levelname == "ERROR" and "error" in r.message
+    ]
+    debugs = [
+        r
+        for r in caplog.records
+        if r.name == monitor_module.__name__
+        and r.levelname == "DEBUG"
+        and "suppressed traceback" in r.message
+    ]
+    # Exactly one ERROR (first hit) and at least one DEBUG-suppressed
+    # follow-up — the repeats. Anything more than one ERROR means the
+    # gate didn't trip; zero DEBUG means the suppressed branch was
+    # never reached.
+    assert len(errors) == 1, [(r.levelname, r.message) for r in errors]
+    assert len(debugs) >= 1
+    # Every DEBUG must include the exception class + message — that's
+    # the whole point of capturing ``as err`` in the broad branch.
+    for record in debugs:
+        assert "RuntimeError" in record.message
+        assert "kaboom" in record.message
+        # And no traceback should be attached at this level — the
+        # promise of "suppressed traceback" is meaningful only if it
+        # actually drops the exc_info too.
+        assert record.exc_info is None
+
+
 # ---------------------------------------------------------------------------
 # Pure helpers — _extract_ip / _decode_payload
 # ---------------------------------------------------------------------------

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -1124,6 +1124,134 @@ async def test_run_reconnects_on_connect_and_listen_failure(
     assert monitor._last_seen == {}
 
 
+@pytest.mark.asyncio
+async def test_run_collapses_repeat_unreachable_errors_to_debug(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Repeat unreachable-broker errors stay at DEBUG, not ERROR+traceback.
+
+    When the broker is offline for a long time the reconnect loop
+    fires every ``_RECONNECT_DELAY`` seconds. Logging a full ERROR
+    with traceback on each tick floods journalctl / Home Assistant's
+    log view (issue #324). The first failure should still be loud
+    (WARNING, no traceback for expected ``TimeoutError`` /
+    ``OSError`` / ``ConnectionError``) so the operator sees the
+    broker went away; subsequent identical failures collapse to
+    DEBUG so the file doesn't fill with copies of the same trace.
+    """
+    monkeypatch.setattr(monitor_module, "_RECONNECT_DELAY", 0)
+
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    call_count = 0
+    third_call = asyncio.Event()
+
+    async def _always_timeout(_client_id: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 3:
+            third_call.set()
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(monitor, "_connect_and_listen", _always_timeout)
+
+    caplog.set_level("DEBUG", logger=monitor_module.__name__)
+
+    run_task = asyncio.create_task(monitor._run())
+    try:
+        await asyncio.wait_for(third_call.wait(), timeout=2.0)
+    finally:
+        run_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await run_task
+
+    unreachable = [
+        r
+        for r in caplog.records
+        if r.name == monitor_module.__name__ and "unreachable" in r.message
+    ]
+    # Exactly one WARNING for the first transition into "unreachable",
+    # the rest collapsed to DEBUG. ``exc_info`` must be None on every
+    # such record — pin that there's no traceback being attached.
+    warnings = [r for r in unreachable if r.levelname == "WARNING"]
+    debugs = [r for r in unreachable if r.levelname == "DEBUG"]
+    assert len(warnings) == 1, [r.levelname for r in unreachable]
+    assert len(debugs) >= 1
+    for record in unreachable:
+        assert record.exc_info is None
+
+
+@pytest.mark.asyncio
+async def test_run_resets_log_gate_after_successful_session(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A successful broker session re-arms the loud-warning gate.
+
+    Without the reset, a broker that goes down → up → down again
+    would only WARN once (on the very first failure) and silently
+    DEBUG every subsequent outage forever, defeating the point of
+    surfacing it in the operator's log. Pin: after
+    ``_connect_and_listen`` returns cleanly, the next failure logs
+    WARNING again.
+    """
+    monkeypatch.setattr(monitor_module, "_RECONNECT_DELAY", 0)
+
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    # Sequence of behaviours per ``_connect_and_listen`` call:
+    # 1. fail (TimeoutError) — first WARNING
+    # 2. succeed (return cleanly) — gate reset
+    # 3. fail (TimeoutError) — should be a *second* WARNING, not DEBUG
+    behaviours = ["fail", "succeed", "fail"]
+    third_failure = asyncio.Event()
+
+    async def _scripted(_client_id: str) -> None:
+        if not behaviours:
+            third_failure.set()
+            await asyncio.Event().wait()
+        action = behaviours.pop(0)
+        if action == "fail":
+            if not behaviours:
+                third_failure.set()
+            raise TimeoutError("timed out")
+        # ``succeed`` — return cleanly, simulating a session that
+        # ran for a while and then closed.
+
+    monkeypatch.setattr(monitor, "_connect_and_listen", _scripted)
+
+    caplog.set_level("DEBUG", logger=monitor_module.__name__)
+
+    run_task = asyncio.create_task(monitor._run())
+    try:
+        await asyncio.wait_for(third_failure.wait(), timeout=2.0)
+        # Give the loop one extra tick to log the third failure
+        # before we tear it down.
+        await asyncio.sleep(0.05)
+    finally:
+        run_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await run_task
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.name == monitor_module.__name__
+        and r.levelname == "WARNING"
+        and "unreachable" in r.message
+    ]
+    assert len(warnings) == 2, [r.message for r in warnings]
+
+
 # ---------------------------------------------------------------------------
 # Pure helpers — _extract_ip / _decode_payload
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

When the MQTT broker stays offline the reconnect loop in `DeviceMqttMonitor._run` fires every `_RECONNECT_DELAY` (5s) and the bare `except Exception` was logging a full ERROR with traceback every tick. A few minutes of broker downtime fills the log with dozens of identical `TimeoutError: timed out` tracebacks, drowning out everything else.

Splits the broad handler into two cases. Expected connection failures (`TimeoutError`, `OSError`, `ConnectionError`) now log `WARNING` without a traceback on the first failure and `DEBUG` on every repeat until the broker comes back. Unexpected exception classes keep their loud `ERROR` + traceback on the first hit so genuine bugs stay visible, but repeats also collapse to `DEBUG`. A successful `_connect_and_listen` session re-arms the gate so the next outage logs loudly again.

**Related issue or feature (if applicable):**

- fixes the user-reported "MQTT broker … reconnecting in 5s" log spam shown when the broker is offline.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable. (`test_run_collapses_repeat_unreachable_errors_to_debug`, `test_run_resets_log_gate_after_successful_session`)
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (No architecture-level changes — pure logging-volume fix in a single internal module.)
