### PR TITLE
Filter component sidebar counts by the active search/exclude/platform

### DIFF
--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -380,7 +380,19 @@ class ComponentCatalog:
             total=total,
             offset=offset,
             limit=limit,
-            categories=self._categories_for_board(board_id),
+            # Sidebar counts share the request's filters (query, exclusions,
+            # platform) so they reflect what's actually findable in the
+            # current view. The selected ``category`` is intentionally not
+            # applied — the user needs to see the *other* categories to
+            # navigate between them. Categories with zero post-filter
+            # matches are dropped from the response so the frontend can
+            # hide empty buckets without a parallel scan.
+            categories=self._categories_for_board(
+                board_id,
+                query=query,
+                exclude_set=exclude_set,
+                target_platform=target_platform,
+            ),
         )
 
     def get_featured_record(self, component_id: str) -> _FeaturedRecord | None:
@@ -416,13 +428,51 @@ class ComponentCatalog:
             if ids:
                 self._featured_by_board[board.id] = ids
 
-    def _categories_for_board(self, board_id: str | None) -> list[dict[str, str | int]]:
-        """Build the category list, optionally with a per-board ``featured`` count."""
+    def _categories_for_board(
+        self,
+        board_id: str | None,
+        *,
+        query: str | None = None,
+        exclude_set: set[str] | None = None,
+        target_platform: str | None = None,
+    ) -> list[dict[str, str | int]]:
+        """Build the category list, optionally with a per-board ``featured`` count.
+
+        With no kwargs this returns the full unfiltered catalog
+        breakdown — the shape used by the standalone
+        ``components/get_categories`` endpoint. ``get_components`` passes
+        its own ``query`` / ``exclude_category`` / ``platform`` filters
+        through so the sidebar counts in its response stay in lockstep
+        with the components the user actually sees. Categories whose
+        post-filter count drops to zero are omitted entirely (issue #380).
+        """
+        query_lower = query.lower() if query else None
         counts: dict[str, int] = {}
         for comp in self._components:
+            if exclude_set is not None and comp.category in exclude_set:
+                continue
+            if (
+                target_platform
+                and comp.supported_platforms
+                and target_platform not in comp.supported_platforms
+            ):
+                continue
+            if query_lower and not (
+                query_lower in comp.name.lower()
+                or query_lower in comp.description.lower()
+                or query_lower in comp.id.lower()
+            ):
+                continue
             counts[comp.category] = counts.get(comp.category, 0) + 1
         if board_id:
-            featured_count = len(self._featured_by_board.get(board_id, []))
+            # Featured rides on the same query — when the user is searching,
+            # the badge should drop to the matches (or vanish entirely).
+            if query_lower is not None:
+                featured_count = len(
+                    self._featured_components_for_board(board_id, target_platform, query)
+                )
+            else:
+                featured_count = len(self._featured_by_board.get(board_id, []))
             if featured_count:
                 counts[ComponentCategory.FEATURED.value] = featured_count
         return sorted(

--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -380,13 +380,10 @@ class ComponentCatalog:
             total=total,
             offset=offset,
             limit=limit,
-            # Sidebar counts share the request's filters (query, exclusions,
-            # platform) so they reflect what's actually findable in the
-            # current view. The selected ``category`` is intentionally not
-            # applied — the user needs to see the *other* categories to
-            # navigate between them. Categories with zero post-filter
-            # matches are dropped from the response so the frontend can
-            # hide empty buckets without a parallel scan.
+            # Sidebar counts share the request's filters so they reflect
+            # what's actually findable. ``category`` is intentionally
+            # left out — the user needs to see the *other* categories
+            # to navigate between them.
             categories=self._categories_for_board(
                 board_id,
                 query=query,
@@ -436,15 +433,16 @@ class ComponentCatalog:
         exclude_set: set[str] | None = None,
         target_platform: str | None = None,
     ) -> list[dict[str, str | int]]:
-        """Build the category list, optionally with a per-board ``featured`` count.
+        """
+        Return the catalog category list, sorted by count desc then name.
 
-        With no kwargs this returns the full unfiltered catalog
-        breakdown — the shape used by the standalone
-        ``components/get_categories`` endpoint. ``get_components`` passes
-        its own ``query`` / ``exclude_category`` / ``platform`` filters
-        through so the sidebar counts in its response stay in lockstep
-        with the components the user actually sees. Categories whose
-        post-filter count drops to zero are omitted entirely (issue #380).
+        Each entry is a ``{id, name, count}`` dict. With no kwargs
+        the counts cover the full catalog. Pass any of ``query`` /
+        ``exclude_set`` / ``target_platform`` to apply the same
+        filters used by :meth:`get_components`; categories whose
+        post-filter count is zero are omitted. ``board_id`` adds
+        the synthetic ``featured`` entry when the board has
+        matching recommendations.
         """
         query_lower = query.lower() if query else None
         counts: dict[str, int] = {}
@@ -465,8 +463,8 @@ class ComponentCatalog:
                 continue
             counts[comp.category] = counts.get(comp.category, 0) + 1
         if board_id:
-            # Featured rides on the same query — when the user is searching,
-            # the badge should drop to the matches (or vanish entirely).
+            # Featured rides on the same query so the badge drops to
+            # the matches (or vanishes) while the user is searching.
             if query_lower is not None:
                 featured_count = len(
                     self._featured_components_for_board(board_id, target_platform, query)

--- a/tests/controllers/test_components.py
+++ b/tests/controllers/test_components.py
@@ -242,14 +242,11 @@ async def test_get_components_query_matches_name_description_or_id() -> None:
 
 
 async def test_get_components_response_categories_track_query_filter() -> None:
-    """Sidebar counts in the response narrow with ``query`` (issue #380).
+    """
+    Response ``categories`` reflect the active ``query``.
 
-    Before this fix, ``categories`` always carried the unfiltered
-    catalog totals — so typing ``debug`` left the sidebar showing
-    "Sensor (277)" while the grid only had a handful of matches. The
-    fix shares the same query/exclusion/platform filters with the
-    counter, and zero-count buckets drop out entirely so the
-    frontend can hide them naturally.
+    Buckets with no post-filter matches drop out entirely so the
+    frontend can hide empty categories.
     """
     cat = ComponentCatalog()
     cat._components = [
@@ -262,19 +259,16 @@ async def test_get_components_response_categories_track_query_filter() -> None:
 
     res = await cat.get_components(query="debug")
     counts = {c["id"]: c["count"] for c in res.categories}
-    # Only the matching ``debug`` entry contributes — its bucket is the
-    # one we expect, and the unrelated buckets are absent (not zero).
+    # The non-matching buckets are absent from the response (not zero).
     assert counts == {ComponentCategory.CORE.value: 1}
 
 
 async def test_get_components_response_categories_ignore_selected_category() -> None:
-    """A selected ``category`` doesn't shrink the sidebar — only ``query`` does.
+    """
+    A selected ``category`` doesn't shrink the sidebar.
 
-    The user picks a category to scope the *grid*; the sidebar still
-    needs to show every category as a navigable option, otherwise
-    they couldn't switch back. Excluded / platform / query filters
-    apply (they describe what's findable at all), but ``category``
-    itself doesn't.
+    The user needs every category visible to navigate between
+    them; only query / exclude / platform narrow the bucket list.
     """
     cat = ComponentCatalog()
     cat._components = [
@@ -306,7 +300,6 @@ async def test_get_components_response_categories_honor_exclude_and_platform() -
     ]
     cat._by_id = {c.id: c for c in cat._components}
 
-    # exclude_category drops the bucket entirely.
     res = await cat.get_components(exclude_category=ComponentCategory.CORE.value)
     assert all(c["id"] != ComponentCategory.CORE.value for c in res.categories)
 
@@ -320,11 +313,11 @@ async def test_get_components_response_categories_honor_exclude_and_platform() -
 
 
 async def test_get_categories_endpoint_unaffected_by_query_filter_change() -> None:
-    """The standalone ``get_categories`` endpoint stays unfiltered.
+    """
+    The standalone ``get_categories`` endpoint stays unfiltered.
 
-    Only ``get_components``' embedded sidebar counts share its
-    filters — the standalone endpoint has no request-side filters
-    to honour and continues to return the full catalog breakdown.
+    Only ``get_components`` shares its request filters with the
+    counter; ``get_categories`` always returns the full breakdown.
     """
     cat = ComponentCatalog()
     cat._components = [

--- a/tests/controllers/test_components.py
+++ b/tests/controllers/test_components.py
@@ -241,6 +241,108 @@ async def test_get_components_query_matches_name_description_or_id() -> None:
     assert {c.id for c in res.components} == {"dht"}
 
 
+async def test_get_components_response_categories_track_query_filter() -> None:
+    """Sidebar counts in the response narrow with ``query`` (issue #380).
+
+    Before this fix, ``categories`` always carried the unfiltered
+    catalog totals — so typing ``debug`` left the sidebar showing
+    "Sensor (277)" while the grid only had a handful of matches. The
+    fix shares the same query/exclusion/platform filters with the
+    counter, and zero-count buckets drop out entirely so the
+    frontend can hide them naturally.
+    """
+    cat = ComponentCatalog()
+    cat._components = [
+        _make_entry(entry_id="dht", name="DHT", category=ComponentCategory.SENSOR),
+        _make_entry(entry_id="bme280", name="BME280", category=ComponentCategory.SENSOR),
+        _make_entry(entry_id="debug", name="Debug", category=ComponentCategory.CORE),
+        _make_entry(entry_id="gpio", name="GPIO", category=ComponentCategory.SWITCH),
+    ]
+    cat._by_id = {c.id: c for c in cat._components}
+
+    res = await cat.get_components(query="debug")
+    counts = {c["id"]: c["count"] for c in res.categories}
+    # Only the matching ``debug`` entry contributes — its bucket is the
+    # one we expect, and the unrelated buckets are absent (not zero).
+    assert counts == {ComponentCategory.CORE.value: 1}
+
+
+async def test_get_components_response_categories_ignore_selected_category() -> None:
+    """A selected ``category`` doesn't shrink the sidebar — only ``query`` does.
+
+    The user picks a category to scope the *grid*; the sidebar still
+    needs to show every category as a navigable option, otherwise
+    they couldn't switch back. Excluded / platform / query filters
+    apply (they describe what's findable at all), but ``category``
+    itself doesn't.
+    """
+    cat = ComponentCatalog()
+    cat._components = [
+        _make_entry(entry_id="dht", category=ComponentCategory.SENSOR),
+        _make_entry(entry_id="gpio", category=ComponentCategory.SWITCH),
+    ]
+    cat._by_id = {c.id: c for c in cat._components}
+
+    res = await cat.get_components(category=ComponentCategory.SENSOR.value)
+    ids = {c["id"] for c in res.categories}
+    assert ids == {ComponentCategory.SENSOR.value, ComponentCategory.SWITCH.value}
+
+
+async def test_get_components_response_categories_honor_exclude_and_platform() -> None:
+    """``exclude_category`` and ``platform`` filters drop matching buckets too."""
+    cat = ComponentCatalog()
+    cat._components = [
+        _make_entry(entry_id="wifi", category=ComponentCategory.CORE),
+        _make_entry(
+            entry_id="esp32-only",
+            category=ComponentCategory.SENSOR,
+            supported_platforms=["esp32"],
+        ),
+        _make_entry(
+            entry_id="esp8266-only",
+            category=ComponentCategory.SWITCH,
+            supported_platforms=["esp8266"],
+        ),
+    ]
+    cat._by_id = {c.id: c for c in cat._components}
+
+    # exclude_category drops the bucket entirely.
+    res = await cat.get_components(exclude_category=ComponentCategory.CORE.value)
+    assert all(c["id"] != ComponentCategory.CORE.value for c in res.categories)
+
+    # ``esp8266-only`` is platform-incompatible and shouldn't contribute.
+    res = await cat.get_components(platform="esp32")
+    counts = {c["id"]: c["count"] for c in res.categories}
+    assert counts == {
+        ComponentCategory.CORE.value: 1,
+        ComponentCategory.SENSOR.value: 1,
+    }
+
+
+async def test_get_categories_endpoint_unaffected_by_query_filter_change() -> None:
+    """The standalone ``get_categories`` endpoint stays unfiltered.
+
+    Only ``get_components``' embedded sidebar counts share its
+    filters — the standalone endpoint has no request-side filters
+    to honour and continues to return the full catalog breakdown.
+    """
+    cat = ComponentCatalog()
+    cat._components = [
+        _make_entry(entry_id="dht", category=ComponentCategory.SENSOR),
+        _make_entry(entry_id="gpio", category=ComponentCategory.SWITCH),
+        _make_entry(entry_id="wifi", category=ComponentCategory.CORE),
+    ]
+    cat._by_id = {c.id: c for c in cat._components}
+
+    cats = await cat.get_categories()
+    counts = {c["id"]: c["count"] for c in cats}
+    assert counts == {
+        ComponentCategory.SENSOR.value: 1,
+        ComponentCategory.SWITCH.value: 1,
+        ComponentCategory.CORE.value: 1,
+    }
+
+
 # ── _build_featured_registry() ──────────────────────────────────────
 
 

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -280,11 +280,11 @@ async def test_get_categories_no_featured_without_board(
 async def test_get_components_response_categories_filter_featured_by_query(
     catalog: ComponentCatalog,
 ) -> None:
-    """The featured count in the sidebar tracks the search query (issue #380).
+    """
+    The synthetic ``featured`` sidebar bucket tracks the query.
 
-    With a query that matches no featured component on the board,
-    the synthetic ``featured`` bucket should drop out so the
-    frontend can hide it.
+    Present when at least one featured component matches, absent
+    otherwise.
     """
     page = await catalog.get_components(
         board_id="apollo-esk-1",
@@ -292,8 +292,6 @@ async def test_get_components_response_categories_filter_featured_by_query(
     )
     assert all(c["id"] != "featured" for c in page.categories)
 
-    # And when the query *does* hit a featured entry the bucket
-    # appears with a count matching the materialised matches.
     page = await catalog.get_components(board_id="apollo-esk-1", query="pir")
     featured = next(c for c in page.categories if c["id"] == "featured")
     assert int(featured["count"]) >= 1

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -277,6 +277,28 @@ async def test_get_categories_no_featured_without_board(
     assert all(c["id"] != "featured" for c in cats)
 
 
+async def test_get_components_response_categories_filter_featured_by_query(
+    catalog: ComponentCatalog,
+) -> None:
+    """The featured count in the sidebar tracks the search query (issue #380).
+
+    With a query that matches no featured component on the board,
+    the synthetic ``featured`` bucket should drop out so the
+    frontend can hide it.
+    """
+    page = await catalog.get_components(
+        board_id="apollo-esk-1",
+        query="zzz-no-such-featured-component",
+    )
+    assert all(c["id"] != "featured" for c in page.categories)
+
+    # And when the query *does* hit a featured entry the bucket
+    # appears with a count matching the materialised matches.
+    page = await catalog.get_components(board_id="apollo-esk-1", query="pir")
+    featured = next(c for c in page.categories if c["id"] == "featured")
+    assert int(featured["count"]) >= 1
+
+
 # ---------------------------------------------------------------------------
 # Add-path preset application
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #380.

Typing in the Add Components search box left the category sidebar showing the unfiltered catalog totals (and surfaced categories with no matches), because `_categories_for_board()` was always counting from the full catalog regardless of the request's filters.

- Pass `get_components`'s `query` / `exclude_category` / `platform` through to the counter so the sidebar tracks the same filters as the grid.
- Drop zero-count buckets from the response so the frontend can hide empty categories naturally.
- Apply the same query to the per-board `featured` count so its badge follows the search too.
- The standalone `components/get_categories` endpoint stays unfiltered (no request context to honour).