### PR TITLE
Carry api_encryption_active across scanner reloads

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -441,7 +441,8 @@ def load_device_from_storage(
 
     *previous* is the prior in-memory Device for this path, when one
     exists. Runtime-only fields populated by monitors (``state``,
-    ``deployed_config_hash``) carry forward from it so a reload
+    ``deployed_config_hash``, ``ip_addresses``,
+    ``api_encryption_active``) carry forward from it so a reload
     doesn't wipe what mDNS / ping has already discovered.
     """
     filename = path.name
@@ -498,6 +499,25 @@ def load_device_from_storage(
     # YAML edit doesn't blank the dashboard's IP list until the next
     # mDNS broadcast lands.
     ip_addresses = list(previous.ip_addresses) if previous else []
+    # Same carry-forward rule for the encryption-active observation:
+    # the next ``_esphomelib._tcp`` announce can be a couple of TTLs
+    # (minutes) away, and a scanner reload triggered by a flash /
+    # YAML edit / ``--only-generate`` between announces would
+    # otherwise wipe a previously-truthy ``api_encryption_active``
+    # back to ``None``. The frontend's ``getEncryptionState`` reads
+    # ``None`` as "mDNS not seen yet" and combines it with
+    # ``has_pending_changes`` to render a "Pending install" chip —
+    # so the user sees a freshly-flashed encrypted device flip into
+    # the warning state for the gap window despite the firmware on
+    # the wire still broadcasting encryption. The
+    # ``apply_api_encryption`` path follows the "Device is the
+    # source of truth" rule established in PR #75 and dedupes
+    # against ``device.api_encryption_active`` (not a monitor-side
+    # cache), so seeding the field from ``previous`` doesn't break
+    # the "next mDNS announce corrects mismatched state" guarantee
+    # — a re-announce with a different value still hits the
+    # callback path.
+    api_encryption_active = previous.api_encryption_active if previous else None
 
     has_pending = compute_has_pending_changes(
         yaml_mtime=yaml_mtime,
@@ -615,6 +635,7 @@ def load_device_from_storage(
         ),
         api_enabled=api_enabled,
         api_encrypted=api_encrypted,
+        api_encryption_active=api_encryption_active,
         mac_address=mac_address,
         ethernet_mac=ethernet_mac,
         bluetooth_mac=bluetooth_mac,

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -933,3 +933,86 @@ def test_load_device_default_labels_is_empty_list(tmp_path: Path) -> None:
 
     assert device.labels == []
     assert isinstance(device.labels, list)
+
+
+# ---------------------------------------------------------------------------
+# load_device_from_storage — monitor-derived field carry-forward
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_carries_api_encryption_active_from_previous(tmp_path: Path) -> None:
+    """Reload preserves the mDNS-observed ``api_encryption_active``.
+
+    The mDNS browser fires on Added/Updated, populates
+    ``api_encryption_active="Noise_..."`` on the live ``Device``,
+    and then sleeps until the next service-record TTL refresh — a
+    couple of minutes in the typical fleet. Anything that triggers
+    ``scanner.reload`` between announces (a successful flash, an
+    ``--only-generate`` run, an unrelated YAML edit on the sibling
+    device, an atomic-save remove/re-add cycle) used to wipe the
+    field back to ``None`` because the new ``Device`` was built
+    from defaults — the user saw a freshly-flashed encrypted
+    device flip into the "Pending install" warning despite the
+    firmware on the wire still broadcasting encryption.
+
+    Mirrors the existing carry-forward shape for ``state``,
+    ``deployed_config_hash``, and ``ip_addresses``: pass
+    ``previous`` and ``api_encryption_active`` round-trips
+    through.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    previous = load_device_from_storage(yaml_path)
+    previous.api_encryption_active = "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+
+    reloaded = load_device_from_storage(yaml_path, previous=previous)
+
+    assert reloaded.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_carries_plaintext_confirmation_from_previous(tmp_path: Path) -> None:
+    """The empty-string ``api_encryption_active`` ("confirmed plaintext") also carries.
+
+    The tri-state shape (``"…"`` / ``""`` / ``None``) means
+    ``""`` is a *positive* observation — mDNS saw the broadcast,
+    the ``api_encryption`` TXT was absent, the device is running
+    plaintext. Wiping that to ``None`` on reload would re-enter
+    the "encryption unknown" UI state and re-trigger the
+    "Pending install" path on devices the dashboard has already
+    confirmed as plaintext. Falsy guards in the carry-forward
+    would silently re-introduce the bug, so the test pins the
+    empty-string case explicitly.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    previous = load_device_from_storage(yaml_path)
+    previous.api_encryption_active = ""
+
+    reloaded = load_device_from_storage(yaml_path, previous=previous)
+
+    assert reloaded.api_encryption_active == ""
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_without_previous_defaults_api_encryption_active_to_none(
+    tmp_path: Path,
+) -> None:
+    """First load (no ``previous``) yields the unknown / not-yet-seen sentinel.
+
+    mDNS hasn't reported and the YAML's ``api_encrypted`` flag
+    can't tell us what's actually on the wire — ``None`` is the
+    correct "trust the YAML until proven otherwise" state.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.api_encryption_active is None


### PR DESCRIPTION
# What does this implement/fix?

`load_device_from_storage` was building the new `Device` from
defaults whenever `scanner.reload(...)` fired, dropping any
`api_encryption_active` value the mDNS browser had already
written. mDNS announces only fire on the service-record TTL —
typically a couple of minutes between `Added`/`Updated`
callbacks — so any reload triggered between announces (a
successful flash, an `--only-generate` run, an unrelated YAML
edit on a sibling, an atomic-save remove/re-add cycle) wiped
the value back to `None` for the gap window.

The frontend's `getEncryptionState` reads
`api_encryption_active` together with `has_pending_changes` and
renders the lock icon's four-state indicator. With
`api_encryption_active=null` and `has_pending_changes=true`
(which the post-flash refresh sets even on an OTA that
succeeded), the indicator flips into the **Pending install**
chip on a freshly-flashed encrypted device that's still
actively broadcasting its noise PSK on the wire. Reported as
"every encryption device that mDNS could see still says pending
install"; a backend restart cleared it because the next mDNS
announce after the fresh subscription repopulated the field.

Mirror the existing carry-forward shape used for `state` /
`deployed_config_hash` / `ip_addresses`: pull
`api_encryption_active` off `previous` when one is provided,
default to `None` on first load. `apply_api_encryption`
follows the "Device is the source of truth" rule from #75 and
dedupes against `device.api_encryption_active` rather than a
monitor-side cache, so seeding the value from `previous`
doesn't break the "next mDNS announce corrects mismatched
state" guarantee — the next genuine observation still hits the
callback path. Adds three regression tests covering the
truthy / `""` / no-`previous` cases.

**Related issue or feature (if applicable):**

- companion to the "fresh HA addon install shows Pending
  install on every encryption device" report addressed by
  #364 (build_info.json path fix). Even with that fix in
  place, the brief reload window kept tripping the indicator
  on healthy devices.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
