### PR TITLE
generate-release-notes: prefix frontend PR refs with `frontend`

### DIFF
--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -209,13 +209,15 @@ def render_change_line(template: str, change: dict[str, Any]) -> str:
     For backend PRs we emit ``#NNN`` literally — GitHub auto-links to
     the surrounding repo, which is the right destination. For frontend
     bullets we pre-substitute ``#$NUMBER`` with an explicit markdown
-    link to the frontend PR; otherwise the same auto-link logic would
-    silently re-resolve the number against the backend repo and either
-    point at the wrong PR or render as a dead link.
+    link to the frontend PR, prefixed with ``frontend`` so readers can
+    tell at a glance which repo the number belongs to; otherwise the
+    same auto-link logic would silently re-resolve the number against
+    the backend repo and either point at the wrong PR or render as a
+    dead link.
     """
     line = template
     if change.get("is_frontend"):
-        line = line.replace("#$NUMBER", f"[#{change['number']}]({change['url']})")
+        line = line.replace("#$NUMBER", f"[frontend#{change['number']}]({change['url']})")
     line = line.replace("$TITLE", str(change["title"]))
     line = line.replace("$AUTHOR", str(change["author"]))
     line = line.replace("$NUMBER", str(change["number"]))

--- a/.github/actions/generate-release-notes/test_generate_notes.py
+++ b/.github/actions/generate-release-notes/test_generate_notes.py
@@ -197,9 +197,10 @@ def test_render_change_line_frontend_emits_explicit_link(gen):
         },
     )
     # Frontend lines must hard-code the URL: the same ``#42`` would
-    # otherwise auto-resolve against the backend repo.
+    # otherwise auto-resolve against the backend repo. The ``frontend``
+    # prefix on the link text disambiguates which repo the PR lives in.
     assert line == (
-        "- [#42](https://github.com/esphome/device-builder-frontend/pull/42) - "
+        "- [frontend#42](https://github.com/esphome/device-builder-frontend/pull/42) - "
         "Fix something (@alice)"
     )
 
@@ -241,7 +242,10 @@ def test_build_release_notes_renders_backend_and_frontend_together(gen):
     assert "_Changes since [0.1.24](https://github.com/owner/backend/releases/tag/0.1.24)_" in notes
     assert "### 🐛 Bug fixes" in notes
     assert "- #1 - Fix backend (@alice)" in notes
-    assert "- [#200](https://github.com/owner/frontend/pull/200) - Fix frontend (@bob)" in notes
+    assert (
+        "- [frontend#200](https://github.com/owner/frontend/pull/200) - Fix frontend (@bob)"
+        in notes
+    )
     # Empty categories are dropped entirely — no Dependencies / CI section here.
     assert "Dependencies" not in notes
 


### PR DESCRIPTION
# What does this implement/fix?

In the rendered release notes, frontend PR references are now linked as `frontend#NNN` instead of `#NNN`. The bare-number form looked like a sibling backend PR when interleaved under the same category, since GitHub's auto-link hint is only carried by the backend's literal `#NNN`. The `frontend` prefix on the link text disambiguates which repo the number belongs to at a glance.

**Related issue or feature (if applicable):**

-

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.