### PR TITLE
Resolve build_info.json through ext_storage_path

### DIFF
--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -35,7 +35,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-from esphome.storage_json import StorageJSON
+from esphome.storage_json import StorageJSON, ext_storage_path
 
 from .json import JSONDecodeError, loads
 
@@ -70,17 +70,21 @@ def read_build_info_hash(yaml_path: Path) -> str | None:
     executor. Returns the same value ``compute_yaml_config_hash``
     awaits to.
 
-    Resolves ``StorageJSON`` from ``<yaml_dir>/.esphome/storage/<name>.json``
-    instead of ``ext_storage_path``. ``ext_storage_path`` is a thin
-    wrapper around ``CORE.data_dir`` that crashes when CORE hasn't
-    been initialised — fine in production (the dashboard sets
-    ``CORE.config_path`` on startup) but a footgun in tests, where
-    leaving the helper coupled to global CORE state would force
-    every test fixture to spin up a CORE just to read a JSON file.
+    Resolves the ``StorageJSON`` sidecar through ``ext_storage_path``
+    so the helper honours ``CORE.data_dir``'s deployment-mode logic:
+    ``/data/storage/...`` on the Home Assistant addon, the
+    ``ESPHOME_DATA_DIR`` env var when set, ``<config_dir>/.esphome/
+    storage/...`` otherwise. The earlier hardcoded
+    ``<yaml_dir>/.esphome/...`` path matched only the default mode
+    and silently returned ``None`` on every addon install, so the
+    drawer's Local hash stayed empty and ``compute_has_pending_
+    changes`` flipped the orange dot on for every device. CORE
+    must be initialised by the time this runs — tests that exercise
+    the helper set ``CORE.config_path`` on a tmp_path sentinel so
+    ``data_dir`` resolves into the same fixture tree the storage
+    sidecar was written into.
     """
-    config_dir = yaml_path.parent
-    storage_path = config_dir / ".esphome" / "storage" / f"{yaml_path.name}.json"
-    storage = StorageJSON.load(storage_path)
+    storage = StorageJSON.load(ext_storage_path(yaml_path.name))
     if storage is None or storage.build_path is None:
         return None
     build_info_path = Path(storage.build_path) / _BUILD_INFO_FILENAME

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -73,16 +73,16 @@ def read_build_info_hash(yaml_path: Path) -> str | None:
     Resolves the ``StorageJSON`` sidecar through ``ext_storage_path``
     so the helper honours ``CORE.data_dir``'s deployment-mode logic:
     ``/data/storage/...`` on the Home Assistant addon, the
-    ``ESPHOME_DATA_DIR`` env var when set, ``<config_dir>/.esphome/
-    storage/...`` otherwise. The earlier hardcoded
-    ``<yaml_dir>/.esphome/...`` path matched only the default mode
-    and silently returned ``None`` on every addon install, so the
-    drawer's Local hash stayed empty and ``compute_has_pending_
-    changes`` flipped the orange dot on for every device. CORE
-    must be initialised by the time this runs — tests that exercise
-    the helper set ``CORE.config_path`` on a tmp_path sentinel so
-    ``data_dir`` resolves into the same fixture tree the storage
-    sidecar was written into.
+    ``ESPHOME_DATA_DIR`` env var when set,
+    ``<config_dir>/.esphome/storage/...`` otherwise. The earlier
+    hardcoded ``<yaml_dir>/.esphome/...`` path matched only the
+    default mode and silently returned ``None`` on every addon
+    install, so the drawer's Local hash stayed empty and
+    ``compute_has_pending_changes`` flipped the orange dot on
+    for every device. CORE must be initialised by the time this
+    runs — tests that exercise the helper set ``CORE.config_path``
+    on a tmp_path sentinel so ``data_dir`` resolves into the same
+    fixture tree the storage sidecar was written into.
     """
     storage = StorageJSON.load(ext_storage_path(yaml_path.name))
     if storage is None or storage.build_path is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,33 @@ def blockbuster() -> Iterator[BlockBuster | None]:
 # ---------------------------------------------------------------------------
 # Catalog fixtures
 #
+# ---------------------------------------------------------------------------
+# CORE.config_path autouse — ``ext_storage_path`` prerequisite
+#
+# Every storage / build-info / firmware-bin lookup in production routes
+# through ``ext_storage_path`` (or ``CORE.data_dir`` directly). Both
+# crash with ``AttributeError: 'NoneType' object has no attribute
+# 'is_dir'`` when ``CORE.config_path`` is the package-default ``None``.
+# Production sets it once at startup; tests need an equivalent. Pinning
+# the sentinel onto ``tmp_path`` keeps the resolved
+# ``data_dir = tmp_path / .esphome`` aligned with where
+# ``write_storage_json`` and the other storage helpers drop their files,
+# so a test that just wants the storage layout to "work" gets that for
+# free without per-module wiring. ``monkeypatch`` auto-restores so
+# tests that override ``CORE.config_path`` (e.g. ``make_settings(
+# with_core_path=True)``) still take precedence, and sibling xdist
+# workers don't see leaked process-globals.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _core_config_path_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(CORE, "config_path", tmp_path / "___DASHBOARD_SENTINEL___.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Component catalog session fixture
+#
 # ``ComponentCatalog.load`` parses ~40 MB of JSON and instantiates ~900 entry
 # objects — about a second wall-time per call, plus blockbuster overhead on
 # Linux CI. Hoisting the load to a session-scoped fixture lets every test

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -22,7 +22,6 @@ from typing import Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from esphome.core import CORE
 
 from esphome_device_builder.controllers._reachability_tracker import ReachabilityTracker
 from esphome_device_builder.controllers.config import set_device_metadata
@@ -33,23 +32,6 @@ from esphome_device_builder.helpers.hostname import normalize_hostname
 from esphome_device_builder.models import AdoptableDevice, DeviceState, EventType
 from tests._recording_scanner import RecordingScanner
 from tests._storage_fixtures import write_storage_json
-
-
-@pytest.fixture(autouse=True)
-def _core_config_path_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Point ``CORE.config_path`` at *tmp_path* for every test in this tree.
-
-    The metadata resolver and storage-regen helpers route every
-    storage / build-info lookup through ``ext_storage_path``, which
-    derives ``<data_dir>/storage/...`` off ``CORE.data_dir``. In
-    default mode that is ``CORE.config_path.parent / .esphome``,
-    so anchoring ``config_path`` inside ``tmp_path`` is what makes
-    the fixtures' on-disk shape match what ``ext_storage_path``
-    actually reads. Production sets ``config_path`` once at
-    startup; tests use ``monkeypatch`` so the override unwinds and
-    sibling xdist workers don't see a leaked value.
-    """
-    monkeypatch.setattr(CORE, "config_path", tmp_path / "___DASHBOARD_SENTINEL___.yaml")
 
 
 class RecordingStateMonitor:

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -22,6 +22,7 @@ from typing import Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from esphome.core import CORE
 
 from esphome_device_builder.controllers._reachability_tracker import ReachabilityTracker
 from esphome_device_builder.controllers.config import set_device_metadata
@@ -32,6 +33,23 @@ from esphome_device_builder.helpers.hostname import normalize_hostname
 from esphome_device_builder.models import AdoptableDevice, DeviceState, EventType
 from tests._recording_scanner import RecordingScanner
 from tests._storage_fixtures import write_storage_json
+
+
+@pytest.fixture(autouse=True)
+def _core_config_path_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``CORE.config_path`` at *tmp_path* for every test in this tree.
+
+    The metadata resolver and storage-regen helpers route every
+    storage / build-info lookup through ``ext_storage_path``, which
+    derives ``<data_dir>/storage/...`` off ``CORE.data_dir``. In
+    default mode that is ``CORE.config_path.parent / .esphome``,
+    so anchoring ``config_path`` inside ``tmp_path`` is what makes
+    the fixtures' on-disk shape match what ``ext_storage_path``
+    actually reads. Production sets ``config_path`` once at
+    startup; tests use ``monkeypatch`` so the override unwinds and
+    sibling xdist workers don't see a leaked value.
+    """
+    monkeypatch.setattr(CORE, "config_path", tmp_path / "___DASHBOARD_SENTINEL___.yaml")
 
 
 class RecordingStateMonitor:

--- a/tests/test_config_hash.py
+++ b/tests/test_config_hash.py
@@ -27,22 +27,6 @@ from esphome_device_builder.helpers.config_hash import (
 from tests._storage_fixtures import write_storage_json
 
 
-@pytest.fixture(autouse=True)
-def _core_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Point ``CORE.config_path`` at *tmp_path* so the helper resolves into the fixture tree.
-
-    ``read_build_info_hash`` routes the storage lookup through
-    ``ext_storage_path``, which derives ``<data_dir>/storage/...``
-    from ``CORE.data_dir`` (which itself is rooted in
-    ``CORE.config_path``'s parent in default mode). Production
-    sets ``CORE.config_path`` on startup; tests use a sentinel
-    YAML inside ``tmp_path`` so ``data_dir`` resolves to
-    ``<tmp_path>/.esphome``, matching where ``write_storage_json``
-    drops the sidecar.
-    """
-    monkeypatch.setattr(CORE, "config_path", tmp_path / "___DASHBOARD_SENTINEL___.yaml")
-
-
 def _write_storage_pointer(yaml_path: Path, build_path: Path | None) -> None:
     """Write the ESPHome ``StorageJSON`` sidecar next to *yaml_path*.
 

--- a/tests/test_config_hash.py
+++ b/tests/test_config_hash.py
@@ -18,12 +18,29 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from esphome.core import CORE
 
 from esphome_device_builder.helpers.config_hash import (
     compute_yaml_config_hash,
     read_build_info_hash,
 )
 from tests._storage_fixtures import write_storage_json
+
+
+@pytest.fixture(autouse=True)
+def _core_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``CORE.config_path`` at *tmp_path* so the helper resolves into the fixture tree.
+
+    ``read_build_info_hash`` routes the storage lookup through
+    ``ext_storage_path``, which derives ``<data_dir>/storage/...``
+    from ``CORE.data_dir`` (which itself is rooted in
+    ``CORE.config_path``'s parent in default mode). Production
+    sets ``CORE.config_path`` on startup; tests use a sentinel
+    YAML inside ``tmp_path`` so ``data_dir`` resolves to
+    ``<tmp_path>/.esphome``, matching where ``write_storage_json``
+    drops the sidecar.
+    """
+    monkeypatch.setattr(CORE, "config_path", tmp_path / "___DASHBOARD_SENTINEL___.yaml")
 
 
 def _write_storage_pointer(yaml_path: Path, build_path: Path | None) -> None:
@@ -196,3 +213,56 @@ def test_returns_none_when_build_info_unreadable(
         "Could not read" in rec.message and "build_info.json" in rec.message
         for rec in caplog.records
     ), "expected a WARNING naming the unreadable build_info.json"
+
+
+def test_resolves_storage_through_ext_storage_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Storage lookup honours ``CORE.data_dir`` (HA-addon parity).
+
+    Reproduces the addon-mode bug: the YAML lives under
+    ``/config/esphome/`` while ESPHome's storage + build trees are
+    rooted at ``/data/`` (because ``CORE.data_dir`` short-circuits
+    when ``is_ha_addon()`` is true). A hardcoded
+    ``<yaml_dir>/.esphome/storage/...`` lookup misses the sidecar
+    entirely and returns ``None`` for every device.
+
+    Recreate the split here without touching ``is_ha_addon`` —
+    point ``CORE.config_path`` at one tmp subtree (the "config")
+    and write the storage sidecar into a different subtree (the
+    "data dir") via ``ESPHOME_DATA_DIR``. ``ext_storage_path``
+    lands on the data-dir copy; the helper finds the build_info
+    and returns the hash.
+    """
+    config_subdir = tmp_path / "config"
+    data_subdir = tmp_path / "data"
+    config_subdir.mkdir()
+    data_subdir.mkdir()
+
+    yaml_path = config_subdir / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    # ``ESPHOME_DATA_DIR`` mode (and HA-addon ``/data``) put the
+    # sidecar at ``<data_dir>/storage/...`` directly — no
+    # ``.esphome`` prefix. ``write_storage_json`` adds the prefix,
+    # which is right for default-mode tests but not this layout,
+    # so write_storage_json into a faux parent and let the dir
+    # join end up at the addon-shaped location.
+    fake_default_root = data_subdir.parent  # so .esphome lands beside data_subdir
+    build_path = data_subdir / "build" / "kitchen"
+    sidecar_path = write_storage_json(
+        fake_default_root,
+        yaml_path.name,
+        firmware_bin_path=build_path / ".pioenvs" / "firmware.bin",
+        build_path=build_path,
+    )
+    # Relocate the sidecar to the addon-shaped path.
+    target = data_subdir / "storage" / f"{yaml_path.name}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(sidecar_path.read_bytes())
+    _write_build_info(build_path, config_hash=0xCAFEBABE)
+
+    monkeypatch.setenv("ESPHOME_DATA_DIR", str(data_subdir))
+    monkeypatch.setattr(CORE, "config_path", config_subdir / "___SENTINEL___.yaml")
+
+    assert read_build_info_hash(yaml_path) == "cafebabe"


### PR DESCRIPTION
# What does this implement/fix?

`helpers/config_hash.read_build_info_hash` hardcoded the StorageJSON
lookup to `<yaml_dir>/.esphome/storage/<name>.json`, which is correct
only in default mode where `CORE.data_dir` lands at
`<config_dir>/.esphome`. On the Home Assistant addon, `CORE.data_dir`
short-circuits to `/data` (and `ESPHOME_DATA_DIR` overrides it
elsewhere), so the actual paths are `/data/storage/<name>.json` and
`/data/build/<name>/build_info.json` — both of which the hardcoded
lookup misses. `read_build_info_hash` returned `None` for every
device on the addon, with two cascading user-visible symptoms:

- The drawer's **Local config hash** stayed empty (em-dash) even
  after a successful flash, since `_persist_expected_config_hash`
  reads back through the same helper.
- `compute_has_pending_changes` fell through to the
  `bin_mtime`-vs-`yaml_mtime` fallback, where `bin_mtime` was also
  `None` (same wrong storage path → no `firmware_bin_path` →
  rule 2 returns pending). Every device flipped to the orange
  "Pending changes" dot. The frontend's `getEncryptionState` then
  combined `has_pending_changes=true` with `api_encryption_active=null`
  and rendered a "Pending install" chip on every encryption-using
  device — the user-reported symptom that led to the diagnosis.

Route the lookup through `ext_storage_path`, which already honours
`CORE.data_dir`'s deployment-mode logic (HA addon, `ESPHOME_DATA_DIR`,
default). Production sets `CORE.config_path` on dashboard startup, so
the prerequisite is met. Tests under `controllers/devices/` get an
autouse fixture that pins the sentinel onto `tmp_path` so
`ext_storage_path` resolves into the same fixture tree
`write_storage_json` writes to. Adds a regression test that recreates
the addon split (config under one tmp subtree, data under another
via `ESPHOME_DATA_DIR`) and asserts the helper finds `build_info.json`
through the data-dir copy.

**Related issue or feature (if applicable):**

- fixes the "fresh HA addon install shows em-dash for Local config
  hash even after flash" report and the "every encryption device
  shows Pending install" follow-up

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
