### PR TITLE
Switch user-YAML write paths to esphome.helpers.write_file

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -18,6 +18,7 @@ from esphome import yaml_util
 from esphome.const import __version__ as esphome_version
 from esphome.core import CORE
 from esphome.helpers import get_bool_env
+from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON, ext_storage_path
 from esphome.util import get_serial_ports
 
@@ -106,15 +107,21 @@ class DashboardSettings:
         self.config_dir = Path(args.configuration)
         self.config_dir.mkdir(parents=True, exist_ok=True)
         self.absolute_config_dir = self.config_dir.resolve()
-        # Ensure secrets.yaml exists (ESPHome fails if !secret references can't find it)
+        # Ensure secrets.yaml exists (ESPHome fails if !secret references
+        # can't find it). Atomic write — a crash mid-write would leave the
+        # user with a half-bootstrap'd secrets file and the next startup
+        # would see ``not exists() == False`` on the partial and skip
+        # this branch, leaving them stuck. ``write_file`` stages in a
+        # sibling tempfile + ``shutil.move`` so the file is either fully
+        # there or not at all.
         secrets_path = self.config_dir / "secrets.yaml"
         if not secrets_path.exists():
-            secrets_path.write_text(
+            atomic_write_file(
+                secrets_path,
                 "# Secrets — referenced from device configs via !secret\n"
                 "# Update these values for your network\n"
                 'wifi_ssid: ""\n'
                 'wifi_password: ""\n',
-                encoding="utf-8",
             )
         self.log_level = getattr(args, "log_level", "info")
         self.port = getattr(args, "port", 6052)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from esphome import const
 from esphome.components.dashboard_import import import_config
+from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 
 from ...helpers.api import CommandError, api_command
@@ -1099,7 +1100,10 @@ class DevicesController:
         """Write device config YAML."""
         path = self._db.settings.rel_path(configuration)
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, path.write_text, content, "utf-8")
+        # Atomic write — see ``edit_friendly_name`` for the
+        # rationale. The YAML editor's "Save" button lands here, so
+        # a non-atomic write would lose the user's config on a crash.
+        await loop.run_in_executor(None, atomic_write_file, path, content)
         await self._scanner.scan()
         # Refresh ``StorageJSON`` so address / loaded_integrations /
         # config_hash etc. reflect the new YAML without waiting for a
@@ -1437,7 +1441,9 @@ class DevicesController:
         # does field-by-field on the input form.
         fields = _drop_unconfigured_dependent_fields(fields, component, existing)
         new_yaml = merge_component_yaml(existing, component, fields)
-        await loop.run_in_executor(None, config_path.write_text, new_yaml, "utf-8")
+        # Atomic write — wizard-driven add-component should not be
+        # able to corrupt the source YAML on a mid-write crash.
+        await loop.run_in_executor(None, atomic_write_file, config_path, new_yaml)
         await self._scanner.scan()
 
         return AddComponentResponse(yaml=new_yaml)
@@ -2527,7 +2533,15 @@ class DevicesController:
         # leave the line alone than silently flip a value the user
         # may have set deliberately.
         new_content = rewrite_esphome_name(content, new_name, only_if_current=old_name)
-        new_path.write_text(new_content, encoding="utf-8")
+        # Atomic write of the new file before unlinking the old.
+        # ``new_path.exists()`` was checked above, but a parallel
+        # rename racing into the same target would otherwise
+        # silently overwrite. ``write_file`` uses
+        # ``shutil.move`` after staging, so the failure mode of a
+        # mid-rename crash leaves the SOURCE intact (we haven't
+        # ``unlink``'d yet) and the staged tempfile cleaned up —
+        # rename can be retried.
+        atomic_write_file(new_path, new_content)
         old_path.unlink()
 
         # Move StorageJSON alongside the YAML rename

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1100,9 +1100,11 @@ class DevicesController:
         """Write device config YAML."""
         path = self._db.settings.rel_path(configuration)
         loop = asyncio.get_running_loop()
-        # Atomic write — see ``edit_friendly_name`` for the
-        # rationale. The YAML editor's "Save" button lands here, so
-        # a non-atomic write would lose the user's config on a crash.
+        # Atomic write — the YAML editor's "Save" button lands
+        # here, so a non-atomic write would lose the user's
+        # config on a mid-write crash. See ``CLAUDE.md`` >
+        # "Things that have bitten us before" for the full
+        # ``Path.write_text`` non-atomicity story.
         await loop.run_in_executor(None, atomic_write_file, path, content)
         await self._scanner.scan()
         # Refresh ``StorageJSON`` so address / loaded_integrations /

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -2534,13 +2534,14 @@ class DevicesController:
         # may have set deliberately.
         new_content = rewrite_esphome_name(content, new_name, only_if_current=old_name)
         # Atomic write of the new file before unlinking the old.
-        # ``new_path.exists()`` was checked above, but a parallel
-        # rename racing into the same target would otherwise
-        # silently overwrite. ``write_file`` uses
-        # ``shutil.move`` after staging, so the failure mode of a
-        # mid-rename crash leaves the SOURCE intact (we haven't
-        # ``unlink``'d yet) and the staged tempfile cleaned up —
-        # rename can be retried.
+        # A mid-write crash leaves the SOURCE intact (we haven't
+        # ``unlink``'d yet) and ``write_file`` cleans up its
+        # staging tempfile — rename can be retried. (Concurrent
+        # rename into the same target is best-effort guarded by
+        # the ``new_path.exists()`` check above; ``write_file``
+        # itself doesn't add race protection — its
+        # ``shutil.move`` will silently overwrite a target that
+        # appeared after our check.)
         atomic_write_file(new_path, new_content)
         old_path.unlink()
 


### PR DESCRIPTION
# What does this implement/fix?

Audit follow-up to the CLAUDE.md `Path.write_text` non-atomicity note (#399) and the upstream `esphome.helpers.write_file` docstring (esphome/esphome#16290). Walks every `Path.write_text` / `open(path, "w")` call site under `esphome_device_builder/` and switches the ones writing user-authored content to `esphome.helpers.write_file`.

## Four real bites surfaced

All four would lose user data on a mid-write crash because `Path.write_text` truncates the destination before writing the new bytes:

1. **`controllers/config.py`** — `secrets.yaml` bootstrap on first startup. A half-written `secrets.yaml` is the worst case: the next startup sees `not secrets_path.exists()` as False (a partial file exists), skips the bootstrap branch, and every subsequent `!secret` reference fails for that user's whole config tree.
2. **`devices/update_config`** — the WS command the YAML editor's "Save" button lands on. Most user-facing bite — directly losing the editor buffer to a crash.
3. **`devices/add_component`** — wizard-driven component-append flow. Partial YAML on disk after a crash means the next compile reads garbage.
4. **`_manual_rename`** — file-level rename fallback. Now atomic-writes the new file *before* unlinking the old, so a mid-rename crash leaves the source intact and recoverable.

Each switches from `path.write_text(content, encoding="utf-8")` to `await loop.run_in_executor(None, atomic_write_file, path, content)` (or the sync direct call where the function is already inside an executor). The import is aliased as `atomic_write_file` to keep call sites readable about intent.

## What was deliberately skipped

The audit walked every write call site; not everything needs to switch:

- **`open(path, "x")` exclusive-create** for new files (`create_device`, `clone_device`'s YAML write) — already atomic on the existence check by virtue of the open mode failing if the target exists. A partial new-file write is recoverable (delete and retry) — different shape from the in-place edit bite. Distinguished in the CLAUDE.md note (#399) as a separate case.
- **`_save_metadata`** (`.device-builder.json`) — already hand-rolls a tempfile + `os.replace` pattern that does the right thing. Could swap for `write_file` for consistency, but the criterion is "user-authored content"; metadata is dashboard-managed sidecar state and recoverable on next save.
- **StorageJSON sidecar writes** — build artefacts; partial loss is recoverable on next compile.
- **`proc.stdin.write`** in `controllers/editor.py` — subprocess pipes, not file writes.

## Testing

1827 backend tests pass. The `update_config` path is covered by the existing editor integration tests; `add_component` by `test_add_component.py`; `_manual_rename` by `test_rename_inline_e2e.py`. No new tests in this PR — the swap is pure refactor (same call signature, same blocking surface in the executor) and the upstream `write_file` has its own test coverage in esphome.

**Related issue or feature (if applicable):**

- N/A — follow-up audit driven by the friendly-name editor PR (#390) and the CLAUDE.md note (#399).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
