### PR TITLE
yaml/search: return before/after context lines on each match

### DIFF
--- a/esphome_device_builder/controllers/devices/_yaml_search.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search.py
@@ -183,9 +183,12 @@ async def search_yaml_devices(
       crowd out hits from other devices.
     - ``context_lines`` — number of ``before`` / ``after``
       lines included on each match. Should already be clamped
-      to ``MAX_CONTEXT_LINES`` by the caller; the WS handler
-      does that so a typo'd / hostile request can't blow the
-      payload here.
+      to ``[0, MAX_CONTEXT_LINES]`` by the caller (today that's
+      ``DevicesController.search_yaml`` on the WS path; future
+      callers — tests, scripts, an HTTP-shim — own the clamp
+      themselves). This function doesn't re-validate so a typo'd
+      / hostile request can't blow the payload IF the caller
+      did its job.
 
     ``live_configurations`` is the *full* set of input device
     configurations regardless of where the walk short-circuited

--- a/esphome_device_builder/controllers/devices/_yaml_search.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search.py
@@ -47,6 +47,22 @@ if TYPE_CHECKING:
 # warm-cache.
 MAX_LINES_PER_FILE = 5000
 
+# Default ``before`` / ``after`` window when the caller doesn't
+# specify one. Two is the same default ``grep -C 2`` / GitHub
+# code search uses — far enough to surface the surrounding key
+# (``device:`` / ``platform:`` / a ``- name:`` list anchor) for
+# a hit deep inside a nested block, narrow enough to keep the
+# wire payload small for chatty needles.
+DEFAULT_CONTEXT_LINES = 2
+
+# Server-side ceiling on the per-side context window. Caps a
+# typo'd or malicious caller (``context_lines=10000``) from
+# blowing the wire payload — at 10 lines per side, even
+# pathological matches at the per-file cap stay under a few KB
+# per device. Clients that want more context for a specific hit
+# can fetch the full file via the editor.
+MAX_CONTEXT_LINES = 10
+
 
 def scan_lines(
     lines: list[str],
@@ -54,6 +70,7 @@ def scan_lines(
     *,
     case_sensitive: bool,
     max_take: int,
+    context_lines: int = DEFAULT_CONTEXT_LINES,
 ) -> list[dict]:
     """Scan a single file's pre-split line list for *needle*.
 
@@ -74,12 +91,38 @@ def scan_lines(
     *needle* must be pre-lowered when ``case_sensitive`` is
     ``False`` — the caller lowers it once outside the per-file
     loop so we don't re-lower the same needle for every device.
+
+    Each match carries ``before`` / ``after`` context windows
+    sliced from *lines* directly (``context_lines`` on each
+    side, clamped at the file edges). The frontend renders the
+    match as a code-snippet block; without context the
+    surrounding ``device:`` / ``platform:`` / list-anchor key
+    that gives the match its meaning is invisible.
+
+    *context_lines* is bounded by ``MAX_CONTEXT_LINES`` at the
+    controller; this function trusts the caller to have already
+    clamped (it's a bare-int slice index, no further validation
+    here). Pass ``0`` for an empty window if a caller ever wants
+    just the matched line — the slice math degenerates cleanly.
     """
     matches: list[dict] = []
+    n = len(lines)
     for i, line in enumerate(lines, start=1):
         haystack = line if case_sensitive else line.lower()
         if needle in haystack:
-            matches.append({"line_number": i, "line_text": line})
+            # ``i`` is 1-indexed (line numbers are user-facing).
+            # ``lines`` is 0-indexed; convert at the slice edges.
+            zero_based = i - 1
+            before_start = max(0, zero_based - context_lines)
+            after_end = min(n, zero_based + 1 + context_lines)
+            matches.append(
+                {
+                    "line_number": i,
+                    "line_text": line,
+                    "before": lines[before_start:zero_based],
+                    "after": lines[zero_based + 1 : after_end],
+                }
+            )
             if len(matches) >= max_take:
                 break
     return matches
@@ -109,6 +152,7 @@ async def search_yaml_devices(
     case_sensitive: bool,
     max_results: int,
     per_file_cap: int,
+    context_lines: int = DEFAULT_CONTEXT_LINES,
 ) -> tuple[list[dict], set[str]]:
     """
     Walk *devices* and return the YAML matches for *needle*.
@@ -137,6 +181,11 @@ async def search_yaml_devices(
       fleet. Walk stops once this is reached.
     - ``per_file_cap`` — per-file cap so a chatty match doesn't
       crowd out hits from other devices.
+    - ``context_lines`` — number of ``before`` / ``after``
+      lines included on each match. Should already be clamped
+      to ``MAX_CONTEXT_LINES`` by the caller; the WS handler
+      does that so a typo'd / hostile request can't blow the
+      payload here.
 
     ``live_configurations`` is the *full* set of input device
     configurations regardless of where the walk short-circuited
@@ -181,7 +230,13 @@ async def search_yaml_devices(
         # max_results); both collapse cleanly into
         # ``min(per_file_cap, remaining)``.
         max_take = min(per_file_cap, max_results - total_matches)
-        matches = scan_lines(scannable, needle, case_sensitive=case_sensitive, max_take=max_take)
+        matches = scan_lines(
+            scannable,
+            needle,
+            case_sensitive=case_sensitive,
+            max_take=max_take,
+            context_lines=context_lines,
+        )
 
         if matches:
             results.append(

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -382,10 +382,14 @@ class DevicesController:
         # Server-clamp the context window. The frontend can dial
         # this between ``0`` (no context, just the matched line)
         # and ``MAX_CONTEXT_LINES`` to render denser or sparser
-        # snippets without a backend redeploy; values outside
-        # that range — typo'd, malicious, or from a future client
-        # we haven't met — collapse to the default. ``None`` means
-        # the caller didn't ask, so use the default too.
+        # snippets without a backend redeploy. ``None`` means the
+        # caller didn't ask — use ``DEFAULT_CONTEXT_LINES``.
+        # Out-of-range values clamp to the nearest endpoint
+        # (negative → 0, > MAX → MAX) rather than falling back
+        # to the default: a caller passing ``10_000`` clearly
+        # wants "as much context as possible", and giving them
+        # ``MAX_CONTEXT_LINES`` is closer to that intent than
+        # silently substituting ``DEFAULT_CONTEXT_LINES``.
         if context_lines is None:
             effective_context_lines = DEFAULT_CONTEXT_LINES
         else:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -66,7 +66,11 @@ from ..config import (
     set_device_metadata,
 )
 from ..firmware.helpers import _find_esphome_cmd
-from ._yaml_search import search_yaml_devices
+from ._yaml_search import (
+    DEFAULT_CONTEXT_LINES,
+    MAX_CONTEXT_LINES,
+    search_yaml_devices,
+)
 from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
     _apply_featured_presets,
@@ -317,6 +321,7 @@ class DevicesController:
         query: str,
         max_results: int = 50,
         case_sensitive: bool = False,
+        context_lines: int | None = None,
         **kwargs: Any,
     ) -> list[dict]:
         """
@@ -374,6 +379,18 @@ class DevicesController:
             return []
         needle = needle_raw if case_sensitive else needle_raw.lower()
 
+        # Server-clamp the context window. The frontend can dial
+        # this between ``0`` (no context, just the matched line)
+        # and ``MAX_CONTEXT_LINES`` to render denser or sparser
+        # snippets without a backend redeploy; values outside
+        # that range — typo'd, malicious, or from a future client
+        # we haven't met — collapse to the default. ``None`` means
+        # the caller didn't ask, so use the default too.
+        if context_lines is None:
+            effective_context_lines = DEFAULT_CONTEXT_LINES
+        else:
+            effective_context_lines = max(0, min(context_lines, MAX_CONTEXT_LINES))
+
         # Global search lock: serialise the I/O-bound walk so two
         # concurrent searches don't double up on stat / read calls
         # against the same fleet. The frontend's per-keystroke
@@ -389,6 +406,7 @@ class DevicesController:
                 case_sensitive=case_sensitive,
                 max_results=max_results,
                 per_file_cap=_YAML_SEARCH_PER_FILE_MATCH_CAP,
+                context_lines=effective_context_lines,
             )
             self._yaml_search_cache.prune(live_configurations)
             return results

--- a/tests/controllers/devices/test_search_yaml.py
+++ b/tests/controllers/devices/test_search_yaml.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from esphome_device_builder.controllers.devices._yaml_search import MAX_CONTEXT_LINES
 from esphome_device_builder.models import Device, DeviceState
 
 if TYPE_CHECKING:
@@ -94,9 +95,10 @@ async def test_search_yaml_substring_match_returns_per_device_hits(
     """A simple substring match returns one entry per matching device.
 
     Pin the result shape (configuration / device_name / friendly_name
-    / matches array of {line_number, line_text}) — the frontend's
-    rendering layer reads each field by name. A field rename here
-    silently breaks the dropdown rendering with no test failure.
+    / matches array of {line_number, line_text, before, after}) — the
+    frontend's rendering layer reads each field by name. A field
+    rename here silently breaks the result rendering with no test
+    failure.
     """
     controller = make_controller(tmp_path)
     controller._scanner.devices = [
@@ -121,7 +123,18 @@ async def test_search_yaml_substring_match_returns_per_device_hits(
     assert hit["configuration"] == "kitchen.yaml"
     assert hit["device_name"] == "kitchen"
     assert hit["friendly_name"] == "Kitchen Lamp"
-    assert hit["matches"] == [{"line_number": 3, "line_text": "wifi:"}]
+    # Match carries ±2-line context windows. Line 3's window
+    # extends back to line 1 (clamped at the file start; only
+    # 2 prior lines exist) and there's a single trailing line
+    # to include in ``after``.
+    assert hit["matches"] == [
+        {
+            "line_number": 3,
+            "line_text": "wifi:",
+            "before": ["esphome:", "  name: kitchen"],
+            "after": ["  ssid: home"],
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -333,3 +346,120 @@ async def test_search_yaml_skips_missing_files(
     # didn't blow up the call.
     assert len(results) == 1
     assert results[0]["configuration"] == "kitchen.yaml"
+
+
+# ---------------------------------------------------------------------------
+# context_lines parameter — caller-tunable, server-clamped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_default_context_is_two_lines(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Omitting ``context_lines`` uses the ``DEFAULT_CONTEXT_LINES`` (2) window.
+
+    Pin the default so a regression that drops the kwarg
+    forwarding (or flips the default) surfaces as a window
+    shape change instead of silently shipping zero or ten lines.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [_device("kitchen")]
+    _seed_yaml(
+        tmp_path,
+        "kitchen",
+        "esphome:\n  name: kitchen\nwifi:\n  ssid: home\n  password: x\n",
+    )
+
+    results = await controller.search_yaml(query="wifi")
+
+    assert results[0]["matches"][0]["before"] == [
+        "esphome:",
+        "  name: kitchen",
+    ]
+    assert results[0]["matches"][0]["after"] == [
+        "  ssid: home",
+        "  password: x",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_context_lines_zero_drops_window(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``context_lines=0`` returns just the matched line (empty before/after).
+
+    A frontend that wants the legacy "matched line only" shape
+    (e.g. a dense compact view) can opt in by passing 0.
+    The slice math has to degenerate to empty windows without
+    error.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [_device("kitchen")]
+    _seed_yaml(
+        tmp_path,
+        "kitchen",
+        "esphome:\n  name: kitchen\nwifi:\n  ssid: home\n",
+    )
+
+    results = await controller.search_yaml(query="wifi", context_lines=0)
+
+    assert results[0]["matches"][0]["before"] == []
+    assert results[0]["matches"][0]["after"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_context_lines_clamped_to_max(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A caller asking for more than ``MAX_CONTEXT_LINES`` lands on the cap.
+
+    Defends against a typo'd / hostile request blowing the wire
+    payload — at the cap, even pathological matches produce
+    bounded responses (per-side cap times two sides times
+    per-file cap times ``max_results`` devices).
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [_device("kitchen")]
+    # File with enough surrounding lines that an unclamped
+    # request would expand the window past MAX_CONTEXT_LINES.
+    surrounding = "\n".join(f"# line_{i}" for i in range(MAX_CONTEXT_LINES + 5))
+    _seed_yaml(
+        tmp_path,
+        "kitchen",
+        f"{surrounding}\nwifi:\n{surrounding}\n",
+    )
+
+    results = await controller.search_yaml(query="wifi", context_lines=10_000)
+
+    assert len(results[0]["matches"][0]["before"]) == MAX_CONTEXT_LINES
+    assert len(results[0]["matches"][0]["after"]) == MAX_CONTEXT_LINES
+
+
+@pytest.mark.asyncio
+async def test_search_yaml_negative_context_lines_falls_back_to_zero(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A negative ``context_lines`` floors at 0 — never inverts the slice.
+
+    A negative slice index against ``lines`` would silently
+    select from the END of the file (``lines[-2:0]`` etc.), which
+    is the worst possible behaviour: random unrelated context
+    leaking into the response. Pin that the floor handles it.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [_device("kitchen")]
+    _seed_yaml(
+        tmp_path,
+        "kitchen",
+        "esphome:\n  name: kitchen\nwifi:\n  ssid: home\n",
+    )
+
+    results = await controller.search_yaml(query="wifi", context_lines=-5)
+
+    assert results[0]["matches"][0]["before"] == []
+    assert results[0]["matches"][0]["after"] == []

--- a/tests/controllers/devices/test_yaml_search_module.py
+++ b/tests/controllers/devices/test_yaml_search_module.py
@@ -98,7 +98,16 @@ async def test_returns_results_and_live_configurations(tmp_path: Path) -> None:
     assert hit["configuration"] == "kitchen.yaml"
     assert hit["device_name"] == "kitchen"
     assert hit["friendly_name"] == "Kitchen"
-    assert hit["matches"] == [{"line_number": 1, "line_text": "wifi:"}]
+    # Match carries ±2-line context windows clamped at the file
+    # edges — line 1 has nothing before it and one line after.
+    assert hit["matches"] == [
+        {
+            "line_number": 1,
+            "line_text": "wifi:",
+            "before": [],
+            "after": ["  ssid: home"],
+        }
+    ]
     # Both devices walked → both in live_configurations, not just
     # the one with a match. Cache prune key.
     assert live == {"kitchen.yaml", "bedroom.yaml"}
@@ -221,8 +230,21 @@ async def test_max_lines_per_file_caps_pathological_files(tmp_path: Path) -> Non
         max_results=50,
         per_file_cap=10,
     )
+    # ``after`` is empty here even though ``# tag-past-cap``
+    # exists on the next line — context is sliced from the
+    # ``MAX_LINES_PER_FILE``-bounded view ``scan_lines`` walks,
+    # so anything past the cap is invisible to both the match
+    # check and the context window. Pin that contract so a
+    # future refactor that "helpfully" pulls context from the
+    # full ``lines`` list outside the slice can't leak
+    # past-cap content into the response.
     assert results[0]["matches"] == [
-        {"line_number": MAX_LINES_PER_FILE, "line_text": "# tag-at-cap"}
+        {
+            "line_number": MAX_LINES_PER_FILE,
+            "line_text": "# tag-at-cap",
+            "before": ["# noise", "# noise"],
+            "after": [],
+        }
     ]
 
     # Same file, different needle that only appears past the cap.
@@ -415,3 +437,52 @@ async def test_yields_to_event_loop_between_devices(tmp_path: Path) -> None:
     # the yield, the search would have monopolised the slice
     # and the ticker would only run after the search returned.
     assert ticks >= len(devices)
+
+
+@pytest.mark.asyncio
+async def test_match_includes_full_context_window_when_not_at_edge(
+    tmp_path: Path,
+) -> None:
+    """A match deep inside a file carries the full ±2-line window.
+
+    The two existing context-bearing assertions
+    (``test_returns_results_and_live_configurations`` for top-of-
+    file, ``test_max_lines_per_file_caps_pathological_files``
+    for cap-edge) only exercise the clamp paths. Pin the un-
+    clamped middle case explicitly so the slice math —
+    ``[zero_based - 2 : zero_based]`` for ``before``,
+    ``[zero_based + 1 : zero_based + 3]`` for ``after`` —
+    can't drift unnoticed (off-by-one would surface as 1 or 3
+    lines instead of 2, which the edge tests can't catch).
+    """
+    cache = YamlSearchCache()
+    yaml = (
+        "esphome:\n"
+        "  name: kitchen\n"
+        "binary_sensor:\n"
+        "  - platform: gpio\n"  # the match
+        "    name: door\n"
+        "    pin: GPIO5\n"
+        "wifi:\n"
+        "  ssid: home\n"
+    )
+    devices = [_seed(tmp_path, "kitchen", yaml)]
+
+    results, _ = await search_yaml_devices(
+        devices=devices,
+        cache=cache,
+        rel_path=_rel(tmp_path),
+        needle="platform",
+        case_sensitive=False,
+        max_results=50,
+        per_file_cap=5,
+    )
+
+    assert results[0]["matches"] == [
+        {
+            "line_number": 4,
+            "line_text": "  - platform: gpio",
+            "before": ["  name: kitchen", "binary_sensor:"],
+            "after": ["    name: door", "    pin: GPIO5"],
+        }
+    ]


### PR DESCRIPTION
# What does this implement/fix?

Extends each `YamlSearchMatch` returned by `yaml/search` with a `before` / `after` window of context lines on either side of the hit. Default is 2 lines (matches `grep -C 2` / GitHub code search), tunable per-call via a new `context_lines` WS argument, server-clamped to `[0, MAX_CONTEXT_LINES=10]` so a typo'd or hostile caller can't blow the wire payload. `None` and out-of-range values collapse to the default.

The existing wire shape returned `{line_number, line_text}` only. The frontend renders a hit as a single matched line — but a match deep inside a nested block (e.g. an `entity_id:` line under a `binary_sensor`) loses every surrounding key (`device:`, `platform:`, the list-anchor `- name:`) that makes it scannable, so the result reads as a free-floating value with no anchor. Adding context restores the surrounding structure without forcing the frontend to load the whole file.

The cap is set to 10 because at 10 × 2 sides × the per-file match cap × `max_results`, even pathological matches stay under a few KB per device. The frontend dial means a future denser/sparser snippet view doesn't need a backend redeploy.

Match shape after this PR:

```json
{
  "line_number": 42,
  "line_text": "    entity_id: switch.foo",
  "before": ["  - platform: homeassistant", "    name: door"],
  "after": ["    id: door_state", ""]
}
```

Tests pin: top-of-file clamp (empty `before`), cap-edge clamp (empty `after` even with content past the cap), unclamped middle (full ±2 window), default of 2 lines, `context_lines=0` returns empty windows, `context_lines=10_000` clamps to `MAX_CONTEXT_LINES`, and a negative value floors at 0 (defending against `lines[-N:0]` silently selecting from the end of the file).

**Frontend coordination:** the new fields are additive — current frontend ignores `before` / `after` and keeps working. Companion frontend PR will land the code-snippet rendering that consumes them.

**Related issue or feature (if applicable):**

- driven by the YAML-search UI feedback that "shows only matched lines" without context

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD — code-snippet renderer using `before` / `after`>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
