### PR TITLE
Address late Copilot follow-ups on #371 (trailing-slash collapse + escape-test fixes)

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -112,12 +112,14 @@ def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
         base = request.path[: -len(tail)] or "/"
     else:
         base = request.path
-    # Normalise to exactly one leading + trailing slash. ``lstrip``
-    # collapses ``//evil.com`` injection attempts to a single
-    # on-origin slash; ``rstrip`` collapses ``/dashboard//`` so the
-    # rendered ``<base href>`` doesn't produce ``//``-runs in
-    # resolved asset URLs. The trailing slash is then re-added.
-    return "/" + base.strip("/") + "/" if base.strip("/") else "/"
+    # Normalise to exactly one leading + trailing slash. ``strip``
+    # collapses both ``//evil.com`` injection attempts (back to a
+    # single on-origin slash) and ``/dashboard//`` runs (so the
+    # rendered ``<base href>`` doesn't produce ``//`` runs in
+    # resolved asset URLs); the leading + trailing slashes are then
+    # re-added.
+    normalized = base.strip("/")
+    return f"/{normalized}/" if normalized else "/"
 
 
 # Worker-thread budget for the default ``ThreadPoolExecutor``. asyncio's

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -75,7 +75,7 @@ _BASE_HREF_PLACEHOLDER = "__ESPHOME_BASE_HREF__"
 # a path prefix announce it via ``X-Forwarded-Prefix`` and the
 # rendered ``<base href>`` differs accordingly — without ``Vary``,
 # an intermediary cache could serve the wrong-prefix shell to a
-# different client. (Copilot-flagged.)
+# different client.
 _BASE_HREF_VARY = "X-Forwarded-Prefix"
 
 
@@ -95,9 +95,11 @@ def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
        the aiohttp ``match_info`` tail in directly so the backend
        doesn't track the SPA route table.
 
-    Always returns a path with leading + trailing slashes;
-    collapses ``//evil.com``-style injection attempts to a single
-    leading slash.
+    Always returns a path with exactly one leading and one
+    trailing slash. Collapses runs of slashes on either end so
+    ``X-Forwarded-Prefix: //evil.com`` can't yield a
+    protocol-relative base, and ``/dashboard//`` can't produce
+    ``//`` runs in resolved asset URLs.
     """
     forwarded = request.headers.get("X-Forwarded-Prefix", "").strip()
     if forwarded:
@@ -110,15 +112,12 @@ def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
         base = request.path[: -len(tail)] or "/"
     else:
         base = request.path
-    # Collapse any leading-slash run to exactly one so
-    # ``X-Forwarded-Prefix: //evil.com`` can't yield a
-    # protocol-relative ``<base href>`` that points at another
-    # origin. (Copilot-flagged.) Same for trailing slashes — keep
-    # exactly one.
-    base = "/" + base.lstrip("/")
-    if not base.endswith("/"):
-        base += "/"
-    return base
+    # Normalise to exactly one leading + trailing slash. ``lstrip``
+    # collapses ``//evil.com`` injection attempts to a single
+    # on-origin slash; ``rstrip`` collapses ``/dashboard//`` so the
+    # rendered ``<base href>`` doesn't produce ``//``-runs in
+    # resolved asset URLs. The trailing slash is then re-added.
+    return "/" + base.strip("/") + "/" if base.strip("/") else "/"
 
 
 # Worker-thread budget for the default ``ThreadPoolExecutor``. asyncio's

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -209,15 +209,23 @@ async def test_register_frontend_missing_base_placeholder_raises(
 async def test_register_frontend_escapes_base_href(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """A hostile ``X-Forwarded-Prefix`` can't break out of the ``<base href>`` attribute."""
+    """A hostile ``X-Forwarded-Prefix`` can't break out of the ``<base href>`` attribute.
+
+    ``html.escape(..., quote=True)`` escapes ``"``/``<``/``>``/``&``,
+    so the closing-quote-then-script-tag payload becomes inert text
+    inside the attribute value rather than leaking past the
+    terminator.
+    """
     client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
     resp = await client.get("/", headers={"X-Forwarded-Prefix": '/"><script>alert(1)</script>'})
     body = await resp.text()
-    # Quote escapes the closing ``"`` so the attribute terminator
-    # stays inside ``href=...``; the literal ``<script>`` leaks
-    # through but as text, not a tag.
     assert "&quot;" in body
     assert '<base href="/&quot;' in body
+    # ``<script>`` and its closing tag escape to ``&lt;script&gt;``,
+    # so the literal tag never appears in the rendered HTML.
+    assert "<script>" not in body
+    assert "&lt;script&gt;" in body
+    assert "&lt;/script&gt;" in body
 
 
 async def test_register_frontend_collapses_double_leading_slash_in_prefix(
@@ -235,6 +243,25 @@ async def test_register_frontend_collapses_double_leading_slash_in_prefix(
     body = await resp.text()
     assert '<base href="/evil.com/" />' in body
     assert '<base href="//evil.com' not in body
+
+
+async def test_register_frontend_collapses_double_trailing_slash_in_prefix(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """``X-Forwarded-Prefix: /dashboard//`` doesn't produce ``//`` in the base.
+
+    A trailing-double-slash would yield ``<base href="/dashboard//">``
+    so a relative ``app.HASH.js`` resolves to
+    ``/dashboard//app.HASH.js`` — the ``//`` run can confuse
+    middlewares (some collapse, some don't) and cache keys
+    upstream. Collapse to exactly one trailing slash so the
+    rendered base is canonical.
+    """
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get("/", headers={"X-Forwarded-Prefix": "/dashboard//"})
+    body = await resp.text()
+    assert '<base href="/dashboard/" />' in body
+    assert '<base href="/dashboard//' not in body
 
 
 async def test_register_frontend_multi_segment_deep_link_strips_full_tail(


### PR DESCRIPTION
# What does this implement/fix?

Three late Copilot follow-ups on the merged #371:

1. **Trailing-slash collapse.** `_resolve_base_href` appended a slash when missing but didn't collapse runs. `X-Forwarded-Prefix: /dashboard//` yielded `<base href="/dashboard//">` and produced `//`-runs in resolved asset URLs (some intermediaries collapse, some don't; the cache keys diverge). Switched the normalization to a single `base.strip("/")` round trip so leading and trailing slash runs both collapse to exactly one. Pinned by `test_register_frontend_collapses_double_trailing_slash_in_prefix`.

2. **Dropped two `(Copilot-flagged.)` annotations** from module comments. The surrounding sentences already explain the rationale; the annotation ages poorly in the codebase.

3. **Fixed the `test_register_frontend_escapes_base_href` comment + assertions.** The original comment claimed the literal `<script>` tag leaked through as text, but `html.escape(..., quote=True)` escapes `<`/`>` so the tag never appears. Comment now matches behavior; added explicit asserts that `<script>` is absent and `&lt;script&gt;` / `&lt;/script&gt;` entities are present.

**Related issue or feature (if applicable):**

- Follow-up to #371 (Copilot review comments arrived after merge).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
