### PR TITLE
Route legacy /compile and /upload through the firmware queue

### DIFF
--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -30,7 +30,7 @@ from aiohttp import web
 from esphome import yaml_util
 
 from ..helpers.api import CommandError
-from ..helpers.event_bus import Event
+from ..helpers.event_bus import Event, StreamControls, stream_events
 from ..helpers.json import (
     JSONDecodeError,
     dumps_str,
@@ -81,6 +81,39 @@ _TERMINAL_EVENT_TYPES = (
 _TERMINAL_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED})
 
 
+class _LegacyWSStreamClient:
+    """``stream_events`` client adapter that writes legacy WS frames.
+
+    ``stream_events`` is the project's standard event-bus → WS
+    pipeline, providing a bounded queue, drop-on-full / force-
+    enqueue / terminate semantics, and listener cleanup on cancel.
+    Reusing it here gives the legacy handler the same OOM
+    protection the multiplexed ``/ws`` follower commands get for
+    free.
+
+    The shape mismatch is small: ``stream_events`` calls
+    ``client.send_event(message_id, name, payload)`` for every
+    drained item, but the legacy protocol uses
+    ``{"event": <name>, "data": payload}`` for lines and
+    ``{"event": "exit", "code": payload}`` for the terminal frame.
+    This adapter does that translation. ``message_id`` is unused
+    by the legacy protocol — the per-WS connection IS the
+    addressing — so we ignore it.
+    """
+
+    def __init__(self, ws: web.WebSocketResponse) -> None:
+        self._ws = ws
+
+    async def send_event(self, _message_id: str, name: str, payload: object) -> None:
+        if name == "exit":
+            await self._ws.send_json({"event": "exit", "code": payload}, dumps=dumps_str)
+            return
+        # ``stream_events`` only ever forwards names this adapter
+        # registers via the ``handle_event`` callback below, so any
+        # other name here is a programming error worth surfacing.
+        await self._ws.send_json({"event": name, "data": payload}, dumps=dumps_str)
+
+
 async def _stream_job_to_legacy_ws(
     ws: web.WebSocketResponse,
     bus: EventBus,
@@ -96,36 +129,59 @@ async def _stream_job_to_legacy_ws(
     bus events (``JOB_OUTPUT`` / ``JOB_COMPLETED`` / ``JOB_FAILED``
     / ``JOB_CANCELLED``) and a buffered ``job.output`` list.
 
-    The race-free pattern:
+    Routes through ``helpers.event_bus.stream_events`` for the
+    core pipeline (subscribe, snapshot+replay, bounded drain,
+    listener cleanup on cancel). Three callbacks define the
+    behaviour:
 
-    1. Snapshot ``job.output`` (sync) — captures every line fired
-       so far. The snapshot is a fresh list copy via ``list(...)``
-       so a subsequent ``_trim_job_output`` reassign of
-       ``job.output`` (``firmware/helpers.py``) doesn't mutate
-       what we replay.
-    2. ``add_listener`` (sync) — attaches before any further
-       events fire. Steps 1 and 2 are sync-adjacent so no
-       coroutine yield can interleave a fire between them; the
-       runner's loop appends to ``job.output``, optionally trims
-       (which reassigns the list — irrelevant to our snapshot
-       copy), and fires ``JOB_OUTPUT`` in the same synchronous
-       block (``firmware/controller.py:899-918``), so a line can
-       either be in the snapshot OR caught by the listener, never
-       both and never neither.
-    3. Replay snapshot. Lines that arrive during the replay queue
-       up via the listener and are drained afterwards.
-    4. Drain the queue until a terminal event arrives.
+    - ``send_initial`` is awaited inside the listening block
+      *after* the listener attaches but *before* the live drain.
+      It snapshots ``job.output`` and replays it, then short-
+      circuits the drain via ``controls.end()`` if the job was
+      already in a terminal state at submit time.
+    - ``handle_event`` runs synchronously inside ``bus.fire`` and
+      decides what to push: lines go through ``controls.push``
+      (drop-on-full, slow follower stays unblocked), terminal
+      events go through ``controls.push_priority`` + ``end()``
+      (must-land, evicts oldest if needed) so the exit frame
+      always lands.
+    - ``_LegacyWSStreamClient.send_event`` translates each drained
+      ``(name, payload)`` into the legacy WS frame shape.
+
+    The race-free snapshot+subscribe ordering is provided by
+    ``stream_events``: the listener is attached before
+    ``send_initial`` is awaited (``event_bus.py`` docstring), so
+    every event fired post-subscribe lands in the queue, and the
+    snapshot is a fresh list copy via ``list(...)`` so a
+    subsequent ``_trim_job_output`` reassign of ``job.output``
+    (``firmware/helpers.py``) doesn't mutate what we replay.
     """
     job_id = job.job_id
+    snapshot = list(job.output)
+    initial_status = job.status
+    initial_exit_code = job.exit_code
 
-    # Pending items are tagged so the drain loop can route line
-    # frames vs. the terminal sentinel without a second lookup.
-    pending: asyncio.Queue[tuple[str, object]] = asyncio.Queue()
+    async def _send_initial(controls: StreamControls) -> None:
+        for line in snapshot:
+            await ws.send_json({"event": "line", "data": line}, dumps=dumps_str)
+        # ``compile`` / ``upload`` may resolve a job that's already
+        # in a terminal state — most common on a duplicate-submit
+        # supersede that lands the previous job in CANCELLED before
+        # the new one is created. Send the exit frame from the
+        # cached status and short-circuit the drain.
+        if initial_status in _TERMINAL_STATUSES:
+            code = initial_exit_code if initial_exit_code is not None else 1
+            await ws.send_json({"event": "exit", "code": code}, dumps=dumps_str)
+            controls.end()
 
-    def _on_event(event: Event) -> None:
+    def _handle_event(event: Event, controls: StreamControls) -> None:
         if event.event_type == EventType.JOB_OUTPUT:
             if event.data.get("job_id") == job_id:
-                pending.put_nowait(("line", event.data.get("line", "")))
+                # Drop-on-full: a slow client shouldn't block the
+                # synchronous ``bus.fire``; losing a line in the
+                # legacy stream is preferable to OOM-ing the
+                # dashboard process.
+                controls.push("line", event.data.get("line", ""))
             return
         ev_job = event.data.get("job")
         if ev_job is None or getattr(ev_job, "job_id", None) != job_id:
@@ -133,35 +189,22 @@ async def _stream_job_to_legacy_ws(
         # ``exit_code`` is None for cancelled / never-ran jobs;
         # legacy clients want a numeric code so coerce to a
         # generic failure (1) rather than serialising null.
+        # ``push_priority`` evicts the oldest queued line if the
+        # queue is full so the exit frame always lands —
+        # otherwise a backpressured client could see an open
+        # connection that never receives the terminal frame.
         code = getattr(ev_job, "exit_code", None)
-        pending.put_nowait(("exit", code if code is not None else 1))
+        controls.push_priority("exit", code if code is not None else 1)
+        controls.end()
 
-    snapshot = list(job.output)
-    initial_status = job.status
-    initial_exit_code = job.exit_code
-
-    with bus.listening((EventType.JOB_OUTPUT, *_TERMINAL_EVENT_TYPES), _on_event):
-        for line in snapshot:
-            await ws.send_json({"event": "line", "data": line}, dumps=dumps_str)
-
-        # ``compile`` / ``upload`` may resolve a job that's already
-        # in a terminal state — most common on a duplicate-submit
-        # supersede that lands the previous job in CANCELLED before
-        # the new one is created, but also any case where the job
-        # transitions during the snapshot above. Send the exit
-        # frame and bail.
-        if initial_status in _TERMINAL_STATUSES:
-            code = initial_exit_code if initial_exit_code is not None else 1
-            await ws.send_json({"event": "exit", "code": code}, dumps=dumps_str)
-            return
-
-        while True:
-            kind, payload = await pending.get()
-            if kind == "line":
-                await ws.send_json({"event": "line", "data": payload}, dumps=dumps_str)
-                continue
-            await ws.send_json({"event": "exit", "code": payload}, dumps=dumps_str)
-            return
+    await stream_events(
+        client=_LegacyWSStreamClient(ws),
+        message_id="",
+        bus=bus,
+        event_types=(EventType.JOB_OUTPUT, *_TERMINAL_EVENT_TYPES),
+        handle_event=_handle_event,
+        send_initial=_send_initial,
+    )
 
 
 async def _handle_legacy_ws_command(

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -42,13 +42,13 @@ from ..models import (
     TERMINAL_JOB_EVENTS,
     TERMINAL_JOB_STATUSES,
     EventType,
+    FirmwareJob,
     JobType,
 )
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
     from ..helpers.event_bus import EventBus
-    from ..models import FirmwareJob
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -103,15 +103,27 @@ async def _stream_job_to_legacy_ws(
     / ``JOB_CANCELLED``) and a buffered ``job.output`` list.
 
     Routes through ``helpers.event_bus.stream_events`` for the
-    core pipeline (subscribe, snapshot+replay, bounded drain,
-    listener cleanup on cancel). Three callbacks define the
-    behaviour:
+    core pipeline (subscribe, bounded drain, listener cleanup on
+    cancel). The execution order matters for race-freeness:
 
-    - ``send_initial`` is awaited inside the listening block
-      *after* the listener attaches but *before* the live drain.
-      It snapshots ``job.output`` and replays it, then short-
-      circuits the drain via ``controls.end()`` if the job was
-      already in a terminal state at submit time.
+    1. ``snapshot = list(job.output)`` — captured *outside*
+       ``stream_events``, in the same sync block that calls it.
+       This is what closes the snapshot/subscribe race; the
+       listener attaches inside ``stream_events`` before any
+       ``await`` yields control, so a line either lands in the
+       snapshot OR is caught by the listener (never both, never
+       neither).
+    2. ``stream_events(...)`` runs:
+       a. ``bus.listening(...)`` — attach listener (sync).
+       b. ``await send_initial(controls)`` — replay the
+          snapshot captured in step 1, and short-circuit the
+          drain via ``controls.end()`` if the job was already
+          in a terminal state at submit time.
+       c. Drain the queue, calling
+          ``_LegacyWSStreamClient.send_event`` for each item.
+
+    Two callbacks define the per-event behaviour:
+
     - ``handle_event`` runs synchronously inside ``bus.fire`` and
       decides what to push: lines go through ``controls.push``
       (drop-on-full, slow follower stays unblocked), terminal
@@ -121,11 +133,7 @@ async def _stream_job_to_legacy_ws(
     - ``_LegacyWSStreamClient.send_event`` translates each drained
       ``(name, payload)`` into the legacy WS frame shape.
 
-    The race-free snapshot+subscribe ordering is provided by
-    ``stream_events``: the listener is attached before
-    ``send_initial`` is awaited (``event_bus.py`` docstring), so
-    every event fired post-subscribe lands in the queue, and the
-    snapshot is a fresh list copy via ``list(...)`` so a
+    The snapshot is a fresh list copy via ``list(...)`` so a
     subsequent ``_trim_job_output`` reassign of ``job.output``
     (``firmware/helpers.py``) doesn't mutate what we replay.
     """
@@ -156,8 +164,17 @@ async def _stream_job_to_legacy_ws(
                 # dashboard process.
                 controls.push("line", event.data.get("line", ""))
             return
+        # ``isinstance`` narrows from the bus's untyped event-data
+        # dict to a real ``FirmwareJob``, which both filters out
+        # any future event payload that lacks the expected ``job``
+        # field and gives the type checker direct attribute
+        # access for ``job_id`` / ``exit_code``. The runner fires
+        # terminal events as ``{"job": job}`` so this matches in
+        # practice; a payload that doesn't satisfy the isinstance
+        # check is silently ignored rather than tearing the WS
+        # down with an ``AttributeError``.
         ev_job = event.data.get("job")
-        if ev_job is None or getattr(ev_job, "job_id", None) != job_id:
+        if not isinstance(ev_job, FirmwareJob) or ev_job.job_id != job_id:
             return
         # ``exit_code`` is None for cancelled / never-ran jobs;
         # legacy clients want a numeric code so coerce to a
@@ -166,8 +183,8 @@ async def _stream_job_to_legacy_ws(
         # queue is full so the exit frame always lands —
         # otherwise a backpressured client could see an open
         # connection that never receives the terminal frame.
-        code = getattr(ev_job, "exit_code", None)
-        controls.push_priority("exit", code if code is not None else 1)
+        code = ev_job.exit_code if ev_job.exit_code is not None else 1
+        controls.push_priority("exit", code)
         controls.end()
 
     await stream_events(
@@ -228,8 +245,19 @@ async def _handle_legacy_ws_command(
         if not isinstance(data, dict) or data.get("type") != "spawn":
             continue
 
+        # ``data.get(key, "")`` only uses the default when the
+        # key is *absent*; an explicit ``"configuration": null``
+        # (or a non-string like ``123`` / an object) would land
+        # here as a non-``str`` and crash the firmware
+        # controller's path validation with a ``TypeError`` /
+        # ``AttributeError`` that aiohttp would surface to HA as a
+        # connection drop. Reject anything that isn't a string up
+        # front via the protocol's only signalling channel.
         configuration = data.get("configuration", "")
         port = data.get("port", "") if job_type is JobType.UPLOAD else ""
+        if not isinstance(configuration, str) or not isinstance(port, str):
+            await ws.send_json({"event": "exit", "code": 1}, dumps=dumps_str)
+            break
 
         try:
             if job_type is JobType.UPLOAD:

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -47,6 +47,7 @@ from ..models import (
 )
 
 if TYPE_CHECKING:
+    from ..controllers.firmware import FirmwareController
     from ..device_builder import DeviceBuilder
     from ..helpers.event_bus import EventBus
 
@@ -54,37 +55,45 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class _LegacyWSStreamClient:
-    """``stream_events`` client adapter that writes legacy WS frames.
+def _line_frame(line: str) -> dict[str, object]:
+    """Build a legacy ``{event: "line", data: <chunk>}`` frame."""
+    return {"event": "line", "data": line}
 
-    ``stream_events`` is the project's standard event-bus → WS
-    pipeline, providing a bounded queue, drop-on-full / force-
-    enqueue / terminate semantics, and listener cleanup on cancel.
-    Reusing it here gives the legacy handler the same OOM
-    protection the multiplexed ``/ws`` follower commands get for
-    free.
 
-    The shape mismatch is small: ``stream_events`` calls
-    ``client.send_event(message_id, name, payload)`` for every
-    drained item, but the legacy protocol uses
-    ``{"event": <name>, "data": payload}`` for lines and
-    ``{"event": "exit", "code": payload}`` for the terminal frame.
-    This adapter does that translation. ``message_id`` is unused
-    by the legacy protocol — the per-WS connection IS the
-    addressing — so we ignore it.
+def _exit_frame(exit_code: int | None) -> dict[str, object]:
+    """Build a legacy ``{event: "exit", code: <int>}`` frame.
+
+    ``exit_code`` is ``None`` for cancelled / never-ran jobs;
+    legacy clients want a numeric code so coerce to a generic
+    failure (1) rather than serialising null.
+    """
+    return {"event": "exit", "code": exit_code if exit_code is not None else 1}
+
+
+class _LegacyWSWriter:
+    """``stream_events`` client adapter that writes pre-built frames.
+
+    ``stream_events``'s contract is ``send_event(message_id, name,
+    payload)`` per drained item; the legacy protocol has neither
+    addressing nor routing, so the adapter ignores the first two
+    args and forwards *payload* (a fully-formed legacy frame dict)
+    to ``ws.send_json``. Building the frame at the producer side
+    (in ``handle_event`` / ``send_initial``) keeps the adapter
+    one line and removes the stringly-typed name switch the
+    earlier version had.
     """
 
     def __init__(self, ws: web.WebSocketResponse) -> None:
         self._ws = ws
 
-    async def send_event(self, _message_id: str, name: str, payload: object) -> None:
-        if name == "exit":
-            await self._ws.send_json({"event": "exit", "code": payload}, dumps=dumps_str)
-            return
-        # ``stream_events`` only ever forwards names this adapter
-        # registers via the ``handle_event`` callback below, so any
-        # other name here is a programming error worth surfacing.
-        await self._ws.send_json({"event": name, "data": payload}, dumps=dumps_str)
+    async def send_event(self, _message_id: str, _name: str, payload: object) -> None:
+        await self._ws.send_json(payload, dumps=dumps_str)
+
+
+# Stream-event ``name`` field is unused by the legacy adapter
+# (the wire framing comes from the payload dict). Pass a single
+# constant so the producer side stays free of dummy strings.
+_FRAME = "frame"
 
 
 async def _stream_job_to_legacy_ws(
@@ -104,38 +113,33 @@ async def _stream_job_to_legacy_ws(
 
     Routes through ``helpers.event_bus.stream_events`` for the
     core pipeline (subscribe, bounded drain, listener cleanup on
-    cancel). The execution order matters for race-freeness:
+    cancel). Every wire frame travels the same path —
+    ``handle_event`` and ``send_initial`` build a legacy-frame
+    dict and push it through ``controls``; ``stream_events``
+    drains the queue and ``_LegacyWSWriter`` writes each dict to
+    the WS verbatim. No direct ``ws.send_json`` calls outside the
+    adapter.
 
-    1. ``snapshot = list(job.output)`` — captured *outside*
-       ``stream_events``, in the same sync block that calls it.
-       This is what closes the snapshot/subscribe race; the
-       listener attaches inside ``stream_events`` before any
-       ``await`` yields control, so a line either lands in the
-       snapshot OR is caught by the listener (never both, never
-       neither).
-    2. ``stream_events(...)`` runs:
-       a. ``bus.listening(...)`` — attach listener (sync).
-       b. ``await send_initial(controls)`` — replay the
-          snapshot captured in step 1, and short-circuit the
-          drain via ``controls.end()`` if the job was already
-          in a terminal state at submit time.
-       c. Drain the queue, calling
-          ``_LegacyWSStreamClient.send_event`` for each item.
+    The snapshot/subscribe race is closed at the call site:
 
-    Two callbacks define the per-event behaviour:
+    1. ``snapshot = list(job.output)`` is captured *outside*
+       ``stream_events`` — a fresh list copy so a later
+       ``_trim_job_output`` reassign of ``job.output``
+       (``firmware/helpers.py``) doesn't mutate what we replay.
+    2. ``stream_events`` attaches the listener (sync) before any
+       ``await`` yields control. No event can fire between the
+       snapshot in (1) and the listener attach in (2), so each
+       line lands in exactly one of the two — never both, never
+       neither.
+    3. ``send_initial`` pushes the snapshot frames synchronously
+       (no awaits between pushes) so they can't interleave with
+       live events that the listener queues after subscribe.
 
-    - ``handle_event`` runs synchronously inside ``bus.fire`` and
-      decides what to push: lines go through ``controls.push``
-      (drop-on-full, slow follower stays unblocked), terminal
-      events go through ``controls.push_priority`` + ``end()``
-      (must-land, evicts oldest if needed) so the exit frame
-      always lands.
-    - ``_LegacyWSStreamClient.send_event`` translates each drained
-      ``(name, payload)`` into the legacy WS frame shape.
-
-    The snapshot is a fresh list copy via ``list(...)`` so a
-    subsequent ``_trim_job_output`` reassign of ``job.output``
-    (``firmware/helpers.py``) doesn't mutate what we replay.
+    Capacity: ``stream_events`` defaults to a 4000-slot queue.
+    Lines push with drop-on-full (slow follower → drop, no
+    bus.fire blocking); the terminal frame pushes with
+    ``push_priority`` (force-enqueue, evicts oldest) so the
+    exit frame always lands even if the queue is saturated.
     """
     job_id = job.job_id
     snapshot = list(job.output)
@@ -144,51 +148,36 @@ async def _stream_job_to_legacy_ws(
 
     async def _send_initial(controls: StreamControls) -> None:
         for line in snapshot:
-            await ws.send_json({"event": "line", "data": line}, dumps=dumps_str)
+            controls.push(_FRAME, _line_frame(line))
         # ``compile`` / ``upload`` may resolve a job that's already
         # in a terminal state — most common on a duplicate-submit
         # supersede that lands the previous job in CANCELLED before
-        # the new one is created. Send the exit frame from the
+        # the new one is created. Push the exit frame from the
         # cached status and short-circuit the drain.
         if initial_status in TERMINAL_JOB_STATUSES:
-            code = initial_exit_code if initial_exit_code is not None else 1
-            await ws.send_json({"event": "exit", "code": code}, dumps=dumps_str)
+            controls.push_priority(_FRAME, _exit_frame(initial_exit_code))
             controls.end()
 
     def _handle_event(event: Event, controls: StreamControls) -> None:
         if event.event_type == EventType.JOB_OUTPUT:
             if event.data.get("job_id") == job_id:
-                # Drop-on-full: a slow client shouldn't block the
-                # synchronous ``bus.fire``; losing a line in the
-                # legacy stream is preferable to OOM-ing the
-                # dashboard process.
-                controls.push("line", event.data.get("line", ""))
+                controls.push(_FRAME, _line_frame(event.data.get("line", "")))
             return
-        # ``isinstance`` narrows from the bus's untyped event-data
-        # dict to a real ``FirmwareJob``, which both filters out
-        # any future event payload that lacks the expected ``job``
-        # field and gives the type checker direct attribute
-        # access for ``job_id`` / ``exit_code``. The runner fires
-        # terminal events as ``{"job": job}`` so this matches in
-        # practice; a payload that doesn't satisfy the isinstance
-        # check is silently ignored rather than tearing the WS
-        # down with an ``AttributeError``.
+        # Narrow the untyped ``event.data["job"]`` to a real
+        # ``FirmwareJob`` so the type checker sees direct
+        # attribute access for ``job_id`` / ``exit_code``. The
+        # runner fires terminal events as ``{"job": job}``;
+        # anything that doesn't satisfy the isinstance check is
+        # silently ignored rather than tearing the WS down with
+        # an ``AttributeError``.
         ev_job = event.data.get("job")
         if not isinstance(ev_job, FirmwareJob) or ev_job.job_id != job_id:
             return
-        # ``exit_code`` is None for cancelled / never-ran jobs;
-        # legacy clients want a numeric code so coerce to a
-        # generic failure (1) rather than serialising null.
-        # ``push_priority`` evicts the oldest queued line if the
-        # queue is full so the exit frame always lands —
-        # otherwise a backpressured client could see an open
-        # connection that never receives the terminal frame.
-        code = ev_job.exit_code if ev_job.exit_code is not None else 1
-        controls.push_priority("exit", code)
+        controls.push_priority(_FRAME, _exit_frame(ev_job.exit_code))
         controls.end()
 
     await stream_events(
-        client=_LegacyWSStreamClient(ws),
+        client=_LegacyWSWriter(ws),
         message_id="",
         bus=bus,
         event_types=(EventType.JOB_OUTPUT, *TERMINAL_JOB_EVENTS),
@@ -221,11 +210,9 @@ async def _handle_legacy_ws_command(
     # populates every controller before HTTP requests are served)
     # is pinned by
     # ``tests/test_device_builder_lifecycle.py::test_start_initialises_all_controllers``.
-    # By the time this handler runs, ``db.firmware`` is non-None
-    # (``db.bus`` is set in ``__init__`` so it's non-Optional from
-    # the type system's perspective). The ``assert`` narrows
-    # ``Optional[FirmwareController]`` for the call sites below
-    # without ``# type: ignore`` shims.
+    # By the time this handler runs, ``db.firmware`` is non-None;
+    # the ``assert`` narrows ``Optional[FirmwareController]`` for
+    # the call sites below without ``# type: ignore`` shims.
     db: DeviceBuilder = request.app["device_builder"]
     firmware = db.firmware
     bus = db.bus
@@ -233,7 +220,7 @@ async def _handle_legacy_ws_command(
 
     async for msg in ws:
         if msg.type != aiohttp.WSMsgType.TEXT:
-            break
+            return ws
         try:
             data = loads(msg.data)
         except JSONDecodeError:
@@ -245,39 +232,53 @@ async def _handle_legacy_ws_command(
         if not isinstance(data, dict) or data.get("type") != "spawn":
             continue
 
-        # ``data.get(key, "")`` only uses the default when the
-        # key is *absent*; an explicit ``"configuration": null``
-        # (or a non-string like ``123`` / an object) would land
-        # here as a non-``str`` and crash the firmware
-        # controller's path validation with a ``TypeError`` /
-        # ``AttributeError`` that aiohttp would surface to HA as a
-        # connection drop. Reject anything that isn't a string up
-        # front via the protocol's only signalling channel.
-        configuration = data.get("configuration", "")
-        port = data.get("port", "") if job_type is JobType.UPLOAD else ""
-        if not isinstance(configuration, str) or not isinstance(port, str):
-            await ws.send_json({"event": "exit", "code": 1}, dumps=dumps_str)
-            break
-
-        try:
-            if job_type is JobType.UPLOAD:
-                job = await firmware.upload(configuration=configuration, port=port)
-            else:
-                job = await firmware.compile(configuration=configuration)
-        except CommandError:
-            # Boundary / validation rejection. The legacy spawn
-            # protocol uses ``{event: "exit", code}`` as its only
-            # signalling channel — any non-zero code reads as
-            # "build failed" in HA's UI, matching the prior
-            # subprocess shape that surfaced the same rejection
-            # via ``code: 1``.
-            await ws.send_json({"event": "exit", "code": 1}, dumps=dumps_str)
-            break
-
-        await _stream_job_to_legacy_ws(ws, bus, job)
-        break
+        await _handle_spawn(ws, firmware, bus, job_type, data)
+        return ws
 
     return ws
+
+
+async def _handle_spawn(
+    ws: web.WebSocketResponse,
+    firmware: FirmwareController,
+    bus: EventBus,
+    job_type: JobType,
+    data: dict[str, object],
+) -> None:
+    """Run one spawn message: validate, submit, stream until terminal.
+
+    Three rejection paths all surface to HA via the protocol's
+    only signalling channel — a ``code: 1`` exit frame:
+
+    1. Non-string ``configuration`` / ``port`` (an explicit
+       ``null`` or a JSON number / object would otherwise crash
+       the firmware controller's path validation with a
+       ``TypeError`` / ``AttributeError`` that aiohttp would
+       surface as a connection drop).
+    2. ``CommandError`` from ``_validate_configuration_boundary``
+       (traversal, empty configuration, etc.).
+    3. Implicit on success after the streaming finishes.
+
+    Extracted from the receive loop so the per-message control
+    flow doesn't tangle with the loop's iteration / break
+    semantics.
+    """
+    configuration = data.get("configuration", "")
+    port = data.get("port", "") if job_type is JobType.UPLOAD else ""
+    if not isinstance(configuration, str) or not isinstance(port, str):
+        await ws.send_json(_exit_frame(1), dumps=dumps_str)
+        return
+
+    try:
+        if job_type is JobType.UPLOAD:
+            job = await firmware.upload(configuration=configuration, port=port)
+        else:
+            job = await firmware.compile(configuration=configuration)
+    except CommandError:
+        await ws.send_json(_exit_frame(1), dumps=dumps_str)
+        return
+
+    await _stream_job_to_legacy_ws(ws, bus, job)
 
 
 def create_legacy_routes() -> web.RouteTableDef:

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 
 import aiohttp
 from aiohttp import web
@@ -38,47 +38,20 @@ from ..helpers.json import (
     json_response,
     loads,
 )
-from ..models import EventType, JobStatus, JobType
+from ..models import (
+    TERMINAL_JOB_EVENTS,
+    TERMINAL_JOB_STATUSES,
+    EventType,
+    JobType,
+)
 
 if TYPE_CHECKING:
+    from ..device_builder import DeviceBuilder
     from ..helpers.event_bus import EventBus
     from ..models import FirmwareJob
 
 
-class _LegacyDB(Protocol):
-    """Narrow protocol for the bits of ``DeviceBuilder`` this module reads.
-
-    Avoids the circular-import / type-erasure pair the previous
-    ``db: object`` + ``# type: ignore[attr-defined]`` shape produced.
-    Both ``firmware`` and ``bus`` are typed as the wrapping
-    ``Optional`` because ``DeviceBuilder`` initialises them after
-    construction (``firmware`` in ``start``, ``bus`` in ``__init__``);
-    the production startup order guarantees they're set by the time
-    HTTP requests are served, but the legacy handler still defends
-    against ``None`` so a future startup-order regression fails
-    closed with a controlled exit frame instead of an
-    ``AttributeError`` that surfaces to HA as a connection drop.
-    """
-
-    bus: EventBus | None
-    # Forward-declare the firmware controller as ``object`` since
-    # importing it here would re-trigger the circular nudge that
-    # motivated the local terminal-event constants below.
-    firmware: object | None
-
-
 _LOGGER = logging.getLogger(__name__)
-
-# Mirrors ``firmware/constants.py``; redefined locally to avoid a
-# circular-import nudge between the API layer and the firmware
-# controller's private constants module. The set is small and
-# stable — three lifecycle events, one terminal status set.
-_TERMINAL_EVENT_TYPES = (
-    EventType.JOB_COMPLETED,
-    EventType.JOB_FAILED,
-    EventType.JOB_CANCELLED,
-)
-_TERMINAL_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED})
 
 
 class _LegacyWSStreamClient:
@@ -169,7 +142,7 @@ async def _stream_job_to_legacy_ws(
         # supersede that lands the previous job in CANCELLED before
         # the new one is created. Send the exit frame from the
         # cached status and short-circuit the drain.
-        if initial_status in _TERMINAL_STATUSES:
+        if initial_status in TERMINAL_JOB_STATUSES:
             code = initial_exit_code if initial_exit_code is not None else 1
             await ws.send_json({"event": "exit", "code": code}, dumps=dumps_str)
             controls.end()
@@ -201,7 +174,7 @@ async def _stream_job_to_legacy_ws(
         client=_LegacyWSStreamClient(ws),
         message_id="",
         bus=bus,
-        event_types=(EventType.JOB_OUTPUT, *_TERMINAL_EVENT_TYPES),
+        event_types=(EventType.JOB_OUTPUT, *TERMINAL_JOB_EVENTS),
         handle_event=_handle_event,
         send_initial=_send_initial,
     )
@@ -227,26 +200,19 @@ async def _handle_legacy_ws_command(
     """
     ws = web.WebSocketResponse()
     await ws.prepare(request)
-    db: _LegacyDB = request.app["device_builder"]
+    # The startup-order invariant (``DeviceBuilder.start()``
+    # populates every controller before HTTP requests are served)
+    # is pinned by
+    # ``tests/test_device_builder_lifecycle.py::test_start_initialises_all_controllers``.
+    # By the time this handler runs, ``db.firmware`` is non-None
+    # (``db.bus`` is set in ``__init__`` so it's non-Optional from
+    # the type system's perspective). The ``assert`` narrows
+    # ``Optional[FirmwareController]`` for the call sites below
+    # without ``# type: ignore`` shims.
+    db: DeviceBuilder = request.app["device_builder"]
     firmware = db.firmware
     bus = db.bus
-    # Defend against a startup-order regression: production sets
-    # both before serving HTTP, but a future refactor that flips
-    # that order would otherwise crash with ``AttributeError`` and
-    # surface to HA as a connection drop. Failing closed with a
-    # ``code: 1`` exit frame keeps the rejection on the legacy
-    # protocol's only signalling channel.
-    if firmware is None or bus is None:
-        _LOGGER.warning(
-            "Legacy %s WS rejected: device_builder not fully initialised (firmware=%s, bus=%s)",
-            request.path,
-            "set" if firmware is not None else "None",
-            "set" if bus is not None else "None",
-        )
-        async for _ in ws:
-            await ws.send_json({"event": "exit", "code": 1}, dumps=dumps_str)
-            break
-        return ws
+    assert firmware is not None
 
     async for msg in ws:
         if msg.type != aiohttp.WSMsgType.TEXT:
@@ -267,13 +233,9 @@ async def _handle_legacy_ws_command(
 
         try:
             if job_type is JobType.UPLOAD:
-                job = await firmware.upload(  # type: ignore[attr-defined]
-                    configuration=configuration, port=port
-                )
+                job = await firmware.upload(configuration=configuration, port=port)
             else:
-                job = await firmware.compile(  # type: ignore[attr-defined]
-                    configuration=configuration
-                )
+                job = await firmware.compile(configuration=configuration)
         except CommandError:
             # Boundary / validation rejection. The legacy spawn
             # protocol uses ``{event: "exit", code}`` as its only

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import aiohttp
 from aiohttp import web
@@ -41,7 +41,31 @@ from ..helpers.json import (
 from ..models import EventType, JobStatus, JobType
 
 if TYPE_CHECKING:
+    from ..helpers.event_bus import EventBus
     from ..models import FirmwareJob
+
+
+class _LegacyDB(Protocol):
+    """Narrow protocol for the bits of ``DeviceBuilder`` this module reads.
+
+    Avoids the circular-import / type-erasure pair the previous
+    ``db: object`` + ``# type: ignore[attr-defined]`` shape produced.
+    Both ``firmware`` and ``bus`` are typed as the wrapping
+    ``Optional`` because ``DeviceBuilder`` initialises them after
+    construction (``firmware`` in ``start``, ``bus`` in ``__init__``);
+    the production startup order guarantees they're set by the time
+    HTTP requests are served, but the legacy handler still defends
+    against ``None`` so a future startup-order regression fails
+    closed with a controlled exit frame instead of an
+    ``AttributeError`` that surfaces to HA as a connection drop.
+    """
+
+    bus: EventBus | None
+    # Forward-declare the firmware controller as ``object`` since
+    # importing it here would re-trigger the circular nudge that
+    # motivated the local terminal-event constants below.
+    firmware: object | None
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +83,7 @@ _TERMINAL_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobStatus
 
 async def _stream_job_to_legacy_ws(
     ws: web.WebSocketResponse,
-    db: object,
+    bus: EventBus,
     job: FirmwareJob,
 ) -> None:
     """
@@ -75,19 +99,23 @@ async def _stream_job_to_legacy_ws(
     The race-free pattern:
 
     1. Snapshot ``job.output`` (sync) — captures every line fired
-       so far.
+       so far. The snapshot is a fresh list copy via ``list(...)``
+       so a subsequent ``_trim_job_output`` reassign of
+       ``job.output`` (``firmware/helpers.py``) doesn't mutate
+       what we replay.
     2. ``add_listener`` (sync) — attaches before any further
        events fire. Steps 1 and 2 are sync-adjacent so no
        coroutine yield can interleave a fire between them; the
-       runner appends to ``job.output`` and fires ``JOB_OUTPUT``
-       in the same synchronous block, so a line can either be in
-       the snapshot OR caught by the listener, never both and
-       never neither.
+       runner's loop appends to ``job.output``, optionally trims
+       (which reassigns the list — irrelevant to our snapshot
+       copy), and fires ``JOB_OUTPUT`` in the same synchronous
+       block (``firmware/controller.py:899-918``), so a line can
+       either be in the snapshot OR caught by the listener, never
+       both and never neither.
     3. Replay snapshot. Lines that arrive during the replay queue
        up via the listener and are drained afterwards.
     4. Drain the queue until a terminal event arrives.
     """
-    bus = db.bus  # type: ignore[attr-defined]
     job_id = job.job_id
 
     # Pending items are tagged so the drain loop can route line
@@ -156,8 +184,26 @@ async def _handle_legacy_ws_command(
     """
     ws = web.WebSocketResponse()
     await ws.prepare(request)
-    db = request.app["device_builder"]
+    db: _LegacyDB = request.app["device_builder"]
     firmware = db.firmware
+    bus = db.bus
+    # Defend against a startup-order regression: production sets
+    # both before serving HTTP, but a future refactor that flips
+    # that order would otherwise crash with ``AttributeError`` and
+    # surface to HA as a connection drop. Failing closed with a
+    # ``code: 1`` exit frame keeps the rejection on the legacy
+    # protocol's only signalling channel.
+    if firmware is None or bus is None:
+        _LOGGER.warning(
+            "Legacy %s WS rejected: device_builder not fully initialised (firmware=%s, bus=%s)",
+            request.path,
+            "set" if firmware is not None else "None",
+            "set" if bus is not None else "None",
+        )
+        async for _ in ws:
+            await ws.send_json({"event": "exit", "code": 1}, dumps=dumps_str)
+            break
+        return ws
 
     async for msg in ws:
         if msg.type != aiohttp.WSMsgType.TEXT:
@@ -178,9 +224,13 @@ async def _handle_legacy_ws_command(
 
         try:
             if job_type is JobType.UPLOAD:
-                job = await firmware.upload(configuration=configuration, port=port)
+                job = await firmware.upload(  # type: ignore[attr-defined]
+                    configuration=configuration, port=port
+                )
             else:
-                job = await firmware.compile(configuration=configuration)
+                job = await firmware.compile(  # type: ignore[attr-defined]
+                    configuration=configuration
+                )
         except CommandError:
             # Boundary / validation rejection. The legacy spawn
             # protocol uses ``{event: "exit", code}`` as its only
@@ -191,7 +241,7 @@ async def _handle_legacy_ws_command(
             await ws.send_json({"event": "exit", "code": 1}, dumps=dumps_str)
             break
 
-        await _stream_job_to_legacy_ws(ws, db, job)
+        await _stream_job_to_legacy_ws(ws, bus, job)
         break
 
     return ws

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -9,20 +9,28 @@ HA uses:
 - GET /json-config?configuration=... (parsed YAML as JSON)
 - /compile (WebSocket, spawn protocol)
 - /upload (WebSocket, spawn protocol)
+
+The ``/compile`` and ``/upload`` WebSocket handlers route through the
+new firmware-job queue rather than spawning subprocesses directly.
+This is what makes HA-triggered builds show up alongside dashboard-
+triggered ones in the "Firmware tasks" panel — see issue #394. The
+legacy WS frame shape (``{event: "line", data}`` / ``{event: "exit",
+code}``) is preserved so unmodified ``esphome-dashboard-api``
+clients keep working.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import sys
-from typing import Any
+from typing import TYPE_CHECKING
 
 import aiohttp
 from aiohttp import web
 from esphome import yaml_util
 
 from ..helpers.api import CommandError
+from ..helpers.event_bus import Event
 from ..helpers.json import (
     JSONDecodeError,
     dumps_str,
@@ -30,69 +38,160 @@ from ..helpers.json import (
     json_response,
     loads,
 )
-from ..helpers.subprocess import create_subprocess_exec
+from ..models import EventType, JobStatus, JobType
+
+if TYPE_CHECKING:
+    from ..models import FirmwareJob
 
 _LOGGER = logging.getLogger(__name__)
 
-_ESPHOME_CMD = [sys.executable, "-m", "esphome"]
+# Mirrors ``firmware/constants.py``; redefined locally to avoid a
+# circular-import nudge between the API layer and the firmware
+# controller's private constants module. The set is small and
+# stable — three lifecycle events, one terminal status set.
+_TERMINAL_EVENT_TYPES = (
+    EventType.JOB_COMPLETED,
+    EventType.JOB_FAILED,
+    EventType.JOB_CANCELLED,
+)
+_TERMINAL_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED})
+
+
+async def _stream_job_to_legacy_ws(
+    ws: web.WebSocketResponse,
+    db: object,
+    job: FirmwareJob,
+) -> None:
+    """
+    Translate a firmware-job's output stream into the legacy WS frame shape.
+
+    The legacy protocol (the only one HA's ``esphome-dashboard-api``
+    speaks) expects ``{event: "line", data: <chunk>}`` per stdout
+    chunk and ``{event: "exit", code: <int>}`` once the build
+    finishes. The new firmware queue exposes those signals via
+    bus events (``JOB_OUTPUT`` / ``JOB_COMPLETED`` / ``JOB_FAILED``
+    / ``JOB_CANCELLED``) and a buffered ``job.output`` list.
+
+    The race-free pattern:
+
+    1. Snapshot ``job.output`` (sync) — captures every line fired
+       so far.
+    2. ``add_listener`` (sync) — attaches before any further
+       events fire. Steps 1 and 2 are sync-adjacent so no
+       coroutine yield can interleave a fire between them; the
+       runner appends to ``job.output`` and fires ``JOB_OUTPUT``
+       in the same synchronous block, so a line can either be in
+       the snapshot OR caught by the listener, never both and
+       never neither.
+    3. Replay snapshot. Lines that arrive during the replay queue
+       up via the listener and are drained afterwards.
+    4. Drain the queue until a terminal event arrives.
+    """
+    bus = db.bus  # type: ignore[attr-defined]
+    job_id = job.job_id
+
+    # Pending items are tagged so the drain loop can route line
+    # frames vs. the terminal sentinel without a second lookup.
+    pending: asyncio.Queue[tuple[str, object]] = asyncio.Queue()
+
+    def _on_event(event: Event) -> None:
+        if event.event_type == EventType.JOB_OUTPUT:
+            if event.data.get("job_id") == job_id:
+                pending.put_nowait(("line", event.data.get("line", "")))
+            return
+        ev_job = event.data.get("job")
+        if ev_job is None or getattr(ev_job, "job_id", None) != job_id:
+            return
+        # ``exit_code`` is None for cancelled / never-ran jobs;
+        # legacy clients want a numeric code so coerce to a
+        # generic failure (1) rather than serialising null.
+        code = getattr(ev_job, "exit_code", None)
+        pending.put_nowait(("exit", code if code is not None else 1))
+
+    snapshot = list(job.output)
+    initial_status = job.status
+    initial_exit_code = job.exit_code
+
+    with bus.listening((EventType.JOB_OUTPUT, *_TERMINAL_EVENT_TYPES), _on_event):
+        for line in snapshot:
+            await ws.send_json({"event": "line", "data": line}, dumps=dumps_str)
+
+        # ``compile`` / ``upload`` may resolve a job that's already
+        # in a terminal state — most common on a duplicate-submit
+        # supersede that lands the previous job in CANCELLED before
+        # the new one is created, but also any case where the job
+        # transitions during the snapshot above. Send the exit
+        # frame and bail.
+        if initial_status in _TERMINAL_STATUSES:
+            code = initial_exit_code if initial_exit_code is not None else 1
+            await ws.send_json({"event": "exit", "code": code}, dumps=dumps_str)
+            return
+
+        while True:
+            kind, payload = await pending.get()
+            if kind == "line":
+                await ws.send_json({"event": "line", "data": payload}, dumps=dumps_str)
+                continue
+            await ws.send_json({"event": "exit", "code": payload}, dumps=dumps_str)
+            return
 
 
 async def _handle_legacy_ws_command(
-    request: web.Request, command: str, extra_args_fn: Any = None
+    request: web.Request,
+    job_type: JobType,
 ) -> web.WebSocketResponse:
-    """Legacy spawn-based WebSocket handler."""
+    """Route a legacy ``/compile`` or ``/upload`` WS into the firmware queue.
+
+    The legacy spawn protocol still drives the wire shape:
+
+    - ``client → server``: ``{"type": "spawn", "configuration": "kitchen.yaml", "port": "..."}``
+    - ``server → client``: ``{"event": "line", "data": "<chunk>"}`` per stdout line
+    - ``server → client``: ``{"event": "exit", "code": <int>}`` on completion
+
+    What changed is *how* the build runs: instead of a per-WS
+    subprocess that bypasses the dashboard's bookkeeping, the
+    request is enqueued through the same ``FirmwareController``
+    the new dashboard uses, so the running build appears in the
+    "Firmware tasks" panel and survives a page refresh. Closes #394.
+    """
     ws = web.WebSocketResponse()
     await ws.prepare(request)
+    db = request.app["device_builder"]
+    firmware = db.firmware
 
     async for msg in ws:
         if msg.type != aiohttp.WSMsgType.TEXT:
             break
-
         try:
             data = loads(msg.data)
         except JSONDecodeError:
-            # Legacy clients shouldn't send non-JSON, but if one does
-            # we'd rather skip the frame than tear down the whole
-            # spawn handler with the next iteration losing its
-            # subprocess output.
+            # Legacy clients shouldn't send non-JSON, but if one
+            # does we'd rather skip the frame than tear down the
+            # whole handler.
             _LOGGER.debug("Ignoring non-JSON frame on %s", request.path)
             continue
         if not isinstance(data, dict) or data.get("type") != "spawn":
             continue
 
         configuration = data.get("configuration", "")
-        settings = request.app["device_builder"].settings
-        loop = asyncio.get_running_loop()
+        port = data.get("port", "") if job_type is JobType.UPLOAD else ""
+
         try:
-            # ``rel_path`` calls ``Path.resolve``, a blocking syscall —
-            # off-loop so blockbuster doesn't fault the request on CI.
-            resolved = await loop.run_in_executor(None, settings.rel_path, configuration)
-            config_path = str(resolved)
+            if job_type is JobType.UPLOAD:
+                job = await firmware.upload(configuration=configuration, port=port)
+            else:
+                job = await firmware.compile(configuration=configuration)
         except CommandError:
-            # Send a controlled exit frame instead of letting the
-            # ``CommandError`` tear the WebSocket down — the legacy
-            # spawn protocol uses ``{event: "exit", code}`` as its
-            # only signalling channel, so this is what HA's
-            # esphome-dashboard-api expects to see on rejection.
+            # Boundary / validation rejection. The legacy spawn
+            # protocol uses ``{event: "exit", code}`` as its only
+            # signalling channel — any non-zero code reads as
+            # "build failed" in HA's UI, matching the prior
+            # subprocess shape that surfaced the same rejection
+            # via ``code: 1``.
             await ws.send_json({"event": "exit", "code": 1}, dumps=dumps_str)
             break
-        cmd = [*_ESPHOME_CMD, command, config_path]
-        if extra_args_fn:
-            cmd.extend(extra_args_fn(data))
 
-        proc = await create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-        assert proc.stdout is not None  # type narrowing
-        async for line in proc.stdout:
-            await ws.send_json(
-                {"event": "line", "data": line.decode("utf-8", errors="replace")},
-                dumps=dumps_str,
-            )
-        exit_code = await proc.wait()
-        await ws.send_json({"event": "exit", "code": exit_code}, dumps=dumps_str)
+        await _stream_job_to_legacy_ws(ws, db, job)
         break
 
     return ws
@@ -165,14 +264,10 @@ def create_legacy_routes() -> web.RouteTableDef:
 
     @routes.get("/compile")
     async def legacy_compile(request: web.Request) -> web.WebSocketResponse:
-        return await _handle_legacy_ws_command(request, "compile")
+        return await _handle_legacy_ws_command(request, JobType.COMPILE)
 
     @routes.get("/upload")
     async def legacy_upload(request: web.Request) -> web.WebSocketResponse:
-        def _extra_args(data: dict) -> list[str]:
-            port = data.get("port", "")
-            return ["--device", port] if port else []
-
-        return await _handle_legacy_ws_command(request, "upload", _extra_args)
+        return await _handle_legacy_ws_command(request, JobType.UPLOAD)
 
     return routes

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -47,7 +47,6 @@ from ..models import (
 )
 
 if TYPE_CHECKING:
-    from ..controllers.firmware import FirmwareController
     from ..device_builder import DeviceBuilder
     from ..helpers.event_bus import EventBus
 
@@ -206,17 +205,7 @@ async def _handle_legacy_ws_command(
     """
     ws = web.WebSocketResponse()
     await ws.prepare(request)
-    # The startup-order invariant (``DeviceBuilder.start()``
-    # populates every controller before HTTP requests are served)
-    # is pinned by
-    # ``tests/test_device_builder_lifecycle.py::test_start_initialises_all_controllers``.
-    # By the time this handler runs, ``db.firmware`` is non-None;
-    # the ``assert`` narrows ``Optional[FirmwareController]`` for
-    # the call sites below without ``# type: ignore`` shims.
     db: DeviceBuilder = request.app["device_builder"]
-    firmware = db.firmware
-    bus = db.bus
-    assert firmware is not None
 
     async for msg in ws:
         if msg.type != aiohttp.WSMsgType.TEXT:
@@ -232,7 +221,7 @@ async def _handle_legacy_ws_command(
         if not isinstance(data, dict) or data.get("type") != "spawn":
             continue
 
-        await _handle_spawn(ws, firmware, bus, job_type, data)
+        await _handle_spawn(ws, db, job_type, data)
         break
 
     return ws
@@ -240,12 +229,21 @@ async def _handle_legacy_ws_command(
 
 async def _handle_spawn(
     ws: web.WebSocketResponse,
-    firmware: FirmwareController,
-    bus: EventBus,
+    db: DeviceBuilder,
     job_type: JobType,
     data: dict[str, Any],
 ) -> None:
     """Run one spawn message: validate, submit, stream until terminal.
+
+    The startup-order invariant (``DeviceBuilder.start()`` populates
+    every controller before HTTP requests are served) is pinned by
+    ``tests/test_device_builder_lifecycle.py::test_start_initialises_all_controllers``.
+    Reading ``db.firmware`` here (rather than at the top of the
+    receive handler) keeps no-op connections — clients that close
+    immediately or send only binary frames — from touching the
+    controller at all. The ``assert`` narrows
+    ``Optional[FirmwareController]`` for the call sites below
+    without ``# type: ignore`` shims.
 
     Three rejection paths all surface to HA via the protocol's
     only signalling channel — a ``code: 1`` exit frame:
@@ -258,11 +256,11 @@ async def _handle_spawn(
     2. ``CommandError`` from ``_validate_configuration_boundary``
        (traversal, empty configuration, etc.).
     3. Implicit on success after the streaming finishes.
-
-    Extracted from the receive loop so the per-message control
-    flow doesn't tangle with the loop's iteration / break
-    semantics.
     """
+    firmware = db.firmware
+    bus = db.bus
+    assert firmware is not None
+
     configuration = data.get("configuration", "")
     port = data.get("port", "") if job_type is JobType.UPLOAD else ""
     if not isinstance(configuration, str) or not isinstance(port, str):

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from aiohttp import web
@@ -55,12 +55,12 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def _line_frame(line: str) -> dict[str, object]:
+def _line_frame(line: str) -> dict[str, Any]:
     """Build a legacy ``{event: "line", data: <chunk>}`` frame."""
     return {"event": "line", "data": line}
 
 
-def _exit_frame(exit_code: int | None) -> dict[str, object]:
+def _exit_frame(exit_code: int | None) -> dict[str, Any]:
     """Build a legacy ``{event: "exit", code: <int>}`` frame.
 
     ``exit_code`` is ``None`` for cancelled / never-ran jobs;
@@ -86,7 +86,7 @@ class _LegacyWSWriter:
     def __init__(self, ws: web.WebSocketResponse) -> None:
         self._ws = ws
 
-    async def send_event(self, _message_id: str, _name: str, payload: object) -> None:
+    async def send_event(self, _message_id: str, _name: str, payload: Any) -> None:
         await self._ws.send_json(payload, dumps=dumps_str)
 
 
@@ -220,7 +220,7 @@ async def _handle_legacy_ws_command(
 
     async for msg in ws:
         if msg.type != aiohttp.WSMsgType.TEXT:
-            return ws
+            break
         try:
             data = loads(msg.data)
         except JSONDecodeError:
@@ -233,7 +233,7 @@ async def _handle_legacy_ws_command(
             continue
 
         await _handle_spawn(ws, firmware, bus, job_type, data)
-        return ws
+        break
 
     return ws
 
@@ -243,7 +243,7 @@ async def _handle_spawn(
     firmware: FirmwareController,
     bus: EventBus,
     job_type: JobType,
-    data: dict[str, object],
+    data: dict[str, Any],
 ) -> None:
     """Run one spawn message: validate, submit, stream until terminal.
 

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -13,7 +13,15 @@ from __future__ import annotations
 
 import re
 
-from ...models import EventType, JobStatus, JobType
+from ...models import (
+    TERMINAL_JOB_EVENTS as _TERMINAL_JOB_EVENTS_PUBLIC,
+)
+from ...models import (
+    TERMINAL_JOB_STATUSES as _TERMINAL_JOB_STATUSES_PUBLIC,
+)
+from ...models import (
+    JobType,
+)
 
 # Metadata key under which the firmware queue persists itself in
 # ``.device-builder.json``.
@@ -89,24 +97,14 @@ _PRIMARY_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL}
 )
 
-# Terminal job states — a job in any of these isn't running and
-# isn't waiting to run. Used by ``_mark_job_terminal`` to validate
-# its argument and by the prune / clear / restore paths to identify
-# completed jobs.
-_TERMINAL_JOB_STATUSES: frozenset[JobStatus] = frozenset(
-    {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
-)
-
-# Lifecycle events that end a follower's tail. Subscribed alongside
-# ``JOB_OUTPUT`` in ``follow_job`` so the follower's queue receives
-# the terminal sentinel for any of the three terminal states. The
-# runner fires exactly one of these per job, matching the
-# ``_TERMINAL_JOB_STATUSES`` set above — keeping them as separate
-# constants because subscriptions key off ``EventType`` while
-# state checks key off ``JobStatus``.
-_JOB_TERMINAL_EVENTS: frozenset[EventType] = frozenset(
-    {EventType.JOB_COMPLETED, EventType.JOB_FAILED, EventType.JOB_CANCELLED}
-)
+# Terminal job states / events — re-exported here under the
+# leading-underscore names every internal call site already imports
+# so the existing references don't churn. The shared definitions
+# live in ``models/firmware.py`` next to ``JobStatus`` so the API
+# layer's WS handlers (``api/legacy.py``, etc.) can reuse the same
+# sets without a circular nudge through this private module.
+_TERMINAL_JOB_STATUSES = _TERMINAL_JOB_STATUSES_PUBLIC
+_JOB_TERMINAL_EVENTS = _TERMINAL_JOB_EVENTS_PUBLIC
 
 # Per-job output cap for retained terminal jobs. Compile output for a
 # successful build runs ~3-10k lines; the head is mostly toolchain

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -2,11 +2,17 @@
 Static configuration for the firmware controller.
 
 Error-pattern regexes used to flag failures even when the
-subprocess exit code is 0, terminal job-state sets shared by the
-runner and the persistence/prune paths, and the queue/cleanup
-tunables. Pure data — no I/O, no controller state. Imported
-unchanged into ``controller.py``; tests reach for individual
-constants from this module directly.
+subprocess exit code is 0, history-retention pool sizes, and the
+queue/cleanup tunables. Pure data — no I/O, no controller state.
+Imported unchanged into ``controller.py``; tests reach for
+individual constants from this module directly.
+
+Terminal job state / event sets — needed by both the firmware
+controller and external callers like ``api/legacy.py`` — live in
+``models/firmware.py`` next to ``JobStatus`` (exported as
+``TERMINAL_JOB_STATUSES`` / ``TERMINAL_JOB_EVENTS``) so consumers
+across both layers can import them through the same public
+interface.
 """
 
 from __future__ import annotations

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -13,15 +13,7 @@ from __future__ import annotations
 
 import re
 
-from ...models import (
-    TERMINAL_JOB_EVENTS as _TERMINAL_JOB_EVENTS_PUBLIC,
-)
-from ...models import (
-    TERMINAL_JOB_STATUSES as _TERMINAL_JOB_STATUSES_PUBLIC,
-)
-from ...models import (
-    JobType,
-)
+from ...models import JobType
 
 # Metadata key under which the firmware queue persists itself in
 # ``.device-builder.json``.
@@ -96,15 +88,6 @@ _MAX_AUX_TERMINAL_JOBS = 5
 _PRIMARY_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL}
 )
-
-# Terminal job states / events — re-exported here under the
-# leading-underscore names every internal call site already imports
-# so the existing references don't churn. The shared definitions
-# live in ``models/firmware.py`` next to ``JobStatus`` so the API
-# layer's WS handlers (``api/legacy.py``, etc.) can reuse the same
-# sets without a circular nudge through this private module.
-_TERMINAL_JOB_STATUSES = _TERMINAL_JOB_STATUSES_PUBLIC
-_JOB_TERMINAL_EVENTS = _TERMINAL_JOB_EVENTS_PUBLIC
 
 # Per-job output cap for retained terminal jobs. Compile output for a
 # successful build runs ~3-10k lines; the head is mostly toolchain

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -34,18 +34,25 @@ from ...helpers.api import CommandError, api_command
 from ...helpers.event_bus import StreamControls, stream_events
 from ...helpers.process import terminate_subtree_with_grace
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
-from ...models import ErrorCode, EventType, FirmwareJob, JobStatus, JobType, StreamEvent
+from ...models import (
+    TERMINAL_JOB_EVENTS,
+    TERMINAL_JOB_STATUSES,
+    ErrorCode,
+    EventType,
+    FirmwareJob,
+    JobStatus,
+    JobType,
+    StreamEvent,
+)
 from ..config import _load_metadata, metadata_transaction
 from .constants import (
     _ERROR_PATTERNS,
     _INFLIGHT_TRIM_KEEP,
-    _JOB_TERMINAL_EVENTS,
     _JOBS_KEY,
     _MAX_AUX_TERMINAL_JOBS,
     _MAX_OUTPUT_LINES_INFLIGHT,
     _MAX_PRIMARY_TERMINAL_JOBS,
     _PRIMARY_JOB_TYPES,
-    _TERMINAL_JOB_STATUSES,
 )
 from .helpers import (
     _find_esphome_cmd,
@@ -464,7 +471,7 @@ class FirmwareController:
         # synchronous-adjacent statements (stream_events' setup is
         # sync up to the first ``await`` inside ``send_initial``).
         snapshot = list(job.output)
-        is_terminal = job.status in _TERMINAL_JOB_STATUSES
+        is_terminal = job.status in TERMINAL_JOB_STATUSES
         terminal_status = job.status.value if is_terminal else ""
         terminal_exit_code = job.exit_code
 
@@ -486,7 +493,7 @@ class FirmwareController:
             if event.event_type == EventType.JOB_OUTPUT:
                 if event.data.get("job_id") == job_id:
                     controls.push(StreamEvent.OUTPUT, event.data["line"])
-            elif event.event_type in _JOB_TERMINAL_EVENTS:
+            elif event.event_type in TERMINAL_JOB_EVENTS:
                 ev_job = event.data.get("job")
                 if ev_job and getattr(ev_job, "job_id", None) == job_id:
                     status = getattr(ev_job, "status", "unknown")
@@ -504,7 +511,7 @@ class FirmwareController:
             client=client,
             message_id=message_id,
             bus=self._db.bus,
-            event_types=(EventType.JOB_OUTPUT, *_JOB_TERMINAL_EVENTS),
+            event_types=(EventType.JOB_OUTPUT, *TERMINAL_JOB_EVENTS),
             handle_event=_handle_event,
             send_initial=_send_initial,
         )
@@ -601,7 +608,7 @@ class FirmwareController:
             event_types=(
                 EventType.JOB_QUEUED,
                 EventType.JOB_STARTED,
-                *_JOB_TERMINAL_EVENTS,
+                *TERMINAL_JOB_EVENTS,
                 EventType.JOB_OUTPUT,
                 EventType.JOB_PROGRESS,
             ),
@@ -662,7 +669,7 @@ class FirmwareController:
         If ``status`` is given, only remove jobs with that status.
         Otherwise removes completed, failed, and cancelled jobs.
         """
-        terminal = _TERMINAL_JOB_STATUSES
+        terminal = TERMINAL_JOB_STATUSES
         to_remove = [
             jid
             for jid, job in self._jobs.items()
@@ -1446,7 +1453,7 @@ class FirmwareController:
         kept in a separate pool capped at ``_MAX_AUX_TERMINAL_JOBS``.
         Caller persists the result.
         """
-        terminal_states = _TERMINAL_JOB_STATUSES
+        terminal_states = TERMINAL_JOB_STATUSES
 
         active: list[FirmwareJob] = []
         primary: list[FirmwareJob] = []

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -21,13 +21,18 @@ from pathlib import Path
 from ...helpers.api import CommandError
 from ...helpers.process import kill_quietly
 from ...helpers.subprocess import create_subprocess_exec
-from ...models import ErrorCode, FirmwareJob, JobStatus, JobType
+from ...models import (
+    TERMINAL_JOB_STATUSES,
+    ErrorCode,
+    FirmwareJob,
+    JobStatus,
+    JobType,
+)
 from .constants import (
     _MAX_OUTPUT_LINES_RETAINED,
     _NO_ESPHOME_MODULE_MARKER,
     _OUTPUT_TRIM_NOTICE_PREFIX,
     _PROGRESS_PATTERNS,
-    _TERMINAL_JOB_STATUSES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -107,7 +112,7 @@ def _mark_job_terminal(job: FirmwareJob, status: JobStatus) -> None:
     still-running job — that would mis-order the dashboard's
     relative-time strings and confuse the prune-on-shutdown logic.
     """
-    if status not in _TERMINAL_JOB_STATUSES:
+    if status not in TERMINAL_JOB_STATUSES:
         msg = f"_mark_job_terminal called with non-terminal status {status!r}"
         raise ValueError(msg)
     job.status = status

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -40,11 +40,16 @@ class JobType(StrEnum):
 
 
 # Terminal job states — a job in any of these isn't running and
-# isn't waiting to run. Lives here (next to ``JobStatus``) rather
-# than inside the firmware controller's private constants module
-# so the API layer's WS handlers — which need to recognise a
-# job that resolved as already-terminal at submit time — can
-# import it without a circular-nudge through the controller.
+# isn't waiting to run. Lives here next to ``JobStatus`` because
+# it's a public set derived directly from the enum's terminal
+# members; ``controllers/firmware/constants.py`` is reserved for
+# constants private to the firmware controller (every name there
+# is ``_``-prefixed), and these need to be reachable from the API
+# layer's WS handlers — which recognise jobs that resolved as
+# already-terminal at submit time — without crossing that
+# private/public boundary. ``firmware/constants.py`` re-exports
+# the same set under its existing internal name so the controller
+# call sites don't churn.
 TERMINAL_JOB_STATUSES: frozenset[JobStatus] = frozenset(
     {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
 )

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -7,6 +7,8 @@ from enum import StrEnum
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
+from .common import EventType
+
 
 class JobStatus(StrEnum):
     """Firmware job status."""
@@ -35,6 +37,25 @@ class JobType(StrEnum):
     # in the firmware-tasks list with live output instead of running
     # silently in the background.
     RENAME = "rename"
+
+
+# Terminal job states — a job in any of these isn't running and
+# isn't waiting to run. Lives here (next to ``JobStatus``) rather
+# than inside the firmware controller's private constants module
+# so the API layer's WS handlers — which need to recognise a
+# job that resolved as already-terminal at submit time — can
+# import it without a circular-nudge through the controller.
+TERMINAL_JOB_STATUSES: frozenset[JobStatus] = frozenset(
+    {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
+)
+
+# Lifecycle events that match ``TERMINAL_JOB_STATUSES``. The runner
+# fires exactly one of these per job, matching the status set above
+# — they're kept as separate constants because subscriptions key
+# off ``EventType`` while state checks key off ``JobStatus``.
+TERMINAL_JOB_EVENTS: frozenset[EventType] = frozenset(
+    {EventType.JOB_COMPLETED, EventType.JOB_FAILED, EventType.JOB_CANCELLED}
+)
 
 
 @dataclass

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -40,23 +40,14 @@ class JobType(StrEnum):
 
 
 # Terminal job states — a job in any of these isn't running and
-# isn't waiting to run. Lives here next to ``JobStatus`` because
-# it's a public set derived directly from the enum's terminal
-# members; ``controllers/firmware/constants.py`` is reserved for
-# constants private to the firmware controller (every name there
-# is ``_``-prefixed), and these need to be reachable from the API
-# layer's WS handlers — which recognise jobs that resolved as
-# already-terminal at submit time — without crossing that
-# private/public boundary. ``firmware/constants.py`` re-exports
-# the same set under its existing internal name so the controller
-# call sites don't churn.
+# isn't waiting to run.
 TERMINAL_JOB_STATUSES: frozenset[JobStatus] = frozenset(
     {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
 )
 
 # Lifecycle events that match ``TERMINAL_JOB_STATUSES``. The runner
-# fires exactly one of these per job, matching the status set above
-# — they're kept as separate constants because subscriptions key
+# fires exactly one of these per job, matching the status set
+# above — kept as a separate constant because subscriptions key
 # off ``EventType`` while state checks key off ``JobStatus``.
 TERMINAL_JOB_EVENTS: frozenset[EventType] = frozenset(
     {EventType.JOB_COMPLETED, EventType.JOB_FAILED, EventType.JOB_CANCELLED}

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -508,9 +508,11 @@ class _FakeFirmwareController:
 
     async def _fire_plan(self) -> None:
         # One ``sleep(0)`` is enough: ``compile()`` returns
-        # synchronously to the handler, the handler does its
-        # sync setup, then awaits ``pending.get()`` — that's the
-        # yield this task is waiting on.
+        # synchronously to the handler, which then runs through
+        # ``stream_events``'s sync setup (subscribe + initial-
+        # frame push) before reaching its first ``await`` on
+        # ``queue.get()``. That await is the yield this task is
+        # waiting on.
         await asyncio.sleep(0)
         for entry in self._plan:
             kind = entry[0]
@@ -901,9 +903,11 @@ async def test_spawn_ws_breaks_on_non_text_frame(
     to ``loads(msg.data)`` would surface here as a malformed
     error frame instead of a clean break.
 
-    Wires up firmware + bus so the post-init message loop runs
-    (rather than the firmware-not-initialised early-exit path,
-    which has its own dedicated test).
+    Wires up firmware + bus so ``_handle_spawn`` (which reads
+    them from the ``DeviceBuilder``) has the controllers
+    available — the receive loop's binary-frame branch should
+    bail before hitting ``_handle_spawn`` either way, so the
+    asserts below confirm no submission happened.
     """
     bus = EventBus()
     job = _make_job()
@@ -1048,9 +1052,10 @@ async def test_stream_helper_releases_listener_when_send_raises() -> None:
     # would make the post-call assertion meaningless.
     assert bus._listeners == {}
 
-    # Pre-stage a JOB_OUTPUT event so the handler wakes from
-    # ``pending.get()`` immediately, attempts the (failing) send,
-    # and exits the ``with`` block.
+    # Pre-stage a JOB_OUTPUT event so ``stream_events``'s drain
+    # wakes from ``queue.get()`` immediately, attempts the
+    # (failing) send through the adapter, and exits the
+    # ``bus.listening`` ``with`` block.
     async def _fire_after_subscribe() -> None:
         await asyncio.sleep(0)
         bus.fire(EventType.JOB_OUTPUT, {"job_id": job.job_id, "line": "x\n"})

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -1040,6 +1040,66 @@ async def test_stream_helper_releases_listener_when_send_raises() -> None:
         assert bus._listeners.get(event_type, set()) == set()
 
 
+@pytest.mark.parametrize(
+    ("payload", "description"),
+    [
+        ({"type": "spawn", "configuration": None}, "configuration: null"),
+        ({"type": "spawn", "configuration": 123}, "configuration: int"),
+        (
+            {"type": "spawn", "configuration": {"nested": "object"}},
+            "configuration: object",
+        ),
+        (
+            {"type": "spawn", "configuration": "kitchen.yaml", "port": None},
+            "port: null (upload route)",
+        ),
+        (
+            {"type": "spawn", "configuration": "kitchen.yaml", "port": 42},
+            "port: int (upload route)",
+        ),
+    ],
+)
+async def test_spawn_ws_emits_exit_frame_on_non_string_fields(
+    tmp_path: Path,
+    aiohttp_client: AiohttpClient,
+    payload: dict[str, Any],
+    description: str,
+) -> None:
+    """Non-string ``configuration`` / ``port`` → ``{event: exit, code: 1}``.
+
+    ``data.get("configuration", "")`` only uses the default when
+    the key is *absent*; an explicit ``"configuration": null`` (or
+    a non-string like ``123`` / an object) lands here as a
+    non-``str``. Forwarding that to the firmware controller's
+    path-validation helpers would crash with ``TypeError`` /
+    ``AttributeError`` and surface to HA as an opaque connection
+    drop. The handler rejects up front via the protocol's only
+    signalling channel — same shape HA already handles for the
+    boundary-rejection case.
+
+    The ``port`` cases use the ``/upload`` route since
+    ``/compile`` ignores the port field entirely (its omission /
+    type doesn't matter on that path).
+    """
+    bus = EventBus()
+    job = _make_job()
+    firmware = _FakeFirmwareController(bus=bus, job=job, plan=None)
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
+
+    route = "/upload" if "port" in payload else "/compile"
+    async with client.ws_connect(route) as ws:
+        await ws.send_json(payload)
+        msg = await ws.receive_json()
+
+    assert msg == {"event": "exit", "code": 1}, description
+    # The bad input must NOT have submitted a job — the rejection
+    # is supposed to happen before the firmware controller is
+    # called, so a regression that forwarded the non-string to
+    # ``firmware.compile`` / ``.upload`` would surface here.
+    assert firmware.compile_calls == []
+    assert firmware.upload_calls == []
+
+
 async def test_spawn_ws_round_trip_through_real_event_bus(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -662,12 +662,14 @@ async def test_upload_ws_submits_upload_job_with_port(
 ) -> None:
     """``/upload`` with ``port`` → upload job carries the port verbatim.
 
-    The port travels through to ``firmware.upload(port=...)``;
-    the new firmware controller forwards it to the esphome CLI
-    via ``--device``. The legacy route's job is to plumb the
-    spawn-message's ``port`` field into the right kwarg —
-    serial path, IP, ``OTA`` literal — esphome's ``--device``
-    resolver handles dispatch.
+    Pins the legacy → ``firmware.upload`` leg of the port-pass-
+    through chain. The next leg — ``firmware.upload`` storing the
+    port on the job and ``_build_command`` translating it into
+    ``["--device", port]`` for the esphome CLI — is pinned by
+    ``tests/controllers/firmware/test_address_cache.py``
+    (search for ``--device``). The two together protect every
+    place a serial / OTA / IP target could get dropped between
+    HA's spawn message and the actual ``esphome upload`` invocation.
     """
     bus = EventBus()
     job = _make_job(job_type=JobType.UPLOAD)
@@ -898,12 +900,23 @@ async def test_spawn_ws_breaks_on_non_text_frame(
     connection. Pin the break so a regression that fell through
     to ``loads(msg.data)`` would surface here as a malformed
     error frame instead of a clean break.
+
+    Wires up firmware + bus so the post-init message loop runs
+    (rather than the firmware-not-initialised early-exit path,
+    which has its own dedicated test).
     """
-    client = await aiohttp_client(_make_app(tmp_path))
+    bus = EventBus()
+    job = _make_job()
+    firmware = _FakeFirmwareController(bus=bus, job=job, plan=None)
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
     async with client.ws_connect("/compile") as ws:
         await ws.send_bytes(b"not-text")
     # No exit frame, no error — the handler returns the empty WS
     # response on the break and the close handshake completes.
+    # Also pins that the binary frame did NOT submit a job (the
+    # message loop should bail before reaching the spawn handler).
+    assert firmware.compile_calls == []
+    assert firmware.upload_calls == []
 
 
 async def test_spawn_ws_breaks_on_close(tmp_path: Path, aiohttp_client: AiohttpClient) -> None:
@@ -917,6 +930,57 @@ async def test_spawn_ws_breaks_on_close(tmp_path: Path, aiohttp_client: AiohttpC
     async with client.ws_connect("/compile") as ws:
         await ws.close()
     # Closing without raising is the assertion.
+
+
+async def test_stream_helper_ignores_terminal_events_for_other_jobs() -> None:
+    """A ``JOB_COMPLETED`` for a different job is filtered out, not sent.
+
+    The handler subscribes to lifecycle events for *all* jobs (the
+    bus broadcast is per-event-type, not per-job) and filters
+    inside the listener by ``job_id``. A misroute here — sending
+    another job's terminal frame as our exit — would tell HA the
+    build finished when ours hadn't even started, and the
+    dashboard's "Firmware tasks" panel would lose the running
+    job's WS follower as a side effect.
+
+    Drives the helper directly with a stub WS that records sends.
+    Fires a ``JOB_COMPLETED`` for an unrelated job, then a
+    ``JOB_OUTPUT`` + ``JOB_COMPLETED`` for ours; only the second
+    pair should appear on the wire.
+    """
+    bus = EventBus()
+    job = _make_job()
+    other_job = _make_job()
+    other_job.job_id = "other-job-id"
+    other_job.status = JobStatus.COMPLETED
+    other_job.exit_code = 0
+
+    sent: list[dict[str, Any]] = []
+
+    class _RecordingWS:
+        async def send_json(self, payload: dict[str, Any], **_kwargs: Any) -> None:
+            sent.append(payload)
+
+    async def _fire() -> None:
+        await asyncio.sleep(0)
+        # Unrelated job's terminal event — must be ignored.
+        bus.fire(EventType.JOB_COMPLETED, {"job": other_job})
+        # Our job's line + terminal — these must come through.
+        bus.fire(EventType.JOB_OUTPUT, {"job_id": job.job_id, "line": "ours\n"})
+        job.status = JobStatus.COMPLETED
+        job.exit_code = 0
+        bus.fire(EventType.JOB_COMPLETED, {"job": job})
+
+    fire_task = asyncio.create_task(_fire())
+    try:
+        await legacy._stream_job_to_legacy_ws(_RecordingWS(), bus, job)  # type: ignore[arg-type]
+    finally:
+        await fire_task
+
+    assert sent == [
+        {"event": "line", "data": "ours\n"},
+        {"event": "exit", "code": 0},
+    ]
 
 
 async def test_stream_helper_releases_listener_when_send_raises() -> None:
@@ -974,39 +1038,6 @@ async def test_stream_helper_releases_listener_when_send_raises() -> None:
         EventType.JOB_CANCELLED,
     ):
         assert bus._listeners.get(event_type, set()) == set()
-
-
-async def test_spawn_ws_rejects_when_firmware_not_initialised(
-    tmp_path: Path, aiohttp_client: AiohttpClient
-) -> None:
-    """``firmware=None`` at request time → ``{event: exit, code: 1}`` not crash.
-
-    Production sets ``DeviceBuilder.firmware`` before HTTP is
-    served, but typing it as ``Optional`` means a startup-order
-    regression would leave the legacy handler reading ``None``
-    and ``AttributeError``-ing on the next ``.compile()`` call —
-    surfacing to HA as an opaque connection drop. The defensive
-    early-return turns that into the protocol's only signalling
-    channel: a ``code: 1`` exit frame.
-    """
-    bus = EventBus()
-    # Build the app with firmware=None deliberately. ``_make_app``
-    # only adds attrs whose value is non-None, so we use a custom
-    # builder that wires firmware=None explicitly.
-    settings = DashboardSettings()
-    settings.config_dir = tmp_path
-    settings.absolute_config_dir = tmp_path.resolve()
-    db_attrs = {"settings": settings, "firmware": None, "bus": bus}
-    app = web.Application()
-    app["device_builder"] = type("DB", (), db_attrs)()
-    app.add_routes(create_legacy_routes())
-
-    client = await aiohttp_client(app)
-    async with client.ws_connect("/compile") as ws:
-        await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
-        msg = await ws.receive_json()
-
-    assert msg == {"event": "exit", "code": 1}
 
 
 async def test_spawn_ws_round_trip_through_real_event_bus(

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -476,11 +476,14 @@ class _FakeFirmwareController:
         """Schedule ``_fire_plan`` to run after the handler subscribes.
 
         The handler's flow after ``compile()`` returns is sync:
-        attach the bus listener, snapshot ``job.output``, check
-        for an already-terminal status, then ``await
-        pending.get()``. The first ``await`` yields back to the
-        loop, at which point the deferred task scheduled here
-        runs and fires events into the now-attached listener.
+        snapshot ``job.output``, then route through
+        ``stream_events``, which attaches the bus listener and
+        awaits ``send_initial`` (the snapshot replay) before
+        starting the live drain. The first ``await`` inside
+        ``send_initial`` yields back to the loop, at which point
+        the deferred task scheduled here runs and fires events
+        into the now-attached listener.
+
         Without the deferral the events fire before the listener
         is attached and are dropped — exactly the behaviour the
         production firmware controller's "subscribe before

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -37,7 +37,6 @@ exercised — not just the handler bodies.
 from __future__ import annotations
 
 import asyncio
-import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -46,16 +45,26 @@ import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
-from esphome_device_builder.api import legacy
 from esphome_device_builder.api.legacy import create_legacy_routes
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.models import (
+    ErrorCode,
+    EventType,
+    FirmwareJob,
+    JobStatus,
+    JobType,
+)
 
 
 def _make_app(
     tmp_path: Path,
     *,
     devices: object | None = None,
+    firmware: object | None = None,
+    bus: EventBus | None = None,
 ) -> web.Application:
     """Build an aiohttp app wired to just enough DeviceBuilder shape.
 
@@ -67,6 +76,10 @@ def _make_app(
     surfaces as the same ``AttributeError`` in CI that production
     raised. Tests that don't hit ``/devices`` can leave it
     ``None``.
+
+    ``firmware`` + ``bus`` wire up the WS spawn handlers (see
+    :class:`_FakeFirmwareController`). Tests that don't open
+    ``/compile`` or ``/upload`` can leave them ``None``.
     """
     settings = DashboardSettings()
     settings.config_dir = tmp_path
@@ -75,6 +88,10 @@ def _make_app(
     db_attrs: dict[str, Any] = {"settings": settings}
     if devices is not None:
         db_attrs["devices"] = devices
+    if firmware is not None:
+        db_attrs["firmware"] = firmware
+    if bus is not None:
+        db_attrs["bus"] = bus
 
     app = web.Application()
     app["device_builder"] = type("DB", (), db_attrs)()
@@ -383,76 +400,147 @@ async def test_json_config_returns_500_on_missing_file(
 #   server → client: {"event": "line", "data": "<utf-8 chunk>"}  (per stdout chunk)
 #   server → client: {"event": "exit", "code": <int>}  (when subprocess exits)
 #
-# These tests use a fake ``create_subprocess_exec`` so the spawned
-# command is a controlled in-memory generator rather than a real
-# ``esphome`` invocation. That lets us pin the cmd shape, the
-# frame ordering, and the exit code passthrough without depending
-# on a working ESPHome install.
+# Since #394 the handler routes through the ``FirmwareController``
+# job queue (so HA-triggered builds show up in the "Firmware tasks"
+# panel) instead of spawning a subprocess directly. These tests
+# inject a fake firmware controller that records the submitted job
+# and a real ``EventBus`` the test drives by firing
+# ``JOB_OUTPUT`` / ``JOB_*`` lifecycle events. That exercises the
+# legacy handler's translation between the bus event shape and
+# the upstream WS frame shape end-to-end without depending on the
+# ``FirmwareController`` itself running an actual build.
 
 
-class _FakeStdout:
-    """Async-iterable stdout stream that yields preset bytes."""
+class _FakeFirmwareController:
+    """Minimal stand-in for ``FirmwareController.compile`` / ``.upload``.
 
-    def __init__(self, lines: list[bytes]) -> None:
-        self._lines = list(lines)
-        self._iter = iter(self._lines)
+    Records the kwargs each method was called with and returns a
+    ``FirmwareJob`` the test can then drive by configuring
+    *plan*: a list of ``("line", "<text>")`` and one final
+    ``("exit", <code>, <status>)`` tuple that the fake will fire
+    on the bus *after* the legacy handler has subscribed. Firing
+    from inside the post-yield deferral (rather than from the
+    test body) is what avoids the race where the test driver's
+    events arrive before the handler attaches its listener — see
+    ``_schedule_plan`` for the timing detail.
 
-    async def read(self, _n: int = -1) -> bytes:
-        try:
-            return next(self._iter)
-        except StopIteration:
-            return b""
-
-    def __aiter__(self) -> _FakeStdout:
-        return self
-
-    async def __anext__(self) -> bytes:
-        try:
-            return next(self._iter)
-        except StopIteration:
-            raise StopAsyncIteration  # noqa: B904
-
-
-class _FakeProc:
-    """Minimal ``asyncio.subprocess.Process`` stand-in."""
-
-    def __init__(self, lines: list[bytes], exit_code: int) -> None:
-        self.stdout = _FakeStdout(lines)
-        self._exit_code = exit_code
-
-    async def wait(self) -> int:
-        return self._exit_code
-
-
-@pytest.fixture
-def captured_spawn(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
-    """Replace ``create_subprocess_exec`` with a recording fake.
-
-    Tests assert on ``captured["cmd"]`` to verify the command
-    shape (this is the upstream-parity check). The default fake
-    yields two output lines and exits 0; a test that needs
-    different behaviour mutates ``captured["lines"]`` /
-    ``captured["exit_code"]`` *before* opening the WS — the
-    fake reads them at spawn time, not at fixture-build time.
+    Optionally raises ``CommandError`` to simulate the boundary-
+    validation rejection path.
     """
-    captured: dict[str, Any] = {
-        "cmd": None,
-        "lines": [b"line one\n", b"line two\n"],
-        "exit_code": 0,
-    }
 
-    async def _fake_create(*args: Any, **_kwargs: Any) -> _FakeProc:
-        captured["cmd"] = list(args)
-        return _FakeProc(captured["lines"], captured["exit_code"])
+    def __init__(
+        self,
+        *,
+        bus: EventBus,
+        job: FirmwareJob,
+        plan: list[tuple] | None = None,
+        raise_on_submit: bool = False,
+    ) -> None:
+        self._bus = bus
+        self._job = job
+        self._plan = plan or []
+        self._raise_on_submit = raise_on_submit
+        self.compile_calls: list[dict[str, Any]] = []
+        self.upload_calls: list[dict[str, Any]] = []
+        self.fire_task: asyncio.Task | None = None
 
-    monkeypatch.setattr("esphome_device_builder.api.legacy.create_subprocess_exec", _fake_create)
-    return captured
+    async def compile(self, *, configuration: str, **kwargs: Any) -> FirmwareJob:
+        self.compile_calls.append({"configuration": configuration, **kwargs})
+        if self._raise_on_submit:
+            raise CommandError(ErrorCode.INVALID_ARGS, "rejected")
+        self._schedule_plan()
+        return self._job
+
+    async def upload(self, *, configuration: str, port: str = "", **kwargs: Any) -> FirmwareJob:
+        self.upload_calls.append({"configuration": configuration, "port": port, **kwargs})
+        if self._raise_on_submit:
+            raise CommandError(ErrorCode.INVALID_ARGS, "rejected")
+        self._schedule_plan()
+        return self._job
+
+    def _schedule_plan(self) -> None:
+        """Schedule ``_fire_plan`` to run after the handler subscribes.
+
+        The handler's flow after ``compile()`` returns is sync:
+        attach the bus listener, snapshot ``job.output``, check
+        for an already-terminal status, then ``await
+        pending.get()``. The first ``await`` yields back to the
+        loop, at which point the deferred task scheduled here
+        runs and fires events into the now-attached listener.
+        Without the deferral the events fire before the listener
+        is attached and are dropped — exactly the behaviour the
+        production firmware controller's "subscribe before
+        snapshot" comment is designed to prevent in
+        ``follow_job``.
+        """
+        if not self._plan:
+            return
+        loop = asyncio.get_running_loop()
+        self.fire_task = loop.create_task(self._fire_plan())
+
+    async def _fire_plan(self) -> None:
+        # One ``sleep(0)`` is enough: ``compile()`` returns
+        # synchronously to the handler, the handler does its
+        # sync setup, then awaits ``pending.get()`` — that's the
+        # yield this task is waiting on.
+        await asyncio.sleep(0)
+        for entry in self._plan:
+            kind = entry[0]
+            if kind == "line":
+                self._bus.fire(
+                    EventType.JOB_OUTPUT,
+                    {"job_id": self._job.job_id, "line": entry[1]},
+                )
+                continue
+            # ("exit", code_or_None, status)
+            _, exit_code, status = entry
+            self._job.status = status
+            self._job.exit_code = exit_code
+            event_type = {
+                JobStatus.COMPLETED: EventType.JOB_COMPLETED,
+                JobStatus.FAILED: EventType.JOB_FAILED,
+                JobStatus.CANCELLED: EventType.JOB_CANCELLED,
+            }[status]
+            self._bus.fire(event_type, {"job": self._job})
+
+
+def _make_job(
+    *,
+    job_type: JobType = JobType.COMPILE,
+    output: list[str] | None = None,
+    status: JobStatus = JobStatus.RUNNING,
+    exit_code: int | None = None,
+) -> FirmwareJob:
+    """Build a ``FirmwareJob`` for tests."""
+    return FirmwareJob(
+        job_id="test-job-id",
+        configuration="kitchen.yaml",
+        job_type=job_type,
+        status=status,
+        output=output if output is not None else [],
+        exit_code=exit_code,
+    )
+
+
+def _plan(
+    *,
+    lines: list[str] | None = None,
+    exit_code: int | None = 0,
+    status: JobStatus = JobStatus.COMPLETED,
+) -> list[tuple]:
+    """Build a ``_FakeFirmwareController.plan`` payload.
+
+    Convenience over a verbose tuple list — most tests want
+    "fire these lines, then exit with this code/status".
+    """
+    out: list[tuple] = [("line", line) for line in (lines or [])]
+    out.append(("exit", exit_code, status))
+    return out
 
 
 async def test_compile_ws_streams_lines_and_exit_frames(
     tmp_path: Path,
     aiohttp_client: AiohttpClient,
-    captured_spawn: dict[str, Any],
 ) -> None:
     """``/compile`` emits ``{event: line}`` per output chunk + ``{event: exit, code}``.
 
@@ -460,13 +548,18 @@ async def test_compile_ws_streams_lines_and_exit_frames(
     dashboard sends ``{"event": "line", "data": <utf-8 string>}``
     per stdout chunk and ``{"event": "exit", "code": <int>}``
     on subprocess exit. HA's ``esphome-dashboard-api`` reads
-    those exact keys.
+    those exact keys, regardless of whether the build runs as a
+    direct subprocess (legacy) or as a queued firmware job (#394).
     """
-    (tmp_path / "kitchen.yaml").write_text("")
-    captured_spawn["lines"] = [b"compile output line 1\n", b"compile output line 2\n"]
-    captured_spawn["exit_code"] = 0
+    bus = EventBus()
+    job = _make_job(job_type=JobType.COMPILE)
+    firmware = _FakeFirmwareController(
+        bus=bus,
+        job=job,
+        plan=_plan(lines=["compile output line 1\n", "compile output line 2\n"]),
+    )
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
 
-    client = await aiohttp_client(_make_app(tmp_path))
     async with client.ws_connect("/compile") as ws:
         await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
         first = await ws.receive_json()
@@ -481,19 +574,22 @@ async def test_compile_ws_streams_lines_and_exit_frames(
 async def test_compile_ws_passes_exit_code_through(
     tmp_path: Path,
     aiohttp_client: AiohttpClient,
-    captured_spawn: dict[str, Any],
 ) -> None:
-    """Non-zero subprocess exit → ``{event: exit, code: N}``.
+    """Non-zero firmware exit → ``{event: exit, code: N}``.
 
     HA renders the compile result based on this code (0 = green
     check, anything else = red X). Pin that the code is passed
     through verbatim, not coerced or normalised.
     """
-    (tmp_path / "kitchen.yaml").write_text("")
-    captured_spawn["lines"] = []
-    captured_spawn["exit_code"] = 42
+    bus = EventBus()
+    job = _make_job()
+    firmware = _FakeFirmwareController(
+        bus=bus,
+        job=job,
+        plan=_plan(exit_code=42, status=JobStatus.FAILED),
+    )
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
 
-    client = await aiohttp_client(_make_app(tmp_path))
     async with client.ws_connect("/compile") as ws:
         await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
         msg = await ws.receive_json()
@@ -501,90 +597,178 @@ async def test_compile_ws_passes_exit_code_through(
     assert msg == {"event": "exit", "code": 42}
 
 
-async def test_compile_ws_builds_command_without_device_arg(
+async def test_compile_ws_submits_compile_job_with_configuration(
     tmp_path: Path,
     aiohttp_client: AiohttpClient,
-    captured_spawn: dict[str, Any],
 ) -> None:
-    """``compile`` doesn't pass ``--device`` (it's not flashing anything).
+    """``/compile`` submits a ``compile`` firmware job with the YAML name.
 
-    Upstream ``EsphomeCompileHandler.build_command`` constructs
-    ``[*ESPHOME_COMMAND, "compile", config_file]`` — no
-    ``--device``. Pin the same shape so a refactor that adds a
-    spurious port flag doesn't break ``esphome compile``.
+    Replaces the upstream "command shape" test now that the WS
+    routes through the firmware queue instead of spawning a
+    subprocess. The shape we care about pinning is "the legacy
+    route reaches the same job-submission API the new dashboard
+    uses, with the configuration travelling verbatim and no
+    spurious port" — that's what makes HA-triggered builds appear
+    in the "Firmware tasks" panel (#394).
     """
-    (tmp_path / "kitchen.yaml").write_text("")
-    client = await aiohttp_client(_make_app(tmp_path))
+    bus = EventBus()
+    job = _make_job(job_type=JobType.COMPILE)
+    firmware = _FakeFirmwareController(bus=bus, job=job, plan=_plan())
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
 
     async with client.ws_connect("/compile") as ws:
-        await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
-        await ws.receive_json()  # line
-        await ws.receive_json()  # line
-        await ws.receive_json()  # exit
+        await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml", "port": "ignored"})
+        await ws.receive_json()
 
-    cmd = captured_spawn["cmd"]
-    assert "--device" not in cmd
-    assert "compile" in cmd
-    # Compile target is the resolved YAML path.
-    assert any(arg.endswith("kitchen.yaml") for arg in cmd)
+    assert firmware.compile_calls == [{"configuration": "kitchen.yaml"}]
+    # Compile path doesn't accept a port — the field on the
+    # spawn message is silently dropped (matches the previous
+    # subprocess shape that never appended ``--device`` for
+    # ``compile``).
+    assert firmware.upload_calls == []
 
 
-async def test_upload_ws_includes_device_arg_when_port_set(
+async def test_upload_ws_submits_upload_job_with_port(
     tmp_path: Path,
     aiohttp_client: AiohttpClient,
-    captured_spawn: dict[str, Any],
 ) -> None:
-    """``upload`` with ``port`` → ``--device <port>`` appended.
+    """``/upload`` with ``port`` → upload job carries the port verbatim.
 
-    Matches upstream's ``EsphomePortCommandWebSocket.build_device_command``
-    which always emits ``["--device", port]``. The port travels
-    verbatim — serial path, IP, ``OTA`` literal — esphome's
-    ``--device`` resolver handles dispatch.
+    The port travels through to ``firmware.upload(port=...)``;
+    the new firmware controller forwards it to the esphome CLI
+    via ``--device``. The legacy route's job is to plumb the
+    spawn-message's ``port`` field into the right kwarg —
+    serial path, IP, ``OTA`` literal — esphome's ``--device``
+    resolver handles dispatch.
     """
-    (tmp_path / "kitchen.yaml").write_text("")
-    client = await aiohttp_client(_make_app(tmp_path))
+    bus = EventBus()
+    job = _make_job(job_type=JobType.UPLOAD)
+    firmware = _FakeFirmwareController(bus=bus, job=job, plan=_plan())
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
 
     async with client.ws_connect("/upload") as ws:
         await ws.send_json(
             {"type": "spawn", "configuration": "kitchen.yaml", "port": "/dev/ttyUSB0"}
         )
         await ws.receive_json()
-        await ws.receive_json()
-        await ws.receive_json()
 
-    cmd = captured_spawn["cmd"]
-    assert "upload" in cmd
-    assert "--device" in cmd
-    assert cmd[cmd.index("--device") + 1] == "/dev/ttyUSB0"
+    assert firmware.upload_calls == [{"configuration": "kitchen.yaml", "port": "/dev/ttyUSB0"}]
 
 
-async def test_upload_ws_omits_device_arg_when_port_empty(
+async def test_upload_ws_submits_upload_job_with_empty_port_when_omitted(
     tmp_path: Path,
     aiohttp_client: AiohttpClient,
-    captured_spawn: dict[str, Any],
 ) -> None:
-    """``upload`` with empty / missing ``port`` → no ``--device`` flag.
+    """``/upload`` without ``port`` → upload job submitted with ``port=""``.
 
     Deviation from upstream: their dashboard requires ``port``
-    in the message and unconditionally appends ``--device port``.
-    Our impl skips the flag when port is empty, letting esphome
-    auto-detect. HA's library always sends a port, so the
+    in the message. Our impl plumbs an empty string through; the
+    firmware controller forwards it to esphome which then
+    auto-detects. HA's library always sends a port, so the
     practical contract isn't observable from the integration —
     but pinning our actual shape protects against a refactor
     that flips this branch silently.
     """
-    (tmp_path / "kitchen.yaml").write_text("")
-    client = await aiohttp_client(_make_app(tmp_path))
+    bus = EventBus()
+    job = _make_job(job_type=JobType.UPLOAD)
+    firmware = _FakeFirmwareController(bus=bus, job=job, plan=_plan())
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
 
     async with client.ws_connect("/upload") as ws:
         await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
         await ws.receive_json()
-        await ws.receive_json()
-        await ws.receive_json()
 
-    cmd = captured_spawn["cmd"]
-    assert "upload" in cmd
-    assert "--device" not in cmd
+    assert firmware.upload_calls == [{"configuration": "kitchen.yaml", "port": ""}]
+
+
+async def test_compile_ws_replays_buffered_output_then_streams_live(
+    tmp_path: Path,
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Lines already in ``job.output`` at submit time are replayed first.
+
+    Because the firmware queue is shared, ``compile()`` may
+    return a job that already has buffered output (e.g. a
+    superseded job that landed mid-build). Pin the contract that
+    the legacy WS replays the snapshot before draining live
+    events, so HA's library sees a contiguous output stream
+    rather than a gap before its own subscription window.
+    """
+    bus = EventBus()
+    job = _make_job(output=["pre-existing line 1\n", "pre-existing line 2\n"])
+    firmware = _FakeFirmwareController(bus=bus, job=job, plan=_plan(lines=["live line\n"]))
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
+
+    async with client.ws_connect("/compile") as ws:
+        await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
+        # Two replayed history lines, one live, one exit.
+        first = await ws.receive_json()
+        second = await ws.receive_json()
+        third = await ws.receive_json()
+        fourth = await ws.receive_json()
+
+    assert first == {"event": "line", "data": "pre-existing line 1\n"}
+    assert second == {"event": "line", "data": "pre-existing line 2\n"}
+    assert third == {"event": "line", "data": "live line\n"}
+    assert fourth == {"event": "exit", "code": 0}
+
+
+async def test_compile_ws_emits_exit_immediately_when_job_already_terminal(
+    tmp_path: Path,
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A job that resolved as terminal before subscribe → snapshot + exit.
+
+    Edge case: ``compile()`` can resolve a job that's already in
+    a terminal state (most commonly when a duplicate-submit
+    supersede lands the previous job in CANCELLED before the
+    new job is created and the queue surfaces the cached
+    terminal). The legacy handler should drain the buffered
+    output and send the exit frame from the job snapshot rather
+    than parking on a queue that will never receive the live
+    terminal event.
+    """
+    bus = EventBus()
+    job = _make_job(output=["final line\n"], status=JobStatus.COMPLETED, exit_code=0)
+    firmware = _FakeFirmwareController(bus=bus, job=job)
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
+
+    async with client.ws_connect("/compile") as ws:
+        await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
+        first = await ws.receive_json()
+        second = await ws.receive_json()
+
+    assert first == {"event": "line", "data": "final line\n"}
+    assert second == {"event": "exit", "code": 0}
+
+
+async def test_compile_ws_coerces_null_exit_code_on_cancellation(
+    tmp_path: Path,
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A cancelled job (no exit code) emits ``{event: exit, code: 1}``.
+
+    Cancellation is the supersede path's "previous build was
+    abandoned" signal; the underlying subprocess never ran to
+    completion so ``exit_code`` is ``None``. The legacy frame
+    requires an integer code (HA's library decodes it as a
+    number), so coerce the absent code to ``1`` — same shape
+    HA would have seen from the subprocess being killed.
+    """
+    bus = EventBus()
+    job = _make_job()
+    firmware = _FakeFirmwareController(
+        bus=bus,
+        job=job,
+        plan=_plan(exit_code=None, status=JobStatus.CANCELLED),
+    )
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
+
+    async with client.ws_connect("/compile") as ws:
+        await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
+        msg = await ws.receive_json()
+
+    assert msg == {"event": "exit", "code": 1}
 
 
 # ---------------------------------------------------------------------------
@@ -595,16 +779,23 @@ async def test_upload_ws_omits_device_arg_when_port_empty(
 async def test_spawn_ws_emits_exit_frame_on_traversal(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """A traversal-shaped configuration trips the boundary, emits exit:1.
+    """A boundary-rejected submission emits ``{event: exit, code: 1}``.
 
     The legacy spawn protocol's only signalling channel is the
     exit frame, so a controlled rejection masquerades as
     "subprocess exited with code 1". Without this, the
-    ``CommandError`` from ``rel_path`` would bubble through
+    ``CommandError`` from the firmware controller's
+    ``_validate_configuration_boundary`` would bubble through
     aiohttp and tear the WebSocket down — HA's library would
-    surface a connection drop instead of a clean reject.
+    surface a connection drop instead of a clean reject. The
+    fake firmware controller raises ``CommandError(INVALID_ARGS)``
+    from ``compile`` to simulate the real boundary rejection.
     """
-    client = await aiohttp_client(_make_app(tmp_path))
+    bus = EventBus()
+    job = _make_job()
+    firmware = _FakeFirmwareController(bus=bus, job=job, raise_on_submit=True)
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
+
     async with client.ws_connect("/compile") as ws:
         await ws.send_json({"type": "spawn", "configuration": "../etc/passwd"})
         msg = await ws.receive_json()
@@ -615,7 +806,6 @@ async def test_spawn_ws_emits_exit_frame_on_traversal(
 async def test_spawn_ws_skips_non_json_frame(
     tmp_path: Path,
     aiohttp_client: AiohttpClient,
-    captured_spawn: dict[str, Any],
 ) -> None:
     """Non-JSON text frames are ignored; the next valid spawn still works.
 
@@ -625,8 +815,10 @@ async def test_spawn_ws_skips_non_json_frame(
     processed. Pin so a refactor that closes the WS on the
     first decode error breaks loudly here.
     """
-    (tmp_path / "kitchen.yaml").write_text("")
-    client = await aiohttp_client(_make_app(tmp_path))
+    bus = EventBus()
+    job = _make_job()
+    firmware = _FakeFirmwareController(bus=bus, job=job, plan=_plan(lines=["a\n", "b\n"]))
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
 
     async with client.ws_connect("/compile") as ws:
         await ws.send_str("not-json-at-all")
@@ -641,7 +833,6 @@ async def test_spawn_ws_skips_non_json_frame(
 async def test_spawn_ws_skips_non_spawn_message_type(
     tmp_path: Path,
     aiohttp_client: AiohttpClient,
-    captured_spawn: dict[str, Any],
 ) -> None:
     """Messages with ``type != "spawn"`` are skipped, not handled.
 
@@ -652,8 +843,10 @@ async def test_spawn_ws_skips_non_spawn_message_type(
     ``spawn``; pin so a follow-up that adds support doesn't
     accidentally break the silent-skip behaviour.
     """
-    (tmp_path / "kitchen.yaml").write_text("")
-    client = await aiohttp_client(_make_app(tmp_path))
+    bus = EventBus()
+    job = _make_job()
+    firmware = _FakeFirmwareController(bus=bus, job=job, plan=_plan(lines=["a\n", "b\n"]))
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
 
     async with client.ws_connect("/compile") as ws:
         await ws.send_json({"type": "stdin", "data": "ignored"})
@@ -698,58 +891,47 @@ async def test_spawn_ws_breaks_on_close(tmp_path: Path, aiohttp_client: AiohttpC
     # Closing without raising is the assertion.
 
 
-async def test_spawn_ws_real_subprocess_streams_output(
+async def test_spawn_ws_round_trip_through_real_event_bus(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """Real subprocess (no mock) → output streams through, exit code passes.
+    """End-to-end: real ``EventBus`` carries lines + terminal event to the WS.
 
-    True end-to-end: drives the actual ``create_subprocess_exec``
-    code path against a real subprocess. Catches a regression
-    where a refactor of the streaming loop or the helper itself
-    breaks the line iteration. Uses ``sys.executable -c '<one-
-    liner>'`` so the test doesn't depend on having ``esphome``
-    installed and stays portable across platforms (Windows
-    ``cmd`` / POSIX shells differ on quoting; a Python one-liner
-    runs identically everywhere).
-
-    Replaces ``_ESPHOME_CMD`` for the duration of the test so
-    the spawn shape becomes ``[python, -c, "<script>", ...]``
-    instead of ``[python, -m, esphome, ...]``.
+    The targeted unit tests above mock individual pieces; this one
+    drives the same ``EventBus`` the production firmware
+    controller fires events on, asserting that the listener
+    setup, the snapshot replay, and the live drain all integrate
+    correctly. Catches refactor regressions like "subscribe-and-
+    snapshot ordering reversed" that wouldn't necessarily show up
+    in the targeted tests if the fakes happened to match the
+    broken order.
     """
-    (tmp_path / "kitchen.yaml").write_text("")
-    client = await aiohttp_client(_make_app(tmp_path))
+    bus = EventBus()
+    job = _make_job(output=["snapshot line\n"])
+    firmware = _FakeFirmwareController(
+        bus=bus,
+        job=job,
+        plan=_plan(lines=["live line A\n", "live line B\n"]),
+    )
+    client = await aiohttp_client(_make_app(tmp_path, firmware=firmware, bus=bus))
 
-    # Replace the esphome command with a Python one-liner that
-    # prints two lines and exits 0. Using ``compile`` as the
-    # command so the existing route mapping doesn't change.
-    original_cmd = legacy._ESPHOME_CMD
-    try:
-        legacy._ESPHOME_CMD = [
-            sys.executable,
-            "-c",
-            "import sys; print('hello'); print('world'); sys.exit(0)",
-        ]
-        async with client.ws_connect("/compile") as ws:
-            # Argument after the python -c is the subcommand name
-            # ('compile') and then the resolved config path —
-            # both ignored by the script.
-            await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
-            received: list[dict[str, Any]] = []
-            try:
-                async with asyncio.timeout(5.0):
-                    while True:
-                        msg = await ws.receive_json()
-                        received.append(msg)
-                        if msg.get("event") == "exit":
-                            break
-            except TimeoutError:  # pragma: no cover — hangs are bugs
-                pytest.fail("never received exit frame")
-    finally:
-        legacy._ESPHOME_CMD = original_cmd
+    async with client.ws_connect("/compile") as ws:
+        await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
+
+        received: list[dict[str, Any]] = []
+        try:
+            async with asyncio.timeout(5.0):
+                while True:
+                    msg = await ws.receive_json()
+                    received.append(msg)
+                    if msg.get("event") == "exit":
+                        break
+        except TimeoutError:  # pragma: no cover — hangs are bugs
+            pytest.fail("never received exit frame")
 
     line_data = "".join(msg["data"] for msg in received if msg.get("event") == "line")
-    assert "hello" in line_data
-    assert "world" in line_data
+    assert "snapshot line" in line_data
+    assert "live line A" in line_data
+    assert "live line B" in line_data
     assert received[-1] == {"event": "exit", "code": 0}
 
 

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -983,6 +983,41 @@ async def test_stream_helper_ignores_terminal_events_for_other_jobs() -> None:
     ]
 
 
+async def test_legacy_ws_writer_forwards_frame_dict_verbatim() -> None:
+    """``_LegacyWSWriter`` writes its ``payload`` arg unchanged to the WS.
+
+    Pins the adapter's contract independently of the rest of the
+    streaming pipeline. The integration tests cover this via
+    composition, but a regression that started post-processing
+    the dict (re-keying, dropping fields, encoding the wrong way)
+    would surface in many tests with confusing failures rather
+    than one focused message. Direct unit test: build a writer
+    around a stub WS, feed it a frame dict, assert the dict
+    arrives unchanged.
+
+    Also pins that ``_message_id`` and ``_name`` really are
+    unused — passing arbitrary values for either must not affect
+    the wire output. A future refactor that started reading them
+    would break this test loudly.
+    """
+    sent: list[dict[str, Any]] = []
+
+    class _RecordingWS:
+        async def send_json(self, payload: dict[str, Any], **_kwargs: Any) -> None:
+            sent.append(payload)
+
+    writer = legacy._LegacyWSWriter(_RecordingWS())  # type: ignore[arg-type]
+
+    frame = {"event": "line", "data": "hello\n"}
+    await writer.send_event("ignored-message-id", "ignored-name", frame)
+    await writer.send_event("", "", {"event": "exit", "code": 7})
+
+    assert sent == [
+        {"event": "line", "data": "hello\n"},
+        {"event": "exit", "code": 7},
+    ]
+
+
 async def test_stream_helper_releases_listener_when_send_raises() -> None:
     """``_stream_job_to_legacy_ws`` removes the listener on a send failure.
 

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -45,6 +45,7 @@ import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
+from esphome_device_builder.api import legacy
 from esphome_device_builder.api.legacy import create_legacy_routes
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.devices import DevicesController
@@ -426,6 +427,19 @@ class _FakeFirmwareController:
 
     Optionally raises ``CommandError`` to simulate the boundary-
     validation rejection path.
+
+    *Not* spec'd against the real ``FirmwareController`` (unlike
+    ``_make_devices_mock`` for the devices controller). The reason
+    is that ``FirmwareController.compile`` / ``.upload`` are
+    decorated with ``@api_command`` and live on a class with a
+    deep import surface (``esphome.components.esp32``,
+    ``esphome.storage_json``, …) that's painful to drag into the
+    legacy unit-test file. The trade-off is that a rename of
+    ``compile`` → ``compile_job`` (etc.) wouldn't surface here —
+    if such a rename ever lands, the integration-style end-to-end
+    test in ``test_spawn_ws_round_trip_through_real_event_bus``
+    catches it the same way #376's regression test catches the
+    devices-controller surface.
     """
 
     def __init__(
@@ -472,11 +486,22 @@ class _FakeFirmwareController:
         production firmware controller's "subscribe before
         snapshot" comment is designed to prevent in
         ``follow_job``.
+
+        Attaches a ``done_callback`` that re-raises any
+        ``_fire_plan`` exception by calling ``task.result()``.
+        Without the callback, an exception inside the deferred
+        task lands in pytest-asyncio's unhandled-task warning
+        channel rather than failing the test loudly — making
+        debugging the next person who breaks this miserable.
         """
         if not self._plan:
             return
         loop = asyncio.get_running_loop()
         self.fire_task = loop.create_task(self._fire_plan())
+        # ``task.result()`` re-raises any exception the task
+        # produced; the bare access surfaces it through the
+        # done-callback path so pytest sees a real failure.
+        self.fire_task.add_done_callback(lambda t: t.result())
 
     async def _fire_plan(self) -> None:
         # One ``sleep(0)`` is enough: ``compile()`` returns
@@ -889,6 +914,96 @@ async def test_spawn_ws_breaks_on_close(tmp_path: Path, aiohttp_client: AiohttpC
     async with client.ws_connect("/compile") as ws:
         await ws.close()
     # Closing without raising is the assertion.
+
+
+async def test_stream_helper_releases_listener_when_send_raises() -> None:
+    """``_stream_job_to_legacy_ws`` removes the listener on a send failure.
+
+    Pins the cleanup contract for the disconnect path. In
+    production, a client that closes mid-stream causes the next
+    ``ws.send_json`` to raise (``ConnectionResetError`` or
+    similar), and ``with bus.listening(...)`` must run the
+    listener-removal callback exactly once on the way out.
+    Without this, a dead listener would stay attached on the
+    bus until the dashboard restarted — fine in the short term,
+    a leak over a long-lived process's lifetime.
+
+    Drives the helper directly with a stub WS rather than going
+    through the aiohttp close handshake (which carries a 10-second
+    server-side timeout that makes the end-to-end version of this
+    test slow). The cleanup path is purely a Python ``with``-exit
+    so the unit-level assertion catches the same regression a
+    full-stack test would.
+    """
+    bus = EventBus()
+    job = _make_job()
+
+    class _BrokenWS:
+        async def send_json(self, *_args: Any, **_kwargs: Any) -> None:
+            raise ConnectionResetError("client gone")
+
+    # Confirm the bus starts with no listeners — a stale fixture
+    # would make the post-call assertion meaningless.
+    assert bus._listeners == {}
+
+    # Pre-stage a JOB_OUTPUT event so the handler wakes from
+    # ``pending.get()`` immediately, attempts the (failing) send,
+    # and exits the ``with`` block.
+    async def _fire_after_subscribe() -> None:
+        await asyncio.sleep(0)
+        bus.fire(EventType.JOB_OUTPUT, {"job_id": job.job_id, "line": "x\n"})
+
+    fire_task = asyncio.create_task(_fire_after_subscribe())
+    try:
+        with pytest.raises(ConnectionResetError):
+            await legacy._stream_job_to_legacy_ws(_BrokenWS(), bus, job)  # type: ignore[arg-type]
+    finally:
+        await fire_task
+
+    # All listener slots must be empty: the helper subscribes to
+    # JOB_OUTPUT plus the three terminal events, and a partial
+    # cleanup (e.g. exit on JOB_OUTPUT before JOB_COMPLETED is
+    # added) would still leave a leaking entry behind.
+    for event_type in (
+        EventType.JOB_OUTPUT,
+        EventType.JOB_COMPLETED,
+        EventType.JOB_FAILED,
+        EventType.JOB_CANCELLED,
+    ):
+        assert bus._listeners.get(event_type, set()) == set()
+
+
+async def test_spawn_ws_rejects_when_firmware_not_initialised(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """``firmware=None`` at request time → ``{event: exit, code: 1}`` not crash.
+
+    Production sets ``DeviceBuilder.firmware`` before HTTP is
+    served, but typing it as ``Optional`` means a startup-order
+    regression would leave the legacy handler reading ``None``
+    and ``AttributeError``-ing on the next ``.compile()`` call —
+    surfacing to HA as an opaque connection drop. The defensive
+    early-return turns that into the protocol's only signalling
+    channel: a ``code: 1`` exit frame.
+    """
+    bus = EventBus()
+    # Build the app with firmware=None deliberately. ``_make_app``
+    # only adds attrs whose value is non-None, so we use a custom
+    # builder that wires firmware=None explicitly.
+    settings = DashboardSettings()
+    settings.config_dir = tmp_path
+    settings.absolute_config_dir = tmp_path.resolve()
+    db_attrs = {"settings": settings, "firmware": None, "bus": bus}
+    app = web.Application()
+    app["device_builder"] = type("DB", (), db_attrs)()
+    app.add_routes(create_legacy_routes())
+
+    client = await aiohttp_client(app)
+    async with client.ws_connect("/compile") as ws:
+        await ws.send_json({"type": "spawn", "configuration": "kitchen.yaml"})
+        msg = await ws.receive_json()
+
+    assert msg == {"event": "exit", "code": 1}
 
 
 async def test_spawn_ws_round_trip_through_real_event_bus(

--- a/tests/controllers/firmware/test_clear.py
+++ b/tests/controllers/firmware/test_clear.py
@@ -51,7 +51,7 @@ async def test_clear_default_removes_all_terminal_states(
     """``clear()`` with no args removes every terminal job (COMPLETED/FAILED/CANCELLED).
 
     Pin all three terminal states in one test so a regression that
-    forgets to include any one of them in ``_TERMINAL_JOB_STATUSES``
+    forgets to include any one of them in ``TERMINAL_JOB_STATUSES``
     surfaces here regardless of which state was missed.
     """
     controller = firmware_controller_factory(

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -350,7 +350,7 @@ async def test_cancelled_terminal_event_returns_with_status(
     """``JOB_CANCELLED`` ends the follow with a ``cancelled`` result.
 
     Mirrors the completed/failed paths but exercises the third
-    entry in ``_JOB_TERMINAL_EVENTS``. Without coverage here a
+    entry in ``TERMINAL_JOB_EVENTS``. Without coverage here a
     listener change that drops ``JOB_CANCELLED`` from the
     subscribed set would silently leave followers parked on the
     queue forever — the build's own runner has stopped firing


### PR DESCRIPTION
# What does this implement/fix?

Routes the legacy `/compile` and `/upload` WebSocket endpoints
through the new `FirmwareController` job queue so HA-triggered
builds appear alongside dashboard-triggered ones in the "Firmware
tasks" panel. Closes #394.

The legacy spawn-protocol wire shape is preserved verbatim — HA's
`esphome-dashboard-api` reads the same `{event: "line", data}` /
`{event: "exit", code}` frames it always has — but the build
itself runs as a queued firmware job instead of the per-WS
subprocess that bypassed the dashboard's bookkeeping.

## How it fits together

Three small pieces in `api/legacy.py`:

- **Frame builders** (`_line_frame` / `_exit_frame`) — return the
  legacy-protocol dicts. `_exit_frame` centralises the
  "`exit_code is None` → coerce to `1`" rule for cancelled /
  never-ran jobs (HA's wire format requires an integer code).
- **`_LegacyWSWriter`** — minimal `stream_events` adapter. Every
  wire frame is built upstream and arrives at the writer as a
  ready-to-send dict, so the adapter is one line:
  `await ws.send_json(payload, dumps=dumps_str)`. No name
  switching, no protocol logic.
- **`_stream_job_to_legacy_ws`** — the actual stream pump. Routes
  through `helpers.event_bus.stream_events` for the
  subscribe / bounded-queue / drain / cleanup pipeline the
  multiplexed `/ws` follower commands already use. Single code
  path: snapshot replay, live `JOB_OUTPUT` events, and the
  terminal frame all go through `controls.push` /
  `controls.push_priority` and out the writer in order. Lines
  drop on full (slow follower → drop, no `bus.fire` blocking);
  the terminal frame uses `push_priority` (force-enqueue, evicts
  oldest) so the exit frame always lands.

`_handle_spawn` factored out of the receive loop so the per-
message logic doesn't tangle with iteration / break semantics.
Three rejection paths all surface via the protocol's only
signalling channel (`code: 1` exit frame): non-string field
types, `CommandError` from boundary validation, and the implicit
exit on terminal stream completion.

## Snapshot+subscribe atomicity

The race-free property is preserved at the call site:

1. `snapshot = list(job.output)` is captured *outside*
   `stream_events` — a fresh list copy so a later
   `_trim_job_output` reassign (`firmware/helpers.py`) doesn't
   mutate what we replay.
2. `stream_events` attaches the listener (sync) before any
   `await` yields control. No event can fire between (1) and
   (2), so each line lands in exactly one of snapshot or live.
3. `send_initial` pushes snapshot frames synchronously (no awaits
   between pushes) so they can't interleave with live events.

## Shared constants

`TERMINAL_JOB_STATUSES` and `TERMINAL_JOB_EVENTS` moved out of
`controllers/firmware/constants.py` (where they were `_`-prefixed
private) into `models/firmware.py` next to `JobStatus`. The
firmware controller, helpers, and the new legacy handler all
import them by their public name from `..models`. No alias
indirection, no duplicate definitions, exported through
`models/__init__.py` for any future external consumer.

## Behaviour notes

Verified against the actual HA usage in
`homeassistant/components/esphome/update.py` and the
`esphome-dashboard-api` library:

- **Concurrency**: HA serialises compiles globally via
  `KEY_UPDATE_LOCK` (`update.py:233`), so the firmware queue's
  single-worker shape never causes a "second compile supersedes
  the first."
- **Output handling**: HA passes `line_received_cb=None` for OTA
  updates so `stream_logs` reads frames and discards their
  payload. The firmware queue's output cap doesn't affect HA's
  UI.
- **WS disconnect mid-build**: pinned by
  `test_stream_helper_releases_listener_when_send_raises`. Under
  HA's normal flow this is a non-issue (HA closes after the exit
  frame); a network blip surfaces as `stream_logs → False` to HA
  while the queued build runs to completion in the dashboard.

## Tests

`tests/api/test_legacy.py` is rewritten end-to-end against a fake
`FirmwareController` + a real `EventBus` so the legacy handler's
translation is exercised against the same bus shape the
production runner fires. 100% coverage on `api/legacy.py`. Notable
cases:

- Wire-frame parity (line + exit frames, exit code passthrough).
- Job submission (compile vs upload, port pass-through, empty
  port, supersede / already-terminal short-circuit, history
  replay).
- Type validation for non-string `configuration` / `port`
  (parametrised: null, int, nested object).
- Cross-job filter — terminal events for a different job_id are
  ignored.
- Listener cleanup on send failure (the disconnect-mid-stream
  path).
- Round-trip end-to-end with a real `EventBus` driving the
  bounded-queue + drain pipeline.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#394

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

The legacy WS frame shape is unchanged, so HA's
`esphome-dashboard-api` keeps working without any change. The
dashboard frontend talks to the new firmware controller over
`/ws` directly — nothing to coordinate there either.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
