### PR TITLE
Add devices/clone command for fast same-config fleet provisioning

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -41,6 +41,7 @@ from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progre
 from ...helpers.yaml import (
     generate_api_encryption_key,
     merge_component_yaml,
+    read_yaml_scalar,
     rewrite_api_encryption_key,
     rewrite_esphome_name,
     rewrite_name_or_substitution,
@@ -854,6 +855,23 @@ class DevicesController:
         # Mixed values (``${prefix}-suffix``) aren't pure references
         # and fall through to the leaf rewrite — we have no way to
         # split the prefix without changing the suffix's meaning.
+        # Precondition: there has to be an ``esphome.name`` leaf in
+        # *this* file for us to rewrite. A package-driven config
+        # (``packages: { base: !include common/base.yaml }`` with the
+        # ``esphome:`` block defined upstream) has no in-file leaf to
+        # touch — the rewrite would silently no-op and the clone
+        # would flash under the source's hostname. Reject up-front
+        # with a typed error so the dialog can show a real message
+        # instead of producing a duplicate device.
+        if read_yaml_scalar(source_content, ("esphome", "name")) is None:
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                "Source has no inline esphome.name to rewrite — clone "
+                "needs an explicit name in this file (move the name "
+                "out of the package or add an esphome: name: line "
+                "before cloning).",
+            )
+
         new_content = rewrite_name_or_substitution(source_content, ("esphome", "name"), new_name)
         if new_friendly_name:
             new_content = rewrite_name_or_substitution(

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -43,7 +43,7 @@ from ...helpers.yaml import (
     merge_component_yaml,
     rewrite_api_encryption_key,
     rewrite_esphome_name,
-    rewrite_friendly_name,
+    rewrite_name_or_substitution,
 )
 from ...models import (
     AddComponentResponse,
@@ -796,7 +796,6 @@ class DevicesController:
         source_path = self._db.settings.rel_path(configuration)
         new_path = self._db.settings.rel_path(new_filename)
         config_dir = self._db.settings.config_dir
-        old_name = configuration.removesuffix(".yaml").removesuffix(".yml")
         # Default the friendly_name to a slug-derived fallback so
         # the dashboard list doesn't show two entries with the same
         # label after a clone. Explicit blank string opts out.
@@ -831,9 +830,30 @@ class DevicesController:
             msg = f"Source device {configuration} not found"
             raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
-        new_content = rewrite_esphome_name(source_content, old_name, new_name)
+        # Land the new identity on whichever line the source actually
+        # uses to drive the value. Two patterns appear in real configs:
+        #
+        # 1. **Direct literal** — ``esphome.name: kitchen``. Rewrite
+        #    the leaf line.
+        # 2. **Substitution reference** — ``esphome.name: ${devicename}``
+        #    with ``substitutions.devicename: kitchen``. This is the
+        #    standard ESPHome wizard / dashboard_import shape. Here
+        #    the *leaf* line carries an indirection name; the actual
+        #    value lives in the substitutions block. Rewriting the
+        #    leaf would land a literal name and silently orphan the
+        #    substitution, breaking any other consumer of the same
+        #    variable (a sensor named ``${devicename}_temp``, etc.).
+        #    Rewrite the substitution definition instead so every
+        #    reference re-targets atomically.
+        #
+        # Mixed values (``${prefix}-suffix``) aren't pure references
+        # and fall through to the leaf rewrite — we have no way to
+        # split the prefix without changing the suffix's meaning.
+        new_content = rewrite_name_or_substitution(source_content, ("esphome", "name"), new_name)
         if new_friendly_name:
-            new_content = rewrite_friendly_name(new_content, new_friendly_name)
+            new_content = rewrite_name_or_substitution(
+                new_content, ("esphome", "friendly_name"), new_friendly_name
+            )
         # ``rewrite_api_encryption_key`` is a no-op when the source
         # uses ``!secret`` / ``${...}`` for the key — those
         # indirections stay shared with the source on purpose.
@@ -2478,7 +2498,12 @@ class DevicesController:
 
         old_name = configuration.removesuffix(".yaml").removesuffix(".yml")
         content = old_path.read_text(encoding="utf-8")
-        new_content = rewrite_esphome_name(content, old_name, new_name)
+        # File-level rename gates the YAML rewrite on the existing
+        # ``esphome.name`` matching the filename — when they've
+        # drifted (hand-edited YAML, substituted name) we'd rather
+        # leave the line alone than silently flip a value the user
+        # may have set deliberately.
+        new_content = rewrite_esphome_name(content, new_name, only_if_current=old_name)
         new_path.write_text(new_content, encoding="utf-8")
         old_path.unlink()
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -38,7 +38,13 @@ from ...helpers.json import JSONDecodeError, dumps_indent, loads
 from ...helpers.mac_addresses import derive_interface_macs
 from ...helpers.process import kill_quietly
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
-from ...helpers.yaml import merge_component_yaml, rewrite_esphome_name
+from ...helpers.yaml import (
+    generate_api_encryption_key,
+    merge_component_yaml,
+    rewrite_api_encryption_key,
+    rewrite_esphome_name,
+    rewrite_friendly_name,
+)
 from ...models import (
     AddComponentResponse,
     AdoptableDevice,
@@ -735,6 +741,139 @@ class DevicesController:
             raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
         job = await self._db.firmware.rename(configuration=configuration, new_name=new_name)
         return {"configuration": new_filename, "job": job.to_dict()}
+
+    @api_command("devices/clone")
+    async def clone_device(
+        self,
+        *,
+        configuration: str,
+        new_name: str,
+        new_friendly_name: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, str]:
+        """
+        Duplicate an existing device YAML under a fresh hostname.
+
+        Designed for "I bought 10 of the same bulb" workflows: the
+        clone copies the source YAML's components and wiring intact
+        but takes a fresh ``esphome.name`` (and therefore a fresh
+        mDNS hostname / API endpoint), a fresh ``friendly_name``,
+        and a freshly-generated ``api.encryption.key`` so two
+        siblings forked from the same source don't share encryption
+        material — compromise of one device must not compromise
+        the others.
+
+        ``new_friendly_name`` is optional: when omitted, defaults
+        to ``friendly_name_slugify(new_name)`` to mirror how
+        ``devices/create`` derives the wizard friendly_name. Pass
+        a blank string to leave the source's ``friendly_name:``
+        line untouched (rare — most callers want a per-clone label).
+
+        Indirections (``key: !secret api_key`` /
+        ``key: ${api_key}``) are deliberately preserved on the
+        clone — the indirection target is shared with the source
+        on disk, so rewriting the indirection name to a fresh
+        literal would silently desync the rendered config from
+        whatever ``secrets.yaml`` / substitutions block actually
+        drives the encryption.
+
+        Returns ``{"configuration": "<new_filename>"}``. Errors
+        propagate as ``INVALID_ARGS`` for collisions / empty
+        names; the source file failing to load surfaces as
+        ``INTERNAL_ERROR``.
+        """
+        new_name = new_name.strip()
+        if not new_name:
+            raise CommandError(ErrorCode.INVALID_ARGS, "new_name is required")
+        new_filename = f"{new_name}.yaml"
+        if new_filename == configuration:
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                "new_name must differ from the source device name",
+            )
+
+        loop = asyncio.get_running_loop()
+        source_path = self._db.settings.rel_path(configuration)
+        new_path = self._db.settings.rel_path(new_filename)
+        config_dir = self._db.settings.config_dir
+        old_name = configuration.removesuffix(".yaml").removesuffix(".yml")
+        # Default the friendly_name to a slug-derived fallback so
+        # the dashboard list doesn't show two entries with the same
+        # label after a clone. Explicit blank string opts out.
+        if new_friendly_name is None:
+            new_friendly_name = friendly_name_slugify(new_name)
+        # Fresh encryption material per clone — generated up here
+        # rather than inside the executor so the off-loop work is
+        # purely I/O.
+        new_key = generate_api_encryption_key()
+
+        # All blocking I/O bundled into one executor hop. Returns the
+        # (raw_source_content, source_metadata, target_existed_at_start)
+        # triple — the caller maps each into either a typed
+        # ``CommandError`` or the rewrite + write step that follows.
+        # ``ext_storage_path`` / metadata helpers / file I/O are all
+        # ``Path``-walking syscalls under the hood; no point in five
+        # round-trips through ``run_in_executor`` when one will do.
+        def _gather() -> tuple[str | None, dict | None, bool]:
+            if new_path.exists():
+                return None, None, True
+            if not source_path.exists():
+                return None, None, False
+            content = source_path.read_text(encoding="utf-8")
+            meta = get_device_metadata(config_dir, configuration)
+            return content, meta, False
+
+        source_content, source_meta, target_existed = await loop.run_in_executor(None, _gather)
+        if target_existed:
+            msg = f"A device named {new_filename} already exists"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+        if source_content is None:
+            msg = f"Source device {configuration} not found"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+
+        new_content = rewrite_esphome_name(source_content, old_name, new_name)
+        if new_friendly_name:
+            new_content = rewrite_friendly_name(new_content, new_friendly_name)
+        # ``rewrite_api_encryption_key`` is a no-op when the source
+        # uses ``!secret`` / ``${...}`` for the key — those
+        # indirections stay shared with the source on purpose.
+        new_content = rewrite_api_encryption_key(new_content, new_key)
+
+        # Carry forward only the source's ``board_id`` — that's the
+        # one piece of dashboard state the scanner can't recover from
+        # the YAML (it's a catalog-key indirection the user picked at
+        # wizard time). Friendly name lives in the YAML we just
+        # wrote, so ``load_device_from_storage`` reads it back on the
+        # next scan; copying to metadata too would just duplicate
+        # truth. ``ip`` is deliberately not carried — the clone
+        # hasn't booted yet, and inheriting the source's address
+        # would mis-route ``devices/logs`` until the first mDNS
+        # announce corrects it. StorageJSON is skipped entirely: it's
+        # a build artefact, the next compile writes a real one, and
+        # ``load_device_from_storage`` handles a missing sidecar by
+        # reading from YAML alone.
+        carry_board_id = source_meta.get("board_id") if source_meta else None
+
+        def _commit() -> None:
+            with open(new_path, "x", encoding="utf-8") as f:
+                f.write(new_content)
+            if carry_board_id:
+                set_device_metadata(config_dir, new_filename, board_id=carry_board_id)
+
+        try:
+            await loop.run_in_executor(None, _commit)
+        except FileExistsError as exc:
+            # Race: another caller created the file between our
+            # gather pass and the ``open(... "x")``. Surface as the
+            # same INVALID_ARGS the preflight produces so the
+            # frontend renders a single message.
+            msg = f"A device named {new_filename} already exists"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
+        # Rescan so the scanner indexes the new YAML and fires the
+        # ADDED event the WS subscribers expect. ``probe_device``
+        # runs from the scan-change handler — no double-probe here.
+        await self._scanner.scan()
+        return {"configuration": new_filename}
 
     async def _yaml_validates(self, config_path: str) -> bool:
         """``esphome config`` precheck.

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -786,7 +786,12 @@ class DevicesController:
         if not new_name:
             raise CommandError(ErrorCode.INVALID_ARGS, "new_name is required")
         new_filename = f"{new_name}.yaml"
-        if new_filename == configuration:
+        # Compare on the *stem*, not the filename, so cloning
+        # ``kitchen.yml`` to ``new_name=kitchen`` is rejected even
+        # though the filenames differ — both files would still carry
+        # the same ``esphome.name`` and collide on mDNS.
+        source_stem = configuration.removesuffix(".yaml").removesuffix(".yml")
+        if new_name == source_stem:
             raise CommandError(
                 ErrorCode.INVALID_ARGS,
                 "new_name must differ from the source device name",

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -227,18 +227,132 @@ def rewrite_yaml_scalar(
     return yaml_text
 
 
-def rewrite_esphome_name(yaml_text: str, old_name: str, new_name: str) -> str:
+def read_yaml_scalar(yaml_text: str, path: Sequence[str]) -> str | None:
+    """
+    Return the raw scalar at the YAML mapping *path*, or ``None``.
+
+    Same walker as :func:`rewrite_yaml_scalar` — same path
+    semantics, same list-item / quoted-key skip rules. The
+    returned value is the substring between the colon's trailing
+    whitespace and any trailing ``# comment``, with surrounding
+    whitespace stripped but quotes intact (the same shape the
+    rewrite transform receives). ``None`` distinguishes "key not
+    present" from "key present, value is empty string".
+    """
+    captured: list[str] = []
+
+    def _capture(raw: str) -> str | None:
+        captured.append(raw)
+        return None  # Don't actually rewrite.
+
+    rewrite_yaml_scalar(yaml_text, path, _capture)
+    return captured[0] if captured else None
+
+
+# ESPHome substitutions are referenced as ``$name`` or ``${name}`` —
+# the ``${name}`` form is the canonical one the wizard emits and
+# what users following the upstream docs will write. We only treat
+# a value as a substitution reference when the *entire* value is
+# the reference (``"$devicename"`` / ``"${devicename}"``); a
+# value with extra glue (``"my-${suffix}"``) stays as a literal
+# rewrite target — replacing the substitution there would replace
+# the suffix's expansion across every other consumer.
+_PURE_SUBSTITUTION_REF = re.compile(r"\A(?:\$\{([A-Za-z_]\w*)\}|\$([A-Za-z_]\w*))\Z")
+
+
+def parse_substitution_ref(value: str) -> str | None:
+    """
+    Return the substitution name when *value* is a pure ``$var``.
+
+    Also accepts ``${var}``. Surrounding whitespace and matched
+    quotes are stripped before the test. ``"my-${suffix}"`` returns
+    ``None`` because only part of the value is the substitution.
+    """
+    stripped = value.strip()
+    # Strip a single matched pair of quotes if present.
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in ('"', "'"):
+        stripped = stripped[1:-1]
+    m = _PURE_SUBSTITUTION_REF.match(stripped)
+    if not m:
+        return None
+    return m.group(1) or m.group(2)
+
+
+def rewrite_name_or_substitution(
+    yaml_text: str,
+    leaf_path: Sequence[str],
+    new_value: str,
+) -> str:
+    """
+    Land *new_value* at *leaf_path* or at the substitution it references.
+
+    Two real-world ESPHome patterns drive this:
+
+    1. **Direct literal** — ``esphome.name: kitchen``. The leaf
+       line carries the value directly; rewrite it.
+    2. **Substitution reference** — ``esphome.name: ${devicename}``
+       paired with ``substitutions.devicename: kitchen`` (the
+       standard wizard / ``dashboard_import`` shape). The leaf
+       carries the indirection name; the actual value lives in
+       the substitutions block. Rewriting the leaf with a literal
+       would silently orphan the substitution and break any other
+       consumer (sensor named ``${devicename}_temp``, etc.).
+
+    When the leaf's current value is a *pure* substitution
+    reference (``$var`` / ``${var}`` with no surrounding glue) the
+    helper walks to ``substitutions.<var>`` and rewrites that
+    leaf instead. Mixed values (``${prefix}-suffix``) and any
+    other shape fall through to the leaf rewrite — we have no
+    way to split a partial reference without changing what the
+    other half resolves to elsewhere.
+
+    Returns the original text unchanged when neither the leaf
+    nor the substitution leaf exists.
+    """
+    raw = read_yaml_scalar(yaml_text, leaf_path)
+    var = parse_substitution_ref(raw) if raw is not None else None
+    if var is not None:
+        sub_path: tuple[str, ...] = ("substitutions", var)
+        # Only redirect when the substitution definition is in
+        # *this* file's top-level ``substitutions:`` block. A
+        # ``!include``d substitutions file or a package-supplied
+        # variable wouldn't be visible here; falling through to the
+        # leaf lands the literal in our YAML and leaves the
+        # remote definition untouched.
+        if read_yaml_scalar(yaml_text, sub_path) is not None:
+            return rewrite_yaml_scalar(yaml_text, sub_path, lambda _raw: new_value)
+    return rewrite_yaml_scalar(yaml_text, leaf_path, lambda _raw: new_value)
+
+
+def rewrite_esphome_name(
+    yaml_text: str,
+    new_name: str,
+    *,
+    only_if_current: str | None = None,
+) -> str:
     """
     Replace ``name:`` under the top-level ``esphome:`` block.
 
-    Only changes the line whose value equals *old_name* (with
-    optional surrounding quotes). Indentation and trailing comments
-    are preserved. Returns the original text unchanged when nothing
-    matches so callers can detect a no-op.
+    By default the rewrite is unconditional — every caller that
+    knows the new name to land on wants the line replaced
+    regardless of what the source had (clone path, future
+    create-then-edit flows). Pass *only_if_current* to gate the
+    rewrite on the existing leaf value matching that string —
+    used by ``_manual_rename``'s file-level fallback as a hedge
+    against renaming a config whose YAML ``name:`` no longer
+    matches its filename. The gate is opt-in because the
+    common case (filename and ``esphome.name`` agree) is the
+    same outcome either way; the gate only matters for
+    drift between the two, where clone wants "force the
+    rename" and rename's fallback wants "leave it alone".
+
+    Indentation and trailing comments are preserved. Returns the
+    original text unchanged when nothing matches the path or the
+    gate.
     """
 
     def _swap(raw: str) -> str | None:
-        if raw.strip().strip('"').strip("'") != old_name:
+        if only_if_current is not None and raw.strip().strip('"').strip("'") != only_if_current:
             return None
         return new_name
 

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -112,30 +112,49 @@ def _split_value_and_comment(rest: str) -> tuple[str, str]:
     A ``#`` only opens a comment when preceded by whitespace
     *and* outside any quoted scalar. Without the quote-state
     check, ``friendly_name: "Bedroom #2"`` would mis-split as
-    ``"Bedroom`` (value) + ``" #2"`` (comment) and every read /
-    rewrite would corrupt the YAML.
+    ``"Bedroom`` (value) + ``" #2"`` (comment).
+
+    Honours both YAML quote-escape conventions so the splitter
+    survives a round-trip through our own ``_quote`` (which emits
+    ``\"`` inside double-quoted output for friendly names that
+    contain ``"``):
+
+    - Double-quoted: ``\"`` escapes a literal quote. Skip the
+      escape sequence body so the quote-flip stays accurate.
+    - Single-quoted: ``''`` is YAML's escape for a literal single
+      quote inside a single-quoted scalar. A doubled closer means
+      "stay in the string"; only an unpaired ``'`` ends the scalar.
 
     *value* keeps the surrounding quotes intact and is stripped
     of trailing whitespace (the comment owns its leading run).
     *comment* includes the leading whitespace + ``#`` so the
     rewriter pastes it back verbatim. Empty *comment* means no
     trailing comment was found.
-
-    Doesn't model double-quoted ``\"`` escapes — ESPHome configs
-    don't use them in practice (single-quoted strings are used
-    for content with ``"``); the simpler quote-flip suffices.
     """
     quote: str | None = None
-    for i, ch in enumerate(rest):
+    i = 0
+    n = len(rest)
+    while i < n:
+        ch = rest[i]
         if quote is not None:
+            if ch == "\\" and quote == '"' and i + 1 < n:
+                # Double-quoted escape — skip the escape body so a
+                # ``\"`` doesn't read as the closing quote.
+                i += 2
+                continue
             if ch == quote:
+                if quote == "'" and i + 1 < n and rest[i + 1] == "'":
+                    # Single-quoted ``''`` is a literal quote, not
+                    # the closer — stay inside the scalar.
+                    i += 2
+                    continue
                 quote = None
-            continue
-        if ch in ('"', "'"):
+        elif ch in ('"', "'"):
             quote = ch
         elif ch == "#" and i > 0 and rest[i - 1] in " \t":
             value = rest[:i].rstrip(" \t")
             return value, rest[len(value) :]
+        i += 1
     return rest, ""
 
 
@@ -491,7 +510,13 @@ def rewrite_api_encryption_key(yaml_text: str, new_key: str) -> str:
     rendered = _quote(new_key)
 
     def _swap(raw: str) -> str | None:
-        if raw.startswith("!secret") or raw.startswith("${"):
+        # Strip quotes before checking for indirection markers — both
+        # ``key: !secret api_key`` and ``key: "${api_key}"`` are
+        # valid YAML, and the second form's quotes would otherwise
+        # mask the ``${`` prefix and cause us to rewrite a value the
+        # user explicitly indirected.
+        unquoted = _strip_yaml_quotes(raw)
+        if unquoted.startswith("!secret") or unquoted.startswith("${"):
             return None
         return rendered
 

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -153,13 +153,16 @@ def rewrite_yaml_scalar(
     if not path:
         return yaml_text
     lines = yaml_text.splitlines(keepends=True)
-    # ``stack`` holds (indent, key) for every ancestor frame whose
-    # body we are currently inside. Mapping keys push their own name;
-    # list items push the sentinel ``_LIST_FRAME`` so a leaf nested
-    # inside a list (``sensor: - name: foo``) can't satisfy a plain
-    # mapping path (``("sensor", "name")``). The leaf is matched when
-    # ``tuple(k for _, k in stack) == path[:-1]`` and the current
-    # line's own key equals ``path[-1]``.
+    # ``stack`` holds (indent, key) for *every* ancestor frame
+    # we're currently inside, on-path or not. Mapping keys push
+    # their own name; list items push the sentinel
+    # ``_LIST_FRAME``. Tracking only on-path ancestors would let
+    # a deeper key satisfy a shorter path — e.g. for path
+    # ``("api", "encryption", "key")``, YAML
+    # ``api: { something: { encryption: { key: ... } } }`` would
+    # falsely match because ``something`` would be invisible to
+    # the ancestor check. We pay one extra ``stack.append`` per
+    # off-path key in exchange for a sound path comparison.
     stack: list[tuple[int, str]] = []
     target_parents = tuple(path[:-1])
     leaf_key = path[-1]
@@ -213,17 +216,13 @@ def rewrite_yaml_scalar(
             ending = "\n" if line.endswith("\n") else ""
             lines[i] = f"{m.group('indent')}{key}: {replacement}{comment}{ending}"
             return "".join(lines)
-        # Push this key onto the ancestor stack only when we're on
-        # the path. Off-path branches don't need their ancestors
-        # tracked for rewrites that touch a different subtree later
-        # (well-formed YAML doesn't reuse keys at the same level
-        # within one mapping).
-        if (
-            len(stack) < len(target_parents)
-            and ancestor_chain == target_parents[: len(ancestor_chain)]
-            and key == target_parents[len(ancestor_chain)]
-        ):
-            stack.append((indent, key))
+        # Push every mapping key — soundness over micro-optimisation.
+        # An off-path key (e.g. ``something:`` between ``api:`` and
+        # ``encryption:`` when the target path is
+        # ``("api", "encryption", "key")``) must show up in the
+        # ancestor chain so the leaf check at the deeper indent
+        # correctly fails to match.
+        stack.append((indent, key))
     return yaml_text
 
 
@@ -249,6 +248,84 @@ def read_yaml_scalar(yaml_text: str, path: Sequence[str]) -> str | None:
     return captured[0] if captured else None
 
 
+# Plain (unquoted) YAML scalars accept most printable characters,
+# but a small set of leading bytes and embedded sequences make the
+# parser interpret the value as something other than a plain
+# string. ``_PLAIN_SCALAR_INDICATOR_LEAD`` covers the YAML
+# indicator characters that, when leading, change scalar shape;
+# ``_PLAIN_SCALAR_FORBIDDEN_SUBSTR`` covers the embedded sequences
+# that flip a plain scalar into a key/value or comment. ``_RESERVED_PLAIN``
+# is the set of plain scalars YAML interprets as bool / null —
+# emitting one of these unquoted would round-trip as a non-string.
+_PLAIN_SCALAR_INDICATOR_LEAD = set("!&*?|>%@`#-,[]{}\"'")
+_PLAIN_SCALAR_FORBIDDEN_SUBSTR = (": ", " #")
+_RESERVED_PLAIN = frozenset(
+    {
+        "true",
+        "false",
+        "null",
+        "yes",
+        "no",
+        "on",
+        "off",
+        "~",
+        "",
+    }
+)
+
+
+def _safe_yaml_scalar(value: str) -> str:
+    r"""
+    Render *value* as a YAML scalar — plain when safe, double-quoted otherwise.
+
+    Used by rewriters that accept arbitrary user-supplied strings
+    (friendly_name, comments, mqtt topics, etc.) where a value
+    like ``"Bedroom #2"`` would otherwise become a comment or
+    ``"Lamp: Bedroom"`` would split into a key/value pair on round
+    trip. Plain identifiers (``"Kitchen"``, ``"my-device"``) round
+    trip without quotes; anything that contains a YAML special
+    sequence, starts with an indicator character, ends in ``:`` /
+    ``-``, or matches a reserved plain scalar gets double-quoted
+    with embedded ``"`` and ``\\`` escaped.
+    """
+    if not value or value.lower() in _RESERVED_PLAIN:
+        return f'"{value}"'
+    if value[0] in _PLAIN_SCALAR_INDICATOR_LEAD:
+        return _quote(value)
+    if value.endswith(":") or value.endswith(" "):
+        return _quote(value)
+    if any(s in value for s in _PLAIN_SCALAR_FORBIDDEN_SUBSTR):
+        return _quote(value)
+    # ``\n``, ``\r``, and ``\t`` would either be silently stripped
+    # (tab) or split into multiple YAML lines. Quote and escape.
+    if any(c in value for c in "\n\r\t"):
+        return _quote(value)
+    return value
+
+
+def _quote(value: str) -> str:
+    """Render *value* as a double-quoted YAML scalar with minimal escapes."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    escaped = escaped.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    return f'"{escaped}"'
+
+
+def _strip_yaml_quotes(value: str) -> str:
+    """
+    Strip a single matched pair of surrounding quotes from *value*.
+
+    YAML scalars accept ``"..."`` and ``'...'`` quoting; both shapes
+    appear in real configs. Helpers that compare against an unquoted
+    target (rename's value gate, the substitution-ref parser) need
+    to peel the wrapper before comparing without crashing on
+    unquoted values.
+    """
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in ('"', "'"):
+        return stripped[1:-1]
+    return stripped
+
+
 # ESPHome substitutions are referenced as ``$name`` or ``${name}`` —
 # the ``${name}`` form is the canonical one the wizard emits and
 # what users following the upstream docs will write. We only treat
@@ -268,11 +345,7 @@ def parse_substitution_ref(value: str) -> str | None:
     quotes are stripped before the test. ``"my-${suffix}"`` returns
     ``None`` because only part of the value is the substitution.
     """
-    stripped = value.strip()
-    # Strip a single matched pair of quotes if present.
-    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in ('"', "'"):
-        stripped = stripped[1:-1]
-    m = _PURE_SUBSTITUTION_REF.match(stripped)
+    m = _PURE_SUBSTITUTION_REF.match(_strip_yaml_quotes(value))
     if not m:
         return None
     return m.group(1) or m.group(2)
@@ -309,6 +382,7 @@ def rewrite_name_or_substitution(
     Returns the original text unchanged when neither the leaf
     nor the substitution leaf exists.
     """
+    rendered = _safe_yaml_scalar(new_value)
     raw = read_yaml_scalar(yaml_text, leaf_path)
     var = parse_substitution_ref(raw) if raw is not None else None
     if var is not None:
@@ -320,8 +394,8 @@ def rewrite_name_or_substitution(
         # leaf lands the literal in our YAML and leaves the
         # remote definition untouched.
         if read_yaml_scalar(yaml_text, sub_path) is not None:
-            return rewrite_yaml_scalar(yaml_text, sub_path, lambda _raw: new_value)
-    return rewrite_yaml_scalar(yaml_text, leaf_path, lambda _raw: new_value)
+            return rewrite_yaml_scalar(yaml_text, sub_path, lambda _raw: rendered)
+    return rewrite_yaml_scalar(yaml_text, leaf_path, lambda _raw: rendered)
 
 
 def rewrite_esphome_name(
@@ -352,28 +426,11 @@ def rewrite_esphome_name(
     """
 
     def _swap(raw: str) -> str | None:
-        if only_if_current is not None and raw.strip().strip('"').strip("'") != only_if_current:
+        if only_if_current is not None and _strip_yaml_quotes(raw) != only_if_current:
             return None
         return new_name
 
     return rewrite_yaml_scalar(yaml_text, ("esphome", "name"), _swap)
-
-
-def rewrite_friendly_name(yaml_text: str, new_friendly_name: str) -> str:
-    """
-    Replace ``friendly_name:`` under the top-level ``esphome:`` block.
-
-    Unlike :func:`rewrite_esphome_name` this doesn't gate on the
-    current value — a clone overrides the friendly name regardless
-    of what the source had. Returns the original text unchanged
-    when no ``friendly_name:`` line exists inside ``esphome:`` so
-    callers can decide whether to insert one.
-    """
-    return rewrite_yaml_scalar(
-        yaml_text,
-        ("esphome", "friendly_name"),
-        lambda _raw: new_friendly_name,
-    )
 
 
 def generate_api_encryption_key() -> str:
@@ -400,11 +457,12 @@ def rewrite_api_encryption_key(yaml_text: str, new_key: str) -> str:
     that happens to start with a YAML special character
     (``!``/``%``/``@``/``-``/``?``/``&``/``*``) parses cleanly.
     """
+    rendered = _quote(new_key)
 
     def _swap(raw: str) -> str | None:
         if raw.startswith("!secret") or raw.startswith("${"):
             return None
-        return f'"{new_key}"'
+        return rendered
 
     return rewrite_yaml_scalar(yaml_text, ("api", "encryption", "key"), _swap)
 

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import base64
 import re
+import secrets
 from typing import TYPE_CHECKING, Any
 
 import yaml
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
     from ..models import ComponentCatalogEntry
 
 # Prefer the libyaml-backed C loader when PyYAML was built against
@@ -93,42 +97,202 @@ _ENTITY_CATEGORIES = {
 # ---------------------------------------------------------------------------
 
 
+# Mapping-key line: optional leading whitespace, an unquoted scalar
+# key, ``:``, optional whitespace, optional value, optional trailing
+# comment. List items (``- foo: bar``) are excluded — none of the
+# rewrite paths we care about land inside a list, and the key stack
+# below assumes parent → child mapping nesting only.
+_MAPPING_KEY_LINE = re.compile(r"^(?P<indent>\s*)(?P<key>[A-Za-z_][\w-]*):\s*(?P<rest>.*)$")
+# Trailing-comment splitter for the value half. ``#`` only opens a
+# comment when preceded by whitespace; ``key: ab#cd`` is the literal
+# scalar ``ab#cd``. Quoted values aren't stripped (we leave the
+# quotes in *raw_value* so the transform sees them).
+_VALUE_AND_COMMENT = re.compile(r"^(?P<value>.*?)(?P<comment>\s+#.*)?$")
+# Sentinel pushed onto the path stack when we descend into a list
+# item. Picked as a string that can't collide with a real YAML key
+# (the leading ``-`` prevents a match against the mapping-key regex's
+# ``[A-Za-z_]`` anchor).
+_LIST_FRAME = "-list-"
+
+
+def rewrite_yaml_scalar(
+    yaml_text: str,
+    path: Sequence[str],
+    transform: Callable[[str], str | None],
+) -> str:
+    """
+    Rewrite the scalar at the YAML mapping *path* in *yaml_text*.
+
+    *path* is the ancestor → leaf chain of mapping keys
+    (e.g. ``("esphome", "name")``, ``("api", "encryption", "key")``).
+    The walker tracks the open ancestor stack by indent and only
+    rewrites a leaf line whose ancestor chain matches *path[:-1]*
+    and whose own key equals *path[-1]*.
+
+    *transform* receives the leaf's *raw value* — the substring
+    between the colon's trailing whitespace and any trailing
+    ``# comment``, with surrounding whitespace stripped but quotes
+    kept. It returns the rendered replacement (caller decides
+    whether to wrap in quotes, regenerate from scratch, etc.) or
+    ``None`` to leave the line untouched.
+
+    Indentation and trailing comments survive the rewrite. Only the
+    first matching leaf is rewritten; pathological YAMLs with the
+    same path appearing twice get only the first one touched —
+    matches our callers' expectation that a well-formed config
+    declares each path once. Returns the input string unchanged when
+    no leaf is found or when *transform* returns ``None``.
+
+    Walker only handles unquoted plain mapping keys nested via
+    indentation (``foo:`` / ``  bar:`` …) — the shape every path
+    our callers care about uses. List items (``- platform: …``)
+    and quoted keys (``"foo": …``) are skipped; supporting them
+    would change the meaning of "the scalar at *path*" in ways that
+    don't match how ESPHome configs are written by hand.
+    """
+    if not path:
+        return yaml_text
+    lines = yaml_text.splitlines(keepends=True)
+    # ``stack`` holds (indent, key) for every ancestor frame whose
+    # body we are currently inside. Mapping keys push their own name;
+    # list items push the sentinel ``_LIST_FRAME`` so a leaf nested
+    # inside a list (``sensor: - name: foo``) can't satisfy a plain
+    # mapping path (``("sensor", "name")``). The leaf is matched when
+    # ``tuple(k for _, k in stack) == path[:-1]`` and the current
+    # line's own key equals ``path[-1]``.
+    stack: list[tuple[int, str]] = []
+    target_parents = tuple(path[:-1])
+    leaf_key = path[-1]
+    for i, line in enumerate(lines):
+        stripped_no_eol = line.rstrip("\n\r")
+        # Blank / comment-only lines stay inside whatever block they
+        # appear in — popping the stack on whitespace would close
+        # blocks that have a blank between the parent and the first
+        # child key.
+        if not stripped_no_eol.strip() or stripped_no_eol.lstrip().startswith("#"):
+            continue
+        # List items break the mapping path: anything indented inside
+        # a list item is "in a list", not a direct child of the
+        # parent mapping. Push an opaque frame at the dash's column
+        # so deeper keys' ancestor chain can't satisfy the caller's
+        # plain-mapping path.
+        lstripped = stripped_no_eol.lstrip(" ")
+        if lstripped.startswith("- ") or lstripped == "-":
+            indent = len(stripped_no_eol) - len(lstripped)
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+            stack.append((indent, _LIST_FRAME))
+            continue
+        m = _MAPPING_KEY_LINE.match(stripped_no_eol)
+        if not m:
+            # Non-key line (block scalar continuation, …) — not on
+            # any of our supported paths. Don't touch the stack.
+            continue
+        indent = len(m.group("indent"))
+        key = m.group("key")
+        rest = m.group("rest")
+        # Walking back out: pop every stack entry whose indent is
+        # ≥ this line's. Those blocks are closed by virtue of this
+        # line living at a sibling-or-shallower position.
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        ancestor_chain = tuple(k for _, k in stack)
+        if key == leaf_key and ancestor_chain == target_parents:
+            value_match = _VALUE_AND_COMMENT.match(rest)
+            assert value_match is not None  # _VALUE_AND_COMMENT always matches
+            raw_value = value_match.group("value").strip()
+            comment = value_match.group("comment") or ""
+            replacement = transform(raw_value)
+            if replacement is None:
+                # Transform opted out — keep walking? No: every
+                # caller wants "rewrite the first match"; a deeper
+                # duplicate isn't more correct than the first one.
+                # Returning unchanged matches the original helpers'
+                # behaviour.
+                return yaml_text
+            ending = "\n" if line.endswith("\n") else ""
+            lines[i] = f"{m.group('indent')}{key}: {replacement}{comment}{ending}"
+            return "".join(lines)
+        # Push this key onto the ancestor stack only when we're on
+        # the path. Off-path branches don't need their ancestors
+        # tracked for rewrites that touch a different subtree later
+        # (well-formed YAML doesn't reuse keys at the same level
+        # within one mapping).
+        if (
+            len(stack) < len(target_parents)
+            and ancestor_chain == target_parents[: len(ancestor_chain)]
+            and key == target_parents[len(ancestor_chain)]
+        ):
+            stack.append((indent, key))
+    return yaml_text
+
+
 def rewrite_esphome_name(yaml_text: str, old_name: str, new_name: str) -> str:
     """
     Replace ``name:`` under the top-level ``esphome:`` block.
 
-    Only changes lines inside the ``esphome:`` section whose value
-    equals *old_name* (with optional surrounding quotes). Indentation
-    and trailing comments are preserved. Returns the original text
-    unchanged when nothing matches so callers can detect a no-op.
+    Only changes the line whose value equals *old_name* (with
+    optional surrounding quotes). Indentation and trailing comments
+    are preserved. Returns the original text unchanged when nothing
+    matches so callers can detect a no-op.
     """
-    lines = yaml_text.splitlines(keepends=True)
-    in_esphome = False
-    changed = False
-    for i, line in enumerate(lines):
-        stripped = line.rstrip("\n\r")
-        # Enter `esphome:` block
-        if re.match(r"^esphome:\s*(#.*)?$", stripped):
-            in_esphome = True
-            continue
-        # A new top-level key (col 0, starts with letter) closes the block
-        if stripped and stripped[0].isalpha():
-            in_esphome = False
-            continue
-        if not in_esphome:
-            continue
-        m = re.match(r"^(\s+)name:\s*(.+?)(\s*#.*)?$", stripped)
-        if not m:
-            continue
-        value = m.group(2).strip().strip('"').strip("'")
-        if value != old_name:
-            continue
-        indent, _, comment = m.groups()
-        ending = "\n" if line.endswith("\n") else ""
-        lines[i] = f"{indent}name: {new_name}{comment or ''}{ending}"
-        changed = True
-        break
-    return "".join(lines) if changed else yaml_text
+
+    def _swap(raw: str) -> str | None:
+        if raw.strip().strip('"').strip("'") != old_name:
+            return None
+        return new_name
+
+    return rewrite_yaml_scalar(yaml_text, ("esphome", "name"), _swap)
+
+
+def rewrite_friendly_name(yaml_text: str, new_friendly_name: str) -> str:
+    """
+    Replace ``friendly_name:`` under the top-level ``esphome:`` block.
+
+    Unlike :func:`rewrite_esphome_name` this doesn't gate on the
+    current value — a clone overrides the friendly name regardless
+    of what the source had. Returns the original text unchanged
+    when no ``friendly_name:`` line exists inside ``esphome:`` so
+    callers can decide whether to insert one.
+    """
+    return rewrite_yaml_scalar(
+        yaml_text,
+        ("esphome", "friendly_name"),
+        lambda _raw: new_friendly_name,
+    )
+
+
+def generate_api_encryption_key() -> str:
+    """Return a fresh 32-byte ESPHome API encryption key, base64-encoded."""
+    return base64.b64encode(secrets.token_bytes(32)).decode()
+
+
+def rewrite_api_encryption_key(yaml_text: str, new_key: str) -> str:
+    """
+    Replace the literal ``key:`` value under ``api: -> encryption:``.
+
+    Used by the clone path so two devices forked from the same
+    source don't share API encryption material — compromise of one
+    device must not compromise its siblings. Only rewrites a
+    *literal* key value; lines whose value is an indirection
+    (``!secret …`` / ``${…}``) are left untouched, because the
+    indirection target is shared on disk and stomping on the key
+    here would silently desync the clone from whatever
+    ``secrets.yaml`` / substitutions block actually drives the
+    encryption. Returns the original text unchanged when no
+    in-scope ``key:`` is found or when the value is an indirection.
+
+    The replacement is rendered double-quoted so a base64 value
+    that happens to start with a YAML special character
+    (``!``/``%``/``@``/``-``/``?``/``&``/``*``) parses cleanly.
+    """
+
+    def _swap(raw: str) -> str | None:
+        if raw.startswith("!secret") or raw.startswith("${"):
+            return None
+        return f'"{new_key}"'
+
+    return rewrite_yaml_scalar(yaml_text, ("api", "encryption", "key"), _swap)
 
 
 def merge_component_yaml(

--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -103,11 +103,42 @@ _ENTITY_CATEGORIES = {
 # rewrite paths we care about land inside a list, and the key stack
 # below assumes parent → child mapping nesting only.
 _MAPPING_KEY_LINE = re.compile(r"^(?P<indent>\s*)(?P<key>[A-Za-z_][\w-]*):\s*(?P<rest>.*)$")
-# Trailing-comment splitter for the value half. ``#`` only opens a
-# comment when preceded by whitespace; ``key: ab#cd`` is the literal
-# scalar ``ab#cd``. Quoted values aren't stripped (we leave the
-# quotes in *raw_value* so the transform sees them).
-_VALUE_AND_COMMENT = re.compile(r"^(?P<value>.*?)(?P<comment>\s+#.*)?$")
+
+
+def _split_value_and_comment(rest: str) -> tuple[str, str]:
+    r"""
+    Split *rest* into ``(value, comment)`` at a real ``\s+#`` separator.
+
+    A ``#`` only opens a comment when preceded by whitespace
+    *and* outside any quoted scalar. Without the quote-state
+    check, ``friendly_name: "Bedroom #2"`` would mis-split as
+    ``"Bedroom`` (value) + ``" #2"`` (comment) and every read /
+    rewrite would corrupt the YAML.
+
+    *value* keeps the surrounding quotes intact and is stripped
+    of trailing whitespace (the comment owns its leading run).
+    *comment* includes the leading whitespace + ``#`` so the
+    rewriter pastes it back verbatim. Empty *comment* means no
+    trailing comment was found.
+
+    Doesn't model double-quoted ``\"`` escapes — ESPHome configs
+    don't use them in practice (single-quoted strings are used
+    for content with ``"``); the simpler quote-flip suffices.
+    """
+    quote: str | None = None
+    for i, ch in enumerate(rest):
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+        elif ch == "#" and i > 0 and rest[i - 1] in " \t":
+            value = rest[:i].rstrip(" \t")
+            return value, rest[len(value) :]
+    return rest, ""
+
+
 # Sentinel pushed onto the path stack when we descend into a list
 # item. Picked as a string that can't collide with a real YAML key
 # (the leading ``-`` prevents a match against the mapping-key regex's
@@ -152,76 +183,54 @@ def rewrite_yaml_scalar(
     """
     if not path:
         return yaml_text
-    lines = yaml_text.splitlines(keepends=True)
-    # ``stack`` holds (indent, key) for *every* ancestor frame
-    # we're currently inside, on-path or not. Mapping keys push
-    # their own name; list items push the sentinel
-    # ``_LIST_FRAME``. Tracking only on-path ancestors would let
-    # a deeper key satisfy a shorter path — e.g. for path
-    # ``("api", "encryption", "key")``, YAML
-    # ``api: { something: { encryption: { key: ... } } }`` would
-    # falsely match because ``something`` would be invisible to
-    # the ancestor check. We pay one extra ``stack.append`` per
-    # off-path key in exchange for a sound path comparison.
-    stack: list[tuple[int, str]] = []
     target_parents = tuple(path[:-1])
     leaf_key = path[-1]
+    lines = yaml_text.splitlines(keepends=True)
+    # ``stack`` holds (indent, key) for *every* enclosing frame —
+    # mapping keys (on-path or off) push their name, list items
+    # push the ``_LIST_FRAME`` sentinel. Tracking off-path keys
+    # too keeps the path comparison sound: for path
+    # ``("api", "encryption", "key")``, YAML ``api: { something:
+    # { encryption: { key: ... } } }`` would otherwise falsely
+    # match because ``something`` would be invisible to the
+    # ancestor check.
+    stack: list[tuple[int, str]] = []
     for i, line in enumerate(lines):
-        stripped_no_eol = line.rstrip("\n\r")
-        # Blank / comment-only lines stay inside whatever block they
-        # appear in — popping the stack on whitespace would close
-        # blocks that have a blank between the parent and the first
-        # child key.
-        if not stripped_no_eol.strip() or stripped_no_eol.lstrip().startswith("#"):
+        body = line.rstrip("\n\r")
+        head = body.lstrip(" ")
+        # Blank / comment-only lines stay inside whatever block
+        # they appear in — popping on whitespace would close blocks
+        # that have a blank between the parent and the first child.
+        if not head or head.startswith("#"):
             continue
-        # List items break the mapping path: anything indented inside
-        # a list item is "in a list", not a direct child of the
-        # parent mapping. Push an opaque frame at the dash's column
-        # so deeper keys' ancestor chain can't satisfy the caller's
-        # plain-mapping path.
-        lstripped = stripped_no_eol.lstrip(" ")
-        if lstripped.startswith("- ") or lstripped == "-":
-            indent = len(stripped_no_eol) - len(lstripped)
-            while stack and stack[-1][0] >= indent:
-                stack.pop()
-            stack.append((indent, _LIST_FRAME))
-            continue
-        m = _MAPPING_KEY_LINE.match(stripped_no_eol)
-        if not m:
-            # Non-key line (block scalar continuation, …) — not on
-            # any of our supported paths. Don't touch the stack.
-            continue
-        indent = len(m.group("indent"))
-        key = m.group("key")
-        rest = m.group("rest")
-        # Walking back out: pop every stack entry whose indent is
-        # ≥ this line's. Those blocks are closed by virtue of this
-        # line living at a sibling-or-shallower position.
+        indent = len(body) - len(head)
+        # Pop every frame at this indent or shallower before we
+        # decide what this line is. The new line lives at a
+        # sibling-or-shallower position, so deeper frames are
+        # closed regardless of which branch follows.
         while stack and stack[-1][0] >= indent:
             stack.pop()
-        ancestor_chain = tuple(k for _, k in stack)
-        if key == leaf_key and ancestor_chain == target_parents:
-            value_match = _VALUE_AND_COMMENT.match(rest)
-            assert value_match is not None  # _VALUE_AND_COMMENT always matches
-            raw_value = value_match.group("value").strip()
-            comment = value_match.group("comment") or ""
-            replacement = transform(raw_value)
+        if head.startswith("- ") or head == "-":
+            # List items break the mapping path — anything nested
+            # inside is "in a list", not a direct child of the
+            # parent mapping. Push the opaque frame so deeper keys
+            # can't satisfy a plain-mapping path.
+            stack.append((indent, _LIST_FRAME))
+            continue
+        m = _MAPPING_KEY_LINE.match(body)
+        if not m:
+            # Block-scalar continuation, plain-scalar list element
+            # without a key, … — not on any supported path.
+            continue
+        key = m.group("key")
+        if key == leaf_key and tuple(k for _, k in stack) == target_parents:
+            value_part, comment = _split_value_and_comment(m.group("rest"))
+            replacement = transform(value_part.strip())
             if replacement is None:
-                # Transform opted out — keep walking? No: every
-                # caller wants "rewrite the first match"; a deeper
-                # duplicate isn't more correct than the first one.
-                # Returning unchanged matches the original helpers'
-                # behaviour.
                 return yaml_text
-            ending = "\n" if line.endswith("\n") else ""
+            ending = line[len(body) :]  # preserves "\n" / "\r\n" / ""
             lines[i] = f"{m.group('indent')}{key}: {replacement}{comment}{ending}"
             return "".join(lines)
-        # Push every mapping key — soundness over micro-optimisation.
-        # An off-path key (e.g. ``something:`` between ``api:`` and
-        # ``encryption:`` when the target path is
-        # ``("api", "encryption", "key")``) must show up in the
-        # ancestor chain so the leaf check at the deeper indent
-        # correctly fails to match.
         stack.append((indent, key))
     return yaml_text
 
@@ -283,10 +292,18 @@ def _safe_yaml_scalar(value: str) -> str:
     like ``"Bedroom #2"`` would otherwise become a comment or
     ``"Lamp: Bedroom"`` would split into a key/value pair on round
     trip. Plain identifiers (``"Kitchen"``, ``"my-device"``) round
-    trip without quotes; anything that contains a YAML special
-    sequence, starts with an indicator character, ends in ``:`` /
-    ``-``, or matches a reserved plain scalar gets double-quoted
-    with embedded ``"`` and ``\\`` escaped.
+    trip without quotes; values get double-quoted (with embedded
+    ``"`` and ``\\`` escaped) when any of these holds:
+
+    - empty string or matches a reserved plain scalar
+      (``true`` / ``false`` / ``null`` / ``yes`` / ``no`` /
+      ``on`` / ``off`` / ``~``);
+    - starts with a YAML indicator character (``! & * ? | > %
+      @ ` # - , [ ] { } " '``);
+    - ends in ``:`` (would parse as a key with empty value) or in
+      whitespace (would lose the trailing space on round trip);
+    - contains ``: `` (key/value split) or `` #`` (comment marker);
+    - contains a control character (``\\n`` / ``\\r`` / ``\\t``).
     """
     if not value or value.lower() in _RESERVED_PLAIN:
         return f'"{value}"'
@@ -303,11 +320,25 @@ def _safe_yaml_scalar(value: str) -> str:
     return value
 
 
+# YAML double-quoted scalar escapes for the five characters that
+# would otherwise break round-trip: ``\`` and ``"`` need escaping
+# because the closing quote / escape leader; the three control
+# characters need escaping because plain-text rendering would split
+# the value across lines or eat the tab.
+_QUOTE_ESCAPES = str.maketrans(
+    {
+        "\\": r"\\",
+        '"': r"\"",
+        "\n": r"\n",
+        "\r": r"\r",
+        "\t": r"\t",
+    }
+)
+
+
 def _quote(value: str) -> str:
     """Render *value* as a double-quoted YAML scalar with minimal escapes."""
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    escaped = escaped.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-    return f'"{escaped}"'
+    return f'"{value.translate(_QUOTE_ESCAPES)}"'
 
 
 def _strip_yaml_quotes(value: str) -> str:

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -11,11 +11,17 @@ a scan so the new file shows up in the next ``devices/list``.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from esphome_device_builder.controllers.config import (
+    get_device_metadata,
+    set_device_metadata,
+)
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
@@ -354,6 +360,85 @@ async def test_clone_device_lands_new_name_when_yaml_name_diverges_from_filename
     new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
     assert "  name: bedroom-bulb\n" in new_yaml
     assert "my-kitchen-bulb" not in new_yaml
+
+
+async def test_clone_device_carries_source_board_id_into_metadata(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Source's ``board_id`` survives the clone via the metadata sidecar.
+
+    ``board_id`` is the one piece of dashboard state that can't be
+    recovered from the YAML — it's a catalog-key indirection set by
+    the user at wizard time. The clone path reads the source's
+    metadata in the gather phase and writes it onto the new file's
+    metadata entry in the commit phase, so the cloned device shows
+    up bound to the same catalog board the source picked.
+    """
+    config_dir = tmp_path
+    # Seed the source's metadata sidecar so the clone has something
+    # to carry forward.
+    await asyncio.to_thread(
+        set_device_metadata,
+        config_dir,
+        "kitchen.yaml",
+        board_id="esp32-s3-devkitc-1",
+    )
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    ctrl._db.settings.config_dir = config_dir
+
+    await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    # Verify the metadata sidecar got the carry-forward write.
+    meta = await asyncio.to_thread(get_device_metadata, config_dir, "bedroom-bulb.yaml")
+    assert meta is not None
+    assert meta["board_id"] == "esp32-s3-devkitc-1"
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_handles_filesystem_race_on_target_filename(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A race that creates the target file between gather + commit raises ``INVALID_ARGS``.
+
+    The exclusive-create ``open(..., "x")`` is the actual race
+    defence — even if the gather pass found ``new_path`` missing,
+    a concurrent caller (another ``devices/clone`` request, the
+    user dropping a file via the editor) could create it before our
+    commit. The mode raises ``FileExistsError`` and we translate it
+    into the same ``INVALID_ARGS`` the preflight produces so the
+    frontend renders one consistent message.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    # Patch the executor's ``_commit`` body via the underlying
+    # ``open`` call. The clone command's commit closure does
+    # ``with open(new_path, "x", ...)`` — flipping that to raise
+    # ``FileExistsError`` simulates the race without needing real
+    # cross-process scheduling.
+    real_open = open
+
+    def _raising_open(path, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        if "x" in mode and str(path).endswith("bedroom-bulb.yaml"):
+            raise FileExistsError(str(path))
+        return real_open(path, mode, *args, **kwargs)
+
+    with (
+        patch(
+            "esphome_device_builder.controllers.devices.controller.open",
+            _raising_open,
+            create=True,
+        ),
+        pytest.raises(CommandError) as excinfo,
+    ):
+        await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "bedroom-bulb.yaml already exists" in excinfo.value.message
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -362,6 +362,32 @@ async def test_clone_device_lands_new_name_when_yaml_name_diverges_from_filename
     assert "my-kitchen-bulb" not in new_yaml
 
 
+async def test_clone_device_rejects_source_with_no_inline_esphome_name(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A package-driven config (no inline ``esphome.name``) is rejected.
+
+    When the ``esphome:`` block lives in a ``packages:`` /
+    ``!include``d file, this YAML has no ``name:`` leaf for the
+    rewriter to touch — the rewrite is a silent no-op and the
+    clone would flash under the source's hostname, colliding on
+    mDNS. Surface the precondition as ``INVALID_ARGS`` with
+    actionable guidance instead of producing a duplicate device.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    yaml = "packages:\n  base: !include common/base.yaml\nesp32:\n  variant: ESP32\n"
+    (tmp_path / "kitchen.yaml").write_text(yaml, "utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "no inline esphome.name" in excinfo.value.message
+    # Clone target should not have been written.
+    assert not (tmp_path / "bedroom-bulb.yaml").exists()
+
+
 async def test_clone_device_carries_source_board_id_into_metadata(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -236,6 +236,77 @@ async def test_clone_device_works_when_api_is_plaintext(
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_redirects_through_substitutions_block(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Wizard / dashboard_import shape: clone updates the substitution.
+
+    When the source uses the standard ESPHome wizard pattern —
+    ``esphome.name: ${devicename}`` paired with
+    ``substitutions.devicename: kitchen`` — the clone must
+    rewrite the substitution rather than the leaf. Rewriting the
+    leaf would orphan the substitution and break any other
+    consumer of ``${devicename}`` in the same file (sensor names,
+    log tags, etc.) by stripping the indirection.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    yaml = (
+        "substitutions:\n"
+        "  devicename: acfloatmonitor32\n"
+        "  friendly_name: AC Float Monitor 32\n"
+        "esphome:\n"
+        "  name: ${devicename}\n"
+        "  friendly_name: ${friendly_name}\n"
+        "esp32:\n  variant: ESP32\n"
+    )
+    (tmp_path / "acfloatmonitor32.yaml").write_text(yaml, "utf-8")
+
+    await ctrl.clone_device(
+        configuration="acfloatmonitor32.yaml",
+        new_name="bedroom-bulb",
+        new_friendly_name="Bedroom Bulb",
+    )
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    # Substitutions flipped, leaves still reference the variables —
+    # any other consumer of ``${devicename}`` now points at the
+    # cloned name automatically.
+    assert "  devicename: bedroom-bulb\n" in new_yaml
+    assert "  friendly_name: Bedroom Bulb\n" in new_yaml
+    assert "  name: ${devicename}\n" in new_yaml
+    assert "  friendly_name: ${friendly_name}\n" in new_yaml
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_lands_new_name_when_yaml_name_diverges_from_filename(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Clone rewrites ``esphome.name`` even when source filename and YAML name disagree.
+
+    Real configs sometimes drift: a file named ``kitchen.yaml`` that
+    carries ``esphome.name: my-kitchen-bulb`` (hand-edited, or
+    legacy from a previous rename), or ``name: $hostname`` with the
+    literal substitution variable in the YAML. Earlier draft
+    derived ``old_name`` from the filename and gated the rewrite on
+    a value-match — that produced clones whose YAML ``name:`` was
+    untouched, leaving the cloned config flashing under the
+    *source's* hostname. Pin the unconditional rewrite so the new
+    name lands regardless of what the source line said.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    yaml = "esphome:\n  name: my-kitchen-bulb\n  friendly_name: Kitchen\nesp32:\n  variant: ESP32\n"
+    (tmp_path / "kitchen.yaml").write_text(yaml, "utf-8")
+
+    await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    assert "  name: bedroom-bulb\n" in new_yaml
+    assert "my-kitchen-bulb" not in new_yaml
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_clone_device_preserves_secret_indirection_key(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -188,6 +188,54 @@ async def test_clone_device_rejects_missing_source(
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_works_when_source_has_no_api_encryption(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A source without ``api: encryption:`` produces a working plaintext clone.
+
+    The encryption-key rewrite is a no-op when the source doesn't
+    use encryption — we deliberately don't *add* a fresh block.
+    The user's choice to run plaintext (private network, custom
+    auth, no HA) is intentional and forcing encryption onto a
+    clone would silently change the security posture.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    yaml = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\nesp32:\n  variant: ESP32\n"
+    (tmp_path / "kitchen.yaml").write_text(yaml, "utf-8")
+
+    await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    assert "name: bedroom-bulb\n" in new_yaml
+    # No spurious api/encryption block sneaks in.
+    assert "api:" not in new_yaml
+    assert "encryption:" not in new_yaml
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_works_when_api_is_plaintext(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A source with ``api:`` but no ``encryption:`` block clones plaintext.
+
+    Same reasoning as the no-api-block case — don't upgrade an
+    explicitly-plaintext config to encrypted on clone.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    yaml = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\napi:\n  password: hunter2\n"
+    (tmp_path / "kitchen.yaml").write_text(yaml, "utf-8")
+
+    await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    assert "name: bedroom-bulb\n" in new_yaml
+    assert "api:\n  password: hunter2\n" in new_yaml
+    assert "encryption:" not in new_yaml
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_clone_device_preserves_secret_indirection_key(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -125,6 +125,56 @@ async def test_clone_device_skips_friendly_rewrite_when_blank(
     assert "friendly_name: Kitchen Lamp\n" in new_yaml
 
 
+async def test_clone_device_rejects_same_stem_across_yaml_yml_extensions(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``kitchen.yml`` + ``new_name=kitchen`` is rejected even though filenames differ.
+
+    Both files would share the same ``esphome.name`` and collide on
+    mDNS once the clone is flashed. The same-name guard now compares
+    *stems* rather than full filenames so the ``.yaml`` / ``.yml``
+    extension difference can't slip past it.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yml").write_text(SOURCE_YAML, "utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.clone_device(configuration="kitchen.yml", new_name="kitchen")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "must differ" in excinfo.value.message
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_safely_quotes_friendly_name_with_yaml_specials(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Friendly names with ``#``, ``:`` etc. round-trip through proper quoting.
+
+    A friendly name like ``Bedroom #2`` written as a plain scalar
+    would be silently truncated to ``Bedroom`` (everything after
+    `` #`` becomes a YAML comment). ``Lamp: Kitchen`` would split
+    into a key/value pair on round trip. Pin that the clone path
+    safely double-quotes these values.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    await ctrl.clone_device(
+        configuration="kitchen.yaml",
+        new_name="bedroom-bulb",
+        new_friendly_name="Bedroom #2",
+    )
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    # Quoted form preserves the ``#``; the unquoted form
+    # (``friendly_name: Bedroom #2``) would silently parse back
+    # as ``Bedroom`` with ``#2`` as a YAML comment.
+    assert 'friendly_name: "Bedroom #2"\n' in new_yaml
+
+
 async def test_clone_device_rejects_collision_with_existing_filename(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -1,0 +1,213 @@
+"""Tests for the ``devices/clone`` command path.
+
+Covers the user-correctable failures (collision, empty / equal name,
+missing source) as typed ``CommandError(INVALID_ARGS, …)`` so the
+clone dialog can show specific messages rather than a generic
+"Command failed" fallback. Also covers the happy path: the new YAML
+swaps ``esphome.name`` / ``friendly_name``, regenerates the API
+encryption key, leaves ``!secret`` indirections alone, and triggers
+a scan so the new file shows up in the next ``devices/list``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
+
+from .conftest import MakeControllerFactory
+
+SOURCE_YAML = """\
+esphome:
+  name: kitchen
+  friendly_name: Kitchen Lamp
+
+esp32:
+  variant: ESP32
+
+logger:
+
+api:
+  encryption:
+    key: "OLDKEYBASE64BASE64BASE64BASE64BASE64BASE64=="
+
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+"""
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_writes_new_yaml_and_swaps_name_friendly_key(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Happy path: clone produces a new YAML with fresh identity material.
+
+    Pin all three rewrites in one trace because they're driven by
+    the same call: ``esphome.name`` swap, ``friendly_name``
+    override (defaulted from ``new_name``), and a fresh
+    base64-encoded ``api.encryption.key`` distinct from the
+    source's. The scanner gets nudged so the new YAML shows up
+    in the next ``devices/list``.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    result = await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    assert result == {"configuration": "bedroom-bulb.yaml"}
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    assert "name: bedroom-bulb\n" in new_yaml
+    # Friendly name defaulted from ``friendly_name_slugify(new_name)``.
+    assert re.search(r"friendly_name: \S", new_yaml)
+    assert "friendly_name: Kitchen Lamp" not in new_yaml
+    # Encryption key is fresh — different from the source's literal.
+    assert "OLDKEYBASE64BASE64BASE64BASE64BASE64BASE64==" not in new_yaml
+    # New key is double-quoted base64 — pinned by ``rewrite_api_encryption_key``.
+    assert re.search(r'    key: "[A-Za-z0-9+/=]+"', new_yaml)
+    # ``!secret`` indirections preserved.
+    assert "ssid: !secret wifi_ssid" in new_yaml
+    assert "password: !secret wifi_password" in new_yaml
+    # Source file untouched.
+    assert (tmp_path / "kitchen.yaml").read_text("utf-8") == SOURCE_YAML
+    # Scanner nudged so the new file lands in the next ``devices/list``.
+    assert ctrl._scanner.calls == [("scan",)]
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_uses_explicit_friendly_name_when_provided(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Caller-supplied friendly name lands verbatim in the new YAML."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    await ctrl.clone_device(
+        configuration="kitchen.yaml",
+        new_name="bedroom-bulb",
+        new_friendly_name="Bedroom Reading Lamp",
+    )
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    assert "friendly_name: Bedroom Reading Lamp\n" in new_yaml
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_skips_friendly_rewrite_when_blank(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """An explicit blank friendly name leaves the source's line untouched.
+
+    Edge case for callers that want the clone to share the source's
+    label (rare but harmless to allow). Defaulting is opt-in via
+    omission; explicit ``""`` opts out.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    await ctrl.clone_device(
+        configuration="kitchen.yaml",
+        new_name="bedroom-bulb",
+        new_friendly_name="",
+    )
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    assert "friendly_name: Kitchen Lamp\n" in new_yaml
+
+
+async def test_clone_device_rejects_collision_with_existing_filename(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A clone target that already exists raises ``INVALID_ARGS``."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+    (tmp_path / "bedroom-bulb.yaml").write_text("esphome:\n  name: bedroom-bulb\n", "utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "bedroom-bulb.yaml already exists" in excinfo.value.message
+    # Pre-flight failure: nothing written, scanner not nudged.
+    assert ctrl._scanner.calls == []
+
+
+async def test_clone_device_rejects_empty_new_name(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Whitespace-only ``new_name`` raises ``INVALID_ARGS``."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.clone_device(configuration="kitchen.yaml", new_name="   ")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "new_name is required" in excinfo.value.message
+
+
+async def test_clone_device_rejects_same_name_as_source(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Cloning to the same hostname is a no-op + raises ``INVALID_ARGS``."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.clone_device(configuration="kitchen.yaml", new_name="kitchen")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "must differ" in excinfo.value.message
+
+
+async def test_clone_device_rejects_missing_source(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A source filename that doesn't exist raises ``INVALID_ARGS``."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.clone_device(configuration="ghost.yaml", new_name="bedroom-bulb")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "ghost.yaml not found" in excinfo.value.message
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_preserves_secret_indirection_key(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``key: !secret api_key`` survives the clone.
+
+    The indirection target is shared with the source on disk
+    (``secrets.yaml``), so swapping the indirection name to a
+    fresh literal would silently desync the rendered config.
+    Pin that the clone leaves the indirection alone — the user
+    keeps using whatever ``!secret`` value drives both devices.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    yaml = (
+        "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
+        "api:\n  encryption:\n    key: !secret api_key\n"
+    )
+    (tmp_path / "kitchen.yaml").write_text(yaml, "utf-8")
+
+    await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    assert "key: !secret api_key" in new_yaml

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -532,6 +532,56 @@ def test_rewrite_yaml_scalar_honours_hash_inside_quoted_value() -> None:
     assert captured == ['"Bedroom #2"']
 
 
+def test_rewrite_yaml_scalar_honours_double_quoted_backslash_escape() -> None:
+    r"""``\"`` inside a double-quoted scalar doesn't end the quote.
+
+    Our own ``_quote`` emits ``\"`` for friendly names that
+    contain a literal ``"`` (``Lamp "Bright"`` → ``"Lamp
+    \"Bright\""``). On a *re*-clone of such a value, the splitter
+    needs to skip the escape body so the inner ``"`` doesn't read
+    as the closer and a later ``\s+#`` doesn't get treated as a
+    trailing comment.
+    """
+    captured: list[str] = []
+
+    def _capture(raw: str) -> str | None:
+        captured.append(raw)
+        return None
+
+    rewrite_yaml_scalar(
+        # The full quoted value includes ``\"`` escapes around
+        # ``Bright`` and an embedded ``#`` after the closing
+        # quote-escape. Without escape handling the splitter would
+        # exit quote mode at the first ``\"``, treat ``Bright`` as
+        # plain text, and split at `` #`` — corrupting the value.
+        'esphome:\n  friendly_name: "Lamp \\"Bright\\" #2"  # tag\n',
+        ("esphome", "friendly_name"),
+        _capture,
+    )
+    assert captured == ['"Lamp \\"Bright\\" #2"']
+
+
+def test_rewrite_yaml_scalar_honours_single_quoted_doubled_quote_escape() -> None:
+    """``''`` inside a single-quoted scalar is a literal quote, not the closer.
+
+    YAML's single-quote escape is ``''`` (doubled). The splitter
+    must recognise the doubled-quote pattern as "stay in the
+    string" rather than treating the first quote as the closer.
+    """
+    captured: list[str] = []
+
+    def _capture(raw: str) -> str | None:
+        captured.append(raw)
+        return None
+
+    rewrite_yaml_scalar(
+        "esphome:\n  friendly_name: 'Bob''s Lamp #1'  # primary\n",
+        ("esphome", "friendly_name"),
+        _capture,
+    )
+    assert captured == ["'Bob''s Lamp #1'"]
+
+
 def test_rewrite_yaml_scalar_preserves_quoted_value_on_rewrite_with_trailing_comment() -> None:
     """Rewriting a quoted-with-hash value preserves the trailing comment.
 
@@ -689,6 +739,31 @@ def test_rewrite_api_encryption_key_skips_secret_indirection() -> None:
 def test_rewrite_api_encryption_key_skips_substitution_indirection() -> None:
     """``key: ${api_key}`` stays untouched, same reasoning as ``!secret``."""
     yaml = "api:\n  encryption:\n    key: ${api_key}\n"
+    assert rewrite_api_encryption_key(yaml, "NEW==") == yaml
+
+
+def test_rewrite_api_encryption_key_skips_quoted_substitution_indirection() -> None:
+    """``key: "${api_key}"`` stays untouched.
+
+    Same intent as the unquoted ``${...}`` case — the value points
+    at a substitution defined elsewhere, so swapping it for a
+    fresh literal would silently desync the rendered config.
+    Earlier versions only matched the ``${`` prefix on the raw
+    quoted value (``"${api_key}"`` doesn't start with ``${``) and
+    would falsely overwrite. Strip quotes before the prefix check.
+    """
+    yaml = 'api:\n  encryption:\n    key: "${api_key}"\n'
+    assert rewrite_api_encryption_key(yaml, "NEW==") == yaml
+
+
+def test_rewrite_api_encryption_key_skips_quoted_secret_indirection() -> None:
+    """``key: "!secret api_key"`` stays untouched.
+
+    Same fix as the substitution case — a quoted ``!secret``
+    indirection is unusual but valid YAML, and rewriting it would
+    desync from the secrets file the source pointed at.
+    """
+    yaml = 'api:\n  encryption:\n    key: "!secret api_key"\n'
     assert rewrite_api_encryption_key(yaml, "NEW==") == yaml
 
 

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -451,6 +451,63 @@ def test_rewrite_yaml_scalar_skips_list_items() -> None:
     assert out == yaml
 
 
+def test_rewrite_yaml_scalar_pops_deeper_frames_at_next_list_item() -> None:
+    """A list-item line at indent N pops every frame at indent ≥ N.
+
+    Pin the inner-pop branch in the list-item handling: when the
+    walker encounters a second list item at the same indent as the
+    first, the first item's contents (which got pushed onto the
+    stack as ``(indent, key)`` frames) must be popped so the new
+    item starts with a clean ancestor chain. Without this, a leaf
+    inside the second item would inherit the previous item's
+    keys in its ancestor check.
+    """
+    # Two ``sensor:`` list items. After processing item 1's
+    # ``name: first``, the stack has ``[(0,"sensor"), (2,"-list-"),
+    # (4,"name")]``. The next item's ``- platform: bme280`` at
+    # indent 2 must pop both ``name`` and the previous list frame
+    # before pushing a fresh list frame.
+    yaml = "sensor:\n  - platform: dht\n    name: first\n  - platform: bme280\n    name: second\n"
+    captured: list[str] = []
+
+    def _capture(raw: str) -> str | None:
+        captured.append(raw)
+        return None
+
+    # Path that doesn't match anything walks the whole document
+    # without an early return — exercises the full pop-then-push
+    # sequence at every list item without short-circuiting on the
+    # first match.
+    rewrite_yaml_scalar(yaml, ("never", "matches"), _capture)
+    assert captured == []  # no leaf at the off-path target
+
+
+def test_rewrite_yaml_scalar_skips_block_scalar_continuation_lines() -> None:
+    """Lines inside a ``|`` block scalar don't match the mapping-key regex.
+
+    Pin the ``not m: continue`` branch: a block scalar's
+    continuation lines (like ``multi-line content`` here) don't
+    satisfy ``_MAPPING_KEY_LINE``'s anchor and aren't list items
+    either, so the walker just skips them without touching the
+    stack. The leaf at the right path further down should still
+    match correctly.
+    """
+    yaml = (
+        "esphome:\n"
+        "  name: kitchen\n"
+        "  comment: |\n"
+        "    multi-line description\n"
+        "    spanning two lines\n"
+        "wifi:\n"
+        "  ssid: home\n"
+    )
+    out = rewrite_yaml_scalar(yaml, ("wifi", "ssid"), lambda _: "renamed")
+    assert "  ssid: renamed\n" in out
+    # Block scalar contents are pure text — must not be modified.
+    assert "    multi-line description\n" in out
+    assert "    spanning two lines\n" in out
+
+
 def test_rewrite_yaml_scalar_passes_raw_value_to_transform() -> None:
     """Transform sees the value with quotes intact, comment stripped.
 

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -29,9 +29,13 @@ import pytest
 
 from esphome_device_builder.helpers.yaml import (
     _splice_into_domain_block,
+    generate_api_encryption_key,
     generate_component_yaml,
     merge_component_yaml,
+    rewrite_api_encryption_key,
     rewrite_esphome_name,
+    rewrite_friendly_name,
+    rewrite_yaml_scalar,
 )
 from esphome_device_builder.models.components import (
     ComponentCatalogEntry,
@@ -185,6 +189,239 @@ def test_rewrite_esphome_name_handles_quoted_value() -> None:
     yaml = 'esphome:\n  name: "kitchen"\n'
     out = rewrite_esphome_name(yaml, "kitchen", "kitchen-2")
     assert "name: kitchen-2" in out
+
+
+# ---------------------------------------------------------------------------
+# rewrite_yaml_scalar (the generic walker)
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_yaml_scalar_walks_arbitrary_path() -> None:
+    """The walker locates a leaf at any nested path the caller supplies.
+
+    Pin that the abstraction isn't hardcoded to the three known
+    callers — a future caller (``logger:`` log levels,
+    ``substitutions:`` keys, etc.) gets the same machinery for free.
+    """
+    yaml = "logger:\n  level: INFO\n  logs:\n    api: WARN\n    wifi: VERBOSE\n"
+    out = rewrite_yaml_scalar(yaml, ("logger", "logs", "api"), lambda _: "DEBUG")
+    assert "    api: DEBUG\n" in out
+    # Sibling untouched.
+    assert "    wifi: VERBOSE\n" in out
+
+
+def test_rewrite_yaml_scalar_transform_returning_none_is_a_noop() -> None:
+    """A transform that returns ``None`` leaves the file unchanged.
+
+    Callers signal "matched but don't rewrite" (e.g. the encryption
+    key path skips ``!secret`` indirections) by returning ``None``;
+    the helper must round-trip the input verbatim then.
+    """
+    yaml = "esphome:\n  name: kitchen\n"
+    assert rewrite_yaml_scalar(yaml, ("esphome", "name"), lambda _: None) == yaml
+
+
+def test_rewrite_yaml_scalar_ignores_lookalike_at_wrong_path() -> None:
+    """A leaf key that matches name but lives elsewhere stays put.
+
+    ``name:`` under ``wifi:`` shares the leaf key with
+    ``esphome.name`` — the path-aware walker must reject the wrong
+    parent chain.
+    """
+    yaml = "esphome:\n  name: kitchen\nwifi:\n  name: home_network\n"
+    out = rewrite_yaml_scalar(yaml, ("esphome", "name"), lambda _: "kitchen-2")
+    assert "  name: kitchen-2\n" in out
+    assert "  name: home_network\n" in out  # untouched
+
+
+def test_rewrite_yaml_scalar_only_rewrites_first_match() -> None:
+    """Pathological YAMLs with two sibling keys: only the first is touched.
+
+    Well-formed configs declare each path once, but the helper's
+    behaviour on duplicates is documented as "first match wins" so
+    callers don't have to defend against it.
+    """
+    yaml = "esphome:\n  name: first\n  name: second\n"
+    out = rewrite_yaml_scalar(yaml, ("esphome", "name"), lambda _: "renamed")
+    assert "  name: renamed\n" in out
+    # Second occurrence stays put (and would still be rejected by
+    # ESPHome at compile time — the helper doesn't fix duplicate
+    # keys, just doesn't make them worse).
+    assert "  name: second\n" in out
+
+
+def test_rewrite_yaml_scalar_empty_path_is_a_noop() -> None:
+    """An empty path is meaningless; helper returns the input unchanged."""
+    yaml = "esphome:\n  name: kitchen\n"
+    assert rewrite_yaml_scalar(yaml, (), lambda _: "x") == yaml
+
+
+def test_rewrite_yaml_scalar_skips_list_items() -> None:
+    """A ``- key: value`` line under a mapping doesn't satisfy the path.
+
+    The walker only matches plain mapping nesting — the path
+    ``("sensor", "name")`` shouldn't accidentally rewrite a sensor
+    list-item's ``name:``. (List support would land as a separate
+    feature with explicit semantics.)
+    """
+    yaml = "sensor:\n  - platform: dht\n    name: first\n"
+    out = rewrite_yaml_scalar(yaml, ("sensor", "name"), lambda _: "x")
+    assert out == yaml
+
+
+def test_rewrite_yaml_scalar_passes_raw_value_to_transform() -> None:
+    """Transform sees the value with quotes intact, comment stripped.
+
+    ``rewrite_api_encryption_key`` relies on the
+    ``!secret`` / ``${`` prefix check working on the raw value;
+    if the helper stripped quotes for the transform, ``!secret``
+    would still parse but a future caller looking for a quoted
+    sentinel would fail. Pin the contract.
+    """
+    seen: list[str] = []
+
+    def _capture(raw: str) -> str | None:
+        seen.append(raw)
+        return None
+
+    rewrite_yaml_scalar(
+        'esphome:\n  name: "kitchen"  # primary device\n',
+        ("esphome", "name"),
+        _capture,
+    )
+    assert seen == ['"kitchen"']
+
+
+# ---------------------------------------------------------------------------
+# rewrite_friendly_name
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_friendly_name_swaps_value_under_esphome_block() -> None:
+    """Happy path: ``friendly_name:`` under ``esphome:`` updates."""
+    yaml = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
+    assert rewrite_friendly_name(yaml, "Living Room") == (
+        "esphome:\n  name: kitchen\n  friendly_name: Living Room\n"
+    )
+
+
+def test_rewrite_friendly_name_no_friendly_name_line_returns_input() -> None:
+    """Returns the original text when ``esphome:`` has no friendly_name yet.
+
+    Caller (``clone_device``) decides whether to insert one — the
+    helper signals "nothing matched" via the no-op return so the
+    caller can detect the missing line without re-parsing.
+    """
+    yaml = "esphome:\n  name: kitchen\n"
+    assert rewrite_friendly_name(yaml, "Living Room") == yaml
+
+
+def test_rewrite_friendly_name_ignores_lookalike_in_other_block() -> None:
+    """A stray ``friendly_name:`` outside ``esphome:`` doesn't get touched.
+
+    Substitutions or packages occasionally carry a
+    ``friendly_name:`` field; the rewrite must leave them alone so
+    the swap doesn't corrupt unrelated config.
+    """
+    yaml = (
+        "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
+        "substitutions:\n  friendly_name: Old Sub\n"
+    )
+    out = rewrite_friendly_name(yaml, "Living Room")
+    assert "friendly_name: Living Room" in out
+    assert "friendly_name: Old Sub" in out
+
+
+def test_rewrite_friendly_name_preserves_trailing_comment() -> None:
+    """Trailing ``# comment`` survives the rewrite."""
+    yaml = "esphome:\n  friendly_name: Kitchen  # primary device\n"
+    out = rewrite_friendly_name(yaml, "Living Room")
+    assert out == "esphome:\n  friendly_name: Living Room  # primary device\n"
+
+
+# ---------------------------------------------------------------------------
+# rewrite_api_encryption_key
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_api_encryption_key_swaps_literal_value() -> None:
+    """Literal key under ``api: -> encryption:`` gets replaced.
+
+    The replacement is rendered double-quoted so a base64 value
+    that happens to start with a YAML special character
+    (``!``/``%``/``@``/``-``/``?``/``&``/``*``) parses cleanly.
+    """
+    yaml = 'api:\n  encryption:\n    key: "OLDKEYBASE64=="\n'
+    out = rewrite_api_encryption_key(yaml, "NEWKEYBASE64==")
+    assert out == ('api:\n  encryption:\n    key: "NEWKEYBASE64=="\n')
+
+
+def test_rewrite_api_encryption_key_no_api_block_returns_input() -> None:
+    """No ``api:`` block at all → no-op."""
+    yaml = "esphome:\n  name: kitchen\nwifi:\n  ssid: home\n"
+    assert rewrite_api_encryption_key(yaml, "NEW==") == yaml
+
+
+def test_rewrite_api_encryption_key_no_encryption_block_returns_input() -> None:
+    """``api:`` exists but plaintext (no encryption block) → no-op."""
+    yaml = "api:\n  password: hunter2\n"
+    assert rewrite_api_encryption_key(yaml, "NEW==") == yaml
+
+
+def test_rewrite_api_encryption_key_skips_secret_indirection() -> None:
+    """``key: !secret api_key`` stays untouched.
+
+    The indirection points at content the clone shares with its
+    source on disk. Replacing the indirection name with a literal
+    here would silently desync the rendered config from
+    ``secrets.yaml``.
+    """
+    yaml = "api:\n  encryption:\n    key: !secret api_key\n"
+    assert rewrite_api_encryption_key(yaml, "NEW==") == yaml
+
+
+def test_rewrite_api_encryption_key_skips_substitution_indirection() -> None:
+    """``key: ${api_key}`` stays untouched, same reasoning as ``!secret``."""
+    yaml = "api:\n  encryption:\n    key: ${api_key}\n"
+    assert rewrite_api_encryption_key(yaml, "NEW==") == yaml
+
+
+def test_rewrite_api_encryption_key_ignores_lookalike_outside_encryption() -> None:
+    """A ``key:`` under another block (remote_receiver button code) doesn't flip."""
+    yaml = (
+        "api:\n"
+        "  encryption:\n"
+        '    key: "OLDKEYBASE64=="\n'
+        "remote_receiver:\n"
+        "  - platform: rc_switch\n"
+        "    key: 0xABCDEF12\n"
+    )
+    out = rewrite_api_encryption_key(yaml, "NEW==")
+    assert 'key: "NEW=="' in out
+    assert "key: 0xABCDEF12" in out
+
+
+def test_rewrite_api_encryption_key_handles_block_with_comments() -> None:
+    """Comment-only / blank lines inside ``api: encryption:`` don't confuse the walker."""
+    yaml = (
+        "api:\n"
+        "  # encryption block — generated by the wizard\n"
+        "  encryption:\n"
+        "\n"
+        '    key: "OLDKEYBASE64=="  # do not share\n'
+    )
+    out = rewrite_api_encryption_key(yaml, "NEW==")
+    assert 'key: "NEW=="  # do not share' in out
+
+
+def test_generate_api_encryption_key_yields_distinct_base64_values() -> None:
+    """Two consecutive calls must return different keys (cryptographic randomness)."""
+    a = generate_api_encryption_key()
+    b = generate_api_encryption_key()
+    assert a != b
+    # 32 raw bytes → 44 base64 chars including padding.
+    assert len(a) == 44
+    assert len(b) == 44
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -28,7 +28,9 @@ from typing import Any
 import pytest
 
 from esphome_device_builder.helpers.yaml import (
+    _safe_yaml_scalar,
     _splice_into_domain_block,
+    _strip_yaml_quotes,
     generate_api_encryption_key,
     generate_component_yaml,
     merge_component_yaml,
@@ -36,7 +38,6 @@ from esphome_device_builder.helpers.yaml import (
     read_yaml_scalar,
     rewrite_api_encryption_key,
     rewrite_esphome_name,
-    rewrite_friendly_name,
     rewrite_name_or_substitution,
     rewrite_yaml_scalar,
 )
@@ -350,6 +351,33 @@ def test_read_yaml_scalar_returns_empty_string_for_empty_value() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_rewrite_yaml_scalar_rejects_off_path_nested_match() -> None:
+    """A leaf at the right depth but wrong ancestor chain doesn't match.
+
+    Pin the soundness fix for an earlier bug: tracking only on-path
+    ancestors meant a YAML like ``api: {something: {encryption:
+    {key: ...}}}`` would falsely satisfy the path
+    ``("api", "encryption", "key")`` because ``something`` was
+    invisible to the ancestor check. The walker now pushes every
+    mapping key — on-path or not — so off-path branches show up in
+    the ancestor chain and the comparison fails correctly.
+    """
+    yaml = (
+        "api:\n"
+        "  something:\n"
+        "    encryption:\n"
+        '      key: "off-path-value"\n'
+        "  encryption:\n"
+        '    key: "real-value"\n'
+    )
+    out = rewrite_yaml_scalar(yaml, ("api", "encryption", "key"), lambda _raw: '"new-key"')
+    # Off-path leaf untouched.
+    assert '      key: "off-path-value"' in out
+    # On-path leaf rewritten.
+    assert '    key: "new-key"' in out
+    assert "real-value" not in out
+
+
 def test_rewrite_yaml_scalar_walks_arbitrary_path() -> None:
     """The walker locates a leaf at any nested path the caller supplies.
 
@@ -447,50 +475,77 @@ def test_rewrite_yaml_scalar_passes_raw_value_to_transform() -> None:
 
 
 # ---------------------------------------------------------------------------
-# rewrite_friendly_name
+# _safe_yaml_scalar / _strip_yaml_quotes
 # ---------------------------------------------------------------------------
 
 
-def test_rewrite_friendly_name_swaps_value_under_esphome_block() -> None:
-    """Happy path: ``friendly_name:`` under ``esphome:`` updates."""
-    yaml = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
-    assert rewrite_friendly_name(yaml, "Living Room") == (
-        "esphome:\n  name: kitchen\n  friendly_name: Living Room\n"
-    )
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Plain identifiers / slugs round-trip unquoted.
+        ("Kitchen", "Kitchen"),
+        ("my-device", "my-device"),
+        ("acfloatmonitor32", "acfloatmonitor32"),
+        # Embedded sequences that flip a plain scalar into something
+        # else MUST be quoted: ``# comment`` (the value would become
+        # a comment) and ``: `` (would split into a key/value pair).
+        ("Bedroom #2", '"Bedroom #2"'),
+        ("Lamp: Bedroom", '"Lamp: Bedroom"'),
+        # Leading indicator characters force quoting.
+        ("!escaped", '"!escaped"'),
+        ("- danger", '"- danger"'),
+        ("@host", '"@host"'),
+        # Trailing colon would parse as a key with empty value.
+        ("Kitchen:", '"Kitchen:"'),
+        # Reserved bool / null plain scalars must be quoted to stay strings.
+        ("yes", '"yes"'),
+        ("Off", '"Off"'),
+        ("null", '"null"'),
+        ("", '""'),
+        # Embedded quotes / backslashes ARE valid in plain scalars
+        # (YAML parses them as literal characters). We don't quote
+        # for them; only leading indicators / comment markers /
+        # key-value splits force quoting.
+        ('Lamp "Bright"', 'Lamp "Bright"'),
+        ("path\\sub", "path\\sub"),
+        # Newlines / tabs become escape sequences inside quotes.
+        ("line1\nline2", '"line1\\nline2"'),
+    ],
+)
+def test_safe_yaml_scalar(value: str, expected: str) -> None:
+    """Pin the plain-vs-quoted rendering decisions on the user-facing values.
 
-
-def test_rewrite_friendly_name_no_friendly_name_line_returns_input() -> None:
-    """Returns the original text when ``esphome:`` has no friendly_name yet.
-
-    Caller (``clone_device``) decides whether to insert one — the
-    helper signals "nothing matched" via the no-op return so the
-    caller can detect the missing line without re-parsing.
+    ``rewrite_friendly_name`` and ``rewrite_name_or_substitution``
+    accept arbitrary strings — including ones a YAML parser would
+    interpret as comments / structure markers / reserved words.
+    Without this normalisation a friendly name like ``Bedroom #2``
+    would round-trip as ``Bedroom`` (everything after `` #`` becomes
+    a comment) and ``yes`` would parse back as a boolean.
     """
-    yaml = "esphome:\n  name: kitchen\n"
-    assert rewrite_friendly_name(yaml, "Living Room") == yaml
+    assert _safe_yaml_scalar(value) == expected
 
 
-def test_rewrite_friendly_name_ignores_lookalike_in_other_block() -> None:
-    """A stray ``friendly_name:`` outside ``esphome:`` doesn't get touched.
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("kitchen", "kitchen"),
+        ('"kitchen"', "kitchen"),
+        ("'kitchen'", "kitchen"),
+        ("  kitchen  ", "kitchen"),
+        ('  "kitchen"  ', "kitchen"),
+        # Mismatched / single quote is not stripped.
+        ('"kitchen', '"kitchen'),
+        ("'kitchen\"", "'kitchen\""),
+    ],
+)
+def test_strip_yaml_quotes(value: str, expected: str) -> None:
+    """Pin the quote-strip helper's accept / reject contract.
 
-    Substitutions or packages occasionally carry a
-    ``friendly_name:`` field; the rewrite must leave them alone so
-    the swap doesn't corrupt unrelated config.
+    Used by ``parse_substitution_ref`` and the rename gate to
+    compare an inline value against an unquoted target without
+    crashing on unquoted values or eating partial quotes.
     """
-    yaml = (
-        "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
-        "substitutions:\n  friendly_name: Old Sub\n"
-    )
-    out = rewrite_friendly_name(yaml, "Living Room")
-    assert "friendly_name: Living Room" in out
-    assert "friendly_name: Old Sub" in out
-
-
-def test_rewrite_friendly_name_preserves_trailing_comment() -> None:
-    """Trailing ``# comment`` survives the rewrite."""
-    yaml = "esphome:\n  friendly_name: Kitchen  # primary device\n"
-    out = rewrite_friendly_name(yaml, "Living Room")
-    assert out == "esphome:\n  friendly_name: Living Room  # primary device\n"
+    assert _strip_yaml_quotes(value) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -32,9 +32,12 @@ from esphome_device_builder.helpers.yaml import (
     generate_api_encryption_key,
     generate_component_yaml,
     merge_component_yaml,
+    parse_substitution_ref,
+    read_yaml_scalar,
     rewrite_api_encryption_key,
     rewrite_esphome_name,
     rewrite_friendly_name,
+    rewrite_name_or_substitution,
     rewrite_yaml_scalar,
 )
 from esphome_device_builder.models.components import (
@@ -76,7 +79,7 @@ def test_rewrite_esphome_name_swaps_value_under_esphome_block() -> None:
     what the wizard emits.
     """
     yaml = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
-    assert rewrite_esphome_name(yaml, "kitchen", "kitchen-2") == (
+    assert rewrite_esphome_name(yaml, "kitchen-2", only_if_current="kitchen") == (
         "esphome:\n  name: kitchen-2\n  friendly_name: Kitchen\n"
     )
 
@@ -93,7 +96,7 @@ def test_rewrite_esphome_name_returns_original_when_no_match() -> None:
     is its own concern; this test stays focused on the helper.
     """
     yaml = "esphome:\n  name: kitchen\n"
-    assert rewrite_esphome_name(yaml, "garage", "garage-2") == yaml
+    assert rewrite_esphome_name(yaml, "garage-2", only_if_current="garage") == yaml
 
 
 def test_rewrite_esphome_name_ignores_lookalike_in_other_block() -> None:
@@ -109,7 +112,7 @@ def test_rewrite_esphome_name_ignores_lookalike_in_other_block() -> None:
         "wifi:\n  ssid: kitchen\n"
         "sensor:\n  - platform: dht\n    name: kitchen\n"
     )
-    out = rewrite_esphome_name(yaml, "kitchen", "kitchen-2")
+    out = rewrite_esphome_name(yaml, "kitchen-2", only_if_current="kitchen")
     assert "name: kitchen-2" in out
     assert "ssid: kitchen\n" in out  # untouched
     assert "    name: kitchen\n" in out  # sensor untouched
@@ -122,7 +125,7 @@ def test_rewrite_esphome_name_preserves_trailing_comment() -> None:
     every rename would be a noisy regression.
     """
     yaml = "esphome:\n  name: kitchen  # primary device\n"
-    out = rewrite_esphome_name(yaml, "kitchen", "kitchen-2")
+    out = rewrite_esphome_name(yaml, "kitchen-2", only_if_current="kitchen")
     assert out == "esphome:\n  name: kitchen-2  # primary device\n"
 
 
@@ -145,7 +148,7 @@ def test_rewrite_esphome_name_no_match_walks_past_sibling_top_level_blocks() -> 
     """
     yaml = "esphome:\n  name: kitchen\nwifi:\n  ssid: home\n"
     # ``other`` doesn't match ``kitchen`` → no rewrite, walker runs to EOF.
-    assert rewrite_esphome_name(yaml, "other", "renamed") == yaml
+    assert rewrite_esphome_name(yaml, "renamed", only_if_current="other") == yaml
 
 
 def test_rewrite_esphome_name_walks_past_non_name_lines_and_other_blocks() -> None:
@@ -172,7 +175,7 @@ def test_rewrite_esphome_name_walks_past_non_name_lines_and_other_blocks() -> No
         "  ssid: home\n"
         "  name: kitchen\n"  # would-be lookalike under wifi block
     )
-    out = rewrite_esphome_name(yaml, "kitchen", "kitchen-2")
+    out = rewrite_esphome_name(yaml, "kitchen-2", only_if_current="kitchen")
     assert "  name: kitchen-2\n" in out
     # Wi-Fi's ``name:`` lookalike survives — the block-exit branch did its job.
     assert out.count("name: kitchen\n") == 1
@@ -187,8 +190,159 @@ def test_rewrite_esphome_name_handles_quoted_value() -> None:
     sees "no match" for a name they can clearly read in the file.
     """
     yaml = 'esphome:\n  name: "kitchen"\n'
-    out = rewrite_esphome_name(yaml, "kitchen", "kitchen-2")
+    out = rewrite_esphome_name(yaml, "kitchen-2", only_if_current="kitchen")
     assert "name: kitchen-2" in out
+
+
+def test_rewrite_esphome_name_unconditional_replaces_regardless_of_value() -> None:
+    """Default mode (no ``only_if_current``) replaces whatever's there.
+
+    Pin the clone-path's behaviour: a YAML whose ``esphome.name``
+    has drifted from its filename (hand-edited config, or a
+    ``name: $hostname`` substitution where the literal in the YAML
+    is ``$hostname``) still gets the new name landed on the line.
+    The gated mode used by ``_manual_rename`` is opt-in via the
+    keyword arg.
+    """
+    yaml = "esphome:\n  name: my-kitchen-bulb\n  friendly_name: Kitchen\n"
+    out = rewrite_esphome_name(yaml, "bedroom-bulb")
+    assert "  name: bedroom-bulb\n" in out
+    assert "my-kitchen-bulb" not in out
+
+
+def test_rewrite_esphome_name_unconditional_replaces_substituted_name() -> None:
+    """Unconditional replace works when the source uses ``$var`` substitutions.
+
+    The literal value on the ``name:`` line is ``$hostname``, not
+    the resolved string. A gated rewrite keyed on the filename
+    would no-op; the unconditional path lands the new name and
+    drops the substitution dependency for the cloned device.
+    """
+    yaml = "esphome:\n  name: $hostname\n"
+    out = rewrite_esphome_name(yaml, "bedroom-bulb")
+    assert out == "esphome:\n  name: bedroom-bulb\n"
+
+
+# ---------------------------------------------------------------------------
+# parse_substitution_ref / rewrite_name_or_substitution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("$devicename", "devicename"),
+        ("${devicename}", "devicename"),
+        ('"$devicename"', "devicename"),
+        ("'${devicename}'", "devicename"),
+        ("  ${devicename}  ", "devicename"),
+        ("kitchen", None),
+        ("$1bad", None),  # name must start with letter / underscore
+        ("my-${suffix}", None),  # mixed value, not a pure ref
+        ("${a}${b}", None),  # multiple refs
+        ("", None),
+    ],
+)
+def test_parse_substitution_ref(value: str, expected: str | None) -> None:
+    """Pin the variable-name parser's accept / reject contract.
+
+    Pure references (``$var`` / ``${var}`` optionally quoted)
+    return the variable name; anything with extra glue or a
+    malformed identifier returns ``None`` so the caller falls
+    back to a literal rewrite rather than wreck a partial match.
+    """
+    assert parse_substitution_ref(value) == expected
+
+
+def test_rewrite_name_or_substitution_redirects_through_substitution() -> None:
+    """The wizard / dashboard_import shape: name lives in substitutions.
+
+    ``esphome.name: ${devicename}`` paired with
+    ``substitutions.devicename: kitchen`` is the canonical pattern
+    ESPHome's wizard emits. Rewriting the leaf with a literal
+    would orphan the substitution and break any other consumer
+    (a sensor named ``${devicename}_temp``, etc.). Pin that the
+    rewrite walks to the substitution definition instead.
+    """
+    yaml = (
+        "substitutions:\n"
+        "  devicename: acfloatmonitor32\n"
+        "  friendly_name: AC Float Monitor 32\n"
+        "esphome:\n"
+        "  name: ${devicename}\n"
+        "  friendly_name: ${friendly_name}\n"
+    )
+    out = rewrite_name_or_substitution(yaml, ("esphome", "name"), "bedroom-bulb")
+    # Substitution definition flipped, leaf still references the var.
+    assert "  devicename: bedroom-bulb\n" in out
+    assert "  name: ${devicename}\n" in out
+    # Other substitutions untouched.
+    assert "  friendly_name: AC Float Monitor 32\n" in out
+
+
+def test_rewrite_name_or_substitution_falls_through_to_literal() -> None:
+    """A literal value gets rewritten on the leaf line directly."""
+    yaml = "esphome:\n  name: kitchen\n"
+    out = rewrite_name_or_substitution(yaml, ("esphome", "name"), "bedroom-bulb")
+    assert out == "esphome:\n  name: bedroom-bulb\n"
+
+
+def test_rewrite_name_or_substitution_handles_dollar_form() -> None:
+    """Both ``$var`` and ``${var}`` reference shapes redirect."""
+    yaml = "substitutions:\n  devicename: kitchen\nesphome:\n  name: $devicename\n"
+    out = rewrite_name_or_substitution(yaml, ("esphome", "name"), "bedroom-bulb")
+    assert "  devicename: bedroom-bulb\n" in out
+    assert "  name: $devicename\n" in out
+
+
+def test_rewrite_name_or_substitution_falls_through_when_substitution_not_local() -> None:
+    """A leaf that references an unresolved variable rewrites the leaf.
+
+    The substitutions block is in a package / ``!include``d file
+    we can't see — better to land the literal on the leaf than
+    silently no-op. The user can then edit the package definition
+    if they want substitution-driven cloning.
+    """
+    yaml = "esphome:\n  name: ${devicename}\n"
+    out = rewrite_name_or_substitution(yaml, ("esphome", "name"), "bedroom-bulb")
+    assert "  name: bedroom-bulb\n" in out
+
+
+def test_rewrite_name_or_substitution_handles_mixed_value_via_leaf() -> None:
+    """Partial reference (``${prefix}-suffix``) rewrites the leaf, not the prefix.
+
+    Splitting ``${prefix}-suffix`` into a substitution rewrite +
+    suffix preservation isn't possible without changing what
+    ``${prefix}`` resolves to elsewhere. Land the new value as a
+    literal on the leaf and let the user clean up.
+    """
+    yaml = "substitutions:\n  prefix: my\nesphome:\n  name: ${prefix}-suffix\n"
+    out = rewrite_name_or_substitution(yaml, ("esphome", "name"), "bedroom-bulb")
+    assert "  prefix: my\n" in out  # untouched
+    assert "  name: bedroom-bulb\n" in out  # leaf flipped to literal
+
+
+# ---------------------------------------------------------------------------
+# read_yaml_scalar
+# ---------------------------------------------------------------------------
+
+
+def test_read_yaml_scalar_returns_raw_value_with_quotes_intact() -> None:
+    """``read_yaml_scalar`` returns what the rewrite transform would see."""
+    yaml = 'esphome:\n  name: "kitchen"  # primary\n'
+    assert read_yaml_scalar(yaml, ("esphome", "name")) == '"kitchen"'
+
+
+def test_read_yaml_scalar_returns_none_when_path_missing() -> None:
+    """Missing path → ``None``."""
+    yaml = "esphome:\n  name: kitchen\n"
+    assert read_yaml_scalar(yaml, ("api", "encryption", "key")) is None
+
+
+def test_read_yaml_scalar_returns_empty_string_for_empty_value() -> None:
+    """Empty scalar → ``""`` (distinguishable from missing path's ``None``)."""
+    yaml = "esphome:\n  name: \n"
+    assert read_yaml_scalar(yaml, ("esphome", "name")) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -508,6 +508,46 @@ def test_rewrite_yaml_scalar_skips_block_scalar_continuation_lines() -> None:
     assert "    spanning two lines\n" in out
 
 
+def test_rewrite_yaml_scalar_honours_hash_inside_quoted_value() -> None:
+    r"""A ``#`` inside a quoted scalar is part of the value, not a comment.
+
+    Earlier draft used ``re.compile(r"^(.*?)(\s+#.*)?$")`` which
+    splits at the first ``\s+#`` regardless of quote state.
+    Reading ``friendly_name: "Bedroom #2"`` would then yield raw
+    value ``"Bedroom`` (truncated) and any subsequent rewrite
+    would corrupt the line. Pin that the splitter walks through
+    quoted strings without splitting.
+    """
+    captured: list[str] = []
+
+    def _capture(raw: str) -> str | None:
+        captured.append(raw)
+        return None
+
+    rewrite_yaml_scalar(
+        'esphome:\n  friendly_name: "Bedroom #2"  # the bedroom\n',
+        ("esphome", "friendly_name"),
+        _capture,
+    )
+    assert captured == ['"Bedroom #2"']
+
+
+def test_rewrite_yaml_scalar_preserves_quoted_value_on_rewrite_with_trailing_comment() -> None:
+    """Rewriting a quoted-with-hash value preserves the trailing comment.
+
+    Pin the round-trip: the value ``"Bedroom #2"`` reads back as
+    a single quoted scalar, gets rewritten to a new quoted
+    scalar, and the trailing ``# the bedroom`` comment survives.
+    """
+    yaml = 'esphome:\n  friendly_name: "Bedroom #2"  # the bedroom\n'
+    out = rewrite_yaml_scalar(
+        yaml,
+        ("esphome", "friendly_name"),
+        lambda _raw: '"Bedroom #3"',
+    )
+    assert out == 'esphome:\n  friendly_name: "Bedroom #3"  # the bedroom\n'
+
+
 def test_rewrite_yaml_scalar_passes_raw_value_to_transform() -> None:
     """Transform sees the value with quotes intact, comment stripped.
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a `devices/clone` WS command for fast same-config fleet provisioning. Closes esphome/feature-requests#2851.

The use case: someone buys 10 of the same device (light bulbs, plugs, etc.), flashes the first one, and wants to spin up nine more configs that mirror the first but each have their own hostname / friendly name / API endpoint. Today they have to copy-paste the YAML manually and fix up identity fields by hand. After this change a single dialog produces a fresh, ready-to-flash YAML.

The clone copies the source's components and wiring intact but takes:

- a fresh `esphome.name` (mDNS hostname / API endpoint),
- a fresh `esphome.friendly_name` (defaults to the slug-derived form of `new_name`; caller can override),
- a freshly-generated `api.encryption.key` so two siblings don't share encryption material — compromise of one device must not compromise the others.

Indirections (`!secret api_key` / `${api_key}`) are preserved deliberately — the indirection target is shared with the source on disk, so swapping the indirection name to a fresh literal would silently desync the rendered config.

**Refactor along the way:** the three call sites that rewrite scalars in user YAML (`rewrite_esphome_name`, `rewrite_friendly_name`, `rewrite_api_encryption_key`) shared the same shape — walk the file line-by-line, find a key at a given parent path, swap the value preserving indentation / trailing comments. Consolidated into a single `rewrite_yaml_scalar(yaml_text, path, transform)` walker driven by a callback; the three concrete helpers are now thin wrappers. The walker handles arbitrary mapping paths and correctly skips list-item nesting (`sensor: -name: foo` does NOT satisfy `("sensor", "name")`), so a future caller wanting `logger.logs.api` or `substitutions.<key>` gets the same machinery for free.

## Why line-based string edits instead of a YAML library

This came up on review, worth pinning the trade-off:

- **`pyyaml`** (already a dep, used for *reading* YAML via `esphome.yaml_util`) loses comments, blank lines, and quote style on round-trip. Useless for in-place edits to user-edited config — a `safe_load` → mutate → `safe_dump` would clobber every comment and reflow the file.
- **`ruamel.yaml`** does round-trip-preserving edits but isn't currently a dependency. Adopting it for the four targeted edits we do (`esphome.name`, `friendly_name`, `api.encryption.key`, `substitutions.<var>`) would be a much bigger commitment than the helpers it would replace, and even ruamel sometimes normalises quoting / indent / flow style.
- **What upstream esphome itself does** for the same job: pure regex on raw YAML text. See `esphome/__main__.py` `command_rename` — `re.sub` against the file contents, with the same `\$\{?name\}?$` substitution-detection shape used here. It refuses "complex YAML" rather than handle every edge case.

`rewrite_yaml_scalar` is a more general / more careful version of that exact pattern — path-aware (so off-path lookalikes don't false-match), list-item-aware (so leaves nested in a list can't satisfy a plain mapping path), and quote-state-aware (so `friendly_name: "Bedroom #2"` doesn't mis-split at the `#`). All formatting / comments / quote style survives untouched, which matters because users hand-edit these configs and review the diffs after a clone.

## Implementation notes

- `clone_device` runs only two executor hops total: one read phase that bundles the existence checks + source read + metadata read, one write phase that bundles the exclusive YAML write + metadata sidecar.
- No StorageJSON init — `load_device_from_storage` already handles a missing sidecar by reading the YAML, and the first compile writes a real one. The wizard-style stub-init that `create_device` does is belt-and-suspenders we don't need to duplicate for clones.
- User-correctable failures (empty `new_name`, same-name as source, target collision, missing source, source has no inline `esphome.name`) raise typed `CommandError(INVALID_ARGS, ...)` so the clone dialog can show specific messages instead of the WS layer's generic "Command failed" fallback.

**Related issue or feature (if applicable):**

- fixes esphome/feature-requests#2851

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#203

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
