### PR TITLE
frontend: per-request <base href> injection + asset 404 SPA fallback

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -71,26 +71,51 @@ _ASSET_EXTENSIONS = frozenset(
 # diff so a partial replacement is loud, not silent.
 _BASE_HREF_PLACEHOLDER = "__ESPHOME_BASE_HREF__"
 
-# Match SPA route tails so we can strip them off the request path
-# to recover the deployment base. Mirrors the routes registered in
-# ``app-shell.ts`` (``/``, ``/secrets``, ``/device/:id``); future
-# top-level routes need an entry here too.
-_SPA_ROUTE_TAIL_RE = re.compile(r"/(?:device(?:/[^/]*)?|secrets)/?$")
+# Header the rendered shell varies on. Reverse proxies that strip
+# a path prefix announce it via ``X-Forwarded-Prefix`` and the
+# rendered ``<base href>`` differs accordingly — without ``Vary``,
+# an intermediary cache could serve the wrong-prefix shell to a
+# different client. (Copilot-flagged.)
+_BASE_HREF_VARY = "X-Forwarded-Prefix"
 
 
-def _resolve_base_href(request: web.Request) -> str:
+def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
     """Pick the ``<base href>`` for *request*'s deployment.
 
-    Honours ``X-Forwarded-Prefix`` (reverse-proxy convention) when
-    present, otherwise strips the SPA route tail off
-    ``request.path`` to reveal the mount-point prefix. Always
-    returns a path with leading + trailing slashes.
+    Sources, in priority order:
+
+    1. ``X-Forwarded-Prefix`` header — the explicit signal from a
+       reverse proxy or ingress layer that's stripping a path
+       prefix. Required for any non-root deployment whose URLs
+       the backend can't infer from ``request.path`` alone (HA
+       add-on ingress, nginx subpath, …).
+    2. The ``request.path`` minus the matched SPA-fallback tail —
+       lets a direct deploy at ``/`` recover the (empty) prefix
+       without the operator having to set a header. Caller passes
+       the aiohttp ``match_info`` tail in directly so the backend
+       doesn't track the SPA route table.
+
+    Always returns a path with leading + trailing slashes;
+    collapses ``//evil.com``-style injection attempts to a single
+    leading slash.
     """
-    base = request.headers.get("X-Forwarded-Prefix", "").strip()
-    if not base:
-        base = _SPA_ROUTE_TAIL_RE.sub("", request.path)
-    if not base.startswith("/"):
-        base = "/" + base
+    forwarded = request.headers.get("X-Forwarded-Prefix", "").strip()
+    if forwarded:
+        base = forwarded
+    elif tail and request.path.endswith(tail):
+        # Slice the matched SPA tail off the request path to get
+        # the mount-point prefix. No SPA-route knowledge needed in
+        # the backend; the aiohttp router already matched the tail
+        # and we trust its match_info.
+        base = request.path[: -len(tail)] or "/"
+    else:
+        base = request.path
+    # Collapse any leading-slash run to exactly one so
+    # ``X-Forwarded-Prefix: //evil.com`` can't yield a
+    # protocol-relative ``<base href>`` that points at another
+    # origin. (Copilot-flagged.) Same for trailing slashes — keep
+    # exactly one.
+    base = "/" + base.lstrip("/")
     if not base.endswith("/"):
         base += "/"
     return base
@@ -621,12 +646,18 @@ class DeviceBuilder:
                 _BASE_HREF_PLACEHOLDER, html.escape(base_href, quote=True)
             )
 
-        def _render_shell(request: web.Request) -> web.Response:
-            return web.Response(
-                text=_shell_html(_resolve_base_href(request)),
+        def _render_shell(request: web.Request, *, tail: str = "") -> web.Response:
+            response = web.Response(
+                text=_shell_html(_resolve_base_href(request, tail=tail)),
                 content_type="text/html",
                 headers=shell_headers,
             )
+            # The rendered shell varies by ``X-Forwarded-Prefix`` —
+            # without ``Vary`` an intermediary cache could serve a
+            # response built for one prefix to a request behind a
+            # different proxy.
+            response.headers["Vary"] = _BASE_HREF_VARY
+            return response
 
         async def handle_index(request: web.Request) -> web.Response:
             return _render_shell(request)
@@ -665,7 +696,7 @@ class DeviceBuilder:
             # ``_ASSET_EXTENSIONS`` for the rationale.
             if tail and Path(tail).suffix.lower() in _ASSET_EXTENSIONS:
                 raise web.HTTPNotFound()
-            return _render_shell(request)
+            return _render_shell(request, tail=tail)
 
         app.router.add_static("/assets", assets_dir)
         app.router.add_get("/", handle_index)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import html
 import logging
 import re
 from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +49,52 @@ _LOGGER = logging.getLogger(__name__)
 _NO_CACHE_HEADERS = {"Cache-Control": "no-cache"}
 _IMMUTABLE_HEADERS = {"Cache-Control": "public, max-age=31536000, immutable"}
 _HASHED_FILENAME_RE = re.compile(r"\.[a-f0-9]{8,}\.")
+
+# Path extensions that should NEVER fall back to ``index.html``. The
+# frontend bundle's entry script is emitted with a relative ``src``
+# (rspack ``publicPath: "auto"`` for ingress / reverse-proxy
+# subpath support), so a hard-reload of a deep SPA URL like
+# ``/device/<id>`` resolves the script as ``/device/app.<hash>.js``.
+# Falling back to ``index.html`` for that path would let the
+# browser parse HTML as JavaScript and white-screen on
+# "Unexpected token '<'". Returning 404 instead keeps the failure
+# mode legible — by then the ``<base>`` injection should have
+# steered the script's URL to the deployment root anyway, so
+# this is the belt to that suspenders.
+_ASSET_EXTENSIONS = frozenset(
+    {".js", ".css", ".map", ".woff", ".woff2", ".ttf", ".otf", ".ico", ".png"}
+)
+
+# Placeholder the frontend's ``index.html`` carries verbatim; the
+# backend renders it per-request with the deployment-base prefix.
+# Sentinel chosen to be HTML-attribute-safe and unambiguous in a
+# diff so a partial replacement is loud, not silent.
+_BASE_HREF_PLACEHOLDER = "__ESPHOME_BASE_HREF__"
+
+# Match SPA route tails so we can strip them off the request path
+# to recover the deployment base. Mirrors the routes registered in
+# ``app-shell.ts`` (``/``, ``/secrets``, ``/device/:id``); future
+# top-level routes need an entry here too.
+_SPA_ROUTE_TAIL_RE = re.compile(r"/(?:device(?:/[^/]*)?|secrets)/?$")
+
+
+def _resolve_base_href(request: web.Request) -> str:
+    """Pick the ``<base href>`` for *request*'s deployment.
+
+    Honours ``X-Forwarded-Prefix`` (reverse-proxy convention) when
+    present, otherwise strips the SPA route tail off
+    ``request.path`` to reveal the mount-point prefix. Always
+    returns a path with leading + trailing slashes.
+    """
+    base = request.headers.get("X-Forwarded-Prefix", "").strip()
+    if not base:
+        base = _SPA_ROUTE_TAIL_RE.sub("", request.path)
+    if not base.startswith("/"):
+        base = "/" + base
+    if not base.endswith("/"):
+        base += "/"
+    return base
+
 
 # Worker-thread budget for the default ``ThreadPoolExecutor``. asyncio's
 # default is ``min(32, os.cpu_count() + 4)`` — too tight for the
@@ -552,9 +600,36 @@ class DeviceBuilder:
 
         frontend_root = frontend_dir.resolve()
         shell_headers = _NO_CACHE_HEADERS if dev_mode else None
+        index_html_text = index_html.read_text(encoding="utf-8")
+        if _BASE_HREF_PLACEHOLDER not in index_html_text:
+            raise RuntimeError(
+                f"Frontend index.html at {index_html} is missing the "
+                f"{_BASE_HREF_PLACEHOLDER!r} placeholder — the wheel is "
+                "out of sync with the backend's expected template."
+            )
 
-        async def handle_index(request: web.Request) -> web.FileResponse:
-            return web.FileResponse(index_html, headers=shell_headers)
+        @lru_cache(maxsize=8)
+        def _shell_html(base_href: str) -> str:
+            """Cache rendered ``index.html`` per deployment base.
+
+            Substituting a single placeholder is cheap, but doing it
+            on every request adds up under load. Cap at 8 entries —
+            most deployments hit one or two distinct prefixes (root
+            + maybe ingress).
+            """
+            return index_html_text.replace(
+                _BASE_HREF_PLACEHOLDER, html.escape(base_href, quote=True)
+            )
+
+        def _render_shell(request: web.Request) -> web.Response:
+            return web.Response(
+                text=_shell_html(_resolve_base_href(request)),
+                content_type="text/html",
+                headers=shell_headers,
+            )
+
+        async def handle_index(request: web.Request) -> web.Response:
+            return _render_shell(request)
 
         def _resolve_static(candidate: Path) -> Path | None:
             """Return the candidate if it's a real file inside ``frontend_root``.
@@ -571,7 +646,7 @@ class DeviceBuilder:
                 return None
             return None
 
-        async def handle_spa(request: web.Request) -> web.FileResponse:
+        async def handle_spa(request: web.Request) -> web.StreamResponse:
             tail = request.match_info["tail"]
             # Only flat names (hashed bundles, license sidecars) get
             # served from disk. Anything with a path separator is an
@@ -584,7 +659,13 @@ class DeviceBuilder:
                         _IMMUTABLE_HEADERS if _HASHED_FILENAME_RE.search(tail) else shell_headers
                     )
                     return web.FileResponse(resolved, headers=headers)
-            return web.FileResponse(index_html, headers=shell_headers)
+            # 404 asset-shaped requests instead of returning the SPA
+            # shell so the browser doesn't try to parse HTML as JS /
+            # CSS / etc. on a hard-reload of a deep URL — see
+            # ``_ASSET_EXTENSIONS`` for the rationale.
+            if tail and Path(tail).suffix.lower() in _ASSET_EXTENSIONS:
+                raise web.HTTPNotFound()
+            return _render_shell(request)
 
         app.router.add_static("/assets", assets_dir)
         app.router.add_get("/", handle_index)

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -21,7 +21,11 @@ def _make_frontend(tmp_path: Path) -> Path:
     """
     frontend = tmp_path / "frontend"
     frontend.mkdir()
-    (frontend / "index.html").write_text("<!doctype html><body></body>")
+    (frontend / "index.html").write_text(
+        "<!doctype html><html><head>"
+        '<base href="__ESPHOME_BASE_HREF__" />'
+        "</head><body></body></html>"
+    )
     # Use 16-char hex hashes to match what rspack actually emits (xxhash64)
     # so the cache-header regex (``\.[a-f0-9]{8,}\.``) classifies them
     # as immutable.
@@ -106,6 +110,114 @@ async def test_register_frontend_serves_top_level_bundles(
     vendors_resp = await client.get("/vendors.def4567890abcdef.js")
     assert (await app_resp.text()) == "// bundle"
     assert (await vendors_resp.text()) == "// vendors"
+
+
+async def test_register_frontend_root_request_renders_base_href_root(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """``GET /`` substitutes the base placeholder with ``/``."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/")
+    body = await resp.text()
+    assert '<base href="/" />' in body
+    assert "__ESPHOME_BASE_HREF__" not in body
+
+
+async def test_register_frontend_deep_link_renders_base_href_root(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """SPA deep link ``/device/foo.yaml`` strips the route tail back to ``/``.
+
+    Without this, the deferred app script's relative ``src``
+    would resolve to ``/device/app.<hash>.js`` and the page would
+    white-screen on a hard reload — that's the bug
+    ``_BASE_HREF_PLACEHOLDER`` exists to fix.
+    """
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/device/foo.yaml")
+    body = await resp.text()
+    assert '<base href="/" />' in body
+
+
+async def test_register_frontend_honours_x_forwarded_prefix(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """Reverse proxies that strip a path prefix announce it via ``X-Forwarded-Prefix``."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/", headers={"X-Forwarded-Prefix": "/dashboard"})
+    body = await resp.text()
+    assert '<base href="/dashboard/" />' in body
+
+
+async def test_register_frontend_ingress_style_path_strips_route_tail(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """An HA-ingress-style path on a deep link resolves to the ingress base."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get(
+        "/api/hassio_ingress/TOKEN/device/foo.yaml",
+        headers={"X-Forwarded-Prefix": "/api/hassio_ingress/TOKEN"},
+    )
+    body = await resp.text()
+    assert '<base href="/api/hassio_ingress/TOKEN/" />' in body
+
+
+async def test_register_frontend_404s_asset_shaped_paths(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """Asset-shaped deep paths get 404, not the SPA shell.
+
+    Without this, a deep ``/device/foo`` hard-reload that misses
+    the base injection would ask for ``/device/app.<hash>.js``,
+    receive ``index.html`` via SPA fallback, and white-screen
+    when the browser parsed HTML as JS.
+    """
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    for path in (
+        "/device/app.abc123def4567890.js",
+        "/secrets/styles.css",
+        "/some/where/source.map",
+        "/icons/font.woff2",
+    ):
+        resp = await client.get(path)
+        assert resp.status == 404, path
+
+
+async def test_register_frontend_yaml_deep_link_still_falls_back(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """``.yaml`` is a real SPA route segment, not an asset — fall through to the shell."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/device/acfloatmonitor32.yaml")
+    assert resp.status == 200
+    assert "<!doctype html>" in (await resp.text())
+
+
+async def test_register_frontend_missing_base_placeholder_raises(
+    tmp_path: Path,
+) -> None:
+    """A wheel whose ``index.html`` lacks the placeholder is a deployment error."""
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "index.html").write_text("<!doctype html><body></body>")
+    (frontend / "assets").mkdir()
+    app = web.Application()
+    with pytest.raises(RuntimeError, match="missing the '__ESPHOME_BASE_HREF__'"):
+        DeviceBuilder._register_frontend(app, frontend)
+
+
+async def test_register_frontend_escapes_base_href(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """A hostile ``X-Forwarded-Prefix`` can't break out of the ``<base href>`` attribute."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/", headers={"X-Forwarded-Prefix": '/"><script>alert(1)</script>'})
+    body = await resp.text()
+    # Quote escapes the closing ``"`` so the attribute terminator
+    # stays inside ``href=...``; the literal ``<script>`` leaks
+    # through but as text, not a tag.
+    assert "&quot;" in body
+    assert '<base href="/&quot;' in body
 
 
 async def test_register_frontend_serves_top_level_license_sidecar(

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -220,6 +220,50 @@ async def test_register_frontend_escapes_base_href(
     assert '<base href="/&quot;' in body
 
 
+async def test_register_frontend_collapses_double_leading_slash_in_prefix(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """``X-Forwarded-Prefix: //evil.com`` doesn't yield a protocol-relative base.
+
+    A protocol-relative ``<base href="//evil.com/">`` would point
+    relative URLs at an attacker-controlled origin. Collapse runs
+    of leading slashes to one so the value always resolves
+    on-origin.
+    """
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/", headers={"X-Forwarded-Prefix": "//evil.com"})
+    body = await resp.text()
+    assert '<base href="/evil.com/" />' in body
+    assert '<base href="//evil.com' not in body
+
+
+async def test_register_frontend_multi_segment_deep_link_strips_full_tail(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """Future SPA routes with multiple path segments get their full tail stripped.
+
+    The backend doesn't track the SPA route table — it slices the
+    aiohttp-matched ``tail`` off ``request.path`` directly. A
+    hypothetical ``/settings/network`` route resolves to base
+    ``/`` regardless of whether the backend's been told about it.
+    """
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/settings/network")
+    body = await resp.text()
+    assert '<base href="/" />' in body
+
+
+async def test_register_frontend_shell_response_carries_vary_header(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """``Vary: X-Forwarded-Prefix`` so caches don't serve cross-prefix shells."""
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    for path in ("/", "/device/foo.yaml", "/settings/network"):
+        resp = await client.get(path)
+        assert resp.status == 200, path
+        assert resp.headers.get("Vary") == "X-Forwarded-Prefix", path
+
+
 async def test_register_frontend_serves_top_level_license_sidecar(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The bundle's entry script ships with a relative `src` (rspack `publicPath: "auto"`, for HA-ingress / reverse-proxy subpath support, added in #189). Without an explicit `<base href>`, hard-reload of a deep SPA URL like `/device/<id>` resolves the script against the route path → SPA fallback returns `index.html` → browser parses HTML as JS → `Uncaught SyntaxError: Unexpected token '<'` → white screen.

Two coordinated fixes:

1. **`<base href>` injection per request.** The frontend's `index.html` carries an `__ESPHOME_BASE_HREF__` placeholder; the backend substitutes it on the way out with the deployment prefix:
   - `X-Forwarded-Prefix` header when present (reverse-proxy convention)
   - otherwise strips the SPA route tail (`/device/<id>`, `/secrets`) off `request.path` to recover the mount-point prefix
   - `lru_cache(maxsize=8)` on the rendered shell — substitution is paid once per distinct prefix.

2. **404 asset-shaped requests in the SPA fallback.** Paths ending in `.js` / `.css` / `.map` / `.woff` / `.woff2` / `.ttf` / `.otf` / `.ico` / `.png` get a 404 instead of `index.html` so the browser doesn't try to parse HTML as JS / CSS / etc. on a hard-reload of a deep URL. `.yaml` stays a real SPA route segment. Belt to fix #1's suspenders.

A frontend wheel without the `__ESPHOME_BASE_HREF__` placeholder raises `RuntimeError` at app construction so version drift surfaces loudly rather than as a runtime white-screen.

CSP-clean: no inline scripts (the existing `default-src 'self'` blocks them anyway). The injected `<base href>` is HTML-attribute-escaped and constrained by the existing `base-uri 'self'` directive, so a hostile `X-Forwarded-Prefix` can't escape same-origin.

**Related issue or feature (if applicable):**

- fixes the "white screen on hard-reload of `/device/<id>?line=...`" report — regression introduced in #189 (`publicPath: "auto"` without the matching `<base href>` injection).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#197

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
