### PR TITLE
Surface esphome.area on the Device model

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -2407,7 +2407,7 @@ class DevicesController:
             except OSError:
                 _LOGGER.debug("Failed to read archived YAML %s", path, exc_info=True)
                 continue
-            name, friendly_name, comment = parse_esphome_meta(content)
+            name, friendly_name, comment, _ = parse_esphome_meta(content)
             if not name or not friendly_name or comment is None:
                 storage = StorageJSON.load(ext_storage_path(path.name))
                 if storage is not None:

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -317,9 +317,9 @@ def config_has_top_level_block(config: dict | None, key: str) -> bool:
 
 def parse_esphome_meta(  # noqa: PLR0912
     yaml_content: str,
-) -> tuple[str | None, str | None, str | None]:
+) -> tuple[str | None, str | None, str | None, str | None]:
     """
-    Parse the top-level ``esphome:`` block for ``(name, friendly_name, comment)``.
+    Parse the top-level ``esphome:`` block for ``(name, friendly_name, comment, area)``.
 
     Returns ``None`` for any field that isn't present in the YAML so
     callers can distinguish "key absent" (fall through to storage) from
@@ -340,6 +340,7 @@ def parse_esphome_meta(  # noqa: PLR0912
     name: str | None = None
     friendly_name: str | None = None
     comment: str | None = None
+    area: str | None = None
     substitutions: dict[str, str] = {}
     current_block: str | None = None
 
@@ -354,7 +355,7 @@ def parse_esphome_meta(  # noqa: PLR0912
         if stripped.startswith("#") or not stripped:
             continue
         if current_block == "esphome":
-            for field in ("name", "friendly_name", "comment"):
+            for field in ("name", "friendly_name", "comment", "area"):
                 prefix = f"{field}:"
                 if stripped.startswith(prefix):
                     value = _parse_inline_value(stripped[len(prefix) :])
@@ -362,8 +363,10 @@ def parse_esphome_meta(  # noqa: PLR0912
                         name = value
                     elif field == "friendly_name":
                         friendly_name = value
-                    else:
+                    elif field == "comment":
                         comment = value
+                    else:
+                        area = value
                     break
         else:  # current_block == "substitutions"
             sub_key, sep, sub_raw = stripped.partition(":")
@@ -374,8 +377,9 @@ def parse_esphome_meta(  # noqa: PLR0912
         name = _resolve_substitutions(name, substitutions)
         friendly_name = _resolve_substitutions(friendly_name, substitutions)
         comment = _resolve_substitutions(comment, substitutions)
+        area = _resolve_substitutions(area, substitutions)
 
-    return name, friendly_name, comment
+    return name, friendly_name, comment, area
 
 
 # ---------------------------------------------------------------------------
@@ -439,7 +443,7 @@ def load_device_from_storage(
         yaml_content = path.read_text(encoding="utf-8")
     except OSError:
         yaml_content = ""
-    yaml_name, yaml_friendly, yaml_comment = parse_esphome_meta(yaml_content)
+    yaml_name, yaml_friendly, yaml_comment, yaml_area = parse_esphome_meta(yaml_content)
     # Full resolved config (``!include`` / packages / ``!secret``
     # expanded) drives the api-encryption flag — a bare regex on raw
     # YAML would miss configs that pull the api block in via include
@@ -469,6 +473,10 @@ def load_device_from_storage(
 
     storage_comment = storage.comment if storage else None
     comment = yaml_comment if yaml_comment is not None else storage_comment
+
+    # ``esphome.area`` only lives in the YAML — StorageJSON doesn't carry
+    # it, so there's no fallback. Empty string when absent.
+    area = yaml_area or ""
 
     yaml_mtime = path.stat().st_mtime if path.exists() else None
     bin_mtime: float | None = None
@@ -561,6 +569,7 @@ def load_device_from_storage(
         friendly_name=friendly_name,
         configuration=filename,
         comment=comment,
+        area=area,
         board_id=board_id,
         target_platform=target_platform,
         # StorageJSON only exists after a successful compile, so a

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -44,6 +44,11 @@ class Device(DataClassORJSONMixin):
     friendly_name: str
     configuration: str  # filename (e.g. "my_device.yaml")
     comment: str | None = None
+    # Optional ``esphome.area`` from the YAML — a free-form room /
+    # location label (Home Assistant uses the same key as a device-area
+    # hint). Empty string when the YAML doesn't carry an ``area:`` line.
+    # Surfaced in the dashboard's drawer and as an opt-in table column.
+    area: str = ""
     board_id: str = ""
     target_platform: str = ""
     address: str = ""  # mDNS hostname from StorageJSON (e.g. "my_device.local")

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -69,7 +69,12 @@ esphome:
   friendly_name: My Device
   comment: A useful little box
 """
-    assert parse_esphome_meta(yaml_content) == ("my-device", "My Device", "A useful little box")
+    assert parse_esphome_meta(yaml_content) == (
+        "my-device",
+        "My Device",
+        "A useful little box",
+        None,
+    )
 
 
 def test_parse_meta_missing_keys_return_none() -> None:
@@ -78,7 +83,7 @@ def test_parse_meta_missing_keys_return_none() -> None:
 esphome:
   name: my-device
 """
-    assert parse_esphome_meta(yaml_content) == ("my-device", None, None)
+    assert parse_esphome_meta(yaml_content) == ("my-device", None, None, None)
 
 
 def test_parse_meta_resolves_dollar_substitution() -> None:
@@ -90,7 +95,7 @@ esphome:
   name: living-room-lamp
   friendly_name: $friendly_name
 """
-    _, friendly_name, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Living Room Lamp"
 
 
@@ -103,7 +108,7 @@ esphome:
   name: kitchen
   friendly_name: ${friendly_name}
 """
-    _, friendly_name, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Kitchen"
 
 
@@ -115,7 +120,7 @@ substitutions:
 esphome:
   friendly_name: "${room} Lamp"
 """
-    _, friendly_name, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Bedroom Lamp"
 
 
@@ -127,7 +132,7 @@ esphome:
 substitutions:
   friendly_name: "Office"
 """
-    _, friendly_name, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Office"
 
 
@@ -139,7 +144,7 @@ substitutions:
 esphome:
   friendly_name: $missing
 """
-    _, friendly_name, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "$missing"
 
 
@@ -152,7 +157,7 @@ esphome:
   name: well
   comment: "${area} sensor"
 """
-    _, _, comment = parse_esphome_meta(yaml_content)
+    _, _, comment, _ = parse_esphome_meta(yaml_content)
     assert comment == "Outside sensor"
 
 
@@ -171,7 +176,7 @@ esphome:
   name: well
   comment: ${comment}
 """
-    _, _, comment = parse_esphome_meta(yaml_content)
+    _, _, comment, _ = parse_esphome_meta(yaml_content)
     assert comment == "Outside, Well | Irrigation A"
 
 
@@ -187,7 +192,7 @@ esphome:
 """
     # Should return without hanging; the exact stuck value is irrelevant
     # — what matters is that the resolver terminates safely.
-    _, friendly_name, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name in {"${a}", "${b}"}
 
 
@@ -360,7 +365,7 @@ esphome:
   name: my-device
   comment: Hand-built controller
 """
-    name, friendly_name, comment = parse_esphome_meta(yaml_content)
+    name, friendly_name, comment, _ = parse_esphome_meta(yaml_content)
     assert name == "my-device"
     assert friendly_name is None
     assert comment == "Hand-built controller"
@@ -380,10 +385,52 @@ esphome:
   # friendly_name: this is just a comment, ignore me
   comment: real comment
 """
-    name, friendly_name, comment = parse_esphome_meta(yaml_content)
+    name, friendly_name, comment, _ = parse_esphome_meta(yaml_content)
     assert name == "my-device"
     assert friendly_name is None  # comment line wasn't picked up
     assert comment == "real comment"
+
+
+# ----------------------------------------------------------------------
+# parse_esphome_meta — area field
+# ----------------------------------------------------------------------
+
+
+def test_parse_meta_area_field() -> None:
+    """``esphome.area`` is captured alongside the other meta fields."""
+    yaml_content = """
+esphome:
+  name: kitchen-lamp
+  friendly_name: Kitchen Lamp
+  area: Kitchen
+"""
+    name, friendly_name, _, area = parse_esphome_meta(yaml_content)
+    assert name == "kitchen-lamp"
+    assert friendly_name == "Kitchen Lamp"
+    assert area == "Kitchen"
+
+
+def test_parse_meta_area_absent_returns_none() -> None:
+    """Without an ``area:`` line, ``area`` is ``None`` (not empty string)."""
+    yaml_content = """
+esphome:
+  name: my-device
+"""
+    *_, area = parse_esphome_meta(yaml_content)
+    assert area is None
+
+
+def test_parse_meta_area_resolves_substitution() -> None:
+    """Substitutions referenced from ``area:`` resolve like the other fields."""
+    yaml_content = """
+substitutions:
+  room: "Living Room"
+esphome:
+  name: lamp
+  area: ${room}
+"""
+    *_, area = parse_esphome_meta(yaml_content)
+    assert area == "Living Room"
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

ESPHome's core config supports an optional `esphome.area` field (a free-form room/location label, e.g. `Kitchen`) but the dashboard never read it. This adds it to the `Device` shape returned by `devices/list` so the frontend can surface it in the device drawer and as an opt-in table column.

- `parse_esphome_meta()` now also extracts `area` (with substitution resolution, like the other fields). Return tuple grows to `(name, friendly_name, comment, area)`.
- `Device` dataclass gains `area: str = ""`; `load_device_from_storage` plumbs the parsed value through.
- Tests for the new field (literal, absent, substitution-resolved).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#192

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.