### PR TITLE
Document the never-generate-invalid-configs principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,37 @@ in case anything has resurfaced.
   use `all(...)` / `any(...)` over the whole bucket; the
   per-device callbacks fan out the actual mutation.
 
+## Design principles
+
+- **Never generate invalid configs; fix the source, not the
+  consumer.** When a downstream code path encounters an invalid
+  YAML — `esphome config` exits non-zero, schema validation
+  rejects, compile fails — the right response is to fix the
+  *generator* (wizard, `dashboard_import`, `clone`,
+  `create_device`, anything that emits a YAML) so it always
+  produces something the next step can validate cleanly. Don't
+  reach for a fallback in the consumer that "tries to make it
+  work anyway." The rename path tried that — a file-level
+  rewrite when `esphome config` failed — and silently desynced
+  on-disk state from the device's running firmware: the YAML
+  got renamed while the device on the network kept its old
+  hostname forever, with no error to the user. The same shape
+  bit `edit_friendly_name` (PR #390 added pre-write validation
+  there) and the rename fallback was deleted entirely (PR #402,
+  with an upstream companion at esphome/esphome#16296).
+
+  When you're tempted to add a defensive branch for "what if
+  the input is broken?", first audit *what generated this YAML*
+  and whether the generator can be hardened so the broken case
+  doesn't reach you. If the generator legitimately can't
+  guarantee validity (e.g. a user hand-edits between create and
+  rename), surface a typed `CommandError(INVALID_ARGS, …)` with
+  the actual validation errors — refuse the operation cleanly —
+  rather than a silent best-effort fallback. Pair the
+  consumer-side error with a generator-side test that runs the
+  output through `editor.validate_yaml` (or the equivalent
+  schema check) so the same shape can't reappear.
+
 ## Things that have bitten us before
 
 When changing the sync script or catalog handling, watch for these:


### PR DESCRIPTION
# What does this implement/fix?

Adds a "Design principles" section to `CLAUDE.md` documenting the **never-generate-invalid-configs** rule.

The rename path's deleted file-level fallback (#402) and the `edit_friendly_name` pre-write validation (#390) both came out of the same shape: a downstream operation got a broken YAML, and the first instinct was to add a defensive branch that "handled" the broken state. Both times the right fix turned out to be one layer up — make sure the generator (wizard, `dashboard_import`, `clone`, `create_device`) never emits something the next step can't validate.

This document captures that as a rule so the next change that runs into "what if the input is invalid?" routes around the same temptation. Future audit PRs (one per generator) will run each generator's output through `editor.validate_yaml` to verify the rule holds end-to-end and pin it with tests.

**Related issue or feature (if applicable):**

- n/a (follow-up to #402)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
