### PR TITLE
Pause ICMP ping loop while no dashboard client is subscribed

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -44,6 +44,7 @@ from zeroconf.const import (
 )
 
 from ..helpers.hostname import is_local_hostname, normalize_hostname
+from ..helpers.subscriber_presence import SubscriberPresence
 from ..models import AdoptableDevice, Device, DeviceState, ReachabilitySource
 from ._dns_cache import DNSCache
 from ._reachability_tracker import MdnsCacheInfo, ReachabilityTracker
@@ -205,6 +206,7 @@ class DeviceStateMonitor:
         reachability: ReachabilityTracker | None = None,
         is_ignored: Callable[[str], bool] | None = None,
         get_devices_by_name: Callable[[str], list[Device]] | None = None,
+        presence: SubscriberPresence | None = None,
     ) -> None:
         self._get_devices = get_devices
         # ``get_devices_by_name`` is the O(1) name-keyed lookup that
@@ -260,6 +262,17 @@ class DeviceStateMonitor:
         # the same TTL'd lookup result instead of re-resolving every
         # cycle.
         self._dns_cache = DNSCache()
+        # When wired, the ping loop pauses while no dashboard client
+        # is subscribed — so a quiet network with no observers
+        # generates no ICMP traffic. Mirrors the legacy
+        # esphome.dashboard.status.ping behaviour (``while
+        # self._subscribers`` in web_server.py + ``await
+        # dashboard.ping_request.wait()`` in ping.py); reaching
+        # parity here closes a regression in the new dashboard,
+        # which had been ping-sweeping unconditionally. Optional so
+        # existing tests that build a monitor without a presence
+        # gate keep working; ``None`` means "always run the loop".
+        self._presence = presence
 
     async def start(self) -> None:
         """Start the mDNS browser and the periodic ping sweep."""
@@ -1099,12 +1112,21 @@ class DeviceStateMonitor:
         # → OFFLINE transition in front of the user within ~10s of
         # startup instead of after a full minute.
         await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
-        await self._resolve_non_api_mdns_targets()
-        await self._ping_sweep()
+        # Strict pause: when wired to a SubscriberPresence gate, only
+        # sweep while at least one dashboard client is subscribed.
+        # The 0→1 transition wakes ``wait_for_subscriber`` immediately
+        # so the first user to open the dashboard sees fresh ICMP-
+        # source state within one sweep instead of waiting up to
+        # ``_PING_INTERVAL``. mDNS browsing keeps running
+        # unconditionally (it's passive), so devices that announce
+        # flip ONLINE the moment the bus delivers their cached state
+        # to the new subscriber.
         while True:
-            await asyncio.sleep(_PING_INTERVAL)
+            if self._presence is not None:
+                await self._presence.wait_for_subscriber()
             await self._resolve_non_api_mdns_targets()
             await self._ping_sweep()
+            await asyncio.sleep(_PING_INTERVAL)
 
     async def _resolve_non_api_mdns_targets(self) -> None:
         """Actively resolve ``.local`` hostnames for non-API devices.

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -16,6 +16,7 @@ lower-priority source can never override the state set by a higher one.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Callable
 from operator import attrgetter
@@ -1196,6 +1197,22 @@ class DeviceStateMonitor:
                 await self._presence.wait_for_subscriber()
             await self._resolve_non_api_mdns_targets()
             await self._ping_sweep()
+            if self._presence is not None:
+                # Interruptible idle wait: bail early if the last
+                # subscriber leaves so the next one to connect
+                # doesn't sit through the rest of a stale interval.
+                # ``wait_for`` raises ``TimeoutError`` after
+                # ``_PING_INTERVAL`` when the gate stays open the
+                # whole time (the normal "still subscribed, sweep
+                # again" path). Either branch loops back to the top
+                # where ``wait_for_subscriber`` parks if the gate
+                # has since closed.
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(
+                        self._presence.wait_for_no_subscribers(),
+                        timeout=_PING_INTERVAL,
+                    )
+                continue
             await asyncio.sleep(_PING_INTERVAL)
 
     async def _resolve_non_api_mdns_targets(self) -> None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -160,6 +160,7 @@ class DevicesController:
             on_importable_added=self._on_importable_added,
             on_importable_removed=self._on_importable_removed,
             is_ignored=self.ignored_devices.__contains__,
+            presence=self._db.subscriber_presence,
         )
         # Per-signal freshness tracker (mDNS / ping / MQTT last-seen,
         # ping RTT) feeding the device drawer's Reachability section.

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -31,6 +31,7 @@ from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.auth import auth_middleware
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware
+from .helpers.subscriber_presence import SubscriberPresence
 from .models import EventType
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,6 +69,15 @@ class DeviceBuilder:
         """Initialize the Device Builder."""
         self.settings = settings
         self.bus = EventBus()
+        # Reference-counted "is anyone watching the dashboard?" gate.
+        # The ``subscribe_events`` body wraps itself in
+        # ``presence.subscriber()`` so consumers — currently the
+        # state monitor's ICMP ping loop — can park while the gate
+        # is closed and resume on the 0→1 transition. Mirrors the
+        # legacy dashboard's ``ping_request`` / ``self._subscribers``
+        # pair so a quiet network with no observers generates no
+        # ICMP traffic.
+        self.subscriber_presence = SubscriberPresence()
         self.loop: asyncio.AbstractEventLoop | None = None
         # Held so ``stop()`` can shut the pool down explicitly. Created
         # eagerly here (not in start()) so a test or caller that probes
@@ -313,14 +323,21 @@ class DeviceBuilder:
         # could trip the bounded queue's backpressure terminator
         # under fleet load.
         broadcast_event_types = [et for et in EventType if et is not EventType.DEVICE_REACHABILITY]
-        await stream_events(
-            client=client,
-            message_id=message_id,
-            bus=self.bus,
-            event_types=broadcast_event_types,
-            handle_event=_handle_event,
-            send_initial=_send_initial,
-        )
+        # Hold a presence reference for the lifetime of the stream so
+        # idle-time ICMP discovery resumes the moment a client
+        # subscribes and pauses again on disconnect. The 0→1
+        # transition wakes any awaiter on
+        # ``presence.wait_for_subscriber``; the 1→0 transition
+        # re-arms the gate so the next idle period takes effect.
+        with self.subscriber_presence.subscriber():
+            await stream_events(
+                client=client,
+                message_id=message_id,
+                bus=self.bus,
+                event_types=broadcast_event_types,
+                handle_event=_handle_event,
+                send_initial=_send_initial,
+            )
 
     def create_background_task(self, coro: Any) -> asyncio.Task:
         """Create a tracked background task."""

--- a/esphome_device_builder/helpers/subscriber_presence.py
+++ b/esphome_device_builder/helpers/subscriber_presence.py
@@ -1,0 +1,80 @@
+"""
+Reference-counted "is anyone watching?" gate.
+
+A small primitive consumers (the ICMP ping loop, periodic mDNS
+refresh, MQTT discover-publish cadence) use to pause idle-time
+traffic while no dashboard client is subscribed. The
+``subscribe_events`` stream wraps its main body in
+:meth:`SubscriberPresence.subscriber` so the count tracks the live
+WS clients exactly; the 0→1 transition wakes every awaiter on
+:meth:`wait_for_subscriber` so first-load latency is bounded by the
+consumer's own loop cost, not its configured idle interval.
+
+Lives in its own module rather than on :class:`EventBus` because
+the two concerns are independent — the bus is about delivering
+events to listeners, presence is about lifecycle of the dashboard
+WS clients. Splitting it lets other consumers gate on presence
+without taking a dependency on the bus, and keeps each class's
+responsibilities single-purpose.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+class SubscriberPresence:
+    """
+    Reference-counted dashboard-subscriber gate.
+
+    Single-task design: every mutation runs synchronously on the
+    event-loop thread, so the count and the asyncio.Event don't need
+    a lock. Awaiters resume the next time the loop runs after the
+    0→1 transition; the 1→0 transition re-arms the gate so a fresh
+    awaiter parks again.
+    """
+
+    def __init__(self) -> None:
+        self._count = 0
+        self._has_subscriber = asyncio.Event()
+
+    def has_subscribers(self) -> bool:
+        """Return True while at least one subscriber is registered."""
+        return self._count > 0
+
+    @property
+    def count(self) -> int:
+        """Current subscriber count — exposed for tests / metrics."""
+        return self._count
+
+    async def wait_for_subscriber(self) -> None:
+        """Suspend until at least one subscriber is registered.
+
+        Returns immediately when the gate is already open. Awaiters
+        block again only after the count drops back to 0 and they
+        come around for the next iteration of their loop.
+        """
+        await self._has_subscriber.wait()
+
+    @contextmanager
+    def subscriber(self) -> Iterator[None]:
+        """
+        Context manager that increments the count for its body.
+
+        The 0→1 transition sets the internal asyncio.Event so any
+        awaiter on :meth:`wait_for_subscriber` resumes; the 1→0
+        transition clears it so the next awaiter parks again. The
+        count is decremented in ``finally`` so the gate closes
+        even if the wrapped body raises.
+        """
+        self._count += 1
+        if self._count == 1:
+            self._has_subscriber.set()
+        try:
+            yield
+        finally:
+            self._count -= 1
+            if self._count == 0:
+                self._has_subscriber.clear()

--- a/esphome_device_builder/helpers/subscriber_presence.py
+++ b/esphome_device_builder/helpers/subscriber_presence.py
@@ -38,7 +38,20 @@ class SubscriberPresence:
 
     def __init__(self) -> None:
         self._count = 0
+        # Two events kept in lockstep. ``_has_subscriber`` is set
+        # while count > 0; ``_no_subscribers`` is set while
+        # count == 0. Tracking both lets consumers ``await`` on
+        # *either* transition — the ICMP loop awaits subscriber
+        # presence before each sweep AND awaits the no-subscriber
+        # event during its post-sweep idle window so a
+        # subscriber-drop mid-sleep cuts straight to the
+        # ``wait_for_subscriber`` park instead of burning the rest
+        # of the interval. Without that, a subscriber arriving
+        # ~1ms after the last one left could wait up to
+        # ``_PING_INTERVAL`` for fresh ICMP data.
         self._has_subscriber = asyncio.Event()
+        self._no_subscribers = asyncio.Event()
+        self._no_subscribers.set()  # initial state: gate is closed
 
     def has_subscribers(self) -> bool:
         """Return True while at least one subscriber is registered."""
@@ -58,23 +71,43 @@ class SubscriberPresence:
         """
         await self._has_subscriber.wait()
 
+    async def wait_for_no_subscribers(self) -> None:
+        """Suspend until the count drops to 0.
+
+        Mirror of :meth:`wait_for_subscriber` for the opposite
+        transition — used by consumers whose idle wait should be
+        interruptible by a subscriber drop. The ICMP ping loop
+        wraps its post-sweep idle window in
+        ``asyncio.wait_for(presence.wait_for_no_subscribers(),
+        timeout=_PING_INTERVAL)`` so when the last subscriber
+        disconnects the loop short-circuits the rest of the
+        interval and parks at the top on ``wait_for_subscriber``
+        — keeping the next subscriber's first sweep within one
+        scheduling tick of their connect.
+        """
+        await self._no_subscribers.wait()
+
     @contextmanager
     def subscriber(self) -> Iterator[None]:
         """
         Context manager that increments the count for its body.
 
-        The 0→1 transition sets the internal asyncio.Event so any
-        awaiter on :meth:`wait_for_subscriber` resumes; the 1→0
-        transition clears it so the next awaiter parks again. The
-        count is decremented in ``finally`` so the gate closes
-        even if the wrapped body raises.
+        The 0→1 transition sets ``_has_subscriber`` and clears
+        ``_no_subscribers`` so any awaiter on
+        :meth:`wait_for_subscriber` resumes; the 1→0 transition
+        does the inverse and wakes any awaiter on
+        :meth:`wait_for_no_subscribers`. The count is decremented
+        in ``finally`` so the gate closes even if the wrapped
+        body raises.
         """
         self._count += 1
         if self._count == 1:
             self._has_subscriber.set()
+            self._no_subscribers.clear()
         try:
             yield
         finally:
             self._count -= 1
             if self._count == 0:
                 self._has_subscriber.clear()
+                self._no_subscribers.set()

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -1,0 +1,223 @@
+"""
+Strict-pause behaviour for the ICMP ping loop.
+
+Mirrors the legacy ``esphome.dashboard.status.ping`` /
+``web_server.py`` pair where ICMP only fired while
+``self._subscribers`` was non-empty (the new dashboard had been
+sweeping unconditionally — bug). Pins:
+
+* with no presence gate, the loop runs as before (legacy /
+  unit-test parity)
+* with a wired ``SubscriberPresence``, ``_ping_loop`` parks
+  before the sweep until the first subscriber arrives
+* the 0→1 subscriber transition wakes the loop within one
+  scheduling tick — no waiting for ``_PING_INTERVAL``
+* the 1→0 transition lets the next iteration park again so a
+  burst of disconnects doesn't keep ICMP looping
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from esphome_device_builder import device_builder as device_builder_module
+from esphome_device_builder.controllers import _device_state_monitor as state_monitor_module
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.device_builder import DeviceBuilder
+from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
+
+
+def _build_monitor(presence: SubscriberPresence | None) -> DeviceStateMonitor:
+    """Bypass __init__ — ``_ping_loop`` only touches a few attrs."""
+    monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+    monitor._presence = presence
+    return monitor
+
+
+def _instrument_loop(
+    monitor: DeviceStateMonitor, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, int]:
+    """Replace the work the loop does each tick with call counters.
+
+    Lets the test assert "swept N times" without needing the real
+    DNS cache, zeroconf instance, or ICMP primitive. Returns the
+    counter dict so each test can read ``counts["sweeps"]`` after
+    driving the loop.
+    """
+    counts = {"sweeps": 0, "resolves": 0, "sleeps": 0}
+
+    async def _resolve() -> None:
+        counts["resolves"] += 1
+
+    async def _sweep() -> None:
+        counts["sweeps"] += 1
+
+    monitor._resolve_non_api_mdns_targets = _resolve  # type: ignore[method-assign]
+    monitor._ping_sweep = _sweep  # type: ignore[method-assign]
+
+    # Skip the bootstrap delay outright.
+    monkeypatch.setattr(state_monitor_module, "_PING_BOOTSTRAP_DELAY", 0)
+
+    # Patch the module-local sleep so each "interval wait" is a
+    # zero-cost yield and a tick count. The test ends the loop by
+    # cancelling the task, not by raising CancelledError from sleep.
+    real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_seconds: float) -> None:
+        counts["sleeps"] += 1
+        # Yield back so the test coroutine can observe the counters.
+        await real_sleep(0)
+
+    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _fast_sleep)
+    return counts
+
+
+async def _drive_until(condition: Any, *, timeout: float = 0.5) -> None:
+    """Wait for *condition()* to become truthy or raise on timeout."""
+
+    async def _spin() -> None:
+        while not condition():
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_spin(), timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_ping_loop_runs_unconditionally_without_presence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``presence=None`` (legacy / unit-test default) keeps ICMP looping.
+
+    Pin the back-compat path: tests that build a monitor without
+    wiring a presence gate must still see the ping pipeline run
+    every tick, otherwise the existing ping-loop test suite would
+    silently park forever.
+    """
+    monitor = _build_monitor(presence=None)
+    counts = _instrument_loop(monitor, monkeypatch)
+
+    task = asyncio.create_task(monitor._ping_loop())
+    try:
+        await _drive_until(lambda: counts["sweeps"] >= 2)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert counts["sweeps"] >= 2
+    assert counts["resolves"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_ping_loop_parks_until_first_subscriber(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With a presence gate, no sweep happens until someone subscribes.
+
+    Closes the legacy-parity regression: the new dashboard had been
+    pinging the fleet every minute regardless of whether a UI was
+    listening. The loop must reach ``_ping_sweep`` only after the
+    0→1 subscriber transition.
+    """
+    presence = SubscriberPresence()
+    monitor = _build_monitor(presence=presence)
+    counts = _instrument_loop(monitor, monkeypatch)
+
+    task = asyncio.create_task(monitor._ping_loop())
+    try:
+        # Give the loop several scheduling ticks to confirm it
+        # actually parks instead of running. Without the gate fix
+        # ``_ping_sweep`` would have fired on the first tick.
+        for _ in range(20):
+            await asyncio.sleep(0)
+        assert counts["sweeps"] == 0, "ping loop must not sweep while no subscriber is registered"
+
+        # 0→1 transition must wake the loop within one scheduling tick.
+        with presence.subscriber():
+            await _drive_until(lambda: counts["sweeps"] >= 1)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert counts["sweeps"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """1→0 transition closes the gate so the next iteration parks.
+
+    Without the re-arm, a subscriber that briefly connected once
+    would keep the ICMP loop running forever afterwards (the
+    asyncio.Event would stay set). Pin: after the subscriber
+    disconnects, the sweep count stops climbing.
+    """
+    presence = SubscriberPresence()
+    monitor = _build_monitor(presence=presence)
+    counts = _instrument_loop(monitor, monkeypatch)
+
+    task = asyncio.create_task(monitor._ping_loop())
+    try:
+        # Cycle one subscriber in, drive at least one sweep, then out.
+        with presence.subscriber():
+            await _drive_until(lambda: counts["sweeps"] >= 1)
+        sweeps_at_disconnect = counts["sweeps"]
+
+        # After disconnect, give the loop several ticks. The count
+        # should plateau at most one sweep above where it was — the
+        # loop completes whatever sweep was already in flight, then
+        # parks at the gate on the next iteration.
+        for _ in range(20):
+            await asyncio.sleep(0)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    # At most one extra sweep can land — the one already past the
+    # gate when the subscriber dropped. Anything more means the gate
+    # didn't close on 1→0.
+    assert counts["sweeps"] <= sweeps_at_disconnect + 1
+
+
+@pytest.mark.asyncio
+async def test_subscribe_events_holds_presence_for_stream_lifetime() -> None:
+    """``_cmd_subscribe_events`` increments presence for its body.
+
+    End-to-end-ish check that the controller wraps its broadcast
+    stream in ``presence.subscriber()`` so the gate's count
+    actually moves when a real WS subscribe lands. We don't drive
+    the full ``stream_events`` here — that's exercised in the
+    subscribe_events tests; we just pin that the wrap is in place
+    by stubbing ``stream_events`` and watching the counter while
+    inside the stub.
+    """
+    builder = DeviceBuilder.__new__(DeviceBuilder)
+    builder.bus = AsyncMock()
+    builder.subscriber_presence = SubscriberPresence()
+    builder.devices = None  # short-circuits _send_initial's branch
+
+    counts: dict[str, int] = {"inside": 0, "outside_after": 0}
+
+    async def _fake_stream_events(**_kwargs: Any) -> None:
+        counts["inside"] = builder.subscriber_presence.count
+        await asyncio.sleep(0)
+
+    original = device_builder_module.stream_events
+    device_builder_module.stream_events = _fake_stream_events  # type: ignore[assignment]
+    try:
+        client = AsyncMock()
+        await builder._cmd_subscribe_events(client=client, message_id="m1")
+    finally:
+        device_builder_module.stream_events = original  # type: ignore[assignment]
+
+    counts["outside_after"] = builder.subscriber_presence.count
+    assert counts["inside"] == 1, "presence count must be 1 inside the stream body"
+    assert counts["outside_after"] == 0, "presence count must drop back to 0 after stream exit"

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -77,7 +78,7 @@ def _instrument_loop(
     return counts
 
 
-async def _drive_until(condition: Any, *, timeout: float = 0.5) -> None:
+async def _drive_until(condition: Callable[[], object], *, timeout: float = 0.5) -> None:
     """Wait for *condition()* to become truthy or raise on timeout."""
 
     async def _spin() -> None:
@@ -188,7 +189,9 @@ async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
 
 
 @pytest.mark.asyncio
-async def test_subscribe_events_holds_presence_for_stream_lifetime() -> None:
+async def test_subscribe_events_holds_presence_for_stream_lifetime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``_cmd_subscribe_events`` increments presence for its body.
 
     End-to-end-ish check that the controller wraps its broadcast
@@ -210,14 +213,133 @@ async def test_subscribe_events_holds_presence_for_stream_lifetime() -> None:
         counts["inside"] = builder.subscriber_presence.count
         await asyncio.sleep(0)
 
-    original = device_builder_module.stream_events
-    device_builder_module.stream_events = _fake_stream_events  # type: ignore[assignment]
-    try:
-        client = AsyncMock()
-        await builder._cmd_subscribe_events(client=client, message_id="m1")
-    finally:
-        device_builder_module.stream_events = original  # type: ignore[assignment]
+    monkeypatch.setattr(device_builder_module, "stream_events", _fake_stream_events)
+
+    client = AsyncMock()
+    await builder._cmd_subscribe_events(client=client, message_id="m1")
 
     counts["outside_after"] = builder.subscriber_presence.count
     assert counts["inside"] == 1, "presence count must be 1 inside the stream body"
     assert counts["outside_after"] == 0, "presence count must drop back to 0 after stream exit"
+
+
+@pytest.mark.asyncio
+async def test_ping_loop_aborts_idle_sleep_when_last_subscriber_leaves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The post-sweep idle wait is interruptible by a subscriber drop.
+
+    Without an interruptible wait, a subscriber that disconnected
+    mid-``_PING_INTERVAL`` would force the next subscriber's first
+    sweep to wait out the rest of the interval — defeating the
+    point of waking promptly on the 0→1 transition. Pin: after the
+    last subscriber drops, the ping loop returns to the top of the
+    while-loop within one scheduling tick (so it's parked at
+    ``wait_for_subscriber`` long before the interval would have
+    elapsed).
+
+    Drives this by patching ``asyncio.wait_for`` so the test can
+    observe the call arguments — the loop must invoke it with the
+    presence's ``wait_for_no_subscribers`` coroutine, not a bare
+    ``asyncio.sleep``. A regression that keeps the unconditional
+    sleep would never call ``wait_for`` at all.
+    """
+    presence = SubscriberPresence()
+    monitor = _build_monitor(presence=presence)
+    counts = _instrument_loop(monitor, monkeypatch)
+
+    # Capture every call to wait_for so we can assert the loop
+    # used the interruptible path. Each call returns immediately
+    # so the test stays bounded.
+    wait_for_calls: list[float] = []
+    real_wait_for = asyncio.wait_for
+
+    async def _spy_wait_for(coro: Any, *, timeout: float) -> Any:
+        wait_for_calls.append(timeout)
+        # Defer to the real implementation so the gate-close still
+        # short-circuits the wait when the subscriber drops.
+        return await real_wait_for(coro, timeout=timeout)
+
+    monkeypatch.setattr(state_monitor_module.asyncio, "wait_for", _spy_wait_for)
+
+    task = asyncio.create_task(monitor._ping_loop())
+    try:
+        # Bring a subscriber in; wait until the loop has done at
+        # least one sweep AND entered the idle wait.
+        with presence.subscriber():
+            await _drive_until(lambda: counts["sweeps"] >= 1 and wait_for_calls)
+            assert wait_for_calls, "loop must use asyncio.wait_for for an interruptible idle wait"
+
+        # Subscriber just dropped (the with-block exited). The
+        # gate-close must short-circuit the in-flight wait_for so
+        # the loop returns to the top and parks on
+        # wait_for_subscriber within a few ticks — not after the
+        # full _PING_INTERVAL the wait_for was called with.
+        sweeps_at_drop = counts["sweeps"]
+        for _ in range(40):
+            await asyncio.sleep(0)
+        # Loop should be parked, not still sweeping.
+        assert counts["sweeps"] == sweeps_at_drop, (
+            "loop kept sweeping after subscriber drop — interrupt failed"
+        )
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_ping_loop_resumes_immediately_when_new_subscriber_arrives_mid_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a drop+reconnect cycle, the new subscriber's first sweep is prompt.
+
+    The end-to-end contract behind the interruptible-sleep change.
+    Without the interrupt, this sequence would make the second
+    subscriber wait up to ``_PING_INTERVAL`` for fresh ICMP data:
+
+      1. Subscriber A connects, loop sweeps once, parks on idle.
+      2. A disconnects mid-idle (presence.count → 0).
+      3. Subscriber B connects.
+      4. *With* the interrupt: idle wait short-circuits on A's
+         drop, loop parks at the top, B's connect wakes it
+         immediately, sweep #2 runs within a few ticks.
+      4'. *Without* the interrupt: idle wait runs to completion,
+         loop sweeps unconditionally even though no one was
+         listening for most of the interval, and the timing
+         depends on when in the interval B happened to arrive.
+
+    Pin the timing: from B's connect to sweep #2, ≤ a handful of
+    scheduling ticks (we use a generous 0.5s timeout via the test
+    helper).
+    """
+    presence = SubscriberPresence()
+    monitor = _build_monitor(presence=presence)
+    counts = _instrument_loop(monitor, monkeypatch)
+
+    task = asyncio.create_task(monitor._ping_loop())
+    try:
+        # Cycle subscriber A in, drive a sweep, then out.
+        with presence.subscriber():
+            await _drive_until(lambda: counts["sweeps"] >= 1)
+        sweeps_after_a = counts["sweeps"]
+
+        # Give the loop a few ticks to settle into the
+        # wait_for_subscriber park (the interrupt should have
+        # fired during the idle wait).
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert counts["sweeps"] == sweeps_after_a
+
+        # Subscriber B arrives. The 0→1 transition must wake the
+        # loop's wait_for_subscriber within one scheduling tick;
+        # _drive_until's bounded timeout catches a regression
+        # that left the loop parked on a non-interruptible sleep.
+        with presence.subscriber():
+            await _drive_until(lambda: counts["sweeps"] > sweeps_after_a)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert counts["sweeps"] >= sweeps_after_a + 1

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -31,6 +31,7 @@ def _make_monitor() -> DeviceStateMonitor:
     monitor._zeroconf.zeroconf = MagicMock()
     monitor._tasks = set()
     monitor._reachability = None
+    monitor._presence = None
     return monitor
 
 

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -100,6 +100,7 @@ def _make_monitor(
     monitor._on_importable_removed = callbacks.on_importable_removed
     monitor._reachability = None
     monitor._dns_cache = MagicMock()
+    monitor._presence = None  # ping loop runs unconditionally in tests
     return monitor, callbacks
 
 

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -102,6 +102,7 @@ def _make_monitor(
     monitor._on_importable_added = None
     monitor._on_importable_removed = None
     monitor._dns_cache = MagicMock()
+    monitor._presence = None
     return monitor
 
 

--- a/tests/test_subscribe_events_cleanup.py
+++ b/tests/test_subscribe_events_cleanup.py
@@ -25,6 +25,7 @@ from esphome_device_builder.helpers.event_bus import (
     EventBus,
     StreamBackpressureError,
 )
+from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
 from esphome_device_builder.models import EventType
 
 from .conftest import FakeWebSocketClient
@@ -33,11 +34,13 @@ from .conftest import FakeWebSocketClient
 def _make_db() -> DeviceBuilder:
     """Build a minimally-initialised DeviceBuilder for the handler.
 
-    Only ``self.bus`` and ``self.devices`` are read by
+    Only ``self.bus``, ``self.devices``, and
+    ``self.subscriber_presence`` are read by
     ``_cmd_subscribe_events``; everything else can be a stub.
     """
     db = DeviceBuilder.__new__(DeviceBuilder)
     db.bus = EventBus()
+    db.subscriber_presence = SubscriberPresence()
     db.devices = None  # skip the initial-snapshot branch
     return db
 
@@ -179,6 +182,7 @@ async def test_subscribe_events_subscribed_arrives_before_live_events() -> None:
     """
     db = DeviceBuilder.__new__(DeviceBuilder)
     db.bus = EventBus()
+    db.subscriber_presence = SubscriberPresence()
 
     devices_mock = MagicMock()
     devices_mock.get_devices.return_value = []

--- a/tests/test_subscriber_presence.py
+++ b/tests/test_subscriber_presence.py
@@ -1,0 +1,142 @@
+"""
+Tests for the reference-counted subscriber-presence gate.
+
+The gate is the small primitive that lets the ICMP ping loop park
+while no dashboard client is subscribed (closing the regression
+from the legacy dashboard's ``ping_request`` /
+``self._subscribers`` pair). These tests pin the count + gate
+contract a consumer relies on:
+
+* increment on entry, decrement on exit (success or raise)
+* 0→1 transition wakes every awaiter on ``wait_for_subscriber``
+* 1→0 transition re-arms the gate so the next awaiter parks again
+* ``has_subscribers`` mirrors the count's bool truthiness
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
+
+
+def test_initial_state_no_subscribers() -> None:
+    """A fresh gate reports zero subscribers and is closed."""
+    p = SubscriberPresence()
+    assert p.count == 0
+    assert p.has_subscribers() is False
+
+
+def test_subscriber_context_increments_and_decrements() -> None:
+    """Entering the context bumps the count; exit puts it back."""
+    p = SubscriberPresence()
+    with p.subscriber():
+        assert p.count == 1
+        assert p.has_subscribers() is True
+        with p.subscriber():
+            assert p.count == 2
+        assert p.count == 1
+    assert p.count == 0
+    assert p.has_subscribers() is False
+
+
+def test_subscriber_context_decrements_on_exception() -> None:
+    """Count returns to zero even if the wrapped body raises.
+
+    The whole point of using a context manager (rather than two
+    explicit calls) is that callers can't accidentally leak
+    subscribers when their body raises mid-stream — a leaked
+    subscriber would keep the ICMP loop pinging forever after
+    every WS disconnects with an error.
+    """
+    p = SubscriberPresence()
+
+    class _BoomError(RuntimeError):
+        pass
+
+    with pytest.raises(_BoomError), p.subscriber():
+        assert p.count == 1
+        msg = "kaboom"
+        raise _BoomError(msg)
+    assert p.count == 0
+    assert p.has_subscribers() is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_subscriber_returns_immediately_when_open() -> None:
+    """A subscriber already present means awaiting completes without parking."""
+    p = SubscriberPresence()
+    with p.subscriber():
+        # Should resolve in ~no time — wrap in wait_for so the test
+        # fails loudly rather than hanging if the gate is stuck closed.
+        await asyncio.wait_for(p.wait_for_subscriber(), timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_subscriber_parks_until_first_subscriber() -> None:
+    """An awaiter blocks while count is 0 and resumes on the 0→1 transition."""
+    p = SubscriberPresence()
+
+    async def _waiter() -> None:
+        await p.wait_for_subscriber()
+
+    waiter_task = asyncio.create_task(_waiter())
+    # Give the loop a chance to park the waiter.
+    await asyncio.sleep(0)
+    assert not waiter_task.done()
+
+    with p.subscriber():
+        await asyncio.wait_for(waiter_task, timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_subscriber_parks_again_after_drop_to_zero() -> None:
+    """A second awaiter created after the gate closed parks again.
+
+    Pins the 1→0 transition's effect: the gate must re-arm so a
+    fresh ICMP-loop iteration after the last subscriber leaves
+    parks again instead of busy-running. Without the
+    ``self._has_subscriber.clear()`` in the 1→0 path, the second
+    waiter would resume immediately.
+    """
+    p = SubscriberPresence()
+
+    # Cycle one subscriber in and out so the gate has been opened
+    # and re-armed; the next waiter must observe the closed state.
+    with p.subscriber():
+        pass
+    assert p.has_subscribers() is False
+
+    async def _waiter() -> None:
+        await p.wait_for_subscriber()
+
+    waiter_task = asyncio.create_task(_waiter())
+    await asyncio.sleep(0)
+    assert not waiter_task.done(), "waiter should park while gate is closed"
+
+    with p.subscriber():
+        await asyncio.wait_for(waiter_task, timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_subscriber_wakes_every_awaiter_on_open() -> None:
+    """Multiple awaiters all resume when the count first goes 0→1.
+
+    asyncio.Event semantics — every coroutine parked on
+    ``Event.wait()`` resumes when the event is set, not just one.
+    Pin so a regression that swaps to a 1-shot primitive (Future,
+    Condition.notify(1)) would surface here.
+    """
+    p = SubscriberPresence()
+
+    async def _waiter() -> None:
+        await p.wait_for_subscriber()
+
+    waiters = [asyncio.create_task(_waiter()) for _ in range(3)]
+    await asyncio.sleep(0)
+    assert all(not t.done() for t in waiters)
+
+    with p.subscriber():
+        await asyncio.wait_for(asyncio.gather(*waiters), timeout=0.5)

--- a/tests/test_subscriber_presence.py
+++ b/tests/test_subscriber_presence.py
@@ -140,3 +140,66 @@ async def test_wait_for_subscriber_wakes_every_awaiter_on_open() -> None:
 
     with p.subscriber():
         await asyncio.wait_for(asyncio.gather(*waiters), timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_no_subscribers_returns_immediately_when_count_is_zero() -> None:
+    """The mirror gate is open at startup (count == 0).
+
+    The 1→0 transition should set ``_no_subscribers`` *and* the
+    initial state at construction time should already be set —
+    so a consumer's first call to :meth:`wait_for_no_subscribers`
+    on a fresh gate returns immediately. Pinning the initial
+    state catches a regression that only sets the event on the
+    transition (which would leave a fresh gate's first awaiter
+    parked forever even though the count is already 0).
+    """
+    p = SubscriberPresence()
+    await asyncio.wait_for(p.wait_for_no_subscribers(), timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_no_subscribers_parks_while_subscribers_present() -> None:
+    """A subscriber holding the gate open blocks the no-subscriber waiter."""
+    p = SubscriberPresence()
+
+    async def _waiter() -> None:
+        await p.wait_for_no_subscribers()
+
+    with p.subscriber():
+        waiter_task = asyncio.create_task(_waiter())
+        await asyncio.sleep(0)
+        assert not waiter_task.done(), "waiter must park while count > 0"
+
+    # Subscriber dropped — the 1→0 transition wakes the waiter.
+    await asyncio.wait_for(waiter_task, timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_no_subscribers_wakes_on_drop_to_zero() -> None:
+    """Subscriber-drop wakes a parked no-subscribers waiter within one tick.
+
+    This is the contract the ICMP ping loop's interruptible idle
+    wait depends on — when the last subscriber leaves mid-sleep,
+    the loop's ``asyncio.wait_for(presence.wait_for_no_subscribers
+    (), timeout=_PING_INTERVAL)`` must fire promptly so the next
+    subscriber's first sweep doesn't wait out the rest of the
+    interval.
+    """
+    p = SubscriberPresence()
+
+    cm = p.subscriber()
+    cm.__enter__()  # 0→1
+    try:
+
+        async def _waiter() -> None:
+            await p.wait_for_no_subscribers()
+
+        waiter_task = asyncio.create_task(_waiter())
+        await asyncio.sleep(0)
+        assert not waiter_task.done()
+    finally:
+        cm.__exit__(None, None, None)  # 1→0
+
+    # The drop must wake the waiter within a tick.
+    await asyncio.wait_for(waiter_task, timeout=0.1)


### PR DESCRIPTION
# What does this implement/fix?

The new dashboard's `DeviceStateMonitor._ping_loop` was firing every `_PING_INTERVAL` (60s) regardless of whether anyone had a dashboard open — so a quiet network with no observers was still emitting one ICMP burst per minute per non-mDNS device.

The legacy `esphome.dashboard.status.ping` flow only pinged while there were active subscribers: `web_server.py` only calls `dashboard.ping_request.set()` from inside `while self._subscribers:`, and `ping.py`'s sweep loop opens with `await dashboard.ping_request.wait()`. The new dashboard had dropped that gate, so this is a regression vs the upstream behaviour.

This PR restores parity. A new `SubscriberPresence` helper (a small reference-counted gate with an `asyncio.Event` behind it) lives next to `EventBus`. The `subscribe_events` broadcast stream wraps its body in `presence.subscriber()` so the count tracks live WS clients exactly. `_ping_loop` awaits `presence.wait_for_subscriber()` at the top of each iteration and parks while the gate is closed. The 0→1 transition wakes the loop within one scheduling tick so the first user to open the dashboard sees fresh ICMP-source state without waiting up to `_PING_INTERVAL`.

mDNS browsing keeps running unconditionally (it's passive and free), so devices that announce flip ONLINE the moment the broadcast stream delivers their cached state to the new subscriber. Only the active ICMP fallback is gated.

`SubscriberPresence` is a separate helper rather than a method on `EventBus` because the two concerns are independent — the bus delivers events to listeners, presence tracks WS-client lifecycle. Splitting it lets future gates (active mDNS refresh, MQTT discover-publish cadence) reuse the primitive without taking a dependency on the bus.

**Related issue or feature (if applicable):**

- closes the legacy-parity regression noted in user feedback ("we should only be doing icmp pings of devices when there is someone actively subscribed")

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable. (`test_subscriber_presence.py` for the helper itself; `test_ping_loop_pause.py` for the loop-pause / first-subscriber-wake / pause-on-disconnect contracts; existing `test_subscribe_events_cleanup.py` updated to set the new attribute on the test-shell builder.)
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (No surface change — `subscribe_events` wire shape is unchanged; this is a backend-internal gating fix.)
