### PR TITLE
Preserve last-known api_encryption when mDNS announcement omits the TXT

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -1171,10 +1171,28 @@ class DeviceStateMonitor:
             self.apply_config_hash(device_name, config_hash)
         if mac := props.get("mac"):
             self.apply_mac_address(device_name, mac)
-        # Always apply api_encryption — empty / missing TXT is itself
-        # a meaningful signal (device is broadcasting plaintext) and
-        # apply_api_encryption distinguishes it from "never seen".
-        self.apply_api_encryption(device_name, props.get("api_encryption") or "")
+        # Apply api_encryption ONLY when the TXT key is actually
+        # present in this announcement (value can be empty — that's
+        # the meaningful "device confirmed plaintext" signal). When
+        # the TXT key is absent we keep the device's current value
+        # as the last-known truth: a transient / fragmented mDNS
+        # re-announcement that omits the TXT used to overwrite a
+        # previously-truthy ``api_encryption_active`` with ``""``,
+        # flipping the dashboard's lock indicator to "mismatch" /
+        # "pending" and prompting the user to reinstall a device
+        # that was actually fine. Tri-state on the model side
+        # (``"…"`` / ``""`` / ``None``) already encodes
+        # "confirmed-encrypted / confirmed-plaintext / unknown"; the
+        # apply path was conflating "TXT absent in *this*
+        # announcement" with "TXT absent on the device", which is
+        # only true once we observe the absence directly. Older
+        # firmwares that never broadcast the TXT remain at the
+        # ``None`` initial — the frontend's ``getEncryptionState``
+        # falls back to the YAML's ``api_encrypted`` flag in that
+        # case, which is the right behaviour.
+        api_encryption = props.get("api_encryption")
+        if api_encryption is not None:
+            self.apply_api_encryption(device_name, api_encryption)
 
     async def _ping_loop(self) -> None:
         # First sweep after the short bootstrap window — gives mDNS a

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -164,13 +164,18 @@ VersionChangeCallback = Callable[[str, str], None]
 ConfigHashChangeCallback = Callable[[str, str], None]
 
 # Callback fired when the mDNS ``api_encryption`` TXT record reports a
-# different value than last seen. Empty string means the device's
-# service announcement was seen but the TXT was absent — i.e. the
-# device is broadcasting plaintext API. A non-empty value (e.g.
+# different value than last seen. Empty string means the TXT key was
+# *present in the announcement* with an empty value — i.e. the device
+# is explicitly broadcasting plaintext API. A non-empty value (e.g.
 # ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) confirms encryption is
-# live on the device. The "no mDNS seen yet" case never fires this
-# callback at all, so the device controller can keep that state as
-# ``None`` to mean "trust whatever the YAML says".
+# live on the device.
+#
+# The "no signal" case (mDNS seen but TXT key absent in this
+# announcement, or no mDNS seen at all) never fires this callback —
+# the apply path at ``_apply_service_info`` gates on the key being
+# present in ``props`` so a quiet re-announce doesn't clobber a
+# previously-confirmed value. The device controller keeps that state
+# as ``None`` to mean "trust whatever the YAML says".
 ApiEncryptionChangeCallback = Callable[[str, str], None]
 
 # Callback fired when the mDNS ``mac`` TXT record reports a different
@@ -681,13 +686,21 @@ class DeviceStateMonitor:
         """
         Record the device's broadcast API encryption status.
 
-        Empty string means the mDNS service was seen but the
-        ``api_encryption`` TXT was absent — i.e. the device is
-        running plaintext API. A non-empty value (e.g.
+        Empty string means the mDNS announcement explicitly carried
+        an empty ``api_encryption`` TXT — the device is confirming
+        plaintext API. A non-empty value (e.g.
         ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) confirms encryption
-        is active. The "never seen" case is represented by the
-        device's ``api_encryption_active`` staying ``None``; the
-        device controller treats that as "trust the YAML".
+        is active.
+
+        Callers must NOT translate "TXT key absent in this
+        announcement" into ``""`` — that conflates a transient quiet
+        re-announce with a real plaintext confirmation, which clobbers
+        the last-known truthy value and trips the frontend's
+        "reinstall to apply" prompt. ``_apply_service_info`` gates on
+        the TXT key being present in ``props`` so absence skips the
+        call entirely; the device's ``api_encryption_active`` stays
+        ``None`` (or whatever was last confirmed) until a real
+        observation lands.
 
         Returns True when the value actually changed and the change
         was forwarded to the callback.

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -484,17 +484,61 @@ async def test_dispatch_added_cache_hit_falls_back_to_v6_when_no_v4(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_added_with_empty_api_encryption_pushes_empty_string(
+async def test_dispatch_added_with_explicit_empty_api_encryption_pushes_empty_string(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Missing api_encryption TXT means plaintext; pushed as empty string.
+    """TXT key explicitly empty means plaintext-confirmed → pushed as empty string.
 
-    The empty-string-vs-None distinction matters: ``None`` means
-    "never seen", ``""`` means "service seen, no encryption
-    advertised → confirmed plaintext". The frontend keys colour-
-    coding off this tri-state.
+    The tri-state on the model side is ``"…"`` (encrypted) /
+    ``""`` (confirmed plaintext) / ``None`` (never observed). An
+    *explicit* empty TXT value is a real signal — the device is
+    advertising the key but with no value, which esphome emits when
+    encryption is genuinely off in the running firmware. Pin that
+    we still hand that down to ``apply_api_encryption``.
     """
     device = _device(api_encryption_active=None)
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    fake_info.decoded_properties = {"api_encryption": ""}
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.api_encryption_active == ""
+    finally:
+        await _stop_and_drain(monitor)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_without_api_encryption_txt_preserves_last_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT key absent in the announcement → current value is preserved.
+
+    Regression test for the "switching to ping clears
+    ``api_encryption`` and the dashboard prompts to reinstall" bug.
+    The two states ``""`` (TXT explicitly empty — plaintext
+    confirmed) and ``None`` (TXT key absent in *this* announcement)
+    used to collapse to the same applied ``""`` via
+    ``props.get("api_encryption") or ""``, so a transient /
+    fragmented re-announcement that omitted the TXT silently
+    overwrote a previously-truthy value with ``""`` and flipped the
+    frontend's lock indicator to "mismatch" / "pending → reinstall".
+
+    Now: TXT absent is treated as "no signal in this announcement",
+    and the device's last-known value (``"Noise…"`` here) survives.
+    """
+    truthy = "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+    device = _device(api_encryption_active=truthy)
     monitor, _callbacks = _make_monitor([device])
 
     fake_info = MagicMock()
@@ -511,7 +555,43 @@ async def test_dispatch_added_with_empty_api_encryption_pushes_empty_string(
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
         )
-        assert device.api_encryption_active == ""
+        # Truthy survives.
+        assert device.api_encryption_active == truthy
+    finally:
+        await _stop_and_drain(monitor)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT key absent + device starts at ``None`` → stays at ``None``.
+
+    Older firmwares that never broadcast the TXT (pre-encryption-TXT
+    rollout) leave the device at the ``None`` initial — the
+    frontend's ``getEncryptionState`` falls back to the YAML's
+    ``api_encrypted`` flag in that case, which is the right
+    behaviour for a device whose actual encryption state is
+    genuinely unknowable from mDNS alone.
+    """
+    device = _device(api_encryption_active=None)
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    fake_info.decoded_properties = {}
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.api_encryption_active is None
     finally:
         await _stop_and_drain(monitor)
 


### PR DESCRIPTION
# What does this implement/fix?

Stops mDNS announcements that omit the `api_encryption` TXT
from clearing a previously-confirmed encryption value, which
was prompting the user to "reinstall the firmware to apply" on
a device that was actually fine.

`_apply_service_info` collapsed two distinct mDNS observations
into one applied value:

```python
self.apply_api_encryption(device_name, props.get("api_encryption") or "")
```

- **TXT key present, value `"Noise_NNpsk0_25519_ChaChaPoly_SHA256"`** → encrypted, push truthy ✅
- **TXT key present, value `""`** → device confirmed plaintext, push `""` ✅
- **TXT key absent in *this* announcement** → no signal yet… but `props.get(...) or ""` collapsed it to push `""` 🚨

The model already encodes the tri-state (`"…"` / `""` / `None`),
and the apply path is supposed to be the seam that distinguishes
them. The `or ""` defaulted "absent" to "plaintext confirmed",
which is only true once we observe absence directly — not
because a single re-announcement happened to drop the TXT
(cache churn, MTU fragmentation, source flipping mDNS → ping,
post-OTA propagation, …).

When this fired against a device whose `api_encryption_active`
had previously been a truthy `Noise_…`, the frontend's
`getEncryptionState` flipped from `"active"` → `"mismatch"` (or
`"pending"` when `has_pending_changes` was set) and the
dashboard's lock indicator told the user to reinstall.

The fix treats TXT-key-absent as "no signal in this
announcement" and preserves the last-known value. Apply only
when the TXT key is actually present (the value can still be
`""` — that's the legitimate "plaintext confirmed" signal):

```python
api_encryption = props.get("api_encryption")
if api_encryption is not None:
    self.apply_api_encryption(device_name, api_encryption)
```

| Current `api_encryption_active` | TXT in announcement | Old behaviour | New behaviour |
|---|---|---|---|
| `None` (unknown) | absent | overwritten to `""` (claimed plaintext) | stays `None` (frontend trusts YAML) |
| `"Noise_…"` (encrypted) | absent | **overwritten to `""` (the bug)** | **stays `"Noise_…"`** ✅ |
| anything | `""` (explicit) | applies `""` | applies `""` |
| anything | `"Noise_…"` (truthy) | applies truthy | applies truthy |

Older firmwares that never broadcast the TXT stay at the `None`
initial; the frontend's `getEncryptionState` already falls back
to the YAML's `api_encrypted` flag in that case.

**Related issue or feature (if applicable):**

- fixes the "lock indicator says reinstall after a quiet
  re-announce" report (no GitHub issue filed; reported in
  chat).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
