### PR TITLE
Pin TXT-absent / TXT-empty preserve last-known for version/config_hash/mac

### DIFF
--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -598,33 +598,75 @@ async def test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none(
 
 
 # ---------------------------------------------------------------------------
-# Defense-in-depth: TXT-absent must preserve last-known value for the other
-# mDNS-derived fields too. Today these are protected by the truthy walrus
-# at the call site (``if version := props.get(...)``) plus an empty-guard
-# at the bottom of each ``apply_*`` method, but pinning the contract here
-# means a future refactor that "simplifies" away either guard surfaces as
-# a test failure rather than a silent regression on a quiet re-announce.
+# Defense-in-depth: TXT-absent / TXT-empty must preserve the device's
+# last-known value for every mDNS-derived field that doesn't have an
+# "explicit empty is meaningful" semantic (i.e. everything except
+# ``api_encryption`` — its plaintext-confirmed signal is covered above).
+#
+# Today these fields are protected by the truthy walrus at the call site
+# (``if version := props.get(...)``) plus an empty-guard at the bottom
+# of each ``apply_*`` method. Pinning the contract here means a future
+# refactor that "simplifies" away either guard surfaces as a test
+# failure rather than a silent regression on a quiet re-announce
+# (MTU fragmentation, source flipping mDNS → ping mid-flight, post-OTA
+# propagation, …).
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    ("device_field", "txt_key", "stored_value"),
+    [
+        # Field on the Device, the TXT key it's read from, and a
+        # representative stored value to round-trip through the test.
+        # ``version`` drives the "Update available" pill;
+        # ``config_hash`` drives the "running firmware out of sync"
+        # indicator (paired with ``expected_config_hash``); ``mac``
+        # drives the drawer's primary-MAC row + the derived
+        # ethernet/bluetooth rows on ESP32.
+        ("deployed_version", "version", "2026.5.0"),
+        ("deployed_config_hash", "config_hash", "5a94a12d"),
+        ("mac_address", "mac", "94:C9:60:1F:8C:F1"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("make_props", "case_id"),
+    [
+        # Absent: a sparse re-announcement that didn't carry the TXT
+        # at all (the canonical fragmentation / OTA-propagation case).
+        (lambda _key: {}, "absent"),
+        # Explicitly empty: TXT key present but with empty value.
+        # No meaningful semantic for these fields (unlike
+        # ``api_encryption`` where empty = "plaintext confirmed"),
+        # so empty is treated the same as absent — drop it and keep
+        # the canonical value.
+        (lambda key: {key: ""}, "empty"),
+    ],
+    ids=lambda v: v if isinstance(v, str) else "",
+)
 @pytest.mark.asyncio
-async def test_dispatch_added_without_version_txt_preserves_last_known(
+async def test_dispatch_added_sparse_announce_preserves_last_known(
+    device_field: str,
+    txt_key: str,
+    stored_value: str,
+    make_props,
+    case_id: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """TXT key absent in the announcement → stored ``deployed_version`` survives.
+    """TXT-absent / TXT-empty announcements preserve the stored field.
 
-    A transient / fragmented re-announcement that omits the
-    ``version`` TXT must NOT wipe the device's previously-observed
-    firmware version. Dropping it would flip the dashboard's
-    "Update available" pill on/off as devices re-announce.
+    Six cases (3 fields x {absent, empty}). With either the call-
+    site walrus or the apply-method empty-guard intact the field
+    survives the announcement unchanged; if a future refactor
+    drops both, at least one of these parametrize legs fails
+    loudly.
     """
-    device = _device(deployed_version="2026.5.0")
+    device = _device(**{device_field: stored_value})
     monitor, _callbacks = _make_monitor([device])
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = True
     fake_info.parsed_scoped_addresses = lambda _mode: []
-    fake_info.decoded_properties = {}  # no version key at all
+    fake_info.decoded_properties = make_props(txt_key)
     monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
@@ -635,180 +677,9 @@ async def test_dispatch_added_without_version_txt_preserves_last_known(
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
         )
-        assert device.deployed_version == "2026.5.0"
-    finally:
-        await _stop_and_drain(monitor)
-
-
-@pytest.mark.asyncio
-async def test_dispatch_added_with_empty_version_txt_preserves_last_known(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """TXT key explicitly empty also preserves the stored value.
-
-    Older firmware that broadcasts ``version=`` (key present, value
-    empty) shouldn't blank out a device's known version either.
-    Empty has no meaningful semantic for ``version`` — there's no
-    such thing as a "confirmed empty version" the way there is for
-    ``api_encryption`` — so empty is just garbage and must be
-    treated the same as absent.
-    """
-    device = _device(deployed_version="2026.5.0")
-    monitor, _callbacks = _make_monitor([device])
-
-    fake_info = MagicMock()
-    fake_info.load_from_cache.return_value = True
-    fake_info.parsed_scoped_addresses = lambda _mode: []
-    fake_info.decoded_properties = {"version": ""}
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
-
-    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
-    try:
-        dispatch(
-            monitor._zeroconf.zeroconf,
-            ESPHOMELIB_SERVICE_TYPE,
-            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
-            ServiceStateChange.Added,
+        assert getattr(device, device_field) == stored_value, (
+            f"{device_field} wiped by sparse announce ({case_id})"
         )
-        assert device.deployed_version == "2026.5.0"
-    finally:
-        await _stop_and_drain(monitor)
-
-
-@pytest.mark.asyncio
-async def test_dispatch_added_without_config_hash_txt_preserves_last_known(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """TXT key absent → stored ``deployed_config_hash`` survives.
-
-    The hash drives the "running firmware out of sync with YAML"
-    indicator (paired with ``expected_config_hash``). A sparse
-    re-announcement that omits the TXT must NOT clear it — that
-    would falsely flip the pending-changes pill back on for a
-    device that's actually up to date.
-    """
-    device = _device(deployed_config_hash="5a94a12d")
-    monitor, _callbacks = _make_monitor([device])
-
-    fake_info = MagicMock()
-    fake_info.load_from_cache.return_value = True
-    fake_info.parsed_scoped_addresses = lambda _mode: []
-    fake_info.decoded_properties = {}  # no config_hash key
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
-
-    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
-    try:
-        dispatch(
-            monitor._zeroconf.zeroconf,
-            ESPHOMELIB_SERVICE_TYPE,
-            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
-            ServiceStateChange.Added,
-        )
-        assert device.deployed_config_hash == "5a94a12d"
-    finally:
-        await _stop_and_drain(monitor)
-
-
-@pytest.mark.asyncio
-async def test_dispatch_added_with_empty_config_hash_txt_preserves_last_known(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """TXT key explicitly empty also preserves the stored hash.
-
-    Pre-#16145 firmware doesn't broadcast ``config_hash`` at all;
-    a device whose firmware was just downgraded shouldn't have its
-    cached hash blanked out by a quiet re-announce that happens to
-    carry an empty value.
-    """
-    device = _device(deployed_config_hash="5a94a12d")
-    monitor, _callbacks = _make_monitor([device])
-
-    fake_info = MagicMock()
-    fake_info.load_from_cache.return_value = True
-    fake_info.parsed_scoped_addresses = lambda _mode: []
-    fake_info.decoded_properties = {"config_hash": ""}
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
-
-    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
-    try:
-        dispatch(
-            monitor._zeroconf.zeroconf,
-            ESPHOMELIB_SERVICE_TYPE,
-            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
-            ServiceStateChange.Added,
-        )
-        assert device.deployed_config_hash == "5a94a12d"
-    finally:
-        await _stop_and_drain(monitor)
-
-
-@pytest.mark.asyncio
-async def test_dispatch_added_without_mac_txt_preserves_last_known(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """TXT key absent → stored ``mac_address`` survives.
-
-    The MAC drives the drawer's primary-MAC row plus the derived
-    ethernet/bluetooth MACs on ESP32. A sparse re-announcement that
-    omits the TXT must NOT clear the cached value — the mDNS
-    broadcast is the only source for the field today, and dropping
-    it would render an em-dash where the user previously saw a real
-    address.
-    """
-    canonical = "94:C9:60:1F:8C:F1"
-    device = _device(mac_address=canonical)
-    monitor, _callbacks = _make_monitor([device])
-
-    fake_info = MagicMock()
-    fake_info.load_from_cache.return_value = True
-    fake_info.parsed_scoped_addresses = lambda _mode: []
-    fake_info.decoded_properties = {}  # no mac key
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
-
-    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
-    try:
-        dispatch(
-            monitor._zeroconf.zeroconf,
-            ESPHOMELIB_SERVICE_TYPE,
-            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
-            ServiceStateChange.Added,
-        )
-        assert device.mac_address == canonical
-    finally:
-        await _stop_and_drain(monitor)
-
-
-@pytest.mark.asyncio
-async def test_dispatch_added_with_empty_mac_txt_preserves_last_known(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """TXT key explicitly empty / non-hex preserves the stored MAC.
-
-    There's no such thing as a "confirmed-empty MAC" the way there
-    is for ``api_encryption``'s plaintext signal — empty / garbage
-    here is just bad data from older firmware or a non-ESPHome
-    service that happens to share the type. Drop it and keep the
-    canonical value.
-    """
-    canonical = "94:C9:60:1F:8C:F1"
-    device = _device(mac_address=canonical)
-    monitor, _callbacks = _make_monitor([device])
-
-    fake_info = MagicMock()
-    fake_info.load_from_cache.return_value = True
-    fake_info.parsed_scoped_addresses = lambda _mode: []
-    fake_info.decoded_properties = {"mac": ""}
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
-
-    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
-    try:
-        dispatch(
-            monitor._zeroconf.zeroconf,
-            ESPHOMELIB_SERVICE_TYPE,
-            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
-            ServiceStateChange.Added,
-        )
-        assert device.mac_address == canonical
     finally:
         await _stop_and_drain(monitor)
 

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -96,6 +96,7 @@ def _make_monitor(
     monitor._on_version_change = callbacks.on_version_change
     monitor._on_config_hash_change = callbacks.on_config_hash_change
     monitor._on_api_encryption_change = callbacks.on_api_encryption_change
+    monitor._on_mac_address_change = callbacks.on_mac_address_change
     monitor._on_importable_added = callbacks.on_importable_added
     monitor._on_importable_removed = callbacks.on_importable_removed
     monitor._reachability = None
@@ -592,6 +593,222 @@ async def test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none(
             ServiceStateChange.Added,
         )
         assert device.api_encryption_active is None
+    finally:
+        await _stop_and_drain(monitor)
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: TXT-absent must preserve last-known value for the other
+# mDNS-derived fields too. Today these are protected by the truthy walrus
+# at the call site (``if version := props.get(...)``) plus an empty-guard
+# at the bottom of each ``apply_*`` method, but pinning the contract here
+# means a future refactor that "simplifies" away either guard surfaces as
+# a test failure rather than a silent regression on a quiet re-announce.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_without_version_txt_preserves_last_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT key absent in the announcement → stored ``deployed_version`` survives.
+
+    A transient / fragmented re-announcement that omits the
+    ``version`` TXT must NOT wipe the device's previously-observed
+    firmware version. Dropping it would flip the dashboard's
+    "Update available" pill on/off as devices re-announce.
+    """
+    device = _device(deployed_version="2026.5.0")
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    fake_info.decoded_properties = {}  # no version key at all
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.deployed_version == "2026.5.0"
+    finally:
+        await _stop_and_drain(monitor)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_with_empty_version_txt_preserves_last_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT key explicitly empty also preserves the stored value.
+
+    Older firmware that broadcasts ``version=`` (key present, value
+    empty) shouldn't blank out a device's known version either.
+    Empty has no meaningful semantic for ``version`` — there's no
+    such thing as a "confirmed empty version" the way there is for
+    ``api_encryption`` — so empty is just garbage and must be
+    treated the same as absent.
+    """
+    device = _device(deployed_version="2026.5.0")
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    fake_info.decoded_properties = {"version": ""}
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.deployed_version == "2026.5.0"
+    finally:
+        await _stop_and_drain(monitor)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_without_config_hash_txt_preserves_last_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT key absent → stored ``deployed_config_hash`` survives.
+
+    The hash drives the "running firmware out of sync with YAML"
+    indicator (paired with ``expected_config_hash``). A sparse
+    re-announcement that omits the TXT must NOT clear it — that
+    would falsely flip the pending-changes pill back on for a
+    device that's actually up to date.
+    """
+    device = _device(deployed_config_hash="5a94a12d")
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    fake_info.decoded_properties = {}  # no config_hash key
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.deployed_config_hash == "5a94a12d"
+    finally:
+        await _stop_and_drain(monitor)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_with_empty_config_hash_txt_preserves_last_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT key explicitly empty also preserves the stored hash.
+
+    Pre-#16145 firmware doesn't broadcast ``config_hash`` at all;
+    a device whose firmware was just downgraded shouldn't have its
+    cached hash blanked out by a quiet re-announce that happens to
+    carry an empty value.
+    """
+    device = _device(deployed_config_hash="5a94a12d")
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    fake_info.decoded_properties = {"config_hash": ""}
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.deployed_config_hash == "5a94a12d"
+    finally:
+        await _stop_and_drain(monitor)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_without_mac_txt_preserves_last_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT key absent → stored ``mac_address`` survives.
+
+    The MAC drives the drawer's primary-MAC row plus the derived
+    ethernet/bluetooth MACs on ESP32. A sparse re-announcement that
+    omits the TXT must NOT clear the cached value — the mDNS
+    broadcast is the only source for the field today, and dropping
+    it would render an em-dash where the user previously saw a real
+    address.
+    """
+    canonical = "94:C9:60:1F:8C:F1"
+    device = _device(mac_address=canonical)
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    fake_info.decoded_properties = {}  # no mac key
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.mac_address == canonical
+    finally:
+        await _stop_and_drain(monitor)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_with_empty_mac_txt_preserves_last_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT key explicitly empty / non-hex preserves the stored MAC.
+
+    There's no such thing as a "confirmed-empty MAC" the way there
+    is for ``api_encryption``'s plaintext signal — empty / garbage
+    here is just bad data from older firmware or a non-ESPHome
+    service that happens to share the type. Drop it and keep the
+    canonical value.
+    """
+    canonical = "94:C9:60:1F:8C:F1"
+    device = _device(mac_address=canonical)
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    fake_info.decoded_properties = {"mac": ""}
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.mac_address == canonical
     finally:
         await _stop_and_drain(monitor)
 


### PR DESCRIPTION
# What does this implement/fix?

Defense-in-depth follow-up to #348 (the `api_encryption`
regression where a sparse mDNS re-announcement that omitted the
TXT key would wipe the device's previously-confirmed encryption
state and trip the dashboard's "reinstall to apply" prompt).

The same bug pattern doesn't apply to the other mDNS-TXT-derived
fields today — `version`, `config_hash`, and `mac` are each
gated twice:

1. The call site in `_apply_service_info` uses a truthy walrus
   (`if version := props.get("version"):`) so absent / empty
   keys skip the apply call entirely.
2. The apply method itself has an early-return on falsy
   (`if not version or callback is None: return False`).

But a future refactor that "simplifies" away either guard would
silently regress: a sparse re-announcement (MTU fragmentation,
source flipping mDNS → ping mid-flight, post-OTA propagation)
would blank out the device's known firmware version, running
config-hash, or MAC address.

This PR pins the contract with six tests — each field × {TXT
absent, TXT explicitly empty} = 6 cases. With either the call-
site walrus or the apply-method guard intact the field's stored
value survives the announcement unchanged; if a future change
drops both, at least one of the six tests fails loudly.

`api_encryption` is intentionally not in this batch — it's the
one outlier that genuinely accepts an explicit empty as "device
confirms plaintext", and its existing absence-vs-empty-distinction
tests already cover both cases.

**Related issue or feature (if applicable):**

- Defense-in-depth for the bug fixed in #348.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
