### PR TITLE
Rename HA add-on dropdown options to "Home Assistant App"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,7 +55,7 @@ body:
         - Wheel from a GitHub release
         - From source (script/setup)
         - ESPHome container (preview toggle)
-        - Home Assistant add-on (preview toggle)
+        - Home Assistant App (preview toggle)
         - Other / not sure
     validations:
       required: true
@@ -70,7 +70,7 @@ body:
         - Local — macOS
         - Local — Windows
         - Docker container
-        - Home Assistant add-on
+        - Home Assistant App
         - Other
     validations:
       required: true


### PR DESCRIPTION
# What does this implement/fix?

Updates the install-method and environment dropdowns in the bug report issue template to use the new "Home Assistant App" branding instead of "Home Assistant add-on".

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.