### PR TITLE
Add labels to devices

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -99,6 +99,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `devices/get_states` | — | `dict` | Get device online/offline states |
 | `devices/create` | `{name, board_id, config_type?, ssid?, psk?, file_content?}` | `WizardResponse` | Create device from board definition |
 | `devices/update` | `{name, friendly_name?, comment?, board_id?}` | `UpdateDeviceResponse` | Update device metadata |
+| `devices/set_labels` | `{configuration, label_ids: string[]}` | `Device` | Replace this device's label assignments. Pass `[]` to clear. Unknown ids return `INVALID_ARGS`. Fires `device_updated` after the scanner reload. |
 | `devices/rename` | `{configuration, new_name}` | — | Rename device via ESPHome CLI |
 | `devices/delete` | `{configuration}` | — | Delete device and associated files |
 | `devices/delete_bulk` | `{configurations: string[]}` | `[{configuration, success, error?}]` | Delete multiple devices |
@@ -229,6 +230,23 @@ The subscription stays open for the connection's lifetime; closing the WebSocket
 | `config/set_preferences` | `{theme?, dashboard_view?, ...}` | `UserPreferences` | Update preferences (partial) |
 | `config/get_secrets` | — | `[string]` | List secret key names |
 
+### Labels
+
+> Models: [`Label`](../esphome_device_builder/models/labels.py)
+>
+> Controller: [`LabelsController`](../esphome_device_builder/controllers/labels.py)
+
+User-defined chips (name + optional `#rrggbb` color) that can be assigned to devices via `devices/set_labels`. The catalog is global; assignments live on each device's `Device.labels` field as a list of label ids.
+
+| Command | Args | Response | Description |
+|---------|------|----------|-------------|
+| `labels/list` | — | `[Label]` | Return every label in the global catalog |
+| `labels/create` | `{name, color?}` | `Label` | Create a label. `name` 1-50 chars, unique case-insensitive. `color` is `#rrggbb` (lowercased on save) or null. Server generates `id`. Fires `label_created`. |
+| `labels/update` | `{label_id, name?, color?}` | `Label` | Rename and / or recolor. Pass `color: null` to clear; omit `color` to leave it unchanged. Fires `label_updated`. |
+| `labels/delete` | `{label_id}` | `{deleted: true}` | Delete a label and cascade — every device entry with this id has it removed in the same transaction, then each affected device fires `device_updated`; finally `label_deleted` fires. |
+
+Renaming or recoloring a label leaves device assignments untouched — devices reference labels by id, not by name. The frontend is expected to subscribe to `subscribe_events`, fetch the catalog once via `labels/list`, then resolve ids → name + color at render time.
+
 ### Utility
 
 | Command | Args | Response | Description |
@@ -239,6 +257,7 @@ The subscription stays open for the connection's lifetime; closing the WebSocket
 **`subscribe_events` events:**
 - `device_added`, `device_removed`, `device_updated`, `device_state_changed`
 - `importable_device_added`, `importable_device_removed`
+- `label_created`, `label_updated`, `label_deleted`
 - `job_queued`, `job_started`, `job_output`, `job_completed`, `job_failed`
 
 ---

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -36,6 +36,10 @@ class DeviceFileMetadata(NamedTuple):
     expected_config_hash: str = ""
     mac_address: str = ""
     build_size_bytes: int = 0
+    # Tuple (immutable) of label IDs assigned to the device. The
+    # global label catalog lives at ``_labels`` in the metadata
+    # sidecar; this carries the per-device assignments.
+    labels: tuple[str, ...] = ()
 
 
 class ScanChange(StrEnum):
@@ -383,6 +387,7 @@ class DeviceScanner:
                     metadata.expected_config_hash,
                     metadata.mac_address,
                     metadata.build_size_bytes,
+                    metadata.labels,
                     previous=self._index.by_path.get(path),
                 )
             except Exception:

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -568,14 +568,20 @@ def set_device_labels(config_dir: Path, configuration: str, label_ids: list[str]
     dangling reference. ``label_ids`` is treated as a set in
     semantics — duplicate IDs in the input are deduplicated while
     preserving first-seen order. Pass ``[]`` to clear all
-    assignments. Raises :class:`ValueError` listing unknown IDs
-    when validation fails (caller translates to
-    ``CommandError(INVALID_ARGS)`` at the API surface).
+    assignments. Raises :class:`ValueError` for non-string entries
+    in *label_ids* and for ids that aren't in the catalog (caller
+    translates to ``CommandError(INVALID_ARGS)`` at the API surface).
     """
     deduped: list[str] = []
     seen: set[str] = set()
     for lid in label_ids:
-        if not isinstance(lid, str) or lid in seen:
+        if not isinstance(lid, str):
+            # Silent skipping would let a payload of all-bad types
+            # become an effective ``[]`` (clear-all) write — surprising
+            # and user-hostile. Surface a clear error instead so the
+            # frontend can fix the payload.
+            raise ValueError(f"label_ids must be strings, got {type(lid).__name__}: {lid!r}")
+        if lid in seen:
             continue
         deduped.append(lid)
         seen.add(lid)
@@ -604,27 +610,40 @@ def set_device_labels(config_dir: Path, configuration: str, label_ids: list[str]
             entry.pop("labels", None)
 
 
-def delete_label_cascade(config_dir: Path, label_id: str) -> set[str]:
+def delete_label_cascade(config_dir: Path, label_id: str) -> tuple[bool, set[str]]:
     """
     Drop *label_id* from the catalog and every device entry.
 
-    Performed inside a single ``metadata_transaction`` so a
-    concurrent ``set_device_metadata`` writer can't reintroduce the
-    deleted ID into a fresh device entry. Returns the set of
-    configuration filenames whose ``labels`` list changed — callers
-    use this to schedule a per-device scanner reload so live
-    ``Device`` objects pick up the cleaned state without having to
-    wait for the next disk-driven scan.
+    Performed inside a single ``metadata_transaction`` so the
+    existence check, catalog removal, and per-device cleanup all
+    share one lock — a concurrent writer can't reintroduce the
+    deleted ID, and the existence check works against the *raw*
+    on-disk dict so a corrupt catalog entry (one that
+    ``Label.from_dict`` would skip) is still removable.
+
+    Returns a tuple ``(found, affected)`` where *found* is ``True``
+    when the catalog actually contained an entry with this id (so
+    the caller can raise ``NOT_FOUND`` otherwise) and *affected* is
+    the set of configuration filenames whose ``labels`` list
+    changed — callers use this to schedule a per-device scanner
+    reload so live ``Device`` objects pick up the cleaned state
+    without having to wait for the next disk-driven scan.
     """
     affected: set[str] = set()
+    found = False
     with metadata_transaction(config_dir) as data:
         existing = data.get(_LABELS_KEY)
         if isinstance(existing, list):
-            data[_LABELS_KEY] = [
-                entry
-                for entry in existing
-                if not (isinstance(entry, dict) and entry.get("id") == label_id)
-            ]
+            new_catalog: list[Any] = []
+            for entry in existing:
+                if isinstance(entry, dict) and entry.get("id") == label_id:
+                    found = True
+                    continue
+                new_catalog.append(entry)
+            if found:
+                data[_LABELS_KEY] = new_catalog
+        if not found:
+            return False, set()
         for filename, entry in data.items():
             if filename.startswith("_") or not isinstance(entry, dict):
                 continue
@@ -637,7 +656,7 @@ def delete_label_cascade(config_dir: Path, label_id: str) -> set[str]:
             else:
                 entry.pop("labels", None)
             affected.add(filename)
-    return affected
+    return True, affected
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -26,7 +26,7 @@ from ..constants import __version__ as server_version
 from ..helpers.api import CommandError, api_command
 from ..helpers.auth import hash_password
 from ..helpers.json import JSONDecodeError, dumps_indent, loads
-from ..models import ErrorCode, UserPreferences
+from ..models import ErrorCode, Label, UserPreferences
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
@@ -36,6 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 _DASHBOARD_SENTINEL_FILE = "___DASHBOARD_SENTINEL___.yaml"
 _METADATA_FILE = ".device-builder.json"
 _PREFS_KEY = "_preferences"
+_LABELS_KEY = "_labels"
 
 
 # ---------------------------------------------------------------------------
@@ -274,6 +275,7 @@ def set_device_metadata(
     build_size_bytes: int | None = None,
     build_size_dir_mtime: int | None = None,
     build_size_info_mtime: int | None = None,
+    labels: list[str] | None = None,
 ) -> None:
     """
     Set metadata fields for a device.
@@ -324,6 +326,13 @@ def set_device_metadata(
     pair drifted from what was persisted. Pass ``0`` for any
     field to clear (used by the archive flow's volatile-field
     scrub).
+
+    ``labels`` is the list of label IDs assigned to this device
+    (opaque ``uuid.uuid4().hex`` references into the global
+    ``_labels`` catalog). ``None`` leaves the persisted list
+    alone; ``[]`` clears it (drops the key entirely so empty
+    entries don't bloat the file); a populated list replaces
+    the assignments wholesale.
     """
     with metadata_transaction(config_dir) as data:
         entry = data.setdefault(filename, {})
@@ -335,6 +344,11 @@ def set_device_metadata(
             entry["comment"] = comment
         if ip:
             entry["ip"] = ip
+        if labels is not None:
+            if labels:
+                entry["labels"] = list(labels)
+            else:
+                entry.pop("labels", None)
         # Tri-state fields: ``None`` means "leave alone", a truthy
         # value writes, an explicit falsy (``""`` / ``0``) clears.
         # The numeric stamps below (``regen_failed_*`` /
@@ -483,6 +497,147 @@ def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
     """Save user preferences to disk."""
     with metadata_transaction(config_dir) as data:
         data[_PREFS_KEY] = prefs.to_dict()
+
+
+def _decode_labels(raw: Any) -> list[Label]:
+    """Parse the on-disk ``_labels`` list, dropping malformed entries."""
+    if not isinstance(raw, list):
+        return []
+    out: list[Label] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            out.append(Label.from_dict(entry))
+        except Exception as err:
+            # A hand-edited sidecar that landed a malformed entry
+            # shouldn't take the whole catalog down — labels are
+            # advisory. Debug-log so a developer hunting "why did
+            # my label disappear?" can find a paper trail without
+            # noisy WARN-level chatter on every load.
+            _LOGGER.debug("Skipping malformed label entry %r: %s", entry, err)
+    return out
+
+
+def load_labels(config_dir: Path) -> list[Label]:
+    """
+    Load the global label catalog.
+
+    Returns an empty list when the ``_labels`` key is missing or
+    corrupt. Individual entries that fail to round-trip through
+    :class:`Label` are skipped silently so a single bad entry can't
+    take the whole catalog down — labels are advisory metadata, not
+    load-bearing state.
+    """
+    return _decode_labels(_load_metadata(config_dir).get(_LABELS_KEY, []))
+
+
+def save_labels(config_dir: Path, labels: list[Label]) -> None:
+    """Replace the global label catalog atomically."""
+    with metadata_transaction(config_dir) as data:
+        data[_LABELS_KEY] = [label.to_dict() for label in labels]
+
+
+@contextmanager
+def labels_transaction(config_dir: Path) -> Iterator[list[Label]]:
+    """
+    Atomic read-modify-write context for the global label catalog.
+
+    Yields a mutable list of :class:`Label` instances decoded from the
+    ``_labels`` key. Mutate the list in place; on a clean exit the
+    catalog is re-encoded and persisted atomically alongside the rest
+    of the metadata file. Exceptions raised inside the block discard
+    the pending mutation. Use when you need uniqueness / existence
+    checks and the write to share a single transaction — the validate
+    happens inside the lock so a concurrent writer can't slip in
+    between.
+    """
+    with metadata_transaction(config_dir) as data:
+        catalog = _decode_labels(data.get(_LABELS_KEY))
+        yield catalog
+        data[_LABELS_KEY] = [label.to_dict() for label in catalog]
+
+
+def set_device_labels(config_dir: Path, configuration: str, label_ids: list[str]) -> None:
+    """
+    Replace a device's label assignments atomically.
+
+    Validates *label_ids* against the live catalog inside the same
+    metadata transaction as the write so a concurrent
+    ``labels/delete`` cascade can't leave the device with a
+    dangling reference. ``label_ids`` is treated as a set in
+    semantics — duplicate IDs in the input are deduplicated while
+    preserving first-seen order. Pass ``[]`` to clear all
+    assignments. Raises :class:`ValueError` listing unknown IDs
+    when validation fails (caller translates to
+    ``CommandError(INVALID_ARGS)`` at the API surface).
+    """
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for lid in label_ids:
+        if not isinstance(lid, str) or lid in seen:
+            continue
+        deduped.append(lid)
+        seen.add(lid)
+    with metadata_transaction(config_dir) as data:
+        catalog = data.get(_LABELS_KEY, [])
+        if isinstance(catalog, list):
+            known = {
+                entry["id"]
+                for entry in catalog
+                if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+            }
+        else:
+            known = set()
+        unknown = [lid for lid in deduped if lid not in known]
+        if unknown:
+            raise ValueError(f"Unknown label id(s): {', '.join(repr(u) for u in unknown)}")
+        entry = data.setdefault(configuration, {})
+        if not isinstance(entry, dict):
+            # A non-dict entry shouldn't survive long — overwrite to
+            # restore the expected shape rather than crash here.
+            entry = {}
+            data[configuration] = entry
+        if deduped:
+            entry["labels"] = deduped
+        else:
+            entry.pop("labels", None)
+
+
+def delete_label_cascade(config_dir: Path, label_id: str) -> set[str]:
+    """
+    Drop *label_id* from the catalog and every device entry.
+
+    Performed inside a single ``metadata_transaction`` so a
+    concurrent ``set_device_metadata`` writer can't reintroduce the
+    deleted ID into a fresh device entry. Returns the set of
+    configuration filenames whose ``labels`` list changed — callers
+    use this to schedule a per-device scanner reload so live
+    ``Device`` objects pick up the cleaned state without having to
+    wait for the next disk-driven scan.
+    """
+    affected: set[str] = set()
+    with metadata_transaction(config_dir) as data:
+        existing = data.get(_LABELS_KEY)
+        if isinstance(existing, list):
+            data[_LABELS_KEY] = [
+                entry
+                for entry in existing
+                if not (isinstance(entry, dict) and entry.get("id") == label_id)
+            ]
+        for filename, entry in data.items():
+            if filename.startswith("_") or not isinstance(entry, dict):
+                continue
+            current = entry.get("labels")
+            if not isinstance(current, list) or label_id not in current:
+                continue
+            new = [lid for lid in current if lid != label_id]
+            if new:
+                entry["labels"] = new
+            else:
+                entry.pop("labels", None)
+            affected.add(filename)
+    return affected
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -590,6 +590,19 @@ class DevicesController:
                 ErrorCode.INVALID_ARGS, "label_ids must be a list of label id strings"
             )
 
+        # Verify the device exists *before* writing the sidecar — a
+        # ``configuration`` that passes ``rel_path`` but isn't tracked
+        # by the scanner (typo, deleted YAML) would otherwise leave an
+        # orphaned ``.device-builder.json`` entry pinning labels to a
+        # non-existent device. The scanner's name index is the
+        # authoritative "what's actually on disk" view.
+        device = next(
+            (d for d in self._scanner.devices if d.configuration == configuration),
+            None,
+        )
+        if device is None:
+            raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
+
         config_dir = self._db.settings.config_dir
 
         def _persist() -> None:
@@ -601,13 +614,15 @@ class DevicesController:
         await asyncio.to_thread(_persist)
         await self._scanner.reload(configuration)
 
-        device = next(
+        # Re-fetch from the scanner — ``reload`` replaces the Device
+        # in the index, so the reference held above is stale.
+        refreshed = next(
             (d for d in self._scanner.devices if d.configuration == configuration),
             None,
         )
-        if device is None:
+        if refreshed is None:
             raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
-        return device
+        return refreshed
 
     @api_command("devices/rename")
     async def rename_device(

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -62,6 +62,7 @@ from .._reachability_tracker import ReachabilityTracker
 from ..config import (
     get_device_metadata,
     remove_device_metadata,
+    set_device_labels,
     set_device_metadata,
 )
 from ..firmware.helpers import _find_esphome_cmd
@@ -248,6 +249,19 @@ class DevicesController:
     def get_devices(self) -> list[Device]:
         """Snapshot of the currently-loaded devices."""
         return self._scanner.devices
+
+    async def reload_configuration(self, filename: str) -> bool:
+        """
+        Force-reload one device's state from disk and the metadata sidecar.
+
+        Use after writing a sidecar field whose value isn't reflected
+        in the YAML's mtime (labels, IP cache after restart-driven
+        re-resolution, etc.) — the scanner's mtime-based cache would
+        otherwise skip the file. Fires ``DEVICE_UPDATED`` via the
+        scanner's existing scan-change pipeline. Returns ``True``
+        when the device exists and was reloaded.
+        """
+        return await self._scanner.reload(filename)
 
     def get_address_cache_args(self, configuration: str) -> list[str]:
         """
@@ -547,6 +561,53 @@ class DevicesController:
             comment=meta.get("comment"),
             board_id=meta.get("board_id"),
         )
+
+    @api_command("devices/set_labels")
+    async def set_labels(
+        self,
+        *,
+        configuration: str,
+        label_ids: list[str],
+        **kwargs: Any,
+    ) -> Device:
+        """
+        Replace this device's label assignments.
+
+        ``label_ids`` is the new full list of assigned label IDs (no
+        diff semantics — ``[]`` clears every assignment). Unknown
+        IDs are rejected with ``INVALID_ARGS``; the catalog check
+        runs inside the same metadata transaction as the write so a
+        concurrent ``labels/delete`` cascade can't leave a dangling
+        reference. After persistence the device is force-reloaded
+        so the live ``Device`` model reflects the new labels — the
+        scanner's mtime cache would otherwise skip the file.
+        """
+        # ``rel_path`` raises ``CommandError(INVALID_ARGS)`` on path
+        # traversal; reuses the existing single chokepoint.
+        self._db.settings.rel_path(configuration)
+        if not isinstance(label_ids, list):
+            raise CommandError(
+                ErrorCode.INVALID_ARGS, "label_ids must be a list of label id strings"
+            )
+
+        config_dir = self._db.settings.config_dir
+
+        def _persist() -> None:
+            try:
+                set_device_labels(config_dir, configuration, label_ids)
+            except ValueError as err:
+                raise CommandError(ErrorCode.INVALID_ARGS, str(err)) from err
+
+        await asyncio.to_thread(_persist)
+        await self._scanner.reload(configuration)
+
+        device = next(
+            (d for d in self._scanner.devices if d.configuration == configuration),
+            None,
+        )
+        if device is None:
+            raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
+        return device
 
     @api_command("devices/rename")
     async def rename_device(
@@ -1602,12 +1663,23 @@ class DevicesController:
         # the scanner's per-device hot path; a single corrupt
         # entry shouldn't fail the whole scan.
         build_size_bytes = coerce_sidecar_int(md.get("build_size_bytes"))
+        # Defensive filter: a hand-edited sidecar could land non-string
+        # entries in the labels list. The scanner is on the hot path,
+        # so silently drop bad entries rather than failing the whole
+        # device load.
+        raw_labels = md.get("labels")
+        labels: tuple[str, ...]
+        if isinstance(raw_labels, list):
+            labels = tuple(item for item in raw_labels if isinstance(item, str))
+        else:
+            labels = ()
         return DeviceFileMetadata(
             board_id=board_id,
             ip=ip,
             expected_config_hash=expected_config_hash,
             mac_address=mac_address,
             build_size_bytes=build_size_bytes,
+            labels=labels,
         )
 
     def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:

--- a/esphome_device_builder/controllers/labels.py
+++ b/esphome_device_builder/controllers/labels.py
@@ -1,0 +1,220 @@
+"""Labels controller — global catalog of user-defined device labels."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from ..helpers.api import CommandError, api_command
+from ..models import ErrorCode, EventType, Label
+from .config import (
+    delete_label_cascade,
+    labels_transaction,
+    load_labels,
+)
+
+if TYPE_CHECKING:
+    from ..device_builder import DeviceBuilder
+
+_LOGGER = logging.getLogger(__name__)
+
+# Sentinel that distinguishes "leave color unchanged" (parameter
+# absent from the WS payload) from "clear the color" (caller
+# explicitly passed ``null``). ``None`` alone can't carry both
+# meanings — see ``update_label`` for the resulting code shape.
+_UNSET: Any = object()
+
+# Keep the regex case-insensitive at the match level but normalize
+# to lowercase before save so the on-disk shape is canonical.
+_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+_NAME_MAX_LEN = 50
+
+
+def _validate_name(name: Any) -> str:
+    """
+    Trim and validate a label name. Returns the canonical form.
+
+    Names are trimmed before storage so a stray space doesn't slip past
+    the uniqueness check. Empty / whitespace-only and over-long names
+    are user errors.
+    """
+    if not isinstance(name, str):
+        raise CommandError(ErrorCode.INVALID_ARGS, "Label name must be a string")
+    trimmed = name.strip()
+    if not trimmed:
+        raise CommandError(ErrorCode.INVALID_ARGS, "Label name must not be empty")
+    if len(trimmed) > _NAME_MAX_LEN:
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            f"Label name must be {_NAME_MAX_LEN} characters or fewer",
+        )
+    return trimmed
+
+
+def _validate_color(color: Any) -> str | None:
+    """Normalize an optional color to lowercase ``#rrggbb`` or ``None``."""
+    if color is None:
+        return None
+    if not isinstance(color, str) or not _COLOR_RE.fullmatch(color):
+        raise CommandError(ErrorCode.INVALID_ARGS, "Label color must be #rrggbb hex or null")
+    return color.lower()
+
+
+def _check_name_unique(catalog: list[Label], name: str, *, exclude_id: str | None = None) -> None:
+    """Raise ``CommandError(INVALID_ARGS)`` if *name* collides with an existing label.
+
+    Comparison is case-insensitive: ``"Kitchen"`` and ``"kitchen"`` are
+    treated as the same name. The caller's preferred case is preserved
+    on save — this only blocks the conflict.
+    """
+    target = name.lower()
+    for label in catalog:
+        if exclude_id is not None and label.id == exclude_id:
+            continue
+        if label.name.lower() == target:
+            raise CommandError(ErrorCode.INVALID_ARGS, f"Label name {name!r} already exists")
+
+
+class LabelsController:
+    """
+    Manages the global label catalog.
+
+    Labels are user-defined chips (name + optional color) that can be
+    assigned to devices via ``devices/set_labels``. The catalog itself
+    lives at the ``_labels`` key in ``.device-builder.json`` alongside
+    per-device entries and ``_preferences``; assignments are stored
+    on each device entry's ``labels`` field as a list of label IDs.
+
+    All CRUD operations validate against the catalog *inside* the
+    metadata transaction so a concurrent writer (e.g. another
+    ``labels/create`` racing on uniqueness, or a ``labels/delete``
+    cascading while ``devices/set_labels`` validates IDs) can't sneak
+    past the lock.
+    """
+
+    def __init__(self, device_builder: DeviceBuilder) -> None:
+        self._db = device_builder
+
+    @api_command("labels/list")
+    async def list_labels(self, **kwargs: Any) -> list[Label]:
+        """Return every label in the global catalog."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, load_labels, self._db.settings.config_dir)
+
+    @api_command("labels/create")
+    async def create_label(
+        self,
+        *,
+        name: str,
+        color: str | None = None,
+        **kwargs: Any,
+    ) -> Label:
+        """
+        Create a new label.
+
+        ``name`` is required; ``color`` is optional ``#rrggbb`` hex
+        (case-insensitive on input, lowercased on save). Label names
+        are unique case-insensitively. The server generates the
+        opaque ``id``; clients should treat it as a stable handle.
+        """
+        clean_name = _validate_name(name)
+        clean_color = _validate_color(color)
+        new_id = uuid.uuid4().hex
+
+        config_dir = self._db.settings.config_dir
+
+        def _persist() -> Label:
+            with labels_transaction(config_dir) as catalog:
+                _check_name_unique(catalog, clean_name)
+                created = Label(id=new_id, name=clean_name, color=clean_color)
+                catalog.append(created)
+                return created
+
+        label = await asyncio.to_thread(_persist)
+        self._db.bus.fire(EventType.LABEL_CREATED, {"label": label})
+        return label
+
+    @api_command("labels/update")
+    async def update_label(
+        self,
+        *,
+        label_id: str,
+        name: str | None = None,
+        color: Any = _UNSET,
+        **kwargs: Any,
+    ) -> Label:
+        """
+        Update a label's name and / or color.
+
+        Pass ``name`` to rename. Pass ``color`` (including
+        ``null``) to change or clear it; omit ``color`` from the
+        request to leave it unchanged. At least one of ``name`` or
+        ``color`` must be provided.
+        """
+        if name is None and color is _UNSET:
+            raise CommandError(ErrorCode.INVALID_ARGS, "Pass at least one of name or color")
+        clean_name = _validate_name(name) if name is not None else None
+        clean_color: Any = _validate_color(color) if color is not _UNSET else _UNSET
+
+        config_dir = self._db.settings.config_dir
+
+        def _persist() -> Label:
+            with labels_transaction(config_dir) as catalog:
+                target_idx = next((i for i, lbl in enumerate(catalog) if lbl.id == label_id), -1)
+                if target_idx < 0:
+                    raise CommandError(ErrorCode.NOT_FOUND, f"Label {label_id!r} not found")
+                current = catalog[target_idx]
+                next_name = clean_name if clean_name is not None else current.name
+                next_color = clean_color if clean_color is not _UNSET else current.color
+                if next_name.lower() != current.name.lower():
+                    _check_name_unique(catalog, next_name, exclude_id=label_id)
+                updated = Label(id=label_id, name=next_name, color=next_color)
+                catalog[target_idx] = updated
+                return updated
+
+        label = await asyncio.to_thread(_persist)
+        self._db.bus.fire(EventType.LABEL_UPDATED, {"label": label})
+        return label
+
+    @api_command("labels/delete")
+    async def delete_label(self, *, label_id: str, **kwargs: Any) -> dict[str, bool]:
+        """
+        Delete a label.
+
+        The deletion cascades: every device entry whose ``labels``
+        list contains this id has the id removed in the same
+        transaction, and a ``DEVICE_UPDATED`` event fires for each
+        affected device after the live ``Device`` reloads from the
+        sidecar. Returns ``{"deleted": True}`` on success; raises
+        ``NOT_FOUND`` if the id wasn't in the catalog.
+        """
+        config_dir = self._db.settings.config_dir
+
+        def _verify_and_cascade() -> tuple[bool, set[str]]:
+            existing = load_labels(config_dir)
+            if not any(label.id == label_id for label in existing):
+                return False, set()
+            return True, delete_label_cascade(config_dir, label_id)
+
+        found, affected = await asyncio.to_thread(_verify_and_cascade)
+        if not found:
+            raise CommandError(ErrorCode.NOT_FOUND, f"Label {label_id!r} not found")
+
+        # Reload every affected device so the live ``Device`` model picks up
+        # its trimmed labels list. Each reload fires its own
+        # ``DEVICE_UPDATED`` via the scanner's existing scan-change
+        # pipeline, so we don't refire here.
+        devices = self._db.devices
+        if devices is not None:
+            for filename in affected:
+                try:
+                    await devices.reload_configuration(filename)
+                except Exception:
+                    _LOGGER.warning("Failed to reload device %s after label cascade", filename)
+
+        self._db.bus.fire(EventType.LABEL_DELETED, {"label_id": label_id})
+        return {"deleted": True}

--- a/esphome_device_builder/controllers/labels.py
+++ b/esphome_device_builder/controllers/labels.py
@@ -191,16 +191,15 @@ class LabelsController:
         affected device after the live ``Device`` reloads from the
         sidecar. Returns ``{"deleted": True}`` on success; raises
         ``NOT_FOUND`` if the id wasn't in the catalog.
+
+        The existence check runs inside ``delete_label_cascade``'s
+        own transaction against the raw on-disk dict, so a corrupt
+        catalog entry (one that wouldn't survive ``Label.from_dict``)
+        is still removable.
         """
         config_dir = self._db.settings.config_dir
 
-        def _verify_and_cascade() -> tuple[bool, set[str]]:
-            existing = load_labels(config_dir)
-            if not any(label.id == label_id for label in existing):
-                return False, set()
-            return True, delete_label_cascade(config_dir, label_id)
-
-        found, affected = await asyncio.to_thread(_verify_and_cascade)
+        found, affected = await asyncio.to_thread(delete_label_cascade, config_dir, label_id)
         if not found:
             raise CommandError(ErrorCode.NOT_FOUND, f"Label {label_id!r} not found")
 

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -27,6 +27,7 @@ from .controllers.config import ConfigController, DashboardSettings
 from .controllers.devices import DevicesController
 from .controllers.editor import EditorController
 from .controllers.firmware import FirmwareController
+from .controllers.labels import LabelsController
 from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.auth import auth_middleware
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
@@ -96,6 +97,7 @@ class DeviceBuilder:
         self.automations: AutomationsController | None = None
         self.firmware: FirmwareController | None = None
         self.editor: EditorController | None = None
+        self.labels: LabelsController | None = None
 
         # Command registry — populated from controllers
         self.command_handlers: dict[str, CommandHandler] = {}
@@ -146,6 +148,7 @@ class DeviceBuilder:
         self.automations = AutomationsController(self)
         self.firmware = FirmwareController(self)
         self.editor = EditorController(self)
+        self.labels = LabelsController(self)
         await self.devices.start()
         await self.firmware.start()
         await self.editor.start()
@@ -160,6 +163,7 @@ class DeviceBuilder:
             self.automations,
             self.firmware,
             self.editor,
+            self.labels,
         ):
             self.command_handlers.update(collect_api_commands(controller))
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -394,6 +394,7 @@ def load_device_from_storage(
     expected_config_hash: str = "",
     mac_address: str = "",
     build_size_bytes: int = 0,
+    labels: tuple[str, ...] = (),
     *,
     previous: Device | None = None,
 ) -> Device:
@@ -430,6 +431,13 @@ def load_device_from_storage(
     driven by :class:`BuildSizeRefresher` (the single-worker
     refresh queue) gated on the freshness-pair equality check, so
     a steady-state re-scan stays off the heavy I/O path.
+
+    *labels* is the per-device list of label IDs (opaque
+    ``uuid.uuid4().hex`` references into the global ``_labels``
+    catalog at ``.device-builder.json``). The metadata round-trip
+    is the source of truth, so a reload triggered by an unrelated
+    YAML edit picks up label changes the same way it picks up
+    board-id edits.
 
     *previous* is the prior in-memory Device for this path, when one
     exists. Runtime-only fields populated by monitors (``state``,
@@ -611,6 +619,7 @@ def load_device_from_storage(
         ethernet_mac=ethernet_mac,
         bluetooth_mac=bluetooth_mac,
         build_size_bytes=build_size_bytes,
+        labels=list(labels),
     )
 
 

--- a/esphome_device_builder/models/__init__.py
+++ b/esphome_device_builder/models/__init__.py
@@ -6,4 +6,5 @@ from .common import *  # noqa: F403
 from .components import *  # noqa: F403
 from .devices import *  # noqa: F403
 from .firmware import *  # noqa: F403
+from .labels import *  # noqa: F403
 from .preferences import *  # noqa: F403

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -58,6 +58,13 @@ class EventType(StrEnum):
     IMPORTABLE_DEVICE_ADDED = "importable_device_added"
     IMPORTABLE_DEVICE_REMOVED = "importable_device_removed"
 
+    # Label catalog mutations. Per-device label assignment changes
+    # ride the existing ``DEVICE_UPDATED`` event (fired automatically
+    # by the scanner reload after the sidecar write).
+    LABEL_CREATED = "label_created"
+    LABEL_UPDATED = "label_updated"
+    LABEL_DELETED = "label_deleted"
+
     # Firmware job lifecycle
     JOB_QUEUED = "job_queued"
     JOB_STARTED = "job_started"

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -150,6 +150,14 @@ class Device(DataClassORJSONMixin):
     # re-walked. See ``helpers/build_size.py`` for the empirical
     # matrix that drove the pair-vs-single-stat decision.
     build_size_bytes: int = 0
+    # User-assigned label IDs (opaque ``uuid.uuid4().hex`` strings
+    # from the global catalog at ``.device-builder.json``'s
+    # ``_labels`` key). Frontend joins against the catalog from
+    # ``labels/list`` to render colored chips. The list itself is
+    # the assignment record; the canonical name and color live on
+    # the catalog entry, so a label rename / recolor needs no
+    # device-level write.
+    labels: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/esphome_device_builder/models/labels.py
+++ b/esphome_device_builder/models/labels.py
@@ -1,0 +1,29 @@
+"""User-defined label models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+
+@dataclass
+class Label(DataClassORJSONMixin):
+    """
+    A user-defined label that can be assigned to devices.
+
+    Stored in ``.device-builder.json`` under the ``_labels`` key and
+    referenced from each device entry by ``id``. Renaming or recoloring
+    a label leaves device assignments untouched — only the catalog
+    entry changes.
+    """
+
+    # Opaque ``uuid.uuid4().hex`` generated server-side. Stable across
+    # name and color edits.
+    id: str
+    # Display name. Trimmed before save; uniqueness is enforced
+    # case-insensitively.
+    name: str
+    # ``#rrggbb`` (lowercase). ``None`` lets the frontend pick a
+    # theme-default chip color.
+    color: str | None = None

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -1,0 +1,256 @@
+"""End-to-end coverage for ``DevicesController.set_labels``.
+
+The handler is a thin shim over the global label catalog plus a
+per-device sidecar write — but the *sequence* matters: if the
+catalog validation runs outside the metadata transaction, a
+concurrent ``labels/delete`` can leave a dangling reference; if
+the live ``Device`` model isn't refreshed after the sidecar
+write, the next ``devices/list`` (which serves from the in-memory
+scanner cache) returns stale labels.
+
+Three contracts to pin:
+
+1. Validation against the catalog runs inside the transaction so
+   unknown ids reject without a partial write.
+2. The sidecar write goes through ``set_device_labels`` (executor)
+   so blockbuster doesn't fault on Linux CI.
+3. After persistence the scanner's ``reload(filename)`` is
+   awaited, so the in-memory ``Device.labels`` list reflects the
+   trimmed sidecar without waiting on the next disk-driven scan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.controllers.config import (
+    get_device_metadata,
+    save_labels,
+)
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import Device, ErrorCode, Label
+from tests._recording_scanner import RecordingScanner
+
+from .conftest import MakeControllerFactory
+
+
+class _ReloadingScanner(RecordingScanner):
+    """RecordingScanner whose ``reload`` rehydrates the live ``Device.labels``.
+
+    The production scanner re-runs the metadata resolver on every
+    ``reload`` and replaces the ``Device`` in its index. The bare
+    ``RecordingScanner`` only records the call, so the controller's
+    ``set_labels`` (which reads back the live ``Device`` from
+    ``self._scanner.devices`` after reload) would always see the
+    stale pre-populated stub.
+
+    This fake walks ``self.devices`` for the matching configuration
+    and copies the freshly-persisted ``labels`` field off the
+    sidecar onto it. Narrower than swapping in
+    ``load_device_from_storage`` (which would require redirecting
+    ``ext_storage_path`` and dragging in the full StorageJSON
+    round-trip), but exactly the slice ``set_labels`` cares about.
+    """
+
+    def __init__(self, config_dir: Path, device: Device) -> None:
+        super().__init__()
+        self._config_dir = config_dir
+        self.devices = [device]
+
+    async def reload(self, filename: str) -> bool:
+        self.calls.append(("reload", filename))
+        md = get_device_metadata(self._config_dir, filename)
+        raw_labels = md.get("labels", [])
+        new_labels = (
+            [item for item in raw_labels if isinstance(item, str)]
+            if isinstance(raw_labels, list)
+            else []
+        )
+        for device in self.devices:
+            if device.configuration == filename:
+                device.labels = new_labels
+        return True
+
+
+def _make_device(filename: str = "kitchen.yaml", labels: list[str] | None = None) -> Device:
+    """Minimal Device fixture for these tests.
+
+    The set_labels handler doesn't read most fields off the device —
+    just ``configuration`` for the find-by-config lookup post-reload
+    and ``labels`` for the assertion. The rest carry safe defaults.
+    """
+    name = filename.removesuffix(".yaml").removesuffix(".yml")
+    return Device(
+        name=name,
+        friendly_name=name,
+        configuration=filename,
+        labels=list(labels or []),
+    )
+
+
+def _attach_reloading_scanner(
+    controller: DevicesController, config_dir: Path, device: Device
+) -> _ReloadingScanner:
+    """Swap ``make_controller``'s default RecordingScanner for the reload-aware one."""
+    scanner = _ReloadingScanner(config_dir, device)
+    controller._scanner = scanner
+    return scanner
+
+
+@pytest.mark.asyncio
+async def test_set_labels_persists_and_reloads(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Happy path: labels land on disk, scanner reload fires, response is fresh."""
+    save_labels(
+        tmp_path,
+        [Label(id="lbl-a", name="Alpha"), Label(id="lbl-b", name="Bravo")],
+    )
+
+    controller = make_controller(tmp_path)
+    scanner = _attach_reloading_scanner(controller, tmp_path, _make_device())
+
+    result = await controller.set_labels(configuration="kitchen.yaml", label_ids=["lbl-a", "lbl-b"])
+
+    # Sidecar reflects the assignment.
+    raw = json.loads((tmp_path / ".device-builder.json").read_bytes())
+    assert raw["kitchen.yaml"]["labels"] == ["lbl-a", "lbl-b"]
+
+    # Scanner was asked to reload the just-written file.
+    assert ("reload", "kitchen.yaml") in scanner.calls
+
+    # The returned Device carries the freshly-loaded labels.
+    assert isinstance(result, Device)
+    assert result.configuration == "kitchen.yaml"
+    assert result.labels == ["lbl-a", "lbl-b"]
+
+
+@pytest.mark.asyncio
+async def test_set_labels_clear_drops_sidecar_key(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Passing ``[]`` removes the labels field entirely (no empty list left over)."""
+    save_labels(tmp_path, [Label(id="lbl-a", name="Alpha")])
+
+    controller = make_controller(tmp_path)
+    _attach_reloading_scanner(controller, tmp_path, _make_device())
+
+    await controller.set_labels(configuration="kitchen.yaml", label_ids=["lbl-a"])
+    result = await controller.set_labels(configuration="kitchen.yaml", label_ids=[])
+
+    raw = json.loads((tmp_path / ".device-builder.json").read_bytes())
+    assert "labels" not in raw["kitchen.yaml"]
+    assert result.labels == []
+
+
+@pytest.mark.asyncio
+async def test_set_labels_unknown_id_rejected_without_partial_write(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """An unknown id raises ``INVALID_ARGS`` and skips both write + reload.
+
+    The catalog check runs inside the metadata transaction; if it
+    fails, the transaction discards its mutations and the scanner
+    never gets the reload signal. Pin both halves — a future
+    refactor that ran reload eagerly would sometimes still fire on
+    the failure path.
+    """
+    save_labels(tmp_path, [Label(id="known", name="Known")])
+
+    controller = make_controller(tmp_path)
+    scanner = _attach_reloading_scanner(controller, tmp_path, _make_device())
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.set_labels(configuration="kitchen.yaml", label_ids=["known", "ghost"])
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+    # Sidecar entry doesn't carry a half-applied list.
+    meta = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert "labels" not in meta
+
+    # No reload was scheduled — the failure path bails before the
+    # scanner is touched.
+    assert ("reload", "kitchen.yaml") not in scanner.calls
+
+
+@pytest.mark.asyncio
+async def test_set_labels_rejects_path_traversal(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``rel_path`` chokepoint catches traversal attempts before any write.
+
+    Reuses the same single-source path validation every other
+    file-touching command does. Without the gate, a crafted
+    ``configuration`` could persist labels into a sidecar entry
+    that doesn't correspond to any real device.
+    """
+    controller = make_controller(tmp_path)
+
+    # The real ``rel_path`` is what raises; ``make_controller``
+    # stubs it as a passthrough lambda, so wire the production
+    # behaviour back in for this test.
+    def _real_rel_path(configuration: str) -> Path:
+        joined = tmp_path / configuration
+        try:
+            joined.resolve().relative_to(tmp_path.resolve())
+        except ValueError as err:
+            raise CommandError(ErrorCode.INVALID_ARGS, "bad path") from err
+        return joined
+
+    controller._db.settings.rel_path = _real_rel_path
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.set_labels(configuration="../escape.yaml", label_ids=[])
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_set_labels_rejects_non_list_label_ids(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A non-list ``label_ids`` arg is a user error.
+
+    The WS layer doesn't enforce schema on raw args; the controller
+    has to. A regression that accepted a string would silently
+    iterate over its characters and validate one-letter ids.
+    """
+    controller = make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.set_labels(configuration="kitchen.yaml", label_ids="lbl-a")  # type: ignore[arg-type]
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_set_labels_round_trips_through_metadata(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """The persisted sidecar entry is shaped exactly as ``get_device_metadata`` reads it.
+
+    This catches a class of regression where the write side and
+    the read side could drift on the labels field's encoding —
+    e.g. one writing a tuple, the other expecting a list.
+    """
+    save_labels(tmp_path, [Label(id="lbl-a", name="Alpha")])
+
+    controller = make_controller(tmp_path)
+    _attach_reloading_scanner(controller, tmp_path, _make_device())
+
+    await controller.set_labels(configuration="kitchen.yaml", label_ids=["lbl-a"])
+
+    md = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert md["labels"] == ["lbl-a"]

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -64,7 +64,11 @@ class _ReloadingScanner(RecordingScanner):
 
     async def reload(self, filename: str) -> bool:
         self.calls.append(("reload", filename))
-        md = get_device_metadata(self._config_dir, filename)
+        # ``get_device_metadata`` reads ``.device-builder.json`` via
+        # ``Path.read_bytes`` — sync I/O. Hop through a thread the
+        # way the production scanner does so blockbuster on Linux CI
+        # doesn't fault on the inner ``os.path.abspath`` resolve.
+        md = await asyncio.to_thread(get_device_metadata, self._config_dir, filename)
         raw_labels = md.get("labels", [])
         new_labels = (
             [item for item in raw_labels if isinstance(item, str)]
@@ -196,18 +200,18 @@ async def test_set_labels_rejects_path_traversal(
     """
     controller = make_controller(tmp_path)
 
-    # The real ``rel_path`` is what raises; ``make_controller``
-    # stubs it as a passthrough lambda, so wire the production
-    # behaviour back in for this test.
-    def _real_rel_path(configuration: str) -> Path:
-        joined = tmp_path / configuration
-        try:
-            joined.resolve().relative_to(tmp_path.resolve())
-        except ValueError as err:
-            raise CommandError(ErrorCode.INVALID_ARGS, "bad path") from err
-        return joined
+    # The production ``rel_path`` calls ``Path.resolve`` (sync
+    # ``os.path.abspath`` under the hood) — fine in production but
+    # blockbuster on Linux CI faults on it from an async test
+    # context. Mimic the rejection on the same surface (a ``..``
+    # segment is what the production guard ultimately catches via
+    # ``relative_to``) without the blocking syscall.
+    def _strict_rel_path(configuration: str) -> Path:
+        if ".." in Path(configuration).parts or Path(configuration).is_absolute():
+            raise CommandError(ErrorCode.INVALID_ARGS, "bad path")
+        return tmp_path / configuration
 
-    controller._db.settings.rel_path = _real_rel_path
+    controller._db.settings.rel_path = _strict_rel_path
 
     with pytest.raises(CommandError) as exc_info:
         await controller.set_labels(configuration="../escape.yaml", label_ids=[])

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -240,6 +240,66 @@ async def test_set_labels_rejects_non_list_label_ids(
 
 
 @pytest.mark.asyncio
+async def test_set_labels_rejects_non_string_label_id(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A non-string item inside ``label_ids`` raises ``INVALID_ARGS``.
+
+    Silent skipping at the persistence layer would let a payload of
+    all-bad types degrade to an effective ``[]`` (clear-all) write.
+    The controller surfaces the validation error from
+    ``set_device_labels`` cleanly.
+    """
+    controller = make_controller(tmp_path)
+    _attach_reloading_scanner(controller, tmp_path, _make_device())
+    await asyncio.to_thread(save_labels, tmp_path, [Label(id="lbl-a", name="Alpha")])
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.set_labels(
+            configuration="kitchen.yaml",
+            label_ids=["lbl-a", 42],  # type: ignore[list-item]
+        )
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+    # No partial / empty write happened.
+    meta = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert "labels" not in meta
+
+
+@pytest.mark.asyncio
+async def test_set_labels_rejects_unknown_configuration(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A ``configuration`` not in the scanner raises ``NOT_FOUND`` before any write.
+
+    Without this check a typo'd configuration name would still pass
+    ``rel_path`` (no traversal involved) and the persist layer would
+    happily create a new sidecar entry — leaving an orphaned
+    ``.device-builder.json`` row pinning labels to a non-existent
+    device.
+    """
+    controller = make_controller(tmp_path)
+    # Empty scanner devices list — no device matches.
+    scanner = _attach_reloading_scanner(controller, tmp_path, _make_device("kitchen.yaml"))
+    scanner.devices = []  # explicitly empty
+    await asyncio.to_thread(save_labels, tmp_path, [Label(id="lbl-a", name="Alpha")])
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.set_labels(configuration="ghost.yaml", label_ids=["lbl-a"])
+
+    assert exc_info.value.code is ErrorCode.NOT_FOUND
+
+    # No sidecar entry created for the unknown configuration.
+    meta = await asyncio.to_thread(get_device_metadata, tmp_path, "ghost.yaml")
+    assert meta == {}
+    # And no scanner reload was triggered.
+    assert ("reload", "ghost.yaml") not in scanner.calls
+
+
+@pytest.mark.asyncio
 async def test_set_labels_round_trips_through_metadata(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -112,7 +112,8 @@ async def test_set_labels_persists_and_reloads(
     make_controller: MakeControllerFactory,
 ) -> None:
     """Happy path: labels land on disk, scanner reload fires, response is fresh."""
-    save_labels(
+    await asyncio.to_thread(
+        save_labels,
         tmp_path,
         [Label(id="lbl-a", name="Alpha"), Label(id="lbl-b", name="Bravo")],
     )
@@ -141,7 +142,7 @@ async def test_set_labels_clear_drops_sidecar_key(
     make_controller: MakeControllerFactory,
 ) -> None:
     """Passing ``[]`` removes the labels field entirely (no empty list left over)."""
-    save_labels(tmp_path, [Label(id="lbl-a", name="Alpha")])
+    await asyncio.to_thread(save_labels, tmp_path, [Label(id="lbl-a", name="Alpha")])
 
     controller = make_controller(tmp_path)
     _attach_reloading_scanner(controller, tmp_path, _make_device())
@@ -167,7 +168,7 @@ async def test_set_labels_unknown_id_rejected_without_partial_write(
     refactor that ran reload eagerly would sometimes still fire on
     the failure path.
     """
-    save_labels(tmp_path, [Label(id="known", name="Known")])
+    await asyncio.to_thread(save_labels, tmp_path, [Label(id="known", name="Known")])
 
     controller = make_controller(tmp_path)
     scanner = _attach_reloading_scanner(controller, tmp_path, _make_device())
@@ -249,7 +250,7 @@ async def test_set_labels_round_trips_through_metadata(
     the read side could drift on the labels field's encoding —
     e.g. one writing a tuple, the other expecting a list.
     """
-    save_labels(tmp_path, [Label(id="lbl-a", name="Alpha")])
+    await asyncio.to_thread(save_labels, tmp_path, [Label(id="lbl-a", name="Alpha")])
 
     controller = make_controller(tmp_path)
     _attach_reloading_scanner(controller, tmp_path, _make_device())

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -300,6 +300,28 @@ async def test_set_labels_rejects_unknown_configuration(
 
 
 @pytest.mark.asyncio
+async def test_reload_configuration_delegates_to_scanner(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """The public ``reload_configuration`` is a thin pass-through to the scanner.
+
+    Pinned because it's the public seam the labels controller calls
+    into during cascade-on-delete. A future refactor that renamed the
+    scanner method or stopped awaiting it would silently break the
+    cascade path; the assertion captures both the call shape and the
+    return value.
+    """
+    controller = make_controller(tmp_path)
+    # ``RecordingScanner.reload`` records every call and returns its
+    # ``_reload_returns`` flag (defaults to ``True``).
+    result = await controller.reload_configuration("kitchen.yaml")
+
+    assert result is True
+    assert ("reload", "kitchen.yaml") in controller._scanner.calls
+
+
+@pytest.mark.asyncio
 async def test_set_labels_round_trips_through_metadata(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/test_labels.py
+++ b/tests/controllers/test_labels.py
@@ -1,0 +1,391 @@
+"""Tests for ``controllers/labels.py`` — global label catalog CRUD.
+
+The labels controller is a thin layer over the ``_labels`` key in
+``.device-builder.json`` plus a pair of broadcast events. Coverage
+focuses on:
+
+* Validation rules (name length, color format, case-insensitive
+  uniqueness) — the controller is the authoritative gate the
+  frontend's input form mirrors, so a regression here lets bad
+  data slip through to disk.
+* Cascade-on-delete — labels are referenced by device entries; a
+  delete must drop them from every assignment AND the catalog in
+  one transaction so a concurrent reader can't see a dangling
+  reference.
+* Event emission shape — the frontend updates its label cache off
+  these events.
+
+Tests bypass-init the controller (``__new__`` + stubbed
+``_db``) so the suite doesn't drag in the full ``DeviceBuilder``
+lifecycle. The scanner reload path is exercised through a stub
+that records its calls, mirroring how the production
+``DevicesController.reload_configuration`` would feed the change
+back into the live ``Device`` model.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.config import (
+    load_labels,
+    save_labels,
+    set_device_labels,
+)
+from esphome_device_builder.controllers.labels import LabelsController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.event_bus import Event, EventBus
+from esphome_device_builder.models import ErrorCode, EventType, Label
+
+
+def _make_controller(
+    config_dir: Path,
+    *,
+    reload_calls: list[str] | None = None,
+) -> tuple[LabelsController, list[Event]]:
+    """Bypass-init a ``LabelsController`` with a real bus + stubbed devices.
+
+    Returns the controller and a live capture list of every event
+    fanned out on the bus. The ``reload_calls`` list, when given,
+    captures filenames passed to ``_db.devices.reload_configuration``
+    so cascade tests can assert on the worklist.
+    """
+    bus = EventBus()
+    captured: list[Event] = []
+    for event_type in EventType:
+        bus.add_listener(event_type, captured.append)
+
+    controller = LabelsController.__new__(LabelsController)
+    controller._db = MagicMock()
+    controller._db.settings.config_dir = config_dir
+    controller._db.bus = bus
+
+    if reload_calls is None:
+        controller._db.devices = None
+    else:
+
+        async def _reload(filename: str) -> bool:
+            reload_calls.append(filename)
+            return True
+
+        controller._db.devices = MagicMock()
+        controller._db.devices.reload_configuration = _reload
+
+    return controller, captured
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_label_persists_and_emits_event(tmp_path: Path) -> None:
+    """Happy path: name + color saved, ``LABEL_CREATED`` fired with the label."""
+    controller, captured = _make_controller(tmp_path)
+
+    label = await controller.create_label(name="Kitchen", color="#FF0000")
+
+    assert label.name == "Kitchen"
+    # Color is normalised to lowercase on save so the on-disk shape is
+    # canonical regardless of the user's input case.
+    assert label.color == "#ff0000"
+    assert len(label.id) == 32  # uuid4().hex
+
+    persisted = load_labels(tmp_path)
+    assert persisted == [label]
+
+    label_events = [e for e in captured if e.event_type == EventType.LABEL_CREATED]
+    assert len(label_events) == 1
+    assert label_events[0].data == {"label": label}
+
+
+@pytest.mark.asyncio
+async def test_create_label_trims_whitespace(tmp_path: Path) -> None:
+    """Surrounding whitespace is stripped before save AND uniqueness check."""
+    controller, _ = _make_controller(tmp_path)
+
+    label = await controller.create_label(name="  Kitchen  ")
+
+    assert label.name == "Kitchen"
+
+
+@pytest.mark.asyncio
+async def test_create_label_default_color_is_none(tmp_path: Path) -> None:
+    """Omitting ``color`` lets the frontend pick a chip color."""
+    controller, _ = _make_controller(tmp_path)
+
+    label = await controller.create_label(name="Kitchen")
+
+    assert label.color is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["", "   ", "\t\n"])
+async def test_create_label_rejects_empty_name(tmp_path: Path, name: str) -> None:
+    """Empty / whitespace-only names raise ``INVALID_ARGS``."""
+    controller, _ = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.create_label(name=name)
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_create_label_rejects_overlong_name(tmp_path: Path) -> None:
+    """Names longer than 50 chars (matches GitHub's cap) are rejected."""
+    controller, _ = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.create_label(name="x" * 51)
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("color", ["red", "#fff", "#GGGGGG", "ff0000", "#ff00ff00"])
+async def test_create_label_rejects_invalid_color(tmp_path: Path, color: str) -> None:
+    """Anything that isn't a 6-digit hex with leading ``#`` is rejected.
+
+    The frontend's chip renderer trusts the saved value as a CSS
+    color; loose parsing here would let ``"red"`` through, which
+    works in CSS but breaks the color-picker round-trip.
+    """
+    controller, _ = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.create_label(name="X", color=color)
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_create_label_unique_name_case_insensitive(tmp_path: Path) -> None:
+    """``"Kitchen"`` and ``"kitchen"`` are treated as the same name."""
+    controller, _ = _make_controller(tmp_path)
+    await controller.create_label(name="Kitchen")
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.create_label(name="kitchen")
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+    # The original entry survives the rejected create.
+    assert [lbl.name for lbl in load_labels(tmp_path)] == ["Kitchen"]
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_labels_returns_catalog_in_insertion_order(tmp_path: Path) -> None:
+    """Catalog read returns labels in the order they were created."""
+    save_labels(
+        tmp_path,
+        [
+            Label(id="a", name="Alpha"),
+            Label(id="b", name="Bravo"),
+            Label(id="c", name="Charlie"),
+        ],
+    )
+    controller, _ = _make_controller(tmp_path)
+
+    result = await controller.list_labels()
+
+    assert [lbl.name for lbl in result] == ["Alpha", "Bravo", "Charlie"]
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_label_rename_preserves_id_and_color(tmp_path: Path) -> None:
+    """Renaming changes the name but keeps the id and existing color.
+
+    Devices reference labels by id — a rename must NOT mint a new
+    id or every device assignment would be orphaned.
+    """
+    controller, captured = _make_controller(tmp_path)
+    created = await controller.create_label(name="Kitchen", color="#ff0000")
+
+    updated = await controller.update_label(label_id=created.id, name="Living Room")
+
+    assert updated.id == created.id
+    assert updated.name == "Living Room"
+    assert updated.color == "#ff0000"  # untouched
+
+    update_events = [e for e in captured if e.event_type == EventType.LABEL_UPDATED]
+    assert len(update_events) == 1
+    assert update_events[0].data == {"label": updated}
+
+
+@pytest.mark.asyncio
+async def test_update_label_clear_color_via_explicit_null(tmp_path: Path) -> None:
+    """``color=None`` clears the color; sentinel pattern distinguishes from "leave alone"."""
+    controller, _ = _make_controller(tmp_path)
+    created = await controller.create_label(name="Kitchen", color="#ff0000")
+
+    updated = await controller.update_label(label_id=created.id, color=None)
+
+    assert updated.name == created.name  # untouched (only color was passed)
+    assert updated.color is None
+
+
+@pytest.mark.asyncio
+async def test_update_label_no_changes_rejected(tmp_path: Path) -> None:
+    """Passing neither name nor color is a user error.
+
+    Without the guard, this would silently no-op and emit a
+    ``LABEL_UPDATED`` event with unchanged data, confusing
+    subscribers.
+    """
+    controller, _ = _make_controller(tmp_path)
+    created = await controller.create_label(name="Kitchen")
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.update_label(label_id=created.id)
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_update_label_unknown_id_returns_not_found(tmp_path: Path) -> None:
+    """An id that isn't in the catalog raises ``NOT_FOUND``."""
+    controller, _ = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.update_label(label_id="ghost", name="X")
+
+    assert exc_info.value.code is ErrorCode.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_update_label_rename_blocked_by_other_label(tmp_path: Path) -> None:
+    """Renaming to another label's name is rejected; existing entries unchanged."""
+    controller, _ = _make_controller(tmp_path)
+    a = await controller.create_label(name="Kitchen")
+    b = await controller.create_label(name="Garage")
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.update_label(label_id=b.id, name="kitchen")  # case folded
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+    # Self-rename to the same case-folded form is fine — it's
+    # comparing the same id.
+    same_case = await controller.update_label(label_id=a.id, name="KITCHEN")
+    assert same_case.name == "KITCHEN"
+
+
+# ---------------------------------------------------------------------------
+# delete + cascade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_label_removes_from_catalog_and_emits_event(tmp_path: Path) -> None:
+    """Delete drops the label and broadcasts ``LABEL_DELETED`` with the id."""
+    controller, captured = _make_controller(tmp_path)
+    created = await controller.create_label(name="Kitchen")
+
+    result = await controller.delete_label(label_id=created.id)
+
+    assert result == {"deleted": True}
+    assert load_labels(tmp_path) == []
+
+    deleted_events = [e for e in captured if e.event_type == EventType.LABEL_DELETED]
+    assert len(deleted_events) == 1
+    assert deleted_events[0].data == {"label_id": created.id}
+
+
+@pytest.mark.asyncio
+async def test_delete_label_unknown_id_raises_not_found(tmp_path: Path) -> None:
+    """Deleting a label that isn't in the catalog raises ``NOT_FOUND``.
+
+    Without the explicit check the call would silently succeed
+    (cascade is a no-op when the id isn't on any device), and the
+    frontend's "delete pressed twice" path would mask a real bug
+    elsewhere.
+    """
+    controller, _ = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.delete_label(label_id="ghost")
+
+    assert exc_info.value.code is ErrorCode.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_delete_label_cascades_through_assigned_devices(tmp_path: Path) -> None:
+    """Devices that referenced the deleted label get reloaded.
+
+    The reload is what makes the in-memory ``Device.labels`` list
+    catch up with the trimmed sidecar — without it, the live model
+    would lag the file until the next disk-driven scan.
+    """
+    reload_calls: list[str] = []
+    controller, captured = _make_controller(tmp_path, reload_calls=reload_calls)
+
+    a = await controller.create_label(name="Kitchen")
+    b = await controller.create_label(name="Garage")
+    set_device_labels(tmp_path, "kitchen.yaml", [a.id, b.id])
+    set_device_labels(tmp_path, "garage.yaml", [a.id])
+    set_device_labels(tmp_path, "office.yaml", [b.id])
+
+    await controller.delete_label(label_id=a.id)
+
+    assert sorted(reload_calls) == ["garage.yaml", "kitchen.yaml"]
+
+    raw = json.loads((tmp_path / ".device-builder.json").read_bytes())
+    assert raw["kitchen.yaml"]["labels"] == [b.id]
+    assert "labels" not in raw["garage.yaml"]
+    assert raw["office.yaml"]["labels"] == [b.id]
+
+    deleted_events = [e for e in captured if e.event_type == EventType.LABEL_DELETED]
+    assert len(deleted_events) == 1
+    assert deleted_events[0].data == {"label_id": a.id}
+
+
+@pytest.mark.asyncio
+async def test_delete_label_tolerates_devices_controller_absent(tmp_path: Path) -> None:
+    """Cascade still completes when no DevicesController is wired.
+
+    Pre-start lifecycle and isolated tests can drive the labels
+    controller without a fully-initialised devices controller.
+    The cascade should still scrub the sidecar — only the live
+    Device reload is skipped.
+    """
+    controller, _ = _make_controller(tmp_path)  # devices=None
+
+    created = await controller.create_label(name="Kitchen")
+    set_device_labels(tmp_path, "kitchen.yaml", [created.id])
+
+    await controller.delete_label(label_id=created.id)
+
+    raw = json.loads((tmp_path / ".device-builder.json").read_bytes())
+    assert "labels" not in raw["kitchen.yaml"]
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persistence_round_trip_across_controller_instances(tmp_path: Path) -> None:
+    """Labels created via one controller survive a fresh instance."""
+    first, _ = _make_controller(tmp_path)
+    a = await first.create_label(name="Alpha", color="#aabbcc")
+    b = await first.create_label(name="Bravo")
+
+    second, _ = _make_controller(tmp_path)
+    result = await second.list_labels()
+
+    assert result == [a, b]

--- a/tests/controllers/test_labels.py
+++ b/tests/controllers/test_labels.py
@@ -25,6 +25,7 @@ back into the live ``Device`` model.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -186,7 +187,8 @@ async def test_create_label_unique_name_case_insensitive(tmp_path: Path) -> None
 @pytest.mark.asyncio
 async def test_list_labels_returns_catalog_in_insertion_order(tmp_path: Path) -> None:
     """Catalog read returns labels in the order they were created."""
-    save_labels(
+    await asyncio.to_thread(
+        save_labels,
         tmp_path,
         [
             Label(id="a", name="Alpha"),
@@ -335,9 +337,9 @@ async def test_delete_label_cascades_through_assigned_devices(tmp_path: Path) ->
 
     a = await controller.create_label(name="Kitchen")
     b = await controller.create_label(name="Garage")
-    set_device_labels(tmp_path, "kitchen.yaml", [a.id, b.id])
-    set_device_labels(tmp_path, "garage.yaml", [a.id])
-    set_device_labels(tmp_path, "office.yaml", [b.id])
+    await asyncio.to_thread(set_device_labels, tmp_path, "kitchen.yaml", [a.id, b.id])
+    await asyncio.to_thread(set_device_labels, tmp_path, "garage.yaml", [a.id])
+    await asyncio.to_thread(set_device_labels, tmp_path, "office.yaml", [b.id])
 
     await controller.delete_label(label_id=a.id)
 
@@ -365,7 +367,7 @@ async def test_delete_label_tolerates_devices_controller_absent(tmp_path: Path) 
     controller, _ = _make_controller(tmp_path)  # devices=None
 
     created = await controller.create_label(name="Kitchen")
-    set_device_labels(tmp_path, "kitchen.yaml", [created.id])
+    await asyncio.to_thread(set_device_labels, tmp_path, "kitchen.yaml", [created.id])
 
     await controller.delete_label(label_id=created.id)
 

--- a/tests/controllers/test_labels.py
+++ b/tests/controllers/test_labels.py
@@ -97,7 +97,7 @@ async def test_create_label_persists_and_emits_event(tmp_path: Path) -> None:
     assert label.color == "#ff0000"
     assert len(label.id) == 32  # uuid4().hex
 
-    persisted = load_labels(tmp_path)
+    persisted = await asyncio.to_thread(load_labels, tmp_path)
     assert persisted == [label]
 
     label_events = [e for e in captured if e.event_type == EventType.LABEL_CREATED]
@@ -176,7 +176,8 @@ async def test_create_label_unique_name_case_insensitive(tmp_path: Path) -> None
 
     assert exc_info.value.code is ErrorCode.INVALID_ARGS
     # The original entry survives the rejected create.
-    assert [lbl.name for lbl in load_labels(tmp_path)] == ["Kitchen"]
+    persisted = await asyncio.to_thread(load_labels, tmp_path)
+    assert [lbl.name for lbl in persisted] == ["Kitchen"]
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +301,7 @@ async def test_delete_label_removes_from_catalog_and_emits_event(tmp_path: Path)
     result = await controller.delete_label(label_id=created.id)
 
     assert result == {"deleted": True}
-    assert load_labels(tmp_path) == []
+    assert await asyncio.to_thread(load_labels, tmp_path) == []
 
     deleted_events = [e for e in captured if e.event_type == EventType.LABEL_DELETED]
     assert len(deleted_events) == 1

--- a/tests/controllers/test_labels.py
+++ b/tests/controllers/test_labels.py
@@ -375,6 +375,38 @@ async def test_delete_label_tolerates_devices_controller_absent(tmp_path: Path) 
     assert "labels" not in raw["kitchen.yaml"]
 
 
+@pytest.mark.asyncio
+async def test_delete_label_can_remove_corrupt_catalog_entry(tmp_path: Path) -> None:
+    """A catalog entry that ``Label.from_dict`` would reject is still deletable.
+
+    The existence check runs against the raw on-disk dict inside the
+    cascade transaction, not against decoded ``Label`` instances.
+    Without that, a hand-edited or partially-written entry would be
+    impossible to clean up — ``load_labels`` would skip it (so
+    ``NOT_FOUND``) but it would still occupy a slot in ``_labels``.
+    """
+    (tmp_path / ".device-builder.json").write_bytes(
+        json.dumps(
+            {
+                "_labels": [
+                    {"id": "corrupt"},  # missing ``name`` — Label.from_dict raises
+                    {"id": "good", "name": "Good", "color": None},
+                ]
+            }
+        ).encode()
+    )
+    controller, captured = _make_controller(tmp_path)
+
+    result = await controller.delete_label(label_id="corrupt")
+
+    assert result == {"deleted": True}
+    raw = json.loads((tmp_path / ".device-builder.json").read_bytes())
+    assert [entry["id"] for entry in raw["_labels"]] == ["good"]
+
+    deleted_events = [e for e in captured if e.event_type == EventType.LABEL_DELETED]
+    assert len(deleted_events) == 1
+
+
 # ---------------------------------------------------------------------------
 # Persistence round-trip
 # ---------------------------------------------------------------------------

--- a/tests/controllers/test_labels.py
+++ b/tests/controllers/test_labels.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -129,6 +130,23 @@ async def test_create_label_default_color_is_none(tmp_path: Path) -> None:
 @pytest.mark.parametrize("name", ["", "   ", "\t\n"])
 async def test_create_label_rejects_empty_name(tmp_path: Path, name: str) -> None:
     """Empty / whitespace-only names raise ``INVALID_ARGS``."""
+    controller, _ = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.create_label(name=name)
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", [123, None, ["bad"], {"bad": True}])
+async def test_create_label_rejects_non_string_name(tmp_path: Path, name: Any) -> None:
+    """Non-string ``name`` payloads raise ``INVALID_ARGS``.
+
+    The WS layer doesn't enforce arg types; the validator has to.
+    Without this guard, ``name.strip()`` would crash with
+    ``AttributeError`` and surface as a generic ``INTERNAL_ERROR``.
+    """
     controller, _ = _make_controller(tmp_path)
 
     with pytest.raises(CommandError) as exc_info:
@@ -374,6 +392,45 @@ async def test_delete_label_tolerates_devices_controller_absent(tmp_path: Path) 
 
     raw = json.loads((tmp_path / ".device-builder.json").read_bytes())
     assert "labels" not in raw["kitchen.yaml"]
+
+
+@pytest.mark.asyncio
+async def test_delete_label_swallows_per_device_reload_failures(tmp_path: Path) -> None:
+    """A reload failure on one device doesn't stop the cascade.
+
+    The cascade transaction has already committed by the time we
+    reach the reload loop, so a transient scanner error (e.g.
+    YAML disappeared between cascade write and reload) is logged
+    and skipped — the next disk-driven scan picks up the cleaned
+    state on its own. Pin: cascade keeps going even when reload
+    raises.
+    """
+    bus = EventBus()
+    captured: list[Event] = []
+    for event_type in EventType:
+        bus.add_listener(event_type, captured.append)
+
+    controller = LabelsController.__new__(LabelsController)
+    controller._db = MagicMock()
+    controller._db.settings.config_dir = tmp_path
+    controller._db.bus = bus
+
+    async def _reload_raises(filename: str) -> bool:
+        raise RuntimeError("scanner failed")
+
+    controller._db.devices = MagicMock()
+    controller._db.devices.reload_configuration = _reload_raises
+
+    created = await controller.create_label(name="Kitchen")
+    await asyncio.to_thread(set_device_labels, tmp_path, "kitchen.yaml", [created.id])
+
+    # Cascade reaches the reload loop and swallows the exception;
+    # ``LABEL_DELETED`` still fires.
+    result = await controller.delete_label(label_id=created.id)
+    assert result == {"deleted": True}
+
+    deleted_events = [e for e in captured if e.event_type == EventType.LABEL_DELETED]
+    assert len(deleted_events) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_label.py
+++ b/tests/models/test_label.py
@@ -1,0 +1,40 @@
+"""Tests for the ``Label`` dataclass round-trip.
+
+The ``Label`` model is the wire shape exposed via ``labels/list``
+and the persisted shape under ``_labels`` in
+``.device-builder.json``. The frontend joins device label-id
+references against this list to render colored chips, so a silent
+serialization regression — say ``color: None`` round-tripping as
+the literal string ``"None"`` — would put junk on every chip.
+Mashumaro handles the encode/decode but the test pins the contract
+so a future field rename or default change can't slip through.
+"""
+
+from __future__ import annotations
+
+from esphome_device_builder.models import Label
+
+
+def test_label_to_dict_round_trip() -> None:
+    """``Label.from_dict(label.to_dict())`` reproduces the original."""
+    label = Label(id="abc123", name="Kitchen", color="#ff0000")
+    assert Label.from_dict(label.to_dict()) == label
+
+
+def test_label_color_optional_round_trips_as_none() -> None:
+    """``color=None`` survives a dict round-trip (not coerced to ``""``)."""
+    label = Label(id="xyz789", name="Dev", color=None)
+    encoded = label.to_dict()
+    assert encoded["color"] is None
+    assert Label.from_dict(encoded) == label
+
+
+def test_label_to_dict_shape_is_stable() -> None:
+    """The persisted keys are exactly id / name / color.
+
+    Pins the wire contract — the frontend reads these keys
+    directly off events and ``labels/list`` responses, so adding
+    or renaming a field needs an explicit, coordinated change.
+    """
+    label = Label(id="abc123", name="Kitchen", color="#ff0000")
+    assert set(label.to_dict().keys()) == {"id", "name", "color"}

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -941,8 +941,9 @@ def test_delete_label_cascade_drops_label_and_returns_affected(tmp_path: Path) -
     set_device_labels(tmp_path, "garage.yaml", ["x"])
     set_device_labels(tmp_path, "office.yaml", ["y"])
 
-    affected = delete_label_cascade(tmp_path, "x")
+    found, affected = delete_label_cascade(tmp_path, "x")
 
+    assert found is True
     assert affected == {"kitchen.yaml", "garage.yaml"}
     raw = _load_metadata(tmp_path)
     # Catalog drops the deleted label.
@@ -955,10 +956,67 @@ def test_delete_label_cascade_drops_label_and_returns_affected(tmp_path: Path) -
 
 
 def test_delete_label_cascade_when_no_devices_assigned(tmp_path: Path) -> None:
-    """A label with no assignments → empty affected set, label still removed."""
+    """A label with no assignments → ``found=True`` and empty affected set."""
     save_labels(tmp_path, [Label(id="ghost", name="Ghost")])
 
-    affected = delete_label_cascade(tmp_path, "ghost")
+    found, affected = delete_label_cascade(tmp_path, "ghost")
 
+    assert found is True
     assert affected == set()
     assert load_labels(tmp_path) == []
+
+
+def test_delete_label_cascade_unknown_id_reports_not_found(tmp_path: Path) -> None:
+    """Deleting an id that isn't in the catalog returns ``found=False``."""
+    save_labels(tmp_path, [Label(id="known", name="Known")])
+
+    found, affected = delete_label_cascade(tmp_path, "ghost")
+
+    assert found is False
+    assert affected == set()
+    # Existing catalog entry untouched.
+    assert [lbl.id for lbl in load_labels(tmp_path)] == ["known"]
+
+
+def test_delete_label_cascade_removes_corrupt_entry(tmp_path: Path) -> None:
+    """A corrupt catalog entry (missing required fields) is still deletable.
+
+    The existence check works against the raw on-disk dict — not the
+    decoded ``Label`` instances ``load_labels`` returns — so a
+    hand-edited or partially-written entry that ``Label.from_dict``
+    would reject can still be cleaned up via ``delete_label``.
+    """
+    (tmp_path / ".device-builder.json").write_bytes(
+        json.dumps(
+            {
+                "_labels": [
+                    {"id": "corrupt"},  # missing ``name`` — Label.from_dict raises
+                    {"id": "good", "name": "Good", "color": None},
+                ]
+            }
+        ).encode()
+    )
+
+    found, affected = delete_label_cascade(tmp_path, "corrupt")
+
+    assert found is True
+    assert affected == set()
+    # Catalog now carries only the well-formed entry.
+    raw = _load_metadata(tmp_path)
+    assert [entry["id"] for entry in raw["_labels"]] == ["good"]
+
+
+def test_set_device_labels_rejects_non_string_items(tmp_path: Path) -> None:
+    """Non-string items in ``label_ids`` raise ``ValueError``.
+
+    The controller wraps this into ``CommandError(INVALID_ARGS)``.
+    Silent skipping would let a bad payload effectively clear all
+    labels, which is surprising and user-hostile.
+    """
+    save_labels(tmp_path, [Label(id="known", name="Known")])
+
+    with pytest.raises(ValueError, match="label_ids must be strings"):
+        set_device_labels(tmp_path, "kitchen.yaml", ["known", 42])  # type: ignore[list-item]
+
+    # No partial write happened.
+    assert "kitchen.yaml" not in _load_metadata(tmp_path)

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -40,16 +40,21 @@ from esphome_device_builder.controllers.config import (
     ConfigController,
     _load_metadata,
     _save_metadata,
+    delete_label_cascade,
     get_device_ip,
     get_device_metadata,
+    labels_transaction,
+    load_labels,
     load_preferences,
     metadata_transaction,
     remove_device_metadata,
+    save_labels,
     save_preferences,
+    set_device_labels,
     set_device_metadata,
 )
 from esphome_device_builder.helpers.api import CommandError
-from esphome_device_builder.models import ErrorCode
+from esphome_device_builder.models import ErrorCode, Label
 from esphome_device_builder.models.preferences import (
     DashboardView,
     Theme,
@@ -770,3 +775,190 @@ async def test_get_serial_ports_returns_empty_when_no_ports(
     result = await controller.get_serial_ports_cmd()
 
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Labels — global catalog + per-device assignments
+# ---------------------------------------------------------------------------
+
+
+def test_load_labels_returns_empty_when_missing(tmp_path: Path) -> None:
+    """A fresh install has no ``_labels`` key — load returns ``[]``."""
+    assert load_labels(tmp_path) == []
+
+
+def test_load_labels_skips_corrupt_entries(tmp_path: Path) -> None:
+    """Malformed entries don't take the whole catalog down.
+
+    Labels are advisory — a hand-edited sidecar that landed a
+    non-dict entry, or an entry missing required fields, would
+    otherwise raise ``KeyError`` on every catalog read and lock the
+    user out of working with the rest of their labels. The
+    implementation skips bad entries silently.
+    """
+    (tmp_path / ".device-builder.json").write_bytes(
+        json.dumps(
+            {
+                "_labels": [
+                    {"id": "good1", "name": "Kitchen", "color": "#ff0000"},
+                    "garbage-string-not-a-dict",
+                    {"name": "missing-id", "color": None},
+                    {"id": "good2", "name": "Dev", "color": None},
+                ]
+            }
+        ).encode()
+    )
+
+    labels = load_labels(tmp_path)
+
+    assert [lbl.id for lbl in labels] == ["good1", "good2"]
+
+
+def test_save_labels_round_trip(tmp_path: Path) -> None:
+    """``save_labels`` writes a list of dicts the loader reads back identically."""
+    catalog = [
+        Label(id="abc", name="Kitchen", color="#ff0000"),
+        Label(id="xyz", name="Dev", color=None),
+    ]
+
+    save_labels(tmp_path, catalog)
+
+    raw = json.loads((tmp_path / ".device-builder.json").read_bytes())
+    assert raw["_labels"] == [
+        {"id": "abc", "name": "Kitchen", "color": "#ff0000"},
+        {"id": "xyz", "name": "Dev", "color": None},
+    ]
+    assert load_labels(tmp_path) == catalog
+
+
+def test_labels_transaction_yields_mutable_list(tmp_path: Path) -> None:
+    """The RMW context yields a list the caller can mutate in-place.
+
+    Mirrors ``metadata_transaction`` — the caller appends / replaces
+    entries, the helper writes the canonical encoded form back on
+    clean exit. A regression that switched to passing a snapshot
+    (instead of the live list) would silently swallow mutations.
+    """
+    save_labels(tmp_path, [Label(id="a", name="One")])
+
+    with labels_transaction(tmp_path) as catalog:
+        assert [lbl.id for lbl in catalog] == ["a"]
+        catalog.append(Label(id="b", name="Two", color="#00ff00"))
+
+    assert [lbl.id for lbl in load_labels(tmp_path)] == ["a", "b"]
+
+
+def test_labels_transaction_discards_changes_on_exception(tmp_path: Path) -> None:
+    """A raise inside the block keeps the prior catalog intact."""
+    save_labels(tmp_path, [Label(id="a", name="One")])
+
+    with (
+        pytest.raises(RuntimeError, match="boom"),
+        labels_transaction(tmp_path) as catalog,
+    ):
+        catalog.append(Label(id="b", name="Two"))
+        raise RuntimeError("boom")
+
+    assert [lbl.id for lbl in load_labels(tmp_path)] == ["a"]
+
+
+def test_set_device_metadata_labels_param_replaces(tmp_path: Path) -> None:
+    """Pass a populated list → the device entry's ``labels`` is replaced."""
+    set_device_metadata(tmp_path, "kitchen.yaml", labels=["a", "b"])
+
+    raw = _load_metadata(tmp_path)
+    assert raw["kitchen.yaml"]["labels"] == ["a", "b"]
+
+
+def test_set_device_metadata_labels_none_leaves_alone(tmp_path: Path) -> None:
+    """``labels=None`` → existing assignments are preserved.
+
+    Tri-state semantics matching the rest of ``set_device_metadata``:
+    ``None`` = leave alone, ``[]`` = clear, populated = replace.
+    """
+    set_device_metadata(tmp_path, "kitchen.yaml", labels=["a"])
+    set_device_metadata(tmp_path, "kitchen.yaml", board_id="esp32", labels=None)
+
+    raw = _load_metadata(tmp_path)
+    assert raw["kitchen.yaml"]["labels"] == ["a"]
+    assert raw["kitchen.yaml"]["board_id"] == "esp32"
+
+
+def test_set_device_metadata_labels_empty_clears(tmp_path: Path) -> None:
+    """``labels=[]`` removes the key entirely (no empty list left behind)."""
+    set_device_metadata(tmp_path, "kitchen.yaml", labels=["a", "b"])
+    set_device_metadata(tmp_path, "kitchen.yaml", labels=[])
+
+    entry = _load_metadata(tmp_path)["kitchen.yaml"]
+    assert "labels" not in entry
+
+
+def test_set_device_labels_validates_against_catalog(tmp_path: Path) -> None:
+    """An ID not in the catalog raises ``ValueError`` and skips the write."""
+    save_labels(tmp_path, [Label(id="known", name="Known")])
+
+    with pytest.raises(ValueError, match="Unknown label id"):
+        set_device_labels(tmp_path, "kitchen.yaml", ["known", "ghost"])
+
+    # No partial write — the device entry shouldn't carry "known"
+    # alone if the call as a whole was supposed to fail.
+    raw = _load_metadata(tmp_path)
+    assert "kitchen.yaml" not in raw
+
+
+def test_set_device_labels_dedupes_and_preserves_order(tmp_path: Path) -> None:
+    """Duplicate IDs in input are dropped; first-seen order wins."""
+    save_labels(tmp_path, [Label(id="a", name="A"), Label(id="b", name="B")])
+
+    set_device_labels(tmp_path, "kitchen.yaml", ["a", "b", "a", "b", "a"])
+
+    raw = _load_metadata(tmp_path)
+    assert raw["kitchen.yaml"]["labels"] == ["a", "b"]
+
+
+def test_set_device_labels_empty_clears(tmp_path: Path) -> None:
+    """Passing ``[]`` removes all assignments without leaving the empty key."""
+    save_labels(tmp_path, [Label(id="a", name="A")])
+    set_device_labels(tmp_path, "kitchen.yaml", ["a"])
+    set_device_labels(tmp_path, "kitchen.yaml", [])
+
+    entry = _load_metadata(tmp_path)["kitchen.yaml"]
+    assert "labels" not in entry
+
+
+def test_delete_label_cascade_drops_label_and_returns_affected(tmp_path: Path) -> None:
+    """Cascade removes the label from the catalog and every device entry.
+
+    This is the operation the controller wraps; the returned
+    set is the worklist of devices the controller force-reloads
+    so their live ``Device`` model picks up the trimmed list.
+    """
+    save_labels(
+        tmp_path,
+        [Label(id="x", name="X"), Label(id="y", name="Y")],
+    )
+    set_device_labels(tmp_path, "kitchen.yaml", ["x", "y"])
+    set_device_labels(tmp_path, "garage.yaml", ["x"])
+    set_device_labels(tmp_path, "office.yaml", ["y"])
+
+    affected = delete_label_cascade(tmp_path, "x")
+
+    assert affected == {"kitchen.yaml", "garage.yaml"}
+    raw = _load_metadata(tmp_path)
+    # Catalog drops the deleted label.
+    assert [entry["id"] for entry in raw["_labels"]] == ["y"]
+    # Devices that referenced it have it removed; the others are
+    # untouched.
+    assert raw["kitchen.yaml"]["labels"] == ["y"]
+    assert "labels" not in raw["garage.yaml"]
+    assert raw["office.yaml"]["labels"] == ["y"]
+
+
+def test_delete_label_cascade_when_no_devices_assigned(tmp_path: Path) -> None:
+    """A label with no assignments → empty affected set, label still removed."""
+    save_labels(tmp_path, [Label(id="ghost", name="Ghost")])
+
+    affected = delete_label_cascade(tmp_path, "ghost")
+
+    assert affected == set()
+    assert load_labels(tmp_path) == []

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -891,3 +891,45 @@ def test_load_device_handles_storage_without_core_platform_attr(
     device = load_device_from_storage(yaml_path)
 
     assert device.target_platform == "esp32"
+
+
+# ---------------------------------------------------------------------------
+# load_device_from_storage — labels threading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_threads_labels_into_device(tmp_path: Path) -> None:
+    """The ``labels`` arg lands on ``Device.labels`` as a list.
+
+    The scanner reads the per-device labels list from the metadata
+    sidecar and threads it through here; the loader's job is only
+    to copy it onto the freshly-built ``Device``. A regression
+    that dropped the assignment would empty every device's labels
+    list on every reload, masking a working sidecar write.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    device = load_device_from_storage(yaml_path, labels=("lbl-a", "lbl-b"))
+
+    assert device.labels == ["lbl-a", "lbl-b"]
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_default_labels_is_empty_list(tmp_path: Path) -> None:
+    """Omitting ``labels`` produces an empty list (not ``None`` or a tuple).
+
+    The wire shape is ``list[str]``; mashumaro would happily
+    serialize a tuple but the frontend expects array semantics.
+    Pin: omit the arg → device.labels is exactly ``[]``.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.labels == []
+    assert isinstance(device.labels, list)


### PR DESCRIPTION
# What does this implement/fix?

adds github-style labels to devices — a global catalog of named, optionally-colored chips that can be assigned to any number of devices so the frontend can group / sort / filter on them. backend only; the matching frontend work (chips in the list / cards view, filter affordance, edit dialog) lands in a follow-up PR.

- new `LabelsController` exposing `labels/list` / `labels/create` / `labels/update` / `labels/delete`
- new `devices/set_labels` command to assign / clear a device's labels in one shot
- catalog stored as `_labels` in `.device-builder.json` alongside `_preferences`; per-device assignments live as `labels: [id, ...]` on each device entry
- ID-based references (opaque `uuid.uuid4().hex`), so renaming or recoloring a label doesn't fan out a write to every device
- delete cascades through every assigned device in a single metadata transaction; each affected device is force-reloaded so the live `Device.labels` reflects the trimmed sidecar without waiting on the next disk-driven scan
- new `label_created` / `label_updated` / `label_deleted` events on `subscribe_events`. per-device label changes ride the existing `device_updated`
- `Device.labels: list[str]` added to the wire shape; frontend joins against the catalog at render time
- `devices/set_labels`'s catalog check runs *inside* the metadata transaction so a concurrent `labels/delete` cascade can't leave a dangling reference

**Related issue or feature (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

frontend follow-up needed — the new wire surface is `Device.labels: list[str]`, plus the `labels/*` commands and `label_created` / `label_updated` / `label_deleted` events. companion PR will land separately.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
