### PR TITLE
Route uncaught exceptions through logging; drop dead prepare() override

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -84,13 +84,8 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     # Route uncaught main-thread and worker-thread exceptions through
     # the logging system so they hit the same console + rotating-file
     # destinations as everything else, instead of going to bare stderr.
-    sys.excepthook = lambda *args: logging.getLogger().exception(
-        "Uncaught exception", exc_info=args
-    )
-    threading.excepthook = lambda args: logging.getLogger().exception(
-        "Uncaught thread exception",
-        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
-    )
+    sys.excepthook = _log_uncaught_exception
+    threading.excepthook = _log_uncaught_thread_exception
 
     # Has to be the last step — handlers added after this run inline
     # on the calling thread instead of being offloaded to the listener.
@@ -206,6 +201,25 @@ def main() -> None:
 
     device_builder = DeviceBuilder(settings)
     device_builder.run()
+
+
+def _log_uncaught_exception(
+    exc_type: type[BaseException],
+    exc_value: BaseException,
+    exc_traceback: object,
+) -> None:
+    """Forward an uncaught main-thread exception into ``logger.exception``."""
+    logging.getLogger().exception(
+        "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
+    )
+
+
+def _log_uncaught_thread_exception(args: threading.ExceptHookArgs) -> None:
+    """Forward an uncaught worker-thread exception into ``logger.exception``."""
+    logging.getLogger().exception(
+        "Uncaught thread exception",
+        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+    )
 
 
 def _esphome_version() -> str | None:

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import sys
+import threading
 from contextlib import suppress
 from logging.handlers import RotatingFileHandler
 from typing import TYPE_CHECKING
@@ -78,6 +80,17 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     logging.getLogger("asyncio").setLevel(logging.WARNING)
     logging.getLogger("aiohttp").setLevel(logging.WARNING)
     logging.getLogger("zeroconf").setLevel(logging.WARNING)
+
+    # Route uncaught main-thread and worker-thread exceptions through
+    # the logging system so they hit the same console + rotating-file
+    # destinations as everything else, instead of going to bare stderr.
+    sys.excepthook = lambda *args: logging.getLogger().exception(
+        "Uncaught exception", exc_info=args
+    )
+    threading.excepthook = lambda args: logging.getLogger().exception(
+        "Uncaught thread exception",
+        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+    )
 
     # Has to be the last step — handlers added after this run inline
     # on the calling thread instead of being offloaded to the listener.

--- a/esphome_device_builder/helpers/logging.py
+++ b/esphome_device_builder/helpers/logging.py
@@ -13,15 +13,6 @@ class LoggingQueueHandler(logging.handlers.QueueHandler):
 
     listener: logging.handlers.QueueListener | None = None
 
-    def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
-        """Prepare a record for queuing."""
-        record = super().prepare(record)
-        # Workaround for CPython issue 46755: a non-None ``stack_info``
-        # survives the ``copy.copy`` inside ``prepare`` and gets
-        # formatted a second time when the listener picks the record up.
-        record.stack_info = None
-        return record
-
     def handle(self, record: logging.LogRecord) -> Any:
         """Filter and emit the record."""
         # ``Handler.handle`` acquires ``self.lock`` before delegating

--- a/tests/test_helpers_logging.py
+++ b/tests/test_helpers_logging.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import logging.handlers
-import queue
 from collections.abc import Generator
 
 import pytest
@@ -123,22 +122,3 @@ def test_records_reach_migrated_handlers(isolated_root_logger: None) -> None:
     queue_handler.listener = None
 
     assert any(r.getMessage() == "hello" for r in capture.records)
-
-
-def test_prepare_clears_stack_info() -> None:
-    """``prepare`` strips ``stack_info`` so the listener can't double-format it."""
-    handler = LoggingQueueHandler(queue.SimpleQueue())
-    record = logging.LogRecord(
-        name="x",
-        level=logging.INFO,
-        pathname=__file__,
-        lineno=1,
-        msg="msg",
-        args=None,
-        exc_info=None,
-    )
-    record.stack_info = "fake stack"
-
-    prepared = handler.prepare(record)
-
-    assert prepared.stack_info is None

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -147,9 +147,12 @@ def _isolated_logging_globals() -> Generator[None]:
     """
     Snapshot the global state ``_setup_logging`` mutates and restore it.
 
-    Without this, the installed excepthooks and queue handler leak
-    across tests and the lambdas hold a reference to whatever root
-    handlers happened to be configured at call time.
+    ``_setup_logging`` reassigns ``sys.excepthook`` /
+    ``threading.excepthook`` and adds handlers (including a
+    ``LoggingQueueHandler`` whose listener thread keeps running) to
+    ``logging.root``. Without restoration these leak into other tests
+    in the suite, and a stuck-running listener thread can hold
+    references to handlers that the next test then mutates.
     """
     saved_sys_hook = sys.excepthook
     saved_thread_hook = threading.excepthook

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -19,13 +19,18 @@ template relies on.
 from __future__ import annotations
 
 import builtins
+import logging
+import sys
+import threading
+from collections.abc import Generator
 from importlib.metadata import PackageNotFoundError
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from esphome_device_builder import __main__ as main_module
 from esphome_device_builder import constants
+from esphome_device_builder.helpers.logging import LoggingQueueHandler
 
 # ---------------------------------------------------------------------------
 # constants._resolve_version
@@ -130,3 +135,121 @@ def test_main_version_flag_prints_and_exits(
     assert excinfo.value.code == 0
     captured = capsys.readouterr()
     assert "esphome-device-builder 2026.5.0 (esphome 2026.3.1)" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# __main__._setup_logging — uncaught-exception hooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolated_logging_globals() -> Generator[None]:
+    """
+    Snapshot the global state ``_setup_logging`` mutates and restore it.
+
+    Without this, the installed excepthooks and queue handler leak
+    across tests and the lambdas hold a reference to whatever root
+    handlers happened to be configured at call time.
+    """
+    saved_sys_hook = sys.excepthook
+    saved_thread_hook = threading.excepthook
+    saved_handlers = logging.root.handlers[:]
+    saved_level = logging.root.level
+    logging.root.handlers = []
+    try:
+        yield
+    finally:
+        for handler in logging.root.handlers[:]:
+            handler.close()
+            logging.root.removeHandler(handler)
+        for handler in saved_handlers:
+            logging.root.addHandler(handler)
+        logging.root.setLevel(saved_level)
+        sys.excepthook = saved_sys_hook
+        threading.excepthook = saved_thread_hook
+
+
+def test_setup_logging_routes_uncaught_main_thread_exception_through_logger(
+    _isolated_logging_globals: None,
+) -> None:
+    """``sys.excepthook`` forwards ``(type, value, tb)`` to ``logger.exception``."""
+    main_module._setup_logging("info")
+
+    # ``_setup_logging`` replaces the default — the new hook must
+    # forward the triple verbatim so ``logging.Formatter`` can render
+    # the traceback.
+    assert sys.excepthook is not sys.__excepthook__
+
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError:
+        exc_info = sys.exc_info()
+
+    with patch("logging.getLogger") as mock_get_logger:
+        sys.excepthook(*exc_info)
+
+    mock_get_logger.assert_called_once_with()
+    mock_get_logger.return_value.exception.assert_called_once_with(
+        "Uncaught exception", exc_info=exc_info
+    )
+
+
+def test_setup_logging_routes_uncaught_thread_exception_through_logger(
+    _isolated_logging_globals: None,
+) -> None:
+    """``threading.excepthook`` unpacks ``ExceptHookArgs`` into ``exc_info``."""
+    main_module._setup_logging("info")
+
+    assert threading.excepthook is not threading.__excepthook__
+
+    args = MagicMock(spec=threading.ExceptHookArgs)
+    args.exc_type = RuntimeError
+    args.exc_value = RuntimeError("boom")
+    args.exc_traceback = None
+    args.thread = None
+
+    with patch("logging.getLogger") as mock_get_logger:
+        threading.excepthook(args)
+
+    mock_get_logger.assert_called_once_with()
+    mock_get_logger.return_value.exception.assert_called_once_with(
+        "Uncaught thread exception",
+        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+    )
+
+
+def test_setup_logging_excepthooks_log_through_queue_listener(
+    _isolated_logging_globals: None,
+) -> None:
+    """End-to-end: a hook firing reaches a handler behind the queue listener."""
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    capture = _Capture()
+    logging.root.addHandler(capture)
+
+    main_module._setup_logging("debug")
+
+    try:
+        raise RuntimeError("boom-from-main-thread")
+    except RuntimeError:
+        sys.excepthook(*sys.exc_info())
+
+    # The queue handler offloads emission to a worker thread; drain by
+    # stopping the listener so the assertion sees the record.
+    queue_handler = next(h for h in logging.root.handlers if isinstance(h, LoggingQueueHandler))
+    listener = queue_handler.listener
+    assert listener is not None
+    listener.stop()
+    queue_handler.listener = None
+
+    # ``QueueHandler.prepare`` bakes the traceback into ``record.msg``
+    # and nulls ``exc_info`` / ``exc_text`` so the record stays
+    # picklable on the way through the queue.
+    messages = [r.getMessage() for r in captured]
+    assert any(
+        "Uncaught exception" in m and "RuntimeError: boom-from-main-thread" in m for m in messages
+    )


### PR DESCRIPTION
# What does this implement/fix?

Two minor follow-ups to #373:

- **Route uncaught exceptions through the logging system.** `_setup_logging` now installs `sys.excepthook` and `threading.excepthook` that forward to `logging.getLogger().exception(...)`, so a main-thread or worker-thread crash lands in the same console + rotating-file destinations as everything else instead of going to bare stderr. Mirrors Home Assistant's `bootstrap.async_enable_logging` (lines 626–636).
- **Drop the redundant `LoggingQueueHandler.prepare()` override.** The CPython bpo-46755 workaround it carried — nulling `record.stack_info` so the listener can't double-format it — was fixed in the base `QueueHandler.prepare` in Python 3.11, and the project requires `>=3.12`, so the override was dead code. Removed the override + its dedicated test.

Adds three tests in `tests/test_main_cli.py`:

- contract test that `sys.excepthook` is replaced and forwards `(exc_type, exc_value, exc_traceback)` verbatim into `logger.exception(..., exc_info=...)`,
- contract test that `threading.excepthook` unpacks `ExceptHookArgs` into the same `exc_info` triple,
- end-to-end smoke test that an uncaught exception fired through the installed `sys.excepthook` reaches a handler on the far side of the queue listener, with the traceback baked into `record.msg` (since `QueueHandler.prepare` nulls `exc_info`/`exc_text` so records stay picklable across the queue).

A `_isolated_logging_globals` fixture snapshots and restores both excepthooks plus the root logger's handlers/level so the global mutation doesn't leak across tests.

**Related issue or feature (if applicable):**

- follow-up to #373

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
