### PR TITLE
Address Copilot follow-ups on PR #343

### DIFF
--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -102,6 +102,21 @@ class BuildSizeRefresher:
         per-iteration ``except`` in the worker missed something —
         and gets logged so the failure isn't invisible during a
         clean controller shutdown.
+
+        A subtlety worth knowing: if the worker is mid-walk
+        inside ``loop.run_in_executor(None, ...)`` when ``stop()``
+        fires, cancelling the task only abandons the *await* — the
+        underlying executor thread keeps running until the walk
+        finishes (Python doesn't expose a way to interrupt a
+        running thread). For build-size refresh the work is just
+        a directory walk + one sidecar write per device, so the
+        thread completes on its own within a few seconds at
+        worst; the dashboard's eventual ``loop.shutdown_asyncgens()``
+        / ``loop.close()`` then waits on the default executor as
+        usual. We accept that over the alternative (a bespoke
+        cancellation channel into the walk), because process
+        shutdown is the only ``stop()`` caller and the residual
+        write is harmless.
         """
         if self._worker_task is None:
             return

--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -111,12 +111,12 @@ class BuildSizeRefresher:
         running thread). For build-size refresh the work is just
         a directory walk + one sidecar write per device, so the
         thread completes on its own within a few seconds at
-        worst; the dashboard's eventual ``loop.shutdown_asyncgens()``
-        / ``loop.close()`` then waits on the default executor as
-        usual. We accept that over the alternative (a bespoke
-        cancellation channel into the walk), because process
-        shutdown is the only ``stop()`` caller and the residual
-        write is harmless.
+        worst; ``DeviceBuilder.stop()`` then calls
+        ``loop.shutdown_default_executor()`` which waits on the
+        residual thread, so process shutdown still drains
+        cleanly. We accept this over a bespoke cancellation
+        channel into the walk, because process shutdown is the
+        only ``stop()`` caller and the trailing write is harmless.
         """
         if self._worker_task is None:
             return

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -213,10 +213,13 @@ def _load_full_metadata(config_dir: Path) -> dict[str, dict]:
     YAML filename; missing entries / wrong shapes return ``{}``
     so callers can treat them as "no cached data."
     """
-    # Import the private helper locally so this module does not
-    # eagerly bind ``_load_metadata`` at import time. Public
-    # helpers from ``controllers.config`` are already imported
-    # at module load time above.
+    # Local import flags this as an intentional reach into
+    # ``controllers.config``'s underscore-prefixed surface (so a
+    # future grep for ``_load_metadata`` finds the call site
+    # alongside the explanation). Module-level ``controllers.config``
+    # is already imported above for the public helpers, so this
+    # isn't a layering boundary — just a "yes, we know we're
+    # touching the private one, here's why" marker.
     from ..controllers.config import _load_metadata  # noqa: PLC0415
 
     try:

--- a/tests/controllers/test_build_size_refresher.py
+++ b/tests/controllers/test_build_size_refresher.py
@@ -151,9 +151,13 @@ async def test_worker_skips_callback_when_refresh_returns_none(tmp_path: Path) -
     loop = asyncio.get_running_loop()
 
     def _refresh(_config_dir: Path, _configuration: str):
-        # Hop back onto the loop so the event flips after the
-        # ``run_in_executor`` await returns to the worker — i.e.
-        # *after* the short-circuit branch runs.
+        # ``call_soon_threadsafe`` only guarantees the event
+        # gets scheduled to fire on the loop — the worker may
+        # not have resumed yet when ``refresh_done.wait()``
+        # returns. The follow-up ``await asyncio.sleep(0)``
+        # cedes control back to the worker so the
+        # ``if result is None: continue`` branch actually
+        # executes before ``stop()`` cancels.
         loop.call_soon_threadsafe(refresh_done.set)
 
     refresher, _ = _make(tmp_path, on_refreshed=_on_refreshed)

--- a/tests/controllers/test_build_size_refresher.py
+++ b/tests/controllers/test_build_size_refresher.py
@@ -134,28 +134,27 @@ async def test_worker_drains_pending_and_fires_on_refreshed(tmp_path: Path) -> N
 async def test_worker_skips_callback_when_refresh_returns_none(tmp_path: Path) -> None:
     """Refresh returning ``None`` (cache hit) → no ``on_refreshed`` invoke.
 
-    Sequences two requests: ``cached.yaml`` returns ``None`` from
-    the helper (cache hit, callback skipped), ``stale.yaml``
-    returns a real result that fires the callback. Waiting on the
-    second one's callback proves the worker took the
-    "continue past skipped callback" branch *and* came back
-    around to drain the next item — i.e. the cache-hit short-
-    circuit doesn't break the drain loop.
+    Single-request shape so the assertion isn't sensitive to
+    ``set.pop()`` ordering: a cache-hit refresh returns ``None``
+    and the worker has to take the ``if result is None:
+    continue`` branch *without* invoking the callback. A
+    ``refresh_done`` event fires after the executor returns, so
+    the test can drive ``stop()`` deterministically once the
+    short-circuit has actually been exercised.
     """
-    success = asyncio.Event()
     refreshed: list[str] = []
 
     async def _on_refreshed(configuration: str) -> None:
         refreshed.append(configuration)
-        success.set()
 
-    def _refresh(_config_dir: Path, configuration: str):
-        if configuration == "cached.yaml":
-            return None
-        return BuildSizeRefreshResult(
-            size_bytes=42,
-            signal=BuildDirSignal(dir_mtime=1, info_mtime=2),
-        )
+    refresh_done = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _refresh(_config_dir: Path, _configuration: str):
+        # Hop back onto the loop so the event flips after the
+        # ``run_in_executor`` await returns to the worker — i.e.
+        # *after* the short-circuit branch runs.
+        loop.call_soon_threadsafe(refresh_done.set)
 
     refresher, _ = _make(tmp_path, on_refreshed=_on_refreshed)
     with patch(
@@ -164,14 +163,16 @@ async def test_worker_skips_callback_when_refresh_returns_none(tmp_path: Path) -
     ):
         refresher.start()
         refresher.request("cached.yaml")
-        refresher.request("stale.yaml")
-        await asyncio.wait_for(success.wait(), timeout=_TIMEOUT)
+        await asyncio.wait_for(refresh_done.wait(), timeout=_TIMEOUT)
+        # Yield once so the worker actually executes the
+        # ``continue`` branch before stop() cancels it.
+        await asyncio.sleep(0)
         await refresher.stop()
 
-    # Only the stale device fired the callback — the cached one
-    # short-circuited at the ``if result is None: continue``
-    # branch.
-    assert refreshed == ["stale.yaml"]
+    # The cache-hit branch must short-circuit without firing the
+    # callback. A regression that drops the ``if result is None:
+    # continue`` guard would invoke ``on_refreshed`` here.
+    assert refreshed == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #343 (build-size cache + refresher). Addresses the
two Copilot review comments that landed after the PR merged plus
the 1-line patch-coverage gap codecov flagged on
`controllers/_build_size_refresher.py`.

* `_build_size_refresher.stop()` — Copilot pointed out that
  cancelling the worker task while it's mid-`run_in_executor`
  doesn't interrupt the executor thread. That behaviour is
  fine for our actual workload (a directory walk + one sidecar
  write per device, ≤ a few seconds at worst) but it isn't
  obvious from the code, so document the trade-off explicitly
  so a future reader doesn't assume `stop()` is synchronous
  with respect to the underlying walk.
* `helpers/build_size._load_full_metadata` — Copilot flagged
  that the previous comment claimed the local import was about
  keeping `controllers.config` out of this module's import
  surface, but the *public* helpers from that module are
  already imported at the top. Reword to call out the actual
  reason: it's a deliberate "yes, we're reaching into
  ``_load_metadata``'s private underscore-prefixed surface,
  here's why" marker.
* `tests/controllers/test_build_size_refresher.py` —
  `test_worker_skips_callback_when_refresh_returns_none` was
  non-deterministic (depended on `set.pop()` order). When the
  stale entry was popped first the test could stop the worker
  before the cache-hit entry got drained, leaving the
  `if result is None: continue` branch uncovered. Restructure
  to a single-request shape that drives `stop()` only after
  the short-circuit branch has actually been exercised — closes
  the patch-coverage gap.

**Related issue or feature (if applicable):**

- follow-up to #343

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
