### PR TITLE
Validate generated YAML before create_device writes; emit a valid stub when no board

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -17,7 +17,7 @@ import time
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from esphome import const
 from esphome.components.dashboard_import import import_config
@@ -100,6 +100,18 @@ if TYPE_CHECKING:
     from ...models import BoardCatalogEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+# Provenance tag for ``_yaml_content_for_create``'s return tuple.
+# ``"user"`` → caller-supplied ``file_content`` (validation
+# failure surfaces as ``INVALID_ARGS``).
+# ``"template"`` → :func:`generate_device_yaml` against a known
+# catalog entry (validation failure → ``INTERNAL_ERROR``).
+# ``"stub"`` → :func:`generate_minimal_stub_yaml` (no inputs;
+# validation failure → ``INTERNAL_ERROR``; caller skips the YAML-
+# driven board-id derivation since the stub's hard-coded
+# ``board: esp32dev`` would otherwise pin metadata to whatever
+# catalog entry happens to share that PIO board).
+_CreateYamlSource = Literal["user", "template", "stub"]
 
 # How long the persisted "regen failed" stamp is honoured before a
 # restart-time check is allowed to re-spawn ``--only-generate`` for
@@ -503,7 +515,7 @@ class DevicesController:
                 raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         friendly = friendly_name_slugify(name)
-        yaml_content, from_user = self._yaml_content_for_create(
+        yaml_content, source = self._yaml_content_for_create(
             name, friendly, board, file_content, ssid, psk
         )
 
@@ -517,24 +529,35 @@ class DevicesController:
             filename,
             yaml_content,
             action="create",
-            on_failure=ErrorCode.INVALID_ARGS if from_user else ErrorCode.INTERNAL_ERROR,
+            on_failure=ErrorCode.INVALID_ARGS if source == "user" else ErrorCode.INTERNAL_ERROR,
         )
 
         # Derive board_id from YAML when not explicitly provided.
         # Mirrors the scanner's resolution chain: pio_board match first,
         # then platform+variant fallback for generic ``esp32:``-style
         # configs without a specific PlatformIO board id.
+        #
+        # Skip derivation for the stub branch. ``generate_minimal_stub_yaml``
+        # hard-codes ``esp32: board: esp32dev`` because the user
+        # hasn't picked hardware yet, but many catalog entries share
+        # that PIO board — running the lookup would pin the new
+        # device to whatever catalog entry the index happens to
+        # surface first, and the wrong entry would stay bound even
+        # after the user rewrites the platform block. ``parsed_platform``
+        # is still set so :func:`StorageJSON` gets a sensible
+        # ``target_platform`` for the initial sidecar.
         parsed_platform = ""
         if not board_id and self._db.boards:
             parsed_platform, pio_board, variant = parse_platform_from_yaml(yaml_content)
-            matched = None
-            if pio_board:
-                matched = self._db.boards.find_by_pio_board(pio_board, variant)
-            if matched is None and parsed_platform:
-                matched = self._db.boards.find_by_platform_variant(parsed_platform, variant)
-            if matched:
-                board = matched
-                board_id = matched.id
+            if source != "stub":
+                matched = None
+                if pio_board:
+                    matched = self._db.boards.find_by_pio_board(pio_board, variant)
+                if matched is None and parsed_platform:
+                    matched = self._db.boards.find_by_platform_variant(parsed_platform, variant)
+                if matched:
+                    board = matched
+                    board_id = matched.id
 
         loop = asyncio.get_running_loop()
 
@@ -1142,21 +1165,19 @@ class DevicesController:
         file_content: str | None,
         ssid: str,
         psk: str,
-    ) -> tuple[str, bool]:
+    ) -> tuple[str, _CreateYamlSource]:
         """
         Pick the YAML body for ``devices/create`` based on the inputs.
 
-        Returns ``(yaml_content, from_user)``. *from_user* tracks
-        whether the YAML came from caller-supplied ``file_content``
-        — the caller uses it to pick the right ``ErrorCode`` on
-        validation failure (``INVALID_ARGS`` for user-supplied,
-        ``INTERNAL_ERROR`` for the two generator branches we own).
+        Returns ``(yaml_content, source)``; see :data:`_CreateYamlSource`
+        for the meaning of each tag and which post-processing the
+        caller applies per branch.
         """
         if file_content:
-            return file_content, True
+            return file_content, "user"
         if board:
-            return generate_device_yaml(name, friendly, board, ssid, psk), False
-        return generate_minimal_stub_yaml(name, friendly), False
+            return generate_device_yaml(name, friendly, board, ssid, psk), "template"
+        return generate_minimal_stub_yaml(name, friendly), "stub"
 
     async def _validate_rewritten_yaml_or_raise(
         self,

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -97,6 +97,7 @@ from .helpers import (
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
+    from ...models import BoardCatalogEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -431,7 +432,7 @@ class DevicesController:
     # ------------------------------------------------------------------
 
     @api_command("devices/create")
-    async def create_device(  # noqa: PLR0912, PLR0915
+    async def create_device(  # noqa: PLR0915
         self,
         *,
         name: str,
@@ -502,14 +503,9 @@ class DevicesController:
                 raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         friendly = friendly_name_slugify(name)
-        from_user = False
-        if file_content:
-            yaml_content = file_content
-            from_user = True
-        elif board:
-            yaml_content = generate_device_yaml(name, friendly, board, ssid, psk)
-        else:
-            yaml_content = generate_minimal_stub_yaml(name, friendly)
+        yaml_content, from_user = self._yaml_content_for_create(
+            name, friendly, board, file_content, ssid, psk
+        )
 
         # Validate before write so an unflashable YAML never lands
         # on disk. ``INVALID_ARGS`` for the user-supplied
@@ -1137,6 +1133,30 @@ class DevicesController:
         await loop.run_in_executor(None, atomic_write_file, config_path, new_content)
         await self._scanner.scan()
         return {"configuration": configuration, "rewritten": True}
+
+    def _yaml_content_for_create(
+        self,
+        name: str,
+        friendly: str,
+        board: BoardCatalogEntry | None,
+        file_content: str | None,
+        ssid: str,
+        psk: str,
+    ) -> tuple[str, bool]:
+        """
+        Pick the YAML body for ``devices/create`` based on the inputs.
+
+        Returns ``(yaml_content, from_user)``. *from_user* tracks
+        whether the YAML came from caller-supplied ``file_content``
+        — the caller uses it to pick the right ``ErrorCode`` on
+        validation failure (``INVALID_ARGS`` for user-supplied,
+        ``INTERNAL_ERROR`` for the two generator branches we own).
+        """
+        if file_content:
+            return file_content, True
+        if board:
+            return generate_device_yaml(name, friendly, board, ssid, psk), False
+        return generate_minimal_stub_yaml(name, friendly), False
 
     async def _validate_rewritten_yaml_or_raise(
         self,

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -431,7 +431,7 @@ class DevicesController:
     # ------------------------------------------------------------------
 
     @api_command("devices/create")
-    async def create_device(  # noqa: PLR0915
+    async def create_device(  # noqa: PLR0912, PLR0915
         self,
         *,
         name: str,

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -477,6 +477,17 @@ class DevicesController:
         filename = f"{name}.yaml"
         config_path = self._db.settings.rel_path(filename)
 
+        # Fast collision check before the (~hundreds of ms) validator
+        # round-trip so a duplicate-name attempt fails on the right
+        # diagnostic instead of surfacing a "config doesn't validate"
+        # for a YAML we weren't about to write anyway. The ``open(...,
+        # "x")`` further down is the actual race-safe write — the
+        # check here is a UX optimisation, not a TOCTOU guard.
+        loop_for_check = asyncio.get_running_loop()
+        if await loop_for_check.run_in_executor(None, config_path.exists):
+            msg = f"Configuration {filename} already exists"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+
         # Surface user-correctable failures (unknown board, name
         # collision) as typed ``INVALID_ARGS`` so the wizard can show
         # a specific message instead of the WS layer's generic

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -30,6 +30,7 @@ from ...helpers.config_hash import compute_yaml_config_hash, read_build_info_has
 from ...helpers.device_yaml import (
     configuration_stem,
     generate_device_yaml,
+    generate_minimal_stub_yaml,
     get_api_encryption_key,
     load_device_yaml,
     parse_esphome_meta,
@@ -443,27 +444,26 @@ class DevicesController:
         """
         Create a new device configuration.
 
-        Two flows, decided by which arguments are provided:
+        Three flows, decided by which arguments are provided:
 
         1. ``file_content`` given → write it as-is (user supplied full YAML).
         2. ``board_id`` given → generate a basic config from the board template.
-
-        Neither argument is rejected up-front: a YAML with just
-        ``esphome.name`` and ``friendly_name`` and no platform block
-        doesn't pass ESPHome's schema, so writing it would land an
-        invalid config on disk that every downstream operation
-        (rename, edit_friendly_name, install) would refuse via its
-        own pre-flight check. The frontend always supplies one of
-        the two — this guard catches direct WS clients that
-        otherwise produce a foot-gun.
+        3. Neither given → emit a minimal valid esp32 stub via
+           :func:`generate_minimal_stub_yaml`. The wizard's
+           "Empty Configuration — for manually writing or pasting"
+           button hits this path; the user wants a starter they
+           can fully rewrite, but the starter must validate so
+           downstream operations don't refuse it. esp32 is the
+           default platform (most common); a leading comment in
+           the stub tells the user to swap the platform block if
+           their hardware differs.
 
         Whichever flow runs, the resulting YAML is validated through
         ``EditorController``'s schema check before the file lands on
         disk. Validation failures surface as ``INVALID_ARGS`` (the
         user's ``file_content`` is unfixable from our side) or
-        ``INTERNAL_ERROR`` (the board template generated something
-        invalid — that's our bug to fix in ``generate_device_yaml``,
-        not the user's problem).
+        ``INTERNAL_ERROR`` (one of the generators emitted an
+        invalid YAML — that's our bug to fix, not the user's).
 
         After writing, we always try to derive a board_id by parsing
         the resulting YAML's platform/board/variant fields and matching
@@ -491,30 +491,26 @@ class DevicesController:
                 raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         friendly = friendly_name_slugify(name)
-        from_template = False
+        from_user = False
         if file_content:
             yaml_content = file_content
+            from_user = True
         elif board:
             yaml_content = generate_device_yaml(name, friendly, board, ssid, psk)
-            from_template = True
         else:
-            raise CommandError(
-                ErrorCode.INVALID_ARGS,
-                "Provide either board_id or file_content; a name-only stub "
-                "doesn't satisfy ESPHome's schema (no platform block) and "
-                "would fail every downstream operation.",
-            )
+            yaml_content = generate_minimal_stub_yaml(name, friendly)
 
         # Validate before write so an unflashable YAML never lands
-        # on disk. ``INTERNAL_ERROR`` for the template branch — a
-        # generator bug we own — and ``INVALID_ARGS`` for the user-
-        # supplied ``file_content`` branch where the user can fix
-        # their input.
+        # on disk. ``INVALID_ARGS`` for the user-supplied
+        # ``file_content`` branch (the user can fix their input);
+        # ``INTERNAL_ERROR`` for the two generator branches because
+        # an invalid template / stub is our regression and we want
+        # it routed to the issue tracker, not to the user.
         await self._validate_rewritten_yaml_or_raise(
             filename,
             yaml_content,
             action="create",
-            on_failure=ErrorCode.INTERNAL_ERROR if from_template else ErrorCode.INVALID_ARGS,
+            on_failure=ErrorCode.INVALID_ARGS if from_user else ErrorCode.INTERNAL_ERROR,
         )
 
         # Derive board_id from YAML when not explicitly provided.

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -443,11 +443,27 @@ class DevicesController:
         """
         Create a new device configuration.
 
-        Three flows, decided by which arguments are provided:
+        Two flows, decided by which arguments are provided:
 
         1. ``file_content`` given → write it as-is (user supplied full YAML).
         2. ``board_id`` given → generate a basic config from the board template.
-        3. Neither → write a minimal stub the user fills in manually.
+
+        Neither argument is rejected up-front: a YAML with just
+        ``esphome.name`` and ``friendly_name`` and no platform block
+        doesn't pass ESPHome's schema, so writing it would land an
+        invalid config on disk that every downstream operation
+        (rename, edit_friendly_name, install) would refuse via its
+        own pre-flight check. The frontend always supplies one of
+        the two — this guard catches direct WS clients that
+        otherwise produce a foot-gun.
+
+        Whichever flow runs, the resulting YAML is validated through
+        ``EditorController``'s schema check before the file lands on
+        disk. Validation failures surface as ``INVALID_ARGS`` (the
+        user's ``file_content`` is unfixable from our side) or
+        ``INTERNAL_ERROR`` (the board template generated something
+        invalid — that's our bug to fix in ``generate_device_yaml``,
+        not the user's problem).
 
         After writing, we always try to derive a board_id by parsing
         the resulting YAML's platform/board/variant fields and matching
@@ -475,12 +491,31 @@ class DevicesController:
                 raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         friendly = friendly_name_slugify(name)
+        from_template = False
         if file_content:
             yaml_content = file_content
         elif board:
             yaml_content = generate_device_yaml(name, friendly, board, ssid, psk)
+            from_template = True
         else:
-            yaml_content = f"esphome:\n  name: {name}\n  friendly_name: {friendly}\n\n"
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                "Provide either board_id or file_content; a name-only stub "
+                "doesn't satisfy ESPHome's schema (no platform block) and "
+                "would fail every downstream operation.",
+            )
+
+        # Validate before write so an unflashable YAML never lands
+        # on disk. ``INTERNAL_ERROR`` for the template branch — a
+        # generator bug we own — and ``INVALID_ARGS`` for the user-
+        # supplied ``file_content`` branch where the user can fix
+        # their input.
+        await self._validate_rewritten_yaml_or_raise(
+            filename,
+            yaml_content,
+            action="create",
+            on_failure=ErrorCode.INTERNAL_ERROR if from_template else ErrorCode.INVALID_ARGS,
+        )
 
         # Derive board_id from YAML when not explicitly provided.
         # Mirrors the scanner's resolution chain: pio_board match first,
@@ -1102,36 +1137,40 @@ class DevicesController:
         content: str,
         *,
         action: str,
+        on_failure: ErrorCode = ErrorCode.INVALID_ARGS,
     ) -> None:
         """
         Schema-validate *content* via the editor; raise if invalid.
 
-        Used by commands that rewrite a device's YAML and depend on
-        a follow-up install to apply the change (``edit_friendly_name``
-        today, future rename / save / mass-edit handlers). The
-        rewritten YAML only takes effect once an install lands the
-        new firmware, so a YAML that won't validate means the
-        install fails and the running device keeps its old state —
-        the dashboard ends up showing a half-finished change that
-        will never reach the device. Refusing the write here keeps
-        on-disk state and live state in lockstep.
+        Used by commands that produce a YAML and depend on a follow-
+        up install to apply the change (``create_device``,
+        ``edit_friendly_name``, future rename / save handlers). A
+        YAML that won't validate means the install fails and the
+        device-on-network keeps its old state — the dashboard ends
+        up showing a half-finished change that will never reach the
+        device. Refusing the write here keeps on-disk state and
+        live state in lockstep.
 
         Reuses :class:`EditorController`'s warm validator subprocess
         (one per configuration), so the cost is single-digit hundreds
         of ms when the session is warm. ``self._db.editor`` is None
         during dashboard boot before
-        :meth:`EditorController.start` finishes; that window is
-        too narrow for a user to hit in practice, but the guard
-        means the controller still behaves coherently if the
-        editor is unavailable for any reason (e.g. the ``esphome``
-        CLI not on PATH) — better to skip validation than reject
-        every rewrite.
+        :meth:`EditorController.start` finishes; that window is too
+        narrow for a user to hit in practice, but the guard means
+        the controller still behaves coherently if the editor is
+        unavailable (e.g. the ``esphome`` CLI not on PATH) — better
+        to skip validation than reject every write.
 
         *action* is interpolated into the error message ("Can't
-        <action> — config doesn't validate: …"); pass the
-        user-facing verb the dialog will show ("rename",
-        "save"). The error list is capped at three entries so a
-        long error pile collapses to "first three + (+N more)"
+        <action> — config doesn't validate: …"); pass the user-
+        facing verb the dialog will show ("rename", "save",
+        "create"). *on_failure* picks the ``ErrorCode`` raised:
+        default ``INVALID_ARGS`` when the user can fix the input
+        themselves, ``INTERNAL_ERROR`` when the broken YAML came
+        from one of *our* generators (``generate_device_yaml``,
+        clone's leaf rewrite, ...) and the user can't do anything
+        but report it. The error list is capped at three entries so
+        a long error pile collapses to "first three + (+N more)"
         rather than overflowing the toast.
         """
         editor = self._db.editor
@@ -1147,12 +1186,20 @@ class DevicesController:
             return
         shown = errors[:3]
         suffix = f" (+{len(errors) - len(shown)} more)" if len(errors) > len(shown) else ""
+        message_tail = (
+            ". Please report this with a redacted snippet of just the "
+            "esphome: / substitutions: blocks (strip Wi-Fi credentials, "
+            "API keys, and static IPs) so the dashboard generator can "
+            "be fixed."
+            if on_failure is ErrorCode.INTERNAL_ERROR
+            else ". Fix the errors in the editor and try again."
+        )
         raise CommandError(
-            ErrorCode.INVALID_ARGS,
+            on_failure,
             f"Can't {action} — config doesn't validate: "
             + "; ".join(shown)
             + suffix
-            + ". Fix the errors in the editor and try again.",
+            + message_tail,
         )
 
     @api_command("devices/delete")

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -190,6 +190,43 @@ def generate_device_yaml(
     return "\n".join(lines)
 
 
+def generate_minimal_stub_yaml(name: str, friendly_name: str) -> str:
+    """
+    Render a minimal ``esphome rename``-compatible stub config.
+
+    Used by the wizard's "Empty Configuration — for manually
+    writing or pasting a configuration" path, where the user
+    wants a starter to fully rewrite. The output validates as-is
+    against ESPHome's schema (so every downstream operation —
+    rename, edit_friendly_name, install — accepts it) but is
+    intentionally minimal so the user can swap the platform
+    block without unwinding wizard-specific defaults like an
+    auto-generated API encryption key.
+
+    The platform defaults to ``esp32`` with ``board: esp32dev``
+    because esp32 is the most common starter target and
+    ``esp32dev`` is upstream-canonical (ships in
+    ``esphome.const.PLATFORMIO_ESP32_LUT`` and validates without
+    the catalog). The leading comment tells the user to replace
+    the platform block if their hardware differs, so the silent-
+    bind concern is at least called out in the file the user is
+    about to edit.
+    """
+    api_key = base64.b64encode(secrets.token_bytes(32)).decode()
+    return (
+        f"esphome:\n  name: {name}\n  friendly_name: {friendly_name}\n\n"
+        "# Replace this with your actual platform if you aren't using ESP32.\n"
+        "esp32:\n  board: esp32dev\n\n"
+        "logger:\n\n"
+        "api:\n  encryption:\n"
+        f'    key: "{api_key}"\n\n'
+        "ota:\n  - platform: esphome\n\n"
+        "wifi:\n"
+        "  ssid: !secret wifi_ssid\n"
+        "  password: !secret wifi_password\n"
+    )
+
+
 # ---------------------------------------------------------------------------
 # YAML parsing
 # ---------------------------------------------------------------------------

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -83,28 +83,38 @@ async def test_create_device_rejects_unknown_board_id(
     assert ctrl._scanner.calls == []
 
 
-async def test_create_device_rejects_when_no_board_or_file_content(
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    r"""Caller must supply ``board_id`` or ``file_content`` — no name-only stub.
+    """No board / no file_content → minimal valid esp32 stub.
 
-    The previous "stub" path wrote ``esphome:\n  name: <x>`` and
-    nothing else; that doesn't satisfy ESPHome's schema (no
-    platform block) so every downstream operation (rename,
-    edit_friendly_name, install) would refuse it via its own
-    pre-flight check. Reject up-front instead so the dashboard
-    label and the device's actual deployable state stay in
-    lockstep from the moment of creation.
+    The wizard's "Empty Configuration — for manually writing or
+    pasting" button hits this path: the user wants a starter
+    they can fully rewrite. The starter MUST validate so every
+    downstream operation (rename, edit_friendly_name, install)
+    accepts it; the previous "name-only" stub failed schema
+    validation and silently broke those flows. The stub now
+    defaults to esp32 + ``board: esp32dev`` with a leading
+    "Replace this with your platform" comment so the silent-
+    bind concern is at least visible in the file the user is
+    about to edit.
     """
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    boards = StubBoardLookups(ctrl)
+    boards.find_by_pio_board_returns(None)
+    boards.find_by_platform_variant_returns(None)
 
-    with pytest.raises(CommandError) as excinfo:
-        await ctrl.create_device(name="kitchen")
+    result = await ctrl.create_device(name="kitchen")
 
-    assert excinfo.value.code == ErrorCode.INVALID_ARGS
-    assert "board_id or file_content" in excinfo.value.message
-    assert ctrl._scanner.calls == []
-    assert not (tmp_path / "kitchen.yaml").exists()
+    assert result.configuration == "kitchen.yaml"
+    yaml_path = tmp_path / "kitchen.yaml"
+    content = yaml_path.read_text("utf-8")
+    assert "esphome:\n  name: kitchen\n  friendly_name: kitchen\n" in content
+    assert "esp32:\n  board: esp32dev\n" in content
+    assert "Replace this with your actual platform" in content
+    assert "api:\n  encryption:\n    key:" in content
+    assert ctrl._scanner.calls == [("scan",)]
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -102,8 +102,11 @@ async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     """
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     boards = StubBoardLookups(ctrl)
-    boards.find_by_pio_board_returns(None)
-    boards.find_by_platform_variant_returns(None)
+    # Catalog returns a board for ``esp32dev`` to model the realistic
+    # scenario flagged in review: many curated entries share that
+    # PIO board, so a naive lookup would happily pick one.
+    pio_lookup = boards.find_by_pio_board_returns("generic-esp32-board")
+    variant_lookup = boards.find_by_platform_variant_returns("generic-esp32-board")
 
     result = await ctrl.create_device(name="kitchen")
 
@@ -115,6 +118,11 @@ async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     assert "Replace this with your actual platform" in content
     assert "api:\n  encryption:\n    key:" in content
     assert ctrl._scanner.calls == [("scan",)]
+    # Stub branch deliberately skips the catalog lookup so an
+    # arbitrary entry sharing ``esp32dev`` doesn't get pinned to
+    # this device's metadata before the user picks real hardware.
+    pio_lookup.assert_not_called()
+    variant_lookup.assert_not_called()
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -138,9 +138,7 @@ async def test_create_device_rejects_invalid_file_content(
     # would actually look like — esphome block with a name but no
     # platform block at all, which the editor rejects with the
     # mocked error below.
-    invalid_file_content = (
-        "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
-    )
+    invalid_file_content = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
     ctrl._db.editor.validate_yaml = AsyncMock(
         return_value={
             "yaml_errors": [],

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -86,9 +86,9 @@ async def test_create_device_rejects_unknown_board_id(
 async def test_create_device_rejects_when_no_board_or_file_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Caller must supply ``board_id`` or ``file_content`` — no name-only stub.
+    r"""Caller must supply ``board_id`` or ``file_content`` — no name-only stub.
 
-    The previous "stub" path wrote ``esphome:\\n  name: <x>`` and
+    The previous "stub" path wrote ``esphome:\n  name: <x>`` and
     nothing else; that doesn't satisfy ESPHome's schema (no
     platform block) so every downstream operation (rename,
     edit_friendly_name, install) would refuse it via its own

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -134,20 +134,27 @@ async def test_create_device_rejects_invalid_file_content(
     boards = StubBoardLookups(ctrl)
     boards.find_by_pio_board_returns(None)
     boards.find_by_platform_variant_returns(None)
+    # File content that mirrors what the user's failing scenario
+    # would actually look like — esphome block with a name but no
+    # platform block at all, which the editor rejects with the
+    # mocked error below.
+    invalid_file_content = (
+        "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
+    )
     ctrl._db.editor.validate_yaml = AsyncMock(
         return_value={
             "yaml_errors": [],
             "validation_errors": [
-                {"message": "[esp32] required key not provided: board"},
+                {"message": "[esphome] required key not provided: a platform"},
             ],
         }
     )
 
     with pytest.raises(CommandError) as excinfo:
-        await ctrl.create_device(name="kitchen", file_content=VALID_FILE_CONTENT)
+        await ctrl.create_device(name="kitchen", file_content=invalid_file_content)
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
-    assert "required key not provided: board" in excinfo.value.message
+    assert "required key not provided: a platform" in excinfo.value.message
     # File never landed on disk.
     assert not (tmp_path / "kitchen.yaml").exists()
     assert ctrl._scanner.calls == []

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -26,6 +26,11 @@ from esphome_device_builder.models import ErrorCode
 
 from .conftest import MakeControllerFactory, StubBoardLookups
 
+VALID_FILE_CONTENT = (
+    "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
+    "esp32:\n  variant: esp32\n  board: nodemcu-32s\n"
+)
+
 
 async def test_create_device_translates_file_exists_to_command_error(
     tmp_path: Path,
@@ -41,7 +46,7 @@ async def test_create_device_translates_file_exists_to_command_error(
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", "utf-8")
 
     with pytest.raises(CommandError) as excinfo:
-        await ctrl.create_device(name="kitchen")
+        await ctrl.create_device(name="kitchen", file_content=VALID_FILE_CONTENT)
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "kitchen.yaml already exists" in excinfo.value.message
@@ -78,26 +83,107 @@ async def test_create_device_rejects_unknown_board_id(
     assert ctrl._scanner.calls == []
 
 
-@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
-async def test_create_device_writes_stub_yaml_and_scans(
+async def test_create_device_rejects_when_no_board_or_file_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Happy path with no board / no file_content: stub YAML lands on disk and scan fires."""
+    """Caller must supply ``board_id`` or ``file_content`` — no name-only stub.
+
+    The previous "stub" path wrote ``esphome:\\n  name: <x>`` and
+    nothing else; that doesn't satisfy ESPHome's schema (no
+    platform block) so every downstream operation (rename,
+    edit_friendly_name, install) would refuse it via its own
+    pre-flight check. Reject up-front instead so the dashboard
+    label and the device's actual deployable state stay in
+    lockstep from the moment of creation.
+    """
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
-    # Catalog lookups must return ``None`` so the derive-from-yaml
-    # branch leaves ``board`` unset; otherwise ``StorageJSON``'s
-    # ``target_platform`` would receive a ``MagicMock``.
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "board_id or file_content" in excinfo.value.message
+    assert ctrl._scanner.calls == []
+    assert not (tmp_path / "kitchen.yaml").exists()
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_create_device_rejects_invalid_file_content(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """User-supplied ``file_content`` that doesn't validate is refused.
+
+    The frontend's "import YAML" flow lets users paste arbitrary
+    text into the wizard. Without this guard a malformed paste
+    would land on disk, every downstream operation would refuse
+    it, and the user would have to delete the device and try
+    again. Surfacing the editor's actual errors gives them
+    something to fix.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     boards = StubBoardLookups(ctrl)
     boards.find_by_pio_board_returns(None)
     boards.find_by_platform_variant_returns(None)
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [
+                {"message": "[esp32] required key not provided: board"},
+            ],
+        }
+    )
 
-    result = await ctrl.create_device(name="kitchen")
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen", file_content=VALID_FILE_CONTENT)
 
-    assert result.configuration == "kitchen.yaml"
-    yaml_path = tmp_path / "kitchen.yaml"
-    assert yaml_path.read_text("utf-8").startswith("esphome:\n  name: kitchen\n")
-    assert (tmp_path / "storage.json").exists()
-    assert ctrl._scanner.calls == [("scan",)]
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "required key not provided: board" in excinfo.value.message
+    # File never landed on disk.
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert ctrl._scanner.calls == []
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_create_device_template_invalid_yaml_surfaces_internal_error(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Generator producing an invalid YAML is *our* bug, not the user's.
+
+    When the wizard's ``board_id`` template emits something that
+    doesn't validate, that's a regression in
+    ``generate_device_yaml`` — the user can't fix it. Raise
+    ``INTERNAL_ERROR`` with a "please report" hint so the
+    diagnostic lands in our issue tracker rather than confusing
+    the user with a "config doesn't validate" they didn't write.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    # Board returns a valid catalog entry that drives ``generate_device_yaml``.
+    board = MagicMock()
+    board.id = "esp32-c3"
+    board.esphome.platform = "esp32"
+    board.esphome.variant = "esp32c3"
+    board.esphome.framework = "esp-idf"
+    board.esphome.board = ""
+    board.hardware.flash_size = "4MB"
+    board.hardware.connectivity = []
+    board.name = "Generic ESP32-C3"
+    board.manufacturer = "Generic"
+    ctrl._db.boards.get_board = AsyncMock(return_value=board)
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [{"message": "[esphome] generator regression"}],
+        }
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen", board_id="esp32-c3")
+
+    assert excinfo.value.code == ErrorCode.INTERNAL_ERROR
+    assert "generator regression" in excinfo.value.message
+    assert "report" in excinfo.value.message.lower()
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert ctrl._scanner.calls == []
 
 
 async def test_create_device_clears_residual_metadata_from_archived_same_name(
@@ -105,16 +191,17 @@ async def test_create_device_clears_residual_metadata_from_archived_same_name(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """Stub create at a previously-archived filename starts with a clean entry.
+    """Create at a previously-archived filename starts with a clean entry.
 
     Archive preserves identity fields (``board_id``,
     ``friendly_name``, ``comment``) so an unarchive of the same
     YAML restores user-visible state. But a *new* device created
-    at the same filename via the stub flow (no ``board_id``
-    provided, no derive match) must NOT inherit those — otherwise
-    the new device is silently bound to the old catalog entry,
-    and the dashboard renders the new YAML's friendly_name as
-    the archived one's. Pin the wipe-on-create contract.
+    at the same filename — even via ``file_content`` whose YAML
+    didn't carry a recognised board — must NOT inherit those
+    archived fields; otherwise the new device is silently bound
+    to the old catalog entry and the dashboard renders the new
+    YAML's friendly_name as the archived one's. Pin the wipe-on-
+    create contract.
     """
     config_dir = tmp_path
     storage_path = tmp_path / "storage.json"
@@ -140,10 +227,10 @@ async def test_create_device_clears_residual_metadata_from_archived_same_name(
     boards.find_by_pio_board_returns(None)
     boards.find_by_platform_variant_returns(None)
 
-    await ctrl.create_device(name="kitchen")
+    await ctrl.create_device(name="kitchen", file_content=VALID_FILE_CONTENT)
 
-    # Stale entry was cleared. The stub flow has no board_id to
-    # write back, so the entry should be absent (not just empty).
+    # Stale entry was cleared. No matching board → no board_id
+    # written back, so the entry should be absent (not just empty).
     post = await asyncio.to_thread(get_device_metadata, config_dir, "kitchen.yaml")
     assert post == {}
 

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -17,6 +17,7 @@ from esphome_device_builder.helpers.device_yaml import (
     configuration_stem,
     detect_platform_from_yaml,
     generate_device_yaml,
+    generate_minimal_stub_yaml,
     load_device_from_storage,
     parse_esphome_meta,
     parse_platform_from_yaml,
@@ -77,6 +78,41 @@ def _make_esp32_board(
 def test_configuration_stem(filename: str, expected: str) -> None:
     """``configuration_stem`` strips ``.yaml`` / ``.yml`` only."""
     assert configuration_stem(filename) == expected
+
+
+def test_generate_minimal_stub_yaml_has_required_blocks() -> None:
+    """Stub YAML carries every block ESPHome's schema requires.
+
+    The wizard's "Empty Configuration" path lands this stub, so a
+    fresh device must compile without the user editing anything
+    yet. ``esphome.name``, ``esphome.friendly_name``, the
+    platform block (``esp32: board: esp32dev``), and a non-empty
+    api-encryption key are the load-bearing pieces; the
+    "Replace this..." comment carries the silent-bind warning.
+    """
+    out = generate_minimal_stub_yaml("kitchen", "Kitchen Lamp")
+    assert "esphome:\n  name: kitchen\n  friendly_name: Kitchen Lamp\n" in out
+    assert "esp32:\n  board: esp32dev\n" in out
+    assert "Replace this with your actual platform" in out
+    assert 'api:\n  encryption:\n    key: "' in out
+    assert "ota:\n  - platform: esphome\n" in out
+
+
+def test_generate_minimal_stub_yaml_emits_per_device_encryption_key() -> None:
+    """API encryption key is freshly generated each call.
+
+    Two stubs created with *the same* name + friendly_name still
+    differ — the only thing that varies between calls is the
+    32-byte ``secrets.token_bytes`` API key. Comparing the
+    extracted key lines directly proves the per-device-key
+    contract regardless of whether other YAML output ever
+    becomes deterministic.
+    """
+    a = generate_minimal_stub_yaml("kitchen", "Kitchen Lamp")
+    b = generate_minimal_stub_yaml("kitchen", "Kitchen Lamp")
+    a_key = next(line for line in a.splitlines() if line.lstrip().startswith("key:"))
+    b_key = next(line for line in b.splitlines() if line.lstrip().startswith("key:"))
+    assert a_key != b_key
 
 
 def test_parse_meta_plain_values() -> None:


### PR DESCRIPTION
# What does this implement/fix?

First of the audit follow-ups to #404 / #402: closes the create-side of the **never-generate-invalid-configs** principle.

`devices/create` had three flows. The first two are real:

1. `file_content` given → write the user-supplied YAML.
2. `board_id` given → render via `generate_device_yaml`.

The third — neither argument supplied — used to write `esphome:\n  name: <x>\n  friendly_name: <y>\n` and call it a stub. That doesn't satisfy ESPHome's schema (no platform block) so every downstream operation (`rename`, `edit_friendly_name`, install) would refuse it via its own pre-flight check. The wizard's "Empty Configuration — for manually writing or pasting a configuration" button hits this path (the `board_id` parameter is sent as `""` when the user doesn't pick a board), so it's actively used and silently producing invalid YAML.

Now the no-board / no-content path emits a minimal valid esp32 stub via a new `generate_minimal_stub_yaml(name, friendly_name)` helper: same shape as `generate_device_yaml` but hand-rolled with a `esp32` + `board: esp32dev` placeholder and a leading `# Replace this with your actual platform if you aren't using ESP32.` comment. The result validates as-is so every downstream operation accepts it; the user swaps the platform block as their first edit, and the comment makes the silent-bind concern visible in the file they're about to rewrite anyway. We never want to hand the user broken YAML in the first place — even a placeholder.

For the remaining two paths, the generated YAML now goes through `_validate_rewritten_yaml_or_raise` before the exclusive-create write:

- `file_content` validation failure → `INVALID_ARGS` (the user can fix their input).
- template (`board_id`) / stub (`generate_minimal_stub_yaml`) validation failure → `INTERNAL_ERROR` (a regression in *our* generators, not the user's problem).

The validation helper grows an `on_failure: ErrorCode` parameter so callers can pick which error code to raise, plus a "report a redacted snippet of just the `esphome:` / `substitutions:` blocks (strip Wi-Fi credentials, API keys, and static IPs)" hint when the `INTERNAL_ERROR` branch fires — keeps generator regressions actionable without users pasting their full YAML into a public issue.

A companion frontend PR will surface backend `CommandError`s on the create-config dialog instead of dropping to the browser console.

**Related issue or feature (if applicable):**

- follow-up to #402 / #404

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: `esphome/device-builder-frontend#216` (surfacing backend `CommandError`s on the create-config dialog so validation rejections don't silently drop to the browser console)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
