### PR TITLE
Strip frontend default-fills from featured-component YAML

### DIFF
--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -215,6 +215,17 @@ def _apply_featured_presets(
       omission falls back to the preset's ``value`` (when set).
     - Plain default: filled in only when the user didn't supply one.
 
+    The manifest is authoritative for featured components, so optional
+    default-fills the frontend submits along with the form (a light's
+    ``gamma_correct: 2.8``, an output's ``frequency: 1kHz``, and so on)
+    are stripped before the YAML render. The filter is intentionally
+    narrow: only fields that carry a catalog ``default_value`` get
+    dropped — fields without a default (nested sub-entities like a
+    multi-sensor's ``current:`` block, MQTT ``availability:`` /
+    ``state_topic:`` overrides, and anything else the user has to opt
+    into explicitly) ride through as user intent. Schema-required keys
+    and any key the manifest curates are always kept.
+
     Pin-typed fields can arrive in two ESPHome shapes — bare GPIO
     (``pin: 12``) or rich mapping (``pin: {number: 12, mode: ..., inverted: ...}``).
     Equality / membership checks compare on the bare GPIO so a manifest's
@@ -263,7 +274,21 @@ def _apply_featured_presets(
             continue
         if not user_supplied and preset.value is not None:
             merged[key] = preset.value
-    return merged
+    keep_unconditional = set(record.featured.fields)
+    keep_unconditional.update(ce.key for ce in record.underlying.config_entries if ce.required)
+    filtered: dict[str, Any] = {}
+    for key, value in merged.items():
+        if key in keep_unconditional:
+            filtered[key] = value
+            continue
+        entry = entries_by_key.get(key)
+        # Unknown keys (no matching catalog entry) ride through —
+        # ``add_component`` doesn't validate against an exhaustive
+        # schema, and silently dropping a typo would mask the input
+        # rather than failing visibly.
+        if entry is None or entry.default_value is None:
+            filtered[key] = value
+    return filtered
 
 
 def _drop_unconfigured_dependent_fields(

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -216,15 +216,16 @@ def _apply_featured_presets(
     - Plain default: filled in only when the user didn't supply one.
 
     The manifest is authoritative for featured components, so optional
-    default-fills the frontend submits along with the form (a light's
+    default-fills the frontend echoes back from the form (a light's
     ``gamma_correct: 2.8``, an output's ``frequency: 1kHz``, and so on)
     are stripped before the YAML render. The filter is intentionally
-    narrow: only fields that carry a catalog ``default_value`` get
-    dropped — fields without a default (nested sub-entities like a
-    multi-sensor's ``current:`` block, MQTT ``availability:`` /
-    ``state_topic:`` overrides, and anything else the user has to opt
-    into explicitly) ride through as user intent. Schema-required keys
-    and any key the manifest curates are always kept.
+    narrow: a non-manifest, non-required key is dropped only when its
+    submitted value equals the catalog ``default_value`` for that
+    entry — a deliberate override (``gamma_correct: 1.5``) survives.
+    Catalog defaults for numeric and time-period fields are stored as
+    strings (``'2.8'``, ``'0 us'``) while the frontend submits parsed
+    scalars; the comparison stringifies both sides so the round-trip
+    matches without false positives on real overrides.
 
     Pin-typed fields can arrive in two ESPHome shapes — bare GPIO
     (``pin: 12``) or rich mapping (``pin: {number: 12, mode: ..., inverted: ...}``).
@@ -276,19 +277,52 @@ def _apply_featured_presets(
             merged[key] = preset.value
     keep_unconditional = set(record.featured.fields)
     keep_unconditional.update(ce.key for ce in record.underlying.config_entries if ce.required)
+    return _strip_default_echoes(merged, entries_by_key, keep_unconditional)
+
+
+def _strip_default_echoes(
+    fields: dict[str, Any],
+    entries_by_key: dict[str, ConfigEntry],
+    keep_unconditional: set[str],
+) -> dict[str, Any]:
+    """
+    Drop fields that just echo their catalog default back at us.
+
+    Unknown keys (no matching catalog entry) and entries with no
+    ``default_value`` ride through — we have no baseline to call them
+    an echo of, and silently dropping a typo would mask input rather
+    than failing visibly.
+    """
     filtered: dict[str, Any] = {}
-    for key, value in merged.items():
+    for key, value in fields.items():
         if key in keep_unconditional:
             filtered[key] = value
             continue
         entry = entries_by_key.get(key)
-        # Unknown keys (no matching catalog entry) ride through —
-        # ``add_component`` doesn't validate against an exhaustive
-        # schema, and silently dropping a typo would mask the input
-        # rather than failing visibly.
         if entry is None or entry.default_value is None:
             filtered[key] = value
+            continue
+        if not _is_catalog_default_echo(value, entry.default_value):
+            filtered[key] = value
     return filtered
+
+
+def _is_catalog_default_echo(value: Any, default: Any) -> bool:
+    """Return True when *value* is just an unmodified echo of *default*.
+
+    Plain ``==`` first (handles bool/bool, str/str, int/int matches),
+    then a stringified compare for the cross-type case where the
+    catalog stores numeric and time-period defaults as strings
+    (``'2.8'``, ``'0 us'``) and the frontend submits the parsed
+    scalar. Container values (dicts, lists) are never treated as an
+    echo — those are nested sub-blocks the user opts into explicitly,
+    and the catalog default is always ``None`` for them anyway.
+    """
+    if value == default:
+        return True
+    if isinstance(value, (dict, list)) or value is None:
+        return False
+    return str(value).strip() == str(default).strip()
 
 
 def _drop_unconfigured_dependent_fields(

--- a/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/apollo-esk-1/manifest.yaml
@@ -221,13 +221,15 @@ featured_components:
   component_id: light.esp32_rmt_led_strip
   name: RGB LED Strip (addon module)
   description: |
-    Addressable LED strip from the RGB+buzzer addon. Defaults to 10 LEDs in
-    GRB order — adjust to match your strip.
+    Addressable LED strip from the RGB+buzzer addon. Ships with a 10-LED
+    WS2812 strip in GRB order — adjust ``num_leds`` / ``rgb_order`` /
+    ``chipset`` if you swap in a different strip.
   fields:
     id: rgb_strip
     name: RGB LED Strip
     pin:
       value: 14
+    chipset: WS2812
     num_leds: 10
     rgb_order: GRB
 - id: buzzer_output
@@ -243,10 +245,13 @@ featured_components:
   component_id: rtttl
   name: RTTTL Player (addon buzzer)
   description: |
-    Plays RTTTL ringtones through the piezo buzzer above. Wire the
-    ``output`` field to the buzzer output you just added.
+    Plays RTTTL ringtones through the piezo buzzer above. Wired to the
+    ``buzzer_output`` LEDC output that ships with the same addon.
   fields:
     id: rtttl_player
+    output:
+      value: buzzer_output
+      locked: true
 featured_bundles:
 - id: rgb_buzzer_module
   name: RGB LED + Buzzer Module

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -408,6 +408,69 @@ async def test_apply_presets_locked_without_value_fails_fast(
         _apply_featured_presets(record, {})
 
 
+async def test_apply_presets_drops_non_manifest_fields(
+    catalog: ComponentCatalog,
+) -> None:
+    """
+    Optional fields not in the manifest are stripped from the output.
+
+    The frontend's add-component form pre-fills every optional field
+    with its catalog default; submitting that whole map shouldn't
+    bloat the emitted YAML with values the manifest never asked for
+    (a light's ``gamma_correct: 2.8``, an output's ``frequency: 1kHz``,
+    ...). Required keys still ride through as a safety net.
+    """
+    record = catalog.get_featured_record("featured.apollo-esk-1.rgb_strip")
+    assert record is not None
+    out = _apply_featured_presets(
+        record,
+        {
+            # Manifest keys — these stay.
+            "pin": 14,
+            "num_leds": 10,
+            "rgb_order": "GRB",
+            "name": "RGB LED Strip",
+            # Frontend default-fills the user never touched — these go.
+            "gamma_correct": 2.8,
+            "is_rgbw": False,
+            "is_wrgb": False,
+            "use_psram": True,
+            "default_transition_length": "1s",
+        },
+    )
+    assert "gamma_correct" not in out
+    assert "is_rgbw" not in out
+    assert "is_wrgb" not in out
+    assert "use_psram" not in out
+    assert "default_transition_length" not in out
+    # Manifest-supplied chipset preset filled in even though the user
+    # didn't submit it — manifest is authoritative.
+    assert out["chipset"] == "WS2812"
+    # Manifest fields the user did submit ride through unchanged.
+    assert out["pin"] == 14
+    assert out["num_leds"] == 10
+    assert out["rgb_order"] == "GRB"
+
+
+async def test_apply_presets_keeps_required_field_outside_manifest(
+    catalog: ComponentCatalog,
+) -> None:
+    """Required schema fields ride through even when the manifest omits them."""
+    # Build a synthetic featured record whose manifest only sets ``id``,
+    # then submit one of the underlying component's required fields and
+    # confirm it survives the filter rather than being treated as
+    # incidental frontend padding.
+    record = deepcopy(catalog.get_featured_record("featured.apollo-esk-1.rgb_strip"))
+    assert record is not None
+    record.featured.fields = {"id": FieldPreset(value="rgb_strip")}
+    out = _apply_featured_presets(record, {"pin": 14, "num_leds": 10, "rgb_order": "GRB"})
+    # ``pin``, ``num_leds`` and ``rgb_order`` are schema-required — kept
+    # despite being absent from the manifest.
+    assert out["pin"] == 14
+    assert out["num_leds"] == 10
+    assert out["rgb_order"] == "GRB"
+
+
 # ---------------------------------------------------------------------------
 # YAML generation: top-level id auto-gen + nested entity sub-block autofill
 # ---------------------------------------------------------------------------
@@ -628,6 +691,58 @@ async def test_add_component_featured_non_entity_emits_id_only(
     assert "output:" in response.yaml
     assert "id: status_led_output" in response.yaml
     assert "name:" not in response.yaml.split("output:")[1]
+
+
+async def test_add_component_featured_drops_non_manifest_defaults(
+    catalog: ComponentCatalog, tmp_path: Any
+) -> None:
+    """
+    The emitted YAML for a featured component carries only manifest fields.
+
+    End-to-end check that bridges the two halves of the fix: the
+    frontend can submit a full form's worth of catalog defaults, and
+    the YAML still comes out as the curated short block the manifest
+    describes — no ``gamma_correct``/``is_rgbw``/``use_psram`` noise.
+    """
+    (tmp_path / "kit.yaml").write_text("esphome:\n  name: kit\napi:\n", "utf-8")
+    ctrl = _make_controller(catalog, tmp_path)
+
+    response = await ctrl.add_component(
+        configuration="kit.yaml",
+        component_id="featured.apollo-esk-1.rgb_strip",
+        fields={
+            # Frontend default-fills:
+            "gamma_correct": 2.8,
+            "is_rgbw": False,
+            "is_wrgb": False,
+            "use_psram": True,
+            "default_transition_length": "1s",
+            "flash_transition_length": "0s",
+            "reset_high": "0 us",
+            "reset_low": "0 us",
+            "restore_mode": "ALWAYS_OFF",
+        },
+    )
+
+    yaml = response.yaml
+    assert "platform: esp32_rmt_led_strip" in yaml
+    # Manifest-curated fields land in the YAML.
+    assert "chipset: WS2812" in yaml
+    assert "num_leds: 10" in yaml
+    assert "rgb_order: GRB" in yaml
+    # Frontend's default-fills are stripped.
+    for noise in (
+        "gamma_correct",
+        "is_rgbw",
+        "is_wrgb",
+        "use_psram",
+        "default_transition_length",
+        "flash_transition_length",
+        "reset_high",
+        "reset_low",
+        "restore_mode",
+    ):
+        assert noise not in yaml, f"{noise} should have been filtered out"
 
 
 async def test_add_component_strips_mqtt_fields_when_no_mqtt_block(

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -452,6 +452,55 @@ async def test_apply_presets_drops_non_manifest_fields(
     assert out["rgb_order"] == "GRB"
 
 
+async def test_apply_presets_keeps_user_overridden_optional_field(
+    catalog: ComponentCatalog,
+) -> None:
+    """
+    A deliberate override of an optional field survives the filter.
+
+    The frontend echoes the catalog default for fields the user
+    didn't touch — those are stripped. But a value that differs from
+    the default is real user intent and must ride through, even when
+    the manifest doesn't curate the key.
+    """
+    record = catalog.get_featured_record("featured.apollo-esk-1.rgb_strip")
+    assert record is not None
+    out = _apply_featured_presets(
+        record,
+        {
+            # Catalog default for ``gamma_correct`` is ``"2.8"`` —
+            # 1.5 is a deliberate override and must be kept.
+            "gamma_correct": 1.5,
+            # ``is_rgbw`` defaults to False — flipping to True is an
+            # override.
+            "is_rgbw": True,
+            # ``use_psram`` defaults to True — sending True is just an
+            # echo and gets dropped.
+            "use_psram": True,
+        },
+    )
+    assert out["gamma_correct"] == 1.5
+    assert out["is_rgbw"] is True
+    assert "use_psram" not in out
+
+
+async def test_apply_presets_strips_numeric_default_echo_across_types(
+    catalog: ComponentCatalog,
+) -> None:
+    """
+    Catalog stores numeric defaults as strings; a parsed-scalar echo still matches.
+
+    ``gamma_correct`` is stored in ``components.json`` as the string
+    ``"2.8"``. The frontend submits the parsed float ``2.8`` — the
+    stringified compare bridges the two so the unmodified default is
+    still recognised as noise.
+    """
+    record = catalog.get_featured_record("featured.apollo-esk-1.rgb_strip")
+    assert record is not None
+    out = _apply_featured_presets(record, {"gamma_correct": 2.8})
+    assert "gamma_correct" not in out
+
+
 async def test_apply_presets_keeps_required_field_outside_manifest(
     catalog: ComponentCatalog,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adding a featured component (or a featured bundle) emitted YAML padded with every catalog default the form pre-filled — `gamma_correct: 2.8`, `is_rgbw: false`, `frequency: 1kHz`, `gain: 0.6`, `restore_mode: ALWAYS_OFF` and so on — even when the manifest only curated a handful of fields. The manifest is meant to be authoritative for the featured add-path, so we drop the noise. The Apollo ESK-1 starter kit's RGB+buzzer bundle also surfaced two manifest gaps in the process.

- backend — `_apply_featured_presets` now drops user-submitted keys whose underlying catalog entry has a `default_value`. Fields without a catalog default (nested sub-entities like an HLW8012's `current:` block, MQTT overrides, anything the user has to opt into explicitly) ride through unchanged. Schema-required keys are kept as a safety net.
- apollo-esk-1 manifest — `rgb_strip` now carries `chipset: WS2812` (the emitted YAML otherwise fails ESPHome's "exactly one of chipset, bit0_high" validator); `rtttl_player` now wires `output: buzzer_output` (locked) so the player auto-connects to the LEDC output the same bundle ships.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
