### PR TITLE
Add colorlog and asyncio-safe queue logging

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -42,13 +42,15 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     """Set up logging with a coloured console handler and an optional rotating file."""
     level = _LOG_LEVELS.get(log_level.lower(), logging.INFO)
 
-    logging.basicConfig(level=level)
+    logging.getLogger().setLevel(level)
 
-    # ``basicConfig`` already seeded a ``StreamHandler`` on the root
-    # logger; swap its plain formatter for one that wraps the message
-    # in per-level ANSI escapes.
+    # Install our own ``StreamHandler`` rather than going through
+    # ``basicConfig`` — the latter is a no-op when handlers are
+    # already configured (e.g., under some test runners), which would
+    # leave the colour formatter unattached.
     colorfmt = f"%(log_color)s{_FORMAT}%(reset)s"
-    logging.getLogger().handlers[0].setFormatter(
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(
         ColoredFormatter(
             colorfmt,
             datefmt=_DATE_FORMAT,
@@ -56,6 +58,7 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
             log_colors=_LOG_COLORS,
         )
     )
+    logging.getLogger().addHandler(console_handler)
 
     # Route ``warnings.warn`` through the logging system instead of
     # raw stderr so the queue handler and our formatter apply.

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+from contextlib import suppress
 from logging.handlers import RotatingFileHandler
 from typing import TYPE_CHECKING
 
+from colorlog import ColoredFormatter
+
 from .constants import DEFAULT_HOST, DEFAULT_INGRESS_PORT, DEFAULT_PORT, __version__
+from .helpers.logging import activate_log_queue_handler
 
 if TYPE_CHECKING:
     from .controllers.config import DashboardSettings
 
-_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+_FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
 _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 _MAX_LOG_SIZE = 5_000_000  # 5 MB
 _LOGGER_NAME = "esphome_device_builder"
@@ -25,15 +29,43 @@ _LOG_LEVELS = {
     "error": logging.ERROR,
 }
 
+_LOG_COLORS = {
+    "DEBUG": "cyan",
+    "INFO": "green",
+    "WARNING": "yellow",
+    "ERROR": "red",
+    "CRITICAL": "red",
+}
+
 
 def _setup_logging(log_level: str, log_file: str | None = None) -> None:
-    """Set up logging with console + optional file handler."""
+    """Set up logging with a coloured console handler and an optional rotating file."""
     level = _LOG_LEVELS.get(log_level.lower(), logging.INFO)
 
-    logging.basicConfig(level=level, format=_FORMAT, datefmt=_DATE_FORMAT)
+    logging.basicConfig(level=level)
+
+    # ``basicConfig`` already seeded a ``StreamHandler`` on the root
+    # logger; swap its plain formatter for one that wraps the message
+    # in per-level ANSI escapes.
+    colorfmt = f"%(log_color)s{_FORMAT}%(reset)s"
+    logging.getLogger().handlers[0].setFormatter(
+        ColoredFormatter(
+            colorfmt,
+            datefmt=_DATE_FORMAT,
+            reset=True,
+            log_colors=_LOG_COLORS,
+        )
+    )
+
+    # Route ``warnings.warn`` through the logging system instead of
+    # raw stderr so the queue handler and our formatter apply.
+    logging.captureWarnings(True)
 
     if log_file:
         file_handler = RotatingFileHandler(log_file, maxBytes=_MAX_LOG_SIZE, backupCount=1)
+        # Fresh log file per process start.
+        with suppress(OSError):
+            file_handler.doRollover()
         file_handler.setFormatter(logging.Formatter(_FORMAT, datefmt=_DATE_FORMAT))
         logging.getLogger().addHandler(file_handler)
 
@@ -43,6 +75,10 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     logging.getLogger("asyncio").setLevel(logging.WARNING)
     logging.getLogger("aiohttp").setLevel(logging.WARNING)
     logging.getLogger("zeroconf").setLevel(logging.WARNING)
+
+    # Has to be the last step — handlers added after this run inline
+    # on the calling thread instead of being offloaded to the listener.
+    activate_log_queue_handler()
 
 
 def main() -> None:

--- a/esphome_device_builder/helpers/logging.py
+++ b/esphome_device_builder/helpers/logging.py
@@ -1,0 +1,74 @@
+"""Asyncio-safe queue logging — keeps handler I/O off the event loop."""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import queue
+from typing import Any
+
+
+class LoggingQueueHandler(logging.handlers.QueueHandler):
+    """``QueueHandler`` that tears down its backing listener on ``close()``."""
+
+    listener: logging.handlers.QueueListener | None = None
+
+    def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
+        """Prepare a record for queuing."""
+        record = super().prepare(record)
+        # Workaround for CPython issue 46755: a non-None ``stack_info``
+        # survives the ``copy.copy`` inside ``prepare`` and gets
+        # formatted a second time when the listener picks the record up.
+        record.stack_info = None
+        return record
+
+    def handle(self, record: logging.LogRecord) -> Any:
+        """Filter and emit the record."""
+        # ``Handler.handle`` acquires ``self.lock`` before delegating
+        # to ``emit``, but ``SimpleQueue.put_nowait`` is already
+        # thread-safe — the lock just adds contention. See CPython
+        # issue 24645.
+        return_value = self.filter(record)
+        if return_value:
+            self.emit(record)
+        return return_value
+
+    def close(self) -> None:
+        """Close the handler and stop the listener thread."""
+        super().close()
+        if not self.listener:
+            return
+        self.listener.stop()
+        self.listener = None
+
+
+def activate_log_queue_handler() -> None:
+    """
+    Migrate the root logger's handlers behind a thread-backed queue.
+
+    Call once during process startup, after the console and rotating-
+    file handlers are configured. Subsequent ``logger.*`` calls return
+    immediately instead of formatting and writing inline, so the
+    asyncio event loop can't be stalled by log I/O.
+
+    Handlers added to the root logger *after* this call run inline
+    again — keep this last in the logging-setup chain. Idempotent:
+    repeat calls are no-ops.
+    """
+    if any(isinstance(h, LoggingQueueHandler) for h in logging.root.handlers):
+        return
+
+    simple_queue: queue.SimpleQueue[logging.Handler] = queue.SimpleQueue()
+    queue_handler = LoggingQueueHandler(simple_queue)
+    logging.root.addHandler(queue_handler)
+
+    migrated_handlers: list[logging.Handler] = []
+    for handler in logging.root.handlers[:]:
+        if handler is queue_handler:
+            continue
+        logging.root.removeHandler(handler)
+        migrated_handlers.append(handler)
+
+    listener = logging.handlers.QueueListener(simple_queue, *migrated_handlers)
+    queue_handler.listener = listener
+    listener.start()

--- a/esphome_device_builder/helpers/logging.py
+++ b/esphome_device_builder/helpers/logging.py
@@ -58,7 +58,7 @@ def activate_log_queue_handler() -> None:
     if any(isinstance(h, LoggingQueueHandler) for h in logging.root.handlers):
         return
 
-    simple_queue: queue.SimpleQueue[logging.Handler] = queue.SimpleQueue()
+    simple_queue: queue.SimpleQueue[logging.LogRecord] = queue.SimpleQueue()
     queue_handler = LoggingQueueHandler(simple_queue)
     logging.root.addHandler(queue_handler)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 dependencies = [
   "esphome-device-builder-frontend==0.1.38",
   "aiohttp>=3.9.0",
+  "colorlog>=6.8.0",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
   "pyyaml>=6.0",

--- a/tests/test_helpers_logging.py
+++ b/tests/test_helpers_logging.py
@@ -1,0 +1,144 @@
+"""Tests for ``helpers/logging.py`` — asyncio-safe queue logging."""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import queue
+from collections.abc import Generator
+
+import pytest
+
+from esphome_device_builder.helpers.logging import (
+    LoggingQueueHandler,
+    activate_log_queue_handler,
+)
+
+
+@pytest.fixture
+def isolated_root_logger() -> Generator[None]:
+    """
+    Snapshot ``logging.root`` and restore it after the test.
+
+    Each case in this file mutates the root logger's handler list,
+    so without this fixture they leak handlers between tests (and
+    into the rest of the suite).
+    """
+    saved_handlers = logging.root.handlers[:]
+    saved_level = logging.root.level
+    logging.root.handlers = []
+    try:
+        yield
+    finally:
+        for handler in logging.root.handlers[:]:
+            handler.close()
+            logging.root.removeHandler(handler)
+        for handler in saved_handlers:
+            logging.root.addHandler(handler)
+        logging.root.setLevel(saved_level)
+
+
+def test_migrates_existing_handlers_behind_a_queue_listener(
+    isolated_root_logger: None,
+) -> None:
+    """``activate_log_queue_handler`` moves existing handlers into the listener."""
+    stream = logging.StreamHandler()
+    file_like = logging.NullHandler()
+    logging.root.addHandler(stream)
+    logging.root.addHandler(file_like)
+
+    activate_log_queue_handler()
+
+    # Root now holds exactly one ``LoggingQueueHandler``; the
+    # originals migrated into the listener it owns. (Pytest may
+    # have re-added its own ``LogCaptureHandler`` to root after our
+    # fixture's reset, hence subset rather than equality on the
+    # listener handlers.)
+    queue_handlers = [h for h in logging.root.handlers if isinstance(h, LoggingQueueHandler)]
+    assert len(queue_handlers) == 1
+    queue_handler = queue_handlers[0]
+    assert queue_handler.listener is not None
+    assert {stream, file_like}.issubset(set(queue_handler.listener.handlers))
+
+
+def test_is_idempotent(isolated_root_logger: None) -> None:
+    """A second call after activation does not nest another queue handler."""
+    logging.root.addHandler(logging.NullHandler())
+
+    activate_log_queue_handler()
+    first_handler = next(h for h in logging.root.handlers if isinstance(h, LoggingQueueHandler))
+    first_listener = first_handler.listener
+
+    activate_log_queue_handler()
+
+    queue_handlers = [h for h in logging.root.handlers if isinstance(h, LoggingQueueHandler)]
+    assert queue_handlers == [first_handler]
+    assert first_handler.listener is first_listener
+
+
+def test_close_stops_listener_thread(isolated_root_logger: None) -> None:
+    """Closing the queue handler shuts the backing listener down."""
+    logging.root.addHandler(logging.NullHandler())
+    activate_log_queue_handler()
+    queue_handler = next(h for h in logging.root.handlers if isinstance(h, LoggingQueueHandler))
+    listener = queue_handler.listener
+    assert listener is not None
+    listener_thread = listener._thread
+    assert listener_thread is not None
+    assert listener_thread.is_alive()
+
+    queue_handler.close()
+
+    assert queue_handler.listener is None
+    listener_thread.join(timeout=2.0)
+    assert not listener_thread.is_alive()
+
+
+def test_records_reach_migrated_handlers(isolated_root_logger: None) -> None:
+    """Records emitted after activation flow through the queue to the migrated handlers."""
+
+    class _Capture(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.records: list[logging.LogRecord] = []
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.records.append(record)
+
+    capture = _Capture()
+    logging.root.addHandler(capture)
+    logging.root.setLevel(logging.DEBUG)
+
+    activate_log_queue_handler()
+
+    logger = logging.getLogger("esphome_device_builder.test_helpers_logging")
+    logger.warning("hello")
+
+    queue_handler = next(h for h in logging.root.handlers if isinstance(h, LoggingQueueHandler))
+    listener = queue_handler.listener
+    assert listener is not None
+    # Listener is on a separate thread — drain by stopping it, which
+    # blocks until the queue is empty and the worker has exited.
+    listener.stop()
+    queue_handler.listener = None
+
+    assert any(r.getMessage() == "hello" for r in capture.records)
+
+
+def test_prepare_clears_stack_info() -> None:
+    """``prepare`` strips ``stack_info`` so the listener can't double-format it."""
+    handler = LoggingQueueHandler(queue.SimpleQueue())
+    record = logging.LogRecord(
+        name="x",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="msg",
+        args=None,
+        exc_info=None,
+    )
+    record.stack_info = "fake stack"
+
+    prepared = handler.prepare(record)
+
+    assert prepared.stack_info is None


### PR DESCRIPTION
# What does this implement/fix?

Brings the dashboard backend in line with how Home Assistant and Music Assistant set up logging:

- adds `colorlog` so console output is per-level coloured — easier to scan in `journalctl` and the HA add-on log view
- routes log records through a `QueueHandler` + listener thread, so `logger.*` from a coroutine never blocks on stderr or rotating-file I/O (asyncio-safe)
- new `helpers/logging.py` with `LoggingQueueHandler` + `activate_log_queue_handler()` (idempotent), wired in from `__main__._setup_logging`
- `_FORMAT` now includes milliseconds and the thread name (matches HA / MA), and `warnings.warn` is captured into the logging system
- log file rolls on each process start so a fresh run gets a clean file

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
