### PR TITLE
Filter ESPHome internal-helper components from the picker

### DIFF
--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -33,6 +33,39 @@ _LOGGER = logging.getLogger(__name__)
 
 _COMPONENTS_JSON = Path(__file__).resolve().parent.parent / "definitions" / "components.json"
 
+# Catalog ids for components that ESPHome auto-loads as transport /
+# helper modules but that the dashboard's Add Configuration picker
+# should not surface as user-facing choices. ESPHome pulls these in
+# automatically when the user adds the public-facing component (e.g.
+# adding ``web_server:`` causes ESPHome to also load ``web_server_idf``
+# / ``web_server_base`` based on the framework). Listing them here is
+# harmless if a user does add one explicitly — ESPHome's own validator
+# accepts the form — but they're confusing noise in the picker.
+#
+# Tradeoff: hand-curated rather than derived from each component's
+# ``auto_load`` chain. Deriving would auto-track new internals as
+# ESPHome adds them, but every legitimate user-facing component that
+# *also* appears in some other component's auto_load list (network,
+# wifi via captive_portal, etc.) would need an opt-out exception —
+# and missing one of those filters out a real choice. Hand-curated
+# fails closed: missing an internal here just leaves a confusing-but-
+# harmless extra option, which the user explicitly preferred ("better
+# to manually exclude than miss one — these are rare edge cases",
+# issue #325). Extend by adding to the set; a JSON regen via
+# ``script/sync_components.py`` is not required for this filter to
+# take effect.
+#
+# Public (non-underscore) name because ``script/sync_components.py``
+# imports this constant so the generator and the runtime loader
+# share one source of truth — extending the denylist edits one set,
+# not two.
+INTERNAL_COMPONENT_IDS: frozenset[str] = frozenset(
+    {
+        "web_server_base",
+        "web_server_idf",
+    }
+)
+
 
 class ComponentCatalog:
     """In-memory component catalog with search and pagination."""
@@ -67,7 +100,13 @@ class ComponentCatalog:
         # platform-locale-encoding trap that bit Windows on read_text
         # without an explicit encoding.
         data = loads(_COMPONENTS_JSON.read_bytes())
-        self._components = [_load_component(c) for c in data.get("components", [])]
+        # Drop ESPHome internal-helper / auto-load-target components
+        # — see ``INTERNAL_COMPONENT_IDS`` for the why.
+        self._components = [
+            _load_component(c)
+            for c in data.get("components", [])
+            if c.get("id") not in INTERNAL_COMPONENT_IDS
+        ]
         self._by_id = {c.id: c for c in self._components}
         self._build_featured_registry()
         _LOGGER.info(

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -74,6 +74,14 @@ _IMAGE_BASE_URL = "https://esphome.io/images/"
 # for the ESPHome team to identify.
 _USER_AGENT = "esphome-device-builder-backend (https://github.com/esphome/device-builder-dashboard)"
 
+# Re-import the runtime catalog's internal-helper denylist so the
+# generator and the runtime loader share one source of truth — see
+# ``controllers/components.py`` for the rationale (issue #325).
+sys.path.insert(0, str(_REPO_ROOT))
+from esphome_device_builder.controllers.components import (  # noqa: E402
+    INTERNAL_COMPONENT_IDS as _INTERNAL_COMPONENT_IDS,
+)
+
 # Top-level platform domains in the schema (also keys in our category enum).
 # Components keyed as ``<id>.<domain>`` in the schema files — e.g.
 # ``dht.sensor`` lives in dht.json under the key ``dht.sensor``.
@@ -884,6 +892,13 @@ def build_catalog(
             continue
         for entry in entries:
             if limit and entry["id"] not in limit:
+                continue
+            # Skip ESPHome internal-helper / auto-load-target
+            # components — they're noise in the picker. The runtime
+            # ``ComponentCatalog.load`` carries the same filter so
+            # this stays a redundant belt-and-braces; the actual
+            # bug fix is the runtime side.
+            if entry["id"] in _INTERNAL_COMPONENT_IDS:
                 continue
             out.append(entry)
 

--- a/tests/controllers/test_components.py
+++ b/tests/controllers/test_components.py
@@ -19,6 +19,7 @@ suite doesn't reach:
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from unittest.mock import patch
@@ -27,6 +28,7 @@ import pytest
 
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import (
+    INTERNAL_COMPONENT_IDS,
     ComponentCatalog,
     _FeaturedRecord,
     _load_options,
@@ -102,6 +104,66 @@ def test_load_warns_and_leaves_catalog_empty_when_components_json_missing(
     assert cat._components == []
     assert cat._by_id == {}
     assert any("Component catalog not found" in rec.message for rec in caplog.records)
+
+
+def test_load_filters_out_internal_helper_components(tmp_path: Path) -> None:
+    """Every id in ``INTERNAL_COMPONENT_IDS`` is dropped at load time.
+
+    These are ESPHome internal helpers auto-loaded by their public-
+    facing parent (e.g. ``web_server`` pulls in ``web_server_base``
+    / ``web_server_idf``). Surfacing them in the Add Configuration
+    picker is just noise — issue #325. The denylist drives the
+    filter, so the test loops over the live constant rather than
+    hard-coding the two current entries; that keeps this test honest
+    when the denylist is extended (and catches a regression that
+    drops the filter against the same set of inputs).
+    """
+    user_facing = {
+        "id": "web_server",
+        "name": "Web Server",
+        "category": "core",
+        "config_entries": [],
+    }
+    components = [user_facing] + [
+        {"id": cid, "name": cid, "category": "core", "config_entries": []}
+        for cid in INTERNAL_COMPONENT_IDS
+    ]
+    components_json = tmp_path / "components.json"
+    components_json.write_text(json.dumps({"components": components}))
+
+    cat = ComponentCatalog()
+    with patch(
+        "esphome_device_builder.controllers.components._COMPONENTS_JSON",
+        components_json,
+    ):
+        cat.load()
+
+    ids = {c.id for c in cat._components}
+    assert "web_server" in ids, "user-facing web_server entry must survive"
+    for cid in INTERNAL_COMPONENT_IDS:
+        assert cid not in ids, f"{cid} must be filtered out at load time"
+        assert cat._by_id.get(cid) is None
+
+
+def test_internal_component_ids_is_single_source_of_truth() -> None:
+    """The sync script imports the runtime denylist — one set, not two.
+
+    Previously the constant was duplicated between the runtime
+    catalog loader and the build-time JSON generator, and a future
+    contributor could update one and forget the other. The
+    contract now is: ``script/sync_components.py`` imports
+    ``INTERNAL_COMPONENT_IDS`` from
+    ``esphome_device_builder.controllers.components``. Pin that
+    invariant so a regression that re-duplicates the set or
+    diverges the values is caught here. Imported lazily because
+    the sync module is a script and pulls in heavier
+    dependencies; the import here is the assertion.
+    """
+    from script.sync_components import (  # noqa: PLC0415 — see docstring
+        _INTERNAL_COMPONENT_IDS as SYNC_INTERNAL_IDS,
+    )
+
+    assert SYNC_INTERNAL_IDS is INTERNAL_COMPONENT_IDS
 
 
 # ── get_integration_docs() ──────────────────────────────────────────


### PR DESCRIPTION
# What does this implement/fix?

`web_server_base` and `web_server_idf` were appearing as pickable options in the Add Configuration picker. Both are ESPHome internal helpers — `web_server` AUTO_LOADs them based on the framework (web_server_base → web_server_idf on IDF), and they have no user-facing role. They're harmless if a user does add them explicitly (the validator accepts the form), but they're noise in the picker.

Adds an `INTERNAL_COMPONENT_IDS` denylist in `controllers/components.py` and filters at catalog load time. The same constant is imported by `script/sync_components.py` so the next nightly JSON regen also drops them; the load-time filter is the authoritative fix and the sync-side filter is belt-and-braces. One set, edited in one place.

**Tradeoffs (why hand-curated, not derived):**

- *Hand-curated denylist:* fails closed — missing an internal here just leaves an extra (harmless) option in the picker. Maintenance is ~one entry every few ESPHome releases as new internals appear; the issue reporter hit two and we now have one set covering both.
- *Derived from the auto-load graph:* would auto-track new internals as ESPHome adds them, but every legitimate user-facing component that *also* shows up in some other component's auto_load list (network, wifi via captive_portal, etc.) would need an opt-out exception — and missing one of those filters out a real choice. Fails open into the wrong direction.

Per the issue thread, manual exclusion is preferred since these are rare edge cases and the cost of missing one is minimal compared to over-filtering a real component.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#325

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable. (`test_load_filters_out_internal_helper_components` loops over the live denylist; `test_internal_component_ids_is_single_source_of_truth` pins the sync-script ↔ runtime contract so a future re-duplication of the set is caught.)
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed). The runtime filter takes effect immediately without a regen; the sync-script change is forward-only.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (No surface change — internal catalog hygiene only.)
