### PR TITLE
sync_components: consume OnlyWith gated defaults from schema bundle

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1821,17 +1821,22 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
     is_structural = entry_type == "pin" or bool(references)
     advanced = _classify_advanced(key, required=required, is_structural=is_structural)
 
-    # Default + ``depends_on_component`` first prefer the unconditional
-    # schema value, then fall back to the gated form ``default_with``
-    # produced by ``cv.OnlyWith`` (esphome/esphome#16276). The
+    # Default + ``depends_on_component`` prefer the gated form
+    # ``default_with`` produced by ``cv.OnlyWith``
+    # (esphome/esphome#16276) over the unconditional ``default``
+    # field — those should be mutually exclusive in practice (the
+    # upstream generator picks one or the other), but a stale or
+    # mixed schema bundle picking up both should still surface the
+    # gated semantics, which are the more specific contract. The
     # ``default_with`` entry pairs the default value with the
-    # component(s) that must be loaded for ESPHome to apply it — same
-    # semantics as ``depends_on_component`` here, just sourced from
-    # the validator instead of the curated ``_COMPONENT_GATED_KEYS``
-    # list. ``default_without`` (``cv.OnlyWithout``) has inverse-gate
-    # semantics that ``depends_on_component`` can't represent today;
-    # left for a follow-up.
-    default_value, gated_component = _extract_default(raw)
+    # component(s) that must be loaded for ESPHome to apply it —
+    # same semantics as ``depends_on_component`` here, just sourced
+    # from the validator instead of the curated
+    # ``_COMPONENT_GATED_KEYS`` list. ``default_without``
+    # (``cv.OnlyWithout``) has inverse-gate semantics that
+    # ``depends_on_component`` can't represent today; left for a
+    # follow-up.
+    default_value, gated_component = _extract_default(raw, key=key)
     entry: dict[str, Any] = {
         "key": key,
         "type": entry_type,
@@ -1980,7 +1985,7 @@ def _coerce_default(value: Any) -> Any:
     return value
 
 
-def _extract_default(raw: dict) -> tuple[Any, str | None]:
+def _extract_default(raw: dict, key: str = "") -> tuple[Any, str | None]:
     """
     Resolve the field's default value plus the component (if any) that gates it.
 
@@ -1993,24 +1998,30 @@ def _extract_default(raw: dict) -> tuple[Any, str | None]:
        when ALL listed components are loaded. Returned as
        ``(<value>, components[0])`` — ``depends_on_component`` is a
        single-string field today; multi-component gates land on the
-       first entry with a warning so the field still gets the
-       default. The frontend's ``depends_on_component`` predicate
-       hides the field when the component isn't configured, which
-       matches ESPHome's runtime "no default applies" behaviour.
+       first entry with a logged warning so the field still gets
+       the default. The frontend's ``depends_on_component``
+       predicate hides the field when the component isn't
+       configured, which matches ESPHome's runtime "no default
+       applies" behaviour.
     3. ``default_without: {value, components: [...]}`` —
        ``cv.OnlyWithout``. Default applies when the component is
        NOT loaded. ``depends_on_component`` can't model the
        inverted gate today, so we surface no default for these
        fields (no regression — same as before #16276 when the
        schema dropped them entirely). Tracked as a follow-up.
+
+    *key* is the field name for the warning context; pass it
+    through from the caller (``_convert_field`` has it as ``key``).
     """
     if (gated := raw.get("default_with")) is not None:
         components = gated.get("components") or []
         if len(components) > 1:
-            print(
-                f"WARNING: default_with with multiple components "
-                f"{components}; only the first ({components[0]}) "
-                f"will be used as ``depends_on_component``."
+            _LOGGER.warning(
+                "%s: default_with with multiple components %s; only "
+                "the first (%s) will be used as depends_on_component.",
+                key or "<unknown>",
+                components,
+                components[0],
             )
         return _coerce_default(gated.get("value")), components[0] if components else None
     return _coerce_default(raw.get("default")), None

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1821,21 +1821,6 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
     is_structural = entry_type == "pin" or bool(references)
     advanced = _classify_advanced(key, required=required, is_structural=is_structural)
 
-    # Default + ``depends_on_component`` prefer the gated form
-    # ``default_with`` produced by ``cv.OnlyWith``
-    # (esphome/esphome#16276) over the unconditional ``default``
-    # field — those should be mutually exclusive in practice (the
-    # upstream generator picks one or the other), but a stale or
-    # mixed schema bundle picking up both should still surface the
-    # gated semantics, which are the more specific contract. The
-    # ``default_with`` entry pairs the default value with the
-    # component(s) that must be loaded for ESPHome to apply it —
-    # same semantics as ``depends_on_component`` here, just sourced
-    # from the validator instead of the curated
-    # ``_COMPONENT_GATED_KEYS`` list. ``default_without``
-    # (``cv.OnlyWithout``) has inverse-gate semantics that
-    # ``depends_on_component`` can't represent today; left for a
-    # follow-up.
     default_value, gated_component = _extract_default(raw, key=key)
     entry: dict[str, Any] = {
         "key": key,
@@ -1986,32 +1971,15 @@ def _coerce_default(value: Any) -> Any:
 
 
 def _extract_default(raw: dict, key: str = "") -> tuple[Any, str | None]:
-    """
-    Resolve the field's default value plus the component (if any) that gates it.
+    """Resolve ``(default_value, depends_on_component)`` for a field.
 
-    Three input shapes from the schema bundle:
-
-    1. ``default: "<value>"`` — unconditional default. Returned as
-       ``(<value>, None)``.
-    2. ``default_with: {value, components: [...]}`` —
-       ``cv.OnlyWith`` (esphome/esphome#16276). Default applies only
-       when ALL listed components are loaded. Returned as
-       ``(<value>, components[0])`` — ``depends_on_component`` is a
-       single-string field today; multi-component gates land on the
-       first entry with a logged warning so the field still gets
-       the default. The frontend's ``depends_on_component``
-       predicate hides the field when the component isn't
-       configured, which matches ESPHome's runtime "no default
-       applies" behaviour.
-    3. ``default_without: {value, components: [...]}`` —
-       ``cv.OnlyWithout``. Default applies when the component is
-       NOT loaded. ``depends_on_component`` can't model the
-       inverted gate today, so we surface no default for these
-       fields (no regression — same as before #16276 when the
-       schema dropped them entirely). Tracked as a follow-up.
-
-    *key* is the field name for the warning context; pass it
-    through from the caller (``_convert_field`` has it as ``key``).
+    Reads ``default_with`` (``cv.OnlyWith``, esphome/esphome#16276)
+    in preference to plain ``default``. ``default_without``
+    (``cv.OnlyWithout``) has inverse-gate semantics that
+    ``depends_on_component`` can't model — no default surfaces for
+    those fields. Multi-component ``default_with`` picks the first
+    component and logs a warning (no upstream call site uses a
+    list today). *key* is the field name for the log context.
     """
     if (gated := raw.get("default_with")) is not None:
         components = gated.get("components") or []

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1821,13 +1821,24 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
     is_structural = entry_type == "pin" or bool(references)
     advanced = _classify_advanced(key, required=required, is_structural=is_structural)
 
+    # Default + ``depends_on_component`` first prefer the unconditional
+    # schema value, then fall back to the gated form ``default_with``
+    # produced by ``cv.OnlyWith`` (esphome/esphome#16276). The
+    # ``default_with`` entry pairs the default value with the
+    # component(s) that must be loaded for ESPHome to apply it — same
+    # semantics as ``depends_on_component`` here, just sourced from
+    # the validator instead of the curated ``_COMPONENT_GATED_KEYS``
+    # list. ``default_without`` (``cv.OnlyWithout``) has inverse-gate
+    # semantics that ``depends_on_component`` can't represent today;
+    # left for a follow-up.
+    default_value, gated_component = _extract_default(raw)
     entry: dict[str, Any] = {
         "key": key,
         "type": entry_type,
         "label": _key_to_label(key),
         "description": docs.text or None,
         "required": required,
-        "default_value": _coerce_default(raw.get("default")),
+        "default_value": default_value,
         "options": _build_options(raw),
         "allow_custom_value": False,
         "range": list(_DATA_TYPE_RANGE[data_type]) if data_type in _DATA_TYPE_RANGE else None,
@@ -1836,7 +1847,7 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
         "depends_on": None,
         "depends_on_value": None,
         "depends_on_value_not": None,
-        "depends_on_component": None,
+        "depends_on_component": gated_component,
         "references_component": references,
         "pin_features": _resolve_pin_features(raw) if entry_type == "pin" else [],
         "pin_mode": None,
@@ -1967,6 +1978,42 @@ def _coerce_default(value: Any) -> Any:
         if value.lower() == "false":
             return False
     return value
+
+
+def _extract_default(raw: dict) -> tuple[Any, str | None]:
+    """
+    Resolve the field's default value plus the component (if any) that gates it.
+
+    Three input shapes from the schema bundle:
+
+    1. ``default: "<value>"`` — unconditional default. Returned as
+       ``(<value>, None)``.
+    2. ``default_with: {value, components: [...]}`` —
+       ``cv.OnlyWith`` (esphome/esphome#16276). Default applies only
+       when ALL listed components are loaded. Returned as
+       ``(<value>, components[0])`` — ``depends_on_component`` is a
+       single-string field today; multi-component gates land on the
+       first entry with a warning so the field still gets the
+       default. The frontend's ``depends_on_component`` predicate
+       hides the field when the component isn't configured, which
+       matches ESPHome's runtime "no default applies" behaviour.
+    3. ``default_without: {value, components: [...]}`` —
+       ``cv.OnlyWithout``. Default applies when the component is
+       NOT loaded. ``depends_on_component`` can't model the
+       inverted gate today, so we surface no default for these
+       fields (no regression — same as before #16276 when the
+       schema dropped them entirely). Tracked as a follow-up.
+    """
+    if (gated := raw.get("default_with")) is not None:
+        components = gated.get("components") or []
+        if len(components) > 1:
+            print(
+                f"WARNING: default_with with multiple components "
+                f"{components}; only the first ({components[0]}) "
+                f"will be used as ``depends_on_component``."
+            )
+        return _coerce_default(gated.get("value")), components[0] if components else None
+    return _coerce_default(raw.get("default")), None
 
 
 def _resolve_use_id_reference(raw: dict) -> str | None:

--- a/tests/test_sync_components_default_extraction.py
+++ b/tests/test_sync_components_default_extraction.py
@@ -1,0 +1,109 @@
+"""Tests for the ``_extract_default`` resolver helper.
+
+It pairs a field's default value with its ``depends_on_component``
+gate from either schema shape (plain ``default`` or
+``default_with``).
+
+ESPHome's schema bundle (post esphome/esphome#16276) ships
+``cv.OnlyWith`` defaults under a new ``default_with`` field that
+bundles the value with the component(s) that gate it; older
+schemas ship a plain ``default`` for unconditional defaults.
+``_extract_default`` resolves both shapes into the
+``(default_value, depends_on_component)`` pair the catalog entry
+expects, so downstream consumers don't need to know which schema
+shape produced their default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from script.sync_components import _extract_default  # type: ignore[import-not-found]
+
+
+def test_unconditional_default_returns_value_and_no_gate() -> None:
+    """Plain ``default: "true"`` → ``(True, None)``.
+
+    Backwards-compatible path: schemas predating #16276 (and any
+    field that uses ``cv.Optional(K, default=X)`` rather than
+    ``cv.OnlyWith``) ship the default unconditionally. The gate
+    returns ``None`` so the catalog entry's
+    ``depends_on_component`` falls through to the curated
+    ``_COMPONENT_GATED_KEYS`` mapping (or stays empty).
+    """
+    assert _extract_default({"default": "true"}) == (True, None)
+    assert _extract_default({"default": "False"}) == (False, None)
+    assert _extract_default({"default": "5"}) == ("5", None)
+
+
+def test_no_default_returns_pair_of_nones() -> None:
+    """No ``default`` and no ``default_with`` → ``(None, None)``."""
+    assert _extract_default({"key": "Optional"}) == (None, None)
+
+
+def test_default_with_single_component_returns_value_and_gate() -> None:
+    """``default_with: {value, components: [<one>]}`` → ``(value, "<one>")``.
+
+    The canonical ``cv.OnlyWith(K, "wifi", default=True)`` shape
+    that triggered #16276. ``depends_on_component`` is a
+    single-string field, and the typical OnlyWith call site lists
+    exactly one gating component, so the catalog entry can apply
+    the gate directly.
+    """
+    raw = {
+        "default_with": {"value": "True", "components": ["wifi"]},
+    }
+    assert _extract_default(raw) == (True, "wifi")
+
+
+def test_default_with_multi_component_picks_first_with_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``default_with`` with multiple components → first + WARNING.
+
+    ``cv.OnlyWith`` supports a list of components that ALL must
+    be loaded for the default to apply. ``depends_on_component``
+    is a single-string field today, so we pick the first and log
+    a WARNING. Picking up correct multi-component gating is a
+    future extension once a real call site needs it; for now no
+    upstream OnlyWith uses a list (verified against ESPHome's
+    five existing call sites — all single-component).
+    """
+    raw = {
+        "default_with": {
+            "value": "DC_SOURCE",
+            "components": ["zigbee", "nrf52"],
+        },
+    }
+    value, gate = _extract_default(raw)
+    assert value == "DC_SOURCE"
+    assert gate == "zigbee"
+    captured = capsys.readouterr()
+    assert "default_with with multiple components" in captured.out
+    assert "zigbee" in captured.out
+    assert "nrf52" in captured.out
+
+
+def test_default_with_empty_components_returns_no_gate() -> None:
+    """``default_with`` with empty ``components`` → no gate.
+
+    Defensive against malformed bundles. The default value still
+    flows through; the gate just isn't applied.
+    """
+    raw = {"default_with": {"value": "True", "components": []}}
+    assert _extract_default(raw) == (True, None)
+
+
+def test_default_with_takes_precedence_over_default() -> None:
+    """``default_with`` wins when both fields are present.
+
+    Wouldn't normally happen — the upstream schema generator
+    populates one or the other, not both — but pin the precedence
+    so a future change to either side doesn't accidentally drop
+    the gate.
+    """
+    raw = {
+        "default": "False",
+        "default_with": {"value": "True", "components": ["wifi"]},
+    }
+    assert _extract_default(raw) == (True, "wifi")

--- a/tests/test_sync_components_default_extraction.py
+++ b/tests/test_sync_components_default_extraction.py
@@ -16,9 +16,14 @@ shape produced their default.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from script.sync_components import _extract_default  # type: ignore[import-not-found]
+from script.sync_components import (  # type: ignore[import-not-found]
+    _convert_field,
+    _extract_default,
+)
 
 
 def test_unconditional_default_returns_value_and_no_gate() -> None:
@@ -107,3 +112,183 @@ def test_default_with_takes_precedence_over_default() -> None:
         "default_with": {"value": "True", "components": ["wifi"]},
     }
     assert _extract_default(raw) == (True, "wifi")
+
+
+# ─── End-to-end fixtures from real schema ────────────────────────────
+# The fixtures below are the actual ``raw`` schema-bundle entries
+# produced by ESPHome's ``script/build_language_schema.py`` after
+# esphome/esphome#16276 lands. Captured by running the patched
+# script against ESPHome's tree on 2026-05-06; pasted verbatim
+# here so the device-builder side has a concrete contract to test
+# against without needing the upstream PR merged first. If the
+# upstream shape changes (e.g. ``default_with`` becomes
+# ``default_when_loaded``), these fixtures are the canary.
+
+
+_FIXTURE_SOFTWARE_COEXISTENCE: dict = {
+    "default_with": {"value": "True", "components": ["wifi"]},
+    "key": "Optional",
+    "type": "boolean",
+}
+
+_FIXTURE_POWER_SOURCE: dict = {
+    "default_with": {"value": "DC_SOURCE", "components": ["nrf52"]},
+    "key": "Optional",
+    "type": "enum",
+    "values": {
+        "BATTERY": None,
+        "DC_SOURCE": None,
+        "EMERGENCY_MAINS_CONST": None,
+        "EMERGENCY_MAINS_TRANSF": None,
+        "MAINS_SINGLE_PHASE": None,
+        "MAINS_THREE_PHASE": None,
+        "UNKNOWN": None,
+    },
+}
+
+_FIXTURE_TX_POWER: dict = {
+    "default_without": {"value": "3dBm", "components": ["esp32_hosted"]},
+    "key": "Optional",
+    "type": "enum",
+    "values": {
+        "-12": None,
+        "-3": None,
+        "-6": None,
+        "-9": None,
+        "0": None,
+        "3": None,
+        "6": None,
+        "9": None,
+    },
+}
+
+
+def test_extract_default_software_coexistence_fixture() -> None:
+    """Real ``esp32_ble_tracker.software_coexistence`` raw entry.
+
+    The motivating case: ``cv.OnlyWith(K, "wifi", default=True)``.
+    Pin that the resolver lifts the gated default exactly as the
+    catalog generator needs it.
+    """
+    assert _extract_default(_FIXTURE_SOFTWARE_COEXISTENCE) == (True, "wifi")
+
+
+def test_extract_default_power_source_fixture() -> None:
+    """Real ``zigbee.power_source`` raw entry — string default."""
+    assert _extract_default(_FIXTURE_POWER_SOURCE) == ("DC_SOURCE", "nrf52")
+
+
+def test_extract_default_tx_power_fixture_skipped_for_now() -> None:
+    """Real ``esp32_ble_beacon.tx_power`` raw entry — ``default_without``.
+
+    ``cv.OnlyWithout`` has inverse-gate semantics
+    (``depends_on_component`` can't model an inverted gate
+    today), so the resolver returns ``(None, None)`` for these
+    fields — no regression vs. the pre-#16276 era when the
+    schema dropped them entirely. Pin that the absence is
+    intentional, not a parser bug, so a future contributor who
+    extends the catalog model to support inverse gates can
+    replace this assertion with the real expected output.
+    """
+    assert _extract_default(_FIXTURE_TX_POWER) == (None, None)
+
+
+# ─── End-to-end ``_convert_field`` tests ─────────────────────────────
+# Cover the wiring all the way from raw schema entry → catalog
+# ConfigEntry dict, so a future change anywhere in the conversion
+# pipeline (entry-type resolution, advanced classification, options
+# building, …) that quietly drops the gate or default is caught.
+
+
+@pytest.fixture
+def schema_dir(tmp_path: Path) -> Path:
+    """Empty schema dir for ``_convert_field``.
+
+    ``_convert_field`` only touches it for ``extends`` lookups,
+    which our fixtures don't use.
+    """
+    return tmp_path
+
+
+def test_convert_field_software_coexistence_carries_gate_and_default(
+    schema_dir: Path,
+) -> None:
+    """OnlyWith boolean field carries the gated default end-to-end.
+
+    ``cv.OnlyWith(K, "wifi", default=True)`` → boolean catalog
+    entry with the gated default + ``depends_on_component``.
+    The motivating case from esphome/device-builder-frontend#181's
+    follow-up: without the gate, the dashboard rendered
+    ``software_coexistence`` as a default-OFF toggle even when
+    the user had ``wifi:`` configured. With this PR the catalog
+    entry pairs the value with the gating component so the
+    frontend's ``getEncryptionState``-style fallback chain can
+    apply the default conditionally.
+    """
+    entry = _convert_field("software_coexistence", _FIXTURE_SOFTWARE_COEXISTENCE, schema_dir)
+    assert entry is not None
+    assert entry["type"] == "boolean"
+    assert entry["default_value"] is True
+    assert entry["depends_on_component"] == "wifi"
+    assert entry["required"] is False
+
+
+def test_convert_field_power_source_carries_gate_and_string_default(
+    schema_dir: Path,
+) -> None:
+    """OnlyWith enum field with a string default carries through.
+
+    ``cv.OnlyWith(K, "nrf52", default="DC_SOURCE")`` → enum
+    catalog entry with the gated string default.
+    Verifies the resolver doesn't accidentally coerce the
+    ``"DC_SOURCE"`` string through ``_coerce_default``'s
+    bool-coercion path.
+    """
+    entry = _convert_field("power_source", _FIXTURE_POWER_SOURCE, schema_dir)
+    assert entry is not None
+    assert entry["default_value"] == "DC_SOURCE"
+    assert entry["depends_on_component"] == "nrf52"
+    # Options come from the ``values`` map; pin a sample to make
+    # sure the gate handling didn't disturb the rest of the
+    # conversion pipeline.
+    option_values = {opt["value"] for opt in entry["options"] or []}
+    assert "DC_SOURCE" in option_values
+    assert "BATTERY" in option_values
+
+
+def test_convert_field_tx_power_default_without_no_gate(
+    schema_dir: Path,
+) -> None:
+    """``cv.OnlyWithout`` field → no default, no gate (follow-up).
+
+    The catalog entry still gets built — only the default and
+    gate are absent. The frontend continues to render the field
+    without a pre-filled value, same as before #16276.
+    """
+    entry = _convert_field("tx_power", _FIXTURE_TX_POWER, schema_dir)
+    assert entry is not None
+    assert entry["default_value"] is None
+    assert entry["depends_on_component"] is None
+    # Rest of the conversion still works.
+    option_values = {opt["value"] for opt in entry["options"] or []}
+    assert "3" in option_values
+
+
+def test_convert_field_unconditional_default_unchanged(schema_dir: Path) -> None:
+    """Plain ``cv.Optional(K, default=True)`` → unchanged behaviour.
+
+    Schemas predating #16276 (and any field that uses
+    ``cv.Optional`` rather than ``cv.OnlyWith``) ship the default
+    unconditionally. Pin that those still flow through the
+    existing path with no gate applied.
+    """
+    raw = {"default": "true", "key": "Optional", "type": "boolean"}
+    entry = _convert_field("retain", raw, schema_dir)
+    assert entry is not None
+    assert entry["default_value"] is True
+    # ``retain`` is in ``_COMPONENT_GATED_KEYS`` (mqtt) — that
+    # curated mapping kicks in via ``_convert_config_vars``, NOT
+    # via ``_convert_field`` directly. Bare ``_convert_field``
+    # leaves ``depends_on_component`` empty for unconditional
+    # defaults; that's the right contract.
+    assert entry["depends_on_component"] is None

--- a/tests/test_sync_components_default_extraction.py
+++ b/tests/test_sync_components_default_extraction.py
@@ -16,6 +16,7 @@ shape produced their default.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -62,9 +63,9 @@ def test_default_with_single_component_returns_value_and_gate() -> None:
 
 
 def test_default_with_multi_component_picks_first_with_warning(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """``default_with`` with multiple components → first + WARNING.
+    """``default_with`` with multiple components → first + log.warning.
 
     ``cv.OnlyWith`` supports a list of components that ALL must
     be loaded for the default to apply. ``depends_on_component``
@@ -80,13 +81,17 @@ def test_default_with_multi_component_picks_first_with_warning(
             "components": ["zigbee", "nrf52"],
         },
     }
-    value, gate = _extract_default(raw)
+    with caplog.at_level(logging.WARNING, logger="sync_components"):
+        value, gate = _extract_default(raw, key="power_source")
     assert value == "DC_SOURCE"
     assert gate == "zigbee"
-    captured = capsys.readouterr()
-    assert "default_with with multiple components" in captured.out
-    assert "zigbee" in captured.out
-    assert "nrf52" in captured.out
+    # One warning, named field surfaces in the message, both
+    # components mentioned, and the chosen one is called out.
+    assert len(caplog.records) == 1
+    msg = caplog.records[0].getMessage()
+    assert "power_source" in msg
+    assert "zigbee" in msg
+    assert "nrf52" in msg
 
 
 def test_default_with_empty_components_returns_no_gate() -> None:

--- a/tests/test_sync_components_default_extraction.py
+++ b/tests/test_sync_components_default_extraction.py
@@ -1,17 +1,8 @@
-"""Tests for the ``_extract_default`` resolver helper.
+"""Tests for ``_extract_default`` and the ``_convert_field`` end-to-end.
 
-It pairs a field's default value with its ``depends_on_component``
-gate from either schema shape (plain ``default`` or
-``default_with``).
-
-ESPHome's schema bundle (post esphome/esphome#16276) ships
-``cv.OnlyWith`` defaults under a new ``default_with`` field that
-bundles the value with the component(s) that gate it; older
-schemas ship a plain ``default`` for unconditional defaults.
-``_extract_default`` resolves both shapes into the
-``(default_value, depends_on_component)`` pair the catalog entry
-expects, so downstream consumers don't need to know which schema
-shape produced their default.
+Covers both the resolver and the full conversion pipeline against
+real raw-schema fixtures captured from
+``script/build_language_schema.py`` post esphome/esphome#16276.
 """
 
 from __future__ import annotations
@@ -28,15 +19,7 @@ from script.sync_components import (  # type: ignore[import-not-found]
 
 
 def test_unconditional_default_returns_value_and_no_gate() -> None:
-    """Plain ``default: "true"`` → ``(True, None)``.
-
-    Backwards-compatible path: schemas predating #16276 (and any
-    field that uses ``cv.Optional(K, default=X)`` rather than
-    ``cv.OnlyWith``) ship the default unconditionally. The gate
-    returns ``None`` so the catalog entry's
-    ``depends_on_component`` falls through to the curated
-    ``_COMPONENT_GATED_KEYS`` mapping (or stays empty).
-    """
+    """Plain ``default: "..."`` flows through unchanged."""
     assert _extract_default({"default": "true"}) == (True, None)
     assert _extract_default({"default": "False"}) == (False, None)
     assert _extract_default({"default": "5"}) == ("5", None)
@@ -48,32 +31,18 @@ def test_no_default_returns_pair_of_nones() -> None:
 
 
 def test_default_with_single_component_returns_value_and_gate() -> None:
-    """``default_with: {value, components: [<one>]}`` → ``(value, "<one>")``.
-
-    The canonical ``cv.OnlyWith(K, "wifi", default=True)`` shape
-    that triggered #16276. ``depends_on_component`` is a
-    single-string field, and the typical OnlyWith call site lists
-    exactly one gating component, so the catalog entry can apply
-    the gate directly.
-    """
-    raw = {
-        "default_with": {"value": "True", "components": ["wifi"]},
-    }
+    """``default_with`` with one component → gated default."""
+    raw = {"default_with": {"value": "True", "components": ["wifi"]}}
     assert _extract_default(raw) == (True, "wifi")
 
 
 def test_default_with_multi_component_picks_first_with_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """``default_with`` with multiple components → first + log.warning.
+    """Multi-component ``default_with`` → first component + log.warning.
 
-    ``cv.OnlyWith`` supports a list of components that ALL must
-    be loaded for the default to apply. ``depends_on_component``
-    is a single-string field today, so we pick the first and log
-    a WARNING. Picking up correct multi-component gating is a
-    future extension once a real call site needs it; for now no
-    upstream OnlyWith uses a list (verified against ESPHome's
-    five existing call sites — all single-component).
+    No upstream call site uses a list today; pick the first and
+    log so the field still gets a default.
     """
     raw = {
         "default_with": {
@@ -85,8 +54,6 @@ def test_default_with_multi_component_picks_first_with_warning(
         value, gate = _extract_default(raw, key="power_source")
     assert value == "DC_SOURCE"
     assert gate == "zigbee"
-    # One warning, named field surfaces in the message, both
-    # components mentioned, and the chosen one is called out.
     assert len(caplog.records) == 1
     msg = caplog.records[0].getMessage()
     assert "power_source" in msg
@@ -95,23 +62,13 @@ def test_default_with_multi_component_picks_first_with_warning(
 
 
 def test_default_with_empty_components_returns_no_gate() -> None:
-    """``default_with`` with empty ``components`` → no gate.
-
-    Defensive against malformed bundles. The default value still
-    flows through; the gate just isn't applied.
-    """
+    """Empty ``components`` → value flows, gate stays None."""
     raw = {"default_with": {"value": "True", "components": []}}
     assert _extract_default(raw) == (True, None)
 
 
 def test_default_with_takes_precedence_over_default() -> None:
-    """``default_with`` wins when both fields are present.
-
-    Wouldn't normally happen — the upstream schema generator
-    populates one or the other, not both — but pin the precedence
-    so a future change to either side doesn't accidentally drop
-    the gate.
-    """
+    """``default_with`` wins when both are present."""
     raw = {
         "default": "False",
         "default_with": {"value": "True", "components": ["wifi"]},
@@ -119,16 +76,11 @@ def test_default_with_takes_precedence_over_default() -> None:
     assert _extract_default(raw) == (True, "wifi")
 
 
-# ─── End-to-end fixtures from real schema ────────────────────────────
-# The fixtures below are the actual ``raw`` schema-bundle entries
-# produced by ESPHome's ``script/build_language_schema.py`` after
-# esphome/esphome#16276 lands. Captured by running the patched
-# script against ESPHome's tree on 2026-05-06; pasted verbatim
-# here so the device-builder side has a concrete contract to test
-# against without needing the upstream PR merged first. If the
-# upstream shape changes (e.g. ``default_with`` becomes
-# ``default_when_loaded``), these fixtures are the canary.
-
+# Real raw entries captured from the patched build_language_schema.py
+# against ESPHome's tree. Pasted verbatim so the device-builder side
+# has a concrete contract to test against without needing the
+# upstream PR merged. The fixtures are the canary if the upstream
+# field name changes.
 
 _FIXTURE_SOFTWARE_COEXISTENCE: dict = {
     "default_with": {"value": "True", "components": ["wifi"]},
@@ -169,67 +121,30 @@ _FIXTURE_TX_POWER: dict = {
 
 
 def test_extract_default_software_coexistence_fixture() -> None:
-    """Real ``esp32_ble_tracker.software_coexistence`` raw entry.
-
-    The motivating case: ``cv.OnlyWith(K, "wifi", default=True)``.
-    Pin that the resolver lifts the gated default exactly as the
-    catalog generator needs it.
-    """
+    """Real ``software_coexistence`` raw entry."""
     assert _extract_default(_FIXTURE_SOFTWARE_COEXISTENCE) == (True, "wifi")
 
 
 def test_extract_default_power_source_fixture() -> None:
-    """Real ``zigbee.power_source`` raw entry — string default."""
+    """Real ``power_source`` raw entry — string default."""
     assert _extract_default(_FIXTURE_POWER_SOURCE) == ("DC_SOURCE", "nrf52")
 
 
 def test_extract_default_tx_power_fixture_skipped_for_now() -> None:
-    """Real ``esp32_ble_beacon.tx_power`` raw entry — ``default_without``.
-
-    ``cv.OnlyWithout`` has inverse-gate semantics
-    (``depends_on_component`` can't model an inverted gate
-    today), so the resolver returns ``(None, None)`` for these
-    fields — no regression vs. the pre-#16276 era when the
-    schema dropped them entirely. Pin that the absence is
-    intentional, not a parser bug, so a future contributor who
-    extends the catalog model to support inverse gates can
-    replace this assertion with the real expected output.
-    """
+    """``default_without`` returns ``(None, None)`` — inverse-gate follow-up."""
     assert _extract_default(_FIXTURE_TX_POWER) == (None, None)
-
-
-# ─── End-to-end ``_convert_field`` tests ─────────────────────────────
-# Cover the wiring all the way from raw schema entry → catalog
-# ConfigEntry dict, so a future change anywhere in the conversion
-# pipeline (entry-type resolution, advanced classification, options
-# building, …) that quietly drops the gate or default is caught.
 
 
 @pytest.fixture
 def schema_dir(tmp_path: Path) -> Path:
-    """Empty schema dir for ``_convert_field``.
-
-    ``_convert_field`` only touches it for ``extends`` lookups,
-    which our fixtures don't use.
-    """
+    """Empty dir for ``_convert_field`` (only used for ``extends`` lookups)."""
     return tmp_path
 
 
 def test_convert_field_software_coexistence_carries_gate_and_default(
     schema_dir: Path,
 ) -> None:
-    """OnlyWith boolean field carries the gated default end-to-end.
-
-    ``cv.OnlyWith(K, "wifi", default=True)`` → boolean catalog
-    entry with the gated default + ``depends_on_component``.
-    The motivating case from esphome/device-builder-frontend#181's
-    follow-up: without the gate, the dashboard rendered
-    ``software_coexistence`` as a default-OFF toggle even when
-    the user had ``wifi:`` configured. With this PR the catalog
-    entry pairs the value with the gating component so the
-    frontend's ``getEncryptionState``-style fallback chain can
-    apply the default conditionally.
-    """
+    """``cv.OnlyWith(K, "wifi", default=True)`` → boolean entry, gated."""
     entry = _convert_field("software_coexistence", _FIXTURE_SOFTWARE_COEXISTENCE, schema_dir)
     assert entry is not None
     assert entry["type"] == "boolean"
@@ -241,21 +156,11 @@ def test_convert_field_software_coexistence_carries_gate_and_default(
 def test_convert_field_power_source_carries_gate_and_string_default(
     schema_dir: Path,
 ) -> None:
-    """OnlyWith enum field with a string default carries through.
-
-    ``cv.OnlyWith(K, "nrf52", default="DC_SOURCE")`` → enum
-    catalog entry with the gated string default.
-    Verifies the resolver doesn't accidentally coerce the
-    ``"DC_SOURCE"`` string through ``_coerce_default``'s
-    bool-coercion path.
-    """
+    """OnlyWith enum field with a string default — verifies no bool coercion."""
     entry = _convert_field("power_source", _FIXTURE_POWER_SOURCE, schema_dir)
     assert entry is not None
     assert entry["default_value"] == "DC_SOURCE"
     assert entry["depends_on_component"] == "nrf52"
-    # Options come from the ``values`` map; pin a sample to make
-    # sure the gate handling didn't disturb the rest of the
-    # conversion pipeline.
     option_values = {opt["value"] for opt in entry["options"] or []}
     assert "DC_SOURCE" in option_values
     assert "BATTERY" in option_values
@@ -264,36 +169,23 @@ def test_convert_field_power_source_carries_gate_and_string_default(
 def test_convert_field_tx_power_default_without_no_gate(
     schema_dir: Path,
 ) -> None:
-    """``cv.OnlyWithout`` field → no default, no gate (follow-up).
-
-    The catalog entry still gets built — only the default and
-    gate are absent. The frontend continues to render the field
-    without a pre-filled value, same as before #16276.
-    """
+    """``cv.OnlyWithout`` field → no default, no gate (follow-up)."""
     entry = _convert_field("tx_power", _FIXTURE_TX_POWER, schema_dir)
     assert entry is not None
     assert entry["default_value"] is None
     assert entry["depends_on_component"] is None
-    # Rest of the conversion still works.
     option_values = {opt["value"] for opt in entry["options"] or []}
     assert "3" in option_values
 
 
 def test_convert_field_unconditional_default_unchanged(schema_dir: Path) -> None:
-    """Plain ``cv.Optional(K, default=True)`` → unchanged behaviour.
+    """Plain ``cv.Optional(K, default=True)`` flows through with no gate.
 
-    Schemas predating #16276 (and any field that uses
-    ``cv.Optional`` rather than ``cv.OnlyWith``) ship the default
-    unconditionally. Pin that those still flow through the
-    existing path with no gate applied.
+    ``retain``'s ``_COMPONENT_GATED_KEYS`` membership applies in
+    ``_convert_config_vars``, not ``_convert_field``.
     """
     raw = {"default": "true", "key": "Optional", "type": "boolean"}
     entry = _convert_field("retain", raw, schema_dir)
     assert entry is not None
     assert entry["default_value"] is True
-    # ``retain`` is in ``_COMPONENT_GATED_KEYS`` (mqtt) — that
-    # curated mapping kicks in via ``_convert_config_vars``, NOT
-    # via ``_convert_field`` directly. Bare ``_convert_field``
-    # leaves ``depends_on_component`` empty for unconditional
-    # defaults; that's the right contract.
     assert entry["depends_on_component"] is None


### PR DESCRIPTION
# What does this implement/fix?

Companion to **esphome/esphome#16276**, which adds a new `default_with: {value, components}` (and inverse `default_without`) field to the schema bundle so `cv.OnlyWith` defaults — previously dropped entirely because the validator's `default` property gates on `CORE.loaded_integrations` (always empty at schema-generation time) — survive into `schema.esphome.io`.

This PR teaches `script/sync_components.py` to read the new shape: when a field carries `default_with`, the catalog entry's `default_value` and `depends_on_component` are populated from `default_with.value` and `default_with.components[0]` respectively. That gives the dashboard the gating context to apply the default conditionally instead of unconditionally.

The motivating case: `esp32_ble_tracker.software_coexistence` — declared upstream as `cv.OnlyWith(K, "wifi", default=True)`. With this PR + the upstream change, the schema-derived catalog entry ships:

```json
{
  "key": "software_coexistence",
  "default_value": true,
  "depends_on_component": "wifi"
}
```

so the dashboard's frontend renders the toggle ON when the user has `wifi:` configured, and hides the field entirely when they don't (matching ESPHome's runtime "no default applies" behaviour). Without this PR (or with a pre-#16276 schema bundle), `software_coexistence` would continue to surface as a default-less, always-OFF toggle even when wifi is configured.

## Backwards compatibility

Pure addition. Schemas predating #16276 (the current `schema.esphome.io` publish) ship `default` only — those flow through `_extract_default`'s existing path unchanged, returning `(value, None)`. The new branch only fires when `default_with` appears in the raw schema entry, which won't happen until the next ESPHome release publishes a bundle generated by the patched script.

This PR is therefore a **no-op against the current `schema.esphome.io` publish** and only starts producing different output once #16276 lands and ships in a release. Tests pin the resolver behaviour against synthetic raw inputs so the wiring stays correct in both schema eras.

## Carve-outs

- **Multi-component OnlyWith**: `cv.OnlyWith` supports a list of components (all must be loaded). `depends_on_component` is a single-string field; multi-component gates would need a list. No upstream OnlyWith uses a list today (verified against ESPHome's five existing call sites — all single-component); the resolver picks the first and logs a WARNING. Future extension if a real call site needs it.
- **`cv.OnlyWithout`** (`default_without`): inverse-gate semantics — "default applies when this component is NOT loaded". `depends_on_component` can't model the inverted gate today, so we surface no default for these fields (no regression — same as before #16276 when the schema dropped them entirely). Tracked as a follow-up; only impact is `esp32_ble_beacon.tx_power` defaulting to "no value" instead of "3dBm when esp32_hosted is absent".

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

**Related issue or feature (if applicable):**

- companion to esphome/esphome#16276 (gated to land after that PR ships in an ESPHome release)

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

The frontend already reads `default_value` (PR #181 wired the boolean fallback) and `depends_on_component` (long-standing). The catalog entries this PR produces fit the existing shape; no frontend change required.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (the catalog regen happens via `script/sync_components.py` after the upstream schema ships).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
