### PR TITLE
Honour HA core's X-Ingress-Path header in <base href> resolution

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -86,20 +86,22 @@ _BASE_HREF_VARY = "X-Ingress-Path, X-Forwarded-Prefix"
 def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
     """Pick the ``<base href>`` for *request*'s deployment.
 
-    Sources, in priority order:
+    Strict precedence — the first source that yields a non-empty
+    value wins, the rest are skipped:
 
     1. ``X-Ingress-Path`` header — set by Home Assistant core's
        ingress proxy to the per-token ingress prefix
        (``/api/hassio_ingress/<token>``, no trailing slash). The
        supervisor's ingress proxy passes it through unchanged, so
        the add-on sees the canonical prefix the browser used.
-       This is the dominant production deployment shape.
+       This is the dominant production deployment shape, so it
+       wins over ``X-Forwarded-Prefix`` in the unlikely case both
+       headers arrive on the same request.
     2. ``X-Forwarded-Prefix`` header — the standardised reverse-
        proxy signal for non-HA setups (nginx subpath, traefik,
-       caddy). Either header alone is enough; the two are
-       checked in addition rather than as a fallback so a
-       deployment that sets only one wins.
-    3. The ``request.path`` minus the matched SPA-fallback tail —
+       caddy). Production deployments only set one of the two
+       headers in practice; this branch is for the non-HA path.
+    3. ``request.path`` minus the matched SPA-fallback tail —
        lets a direct deploy at ``/`` recover the (empty) prefix
        without the operator having to set a header. Caller passes
        the aiohttp ``match_info`` tail in directly so the backend

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -71,12 +71,16 @@ _ASSET_EXTENSIONS = frozenset(
 # diff so a partial replacement is loud, not silent.
 _BASE_HREF_PLACEHOLDER = "__ESPHOME_BASE_HREF__"
 
-# Header the rendered shell varies on. Reverse proxies that strip
-# a path prefix announce it via ``X-Forwarded-Prefix`` and the
-# rendered ``<base href>`` differs accordingly — without ``Vary``,
-# an intermediary cache could serve the wrong-prefix shell to a
+# Headers the rendered shell varies on. Both reverse proxies and
+# the HA add-on ingress layer announce a stripped path prefix —
+# nginx-style proxies via ``X-Forwarded-Prefix`` and HA core's
+# ingress proxy via ``X-Ingress-Path`` (set in
+# ``homeassistant/components/hassio/ingress.py:_init_header``,
+# passed through unchanged by the supervisor proxy). The rendered
+# ``<base href>`` differs per source, so without ``Vary`` an
+# intermediary cache could serve the wrong-prefix shell to a
 # different client.
-_BASE_HREF_VARY = "X-Forwarded-Prefix"
+_BASE_HREF_VARY = "X-Ingress-Path, X-Forwarded-Prefix"
 
 
 def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
@@ -84,12 +88,18 @@ def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
 
     Sources, in priority order:
 
-    1. ``X-Forwarded-Prefix`` header — the explicit signal from a
-       reverse proxy or ingress layer that's stripping a path
-       prefix. Required for any non-root deployment whose URLs
-       the backend can't infer from ``request.path`` alone (HA
-       add-on ingress, nginx subpath, …).
-    2. The ``request.path`` minus the matched SPA-fallback tail —
+    1. ``X-Ingress-Path`` header — set by Home Assistant core's
+       ingress proxy to the per-token ingress prefix
+       (``/api/hassio_ingress/<token>``, no trailing slash). The
+       supervisor's ingress proxy passes it through unchanged, so
+       the add-on sees the canonical prefix the browser used.
+       This is the dominant production deployment shape.
+    2. ``X-Forwarded-Prefix`` header — the standardised reverse-
+       proxy signal for non-HA setups (nginx subpath, traefik,
+       caddy). Either header alone is enough; the two are
+       checked in addition rather than as a fallback so a
+       deployment that sets only one wins.
+    3. The ``request.path`` minus the matched SPA-fallback tail —
        lets a direct deploy at ``/`` recover the (empty) prefix
        without the operator having to set a header. Caller passes
        the aiohttp ``match_info`` tail in directly so the backend
@@ -101,8 +111,11 @@ def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
     protocol-relative base, and ``/dashboard//`` can't produce
     ``//`` runs in resolved asset URLs.
     """
+    ingress = request.headers.get("X-Ingress-Path", "").strip()
     forwarded = request.headers.get("X-Forwarded-Prefix", "").strip()
-    if forwarded:
+    if ingress:
+        base = ingress
+    elif forwarded:
         base = forwarded
     elif tail and request.path.endswith(tail):
         # Slice the matched SPA tail off the request path to get

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -283,12 +283,56 @@ async def test_register_frontend_multi_segment_deep_link_strips_full_tail(
 async def test_register_frontend_shell_response_carries_vary_header(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """``Vary: X-Forwarded-Prefix`` so caches don't serve cross-prefix shells."""
+    """``Vary: X-Ingress-Path, X-Forwarded-Prefix`` so caches don't serve cross-prefix shells."""
     client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
     for path in ("/", "/device/foo.yaml", "/settings/network"):
         resp = await client.get(path)
         assert resp.status == 200, path
-        assert resp.headers.get("Vary") == "X-Forwarded-Prefix", path
+        assert resp.headers.get("Vary") == "X-Ingress-Path, X-Forwarded-Prefix", path
+
+
+async def test_register_frontend_honours_x_ingress_path(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """HA core's ingress proxy announces the prefix via ``X-Ingress-Path``.
+
+    See ``homeassistant/components/hassio/ingress.py:_init_header`` —
+    HA core sets ``X-Ingress-Path: /api/hassio_ingress/<token>``
+    (no trailing slash) and the supervisor's ingress proxy passes
+    it through unchanged. The add-on never sees
+    ``X-Forwarded-Prefix`` on this path, so the backend must read
+    ``X-Ingress-Path`` independently or every ingress hard-reload
+    of a deep SPA link white-screens (the asset-shaped relative
+    URL resolves against the bare host).
+    """
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get(
+        "/device/foo.yaml",
+        headers={"X-Ingress-Path": "/api/hassio_ingress/TOKEN"},
+    )
+    body = await resp.text()
+    assert '<base href="/api/hassio_ingress/TOKEN/" />' in body
+
+
+async def test_register_frontend_x_ingress_path_takes_precedence_over_forwarded(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """``X-Ingress-Path`` wins when both headers arrive.
+
+    Production deployments only set one or the other, but if both
+    show up we trust the HA-specific signal — it's the canonical
+    per-token prefix from core's ingress proxy.
+    """
+    client = await aiohttp_client(_make_app(_make_frontend(tmp_path)))
+    resp = await client.get(
+        "/",
+        headers={
+            "X-Ingress-Path": "/api/hassio_ingress/TOKEN",
+            "X-Forwarded-Prefix": "/dashboard",
+        },
+    )
+    body = await resp.text()
+    assert '<base href="/api/hassio_ingress/TOKEN/" />' in body
 
 
 async def test_register_frontend_serves_top_level_license_sidecar(


### PR DESCRIPTION
# What does this implement/fix?

Hard-reloading a deep SPA URL through the HA add-on ingress (e.g.
`https://<ha-host>/api/hassio_ingress/<token>/device/foo`) white-
screens because `app.HASH.js` resolves against the bare host
(`https://<ha-host>/app.HASH.js` → 404) instead of against the
per-token ingress prefix.

**Root cause.** HA core's ingress proxy announces the stripped
prefix via `X-Ingress-Path`, not `X-Forwarded-Prefix`. From
`homeassistant/components/hassio/ingress.py:_init_header`:

```python
headers[X_HASS_SOURCE] = "core.ingress"
headers[X_INGRESS_PATH] = f"/api/hassio_ingress/{token}"
```

The supervisor's ingress proxy (`supervisor/api/ingress.py:_init_header`)
passes the header through unchanged, so the add-on receives
`X-Ingress-Path: /api/hassio_ingress/<token>` (no trailing slash)
and never sees `X-Forwarded-Prefix`. PR #371's `_resolve_base_href`
only checked the latter, so it fell back to `request.path` and
rendered `<base href="/" />`. PR #371's 404-on-asset-shape SPA
fallback then 404'd `app.HASH.js` and the browser white-screened.

**Fix.** Read `X-Ingress-Path` first, `X-Forwarded-Prefix` second,
`request.path`-minus-tail third. The HA-specific header wins
because it's the canonical per-token prefix from core; the
fallback to `X-Forwarded-Prefix` keeps non-HA reverse-proxy
deployments (nginx subpath, traefik, caddy) working unchanged.
Both headers are listed in the `Vary` response header
(`Vary: X-Ingress-Path, X-Forwarded-Prefix`) so an intermediary
cache can't serve the wrong-prefix shell to a different client.

**Verified manually** by reading the HA-core and supervisor
ingress proxies (`homeassistant/components/hassio/ingress.py`,
`supervisor/api/ingress.py`) — neither sets `X-Forwarded-Prefix`
on this path, both rely on `X-Ingress-Path`.

**Related issue or feature (if applicable):**

- Bug found while validating PR #371 (`<base href>` per-request
  injection) on real HA add-on ingress — the original PR fixed
  the reverse-proxy case but missed the HA-specific header.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
