### PR TITLE
Gate background YAML poll on SubscriberPresence

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -39,6 +39,16 @@ from .models import EventType
 
 _LOGGER = logging.getLogger(__name__)
 
+# How often ``_run_background`` re-runs ``DevicesController.poll``
+# while at least one WS client is subscribed. Bounded above by how
+# stale a "user dropped a YAML in via SSH" change is allowed to look
+# in the dashboard's device list; bounded below by the cost of the
+# directory-walk + per-file stat the poll triggers via
+# ``DeviceScanner.scan``. The ICMP ping sweep already runs on a
+# similar cadence — keep the two in the same ballpark so a fleet's
+# steady-state idle CPU doesn't spike on either alone.
+_BACKGROUND_POLL_INTERVAL_SECONDS = 5
+
 # Cache policy for the SPA shell:
 #   - ``index.html`` and any non-hashed top-level file: must always
 #     revalidate so a re-deployed wheel doesn't get masked by a
@@ -315,11 +325,38 @@ class DeviceBuilder:
                 executor.shutdown(wait=False)
 
     async def _run_background(self) -> None:
-        """Background polling loop."""
+        """Background polling loop.
+
+        Drives ``DevicesController.poll`` for filesystem drift the
+        push paths can't see (YAML file dropped in via SSH /
+        Samba, atomic-save mid-edit, sidecar mtime change). Gated
+        on ``SubscriberPresence`` — when no WS client is
+        subscribed, no UI is showing the device list, so paying
+        for a directory enumeration + per-file stat every 5 s is
+        idle CPU we can skip. The 0→1 subscriber transition
+        wakes ``wait_for_subscriber`` immediately, so the first
+        client to connect picks up freshly-dropped YAMLs within
+        one ``_BACKGROUND_POLL_INTERVAL_SECONDS`` instead of
+        having to wait for the next scheduled tick — same shape
+        ``_ping_loop`` uses for the ICMP sweep.
+        """
+        presence = self.subscriber_presence
         while True:
-            await asyncio.sleep(5)
+            await presence.wait_for_subscriber()
             if self.devices:
                 await self.devices.poll()
+            # Interruptible idle wait: bail early if the last
+            # subscriber leaves so the next one to connect doesn't
+            # sit through the rest of a stale interval. The
+            # ``TimeoutError`` branch is the steady-state "still
+            # subscribed, poll again" path; either way we loop
+            # back to ``wait_for_subscriber`` which parks if the
+            # gate has since closed.
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    presence.wait_for_no_subscribers(),
+                    timeout=_BACKGROUND_POLL_INTERVAL_SECONDS,
+                )
 
     @staticmethod
     async def _cmd_ping(**kwargs: Any) -> dict:

--- a/tests/test_device_builder_lifecycle.py
+++ b/tests/test_device_builder_lifecycle.py
@@ -223,6 +223,61 @@ async def test_start_spawns_background_polling_task(
         await db.stop()
 
 
+@pytest.mark.asyncio
+async def test_background_poll_skips_when_no_subscribers(
+    make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
+) -> None:
+    """The background loop parks at ``wait_for_subscriber`` until a client connects.
+
+    Polling for filesystem drift is cheap-but-not-free
+    (``DeviceScanner._build_cache_keys`` walks the config dir and
+    stats every YAML on every tick) and the only consumer of the
+    refreshed state is the dashboard UI. With no WS subscriber
+    attached, no UI is showing the device list, so the work is
+    pure idle CPU. Pin that the gate keeps ``DevicesController.poll``
+    asleep across the steady-state interval so a regression that
+    drops the gate (or wires the wrong presence object) surfaces
+    here instead of in a customer's flame graph.
+    """
+    db = DeviceBuilder(make_settings(with_core_path=True))
+    try:
+        await db.start()
+        # ``DevicesController.poll`` is what the loop calls under the
+        # gate. Wrap it to fire an Event so the test can ``await``
+        # the wakeup deterministically instead of busy-looping over
+        # ``asyncio.sleep(0)`` and hoping enough turns drain.
+        polled = asyncio.Event()
+        poll_calls = 0
+
+        async def _counting_poll() -> None:
+            nonlocal poll_calls
+            poll_calls += 1
+            polled.set()
+
+        db.devices.poll = _counting_poll  # type: ignore[method-assign]
+
+        # No subscribers attached: ``polled`` should NOT fire.
+        # ``wait_for`` with a tiny timeout is the deterministic
+        # negative-case shape — if the gate were broken and the
+        # poll fired, the event would set, ``wait_for`` would
+        # return, and the assertion below would catch it.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(polled.wait(), timeout=0.05)
+        assert poll_calls == 0, (
+            f"poll fired {poll_calls} times with no subscribers; gate isn't holding"
+        )
+
+        # 0→1 transition wakes the loop. Same ``subscriber()`` ctx
+        # manager the WS handler uses — entering opens the gate and
+        # ``wait_for_subscriber`` returns, letting the loop call
+        # ``poll`` exactly once before parking on the interval wait.
+        with db.subscriber_presence.subscriber():
+            await asyncio.wait_for(polled.wait(), timeout=1.0)
+        assert poll_calls >= 1
+    finally:
+        await db.stop()
+
+
 # ---------------------------------------------------------------------------
 # stop()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Idle profile of a real fleet showed `DeviceScanner._build_cache_keys` (and its descendants `util.list_yaml_files`, `Path.stat`) accounting for ~5% of executor-thread CPU when nothing else was happening — pure overhead for a dashboard with no UI attached. The 5 s background loop in `DeviceBuilder._run_background` was firing `DevicesController.poll` → `scanner.scan` → directory walk + per-file stat unconditionally.

Reuse the existing `SubscriberPresence` gate the ICMP ping loop already uses (`controllers/_device_state_monitor._ping_loop`):

- Park at `wait_for_subscriber` when no clients are attached.
- Wake on the 0→1 transition so the first client to connect picks up freshly-dropped YAMLs within one interval.
- Interruptible idle wait: `asyncio.wait_for(wait_for_no_subscribers(), timeout=_BACKGROUND_POLL_INTERVAL_SECONDS)` so the loop exits the wait early when the last client disconnects, instead of holding a stale interval through the next subscribe.

Push paths (`devices/list`, `devices/create`, every controller endpoint that calls `scanner.scan` / `scanner.reload` directly) and the startup scan in `DevicesController.start` are unchanged — the gate only affects the standby-fleet polling path.

Adds a regression test in `tests/test_device_builder_lifecycle.py` using deterministic `asyncio.Event`-based sync (matches the pattern used by the existing ping-loop tests) — pins both halves of the contract: poll never fires while no subscribers are attached, and the 0→1 subscribe transition wakes the loop within the wait.

**Related issue or feature (if applicable):**

- driven by the `_build_cache_keys` flame-graph hot path reported in chat (no GitHub issue filed)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
