### PR TITLE
Surface per-device build directory size with mtime-gated cache

### DIFF
--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -91,18 +91,23 @@ class BuildSizeRefresher:
         self._worker_task = asyncio.create_task(self._worker())
 
     async def stop(self) -> None:
-        """Cancel the worker and wait for it to exit cleanly."""
+        """Cancel the worker and wait for it to exit cleanly.
+
+        ``CancelledError`` is the expected exit and gets
+        suppressed silently. Anything else is unexpected — a
+        per-iteration ``except`` in the worker missed something —
+        and gets logged so the failure isn't invisible during a
+        clean controller shutdown.
+        """
         if self._worker_task is None:
             return
         self._worker_task.cancel()
         try:
             await self._worker_task
-        except (asyncio.CancelledError, Exception):
-            # Cancellation surfaces as ``CancelledError``; any
-            # other exception means a per-iteration ``except``
-            # missed something, which we still don't want to
-            # propagate up the controller's ``stop()`` chain.
+        except asyncio.CancelledError:
             pass
+        except Exception:
+            _LOGGER.exception("Build-size worker failed during shutdown")
         self._worker_task = None
 
     async def enqueue_stale_fleet(self) -> None:

--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -31,6 +31,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Iterable
 from pathlib import Path
+from typing import Any
 
 from ..helpers.build_size import find_stale_build_dirs, refresh_build_size_if_stale
 
@@ -39,8 +40,11 @@ _LOGGER = logging.getLogger(__name__)
 # Callback fired after a successful refresh actually changed the
 # cached triple. The owner uses it to reload the device through
 # the scanner so the in-memory ``Device.build_size_bytes`` picks
-# up the freshly-persisted value via the metadata resolver.
-RefreshedCallback = Callable[[str], Awaitable[None]]
+# up the freshly-persisted value via the metadata resolver. The
+# return value is ignored — typed ``Awaitable[Any]`` so the
+# scanner's existing ``async def reload(...) -> bool`` can be
+# wired directly without a no-return adapter wrapper.
+RefreshedCallback = Callable[[str], Awaitable[Any]]
 
 
 class BuildSizeRefresher:

--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -1,0 +1,174 @@
+"""Single-worker per-device build-directory size refresher.
+
+Owns the full build-size cache lifecycle so the
+:class:`DevicesController` doesn't carry the bookkeeping for
+yet another background job. The refresher exposes a tiny sync
+``request(configuration)`` API for "this device probably needs a
+fresh walk" and a ``start()`` / ``stop()`` pair for lifecycle.
+
+Design constraints driving the class shape:
+
+- **Heavy walks must serialize.** A typical compile dir is
+  50 MB+ and a fleet of 50 devices on a backend cold-start would
+  otherwise saturate disk I/O. One worker, one walk at a time —
+  guaranteed by construction (a single ``while True:`` loop).
+
+- **Bulk operations must coalesce.** "Clean N devices in a row"
+  fires N ``JOB_COMPLETED`` events; if each spawned its own
+  background task we'd pile up N coroutines all blocked on a
+  shared lock. The pending queue is a ``set`` so repeated
+  requests for the same configuration collapse to one slot,
+  and there's no per-request task to pile up either.
+
+- **Errors must not kill the worker.** A bad walk on one
+  configuration logs and continues with the next; the worker
+  sleeps on ``self._wake`` until the next request lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Iterable
+from pathlib import Path
+
+from ..helpers.build_size import find_stale_build_dirs, refresh_build_size_if_stale
+
+_LOGGER = logging.getLogger(__name__)
+
+# Callback fired after a successful refresh actually changed the
+# cached triple. The owner uses it to reload the device through
+# the scanner so the in-memory ``Device.build_size_bytes`` picks
+# up the freshly-persisted value via the metadata resolver.
+RefreshedCallback = Callable[[str], Awaitable[None]]
+
+
+class BuildSizeRefresher:
+    """
+    One persistent worker that drains build-size refresh requests serially.
+
+    The owner pushes work via :meth:`request` (sync, side-effect-only)
+    or :meth:`enqueue_stale_fleet` (async, runs the phase-A sweep
+    and pushes any divergent configurations). The single worker
+    task wakes whenever the pending set is non-empty, walks one
+    device at a time, and notifies the owner via the
+    ``on_refreshed`` callback after each successful change.
+    """
+
+    def __init__(
+        self,
+        config_dir: Path,
+        get_filenames: Callable[[], Iterable[str]],
+        on_refreshed: RefreshedCallback,
+    ) -> None:
+        self._config_dir = config_dir
+        self._get_filenames = get_filenames
+        self._on_refreshed = on_refreshed
+        self._pending: set[str] = set()
+        self._wake = asyncio.Event()
+        self._worker_task: asyncio.Task[None] | None = None
+
+    def request(self, configuration: str) -> None:
+        """
+        Queue a refresh and wake the worker.
+
+        Cheap, sync, side-effect-only — safe to call from any
+        event-loop callback. Repeated requests for the same
+        configuration coalesce because the queue is a ``set``,
+        and a refresh that's already queued doesn't add a second
+        slot. The worker picks the request up on its next
+        iteration; mid-walk requests for an already-running
+        configuration land in the same set and get a fresh walk
+        right after the current one finishes.
+        """
+        self._pending.add(configuration)
+        self._wake.set()
+
+    def start(self) -> None:
+        """Spawn the worker task. Idempotent — a second call is a no-op."""
+        if self._worker_task is not None and not self._worker_task.done():
+            return
+        self._worker_task = asyncio.create_task(self._worker())
+
+    async def stop(self) -> None:
+        """Cancel the worker and wait for it to exit cleanly."""
+        if self._worker_task is None:
+            return
+        self._worker_task.cancel()
+        try:
+            await self._worker_task
+        except (asyncio.CancelledError, Exception):
+            # Cancellation surfaces as ``CancelledError``; any
+            # other exception means a per-iteration ``except``
+            # missed something, which we still don't want to
+            # propagate up the controller's ``stop()`` chain.
+            pass
+        self._worker_task = None
+
+    async def enqueue_stale_fleet(self) -> None:
+        """
+        Phase-A fleet sweep: find stale configurations and queue them.
+
+        One executor job stats every configured device's build
+        dir + freshness pair against the cached pair in the
+        sidecar and returns the divergent set. Each one gets
+        pushed into the worker queue via :meth:`request`; the
+        worker drains the queue on its own. Used on controller
+        start to pick up CLI-compile drift across the whole
+        catalog without saturating disk I/O on the cold path.
+        """
+        loop = asyncio.get_running_loop()
+        filenames = list(self._get_filenames())
+        if not filenames:
+            return
+        stale = await loop.run_in_executor(None, find_stale_build_dirs, self._config_dir, filenames)
+        for configuration in stale:
+            self.request(configuration)
+
+    async def _worker(self) -> None:
+        """
+        Long-lived loop: drain the pending set when woken.
+
+        On first iteration, runs the phase-A fleet sweep so the
+        backend picks up CLI-compile drift across the whole
+        catalog without the controller having to fire a separate
+        startup task. Subsequent iterations sleep on ``self._wake``
+        until there's work, clear the event, then walk the queue
+        one configuration at a time until it's empty, then sleep
+        again. ``set.pop()`` is arbitrary-order — fine here, every
+        queued device gets walked. New requests that arrive
+        mid-iteration land in the same set and get processed
+        before the next sleep.
+
+        Per-iteration ``try`` swallows configuration-specific
+        errors so one bad walk can't kill the worker (typical
+        cause: a permission error or a vanishing path during the
+        walk). Cancellation propagates through the ``await`` and
+        breaks the outer ``while True:`` cleanly.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            await self.enqueue_stale_fleet()
+        except Exception:
+            _LOGGER.exception("Initial build-size fleet sweep failed")
+        while True:
+            await self._wake.wait()
+            self._wake.clear()
+            while self._pending:
+                configuration = self._pending.pop()
+                try:
+                    result = await loop.run_in_executor(
+                        None,
+                        refresh_build_size_if_stale,
+                        self._config_dir,
+                        configuration,
+                    )
+                except Exception:
+                    _LOGGER.exception("Build-size refresh failed for %s", configuration)
+                    continue
+                if result is None:
+                    continue  # cache hit / no artifacts — nothing to publish
+                try:
+                    await self._on_refreshed(configuration)
+                except Exception:
+                    _LOGGER.exception("on_refreshed callback failed for %s", configuration)

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -35,6 +35,7 @@ class DeviceFileMetadata(NamedTuple):
     ip: str
     expected_config_hash: str = ""
     mac_address: str = ""
+    build_size_bytes: int = 0
 
 
 class ScanChange(StrEnum):
@@ -381,6 +382,7 @@ class DeviceScanner:
                     metadata.ip,
                     metadata.expected_config_hash,
                     metadata.mac_address,
+                    metadata.build_size_bytes,
                     previous=self._index.by_path.get(path),
                 )
             except Exception:

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -318,31 +318,24 @@ def set_device_metadata(
             entry["comment"] = comment
         if ip:
             entry["ip"] = ip
-        if expected_config_hash is not None:
-            if expected_config_hash:
-                entry["expected_config_hash"] = expected_config_hash
+        # Tri-state fields: ``None`` means "leave alone", a truthy
+        # value writes, an explicit falsy (``""`` / ``0``) clears.
+        # Loop over the (key, value) pairs so adding a new
+        # tri-state field doesn't bump this function's branch
+        # count (ruff PLR0912 caps at 12).
+        for key, value in (
+            ("expected_config_hash", expected_config_hash),
+            ("mac_address", mac_address),
+            ("build_size_bytes", build_size_bytes),
+            ("build_size_dir_mtime", build_size_dir_mtime),
+            ("build_size_info_mtime", build_size_info_mtime),
+        ):
+            if value is None:
+                continue
+            if value:
+                entry[key] = value
             else:
-                entry.pop("expected_config_hash", None)
-        if mac_address is not None:
-            if mac_address:
-                entry["mac_address"] = mac_address
-            else:
-                entry.pop("mac_address", None)
-        if build_size_bytes is not None:
-            if build_size_bytes:
-                entry["build_size_bytes"] = build_size_bytes
-            else:
-                entry.pop("build_size_bytes", None)
-        if build_size_dir_mtime is not None:
-            if build_size_dir_mtime:
-                entry["build_size_dir_mtime"] = build_size_dir_mtime
-            else:
-                entry.pop("build_size_dir_mtime", None)
-        if build_size_info_mtime is not None:
-            if build_size_info_mtime:
-                entry["build_size_info_mtime"] = build_size_info_mtime
-            else:
-                entry.pop("build_size_info_mtime", None)
+                entry.pop(key, None)
 
 
 def get_device_metadata(config_dir: Path, filename: str) -> dict[str, Any]:

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -269,6 +269,9 @@ def set_device_metadata(
     ip: str | None = None,
     expected_config_hash: str | None = None,
     mac_address: str | None = None,
+    build_size_bytes: int | None = None,
+    build_size_dir_mtime: int | None = None,
+    build_size_info_mtime: int | None = None,
 ) -> None:
     """
     Set metadata fields for a device.
@@ -290,6 +293,20 @@ def set_device_metadata(
     Persisted so the dashboard renders the address immediately on
     startup, before the first mDNS probe response. Passing an
     empty string clears it.
+
+    ``build_size_bytes`` caches the total size of the per-device
+    ``.esphome/build/<name>/`` tree at the freshness pair
+    captured by the last walk. The pair is split because each
+    half catches a class of compile-time changes the other
+    misses: ``build_size_dir_mtime`` moves on entry-set churn
+    (PlatformIO atomic-replaces, sibling add/remove),
+    ``build_size_info_mtime`` moves on every real ESPHome
+    recompile (``write_file_if_changed`` rewrites
+    ``build_info.json``). Either side moving counts as stale,
+    so a freshly-restarted dashboard re-walks any device whose
+    pair drifted from what was persisted. Pass ``0`` for any
+    field to clear (used by the archive flow's volatile-field
+    scrub).
     """
     with metadata_transaction(config_dir) as data:
         entry = data.setdefault(filename, {})
@@ -311,6 +328,21 @@ def set_device_metadata(
                 entry["mac_address"] = mac_address
             else:
                 entry.pop("mac_address", None)
+        if build_size_bytes is not None:
+            if build_size_bytes:
+                entry["build_size_bytes"] = build_size_bytes
+            else:
+                entry.pop("build_size_bytes", None)
+        if build_size_dir_mtime is not None:
+            if build_size_dir_mtime:
+                entry["build_size_dir_mtime"] = build_size_dir_mtime
+            else:
+                entry.pop("build_size_dir_mtime", None)
+        if build_size_info_mtime is not None:
+            if build_size_info_mtime:
+                entry["build_size_info_mtime"] = build_size_info_mtime
+            else:
+                entry.pop("build_size_info_mtime", None)
 
 
 def get_device_metadata(config_dir: Path, filename: str) -> dict[str, Any]:
@@ -355,6 +387,14 @@ _VOLATILE_DEVICE_METADATA_FIELDS: frozenset[str] = frozenset(
         # stale persisted MAC would render until the next mDNS
         # announce overwrote it.
         "mac_address",
+        # Cached size of the per-device build directory at the
+        # freshness pair captured alongside it. Archive wipes the
+        # build tree (``_wipe_device_build_dir``) so the cached
+        # triple would describe a directory that no longer
+        # exists.
+        "build_size_bytes",
+        "build_size_dir_mtime",
+        "build_size_info_mtime",
     }
 )
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1425,7 +1425,17 @@ class DevicesController:
         if not board_id:
             board_id = self._derive_board_id_from_yaml(config_dir, filename)
         mac_address = str(md.get("mac_address", ""))
-        build_size_bytes = int(md.get("build_size_bytes", 0) or 0)
+        # Defensive ``int()`` coercion: a hand-edited / partially-
+        # written sidecar could land here with a non-numeric value
+        # (e.g. ``null``, an object). The metadata resolver is on
+        # the scanner's per-device hot path and a single corrupt
+        # entry shouldn't fail the whole scan — fall back to ``0``
+        # (the same sentinel ``set_device_metadata`` writes when
+        # clearing) and let the next walk re-populate.
+        try:
+            build_size_bytes = int(md.get("build_size_bytes") or 0)
+        except (TypeError, ValueError):
+            build_size_bytes = 0
         return DeviceFileMetadata(
             board_id=board_id,
             ip=ip,

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1904,11 +1904,13 @@ class DevicesController:
         await self._scanner.reload(configuration)
         if flashed:
             self._sync_deployed_hash_after_flash(configuration)
-        # Compile bumps the build directory's mtime, which is what
-        # gates the cached size walk. Hand off to the build-size
-        # worker so the drawer / table show an up-to-date "Build
-        # size" value the next time the frontend reads the
-        # device list.
+        # A real compile moves the freshness pair the build-size
+        # cache keys off (build-dir mtime + ``build_info.json``
+        # mtime); hand off to the build-size worker so the drawer
+        # / table show an up-to-date "Build size" value the next
+        # time the frontend reads the device list. The worker
+        # short-circuits when the pair didn't actually move (e.g.
+        # an UPLOAD-only job that didn't recompile).
         self._build_size.request(configuration)
 
     async def _persist_expected_config_hash(self, configuration: str) -> None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -23,6 +23,7 @@ from esphome.components.dashboard_import import import_config
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 
 from ...helpers.api import CommandError, api_command
+from ...helpers.build_size import coerce_sidecar_int
 from ...helpers.config_hash import compute_yaml_config_hash, read_build_info_hash
 from ...helpers.device_yaml import (
     generate_device_yaml,
@@ -1425,17 +1426,13 @@ class DevicesController:
         if not board_id:
             board_id = self._derive_board_id_from_yaml(config_dir, filename)
         mac_address = str(md.get("mac_address", ""))
-        # Defensive ``int()`` coercion: a hand-edited / partially-
-        # written sidecar could land here with a non-numeric value
-        # (e.g. ``null``, an object). The metadata resolver is on
-        # the scanner's per-device hot path and a single corrupt
-        # entry shouldn't fail the whole scan — fall back to ``0``
-        # (the same sentinel ``set_device_metadata`` writes when
-        # clearing) and let the next walk re-populate.
-        try:
-            build_size_bytes = int(md.get("build_size_bytes") or 0)
-        except (TypeError, ValueError):
-            build_size_bytes = 0
+        # ``coerce_sidecar_int`` handles the bad-data fall-throughs
+        # (``None`` / object / decimal-string / etc.) — same
+        # defensive shape used by the build-size cache reads in
+        # ``helpers/build_size.py``. The metadata resolver is on
+        # the scanner's per-device hot path; a single corrupt
+        # entry shouldn't fail the whole scan.
+        build_size_bytes = coerce_sidecar_int(md.get("build_size_bytes"))
         return DeviceFileMetadata(
             board_id=board_id,
             ip=ip,

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -52,6 +52,7 @@ from ...models import (
     UpdateDeviceResponse,
     WizardResponse,
 )
+from .._build_size_refresher import BuildSizeRefresher
 from .._device_mqtt_coordinator import DeviceMqttCoordinator
 from .._device_scanner import DeviceFileMetadata, DeviceScanner, ScanChange
 from .._device_state_monitor import _MDNS_REFRESH_PADDING_SECONDS, DeviceStateMonitor
@@ -142,6 +143,17 @@ class DevicesController:
             get_metadata=self._resolve_device_metadata,
             on_change=self._on_scan_change,
         )
+        # Single-worker build-size refresher. Bulk operations
+        # (clean / delete N devices in a row, fleet-wide startup
+        # sweep) all funnel into one queue so repeated requests
+        # for the same configuration coalesce and we never pile
+        # up background tasks. Constructed after the scanner so
+        # ``on_refreshed=self._scanner.reload`` is bindable.
+        self._build_size = BuildSizeRefresher(
+            config_dir=self._db.settings.config_dir,
+            get_filenames=lambda: (d.configuration for d in self._get_devices()),
+            on_refreshed=self._scanner.reload,
+        )
         # Build the state monitor first so the reachability tracker
         # can take its ``get_mdns_cache_info`` bound method directly
         # as the mDNS cache reader (no wrapper lambda — bound
@@ -199,12 +211,18 @@ class DevicesController:
         self._unsub_job_completed = self._db.bus.add_listener(
             EventType.JOB_COMPLETED, self._on_firmware_job_completed
         )
+        # Build-size worker — runs its own initial fleet sweep
+        # on first iteration to pick up CLI-compile drift, then
+        # drains per-device requests as they arrive from the
+        # job-completion hook.
+        self._build_size.start()
 
     async def stop(self) -> None:
         """Stop background monitors so the process exits cleanly."""
         if self._unsub_job_completed is not None:
             self._unsub_job_completed()
             self._unsub_job_completed = None
+        await self._build_size.stop()
         await self._mqtt_coordinator.stop()
         await self._state_monitor.stop()
 
@@ -1407,11 +1425,13 @@ class DevicesController:
         if not board_id:
             board_id = self._derive_board_id_from_yaml(config_dir, filename)
         mac_address = str(md.get("mac_address", ""))
+        build_size_bytes = int(md.get("build_size_bytes", 0) or 0)
         return DeviceFileMetadata(
             board_id=board_id,
             ip=ip,
             expected_config_hash=expected_config_hash,
             mac_address=mac_address,
+            build_size_bytes=build_size_bytes,
         )
 
     def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:
@@ -1824,10 +1844,21 @@ class DevicesController:
             # old entry and the appearance of the new one.
             self._db.create_background_task(self._scanner.scan())
             return
-        if job_type not in (JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL):
-            return
         configuration = getattr(job, "configuration", "")
         if not configuration:
+            return
+        if job_type == JobType.CLEAN:
+            # ``esphome clean`` removes the per-device build tree;
+            # the build-size cache for this device is now stale
+            # (cached non-zero, current dir mtime → 0). The pair-
+            # equality short-circuit in
+            # ``refresh_build_size_if_stale`` detects that and
+            # walks once to clear the cached triple, so the drawer
+            # / table flip back to the em-dash placeholder. No
+            # hash recompute / flash bookkeeping needed for CLEAN.
+            self._build_size.request(configuration)
+            return
+        if job_type not in (JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL):
             return
         recompute_hash = job_type in (JobType.COMPILE, JobType.INSTALL)
         flashed = job_type in (JobType.UPLOAD, JobType.INSTALL)
@@ -1873,6 +1904,12 @@ class DevicesController:
         await self._scanner.reload(configuration)
         if flashed:
             self._sync_deployed_hash_after_flash(configuration)
+        # Compile bumps the build directory's mtime, which is what
+        # gates the cached size walk. Hand off to the build-size
+        # worker so the drawer / table show an up-to-date "Build
+        # size" value the next time the frontend reads the
+        # device list.
+        self._build_size.request(configuration)
 
     async def _persist_expected_config_hash(self, configuration: str) -> None:
         """

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -51,6 +51,7 @@ callers treat that the same as "no cached value, total = 0".
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -327,17 +328,28 @@ def compute_build_dir_size(build_dir: Path) -> int:
     walk during a concurrent compile) is swallowed so the total
     reflects what we could see rather than failing the whole
     operation.
+
+    Walks via ``os.walk()`` rather than ``Path.rglob`` — the
+    former delegates to ``os.scandir()`` since Python 3.5, which
+    gets cached ``d_type`` from ``readdir()`` so we don't pay a
+    syscall just to know "is this a file or a dir". ``rglob``
+    allocates a ``Path`` per entry and re-stats for ``is_file()``,
+    which roughly doubles the syscall count on big build trees
+    (PlatformIO checkouts can be 10k+ files).
     """
-    if not build_dir.exists():
-        return 0
     total = 0
-    for entry in build_dir.rglob("*"):
-        try:
-            if entry.is_file():
-                total += entry.stat().st_size
-        except OSError:
-            # File vanished mid-walk (concurrent compile cleanup,
-            # symlink target removed, …). Skip and keep going —
-            # a partial total is better than no total.
-            continue
+    # ``onerror`` swallows top-level failures (missing dir,
+    # permission denied at root). Per-file ``getsize`` errors
+    # are caught individually below so a vanishing file mid-walk
+    # doesn't kill the whole operation.
+    for dirpath, _dirnames, filenames in os.walk(build_dir, onerror=lambda _e: None):
+        for filename in filenames:
+            try:
+                total += os.path.getsize(os.path.join(dirpath, filename))
+            except OSError:
+                # File vanished mid-walk (concurrent compile
+                # cleanup, symlink target removed, …). Skip and
+                # keep going — a partial total is better than
+                # no total.
+                continue
     return total

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -2,7 +2,7 @@
 
 ESPHome compiles produce a meaty ``.esphome/build/<device>/`` tree —
 PlatformIO checkouts, framework toolchain output, intermediate ``.o``
-files, the linked binaries. A typical board lands at 50–250 MB, with
+files, the linked binaries. A typical board lands at 50-250 MB, with
 heavier configs (BLE-tracker fleets, multi-bus designs) easily past a
 gigabyte. The dashboard surfaces this size in the per-device drawer
 and as a hidden-by-default table column so a user planning a clean-up
@@ -51,6 +51,7 @@ callers treat that the same as "no cached value, total = 0".
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 from esphome.storage_json import StorageJSON, ext_storage_path
@@ -58,6 +59,34 @@ from esphome.storage_json import StorageJSON, ext_storage_path
 from ..controllers.config import get_device_metadata, set_device_metadata
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class BuildDirSignal:
+    """Two-stat freshness signal for a per-device build directory.
+
+    ``dir_mtime`` and ``info_mtime`` are whole-second
+    ``int(stat.st_mtime)`` values; ``0`` means that path is
+    missing. Each catches a class of changes the other misses
+    (see the module docstring's empirical matrix), so the cache
+    treats inequality on either half as "stale".
+    """
+
+    dir_mtime: int
+    info_mtime: int
+
+
+@dataclass(frozen=True, slots=True)
+class BuildSizeRefreshResult:
+    """The persisted triple after a successful walk: size + freshness pair.
+
+    ``size_bytes`` is the recursive-walk sum;
+    ``signal`` is the freshness pair captured at walk time, used
+    to short-circuit the next call when the dir hasn't moved.
+    """
+
+    size_bytes: int
+    signal: BuildDirSignal
 
 
 def resolve_build_dir(filename: str) -> Path | None:
@@ -84,13 +113,13 @@ def resolve_build_dir(filename: str) -> Path | None:
     return Path(storage.build_path)
 
 
-def get_build_dir_signal(build_dir: Path) -> tuple[int, int]:
+def get_build_dir_signal(build_dir: Path) -> BuildDirSignal:
     """
-    Return ``(dir_mtime, build_info_mtime)`` — the freshness-pair signal.
+    Return the :class:`BuildDirSignal` freshness pair for *build_dir*.
 
-    Both are whole-second ints; ``0`` means that path is missing.
-    Tracking *both* because each catches a class of changes the
-    other misses — empirically verified:
+    Both stats are whole-second ints; ``0`` means that path is
+    missing. Tracking *both* because each catches a class of
+    changes the other misses — empirically verified:
 
     - **Dir mtime** moves on entry-set churn (sibling add /
       remove / rename, atomic-replace via ``os.replace``). Misses
@@ -110,9 +139,9 @@ def get_build_dir_signal(build_dir: Path) -> tuple[int, int]:
     file (``mtime == 0``) just means we lean on the dir mtime
     half until ESPHome catches up.
     """
-    return (
-        get_build_dir_mtime(build_dir),
-        _stat_int_mtime(build_dir / "build_info.json"),
+    return BuildDirSignal(
+        dir_mtime=get_build_dir_mtime(build_dir),
+        info_mtime=_stat_int_mtime(build_dir / "build_info.json"),
     )
 
 
@@ -160,13 +189,15 @@ def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
         build_dir = resolve_build_dir(filename)
         if build_dir is None:
             continue
-        current_dir, current_info = get_build_dir_signal(build_dir)
-        if not current_dir and not current_info:
+        current = get_build_dir_signal(build_dir)
+        if not current.dir_mtime and not current.info_mtime:
             continue  # build dir vanished; cached zero is correct
         md = get_device_metadata(config_dir, filename)
-        cached_dir = int(md.get("build_size_dir_mtime") or 0)
-        cached_info = int(md.get("build_size_info_mtime") or 0)
-        if current_dir != cached_dir or current_info != cached_info:
+        cached = BuildDirSignal(
+            dir_mtime=int(md.get("build_size_dir_mtime") or 0),
+            info_mtime=int(md.get("build_size_info_mtime") or 0),
+        )
+        if current != cached:
             stale.append(filename)
     return stale
 
@@ -174,7 +205,7 @@ def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
 def refresh_build_size_if_stale(
     config_dir: Path,
     filename: str,
-) -> tuple[int, int, int] | None:
+) -> BuildSizeRefreshResult | None:
     """
     Refresh the cached size when the build dir's freshness pair moved.
 
@@ -184,11 +215,10 @@ def refresh_build_size_if_stale(
     stat / walk / sidecar-write). Returns ``None`` when the
     cached pair was already fresh — the steady-state
     dashboard-poll path, where we want to skip every executor
-    handoff we can. When stale, returns the new
-    ``(size_bytes, dir_mtime, build_info_mtime)`` triple after
-    persisting it to the metadata sidecar; the caller uses the
-    non-None return as the signal to reload / fire
-    ``DEVICE_UPDATED``.
+    handoff we can. When stale, returns the freshly-persisted
+    :class:`BuildSizeRefreshResult` (size + freshness pair); the
+    caller uses the non-None return as the signal to reload /
+    fire ``DEVICE_UPDATED``.
 
     Sequencing is cheap-first-then-heavy:
     ``get_device_metadata`` → JSON read on a small file,
@@ -203,30 +233,32 @@ def refresh_build_size_if_stale(
     build_dir = resolve_build_dir(filename)
     if build_dir is None:
         return None
-    current_dir, current_info = get_build_dir_signal(build_dir)
+    current = get_build_dir_signal(build_dir)
     md = get_device_metadata(config_dir, filename)
-    cached_dir = int(md.get("build_size_dir_mtime") or 0)
-    cached_info = int(md.get("build_size_info_mtime") or 0)
+    cached = BuildDirSignal(
+        dir_mtime=int(md.get("build_size_dir_mtime") or 0),
+        info_mtime=int(md.get("build_size_info_mtime") or 0),
+    )
     # Pure equality check across the whole pair. Crucially this
     # short-circuits the "build dir is missing AND we never had
-    # one cached" case ((0, 0) == (0, 0) → fresh → return None);
-    # without that we'd walk the missing path on every poll and
-    # ``set_device_metadata`` would re-clear three fields that
-    # are already absent, with the non-None return retriggering a
-    # scanner.reload each time. The "dir vanished but cache was
-    # populated" case ((0, 0) ≠ (X, Y)) still falls through to
-    # walk so the cache gets cleared exactly once.
-    if (current_dir, current_info) == (cached_dir, cached_info):
+    # one cached" case (signal(0, 0) == signal(0, 0) → fresh →
+    # return None); without that we'd walk the missing path on
+    # every poll and ``set_device_metadata`` would re-clear
+    # three fields that are already absent, with the non-None
+    # return retriggering a scanner.reload each time. The "dir
+    # vanished but cache was populated" case still falls through
+    # to walk so the cache gets cleared exactly once.
+    if current == cached:
         return None
     size = compute_build_dir_size(build_dir)
     set_device_metadata(
         config_dir,
         filename,
         build_size_bytes=size,
-        build_size_dir_mtime=current_dir,
-        build_size_info_mtime=current_info,
+        build_size_dir_mtime=current.dir_mtime,
+        build_size_info_mtime=current.info_mtime,
     )
-    return size, current_dir, current_info
+    return BuildSizeRefreshResult(size_bytes=size, signal=current)
 
 
 def get_build_dir_mtime(build_dir: Path) -> int:

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -1,0 +1,288 @@
+"""Cached, mtime-gated walk of a device's per-build artifact directory.
+
+ESPHome compiles produce a meaty ``.esphome/build/<device>/`` tree —
+PlatformIO checkouts, framework toolchain output, intermediate ``.o``
+files, the linked binaries. A typical board lands at 50–250 MB, with
+heavier configs (BLE-tracker fleets, multi-bus designs) easily past a
+gigabyte. The dashboard surfaces this size in the per-device drawer
+and as a hidden-by-default table column so a user planning a clean-up
+can see at a glance which devices are eating disk.
+
+The walk itself is heavy + I/O-bound — every entry under the tree
+needs an ``stat()`` to get its size, and a fleet with dozens of
+devices would otherwise burn measurable time on every dashboard
+load. We cache the computed total in the per-device metadata sidecar
+keyed off a *freshness pair*: ``(dir_mtime, build_info_mtime)``.
+Either side moving counts as stale; both halves are needed because
+each catches a class of changes the other misses.
+
+Empirical matrix (Python 3.12, macOS APFS) — which signal moves
+under each write pattern that ESPHome / PlatformIO actually use::
+
+    case                      | dir       | firmware  | sibling
+    --------------------------+-----------+-----------+----------
+    truncate + same content   | unchanged | moved     | unchanged
+    truncate + diff content   | unchanged | moved     | unchanged
+    atomic-replace (rename)   | MOVED     | moved     | unchanged
+    add a sibling             | MOVED     | unchanged | unchanged
+    remove a sibling          | MOVED     | unchanged | unchanged
+    write_file_if_changed=    | unchanged | unchanged | unchanged
+    write_file_if_changed≠    | unchanged | unchanged | MOVED
+
+``write_file_if_changed`` (used by ``esphome/writer.py`` for
+``build_info.json``, ``main.cpp``, etc.) deliberately skips the
+write when content is identical — so a no-op recompile is correctly
+a no-op for the cache too. When the compile *does* produce
+different output, ``write_file_if_changed`` truncates-and-writes,
+which moves the file's own mtime (caught by ``build_info_mtime``)
+but leaves the parent dir's mtime alone. PlatformIO's intermediate
+work churns siblings, which moves the parent dir's mtime
+(caught by ``dir_mtime``) but leaves ``build_info.json`` alone.
+Tracking both gives full coverage; tracking either alone has
+real holes.
+
+The build path itself comes from the device's ``StorageJSON``
+sidecar (written by ESPHome at compile time), via
+``resolve_build_dir``. Devices that haven't been compiled yet —
+fresh adoption / wizard / on-disk YAML drop — return ``None``;
+callers treat that the same as "no cached value, total = 0".
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from esphome.storage_json import StorageJSON, ext_storage_path
+
+from ..controllers.config import get_device_metadata, set_device_metadata
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def resolve_build_dir(filename: str) -> Path | None:
+    """
+    Return the per-device build directory path, or ``None`` if unknown.
+
+    Reads the canonical ``build_path`` off the device's StorageJSON
+    sidecar — the same path ``shutil.rmtree``'d by the archive /
+    delete flow's ``_wipe_device_build_dir``. ``None`` covers two
+    cases: no StorageJSON yet (device hasn't been compiled) and an
+    older StorageJSON whose ``build_path`` was never populated.
+    Both legitimately mean "we have no build artifacts to size."
+    """
+    try:
+        storage = StorageJSON.load(ext_storage_path(filename))
+    except Exception:
+        # ``StorageJSON.load`` returns ``None`` on a missing file
+        # but raises on a corrupt one; treat both as "no build
+        # artifacts on disk."
+        _LOGGER.debug("StorageJSON load failed for %s", filename, exc_info=True)
+        return None
+    if storage is None or not storage.build_path:
+        return None
+    return Path(storage.build_path)
+
+
+def get_build_dir_signal(build_dir: Path) -> tuple[int, int]:
+    """
+    Return ``(dir_mtime, build_info_mtime)`` — the freshness-pair signal.
+
+    Both are whole-second ints; ``0`` means that path is missing.
+    Tracking *both* because each catches a class of changes the
+    other misses — empirically verified:
+
+    - **Dir mtime** moves on entry-set churn (sibling add /
+      remove / rename, atomic-replace via ``os.replace``). Misses
+      truncate-overwrites of an existing file (no entry change).
+
+    - **build_info.json mtime** moves on every real ESPHome
+      recompile because :func:`esphome.writer.write_file_if_changed`
+      rewrites it with the new ``config_hash`` / ``esphome_version``.
+      Misses PlatformIO's intermediate sibling churn (since
+      ``build_info.json`` itself isn't touched on those passes).
+
+    Either side moving means "something real happened," so the
+    cache compares both halves of the pair and treats inequality
+    on either as stale. ``build_info.json`` is the *preferred*
+    signal — it's the one ESPHome guarantees to write per
+    successful compile / ``--only-generate`` — but a missing
+    file (``mtime == 0``) just means we lean on the dir mtime
+    half until ESPHome catches up.
+    """
+    return (
+        get_build_dir_mtime(build_dir),
+        _stat_int_mtime(build_dir / "build_info.json"),
+    )
+
+
+def _stat_int_mtime(path: Path) -> int:
+    """Whole-second mtime stat. ``0`` when the path is missing.
+
+    Whole seconds for the same cross-filesystem reason
+    :func:`get_build_dir_mtime` truncates: FAT32 / older NFS /
+    CIFS round on write, and a fractional cached value would
+    never compare equal after a cross-mount move.
+    """
+    try:
+        return int(path.stat().st_mtime)
+    except OSError:
+        return 0
+
+
+def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
+    """
+    Cheap fleet-wide stat: return the subset whose freshness pair moved.
+
+    Run this in one executor job ahead of the heavy walk so the
+    thread-pool round-trip overhead stays at a single hop for the
+    "is anything actually out of date?" question — if the answer
+    is "nothing", we never have to schedule a walk job at all.
+
+    For each *filename*, resolves the build dir via
+    ``StorageJSON`` and stats the
+    ``(dir_mtime, build_info_mtime)`` pair in whole seconds, then
+    compares against the cached pair in the sidecar. The
+    filenames where *either* current ≠ cached (and a build dir
+    exists) are returned in the same order the caller passed
+    them. Devices with no StorageJSON / no ``build_path`` are
+    silently skipped — pre-first-compile devices have nothing to
+    walk.
+
+    Used at startup to catch CLI-driven compiles that ran while
+    the dashboard wasn't watching, plus any other fleet-refresh
+    trigger; the per-device hot path
+    (``refresh_build_size_if_stale``) covers a single device on
+    demand.
+    """
+    stale: list[str] = []
+    for filename in filenames:
+        build_dir = resolve_build_dir(filename)
+        if build_dir is None:
+            continue
+        current_dir, current_info = get_build_dir_signal(build_dir)
+        if not current_dir and not current_info:
+            continue  # build dir vanished; cached zero is correct
+        md = get_device_metadata(config_dir, filename)
+        cached_dir = int(md.get("build_size_dir_mtime") or 0)
+        cached_info = int(md.get("build_size_info_mtime") or 0)
+        if current_dir != cached_dir or current_info != cached_info:
+            stale.append(filename)
+    return stale
+
+
+def refresh_build_size_if_stale(
+    config_dir: Path,
+    filename: str,
+) -> tuple[int, int, int] | None:
+    """
+    Refresh the cached size when the build dir's freshness pair moved.
+
+    Bundles the whole refresh into one synchronous unit so callers
+    can hand it to a single ``run_in_executor`` rather than
+    chaining four separate executor hops (sidecar-read / resolve /
+    stat / walk / sidecar-write). Returns ``None`` when the
+    cached pair was already fresh — the steady-state
+    dashboard-poll path, where we want to skip every executor
+    handoff we can. When stale, returns the new
+    ``(size_bytes, dir_mtime, build_info_mtime)`` triple after
+    persisting it to the metadata sidecar; the caller uses the
+    non-None return as the signal to reload / fire
+    ``DEVICE_UPDATED``.
+
+    Sequencing is cheap-first-then-heavy:
+    ``get_device_metadata`` → JSON read on a small file,
+    ``resolve_build_dir`` → small StorageJSON read,
+    ``get_build_dir_signal`` → two ``stat()`` calls,
+    ``compute_build_dir_size`` → the recursive walk we're trying
+    to avoid. The walk only runs when *either* half of the
+    freshness pair moved; the dashboard-restart cold path takes
+    the walk once per device and every subsequent poll
+    short-circuits on the cached pair match.
+    """
+    build_dir = resolve_build_dir(filename)
+    if build_dir is None:
+        return None
+    current_dir, current_info = get_build_dir_signal(build_dir)
+    md = get_device_metadata(config_dir, filename)
+    cached_dir = int(md.get("build_size_dir_mtime") or 0)
+    cached_info = int(md.get("build_size_info_mtime") or 0)
+    # Pure equality check across the whole pair. Crucially this
+    # short-circuits the "build dir is missing AND we never had
+    # one cached" case ((0, 0) == (0, 0) → fresh → return None);
+    # without that we'd walk the missing path on every poll and
+    # ``set_device_metadata`` would re-clear three fields that
+    # are already absent, with the non-None return retriggering a
+    # scanner.reload each time. The "dir vanished but cache was
+    # populated" case ((0, 0) ≠ (X, Y)) still falls through to
+    # walk so the cache gets cleared exactly once.
+    if (current_dir, current_info) == (cached_dir, cached_info):
+        return None
+    size = compute_build_dir_size(build_dir)
+    set_device_metadata(
+        config_dir,
+        filename,
+        build_size_bytes=size,
+        build_size_dir_mtime=current_dir,
+        build_size_info_mtime=current_info,
+    )
+    return size, current_dir, current_info
+
+
+def get_build_dir_mtime(build_dir: Path) -> int:
+    """
+    Stat the build dir's top-level mtime in whole seconds. ``0`` when gone.
+
+    The top-level directory's mtime moves forward each time
+    PlatformIO writes into it, so this single ``stat()`` is enough
+    to dedupe a "did anything change?" check against the cached
+    value in the sidecar.
+
+    We deliberately truncate to whole seconds rather than carrying
+    ``st_mtime``'s native float precision: filesystems that don't
+    support sub-second mtimes (FAT32 on a USB-mounted backup, some
+    NFS / CIFS shares, older ext3) round to the nearest second on
+    write. A cached fractional value from one filesystem would
+    then never compare equal to the truncated re-stat after a
+    cross-mount move, so the dashboard would walk the tree on
+    every poll. Whole seconds give us the cross-filesystem safety
+    at the cost of one false-negative re-walk per second of clock
+    drift around a real change — entirely fine for a heavy-I/O
+    cache primarily meant to skip steady-state polls.
+
+    Returning ``0`` for a missing dir short-circuits the cache
+    (any non-zero cached mtime wouldn't match) and naturally
+    drives the cached size back to zero on the next refresh.
+    """
+    try:
+        return int(build_dir.stat().st_mtime)
+    except OSError:
+        return 0
+
+
+def compute_build_dir_size(build_dir: Path) -> int:
+    """
+    Sum every regular-file size under *build_dir*, recursive.
+
+    Heavy + I/O-bound — caller is responsible for gating this
+    behind an mtime check (``get_build_dir_mtime`` above) and for
+    running it off the event loop (e.g. via
+    ``asyncio.to_thread``). Returns ``0`` when the dir is missing
+    or empty. Per-entry ``OSError`` (e.g. a vanishing file mid-
+    walk during a concurrent compile) is swallowed so the total
+    reflects what we could see rather than failing the whole
+    operation.
+    """
+    if not build_dir.exists():
+        return 0
+    total = 0
+    for entry in build_dir.rglob("*"):
+        try:
+            if entry.is_file():
+                total += entry.stat().st_size
+        except OSError:
+            # File vanished mid-walk (concurrent compile cleanup,
+            # symlink target removed, …). Skip and keep going —
+            # a partial total is better than no total.
+            continue
+    return total

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -188,8 +188,8 @@ def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
         current = get_build_dir_signal(build_dir)
         entry = full_metadata.get(filename, {})
         cached = BuildDirSignal(
-            dir_mtime=int(entry.get("build_size_dir_mtime") or 0),
-            info_mtime=int(entry.get("build_size_info_mtime") or 0),
+            dir_mtime=coerce_sidecar_int(entry.get("build_size_dir_mtime")),
+            info_mtime=coerce_sidecar_int(entry.get("build_size_info_mtime")),
         )
         # Equality covers every case correctly: dir-gone +
         # cache-empty short-circuits ((0, 0) == (0, 0)),
@@ -259,8 +259,8 @@ def refresh_build_size_if_stale(
     current = get_build_dir_signal(build_dir)
     md = get_device_metadata(config_dir, filename)
     cached = BuildDirSignal(
-        dir_mtime=int(md.get("build_size_dir_mtime") or 0),
-        info_mtime=int(md.get("build_size_info_mtime") or 0),
+        dir_mtime=coerce_sidecar_int(md.get("build_size_dir_mtime")),
+        info_mtime=coerce_sidecar_int(md.get("build_size_info_mtime")),
     )
     # Pure equality check across the whole pair. Crucially this
     # short-circuits the "build dir is missing AND we never had
@@ -282,6 +282,24 @@ def refresh_build_size_if_stale(
         build_size_info_mtime=current.info_mtime,
     )
     return BuildSizeRefreshResult(size_bytes=size, signal=current)
+
+
+def coerce_sidecar_int(value: object) -> int:
+    """Coerce a cached sidecar value to ``int``; ``0`` on any failure.
+
+    Same defensive shape ``_resolve_device_metadata`` uses for the
+    cached size — a hand-edited or partially-written sidecar
+    could land here with a non-numeric value (``None``, an
+    object, a decimal-string like ``"12.7"``). Falling back to
+    ``0`` matches the "never walked" sentinel and lets the next
+    refresh repopulate from the build dir.
+    """
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
 
 
 def get_build_dir_mtime(path: Path) -> int:

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -213,9 +213,10 @@ def _load_full_metadata(config_dir: Path) -> dict[str, dict]:
     YAML filename; missing entries / wrong shapes return ``{}``
     so callers can treat them as "no cached data."
     """
-    # Local import to keep ``controllers`` out of the top-level
-    # import surface for this helper, which a few module-level
-    # consumers rely on staying side-effect-free.
+    # Import the private helper locally so this module does not
+    # eagerly bind ``_load_metadata`` at import time. Public
+    # helpers from ``controllers.config`` are already imported
+    # at module load time above.
     from ..controllers.config import _load_metadata  # noqa: PLC0415
 
     try:

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -185,21 +185,54 @@ def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
     demand.
     """
     stale: list[str] = []
+    # Load the metadata file once for the whole sweep — the
+    # per-device entries live in a single JSON blob, and
+    # ``get_device_metadata`` would re-parse it from disk N times
+    # in the loop otherwise. The fleet sweep is the cheap-cost
+    # path the cache exists to keep cheap; one read is correct.
+    full_metadata = _load_full_metadata(config_dir)
     for filename in filenames:
         build_dir = resolve_build_dir(filename)
         if build_dir is None:
             continue
         current = get_build_dir_signal(build_dir)
-        if not current.dir_mtime and not current.info_mtime:
-            continue  # build dir vanished; cached zero is correct
-        md = get_device_metadata(config_dir, filename)
+        entry = full_metadata.get(filename, {})
         cached = BuildDirSignal(
-            dir_mtime=int(md.get("build_size_dir_mtime") or 0),
-            info_mtime=int(md.get("build_size_info_mtime") or 0),
+            dir_mtime=int(entry.get("build_size_dir_mtime") or 0),
+            info_mtime=int(entry.get("build_size_info_mtime") or 0),
         )
+        # Equality covers every case correctly: dir-gone +
+        # cache-empty short-circuits ((0, 0) == (0, 0)),
+        # dir-gone + cache-populated falls through to walk
+        # (which clears), dir-present + cache-stale falls
+        # through to walk. We *don't* short-circuit on
+        # "current is empty" — that case used to be skipped
+        # but it leaked stale non-zero cache state forever
+        # when a user manually wiped a build dir.
         if current != cached:
             stale.append(filename)
     return stale
+
+
+def _load_full_metadata(config_dir: Path) -> dict[str, dict]:
+    """Read the per-device metadata file once. Returns ``{}`` on any error.
+
+    Used by :func:`find_stale_build_dirs` to amortize the JSON
+    parse across an N-device fleet sweep into a single read.
+    The format is a plain dict-of-dicts keyed on the device's
+    YAML filename; missing entries / wrong shapes return ``{}``
+    so callers can treat them as "no cached data."
+    """
+    # Local import to keep ``controllers`` out of the top-level
+    # import surface for this helper, which a few module-level
+    # consumers rely on staying side-effect-free.
+    from ..controllers.config import _load_metadata  # noqa: PLC0415
+
+    try:
+        raw = _load_metadata(config_dir)
+    except Exception:
+        return {}
+    return {k: v for k, v in raw.items() if isinstance(v, dict)}
 
 
 def refresh_build_size_if_stale(

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -141,22 +141,8 @@ def get_build_dir_signal(build_dir: Path) -> BuildDirSignal:
     """
     return BuildDirSignal(
         dir_mtime=get_build_dir_mtime(build_dir),
-        info_mtime=_stat_int_mtime(build_dir / "build_info.json"),
+        info_mtime=get_build_dir_mtime(build_dir / "build_info.json"),
     )
-
-
-def _stat_int_mtime(path: Path) -> int:
-    """Whole-second mtime stat. ``0`` when the path is missing.
-
-    Whole seconds for the same cross-filesystem reason
-    :func:`get_build_dir_mtime` truncates: FAT32 / older NFS /
-    CIFS round on write, and a fractional cached value would
-    never compare equal after a cross-mount move.
-    """
-    try:
-        return int(path.stat().st_mtime)
-    except OSError:
-        return 0
 
 
 def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
@@ -172,11 +158,14 @@ def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
     ``StorageJSON`` and stats the
     ``(dir_mtime, build_info_mtime)`` pair in whole seconds, then
     compares against the cached pair in the sidecar. The
-    filenames where *either* current ≠ cached (and a build dir
-    exists) are returned in the same order the caller passed
-    them. Devices with no StorageJSON / no ``build_path`` are
-    silently skipped — pre-first-compile devices have nothing to
-    walk.
+    filenames where *either* current ≠ cached are returned in the
+    same order the caller passed them — including the
+    ``current = (0, 0)`` but cached non-zero case, where the
+    build dir vanished after the last walk and the worker still
+    needs to clear the stale cached values. Devices with no
+    StorageJSON / no ``build_path`` are silently skipped —
+    pre-first-compile devices have nothing to walk in the first
+    place, so there's no cache state to clear either.
 
     Used at startup to catch CLI-driven compiles that ran while
     the dashboard wasn't watching, plus any other fleet-refresh
@@ -294,14 +283,15 @@ def refresh_build_size_if_stale(
     return BuildSizeRefreshResult(size_bytes=size, signal=current)
 
 
-def get_build_dir_mtime(build_dir: Path) -> int:
+def get_build_dir_mtime(path: Path) -> int:
     """
-    Stat the build dir's top-level mtime in whole seconds. ``0`` when gone.
+    Stat *path*'s mtime in whole seconds. ``0`` when the path is missing.
 
-    The top-level directory's mtime moves forward each time
-    PlatformIO writes into it, so this single ``stat()`` is enough
-    to dedupe a "did anything change?" check against the cached
-    value in the sidecar.
+    Used for both halves of the freshness pair —
+    :func:`get_build_dir_signal` calls it on the build dir
+    itself (entry-set churn) and on ``build_info.json``
+    (ESPHome's per-recompile rewrite). Same cross-filesystem
+    rationale either way.
 
     We deliberately truncate to whole seconds rather than carrying
     ``st_mtime``'s native float precision: filesystems that don't
@@ -315,12 +305,12 @@ def get_build_dir_mtime(build_dir: Path) -> int:
     drift around a real change — entirely fine for a heavy-I/O
     cache primarily meant to skip steady-state polls.
 
-    Returning ``0`` for a missing dir short-circuits the cache
+    Returning ``0`` for a missing path short-circuits the cache
     (any non-zero cached mtime wouldn't match) and naturally
     drives the cached size back to zero on the next refresh.
     """
     try:
-        return int(build_dir.stat().st_mtime)
+        return int(path.stat().st_mtime)
     except OSError:
         return 0
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -389,6 +389,7 @@ def load_device_from_storage(
     ip: str = "",
     expected_config_hash: str = "",
     mac_address: str = "",
+    build_size_bytes: int = 0,
     *,
     previous: Device | None = None,
 ) -> Device:
@@ -416,6 +417,14 @@ def load_device_from_storage(
     render the address immediately on startup — ESPHome devices
     stay mDNS-silent until probed, and the sidecar bridges the gap
     until the discovery sweep prompts a fresh announcement.
+
+    *build_size_bytes* is the cached total size of the per-device
+    ``.esphome/build/<name>/`` tree at the mtime captured by the
+    last walk. Threaded through the scanner so the drawer / table
+    render the size immediately on startup; recomputation is
+    gated by mtime in the controller's
+    :meth:`_maybe_refresh_build_size_async` so a steady-state
+    re-scan stays off the heavy I/O path.
 
     *previous* is the prior in-memory Device for this path, when one
     exists. Runtime-only fields populated by monitors (``state``,
@@ -591,6 +600,7 @@ def load_device_from_storage(
         mac_address=mac_address,
         ethernet_mac=ethernet_mac,
         bluetooth_mac=bluetooth_mac,
+        build_size_bytes=build_size_bytes,
     )
 
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -419,12 +419,13 @@ def load_device_from_storage(
     until the discovery sweep prompts a fresh announcement.
 
     *build_size_bytes* is the cached total size of the per-device
-    ``.esphome/build/<name>/`` tree at the mtime captured by the
+    ``.esphome/build/<name>/`` tree at the freshness pair
+    (build-dir mtime + ``build_info.json`` mtime) captured by the
     last walk. Threaded through the scanner so the drawer / table
     render the size immediately on startup; recomputation is
-    gated by mtime in the controller's
-    :meth:`_maybe_refresh_build_size_async` so a steady-state
-    re-scan stays off the heavy I/O path.
+    driven by :class:`BuildSizeRefresher` (the single-worker
+    refresh queue) gated on the freshness-pair equality check, so
+    a steady-state re-scan stays off the heavy I/O path.
 
     *previous* is the prior in-memory Device for this path, when one
     exists. Runtime-only fields populated by monitors (``state``,

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -132,6 +132,16 @@ class Device(DataClassORJSONMixin):
     # allocation scheme, so we don't derive there. Per
     # Espressif's table this is base + 2 to the last octet.
     bluetooth_mac: str = ""
+    # Total bytes under the per-device ``.esphome/build/<name>/``
+    # tree at last walk. ``0`` when the device hasn't been compiled
+    # yet (no StorageJSON / no build artifacts on disk) or when the
+    # cached value hasn't been populated since startup. The walk is
+    # gated on the build directory's mtime: only a real compile
+    # bumps it forward, so a steady-state dashboard reload reuses
+    # the cached total without re-walking. Stored alongside the
+    # mtime in the metadata sidecar so a backend restart picks up
+    # the cached total without an N-device cold-start walk.
+    build_size_bytes: int = 0
 
 
 @dataclass

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -136,11 +136,14 @@ class Device(DataClassORJSONMixin):
     # tree at last walk. ``0`` when the device hasn't been compiled
     # yet (no StorageJSON / no build artifacts on disk) or when the
     # cached value hasn't been populated since startup. The walk is
-    # gated on the build directory's mtime: only a real compile
-    # bumps it forward, so a steady-state dashboard reload reuses
-    # the cached total without re-walking. Stored alongside the
-    # mtime in the metadata sidecar so a backend restart picks up
-    # the cached total without an N-device cold-start walk.
+    # gated on a freshness pair (the build dir's top-level mtime
+    # *and* ``build_info.json``'s mtime) — either side moving
+    # counts as stale. Both halves are persisted alongside the
+    # cached total in the metadata sidecar so a backend restart
+    # picks up the value without an N-device cold-start walk; only
+    # devices whose pair drifted from what was persisted get
+    # re-walked. See ``helpers/build_size.py`` for the empirical
+    # matrix that drove the pair-vs-single-stat decision.
     build_size_bytes: int = 0
 
 

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -170,6 +170,9 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
         ip="192.168.1.42",
         expected_config_hash="deadbeef",
         mac_address="94:C9:60:1F:8C:F1",
+        build_size_bytes=12345678,
+        build_size_dir_mtime=1714900000,
+        build_size_info_mtime=1714900050,
     )
     pre = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
     # Sanity that the seeding above wrote everything we expect.
@@ -177,6 +180,9 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
     assert pre["ip"] == "192.168.1.42"
     assert pre["expected_config_hash"] == "deadbeef"
     assert pre["mac_address"] == "94:C9:60:1F:8C:F1"
+    assert pre["build_size_bytes"] == 12345678
+    assert pre["build_size_dir_mtime"] == 1714900000
+    assert pre["build_size_info_mtime"] == 1714900050
 
     await controller._archive_single("kitchen.yaml")
 

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, EventType
@@ -276,3 +278,33 @@ def test_board_id_from_sidecar_takes_priority_over_yaml(tmp_path: Path, monkeypa
 
     assert metadata.board_id == "esp32-poe"
     derive.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [None, "not-a-number", {}, [], "12.7"],
+)
+def test_corrupt_build_size_bytes_falls_back_to_zero(
+    tmp_path: Path, monkeypatch: Any, bad_value: Any
+) -> None:
+    """A non-numeric ``build_size_bytes`` in the sidecar coerces to 0.
+
+    Defensive coverage for the metadata resolver's hot path: a
+    hand-edited or partially-written sidecar entry could land with
+    a value that ``int()`` can't accept (``None``, an object, a
+    decimal string). The resolver runs per-device on every scan
+    so a single corrupt entry shouldn't fail the whole scan; the
+    fallback ``0`` matches the "never walked" sentinel and the
+    next ``BuildSizeRefresher`` pass repopulates from the build
+    dir.
+    """
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    _stub_get_metadata(monkeypatch, {"board_id": "esp32", "build_size_bytes": bad_value})
+
+    controller = _make_controller(monkeypatch)
+    metadata = controller._resolve_device_metadata(config_dir, filename)
+
+    assert metadata.build_size_bytes == 0

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -209,7 +209,7 @@ def test_failed_job_does_not_schedule_refresh() -> None:
 
 
 def test_clean_job_skips_full_refresh_but_pokes_build_size() -> None:
-    """CLEAN doesn't run the YAML-hash / flash-bookkeeping path, but the build-size cache must update.
+    """CLEAN skips the hash / flash bookkeeping path but pokes the build-size cache.
 
     The build tree has just been wiped, so the cached
     ``build_size_bytes`` triple is now stale (pre-clean

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -142,6 +142,10 @@ def _make_controller() -> tuple[Any, list[tuple[str, bool, bool]]]:
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
     controller._scanner = MagicMock()
+    # The build-size refresher's ``request`` is the post-CLEAN
+    # hand-off; mock it so tests can assert per-job behaviour
+    # without needing the full worker lifecycle.
+    controller._build_size = MagicMock()
     controller._refresh_after_firmware_job = _capturing_refresh  # type: ignore[method-assign]
     return controller, captured
 
@@ -204,14 +208,24 @@ def test_failed_job_does_not_schedule_refresh() -> None:
     assert captured == []
 
 
-def test_clean_job_does_not_schedule_refresh() -> None:
-    """CLEAN doesn't move the binary mtime in a way that affects has_pending."""
+def test_clean_job_skips_full_refresh_but_pokes_build_size() -> None:
+    """CLEAN doesn't run the YAML-hash / flash-bookkeeping path, but the build-size cache must update.
+
+    The build tree has just been wiped, so the cached
+    ``build_size_bytes`` triple is now stale (pre-clean
+    non-zero, current dir mtime → 0). The job-completion hook
+    pokes the build-size worker for this device; the worker's
+    pair-equality short-circuit then walks once to clear the
+    cache. ``_refresh_after_firmware_job`` (hash recompute,
+    optimistic flash sync) doesn't apply to CLEAN.
+    """
     controller, captured = _make_controller()
     job = _job(JobType.CLEAN, JobStatus.COMPLETED)
 
     controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
 
     assert captured == []
+    controller._build_size.request.assert_called_once_with("kitchen.yaml")
 
 
 def test_reset_build_env_does_not_schedule_refresh() -> None:
@@ -270,6 +284,7 @@ async def test_refresh_after_compile_persists_hash_and_reloads(
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
     controller._scanner = RecordingScanner()
+    controller._build_size = MagicMock()
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=True, flashed=False)
 
@@ -306,6 +321,7 @@ async def test_refresh_after_compile_skips_persist_on_hash_failure(
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
     controller._scanner = RecordingScanner()
+    controller._build_size = MagicMock()
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=True, flashed=False)
 
@@ -334,6 +350,7 @@ async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypat
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
     controller._scanner = RecordingScanner()
+    controller._build_size = MagicMock()
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=False, flashed=True)
 

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -238,6 +238,29 @@ def test_reset_build_env_does_not_schedule_refresh() -> None:
     assert captured == []
 
 
+def test_unhandled_job_type_with_configuration_falls_through_silently() -> None:
+    """Job types outside CLEAN/COMPILE/UPLOAD/INSTALL/RENAME bail at the type check.
+
+    Belt-and-braces test for the post-CLEAN dispatch table — a
+    ``RESET_BUILD_ENV`` job that did happen to carry a
+    configuration (or any future job type we haven't wired
+    explicitly) bails at the ``if job_type not in (...)`` guard
+    *after* the empty-configuration short-circuit, leaving the
+    refresh + build-size hooks alone.
+    """
+    controller, captured = _make_controller()
+    job = _job(
+        JobType.RESET_BUILD_ENV,
+        JobStatus.COMPLETED,
+        configuration="kitchen.yaml",
+    )
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
+
+    assert captured == []
+    controller._build_size.request.assert_not_called()
+
+
 def test_event_without_job_payload_is_safe() -> None:
     """Defensive: ``data["job"]`` missing must not raise."""
     controller, captured = _make_controller()

--- a/tests/controllers/test_build_size_refresher.py
+++ b/tests/controllers/test_build_size_refresher.py
@@ -1,0 +1,408 @@
+"""Tests for the single-worker ``BuildSizeRefresher``.
+
+Covers the queue-and-drain shape end-to-end: requests get
+coalesced into the pending set, the worker wakes on the event,
+walks one configuration at a time, fires the ``on_refreshed``
+callback when the underlying helper actually changed something,
+and survives per-iteration errors. The helper itself is mocked so
+the test doesn't need a real build directory; what's being
+validated here is the *plumbing* between ``request()`` /
+``enqueue_stale_fleet()`` / the worker loop.
+
+Synchronization uses ``asyncio.Event`` rather than sleep-poll
+loops — every test signals "the worker is done with the work I
+care about" via a fixture-installed callback hook so the test
+just ``await``s on a single event with a generous timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder.controllers._build_size_refresher import BuildSizeRefresher
+from esphome_device_builder.helpers.build_size import (
+    BuildDirSignal,
+    BuildSizeRefreshResult,
+)
+
+# Generous upper bound for any single worker-tick we wait on.
+# Real refreshes complete in microseconds since everything's
+# mocked — the timeout exists to surface deadlocks rather than
+# wait-time, so a regression where the worker stops draining
+# fails fast instead of hanging the suite.
+_TIMEOUT = 5.0
+
+
+def _make(
+    tmp_path: Path,
+    *,
+    filenames: list[str] | None = None,
+    on_refreshed=None,
+) -> tuple[BuildSizeRefresher, list[str]]:
+    """Build a refresher + the list its ``on_refreshed`` callback appends to."""
+    refreshed: list[str] = []
+
+    async def _default_callback(configuration: str) -> None:
+        refreshed.append(configuration)
+
+    refresher = BuildSizeRefresher(
+        config_dir=tmp_path,
+        get_filenames=lambda: filenames or [],
+        on_refreshed=on_refreshed or _default_callback,
+    )
+    return refresher, refreshed
+
+
+# ----------------------------------------------------------------------
+# Synchronous primitives — no worker running
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_adds_to_pending_set_and_wakes_event(tmp_path: Path) -> None:
+    """``request`` is sync, idempotent, and signals the wake event."""
+    refresher, _ = _make(tmp_path)
+    refresher.request("kitchen.yaml")
+    refresher.request("kitchen.yaml")  # dedupe
+    refresher.request("bedroom.yaml")
+    assert refresher._pending == {"kitchen.yaml", "bedroom.yaml"}
+    assert refresher._wake.is_set()
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent(tmp_path: Path) -> None:
+    """A second ``start`` while the worker is alive is a no-op."""
+    refresher, _ = _make(tmp_path)
+    refresher.start()
+    first_task = refresher._worker_task
+    refresher.start()
+    assert refresher._worker_task is first_task
+    await refresher.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_with_no_running_worker_is_noop(tmp_path: Path) -> None:
+    """``stop`` on a never-started refresher must not raise."""
+    refresher, _ = _make(tmp_path)
+    await refresher.stop()  # no exception
+    assert refresher._worker_task is None
+
+
+# ----------------------------------------------------------------------
+# Worker drain loop
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_drains_pending_and_fires_on_refreshed(tmp_path: Path) -> None:
+    """A request lands in the queue; the worker walks + fires the callback."""
+    done = asyncio.Event()
+    refreshed: list[str] = []
+
+    async def _on_refreshed(configuration: str) -> None:
+        refreshed.append(configuration)
+        done.set()
+
+    refresher, _ = _make(tmp_path, on_refreshed=_on_refreshed)
+
+    def _refresh(_config_dir: Path, _configuration: str) -> BuildSizeRefreshResult:
+        return BuildSizeRefreshResult(
+            size_bytes=1024,
+            signal=BuildDirSignal(dir_mtime=10, info_mtime=20),
+        )
+
+    with patch(
+        "esphome_device_builder.controllers._build_size_refresher.refresh_build_size_if_stale",
+        side_effect=_refresh,
+    ):
+        refresher.start()
+        refresher.request("kitchen.yaml")
+        await asyncio.wait_for(done.wait(), timeout=_TIMEOUT)
+        await refresher.stop()
+
+    assert refreshed == ["kitchen.yaml"]
+    assert refresher._pending == set()
+
+
+@pytest.mark.asyncio
+async def test_worker_skips_callback_when_refresh_returns_none(tmp_path: Path) -> None:
+    """Refresh returning ``None`` (cache hit) → no ``on_refreshed`` invoke.
+
+    Sequences two requests: ``cached.yaml`` returns ``None`` from
+    the helper (cache hit, callback skipped), ``stale.yaml``
+    returns a real result that fires the callback. Waiting on the
+    second one's callback proves the worker took the
+    "continue past skipped callback" branch *and* came back
+    around to drain the next item — i.e. the cache-hit short-
+    circuit doesn't break the drain loop.
+    """
+    success = asyncio.Event()
+    refreshed: list[str] = []
+
+    async def _on_refreshed(configuration: str) -> None:
+        refreshed.append(configuration)
+        success.set()
+
+    def _refresh(_config_dir: Path, configuration: str):
+        if configuration == "cached.yaml":
+            return None
+        return BuildSizeRefreshResult(
+            size_bytes=42,
+            signal=BuildDirSignal(dir_mtime=1, info_mtime=2),
+        )
+
+    refresher, _ = _make(tmp_path, on_refreshed=_on_refreshed)
+    with patch(
+        "esphome_device_builder.controllers._build_size_refresher.refresh_build_size_if_stale",
+        side_effect=_refresh,
+    ):
+        refresher.start()
+        refresher.request("cached.yaml")
+        refresher.request("stale.yaml")
+        await asyncio.wait_for(success.wait(), timeout=_TIMEOUT)
+        await refresher.stop()
+
+    # Only the stale device fired the callback — the cached one
+    # short-circuited at the ``if result is None: continue``
+    # branch.
+    assert refreshed == ["stale.yaml"]
+
+
+@pytest.mark.asyncio
+async def test_worker_logs_and_continues_on_refresh_exception(tmp_path: Path, caplog: Any) -> None:
+    """A per-iteration walk error logs + keeps the worker alive for the next item.
+
+    Uses a log-event handler to wait for the failure log to land,
+    plus a separate event for the successful follow-up — pending
+    set's pop order is arbitrary, so synchronizing on both
+    independently is necessary to avoid a race where the test
+    asserts before either has actually run.
+    """
+    error_seen = asyncio.Event()
+    success_seen = asyncio.Event()
+    refreshed: list[str] = []
+
+    class _LogTrap(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            if "Build-size refresh failed for broken.yaml" in record.getMessage():
+                error_seen.set()
+
+    async def _on_refreshed(configuration: str) -> None:
+        refreshed.append(configuration)
+        success_seen.set()
+
+    def _refresh(_config_dir: Path, configuration: str):
+        if configuration == "broken.yaml":
+            raise RuntimeError("disk on fire")
+        return BuildSizeRefreshResult(
+            size_bytes=42,
+            signal=BuildDirSignal(dir_mtime=1, info_mtime=2),
+        )
+
+    refresher, _ = _make(tmp_path, on_refreshed=_on_refreshed)
+    handler = _LogTrap()
+    logging.getLogger("esphome_device_builder.controllers._build_size_refresher").addHandler(
+        handler
+    )
+    caplog.set_level(logging.ERROR)
+    try:
+        with patch(
+            "esphome_device_builder.controllers._build_size_refresher.refresh_build_size_if_stale",
+            side_effect=_refresh,
+        ):
+            refresher.start()
+            refresher.request("broken.yaml")
+            refresher.request("kitchen.yaml")
+            await asyncio.wait_for(error_seen.wait(), timeout=_TIMEOUT)
+            await asyncio.wait_for(success_seen.wait(), timeout=_TIMEOUT)
+            await refresher.stop()
+    finally:
+        logging.getLogger("esphome_device_builder.controllers._build_size_refresher").removeHandler(
+            handler
+        )
+
+    assert refreshed == ["kitchen.yaml"]
+
+
+@pytest.mark.asyncio
+async def test_worker_logs_and_continues_on_callback_exception(tmp_path: Path, caplog: Any) -> None:
+    """``on_refreshed`` raising must not kill the worker either."""
+    error_seen = asyncio.Event()
+    success_seen = asyncio.Event()
+
+    class _LogTrap(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            if "on_refreshed callback failed for broken.yaml" in record.getMessage():
+                error_seen.set()
+
+    async def _bad_callback(configuration: str) -> None:
+        if configuration == "broken.yaml":
+            raise RuntimeError("scanner blew up")
+        success_seen.set()
+
+    def _refresh(_config_dir: Path, _configuration: str) -> BuildSizeRefreshResult:
+        return BuildSizeRefreshResult(
+            size_bytes=1,
+            signal=BuildDirSignal(dir_mtime=1, info_mtime=1),
+        )
+
+    refresher, _ = _make(tmp_path, on_refreshed=_bad_callback)
+    handler = _LogTrap()
+    logging.getLogger("esphome_device_builder.controllers._build_size_refresher").addHandler(
+        handler
+    )
+    caplog.set_level(logging.ERROR)
+    try:
+        with patch(
+            "esphome_device_builder.controllers._build_size_refresher.refresh_build_size_if_stale",
+            side_effect=_refresh,
+        ):
+            refresher.start()
+            refresher.request("broken.yaml")
+            await asyncio.wait_for(error_seen.wait(), timeout=_TIMEOUT)
+            # Worker is still alive — request a second one and
+            # confirm it's serviced normally.
+            refresher.request("kitchen.yaml")
+            await asyncio.wait_for(success_seen.wait(), timeout=_TIMEOUT)
+            await refresher.stop()
+    finally:
+        logging.getLogger("esphome_device_builder.controllers._build_size_refresher").removeHandler(
+            handler
+        )
+
+
+# ----------------------------------------------------------------------
+# enqueue_stale_fleet — phase-A sweep wiring
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enqueue_stale_fleet_pushes_divergent_filenames(tmp_path: Path) -> None:
+    """``find_stale_build_dirs`` returns a list → each one ends up in pending."""
+    refresher, _ = _make(tmp_path, filenames=["a.yaml", "b.yaml", "c.yaml"])
+    with patch(
+        "esphome_device_builder.controllers._build_size_refresher.find_stale_build_dirs",
+        return_value=["a.yaml", "c.yaml"],
+    ):
+        await refresher.enqueue_stale_fleet()
+
+    assert refresher._pending == {"a.yaml", "c.yaml"}
+
+
+@pytest.mark.asyncio
+async def test_enqueue_stale_fleet_empty_filenames_skips_executor(tmp_path: Path) -> None:
+    """No configured devices → no executor handoff at all."""
+    calls: list[Any] = []
+
+    def _track(*args: Any, **_kw: Any) -> Any:
+        calls.append(args)
+        return []
+
+    refresher, _ = _make(tmp_path, filenames=[])
+    with patch(
+        "esphome_device_builder.controllers._build_size_refresher.find_stale_build_dirs",
+        side_effect=_track,
+    ):
+        await refresher.enqueue_stale_fleet()
+
+    assert calls == []  # short-circuited before scheduling anything
+    assert refresher._pending == set()
+
+
+# ----------------------------------------------------------------------
+# Initial fleet sweep + stop() error paths
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_logs_when_initial_fleet_sweep_raises(tmp_path: Path, caplog: Any) -> None:
+    """Initial sweep raising must not kill the worker — log + carry on."""
+    sweep_failed = asyncio.Event()
+    success = asyncio.Event()
+
+    class _LogTrap(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            if "Initial build-size fleet sweep failed" in record.getMessage():
+                sweep_failed.set()
+
+    refreshed: list[str] = []
+
+    async def _on_refreshed(configuration: str) -> None:
+        refreshed.append(configuration)
+        success.set()
+
+    def _refresh(_config_dir: Path, _configuration: str) -> BuildSizeRefreshResult:
+        return BuildSizeRefreshResult(
+            size_bytes=1,
+            signal=BuildDirSignal(dir_mtime=1, info_mtime=1),
+        )
+
+    refresher, _ = _make(tmp_path, filenames=["a.yaml"], on_refreshed=_on_refreshed)
+    handler = _LogTrap()
+    logging.getLogger("esphome_device_builder.controllers._build_size_refresher").addHandler(
+        handler
+    )
+    caplog.set_level(logging.ERROR)
+    try:
+        with (
+            patch(
+                "esphome_device_builder.controllers._build_size_refresher.find_stale_build_dirs",
+                side_effect=RuntimeError("metadata corrupt"),
+            ),
+            patch(
+                "esphome_device_builder.controllers._build_size_refresher.refresh_build_size_if_stale",
+                side_effect=_refresh,
+            ),
+        ):
+            refresher.start()
+            await asyncio.wait_for(sweep_failed.wait(), timeout=_TIMEOUT)
+            # Worker is still alive — a fresh request gets serviced.
+            refresher.request("a.yaml")
+            await asyncio.wait_for(success.wait(), timeout=_TIMEOUT)
+            await refresher.stop()
+    finally:
+        logging.getLogger("esphome_device_builder.controllers._build_size_refresher").removeHandler(
+            handler
+        )
+
+    assert refreshed == ["a.yaml"]
+
+
+@pytest.mark.asyncio
+async def test_stop_logs_unexpected_worker_exception(tmp_path: Path, caplog: Any) -> None:
+    """Anything other than ``CancelledError`` from the worker gets logged.
+
+    The worker's outer ``while True:`` doesn't catch errors raised
+    *outside* the per-iteration ``try`` (e.g. an executor that
+    explodes before reaching the per-iteration handler). Those
+    propagate through ``await self._worker_task`` during ``stop``;
+    we log so the failure isn't invisible during a clean
+    shutdown.
+    """
+    refresher, _ = _make(tmp_path)
+
+    async def _failing_worker(self_: BuildSizeRefresher) -> None:
+        # Block until cancelled by ``stop()``, then convert the
+        # cancellation into an unexpected exception. This is what
+        # an "outside the per-iteration try" failure looks like
+        # at the await boundary in ``stop()``.
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise RuntimeError("worker exploded") from None
+
+    caplog.set_level(logging.ERROR)
+    with patch.object(BuildSizeRefresher, "_worker", _failing_worker):
+        refresher.start()
+        # Yield once so the worker actually starts awaiting; without
+        # this, ``stop`` cancels before the task entered the try.
+        await asyncio.sleep(0)
+        await refresher.stop()
+
+    assert any("Build-size worker failed during shutdown" in r.message for r in caplog.records)

--- a/tests/test_build_size.py
+++ b/tests/test_build_size.py
@@ -19,7 +19,9 @@ from esphome_device_builder.controllers.config import (
     set_device_metadata,
 )
 from esphome_device_builder.helpers.build_size import (
+    BuildDirSignal,
     compute_build_dir_size,
+    find_stale_build_dirs,
     get_build_dir_mtime,
     refresh_build_size_if_stale,
     resolve_build_dir,
@@ -230,17 +232,15 @@ def test_refresh_build_size_if_stale_walks_and_persists_on_first_run(
         result = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
 
     assert result is not None
-    size, dir_mtime, info_mtime = result
-    # Walked total = both files: 4096 + body of build_info.json
     body_len = len('{"config_hash": "abc"}')
-    assert size == 4096 + body_len
-    assert dir_mtime == int(build_dir.stat().st_mtime)
-    assert info_mtime == int((build_dir / "build_info.json").stat().st_mtime)
+    assert result.size_bytes == 4096 + body_len
+    assert result.signal.dir_mtime == int(build_dir.stat().st_mtime)
+    assert result.signal.info_mtime == int((build_dir / "build_info.json").stat().st_mtime)
     # Triple is persisted so the next call short-circuits.
     md = get_device_metadata(config_dir, "kitchen.yaml")
-    assert md["build_size_bytes"] == size
-    assert md["build_size_dir_mtime"] == dir_mtime
-    assert md["build_size_info_mtime"] == info_mtime
+    assert md["build_size_bytes"] == result.size_bytes
+    assert md["build_size_dir_mtime"] == result.signal.dir_mtime
+    assert md["build_size_info_mtime"] == result.signal.info_mtime
 
 
 def test_refresh_build_size_if_stale_short_circuits_when_pair_matches(
@@ -307,9 +307,8 @@ def test_refresh_build_size_if_stale_re_walks_on_dir_mtime_change(
         result = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
 
     assert result is not None
-    size, _dir_mt, _info_mt = result
     body_len = len('{"config_hash": "abc"}')
-    assert size == 1024 + body_len  # actual, not stale 999
+    assert result.size_bytes == 1024 + body_len  # actual, not stale 999
 
 
 def test_refresh_build_size_if_stale_re_walks_on_info_mtime_change(
@@ -345,9 +344,8 @@ def test_refresh_build_size_if_stale_re_walks_on_info_mtime_change(
         result = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
 
     assert result is not None
-    size, _dir_mt, _info_mt = result
     body_len = len('{"config_hash": "abc"}')
-    assert size == 1024 + body_len  # actual, not stale 999
+    assert result.size_bytes == 1024 + body_len  # actual, not stale 999
 
 
 def test_refresh_build_size_if_stale_no_loop_when_build_dir_missing(
@@ -419,7 +417,8 @@ def test_refresh_build_size_if_stale_clears_cache_when_build_dir_disappears(
 
     # First call: cleared the cache (returned non-None to signal change).
     assert first is not None
-    assert first == (0, 0, 0)
+    assert first.size_bytes == 0
+    assert first.signal == BuildDirSignal(dir_mtime=0, info_mtime=0)
     # Second call: short-circuits on pair equality, no churn.
     assert second is None
     md = get_device_metadata(config_dir, "kitchen.yaml")
@@ -451,15 +450,14 @@ def test_refresh_build_size_if_stale_works_without_build_info_json(
         first = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
 
     assert first is not None
-    size, dir_mt, info_mt = first
-    assert size == 1024
-    assert dir_mt > 0
-    assert info_mt == 0  # the explicit "no build_info.json" sentinel
+    assert first.size_bytes == 1024
+    assert first.signal.dir_mtime > 0
+    assert first.signal.info_mtime == 0  # explicit "no build_info.json"
     md = get_device_metadata(config_dir, "kitchen.yaml")
     # ``set_device_metadata`` clears keys passed as 0, so info_mtime
     # is intentionally absent rather than persisted as 0 — the
     # subsequent read defaults to 0 anyway.
-    assert md["build_size_dir_mtime"] == dir_mt
+    assert md["build_size_dir_mtime"] == first.signal.dir_mtime
     assert "build_size_info_mtime" not in md
 
     # Second call: nothing changed, so the helper short-circuits.
@@ -533,8 +531,6 @@ def test_find_stale_build_dirs_returns_only_divergent_filenames(tmp_path: Path) 
             side_effect=_fake_load,
         ),
     ):
-        from esphome_device_builder.helpers.build_size import find_stale_build_dirs
-
         result = find_stale_build_dirs(
             config_dir, ["fresh.yaml", "stale.yaml", "never_compiled.yaml"]
         )
@@ -544,8 +540,6 @@ def test_find_stale_build_dirs_returns_only_divergent_filenames(tmp_path: Path) 
 
 def test_find_stale_build_dirs_empty_list_returns_empty(tmp_path: Path) -> None:
     """No devices in → no executor work, no walks, no stale list."""
-    from esphome_device_builder.helpers.build_size import find_stale_build_dirs
-
     assert find_stale_build_dirs(tmp_path, []) == []
 
 

--- a/tests/test_build_size.py
+++ b/tests/test_build_size.py
@@ -1,0 +1,590 @@
+"""Tests for the cached build-directory size helper.
+
+The helper walks ``.esphome/build/<device>/`` to compute the total
+size of a device's compile artifacts. The walk is heavy + I/O-bound,
+so callers gate it behind a stat-only ``get_build_dir_mtime`` check
+and persist the (mtime, bytes) pair in the per-device metadata
+sidecar. These tests cover the helper itself; the controller's
+mtime-gated refresh path is exercised in
+``test_maybe_refresh_build_size``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from esphome_device_builder.controllers.config import (
+    get_device_metadata,
+    set_device_metadata,
+)
+from esphome_device_builder.helpers.build_size import (
+    compute_build_dir_size,
+    get_build_dir_mtime,
+    refresh_build_size_if_stale,
+    resolve_build_dir,
+)
+
+# ----------------------------------------------------------------------
+# compute_build_dir_size
+# ----------------------------------------------------------------------
+
+
+def test_compute_build_dir_size_sums_files(tmp_path: Path) -> None:
+    """Recursive walk sums every regular-file size under the dir."""
+    (tmp_path / "a.bin").write_bytes(b"x" * 1024)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.bin").write_bytes(b"y" * 2048)
+    (tmp_path / "sub" / "deep").mkdir()
+    (tmp_path / "sub" / "deep" / "c.bin").write_bytes(b"z" * 512)
+
+    assert compute_build_dir_size(tmp_path) == 1024 + 2048 + 512
+
+
+def test_compute_build_dir_size_missing_dir_yields_zero(tmp_path: Path) -> None:
+    """A path that doesn't exist returns 0 (not an error).
+
+    The drawer / table read this directly; raising would force
+    every caller to wrap the helper in a try/except.
+    """
+    assert compute_build_dir_size(tmp_path / "does-not-exist") == 0
+
+
+def test_compute_build_dir_size_empty_dir_yields_zero(tmp_path: Path) -> None:
+    """An empty directory contributes nothing to the total."""
+    (tmp_path / "empty").mkdir()
+    assert compute_build_dir_size(tmp_path / "empty") == 0
+
+
+def test_compute_build_dir_size_skips_directories(tmp_path: Path) -> None:
+    """Only regular files count — directory entries themselves are not summed."""
+    (tmp_path / "sub1").mkdir()
+    (tmp_path / "sub2").mkdir()
+    (tmp_path / "sub3").mkdir()
+    # No files anywhere.
+    assert compute_build_dir_size(tmp_path) == 0
+
+
+def test_compute_build_dir_size_swallows_per_entry_errors(tmp_path: Path) -> None:
+    """A vanishing file mid-walk doesn't fail the whole operation.
+
+    Concurrent compile cleanup can yank entries between the
+    ``rglob`` and the ``stat`` call. Returning the partial total
+    is better than crashing the dashboard.
+    """
+    (tmp_path / "good.bin").write_bytes(b"x" * 100)
+    bad = tmp_path / "vanished.bin"
+    bad.write_bytes(b"y" * 200)
+
+    real_stat = Path.stat
+
+    def fake_stat(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if self == bad:
+            raise OSError("file disappeared")
+        return real_stat(self, *args, **kwargs)
+
+    with patch.object(Path, "stat", fake_stat):
+        # 100 from good.bin; the bad one is skipped.
+        assert compute_build_dir_size(tmp_path) == 100
+
+
+# ----------------------------------------------------------------------
+# get_build_dir_mtime
+# ----------------------------------------------------------------------
+
+
+def test_get_build_dir_mtime_returns_whole_seconds(tmp_path: Path) -> None:
+    """The mtime stat is truncated to whole seconds for cross-FS safety.
+
+    Filesystems without sub-second mtime precision (FAT32 / older
+    NFS / CIFS) round on write; carrying the float ``st_mtime``
+    in the cache would never compare equal after a cross-mount
+    move, defeating the cache. Truncating to ``int`` seconds
+    here keeps the comparison stable.
+    """
+    expected = int(tmp_path.stat().st_mtime)
+    result = get_build_dir_mtime(tmp_path)
+    assert isinstance(result, int)
+    assert result == expected
+
+
+def test_get_build_dir_mtime_missing_dir_yields_zero(tmp_path: Path) -> None:
+    """A missing dir returns 0 (sentinel, never matches a real mtime).
+
+    The cache-freshness check in the controller compares this
+    against the persisted ``build_size_mtime``; returning 0 for
+    a missing dir means the next refresh re-walks (and records 0
+    bytes), naturally driving the cached total back to zero
+    after the build dir is wiped (e.g. archive flow).
+    """
+    assert get_build_dir_mtime(tmp_path / "does-not-exist") == 0
+
+
+# ----------------------------------------------------------------------
+# resolve_build_dir
+# ----------------------------------------------------------------------
+
+
+def test_resolve_build_dir_returns_none_when_storage_missing(tmp_path: Path) -> None:
+    """No StorageJSON sidecar (device never compiled) → None.
+
+    The helper module guards every other operation behind a None
+    check, so callers don't have to special-case the
+    pre-first-compile state — they just see ``size = 0``.
+    """
+    with (
+        patch(
+            "esphome_device_builder.helpers.build_size.ext_storage_path",
+            return_value=tmp_path / "fake.json",
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.StorageJSON.load",
+            return_value=None,
+        ),
+    ):
+        assert resolve_build_dir("kitchen.yaml") is None
+
+
+def test_resolve_build_dir_returns_none_when_build_path_blank(tmp_path: Path) -> None:
+    """Older StorageJSON without ``build_path`` populated → None.
+
+    Pre-PIO StorageJSON shapes occasionally land without
+    ``build_path``. Treat the same as "no build artifacts."
+    """
+
+    class _FakeStorage:
+        build_path = ""
+
+    with (
+        patch(
+            "esphome_device_builder.helpers.build_size.ext_storage_path",
+            return_value=tmp_path / "fake.json",
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.StorageJSON.load",
+            return_value=_FakeStorage(),
+        ),
+    ):
+        assert resolve_build_dir("kitchen.yaml") is None
+
+
+def test_resolve_build_dir_returns_path_when_storage_has_build_path(
+    tmp_path: Path,
+) -> None:
+    """A populated ``build_path`` round-trips as a Path."""
+
+    class _FakeStorage:
+        build_path = str(tmp_path / "build" / "kitchen")
+
+    with (
+        patch(
+            "esphome_device_builder.helpers.build_size.ext_storage_path",
+            return_value=tmp_path / "fake.json",
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.StorageJSON.load",
+            return_value=_FakeStorage(),
+        ),
+    ):
+        result = resolve_build_dir("kitchen.yaml")
+        assert result == tmp_path / "build" / "kitchen"
+
+
+def _fake_storage_patches(tmp_path: Path, build_dir: Path):
+    """Patch ``ext_storage_path`` + ``StorageJSON.load`` to point at *build_dir*."""
+
+    class _FakeStorage:
+        build_path = str(build_dir)
+
+    return (
+        patch(
+            "esphome_device_builder.helpers.build_size.ext_storage_path",
+            return_value=tmp_path / "fake.json",
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.StorageJSON.load",
+            return_value=_FakeStorage(),
+        ),
+    )
+
+
+def test_refresh_build_size_if_stale_walks_and_persists_on_first_run(
+    tmp_path: Path,
+) -> None:
+    """No cached pair → walk, persist, and return the new triple.
+
+    Cold-start path: no metadata sidecar entry yet, the build dir
+    has files including ``build_info.json``, and the helper
+    writes the canonical (size, dir_mtime, info_mtime) triple to
+    the sidecar so the next call short-circuits.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    build_dir = tmp_path / "build" / "kitchen"
+    build_dir.mkdir(parents=True)
+    (build_dir / "firmware.bin").write_bytes(b"x" * 4096)
+    (build_dir / "build_info.json").write_text('{"config_hash": "abc"}')
+
+    p1, p2 = _fake_storage_patches(tmp_path, build_dir)
+    with p1, p2:
+        result = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+
+    assert result is not None
+    size, dir_mtime, info_mtime = result
+    # Walked total = both files: 4096 + body of build_info.json
+    body_len = len('{"config_hash": "abc"}')
+    assert size == 4096 + body_len
+    assert dir_mtime == int(build_dir.stat().st_mtime)
+    assert info_mtime == int((build_dir / "build_info.json").stat().st_mtime)
+    # Triple is persisted so the next call short-circuits.
+    md = get_device_metadata(config_dir, "kitchen.yaml")
+    assert md["build_size_bytes"] == size
+    assert md["build_size_dir_mtime"] == dir_mtime
+    assert md["build_size_info_mtime"] == info_mtime
+
+
+def test_refresh_build_size_if_stale_short_circuits_when_pair_matches(
+    tmp_path: Path,
+) -> None:
+    """Cached pair equals current → return None without walking.
+
+    The whole point of the cache: a steady-state poll should be
+    two ``stat()``s per device, never the recursive walk.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    build_dir = tmp_path / "build" / "kitchen"
+    build_dir.mkdir(parents=True)
+    (build_dir / "firmware.bin").write_bytes(b"x" * 4096)
+    (build_dir / "build_info.json").write_text('{"config_hash": "abc"}')
+    current_dir = int(build_dir.stat().st_mtime)
+    current_info = int((build_dir / "build_info.json").stat().st_mtime)
+
+    # Seed the cache with the current pair + a deliberately-wrong
+    # cached size. If the helper walks anyway, the persisted size
+    # would be corrected; that's how we detect a regression.
+    set_device_metadata(
+        config_dir,
+        "kitchen.yaml",
+        build_size_bytes=999,
+        build_size_dir_mtime=current_dir,
+        build_size_info_mtime=current_info,
+    )
+
+    p1, p2 = _fake_storage_patches(tmp_path, build_dir)
+    with p1, p2:
+        result = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+
+    assert result is None
+    # The persisted size stayed the deliberately-wrong 999 — proof
+    # that the helper short-circuited and didn't walk.
+    md = get_device_metadata(config_dir, "kitchen.yaml")
+    assert md["build_size_bytes"] == 999
+
+
+def test_refresh_build_size_if_stale_re_walks_on_dir_mtime_change(
+    tmp_path: Path,
+) -> None:
+    """A bumped dir-mtime alone invalidates the cache (PlatformIO sibling churn)."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    build_dir = tmp_path / "build" / "kitchen"
+    build_dir.mkdir(parents=True)
+    (build_dir / "firmware.bin").write_bytes(b"x" * 1024)
+    (build_dir / "build_info.json").write_text('{"config_hash": "abc"}')
+
+    # Seed with a stale dir mtime; info mtime matches current.
+    set_device_metadata(
+        config_dir,
+        "kitchen.yaml",
+        build_size_bytes=999,
+        build_size_dir_mtime=int(build_dir.stat().st_mtime) - 1000,
+        build_size_info_mtime=int((build_dir / "build_info.json").stat().st_mtime),
+    )
+
+    p1, p2 = _fake_storage_patches(tmp_path, build_dir)
+    with p1, p2:
+        result = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+
+    assert result is not None
+    size, _dir_mt, _info_mt = result
+    body_len = len('{"config_hash": "abc"}')
+    assert size == 1024 + body_len  # actual, not stale 999
+
+
+def test_refresh_build_size_if_stale_re_walks_on_info_mtime_change(
+    tmp_path: Path,
+) -> None:
+    """A bumped build_info.json mtime alone invalidates the cache.
+
+    This is the case dir-mtime alone would miss — ESPHome's
+    ``write_file_if_changed`` truncates-and-writes the file on a
+    real recompile (different config_hash), bumping the file's
+    own mtime without touching the parent dir's. Tracking the
+    pair catches it; tracking only dir mtime would let the
+    drawer / table show a stale size.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    build_dir = tmp_path / "build" / "kitchen"
+    build_dir.mkdir(parents=True)
+    (build_dir / "firmware.bin").write_bytes(b"x" * 1024)
+    (build_dir / "build_info.json").write_text('{"config_hash": "abc"}')
+
+    # Seed with current dir mtime; info mtime stale.
+    set_device_metadata(
+        config_dir,
+        "kitchen.yaml",
+        build_size_bytes=999,
+        build_size_dir_mtime=int(build_dir.stat().st_mtime),
+        build_size_info_mtime=int((build_dir / "build_info.json").stat().st_mtime) - 1000,
+    )
+
+    p1, p2 = _fake_storage_patches(tmp_path, build_dir)
+    with p1, p2:
+        result = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+
+    assert result is not None
+    size, _dir_mt, _info_mt = result
+    body_len = len('{"config_hash": "abc"}')
+    assert size == 1024 + body_len  # actual, not stale 999
+
+
+def test_refresh_build_size_if_stale_no_loop_when_build_dir_missing(
+    tmp_path: Path,
+) -> None:
+    """A device whose build dir doesn't exist on disk doesn't re-walk forever.
+
+    Pre-#338 regression risk: ``StorageJSON`` carries a
+    ``build_path`` that points at a directory that doesn't
+    actually exist (clean checkout, archive flow that didn't
+    fully finalise, manual rmtree). Previous logic walked the
+    missing path on every poll and ``set_device_metadata`` cleared
+    three fields that were already absent — but the non-None
+    return triggered a ``scanner.reload`` that would re-fire
+    ``DEVICE_UPDATED`` for nothing on every cycle. The pure-pair
+    equality check short-circuits ``(0, 0) == (0, 0)`` → fresh →
+    no walk, no reload, no churn.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    # Build dir path is recorded in StorageJSON but doesn't exist
+    # on disk.
+    nonexistent_build_dir = tmp_path / "build" / "kitchen"
+
+    p1, p2 = _fake_storage_patches(tmp_path, nonexistent_build_dir)
+    with p1, p2:
+        first = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+        # Repeat the call: it must short-circuit, not loop.
+        second = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+        third = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+
+    assert first is None
+    assert second is None
+    assert third is None
+    # And the sidecar stays clean — no 0-valued fields persisted.
+    md = get_device_metadata(config_dir, "kitchen.yaml")
+    assert "build_size_bytes" not in md
+    assert "build_size_dir_mtime" not in md
+    assert "build_size_info_mtime" not in md
+
+
+def test_refresh_build_size_if_stale_clears_cache_when_build_dir_disappears(
+    tmp_path: Path,
+) -> None:
+    """A previously-walked build dir that's been wiped clears the cache once.
+
+    Companion to the no-loop test: when cached values exist but
+    the dir is gone (user manually wiped, archive flow ran), the
+    helper falls through to the walk *once*, which writes back
+    zeros (clearing the cached fields), then subsequent calls
+    short-circuit on the (0, 0) == (0, 0) equality.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    # Seed the cache with a populated triple.
+    set_device_metadata(
+        config_dir,
+        "kitchen.yaml",
+        build_size_bytes=12345,
+        build_size_dir_mtime=1714900000,
+        build_size_info_mtime=1714900050,
+    )
+    nonexistent_build_dir = tmp_path / "build" / "kitchen"
+
+    p1, p2 = _fake_storage_patches(tmp_path, nonexistent_build_dir)
+    with p1, p2:
+        first = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+        second = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+
+    # First call: cleared the cache (returned non-None to signal change).
+    assert first is not None
+    assert first == (0, 0, 0)
+    # Second call: short-circuits on pair equality, no churn.
+    assert second is None
+    md = get_device_metadata(config_dir, "kitchen.yaml")
+    assert "build_size_bytes" not in md
+    assert "build_size_dir_mtime" not in md
+    assert "build_size_info_mtime" not in md
+
+
+def test_refresh_build_size_if_stale_works_without_build_info_json(
+    tmp_path: Path,
+) -> None:
+    """Older firmware lacking ``build_info.json`` falls through on dir mtime alone.
+
+    Pre-#16145 builds don't write ``build_info.json``. The
+    freshness pair becomes ``(dir_mtime, 0)``; both halves still
+    persist verbatim, the cache compares both, and a steady-state
+    poll on such a device short-circuits because both halves
+    match (``0 == 0``).
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    build_dir = tmp_path / "build" / "kitchen"
+    build_dir.mkdir(parents=True)
+    (build_dir / "firmware.bin").write_bytes(b"x" * 1024)
+    # Deliberately no build_info.json.
+
+    p1, p2 = _fake_storage_patches(tmp_path, build_dir)
+    with p1, p2:
+        first = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+
+    assert first is not None
+    size, dir_mt, info_mt = first
+    assert size == 1024
+    assert dir_mt > 0
+    assert info_mt == 0  # the explicit "no build_info.json" sentinel
+    md = get_device_metadata(config_dir, "kitchen.yaml")
+    # ``set_device_metadata`` clears keys passed as 0, so info_mtime
+    # is intentionally absent rather than persisted as 0 — the
+    # subsequent read defaults to 0 anyway.
+    assert md["build_size_dir_mtime"] == dir_mt
+    assert "build_size_info_mtime" not in md
+
+    # Second call: nothing changed, so the helper short-circuits.
+    p1, p2 = _fake_storage_patches(tmp_path, build_dir)
+    with p1, p2:
+        second = refresh_build_size_if_stale(config_dir, "kitchen.yaml")
+    assert second is None
+
+
+def test_find_stale_build_dirs_returns_only_divergent_filenames(tmp_path: Path) -> None:
+    """Phase-A sweep returns only filenames whose mtime moved past cached.
+
+    Three devices: one with cached mtime that matches the current
+    (fresh — must NOT appear), one with a cached mtime older than
+    the current (stale — must appear), one with no StorageJSON
+    (pre-first-compile — must NOT appear). Order of stale results
+    matches the input order.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    fresh_dir = tmp_path / "build" / "fresh"
+    fresh_dir.mkdir(parents=True)
+    (fresh_dir / "f.bin").write_bytes(b"a" * 100)
+    stale_dir = tmp_path / "build" / "stale"
+    stale_dir.mkdir(parents=True)
+    (stale_dir / "s.bin").write_bytes(b"b" * 200)
+
+    fresh_dir_mtime = int(fresh_dir.stat().st_mtime)
+    set_device_metadata(
+        config_dir,
+        "fresh.yaml",
+        build_size_bytes=100,
+        build_size_dir_mtime=fresh_dir_mtime,
+        # No build_info.json — the absent-info sentinel is 0
+        # (set_device_metadata's clear path), which equals the
+        # current 0 stat for the missing file. Both halves match.
+    )
+    set_device_metadata(
+        config_dir,
+        "stale.yaml",
+        build_size_bytes=200,
+        build_size_dir_mtime=int(stale_dir.stat().st_mtime) - 1000,
+    )
+
+    storage_map = {
+        "fresh.yaml": fresh_dir,
+        "stale.yaml": stale_dir,
+    }
+
+    class _FakeStorage:
+        def __init__(self, build_path: str) -> None:
+            self.build_path = build_path
+
+    def _fake_load(path):  # type: ignore[no-untyped-def]
+        # The mock's ext_storage_path returns one of three sentinel
+        # values; map each back to the device's fake build dir.
+        # ``never_compiled`` returns None to simulate a missing
+        # StorageJSON.
+        for filename, build_dir in storage_map.items():
+            if path == tmp_path / f"{filename}.json":
+                return _FakeStorage(str(build_dir))
+        return None
+
+    with (
+        patch(
+            "esphome_device_builder.helpers.build_size.ext_storage_path",
+            side_effect=lambda f: tmp_path / f"{f}.json",
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.StorageJSON.load",
+            side_effect=_fake_load,
+        ),
+    ):
+        from esphome_device_builder.helpers.build_size import find_stale_build_dirs
+
+        result = find_stale_build_dirs(
+            config_dir, ["fresh.yaml", "stale.yaml", "never_compiled.yaml"]
+        )
+
+    assert result == ["stale.yaml"]
+
+
+def test_find_stale_build_dirs_empty_list_returns_empty(tmp_path: Path) -> None:
+    """No devices in → no executor work, no walks, no stale list."""
+    from esphome_device_builder.helpers.build_size import find_stale_build_dirs
+
+    assert find_stale_build_dirs(tmp_path, []) == []
+
+
+def test_refresh_build_size_if_stale_returns_none_when_no_storage(tmp_path: Path) -> None:
+    """Pre-first-compile devices (no StorageJSON) skip the whole pipeline."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    with (
+        patch(
+            "esphome_device_builder.helpers.build_size.ext_storage_path",
+            return_value=tmp_path / "fake.json",
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.StorageJSON.load",
+            return_value=None,
+        ),
+    ):
+        assert refresh_build_size_if_stale(config_dir, "kitchen.yaml") is None
+    # And no sidecar entry was created either.
+    assert get_device_metadata(config_dir, "kitchen.yaml") == {}
+
+
+def test_resolve_build_dir_returns_none_when_storage_load_raises(tmp_path: Path) -> None:
+    """A corrupt StorageJSON returns None instead of propagating.
+
+    ``StorageJSON.load`` returns ``None`` on a missing file but
+    raises on a malformed one. The drawer renders for every
+    device, so a single corrupt sidecar shouldn't fail the whole
+    list — treat the same as "no build artifacts."
+    """
+    with (
+        patch(
+            "esphome_device_builder.helpers.build_size.ext_storage_path",
+            return_value=tmp_path / "fake.json",
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.StorageJSON.load",
+            side_effect=ValueError("malformed"),
+        ),
+    ):
+        assert resolve_build_dir("kitchen.yaml") is None

--- a/tests/test_build_size.py
+++ b/tests/test_build_size.py
@@ -18,6 +18,7 @@ that pins the post-CLEAN refresh hand-off).
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -77,22 +78,23 @@ def test_compute_build_dir_size_skips_directories(tmp_path: Path) -> None:
 def test_compute_build_dir_size_swallows_per_entry_errors(tmp_path: Path) -> None:
     """A vanishing file mid-walk doesn't fail the whole operation.
 
-    Concurrent compile cleanup can yank entries between the
-    ``rglob`` and the ``stat`` call. Returning the partial total
-    is better than crashing the dashboard.
+    Concurrent compile cleanup can yank entries between
+    ``os.walk`` returning the filename and ``os.path.getsize``
+    stat'ing it. Returning the partial total is better than
+    crashing the dashboard.
     """
     (tmp_path / "good.bin").write_bytes(b"x" * 100)
-    bad = tmp_path / "vanished.bin"
-    bad.write_bytes(b"y" * 200)
+    bad_path = str(tmp_path / "vanished.bin")
+    (tmp_path / "vanished.bin").write_bytes(b"y" * 200)
 
-    real_stat = Path.stat
+    real_getsize = os.path.getsize
 
-    def fake_stat(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
-        if self == bad:
+    def fake_getsize(path: str) -> int:
+        if path == bad_path:
             raise OSError("file disappeared")
-        return real_stat(self, *args, **kwargs)
+        return real_getsize(path)
 
-    with patch.object(Path, "stat", fake_stat):
+    with patch("esphome_device_builder.helpers.build_size.os.path.getsize", fake_getsize):
         # 100 from good.bin; the bad one is skipped.
         assert compute_build_dir_size(tmp_path) == 100
 

--- a/tests/test_build_size.py
+++ b/tests/test_build_size.py
@@ -22,12 +22,15 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from esphome_device_builder.controllers.config import (
     get_device_metadata,
     set_device_metadata,
 )
 from esphome_device_builder.helpers.build_size import (
     BuildDirSignal,
+    coerce_sidecar_int,
     compute_build_dir_size,
     find_stale_build_dirs,
     get_build_dir_mtime,
@@ -102,6 +105,34 @@ def test_compute_build_dir_size_swallows_per_entry_errors(tmp_path: Path) -> Non
 # ----------------------------------------------------------------------
 # get_build_dir_mtime
 # ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1714900000, 1714900000),
+        ("1714900000", 1714900000),
+        (None, 0),
+        (0, 0),
+        ("", 0),
+        ("not-a-number", 0),
+        ("12.7", 0),  # int() rejects fractional strings
+        ({}, 0),
+        ([], 0),
+        (12.9, 12),  # truncates floats — same as ``int()`` on numeric values
+    ],
+)
+def test_coerce_sidecar_int(value: object, expected: int) -> None:
+    """``coerce_sidecar_int`` falls back to ``0`` on every shape ``int()`` rejects.
+
+    Same defensive shape both ``find_stale_build_dirs`` /
+    ``refresh_build_size_if_stale`` (cached mtimes) and
+    ``_resolve_device_metadata`` (cached size) use. Corrupt /
+    hand-edited sidecar entries shouldn't crash the per-device
+    hot path; the next ``BuildSizeRefresher`` pass repopulates
+    fresh values.
+    """
+    assert coerce_sidecar_int(value) == expected
 
 
 def test_get_build_dir_mtime_returns_whole_seconds(tmp_path: Path) -> None:

--- a/tests/test_build_size.py
+++ b/tests/test_build_size.py
@@ -2,11 +2,18 @@
 
 The helper walks ``.esphome/build/<device>/`` to compute the total
 size of a device's compile artifacts. The walk is heavy + I/O-bound,
-so callers gate it behind a stat-only ``get_build_dir_mtime`` check
-and persist the (mtime, bytes) pair in the per-device metadata
-sidecar. These tests cover the helper itself; the controller's
-mtime-gated refresh path is exercised in
-``test_maybe_refresh_build_size``.
+so callers gate it behind a freshness pair (``BuildDirSignal``:
+``dir_mtime`` + ``build_info_mtime``) and persist the
+``(size_bytes, dir_mtime, info_mtime)`` triple in the per-device
+metadata sidecar — either side of the pair moving counts as
+stale, see ``helpers/build_size.py``'s module docstring for the
+empirical matrix that drove the pair-vs-single-stat decision.
+
+These tests cover the helper itself plus the
+``BuildSizeRefresher`` worker's behaviour is exercised through
+``tests/controllers/firmware/test_refresh.py`` (the
+``test_clean_job_skips_full_refresh_but_pokes_build_size`` case
+that pins the post-CLEAN refresh hand-off).
 """
 
 from __future__ import annotations
@@ -541,6 +548,43 @@ def test_find_stale_build_dirs_returns_only_divergent_filenames(tmp_path: Path) 
 def test_find_stale_build_dirs_empty_list_returns_empty(tmp_path: Path) -> None:
     """No devices in → no executor work, no walks, no stale list."""
     assert find_stale_build_dirs(tmp_path, []) == []
+
+
+def test_find_stale_build_dirs_handles_corrupt_metadata_file(tmp_path: Path) -> None:
+    """A metadata read that raises falls back to "no cached data" → all stale.
+
+    A corrupt ``.device-builder.json`` (truncated, permissions
+    issue) shouldn't crash the cold-start fleet sweep. The
+    helper treats the read failure as "no cached entries", so
+    every device whose build dir exists returns as stale on
+    that pass.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    build_dir = tmp_path / "build" / "kitchen"
+    build_dir.mkdir(parents=True)
+
+    class _FakeStorage:
+        build_path = str(build_dir)
+
+    with (
+        patch(
+            "esphome_device_builder.controllers.config._load_metadata",
+            side_effect=OSError("permission denied"),
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.ext_storage_path",
+            return_value=tmp_path / "fake.json",
+        ),
+        patch(
+            "esphome_device_builder.helpers.build_size.StorageJSON.load",
+            return_value=_FakeStorage(),
+        ),
+    ):
+        result = find_stale_build_dirs(config_dir, ["kitchen.yaml"])
+
+    # No cached pair → drift detected → kitchen flagged stale.
+    assert result == ["kitchen.yaml"]
 
 
 def test_refresh_build_size_if_stale_returns_none_when_no_storage(tmp_path: Path) -> None:

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -241,6 +241,57 @@ def test_set_device_metadata_clears_mac_on_empty(tmp_path: Path) -> None:
     assert "mac_address" not in get_device_metadata(tmp_path, "kitchen.yaml")
 
 
+def test_set_device_metadata_persists_build_size_triple(tmp_path: Path) -> None:
+    """The (bytes, dir_mtime, info_mtime) triple round-trips together.
+
+    Both halves of the freshness pair gate the cache, the bytes
+    field carries the cached total, and all three are written
+    atomically by a single ``set_device_metadata`` call. Persisting
+    lets a backend restart skip the heavy recursive walk for every
+    device whose pair hasn't moved.
+    """
+    set_device_metadata(
+        tmp_path,
+        "kitchen.yaml",
+        build_size_bytes=12345678,
+        build_size_dir_mtime=1714900000,
+        build_size_info_mtime=1714900050,
+    )
+
+    md = get_device_metadata(tmp_path, "kitchen.yaml")
+    assert md["build_size_bytes"] == 12345678
+    assert md["build_size_dir_mtime"] == 1714900000
+    assert md["build_size_info_mtime"] == 1714900050
+
+
+def test_set_device_metadata_clears_build_size_on_zero(tmp_path: Path) -> None:
+    """Passing ``0`` for any field actively clears it.
+
+    Used by the archive flow's volatile-field scrub: the build
+    tree is wiped, so the cached triple would describe a directory
+    that no longer exists.
+    """
+    set_device_metadata(
+        tmp_path,
+        "kitchen.yaml",
+        build_size_bytes=12345678,
+        build_size_dir_mtime=1714900000,
+        build_size_info_mtime=1714900050,
+    )
+    set_device_metadata(
+        tmp_path,
+        "kitchen.yaml",
+        build_size_bytes=0,
+        build_size_dir_mtime=0,
+        build_size_info_mtime=0,
+    )
+
+    md = get_device_metadata(tmp_path, "kitchen.yaml")
+    assert "build_size_bytes" not in md
+    assert "build_size_dir_mtime" not in md
+    assert "build_size_info_mtime" not in md
+
+
 def test_remove_device_metadata_clears_only_target(tmp_path: Path) -> None:
     """Removing one device's entry leaves siblings intact."""
     set_device_metadata(tmp_path, "a.yaml", board_id="esp32")


### PR DESCRIPTION
# What does this implement/fix?

Adds a `build_size_bytes` field to `Device` so the dashboard can show how much disk each device's compile artifacts are eating. ESPHome compiles produce 50 MB to 1 GB+ under `.esphome/build/<name>/`; surfacing the per-device total lets a user planning a clean-up see which devices are heaviest at a glance. Companion frontend renders it as a drawer row + hidden table column.

The walk that produces the size is heavy + I/O-bound, so it's gated by a freshness pair persisted in the metadata sidecar: `(build_size_dir_mtime, build_size_info_mtime)`. Either half moving counts as stale; both are needed because each catches a class of compile-time changes the other misses (empirical matrix in the helper's module docstring — the short version: ESPHome's `write_file_if_changed` for `build_info.json` moves the file's mtime without touching the parent dir on a real recompile, while PlatformIO's intermediate sibling churn moves the parent dir without touching `build_info.json`).

The walks are managed by a new `BuildSizeRefresher` class — one persistent worker task that drains a pending set keyed on configuration filename. Pulled out of the controller so the controller doesn't carry the bookkeeping for yet another background job. `request(configuration)` is sync + side-effect-only; repeated requests coalesce in the set, the worker walks one device at a time so disk I/O stays bounded, and the worker's first iteration runs an initial fleet sweep to pick up CLI-compile drift across the whole catalog.

Refresh triggers (event-driven only, no periodic timer): backend startup (worker's initial sweep) and after every successful firmware job (COMPILE / UPLOAD / INSTALL / CLEAN). CLEAN specifically lets the cached triple drop back to zero — the build dir is wiped so the freshness pair becomes `(0, 0)` and the worker walks once to clear.

The pure pair-equality short-circuit in `refresh_build_size_if_stale` makes both "no build dir ever" and "dir was wiped manually" idempotent: `(0, 0) == (0, 0)` returns `None` without walking, so the worker doesn't churn on configurations whose build dir never existed. Whole-second mtime precision (`int(stat.st_mtime)`) so the cache works on filesystems without sub-second mtime support (FAT32 / older NFS / CIFS).

`build_size_bytes` / `build_size_dir_mtime` / `build_size_info_mtime` join `ip` / `expected_config_hash` / `mac_address` in `_VOLATILE_DEVICE_METADATA_FIELDS` so archive scrubs them — the build tree is wiped on archive and the cached triple would describe a directory that no longer exists.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#172

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
