### PR TITLE
Persist storage-regen failure across restarts with a TTL

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -306,7 +306,7 @@ def set_device_metadata(
     OR when the cached stamp is older than the controller's
     failure-TTL (so transient external problems eventually get
     re-checked). The two fields are written together by
-    :meth:`DevicesController._persist_regen_failed_stamp`; the
+    :meth:`DevicesController._stamp_regen_failure`; the
     success / archive paths clear them by passing ``0.0`` to
     *both* — clearing only one half leaves the other behind, so
     callers should always touch the pair as a unit.

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -269,6 +269,8 @@ def set_device_metadata(
     ip: str | None = None,
     expected_config_hash: str | None = None,
     mac_address: str | None = None,
+    regen_failed_mtime: float | None = None,
+    regen_failed_at: float | None = None,
 ) -> None:
     """
     Set metadata fields for a device.
@@ -290,6 +292,18 @@ def set_device_metadata(
     Persisted so the dashboard renders the address immediately on
     startup, before the first mDNS probe response. Passing an
     empty string clears it.
+
+    ``regen_failed_mtime`` is the YAML's mtime when the last
+    ``--only-generate`` storage-regen attempt failed; pair it with
+    ``regen_failed_at`` (the wall-clock time the failure was
+    recorded). Together they let a backend restart skip retrying
+    the same broken config (missing ``!secret`` / ``!include`` /
+    unreachable git package) — the next attempt only runs when
+    the YAML's mtime has actually moved past the cached stamp,
+    OR when the cached stamp is older than the controller's
+    failure-TTL (so transient external problems eventually get
+    re-checked). Pass ``0`` on either to clear (used on success
+    and on archive's volatile scrub).
     """
     with metadata_transaction(config_dir) as data:
         entry = data.setdefault(filename, {})
@@ -301,16 +315,20 @@ def set_device_metadata(
             entry["comment"] = comment
         if ip:
             entry["ip"] = ip
-        if expected_config_hash is not None:
-            if expected_config_hash:
-                entry["expected_config_hash"] = expected_config_hash
+        # Tri-state fields: ``None`` means "leave alone", a truthy
+        # value writes, an explicit falsy (``""`` / ``0``) clears.
+        for key, value in (
+            ("expected_config_hash", expected_config_hash),
+            ("mac_address", mac_address),
+            ("regen_failed_mtime", regen_failed_mtime),
+            ("regen_failed_at", regen_failed_at),
+        ):
+            if value is None:
+                continue
+            if value:
+                entry[key] = value
             else:
-                entry.pop("expected_config_hash", None)
-        if mac_address is not None:
-            if mac_address:
-                entry["mac_address"] = mac_address
-            else:
-                entry.pop("mac_address", None)
+                entry.pop(key, None)
 
 
 def get_device_metadata(config_dir: Path, filename: str) -> dict[str, Any]:
@@ -355,6 +373,13 @@ _VOLATILE_DEVICE_METADATA_FIELDS: frozenset[str] = frozenset(
         # stale persisted MAC would render until the next mDNS
         # announce overwrote it.
         "mac_address",
+        # YAML mtime + wall-clock timestamp at the last failed
+        # storage-regen attempt. Archive moves the YAML; a future
+        # unarchive may put it back with a fresh mtime, so any
+        # cached failure stamp would be meaningless. Cleared so
+        # the next scan retries the regen.
+        "regen_failed_mtime",
+        "regen_failed_at",
     }
 )
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -889,32 +889,26 @@ class DevicesController:
                 # failed. If the file hasn't been touched since
                 # *and* the failure stamp is still within the TTL,
                 # replay would fail the same way — turn it into a
-                # no-op. Done here rather than in the sync caller
-                # because the ``stat()`` + metadata-sidecar read
-                # would stall the event loop on a fleet-wide
-                # cold-start sweep.
+                # no-op. The check itself batches its disk reads
+                # into one executor hop.
                 if await self._regen_already_failed_recently_async(configuration):
                     self._regenerate_failed.add(configuration)
                     return
                 async with self._regenerate_lock:
-                    if await self._spawn_only_generate(configuration):
-                        # ``--only-generate`` writes build_info.json
-                        # with the canonical config_hash before
-                        # exiting, same as a real compile. Persist
-                        # it so the drawer can show "Local: <hash>"
-                        # before the first real flash; also clear
-                        # any leftover regen-failure stamp now
-                        # that the YAML generates cleanly.
-                        await self._persist_expected_config_hash(configuration)
-                        await self._persist_device_metadata_async(
-                            configuration,
-                            regen_failed_mtime=0.0,
-                            regen_failed_at=0.0,
-                        )
-                        await self._scanner.reload(configuration)
-                    else:
-                        self._regenerate_failed.add(configuration)
-                        await self._persist_regen_failed_stamp(configuration)
+                    success = await self._spawn_only_generate(configuration)
+                if success:
+                    # ``--only-generate`` writes build_info.json
+                    # with the canonical config_hash before
+                    # exiting, same as a real compile. The single
+                    # executor hop below reads that hash and
+                    # writes the sidecar in one transaction, also
+                    # clearing the regen-failure stamp now that
+                    # the YAML generates cleanly.
+                    await self._finalize_regen_success(configuration)
+                    await self._scanner.reload(configuration)
+                else:
+                    self._regenerate_failed.add(configuration)
+                    await self._stamp_regen_failure(configuration)
             finally:
                 self._regenerate_pending.discard(configuration)
 
@@ -1003,27 +997,77 @@ class DevicesController:
             return False
         return mtime_matches and age < _REGEN_FAILURE_TTL_SECONDS
 
-    async def _persist_regen_failed_stamp(self, configuration: str) -> None:
-        """Stamp the YAML's mtime + wall-clock as a "we already tried, gave up" marker.
+    async def _stamp_regen_failure(self, configuration: str) -> None:
+        """Persist the cross-restart "we already tried, gave up" marker — one executor hop.
 
-        Read in :meth:`_regen_already_failed_recently_async` on the
-        next ``_schedule_storage_regenerate`` call. Any edit to
-        the YAML moves the mtime forward and bypasses the guard
-        naturally; the wall-clock pair lets the TTL release the
-        guard for transient external problems even when the YAML
-        is untouched.
+        Combines the YAML ``stat()`` and the sidecar write into a
+        single closure handed to ``run_in_executor``. The standalone
+        old standalone-stamp shape used to take two hops
+        (one to stat, one to write); on a fleet-wide cold-start
+        each saved hop is a thread-pool slot back to the pool.
+
+        The wall-clock half is sampled inside the closure too, so
+        the stamp captures the same instant the file's mtime was
+        observed instead of straddling a hop.
         """
+        config_dir = self._db.settings.config_dir
         config_path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        try:
-            stat = await loop.run_in_executor(None, config_path.stat)
-        except OSError:
-            return  # file vanished mid-regen; nothing useful to stamp
-        await self._persist_device_metadata_async(
-            configuration,
-            regen_failed_mtime=stat.st_mtime,
-            regen_failed_at=time.time(),
-        )
+
+        def _stamp() -> None:
+            try:
+                mtime = config_path.stat().st_mtime
+            except OSError:
+                return  # file vanished mid-regen; nothing useful to stamp
+            set_device_metadata(
+                config_dir,
+                configuration,
+                regen_failed_mtime=mtime,
+                regen_failed_at=time.time(),
+            )
+
+        await asyncio.get_running_loop().run_in_executor(None, _stamp)
+
+    async def _finalize_regen_success(self, configuration: str) -> None:
+        """Read the post-only-generate hash and clear the failure stamp — one executor hop.
+
+        Used to be three separate awaits — read ``build_info.json``,
+        write the hash, write the cleared regen stamp — totalling
+        three executor hops and two sidecar transactions. The
+        closure here folds them together: one ``read_build_info_hash``
+        call, one ``set_device_metadata`` transaction that writes
+        ``expected_config_hash`` and clears
+        ``regen_failed_mtime`` / ``regen_failed_at`` atomically.
+
+        See :meth:`_persist_expected_config_hash` for the rationale
+        on why the hash is read off ``build_info.json`` rather than
+        recomputed in-process — a missing / malformed file is
+        unexpected on this code path so the warning log lives there.
+        """
+        config_dir = self._db.settings.config_dir
+        yaml_path = self._db.settings.rel_path(configuration)
+
+        def _finalize() -> str | None:
+            new_hash = read_build_info_hash(yaml_path)
+            kwargs: dict[str, Any] = {
+                "regen_failed_mtime": 0.0,
+                "regen_failed_at": 0.0,
+            }
+            if new_hash:
+                kwargs["expected_config_hash"] = new_hash
+            set_device_metadata(config_dir, configuration, **kwargs)
+            return new_hash
+
+        new_hash = await asyncio.get_running_loop().run_in_executor(None, _finalize)
+        if not new_hash:
+            _LOGGER.warning(
+                "Could not read config_hash from build_info.json for %s — "
+                "the drawer's Local hash may stay stale until the next flash. "
+                "If this persists across compiles, check that ESPHome's "
+                "build_info.json schema hasn't changed.",
+                configuration,
+            )
+            return
+        _LOGGER.debug("Stored expected_config_hash for %s: %s", configuration, new_hash)
 
     @api_command("devices/get_api_key")
     async def get_api_key(self, *, configuration: str, **kwargs: Any) -> dict[str, str]:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1001,10 +1001,10 @@ class DevicesController:
         """Persist the cross-restart "we already tried, gave up" marker — one executor hop.
 
         Combines the YAML ``stat()`` and the sidecar write into a
-        single closure handed to ``run_in_executor``. The standalone
-        old standalone-stamp shape used to take two hops
-        (one to stat, one to write); on a fleet-wide cold-start
-        each saved hop is a thread-pool slot back to the pool.
+        single closure handed to ``run_in_executor``. The earlier
+        standalone-stamp shape took two hops (one to stat, one to
+        write); on a fleet-wide cold-start each saved hop is a
+        thread-pool slot back to the pool.
 
         The wall-clock half is sampled inside the closure too, so
         the stamp captures the same instant the file's mtime was

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -13,6 +13,7 @@ import contextlib
 import logging
 import os
 import shutil
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
@@ -80,6 +81,18 @@ if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long the persisted "regen failed" stamp is honoured before a
+# restart-time check is allowed to re-spawn ``--only-generate`` for
+# the same untouched YAML. The in-memory ``_regenerate_failed`` set
+# blocks within a session until the user edits the YAML; the TTL
+# only applies cross-restart, so a transient external problem
+# (git package server flaky, DNS hiccup) eventually recovers
+# without forcing the user to touch the file. One hour is short
+# enough that "I'll come back to this in a bit and restart" works,
+# long enough that a debugger restarting the dashboard 10x in a
+# row doesn't churn through 10 spawns on the same broken config.
+_REGEN_FAILURE_TTL_SECONDS: float = 3600.0
 
 # Per-file match cap for ``yaml/search``. Each device contributes
 # at most this many lines so a chatty match (a query of ``:``
@@ -815,6 +828,20 @@ class DevicesController:
         * ``_regenerate_failed`` skips YAMLs whose last attempt
           failed; entries are cleared in ``_on_scan_change`` when the
           file's cache key changes (i.e. the user actually edited it).
+        * ``regen_failed_mtime`` + ``regen_failed_at`` in the
+          metadata sidecar is the *cross-restart* version of the
+          same skip. The previous backend stamped the YAML's
+          mtime alongside ``time.time()``; a fresh start that
+          finds those two intact and within ``_REGEN_FAILURE_TTL``
+          short-circuits without spawning another ``esphome
+          compile`` on the same broken config. Two retry signals
+          release the guard:
+
+          * The user edits the YAML — its mtime moves past the
+            stamp, so the equality check fails naturally.
+          * The TTL elapses — covers transient external problems
+            (git package server flaky, DNS hiccup) where the
+            user shouldn't have to touch the YAML to recover.
         * ``_regenerate_lock`` serialises the subprocess itself so we
           never spawn more than one esphome compile at a time.
 
@@ -828,9 +855,17 @@ class DevicesController:
         if configuration in self._regenerate_pending:
             return  # already scheduled, don't queue a duplicate.
         if configuration in self._regenerate_failed:
-            # Last attempt failed and the YAML hasn't changed since;
-            # rerunning would just produce the same error and burn a
-            # subprocess. Wait for an UPDATED scan to clear the marker.
+            # Last attempt this session failed and the YAML hasn't
+            # changed since; rerunning would produce the same error.
+            return
+        # Cross-restart skip: the previous backend persisted the
+        # YAML's mtime + wall-clock when the regen failed. If the
+        # file hasn't been touched since *and* the failure stamp
+        # is still within the TTL, replay would fail the same way
+        # — turn it into a no-op. The user editing the YAML or
+        # the TTL elapsing both release the guard.
+        if self._regen_already_failed_recently(configuration):
+            self._regenerate_failed.add(configuration)
             return
 
         async def _run() -> None:
@@ -859,6 +894,7 @@ class DevicesController:
                             exc_info=True,
                         )
                         self._regenerate_failed.add(configuration)
+                        await self._persist_regen_failed_stamp(configuration)
                         return
                     if proc.returncode != 0:
                         _LOGGER.debug(
@@ -868,18 +904,88 @@ class DevicesController:
                             stderr.decode(errors="replace").strip()[:500],
                         )
                         self._regenerate_failed.add(configuration)
+                        await self._persist_regen_failed_stamp(configuration)
                         return
                     # ``--only-generate`` writes build_info.json with
                     # the canonical config_hash before exiting, same as
                     # a real compile. Persist it to the metadata
                     # sidecar so the drawer can show "Local: <hash>"
-                    # before the first real flash.
+                    # before the first real flash. Also clear any
+                    # previously-cached regen-failure stamp — the
+                    # YAML now generates cleanly.
                     await self._persist_expected_config_hash(configuration)
+                    await self._persist_device_metadata_async(
+                        configuration,
+                        regen_failed_mtime=0.0,
+                        regen_failed_at=0.0,
+                    )
                     await self._scanner.reload(configuration)
             finally:
                 self._regenerate_pending.discard(configuration)
 
         self._db.create_background_task(_run())
+
+    def _regen_already_failed_recently(self, configuration: str) -> bool:
+        """Return True iff the persisted failure stamp is unchanged-and-fresh.
+
+        Both halves have to hold:
+
+        * The YAML's current ``stat.st_mtime`` equals the cached
+          ``regen_failed_mtime`` — the file is the exact same one
+          we already tried (any edit moves the mtime forward).
+        * Less than ``_REGEN_FAILURE_TTL_SECONDS`` has elapsed
+          since the cached ``regen_failed_at`` wall-clock stamp —
+          transient external causes (git package server, DNS,
+          ESPHome update mid-flight) get a re-check after that.
+
+        Equality comparison on the mtime works because both sides
+        come from the same filesystem during the same backend
+        lifecycle's view of the file. There's no cross-mount
+        precision worry the way there is for the build-size cache
+        (which is keyed off whole-second mtimes deliberately for
+        cross-FS robustness); for regen we only care about "is
+        this the exact same file we already tried", and a
+        sub-second precision difference means the user touched
+        the file — the retry signal we want.
+        """
+        config_path = self._db.settings.rel_path(configuration)
+        try:
+            current_mtime = config_path.stat().st_mtime
+        except OSError:
+            return False
+        md = get_device_metadata(self._db.settings.config_dir, configuration)
+        cached_mtime = md.get("regen_failed_mtime")
+        cached_at = md.get("regen_failed_at")
+        if not cached_mtime or not cached_at:
+            return False
+        try:
+            mtime_matches = float(cached_mtime) == current_mtime
+            age = time.time() - float(cached_at)
+        except (TypeError, ValueError):
+            return False
+        return mtime_matches and age < _REGEN_FAILURE_TTL_SECONDS
+
+    async def _persist_regen_failed_stamp(self, configuration: str) -> None:
+        """Stamp the YAML's mtime + wall-clock as a "we already tried, gave up" marker.
+
+        Read in :meth:`_regen_already_failed_recently` on the
+        next ``_schedule_storage_regenerate`` call. Any edit to
+        the YAML moves the mtime forward and bypasses the guard
+        naturally; the wall-clock pair lets the TTL release the
+        guard for transient external problems even when the YAML
+        is untouched.
+        """
+        config_path = self._db.settings.rel_path(configuration)
+        loop = asyncio.get_running_loop()
+        try:
+            stat = await loop.run_in_executor(None, config_path.stat)
+        except OSError:
+            return  # file vanished mid-regen; nothing useful to stamp
+        await self._persist_device_metadata_async(
+            configuration,
+            regen_failed_mtime=stat.st_mtime,
+            regen_failed_at=time.time(),
+        )
 
     @api_command("devices/get_api_key")
     async def get_api_key(self, *, configuration: str, **kwargs: Any) -> dict[str, str]:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -890,117 +890,104 @@ class DevicesController:
                 # *and* the failure stamp is still within the TTL,
                 # replay would fail the same way — turn it into a
                 # no-op. Done here rather than in the sync caller
-                # because it does ``stat()`` + a metadata-sidecar
-                # read; on a cold-start fleet sweep that adds up
-                # fast on the event loop.
+                # because the ``stat()`` + metadata-sidecar read
+                # would stall the event loop on a fleet-wide
+                # cold-start sweep.
                 if await self._regen_already_failed_recently_async(configuration):
                     self._regenerate_failed.add(configuration)
                     return
                 async with self._regenerate_lock:
-                    config_path = str(self._db.settings.rel_path(configuration))
-                    cmd = [
-                        *self._esphome_cmd,
-                        "--dashboard",
-                        "compile",
-                        "--only-generate",
-                        config_path,
-                    ]
-                    try:
-                        proc = await create_subprocess_exec(
-                            *cmd,
-                            stdout=asyncio.subprocess.DEVNULL,
-                            stderr=asyncio.subprocess.PIPE,
-                        )
-                        _, stderr = await proc.communicate()
-                    except Exception:
-                        _LOGGER.debug(
-                            "Storage regenerate spawn failed for %s",
+                    if await self._spawn_only_generate(configuration):
+                        # ``--only-generate`` writes build_info.json
+                        # with the canonical config_hash before
+                        # exiting, same as a real compile. Persist
+                        # it so the drawer can show "Local: <hash>"
+                        # before the first real flash; also clear
+                        # any leftover regen-failure stamp now
+                        # that the YAML generates cleanly.
+                        await self._persist_expected_config_hash(configuration)
+                        await self._persist_device_metadata_async(
                             configuration,
-                            exc_info=True,
+                            regen_failed_mtime=0.0,
+                            regen_failed_at=0.0,
                         )
+                        await self._scanner.reload(configuration)
+                    else:
                         self._regenerate_failed.add(configuration)
                         await self._persist_regen_failed_stamp(configuration)
-                        return
-                    if proc.returncode != 0:
-                        _LOGGER.debug(
-                            "Storage regenerate for %s exited %s: %s",
-                            configuration,
-                            proc.returncode,
-                            stderr.decode(errors="replace").strip()[:500],
-                        )
-                        self._regenerate_failed.add(configuration)
-                        await self._persist_regen_failed_stamp(configuration)
-                        return
-                    # ``--only-generate`` writes build_info.json with
-                    # the canonical config_hash before exiting, same as
-                    # a real compile. Persist it to the metadata
-                    # sidecar so the drawer can show "Local: <hash>"
-                    # before the first real flash. Also clear any
-                    # previously-cached regen-failure stamp — the
-                    # YAML now generates cleanly.
-                    await self._persist_expected_config_hash(configuration)
-                    await self._persist_device_metadata_async(
-                        configuration,
-                        regen_failed_mtime=0.0,
-                        regen_failed_at=0.0,
-                    )
-                    await self._scanner.reload(configuration)
             finally:
                 self._regenerate_pending.discard(configuration)
 
         self._db.create_background_task(_run())
 
+    async def _spawn_only_generate(self, configuration: str) -> bool:
+        """Run ``esphome compile --only-generate`` once. Return True iff exit-0.
+
+        Both failure modes (spawn raised, or the subprocess exited
+        non-zero) get logged at debug and produce ``False`` so the
+        caller takes the same persist-failure-stamp branch in
+        either case. Pulled out of ``_run()`` so the two failure
+        paths don't have to duplicate the marker-set + persist
+        sequence.
+        """
+        config_path = str(self._db.settings.rel_path(configuration))
+        cmd = [*self._esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
+        try:
+            proc = await create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+        except Exception:
+            _LOGGER.debug("Storage regenerate spawn failed for %s", configuration, exc_info=True)
+            return False
+        if proc.returncode != 0:
+            _LOGGER.debug(
+                "Storage regenerate for %s exited %s: %s",
+                configuration,
+                proc.returncode,
+                stderr.decode(errors="replace").strip()[:500],
+            )
+            return False
+        return True
+
     async def _regen_already_failed_recently_async(self, configuration: str) -> bool:
         """Return True iff the persisted failure stamp is unchanged-and-fresh.
 
-        Both halves have to hold:
+        Both halves have to hold for the guard to fire:
 
         * The YAML's current ``stat.st_mtime`` equals the cached
-          ``regen_failed_mtime`` — the file is the exact same one
-          we already tried (any edit moves the mtime forward).
+          ``regen_failed_mtime`` — same file as last time (any
+          edit moves the mtime forward).
         * Less than ``_REGEN_FAILURE_TTL_SECONDS`` has elapsed
-          since the cached ``regen_failed_at`` wall-clock stamp —
-          transient external causes (git package server, DNS,
-          ESPHome update mid-flight) get a re-check after that.
+          since the cached ``regen_failed_at`` — covers transient
+          external causes (git package server, DNS, ESPHome
+          mid-flight) by allowing a re-check after the TTL.
 
-        Async because the disk reads (``Path.stat`` and the
-        ``.device-builder.json`` parse via ``get_device_metadata``)
-        would otherwise stall the event loop on a fleet-wide
-        cold-start regenerate sweep — both go through the default
-        executor.
-
-        A negative age (system clock moved backwards, NTP step,
-        bad sidecar value with ``regen_failed_at`` in the future)
-        is *not* treated as "still fresh"; we clamp at zero and
-        let the equality on mtime decide. Otherwise a future-dated
-        stamp would lock out the regen indefinitely.
-
-        Equality comparison on the mtime works because both sides
-        come from the same filesystem during the same backend
-        lifecycle's view of the file. There's no cross-mount
-        precision worry the way there is for the build-size cache
-        (which is keyed off whole-second mtimes deliberately for
-        cross-FS robustness); for regen we only care about "is
-        this the exact same file we already tried", and a
-        sub-second precision difference means the user touched
-        the file — the retry signal we want.
+        Disk reads (``Path.stat``, the ``.device-builder.json``
+        parse) go through the default executor so a cold-start
+        fleet sweep doesn't stall the event loop. A negative age
+        (clock skew, NTP step, future-dated stamp) clamps to zero;
+        without that clamp a bad sidecar value could lock out the
+        regen indefinitely.
         """
-        config_path = self._db.settings.rel_path(configuration)
         loop = asyncio.get_running_loop()
+        config_dir = self._db.settings.config_dir
+        config_path = self._db.settings.rel_path(configuration)
         try:
-            stat_result = await loop.run_in_executor(None, config_path.stat)
+            stat_result, md = await asyncio.gather(
+                loop.run_in_executor(None, config_path.stat),
+                loop.run_in_executor(None, get_device_metadata, config_dir, configuration),
+            )
         except OSError:
             return False
-        current_mtime = stat_result.st_mtime
-        md = await loop.run_in_executor(
-            None, get_device_metadata, self._db.settings.config_dir, configuration
-        )
         cached_mtime = md.get("regen_failed_mtime")
         cached_at = md.get("regen_failed_at")
         if not cached_mtime or not cached_at:
             return False
         try:
-            mtime_matches = float(cached_mtime) == current_mtime
+            mtime_matches = float(cached_mtime) == stat_result.st_mtime
             age = max(0.0, time.time() - float(cached_at))
         except (TypeError, ValueError):
             return False

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -966,28 +966,38 @@ class DevicesController:
           mid-flight) by allowing a re-check after the TTL.
 
         Disk reads (``Path.stat``, the ``.device-builder.json``
-        parse) go through the default executor so a cold-start
-        fleet sweep doesn't stall the event loop. A negative age
-        (clock skew, NTP step, future-dated stamp) clamps to zero;
-        without that clamp a bad sidecar value could lock out the
-        regen indefinitely.
+        parse) batch into a single executor job so a cold-start
+        fleet sweep neither stalls the event loop nor double-books
+        the default thread pool. A negative age (clock skew, NTP
+        step, future-dated stamp) clamps to zero; without that
+        clamp a bad sidecar value could lock out the regen
+        indefinitely.
         """
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
         config_path = self._db.settings.rel_path(configuration)
-        try:
-            stat_result, md = await asyncio.gather(
-                loop.run_in_executor(None, config_path.stat),
-                loop.run_in_executor(None, get_device_metadata, config_dir, configuration),
-            )
-        except OSError:
+
+        def _read() -> tuple[float, dict[str, Any]] | None:
+            # One executor hop for both reads — paying for two
+            # parallel ``run_in_executor`` jobs would just consume
+            # two slots in the shared default thread pool for work
+            # that's already serial on disk anyway.
+            try:
+                mtime = config_path.stat().st_mtime
+            except OSError:
+                return None
+            return mtime, get_device_metadata(config_dir, configuration)
+
+        result = await loop.run_in_executor(None, _read)
+        if result is None:
             return False
+        current_mtime, md = result
         cached_mtime = md.get("regen_failed_mtime")
         cached_at = md.get("regen_failed_at")
         if not cached_mtime or not cached_at:
             return False
         try:
-            mtime_matches = float(cached_mtime) == stat_result.st_mtime
+            mtime_matches = float(cached_mtime) == current_mtime
             age = max(0.0, time.time() - float(cached_at))
         except (TypeError, ValueError):
             return False

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -170,6 +170,8 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
         ip="192.168.1.42",
         expected_config_hash="deadbeef",
         mac_address="94:C9:60:1F:8C:F1",
+        regen_failed_mtime=1700000000.5,
+        regen_failed_at=1700000005.0,
     )
     pre = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
     # Sanity that the seeding above wrote everything we expect.
@@ -177,6 +179,8 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
     assert pre["ip"] == "192.168.1.42"
     assert pre["expected_config_hash"] == "deadbeef"
     assert pre["mac_address"] == "94:C9:60:1F:8C:F1"
+    assert pre["regen_failed_mtime"] == 1700000000.5
+    assert pre["regen_failed_at"] == 1700000005.0
 
     await controller._archive_single("kitchen.yaml")
 
@@ -186,7 +190,10 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
     # (the previous shape) fails here. The MAC counts as volatile
     # (the YAML may later be redeployed to a different physical
     # board on unarchive) and must be scrubbed alongside ``ip`` /
-    # ``expected_config_hash``.
+    # ``expected_config_hash``. ``regen_failed_mtime`` /
+    # ``regen_failed_at`` are volatile too — archive moves the
+    # YAML, and a future unarchive may put it back with a fresh
+    # mtime, so any cached failure stamp would be meaningless.
     assert post == {
         "board_id": "esp32-c3-devkitm-1",
         "friendly_name": "Kitchen Sensor",

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -100,10 +100,10 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
     )
     persist_calls: list[str] = []
 
-    async def _fake_persist(_self: Any, configuration: str) -> None:
+    async def _fake_finalize(_self: Any, configuration: str) -> None:
         persist_calls.append(configuration)
 
-    monkeypatch.setattr(DevicesController, "_persist_expected_config_hash", _fake_persist)
+    monkeypatch.setattr(DevicesController, "_finalize_regen_success", _fake_finalize)
 
     await controller.update_config(
         configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -26,6 +26,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from esphome_device_builder.controllers.config import (
+    get_device_metadata,
+    set_device_metadata,
+)
 from esphome_device_builder.controllers.devices import DevicesController
 
 from .conftest import MakeControllerFactory
@@ -316,3 +320,437 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
     release.set()
     await _drain(controller)
     assert controller._regenerate_pending == set()
+
+
+# ---------------------------------------------------------------------------
+# Cross-restart failure persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_regenerate_persists_mtime_and_wallclock_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Failure → YAML mtime + wall-clock stamped into the metadata sidecar.
+
+    The whole point of the cross-restart guard: a backend reboot
+    that re-encounters the same broken YAML reads these stamps,
+    sees the mtime hasn't moved AND the failure is fresh, and
+    skips replaying the regen. The wall-clock side feeds the
+    TTL — without it, a transient external problem (git package
+    server flake) would never get re-checked.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("not: valid: yaml\n", encoding="utf-8")
+    expected_mtime = yaml_path.stat().st_mtime
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=1, stderr=b"YAML parse error")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+    # Pin wall-clock so the assertion isn't racy.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.time.time",
+        lambda: 1700000000.0,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    md = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert md.get("regen_failed_mtime") == expected_mtime
+    assert md.get("regen_failed_at") == 1700000000.0
+
+
+@pytest.mark.asyncio
+async def test_regenerate_persists_stamp_on_spawn_oserror(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Spawn-raises path also stamps the failure marker.
+
+    Both failure exits — non-zero returncode and ``OSError`` from
+    the spawn itself — feed the same persistent guard. Catches
+    regressions where one branch persists and the other doesn't.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    expected_mtime = yaml_path.stat().st_mtime
+
+    async def _broken_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        raise OSError("esphome: command not found")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _broken_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.time.time",
+        lambda: 1700000050.0,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    md = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert md.get("regen_failed_mtime") == expected_mtime
+    assert md.get("regen_failed_at") == 1700000050.0
+
+
+@pytest.mark.asyncio
+async def test_regenerate_clears_failure_stamp_on_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A subsequent successful regen wipes both halves of the failure stamp.
+
+    User edits the broken YAML → mtime moves → the next schedule
+    bypasses the cross-restart guard, the spawn succeeds, and the
+    stale ``regen_failed_mtime`` *and* ``regen_failed_at`` get
+    cleared so a future restart doesn't see them. Pairs with the
+    failure-persistence test above to pin the full set/clear cycle.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    # Simulate the leftover stamp from an earlier failed attempt.
+    await asyncio.to_thread(
+        set_device_metadata,
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=1.0,
+        regen_failed_at=1700000000.0,
+    )
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    md = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert "regen_failed_mtime" not in md
+    assert "regen_failed_at" not in md
+
+
+@pytest.mark.asyncio
+async def test_regenerate_skips_when_stamp_fresh_and_mtime_matches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Cross-restart skip: persisted stamp matches and is within TTL → no spawn.
+
+    Simulates the "broken config + backend restart" case. The
+    in-memory ``_regenerate_failed`` set is empty (fresh process)
+    but the sidecar carries the prior backend's failure stamp;
+    the schedule call must populate ``_regenerate_failed`` and
+    skip the spawn rather than burning another subprocess.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("not: valid: yaml\n", encoding="utf-8")
+    current_mtime = yaml_path.stat().st_mtime
+    await asyncio.to_thread(
+        set_device_metadata,
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=current_mtime,
+        regen_failed_at=1700000000.0,
+    )
+    # 60s after the stamp — well within the 1h TTL.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.time.time",
+        lambda: 1700000060.0,
+    )
+
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert spawn_calls == []
+    # The skip path also seeds the in-memory set so subsequent
+    # same-session schedules hit the cheaper guard instead of
+    # re-reading the sidecar.
+    assert controller._regenerate_failed == {"kitchen.yaml"}
+
+
+@pytest.mark.asyncio
+async def test_regenerate_retries_when_stamp_older_than_ttl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """TTL elapsed: even with mtime untouched, the next restart retries.
+
+    Covers the user's "external package problem" case — a flaky
+    git server or ESPHome update that resolves on its own. The
+    YAML doesn't change but enough wall-clock time has passed
+    that we should re-check rather than blocking forever.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    current_mtime = yaml_path.stat().st_mtime
+    await asyncio.to_thread(
+        set_device_metadata,
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=current_mtime,
+        regen_failed_at=1700000000.0,
+    )
+    # Advance the clock just past the 1h TTL.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.time.time",
+        lambda: 1700000000.0 + 3700.0,
+    )
+
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert len(spawn_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_regenerate_runs_when_yaml_mtime_moves_past_stamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """User edits the broken YAML → mtime moves → cross-restart guard releases.
+
+    The natural retry signal. Without this the user's only escape
+    from a bad regen would be deleting the metadata sidecar by
+    hand, which they can't reasonably be expected to know about.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    # Stamp from a prior failed attempt at an *older* mtime — the
+    # YAML has since been edited so the live stat doesn't match.
+    # The wall-clock stamp is fresh (within TTL) so only the mtime
+    # mismatch is what releases the guard.
+    await asyncio.to_thread(
+        set_device_metadata,
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=1.0,
+        regen_failed_at=1700000000.0,
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.time.time",
+        lambda: 1700000060.0,
+    )
+
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert len(spawn_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_regenerate_runs_when_yaml_missing_for_stamp_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """YAML file vanished between scan and schedule → guard is permissive.
+
+    A torn ``stat()`` (file removed mid-flight by an editor or
+    archive) returns ``OSError``; the guard treats that as "we
+    can't verify, let the spawn try" rather than silently
+    skipping. The spawn itself will then fail and re-stamp; the
+    important thing is we don't dead-end on a missing file.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    # Persist a stamp without ever creating the YAML — simulates the
+    # race window. The metadata sidecar's entry is keyed by filename,
+    # not file-existence.
+    await asyncio.to_thread(
+        set_device_metadata,
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=12345.0,
+        regen_failed_at=1700000000.0,
+    )
+
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=1, stderr=b"missing")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    # The spawn ran (the stat() failed → guard didn't short-circuit).
+    assert len(spawn_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_regenerate_runs_when_only_one_stamp_half_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Half-written sidecar (only mtime, only wall-clock) → guard treats as absent.
+
+    The two stamp halves are written together; any state where
+    only one is present came from a partial write or a hand-edit
+    and shouldn't lock out retries indefinitely. Both-or-neither
+    is the contract the guard enforces.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    current_mtime = yaml_path.stat().st_mtime
+    # Only the mtime half — sidecar carries no wall-clock pair.
+    await asyncio.to_thread(
+        set_device_metadata,
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=current_mtime,
+    )
+
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert len(spawn_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_regenerate_runs_when_stamp_has_corrupt_value(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A non-numeric stamp half (hand-edit, partial write) is treated as absent.
+
+    Production stamps via ``set_device_metadata`` only — but a
+    user editing ``.device-builder.json`` could leave the field as
+    a string or arbitrary object. The guard's ``float(...)``
+    coercion has to recover gracefully; otherwise a single bad
+    write would lock the device out of regen forever.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    # Hand-edit shape — the value is a string, not a number.
+    raw_path = tmp_path / ".device-builder.json"
+    raw_path.write_text(
+        '{"kitchen.yaml": {"regen_failed_mtime": "garbage", "regen_failed_at": "garbage"}}',
+        encoding="utf-8",
+    )
+
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_persist_expected_config_hash",
+        AsyncMock(),
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert len(spawn_calls) == 1

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -20,6 +20,7 @@ tests exercise the actual coroutine the production code spawns.
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
@@ -31,6 +32,7 @@ from esphome_device_builder.controllers.config import (
     set_device_metadata,
 )
 from esphome_device_builder.controllers.devices import DevicesController
+from tests._storage_fixtures import write_storage_json
 
 from .conftest import MakeControllerFactory
 
@@ -803,3 +805,137 @@ async def test_regenerate_runs_when_stamp_has_corrupt_value(
     await _drain(controller)
 
     assert len(spawn_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Real ``_finalize_regen_success`` — covers the in-executor closure that
+# reads ``build_info.json`` and writes the sidecar in one transaction.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_regenerate_persists_hash_and_clears_stamp_in_one_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Success path runs the real ``_finalize_regen_success`` end-to-end.
+
+    Other tests in this file mock the finalize helper to verify that
+    the spawn-success branch invokes it; this one lets it execute so
+    the in-executor closure (``read_build_info_hash`` →
+    ``set_device_metadata``) gets exercised against real fixtures.
+    Asserts the sidecar after the run carries the canonical hash AND
+    has the leftover regen-failure stamp cleared in the same write.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    # Pre-seed a leftover failure stamp from a notional prior backend
+    # so the test can verify it's cleared in the same transaction
+    # that writes the new hash.
+    await asyncio.to_thread(
+        set_device_metadata,
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=1.0,
+        regen_failed_at=2.0,
+    )
+
+    # StorageJSON sidecar pointing at a build dir + build_info.json
+    # carrying the canonical hash. ``read_build_info_hash`` reads
+    # both during the executor closure.
+    build_path = tmp_path / ".esphome" / "build" / "kitchen"
+    write_storage_json(
+        tmp_path,
+        "kitchen.yaml",
+        firmware_bin_path=build_path / ".pioenvs" / "firmware.bin",
+        build_path=build_path,
+    )
+    build_path.mkdir(parents=True, exist_ok=True)
+    (build_path / "build_info.json").write_text(
+        # 0x5a94a12d — same hash the metadata-resolver tests use,
+        # matches ``acfloatmonitor32.yaml``'s post-codegen value.
+        '{"config_hash": 1519690029, "build_time": 1700000000, '
+        '"build_time_str": "2025-11-14 12:00:00", '
+        '"esphome_version": "2026.5.0-dev"}',
+        encoding="utf-8",
+    )
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    md = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    # Hash got written and the leftover stamps got cleared in the
+    # same transaction — both halves of the closure.
+    assert md.get("expected_config_hash") == "5a94a12d"
+    assert "regen_failed_mtime" not in md
+    assert "regen_failed_at" not in md
+
+
+@pytest.mark.asyncio
+async def test_regenerate_success_clears_stamp_when_build_info_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Success spawn but no ``build_info.json`` → log warn, still clear stamps.
+
+    Pins the "missing build_info.json" branch in
+    ``_finalize_regen_success``: when ``read_build_info_hash``
+    returns ``None`` the closure still writes the cleared regen
+    stamps (so the next restart picks up the now-good YAML), and
+    the caller logs a warning rather than silently dropping the
+    case.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    await asyncio.to_thread(
+        set_device_metadata,
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=1.0,
+        regen_failed_at=2.0,
+    )
+
+    # No StorageJSON sidecar → ``read_build_info_hash`` returns
+    # None.
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.controller.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="esphome_device_builder.controllers.devices.controller",
+    ):
+        controller._schedule_storage_regenerate("kitchen.yaml")
+        await _drain(controller)
+
+    md = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    # Stamps cleared even though the hash couldn't be read — the
+    # YAML now generates cleanly, the missing build_info.json is
+    # a separate concern surfaced by the warning log.
+    assert "expected_config_hash" not in md
+    assert "regen_failed_mtime" not in md
+    assert "regen_failed_at" not in md
+    assert any(
+        "Could not read config_hash from build_info.json" in record.message
+        for record in caplog.records
+    )

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -241,6 +241,56 @@ def test_set_device_metadata_clears_mac_on_empty(tmp_path: Path) -> None:
     assert "mac_address" not in get_device_metadata(tmp_path, "kitchen.yaml")
 
 
+def test_set_device_metadata_persists_regen_failure_stamp(tmp_path: Path) -> None:
+    """``regen_failed_mtime`` + ``regen_failed_at`` round-trip together.
+
+    Persisted so a backend restart skips replaying a regen on a
+    YAML that already failed at this exact mtime — without it,
+    every dashboard boot burns a subprocess on broken configs
+    (missing ``!secret``, unreachable git package) just to fail
+    again. The wall-clock half feeds the controller-side TTL so
+    transient external problems eventually get re-checked even
+    when the YAML is untouched.
+    """
+    set_device_metadata(
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=1700000000.5,
+        regen_failed_at=1700000005.0,
+    )
+
+    assert get_device_metadata(tmp_path, "kitchen.yaml") == {
+        "regen_failed_mtime": 1700000000.5,
+        "regen_failed_at": 1700000005.0,
+    }
+
+
+def test_set_device_metadata_clears_regen_failure_stamp_on_zero(tmp_path: Path) -> None:
+    """Both stamp halves cleared explicitly via ``0.0``.
+
+    The success path of ``_schedule_storage_regenerate`` clears
+    both fields so a future backend restart picks up the now-good
+    YAML. Passing ``0.0`` is the explicit clear path; ``None``
+    leaves the field alone.
+    """
+    set_device_metadata(
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=1700000000.5,
+        regen_failed_at=1700000005.0,
+    )
+    set_device_metadata(
+        tmp_path,
+        "kitchen.yaml",
+        regen_failed_mtime=0.0,
+        regen_failed_at=0.0,
+    )
+
+    md = get_device_metadata(tmp_path, "kitchen.yaml")
+    assert "regen_failed_mtime" not in md
+    assert "regen_failed_at" not in md
+
+
 def test_remove_device_metadata_clears_only_target(tmp_path: Path) -> None:
     """Removing one device's entry leaves siblings intact."""
     set_device_metadata(tmp_path, "a.yaml", board_id="esp32")


### PR DESCRIPTION
# What does this implement/fix?

Stops the dashboard from re-running `esphome compile --only-generate`
on the same broken config every time the backend restarts.

The in-memory `_regenerate_failed` set forgets everything on
restart. Combined with the ADDED scan-change handler that queues
a regen for any device with empty `loaded_integrations` or
`expected_config_hash` (both of which stay empty when the regen
keeps failing), a broken YAML — missing `!secret`, unreachable
git package, syntax error — burns one subprocess per dashboard
boot forever. The user-visible symptom is a stack trace per
broken file in `esphome.log` on every restart, with the dashboard
slow-starting while the spawns finish.

Persist a `(regen_failed_mtime, regen_failed_at)` pair to the
metadata sidecar on the failure paths. The next schedule call
reads them back and skips iff:

* the YAML's current `stat.st_mtime` equals the cached
  `regen_failed_mtime` — same file as last time, AND
* less than `_REGEN_FAILURE_TTL_SECONDS` (1h) has elapsed since
  `regen_failed_at` — recent enough that retrying would almost
  certainly fail the same way.

Either side releasing the guard retries: editing the YAML moves
the mtime forward, and the TTL elapsing covers transient external
causes (flaky git package server, DNS hiccup) where the user
shouldn't have to touch the file to recover. A successful regen
clears both halves.

The TTL constant lives at the top of
`controllers/devices/controller.py` next to `_LOGGER` so it's
easy to find and tune. Both fields are listed in
`_VOLATILE_DEVICE_METADATA_FIELDS` so archive scrubs them — a
future unarchive may put the YAML back at a different mtime,
which would make a stale stamp meaningless.

**Related issue or feature (if applicable):**

- fixes the "broken configs regen over and over every time we
  restart" report (no GitHub issue filed; raised in chat).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
