### PR TITLE
Document the Path.write_text non-atomicity bite + write_file convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,34 @@ When changing the sync script or catalog handling, watch for these:
   mock has a `side_effect` that flips the device's field. See
   the `_flip_state` / `_flip` helpers in `tests/test_mdns_*.py`
   for the pattern.
+- **In-place file writes need `esphome.helpers.write_file`,
+  not `Path.write_text`.** Both `Path.write_text` and a plain
+  `open(path, "w")` truncate the destination *before* writing
+  the new bytes — a crash or exception between the truncate and
+  the flush leaves the user with an empty or half-written file.
+  For YAML configs that's unrecoverable; the device's config is
+  gone. `esphome.helpers.write_file` is the canonical helper:
+  stages the new bytes in a `NamedTemporaryFile` in the
+  *destination* directory, then `shutil.move`s into place — atomic
+  on POSIX (same-FS rename) and Windows (`os.replace` semantics
+  underneath), with `fchmod` to 0o644 by default and
+  `EsphomeError` wrapping. Use it for any in-place rewrite of
+  user-editable YAML / settings (`edit_friendly_name` is the
+  canonical example). Same-directory tempfile matters: the
+  default `tempfile.mkstemp` lands on `/tmp`, which is a separate
+  filesystem from `/config` in the HA addon — `shutil.move`
+  silently degrades to copy+delete across filesystems and you
+  lose atomicity. Don't hand-roll a temp+rename dance for
+  in-place edits; the helper already does it correctly.
+
+  *New* files are a different shape — `clone_device` opens via
+  `open(path, "x")` (exclusive-create), which is already atomic
+  by virtue of failing if the target exists. Only in-place
+  *edits* of an existing file need `write_file`. Build artefacts
+  (StorageJSON sidecars, `.device-builder.json` metadata) where a
+  partial write is recoverable on next compile / scan can stay
+  on direct-write paths — the criterion is "would losing this
+  file lose user-authored content."
 
 ## Useful entry points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,17 +359,20 @@ When changing the sync script or catalog handling, watch for these:
   For YAML configs that's unrecoverable; the device's config is
   gone. `esphome.helpers.write_file` is the canonical helper:
   stages the new bytes in a `NamedTemporaryFile` in the
-  *destination* directory, then `shutil.move`s into place — atomic
-  on POSIX (same-FS rename) and Windows (`os.replace` semantics
-  underneath), with `fchmod` to 0o644 by default and
-  `EsphomeError` wrapping. Use it for any in-place rewrite of
-  user-editable YAML / settings (`edit_friendly_name` is the
-  canonical example). Same-directory tempfile matters: the
-  default `tempfile.mkstemp` lands on `/tmp`, which is a separate
-  filesystem from `/config` in the HA addon — `shutil.move`
-  silently degrades to copy+delete across filesystems and you
-  lose atomicity. Don't hand-roll a temp+rename dance for
-  in-place edits; the helper already does it correctly.
+  *destination* directory, then `shutil.move`s into place. The
+  resulting move is atomic only when it can resolve to a same-FS
+  `os.rename` / `os.replace`; cross-filesystem it degrades to
+  copy+delete which is *not* atomic. Staging the tempfile in the
+  destination directory keeps it same-FS and the move atomic.
+  `write_file` also handles `fchmod` to 0o644 by default and
+  wraps `OSError` as `EsphomeError`. Use it for any in-place
+  rewrite of user-editable YAML / settings (`edit_friendly_name`
+  is the canonical example). Don't fall back to
+  `tempfile.mkstemp` without the `dir=` argument — it lands on
+  `/tmp`, which is a separate filesystem from `/config` in the
+  HA addon, and the cross-FS `shutil.move` silently loses
+  atomicity. Don't hand-roll a temp+rename dance either; the
+  helper already does it correctly.
 
   *New* files are a different shape — `clone_device` opens via
   `open(path, "x")` (exclusive-create), which is already atomic


### PR DESCRIPTION
# What does this implement/fix?

Documents the `Path.write_text` non-atomicity bite and the `esphome.helpers.write_file` convention in `CLAUDE.md`. Surfaced on PR #390 (the friendly-name editor) when Copilot flagged the in-place YAML write — the helper's bite is real, the upstream-canonical fix is `write_file`, and we want future contributors to know both before they hand-roll a write+rename dance or land another raw `Path.write_text` on user YAML.

## What the new entry says

Three things, all in one bullet under "Things that have bitten us before":

1. **The bite** — `Path.write_text` and a plain `open(path, "w")` truncate the destination *before* writing the new bytes. A crash or exception between the truncate and the flush leaves the user with an empty or partial file. For YAML configs that's unrecoverable.
2. **The fix** — `esphome.helpers.write_file` is the canonical helper. Stages new bytes in a `NamedTemporaryFile` in the *destination* directory, then `shutil.move`s into place. Atomic on POSIX (same-FS rename) and Windows (`os.replace` semantics underneath), with `fchmod` and `EsphomeError` wrapping.
3. **The subtlety that bit me on #390** — the tempfile has to be in the destination directory. The default `tempfile.mkstemp` lands on `/tmp`, which is a separate filesystem from `/config` in the HA addon — `shutil.move` silently degrades to copy+delete across filesystems and you lose the atomic guarantee. `write_file` already gets this right; hand-rolled versions usually don't.

Plus a note distinguishing the cases: in-place edits need `write_file`; new-file creation via `open(path, "x")` (exclusive-create) is already atomic by virtue of failing on exists; build artefact writes where partial loss is recoverable on next compile / scan can stay on direct-write paths.

## Why this lands now

Two follow-ups depend on it:

- A separate audit PR (queued) walks all `Path.write_text` / `open(...).write` call sites in `esphome_device_builder/` and switches the ones writing user YAML to `write_file`. The CLAUDE.md note gives that PR's reasoning a stable home to point at.
- An upstream esphome PR (esphome/esphome#16290) adds a parallel docstring to `write_file` itself naming the device-builder as an external consumer, so changes to the upstream helper's atomicity / wrapping semantics surface as a deliberate contract change rather than a silent behaviour shift in our YAML edits.

**Related issue or feature (if applicable):**

- N/A — driven by review feedback on PR #390 + the sibling upstream PR esphome/esphome#16290.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
