### PR TITLE
Consume schema-author visibility hints + cascade strictness through nested groups

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -579,14 +579,28 @@ _DOC_PREFIX_TYPES: dict[str, str] = {
 # ``"5min"``, ``"1h30s"``. This regex matches that shape.
 _TIME_PERIOD_DEFAULT = re.compile(r"^\d+(\.\d+)?\s*(ms|us|ns|s|min|h|d)(\d+\s*\w+)*$")
 
-# On-the-wire spelling of the schema's UI-hint enum (mirrors
-# upstream esphome's ``cv.Visibility`` ``StrEnum`` values from
-# esphome/esphome#16267). The dumper emits these strings; the
-# catalog consumer compares against them. Two-tier strictness:
-# ``YAML_ONLY`` is strictly stronger than ``ADVANCED``, which is
-# strictly stronger than no setting at all.
-_VISIBILITY_ADVANCED = "advanced"
-_VISIBILITY_YAML_ONLY = "yaml_only"
+
+class Visibility(StrEnum):
+    """Consumer-side mirror of upstream esphome's ``cv.Visibility``.
+
+    Upstream (esphome/esphome#16267, 2026.5.0b1) models the
+    schema-author UI hint as a ``StrEnum`` and dumps the string
+    form (``"advanced"`` / ``"yaml_only"``) onto each field. The
+    key is absent when the author didn't mark the field. Mirror
+    that as a ``StrEnum`` here so the consumer compares against
+    a typed value rather than bare string literals; the enum
+    member's string value is what the dumper emits, so
+    ``raw["visibility"] == Visibility.ADVANCED`` works directly.
+
+    Two-tier strictness ordering: ``YAML_ONLY`` is strictly
+    stronger than ``ADVANCED``, which is strictly stronger than
+    no setting at all. The cascade pass below relies on that
+    ordering.
+    """
+
+    ADVANCED = "advanced"
+    YAML_ONLY = "yaml_only"
+
 
 # Base entity / framework fields that always render under "Advanced" by
 # default — valid but rarely tweaked. Same set as the previous sync.
@@ -1925,10 +1939,10 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
     # pass walks the resulting tree and pushes parent strictness
     # down where descendants would otherwise be more visible.
     schema_visibility = raw.get("visibility")
-    advanced = schema_visibility == _VISIBILITY_ADVANCED or _classify_advanced(
+    advanced = schema_visibility == Visibility.ADVANCED or _classify_advanced(
         key, required=required, is_structural=is_structural
     )
-    yaml_only = schema_visibility == _VISIBILITY_YAML_ONLY
+    yaml_only = schema_visibility == Visibility.YAML_ONLY
 
     default_value, gated_component = _extract_default(raw, key=key)
     entry: dict[str, Any] = {

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -579,6 +579,15 @@ _DOC_PREFIX_TYPES: dict[str, str] = {
 # ``"5min"``, ``"1h30s"``. This regex matches that shape.
 _TIME_PERIOD_DEFAULT = re.compile(r"^\d+(\.\d+)?\s*(ms|us|ns|s|min|h|d)(\d+\s*\w+)*$")
 
+# On-the-wire spelling of the schema's UI-hint enum (mirrors
+# upstream esphome's ``cv.Visibility`` ``StrEnum`` values from
+# esphome/esphome#16267). The dumper emits these strings; the
+# catalog consumer compares against them. Two-tier strictness:
+# ``YAML_ONLY`` is strictly stronger than ``ADVANCED``, which is
+# strictly stronger than no setting at all.
+_VISIBILITY_ADVANCED = "advanced"
+_VISIBILITY_YAML_ONLY = "yaml_only"
+
 # Base entity / framework fields that always render under "Advanced" by
 # default — valid but rarely tweaked. Same set as the previous sync.
 _ADVANCED_BASE_KEYS: frozenset[str] = frozenset(
@@ -1647,7 +1656,60 @@ def _extract_config_entries(
     schema = config_schema.get("schema") or {}
     if not schema:
         return []
-    return _convert_config_vars(schema, schema_dir, component_id=component_id)
+    entries = _convert_config_vars(schema, schema_dir, component_id=component_id)
+    # Apply the visibility-cascade rule once at the top of the
+    # tree: a stricter parent forces all descendants at-least
+    # as strict. ``YAML_ONLY`` > ``ADVANCED`` > no setting. The
+    # cascade is at-the-top so nested-NESTED structures get the
+    # full chain of ancestors considered without recursive
+    # bookkeeping inside ``_convert_field``.
+    _apply_visibility_cascade(entries, parent_advanced=False, parent_yaml_only=False)
+    return entries
+
+
+def _apply_visibility_cascade(
+    entries: list[dict],
+    *,
+    parent_advanced: bool,
+    parent_yaml_only: bool,
+) -> None:
+    """In-place push parent strictness onto descendants.
+
+    ``YAML_ONLY`` (mapped to ``hidden=True``) is strictly stronger
+    than ``ADVANCED`` (``advanced=True``), which is strictly
+    stronger than the un-marked default. A child can declare its
+    own setting independently — but the child's *effective*
+    setting after this pass is ``max(parent_chain, self)``.
+
+    The rationale is UX: if a parent block is "advanced", every
+    field inside it is at-least advanced (otherwise the disclosure
+    is leaky — you'd hide the parent header but render a child on
+    the main form). Same one level deeper for ``YAML_ONLY`` — a
+    block hidden from the editor must hide every descendant or
+    the user gets a half-rendered control with no way to set the
+    surrounding context.
+    """
+    for entry in entries:
+        own_advanced = entry.get("advanced", False)
+        own_hidden = entry.get("hidden", False)
+        # Strictness ordering: ``YAML_ONLY`` (``hidden=True``) is
+        # strictly stronger than ``ADVANCED`` (``advanced=True``).
+        # Apply that locally first — a self-hidden entry is also
+        # implicitly advanced — then OR with the parent's
+        # strictness so the cascade pushes both flags down.
+        entry["advanced"] = own_advanced or own_hidden or parent_advanced or parent_yaml_only
+        entry["hidden"] = own_hidden or parent_yaml_only
+        # Recurse into NESTED groups, MAP value templates, and any
+        # other shape that carries inner ``config_entries``. The
+        # child's effective state becomes the parent state for the
+        # next level.
+        inner = entry.get("config_entries")
+        if isinstance(inner, list):
+            _apply_visibility_cascade(
+                inner,
+                parent_advanced=entry["advanced"],
+                parent_yaml_only=entry["hidden"],
+            )
 
 
 def _convert_config_vars(
@@ -1847,29 +1909,26 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
     # form even when optional — users almost always want to see what's
     # wired to what.
     is_structural = entry_type == "pin" or bool(references)
-    # Schema-author UI hints from upstream esphome
-    # (esphome/esphome#16267): when the key is *present* on the raw
-    # dict, the schema's value wins over the name-based heuristic —
-    # the field author marked it explicitly, so respect that even if
-    # they marked it ``False`` to override a heuristic that would
-    # otherwise flip it on. The heuristic stays as the fallback for
-    # the long tail of fields the schema doesn't yet annotate; as
-    # more fields opt in upstream, the heuristic rules out of
-    # ``_classify_advanced`` can shrink toward zero.
+    # Schema-author UI hint from upstream esphome
+    # (esphome/esphome#16267): the dumper emits ``"visibility":
+    # "advanced" | "yaml_only"`` for fields whose ``cv.Optional`` /
+    # ``cv.Required`` set ``visibility=Visibility.ADVANCED`` or
+    # ``=Visibility.YAML_ONLY``. Absent → fall back to the name-based
+    # heuristic (the long tail of fields the schema doesn't yet
+    # annotate; as upstream adoption grows the heuristic rules out
+    # of ``_classify_advanced`` can shrink toward zero).
     #
-    # Today the dumper only emits the keys when ``True`` (a
-    # backwards-compat optimisation — absent keys preserve the old
-    # consumer behaviour). Keying off ``in raw`` instead of
-    # truthiness keeps that contract clean: when the upstream
-    # dumper one day emits ``advanced: false`` to express "schema
-    # author explicitly opted out of the advanced section", the
-    # consumer already does the right thing without a follow-up
-    # change here.
-    if "advanced" in raw:
-        advanced = bool(raw["advanced"])
-    else:
-        advanced = _classify_advanced(key, required=required, is_structural=is_structural)
-    yaml_only = bool(raw.get("yaml_only"))
+    # The cascade rule (a stricter parent forces its descendants
+    # at-least as strict) is applied after leaf conversion by
+    # :func:`_apply_visibility_cascade`. This function records the
+    # per-field setting as the schema author wrote it; the cascade
+    # pass walks the resulting tree and pushes parent strictness
+    # down where descendants would otherwise be more visible.
+    schema_visibility = raw.get("visibility")
+    advanced = schema_visibility == _VISIBILITY_ADVANCED or _classify_advanced(
+        key, required=required, is_structural=is_structural
+    )
+    yaml_only = schema_visibility == _VISIBILITY_YAML_ONLY
 
     default_value, gated_component = _extract_default(raw, key=key)
     entry: dict[str, Any] = {

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1848,17 +1848,28 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
     # wired to what.
     is_structural = entry_type == "pin" or bool(references)
     # Schema-author UI hints from upstream esphome
-    # (esphome/esphome#16267): when present, an explicit
-    # ``advanced`` / ``yaml_only`` on the schema entry wins over the
-    # name-based heuristic. The heuristic stays as the fallback for
+    # (esphome/esphome#16267): when the key is *present* on the raw
+    # dict, the schema's value wins over the name-based heuristic —
+    # the field author marked it explicitly, so respect that even if
+    # they marked it ``False`` to override a heuristic that would
+    # otherwise flip it on. The heuristic stays as the fallback for
     # the long tail of fields the schema doesn't yet annotate; as
     # more fields opt in upstream, the heuristic rules out of
     # ``_classify_advanced`` can shrink toward zero.
-    schema_advanced = bool(raw.get("advanced"))
+    #
+    # Today the dumper only emits the keys when ``True`` (a
+    # backwards-compat optimisation — absent keys preserve the old
+    # consumer behaviour). Keying off ``in raw`` instead of
+    # truthiness keeps that contract clean: when the upstream
+    # dumper one day emits ``advanced: false`` to express "schema
+    # author explicitly opted out of the advanced section", the
+    # consumer already does the right thing without a follow-up
+    # change here.
+    if "advanced" in raw:
+        advanced = bool(raw["advanced"])
+    else:
+        advanced = _classify_advanced(key, required=required, is_structural=is_structural)
     yaml_only = bool(raw.get("yaml_only"))
-    advanced = schema_advanced or _classify_advanced(
-        key, required=required, is_structural=is_structural
-    )
 
     default_value, gated_component = _extract_default(raw, key=key)
     entry: dict[str, Any] = {

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1847,7 +1847,18 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
     # form even when optional — users almost always want to see what's
     # wired to what.
     is_structural = entry_type == "pin" or bool(references)
-    advanced = _classify_advanced(key, required=required, is_structural=is_structural)
+    # Schema-author UI hints from upstream esphome
+    # (esphome/esphome#16267): when present, an explicit
+    # ``advanced`` / ``yaml_only`` on the schema entry wins over the
+    # name-based heuristic. The heuristic stays as the fallback for
+    # the long tail of fields the schema doesn't yet annotate; as
+    # more fields opt in upstream, the heuristic rules out of
+    # ``_classify_advanced`` can shrink toward zero.
+    schema_advanced = bool(raw.get("advanced"))
+    yaml_only = bool(raw.get("yaml_only"))
+    advanced = schema_advanced or _classify_advanced(
+        key, required=required, is_structural=is_structural
+    )
 
     default_value, gated_component = _extract_default(raw, key=key)
     entry: dict[str, Any] = {
@@ -1871,7 +1882,11 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
         "pin_features": _resolve_pin_features(raw) if entry_type == "pin" else [],
         "pin_mode": None,
         "advanced": advanced,
-        "hidden": False,
+        # ``yaml_only`` from the schema → ``hidden`` on the catalog
+        # entry. The frontend already knows how to skip ``hidden``
+        # entries; the rename keeps the consumer-facing surface
+        # unchanged.
+        "hidden": yaml_only,
         "help_link": docs.url,
         "translation_key": None,
         "translation_params": None,

--- a/tests/test_sync_components_ui_hints.py
+++ b/tests/test_sync_components_ui_hints.py
@@ -1,20 +1,22 @@
-"""Unit tests for the schema-author UI-hint passthrough in ``_convert_field``.
+"""Unit tests for the schema-author UI-hint passthrough + cascade.
 
-Pairs with esphome/esphome#16267, which adds ``advanced`` /
-``yaml_only`` kwargs to ``cv.Optional`` / ``cv.Required`` so the
-field author can mark a config_var's UI treatment in the schema
-itself. The dumper emits those flags onto the per-field dict in the
-schema bundle; ``_convert_field`` is the consumer that maps them
-onto the catalog's ``advanced`` / ``hidden`` fields.
+Pairs with esphome/esphome#16267, which adds a ``visibility``
+kwarg (``cv.Visibility`` ``StrEnum``) to ``cv.Optional`` /
+``cv.Required`` so the field author can mark a config_var's UI
+treatment in the schema itself. The dumper emits the str form
+(``"advanced"`` / ``"yaml_only"``) onto the per-field dict in
+the schema bundle.
 
-These tests pin three behavioural invariants:
+This module pins three behavioural invariants:
 
-1. The schema's value wins over the name-based heuristic when the
-   key is *present* on the raw dict (even when the schema marks
-   the field ``False`` to override a heuristic that would otherwise
-   flip it on).
-2. The heuristic is the fallback when the schema doesn't carry the
-   key at all.
+1. The schema's ``visibility`` value drives the catalog entry's
+   ``advanced`` / ``hidden`` flags directly when present; the
+   name-based heuristic is the fallback.
+2. The cascade rule: a stricter parent forces its descendants
+   at-least as strict (``YAML_ONLY`` > ``ADVANCED`` > unset). The
+   schema marker is per-field as the author wrote it; the
+   catalog generator computes the effective value when it walks
+   the tree.
 3. ``yaml_only`` maps cleanly onto the catalog's existing
    ``hidden`` field — no rename, no consumer-facing surface change.
 """
@@ -23,7 +25,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from script.sync_components import _convert_field  # type: ignore[import-not-found]
+from script.sync_components import (  # type: ignore[import-not-found]
+    _apply_visibility_cascade,
+    _convert_field,
+)
 
 # ``_convert_field`` only touches ``schema_dir`` for nested
 # ``extends`` resolution, which the leaf-field cases below don't
@@ -40,35 +45,29 @@ def _leaf(**raw: object) -> dict:
     }
 
 
-def test_schema_advanced_true_wins_over_heuristic_false() -> None:
-    """Schema ``advanced=True`` flips a heuristic-False field to advanced.
+def test_schema_visibility_advanced_wins_over_heuristic_false() -> None:
+    """``visibility: "advanced"`` flips a heuristic-False field to advanced.
 
     ``name`` is in ``_IMPORTANT_KEYS`` so the heuristic returns
     False; the schema flag flips it to True.
     """
-    entry = _convert_field("name", _leaf(advanced=True), _SCHEMA_DIR)
+    entry = _convert_field("name", _leaf(visibility="advanced"), _SCHEMA_DIR)
     assert entry is not None
     assert entry["advanced"] is True
+    assert entry["hidden"] is False
 
 
-def test_schema_advanced_false_overrides_heuristic_true() -> None:
-    """Schema ``advanced=False`` overrides a heuristic-True field.
-
-    ``setup_priority`` would normally be advanced via the heuristic
-    (it's in ``_ADVANCED_BASE_KEYS``); explicit ``advanced=False``
-    on the schema must override that.
-
-    Today the upstream dumper only emits the key when ``True``, but
-    pinning the override-on-False semantics now keeps the consumer
-    forward-compatible with a future dumper that emits both
-    polarities.
-    """
-    entry = _convert_field("setup_priority", _leaf(advanced=False), _SCHEMA_DIR)
+def test_schema_visibility_yaml_only_sets_hidden() -> None:
+    """``visibility: "yaml_only"`` sets the catalog's ``hidden`` flag."""
+    entry = _convert_field("foo", _leaf(visibility="yaml_only"), _SCHEMA_DIR)
     assert entry is not None
-    assert entry["advanced"] is False
+    assert entry["hidden"] is True
+    # ``advanced`` from the heuristic isn't relevant when ``hidden``
+    # is set — the frontend skips the entry entirely. Don't pin it
+    # here; let the heuristic decide.
 
 
-def test_no_schema_flag_falls_back_to_heuristic() -> None:
+def test_no_visibility_falls_back_to_heuristic() -> None:
     """Without the schema flag, the heuristic decides ``advanced``.
 
     ``setup_priority`` has the heuristic-derived ``True``;
@@ -77,59 +76,197 @@ def test_no_schema_flag_falls_back_to_heuristic() -> None:
     advanced_entry = _convert_field("setup_priority", _leaf(), _SCHEMA_DIR)
     assert advanced_entry is not None
     assert advanced_entry["advanced"] is True
+    assert advanced_entry["hidden"] is False
 
     name_entry = _convert_field("name", _leaf(), _SCHEMA_DIR)
     assert name_entry is not None
     assert name_entry["advanced"] is False
+    assert name_entry["hidden"] is False
 
 
-def test_yaml_only_maps_to_hidden() -> None:
-    """Schema ``yaml_only=True`` sets the catalog's ``hidden=True``.
+def test_unrecognised_visibility_string_falls_back_to_heuristic() -> None:
+    """An unknown ``visibility`` value falls back to the heuristic.
 
-    The frontend already filters ``hidden`` entries (via
-    ``isEntryVisible``), so the schema concept piggybacks on that
-    surface — no consumer rename needed.
+    Future-compatibility: if upstream adds a third visibility level
+    (e.g. ``"deprecated"``) the field doesn't silently disappear
+    from the form. Neither ``advanced`` nor ``hidden`` flips on
+    speculatively; the heuristic still applies.
     """
-    entry = _convert_field("foo", _leaf(yaml_only=True), _SCHEMA_DIR)
+    entry = _convert_field("name", _leaf(visibility="someday-new-value"), _SCHEMA_DIR)
     assert entry is not None
-    assert entry["hidden"] is True
-
-
-def test_yaml_only_default_false_when_absent() -> None:
-    """A field without ``yaml_only`` on the schema gets ``hidden: False``."""
-    entry = _convert_field("foo", _leaf(), _SCHEMA_DIR)
-    assert entry is not None
+    assert entry["advanced"] is False
     assert entry["hidden"] is False
 
 
-def test_advanced_and_yaml_only_are_independent() -> None:
-    """Both flags can be set on the same field, independently.
+# ---------------------------------------------------------------------------
+# Cascade rule
+# ---------------------------------------------------------------------------
 
-    ``advanced=True`` AND ``hidden=True`` is a legal combination
-    (a sensible consumer treats ``hidden`` as "skip" regardless of
-    ``advanced``, but the catalog passes both through faithfully).
+
+def _entry(
+    key: str, *, advanced: bool = False, hidden: bool = False, inner: list | None = None
+) -> dict:
+    """Minimal catalog-entry shape for the cascade pass."""
+    e: dict = {"key": key, "advanced": advanced, "hidden": hidden}
+    if inner is not None:
+        e["config_entries"] = inner
+    return e
+
+
+def test_cascade_parent_advanced_pushes_to_unset_children() -> None:
+    """An ``ADVANCED`` parent makes every un-marked descendant ``ADVANCED``.
+
+    Without the cascade an ``advanced`` parent would render under
+    a disclosure but its inner fields would surface on the main
+    form — leaky disclosure UX.
     """
-    entry = _convert_field("foo", _leaf(advanced=True, yaml_only=True), _SCHEMA_DIR)
-    assert entry is not None
-    assert entry["advanced"] is True
-    assert entry["hidden"] is True
+    entries = [
+        _entry(
+            "parent",
+            advanced=True,
+            inner=[
+                _entry("child_a"),
+                _entry("child_b"),
+            ],
+        ),
+    ]
+    _apply_visibility_cascade(entries, parent_advanced=False, parent_yaml_only=False)
+    inner = entries[0]["config_entries"]
+    assert entries[0]["advanced"] is True
+    assert inner[0]["advanced"] is True
+    assert inner[1]["advanced"] is True
+    # No ``YAML_ONLY`` anywhere → ``hidden`` stays False.
+    assert all(e["hidden"] is False for e in [entries[0], *inner])
 
 
-def test_advanced_explicit_false_with_yaml_only_true() -> None:
-    """``yaml_only`` doesn't imply ``advanced`` — they're distinct dimensions.
+def test_cascade_yaml_only_parent_hides_all_descendants() -> None:
+    """A ``YAML_ONLY`` parent hides every descendant.
 
-    A consumer must not infer ``advanced=True`` from
-    ``yaml_only=True``: the schema's explicit ``advanced=False``
-    overrides the heuristic for ``setup_priority`` (which would
-    otherwise say True).
+    A block the user shouldn't edit through a UI must take its
+    children with it — otherwise the form renders an unrooted
+    control with no surrounding context to interpret it.
     """
-    entry = _convert_field(
-        "setup_priority",
-        _leaf(advanced=False, yaml_only=True),
-        _SCHEMA_DIR,
-    )
-    assert entry is not None
-    # advanced honours the schema's explicit False even though the
-    # heuristic for ``setup_priority`` would say True.
-    assert entry["advanced"] is False
-    assert entry["hidden"] is True
+    entries = [
+        _entry(
+            "parent",
+            hidden=True,
+            inner=[
+                _entry("child_a"),
+                _entry("child_b", advanced=True),
+            ],
+        ),
+    ]
+    _apply_visibility_cascade(entries, parent_advanced=False, parent_yaml_only=False)
+    inner = entries[0]["config_entries"]
+    # ``hidden`` cascades into both children regardless of what
+    # they originally said.
+    assert entries[0]["hidden"] is True
+    assert inner[0]["hidden"] is True
+    assert inner[1]["hidden"] is True
+    # And ``advanced`` is also forced True under a hidden parent —
+    # ``YAML_ONLY`` is strictly stronger than ``ADVANCED``.
+    assert all(e["advanced"] is True for e in [entries[0], *inner])
+
+
+def test_cascade_inner_yaml_only_under_advanced_parent() -> None:
+    """A child marked ``YAML_ONLY`` keeps its hidden status under an ``ADVANCED`` parent.
+
+    The cascade is monotonically-non-decreasing in strictness:
+    children can be stricter than their parent (the child's own
+    ``hidden=True`` survives), but never less strict (the parent's
+    ``advanced=True`` is pushed onto sibling children).
+    """
+    entries = [
+        _entry(
+            "parent",
+            advanced=True,
+            inner=[
+                _entry("child_unmarked"),
+                _entry("child_yaml_only", hidden=True),
+            ],
+        ),
+    ]
+    _apply_visibility_cascade(entries, parent_advanced=False, parent_yaml_only=False)
+    inner = entries[0]["config_entries"]
+    # Parent stays ``advanced``.
+    assert entries[0]["advanced"] is True
+    assert entries[0]["hidden"] is False
+    # Sibling without its own setting picks up the parent's
+    # ``advanced``.
+    assert inner[0]["advanced"] is True
+    assert inner[0]["hidden"] is False
+    # ``YAML_ONLY`` child stays hidden — and its ``advanced`` is
+    # also True (every yaml-only field is also advanced by the
+    # strictness ordering).
+    assert inner[1]["advanced"] is True
+    assert inner[1]["hidden"] is True
+
+
+def test_cascade_recurses_through_multiple_levels() -> None:
+    """The cascade walks all the way down nested groups.
+
+    Three-level structure: parent (advanced) → middle (unset) →
+    leaf (unset). The leaf must end up advanced because its
+    grandparent is.
+    """
+    entries = [
+        _entry(
+            "grandparent",
+            advanced=True,
+            inner=[
+                _entry(
+                    "parent",
+                    inner=[
+                        _entry("leaf"),
+                    ],
+                ),
+            ],
+        ),
+    ]
+    _apply_visibility_cascade(entries, parent_advanced=False, parent_yaml_only=False)
+    parent = entries[0]["config_entries"][0]
+    leaf = parent["config_entries"][0]
+    assert entries[0]["advanced"] is True
+    assert parent["advanced"] is True
+    assert leaf["advanced"] is True
+
+
+def test_cascade_no_op_when_no_strict_parent() -> None:
+    """A tree with no strict markers stays as the heuristic decided.
+
+    The cascade only ever flips flags from False to True; it
+    never flips True to False. A baseline tree should round-trip
+    through the cascade unchanged.
+    """
+    entries = [
+        _entry("a", advanced=False),
+        _entry("b", advanced=True),
+        _entry(
+            "c",
+            advanced=False,
+            inner=[_entry("c1", advanced=True)],
+        ),
+    ]
+    _apply_visibility_cascade(entries, parent_advanced=False, parent_yaml_only=False)
+    assert entries[0]["advanced"] is False
+    assert entries[1]["advanced"] is True
+    assert entries[2]["advanced"] is False
+    assert entries[2]["config_entries"][0]["advanced"] is True
+    assert all(e["hidden"] is False for e in entries)
+
+
+def test_cascade_non_list_inner_is_skipped() -> None:
+    """``config_entries: None`` is tolerated without traversal.
+
+    Some catalog entry shapes carry an explicit ``None`` for the
+    nested list (NESTED-but-empty groups); the cascade must skip
+    those rather than crashing on attribute access.
+    """
+    entries = [
+        _entry("a", advanced=True),
+    ]
+    # Add the ``config_entries`` key as None — the catalog uses
+    # this for nested-but-empty groups.
+    entries[0]["config_entries"] = None
+    _apply_visibility_cascade(entries, parent_advanced=False, parent_yaml_only=False)
+    assert entries[0]["advanced"] is True

--- a/tests/test_sync_components_ui_hints.py
+++ b/tests/test_sync_components_ui_hints.py
@@ -1,0 +1,135 @@
+"""Unit tests for the schema-author UI-hint passthrough in ``_convert_field``.
+
+Pairs with esphome/esphome#16267, which adds ``advanced`` /
+``yaml_only`` kwargs to ``cv.Optional`` / ``cv.Required`` so the
+field author can mark a config_var's UI treatment in the schema
+itself. The dumper emits those flags onto the per-field dict in the
+schema bundle; ``_convert_field`` is the consumer that maps them
+onto the catalog's ``advanced`` / ``hidden`` fields.
+
+These tests pin three behavioural invariants:
+
+1. The schema's value wins over the name-based heuristic when the
+   key is *present* on the raw dict (even when the schema marks
+   the field ``False`` to override a heuristic that would otherwise
+   flip it on).
+2. The heuristic is the fallback when the schema doesn't carry the
+   key at all.
+3. ``yaml_only`` maps cleanly onto the catalog's existing
+   ``hidden`` field — no rename, no consumer-facing surface change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from script.sync_components import _convert_field  # type: ignore[import-not-found]
+
+# ``_convert_field`` only touches ``schema_dir`` for nested
+# ``extends`` resolution, which the leaf-field cases below don't
+# trigger. ``Path("/")`` is fine for these tests.
+_SCHEMA_DIR = Path("/")
+
+
+def _leaf(**raw: object) -> dict:
+    """Build a minimal raw schema dict for a string-typed Optional leaf."""
+    return {
+        "key": "Optional",
+        "type": "string",
+        **raw,
+    }
+
+
+def test_schema_advanced_true_wins_over_heuristic_false() -> None:
+    """Schema ``advanced=True`` flips a heuristic-False field to advanced.
+
+    ``name`` is in ``_IMPORTANT_KEYS`` so the heuristic returns
+    False; the schema flag flips it to True.
+    """
+    entry = _convert_field("name", _leaf(advanced=True), _SCHEMA_DIR)
+    assert entry is not None
+    assert entry["advanced"] is True
+
+
+def test_schema_advanced_false_overrides_heuristic_true() -> None:
+    """Schema ``advanced=False`` overrides a heuristic-True field.
+
+    ``setup_priority`` would normally be advanced via the heuristic
+    (it's in ``_ADVANCED_BASE_KEYS``); explicit ``advanced=False``
+    on the schema must override that.
+
+    Today the upstream dumper only emits the key when ``True``, but
+    pinning the override-on-False semantics now keeps the consumer
+    forward-compatible with a future dumper that emits both
+    polarities.
+    """
+    entry = _convert_field("setup_priority", _leaf(advanced=False), _SCHEMA_DIR)
+    assert entry is not None
+    assert entry["advanced"] is False
+
+
+def test_no_schema_flag_falls_back_to_heuristic() -> None:
+    """Without the schema flag, the heuristic decides ``advanced``.
+
+    ``setup_priority`` has the heuristic-derived ``True``;
+    ``name`` has ``False``.
+    """
+    advanced_entry = _convert_field("setup_priority", _leaf(), _SCHEMA_DIR)
+    assert advanced_entry is not None
+    assert advanced_entry["advanced"] is True
+
+    name_entry = _convert_field("name", _leaf(), _SCHEMA_DIR)
+    assert name_entry is not None
+    assert name_entry["advanced"] is False
+
+
+def test_yaml_only_maps_to_hidden() -> None:
+    """Schema ``yaml_only=True`` sets the catalog's ``hidden=True``.
+
+    The frontend already filters ``hidden`` entries (via
+    ``isEntryVisible``), so the schema concept piggybacks on that
+    surface — no consumer rename needed.
+    """
+    entry = _convert_field("foo", _leaf(yaml_only=True), _SCHEMA_DIR)
+    assert entry is not None
+    assert entry["hidden"] is True
+
+
+def test_yaml_only_default_false_when_absent() -> None:
+    """A field without ``yaml_only`` on the schema gets ``hidden: False``."""
+    entry = _convert_field("foo", _leaf(), _SCHEMA_DIR)
+    assert entry is not None
+    assert entry["hidden"] is False
+
+
+def test_advanced_and_yaml_only_are_independent() -> None:
+    """Both flags can be set on the same field, independently.
+
+    ``advanced=True`` AND ``hidden=True`` is a legal combination
+    (a sensible consumer treats ``hidden`` as "skip" regardless of
+    ``advanced``, but the catalog passes both through faithfully).
+    """
+    entry = _convert_field("foo", _leaf(advanced=True, yaml_only=True), _SCHEMA_DIR)
+    assert entry is not None
+    assert entry["advanced"] is True
+    assert entry["hidden"] is True
+
+
+def test_advanced_explicit_false_with_yaml_only_true() -> None:
+    """``yaml_only`` doesn't imply ``advanced`` — they're distinct dimensions.
+
+    A consumer must not infer ``advanced=True`` from
+    ``yaml_only=True``: the schema's explicit ``advanced=False``
+    overrides the heuristic for ``setup_priority`` (which would
+    otherwise say True).
+    """
+    entry = _convert_field(
+        "setup_priority",
+        _leaf(advanced=False, yaml_only=True),
+        _SCHEMA_DIR,
+    )
+    assert entry is not None
+    # advanced honours the schema's explicit False even though the
+    # heuristic for ``setup_priority`` would say True.
+    assert entry["advanced"] is False
+    assert entry["hidden"] is True


### PR DESCRIPTION
# What does this implement/fix?

Consumer-side wire-up for [esphome/esphome#16267](https://github.com/esphome/esphome/pull/16267), which landed upstream in milestone 2026.5.0b1 and added a `visibility=` kwarg (`cv.Visibility` `StrEnum`) to `cv.Optional` / `cv.Required` so the field author can mark a config_var's UI treatment in the schema itself. The dumper emits `"visibility": "advanced" | "yaml_only"` on the per-field dict in the schema bundle this script consumes; the key is absent when not set so the change is fully backwards-compatible with existing consumers.

This PR teaches `script/sync_components.py` to honour the schema's intent and apply a strictness-cascade to nested structures.

## Schema-driven flag mapping

| Schema `visibility` | Catalog flag |
|---|---|
| _absent_ | name-based heuristic decides `advanced` (existing behaviour) |
| `"advanced"` | `advanced=True` |
| `"yaml_only"` | `hidden=True` (the frontend already filters `hidden`) |

The hand-curated `_ADVANCED_BASE_KEYS` / `_IMPORTANT_KEYS` classifier stays as the fallback for the long tail of fields the schema doesn't yet annotate; as upstream adoption grows, the heuristic shrinks toward zero.

Two real fields ship marked upstream in 2026.5.0b1: `setup_priority` on `core.COMPONENT_SCHEMA` (`yaml_only`); `update_interval` on the `time` platform via `cv.polling_component_schema(visibility=Visibility.ADVANCED)` (`advanced`). Sensors and other polling components stay un-flagged so their `update_interval` still surfaces on the main form where users want to tune the polling cadence.

## Cascade pass

Upstream is explicit that cascading lives on the consumer side; the schema dump records each field's own author-declared intent and nothing more. A new `_apply_visibility_cascade` walks the catalog tree once at the top of `_extract_config_entries` and pushes parent strictness down. The strictness ordering is `YAML_ONLY` > `ADVANCED` > unset; a child can be stricter than its parent, never less strict. Without the cascade:

- An `advanced` parent block would render under a disclosure while its inner fields surfaced on the main form (leaky disclosure UX).
- A `yaml_only` parent would leak controls into the editor with no surrounding context.

The cascade also enforces the per-entry strictness ordering: a field with `hidden=True` is also forced `advanced=True`, since every yaml-only field is at-least advanced by definition.

## Tests

`tests/test_sync_components_ui_hints.py` covers:

- Schema-driven mapping in both directions (`"advanced"` → `advanced=True`, `"yaml_only"` → `hidden=True`)
- Heuristic fallback when `visibility` is absent
- Forward-compat: an unrecognised `visibility` value falls back to the heuristic (so a future upstream level like `"deprecated"` doesn't silently disappear from the form)
- Cascade rule: parent-`ADVANCED` pushes to unset children; parent-`YAML_ONLY` hides every descendant; inner `YAML_ONLY` under an `ADVANCED` parent stays hidden
- Multi-level descent (grandparent forces leaf strictness)
- Cascade no-op on a tree with no strict markers
- `config_entries: None` tolerated without traversal

## Activation

The next nightly catalog sync against the published 2026.5.0b1 schema (or whichever release first ships with #16267 in the bundle on https://schema.esphome.io) is what flips the two real fields above to their new visibility values in `components.json`. Until that schema version is the catalog's pin, this change is a no-op — the existing heuristic-derived `advanced` values stay; the cascade only mutates fields that already carry one of the strict flags from somewhere.

**Related issue or feature (if applicable):**

- Consumer for esphome/esphome#16267 (merged upstream into 2026.5.0b1)
- Companion frontend PR: esphome/device-builder-frontend#182

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#182

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
