### PR TITLE
Validate cloned YAML before write

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -923,6 +923,18 @@ class DevicesController:
         # indirections stay shared with the source on purpose.
         new_content = rewrite_api_encryption_key(new_content, new_key)
 
+        # Validate the rewritten YAML before the exclusive-create
+        # write so a clone of an invalid source doesn't silently
+        # land a second unflashable YAML on disk. The leaf-line
+        # rewrites we run here (name / friendly_name / api key)
+        # don't reshape the structural parts of the YAML, so a
+        # validation failure on the clone means the source itself
+        # didn't pass schema — the user fixes the source and
+        # retries. Surfaces as ``INVALID_ARGS`` so the dialog can
+        # point them at the source's actual errors instead of
+        # showing a generic "clone failed."
+        await self._validate_rewritten_yaml_or_raise(new_filename, new_content, action="clone")
+
         # Carry forward only the source's ``board_id`` — that's the
         # one piece of dashboard state the scanner can't recover from
         # the YAML (it's a catalog-key indirection the user picked at

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -880,6 +880,19 @@ class DevicesController:
             msg = f"Source device {configuration} not found"
             raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
+        # Validate the *source* before doing any rewrite work. The
+        # leaf-line rewrites that follow (name / friendly_name / api
+        # key) are structure-preserving, so a valid source always
+        # produces a valid clone — and an invalid source always
+        # produces an invalid clone. Bail early on a broken source
+        # with a message that points at the source's actual schema
+        # errors, so the user fixes the source first and retries.
+        # Surfacing this here also means we don't burn the rewrite
+        # work just to re-discover the source was unflashable.
+        await self._validate_rewritten_yaml_or_raise(
+            configuration, source_content, action="clone"
+        )
+
         # Land the new identity on whichever line the source actually
         # uses to drive the value. Two patterns appear in real configs:
         #
@@ -922,18 +935,6 @@ class DevicesController:
         # uses ``!secret`` / ``${...}`` for the key — those
         # indirections stay shared with the source on purpose.
         new_content = rewrite_api_encryption_key(new_content, new_key)
-
-        # Validate the rewritten YAML before the exclusive-create
-        # write so a clone of an invalid source doesn't silently
-        # land a second unflashable YAML on disk. The leaf-line
-        # rewrites we run here (name / friendly_name / api key)
-        # don't reshape the structural parts of the YAML, so a
-        # validation failure on the clone means the source itself
-        # didn't pass schema — the user fixes the source and
-        # retries. Surfaces as ``INVALID_ARGS`` so the dialog can
-        # point them at the source's actual errors instead of
-        # showing a generic "clone failed."
-        await self._validate_rewritten_yaml_or_raise(new_filename, new_content, action="clone")
 
         # Carry forward only the source's ``board_id`` — that's the
         # one piece of dashboard state the scanner can't recover from

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -889,9 +889,7 @@ class DevicesController:
         # errors, so the user fixes the source first and retries.
         # Surfacing this here also means we don't burn the rewrite
         # work just to re-discover the source was unflashable.
-        await self._validate_rewritten_yaml_or_raise(
-            configuration, source_content, action="clone"
-        )
+        await self._validate_rewritten_yaml_or_raise(configuration, source_content, action="clone")
 
         # Land the new identity on whichever line the source actually
         # uses to drive the value. Two patterns appear in real configs:

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -244,6 +244,66 @@ async def test_clone_device_rejects_missing_source(
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_rejects_when_rewritten_yaml_does_not_validate(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Source YAML failing schema validation refuses the clone.
+
+    The clone path's leaf-line rewrites (name / friendly_name /
+    api key) don't reshape the YAML's structure, so a validation
+    failure on the clone means the *source* itself doesn't pass
+    schema. Refusing the clone here surfaces the editor's actual
+    errors so the user can fix the source and retry, instead of
+    landing two unflashable YAMLs on disk and having every
+    downstream operation refuse them.
+    """
+    from unittest.mock import AsyncMock
+
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [
+                {"message": "[esp32] Unsupported chip variant: esp32h2"},
+            ],
+        }
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "Unsupported chip variant: esp32h2" in excinfo.value.message
+    # Clone never landed — source untouched, target absent.
+    assert (tmp_path / "kitchen.yaml").read_text("utf-8") == SOURCE_YAML
+    assert not (tmp_path / "bedroom-bulb.yaml").exists()
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_skips_validation_when_editor_unavailable(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Editor not yet started → clone proceeds without validation.
+
+    Mirrors the same boot-window guard the create / edit_friendly_name
+    paths already have. Better to land a clone of a working
+    config than to refuse every clone for the lifetime of the
+    process if the editor subprocess is unavailable.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+    ctrl._db.editor = None
+
+    result = await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    assert result == {"configuration": "bedroom-bulb.yaml"}
+    assert (tmp_path / "bedroom-bulb.yaml").exists()
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_clone_device_works_when_source_has_no_api_encryption(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -244,23 +244,23 @@ async def test_clone_device_rejects_missing_source(
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
-async def test_clone_device_rejects_when_rewritten_yaml_does_not_validate(
+async def test_clone_device_rejects_when_source_does_not_validate(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """Source YAML failing schema validation refuses the clone.
+    """A broken source YAML refuses the clone before any rewrite work runs.
 
     The clone path's leaf-line rewrites (name / friendly_name /
-    api key) don't reshape the YAML's structure, so a validation
-    failure on the clone means the *source* itself doesn't pass
-    schema. Refusing the clone here surfaces the editor's actual
-    errors so the user can fix the source and retry, instead of
-    landing two unflashable YAMLs on disk and having every
-    downstream operation refuse them.
+    api key) are structure-preserving, so an invalid source
+    always produces an invalid clone. Validating the source
+    up-front surfaces the editor's actual schema errors and
+    lets the user fix the source first — rather than burning
+    the rewrite work and discovering the same errors after the
+    fact.
     """
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
-    ctrl._db.editor.validate_yaml = AsyncMock(
+    validate = AsyncMock(
         return_value={
             "yaml_errors": [],
             "validation_errors": [
@@ -268,12 +268,18 @@ async def test_clone_device_rejects_when_rewritten_yaml_does_not_validate(
             ],
         }
     )
+    ctrl._db.editor.validate_yaml = validate
 
     with pytest.raises(CommandError) as excinfo:
         await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "Unsupported chip variant: esp32h2" in excinfo.value.message
+    # Validator was called on the source filename — pinning this
+    # makes a regression that revalidates the rewrite (instead of
+    # the source) fail loudly. The error message would still surface
+    # but the diagnostic would point at the wrong file.
+    assert validate.await_args.kwargs["configuration"] == "kitchen.yaml"
     # Clone never landed — source untouched, target absent.
     assert (tmp_path / "kitchen.yaml").read_text("utf-8") == SOURCE_YAML
     assert not (tmp_path / "bedroom-bulb.yaml").exists()

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import re
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -258,8 +258,6 @@ async def test_clone_device_rejects_when_rewritten_yaml_does_not_validate(
     landing two unflashable YAMLs on disk and having every
     downstream operation refuse them.
     """
-    from unittest.mock import AsyncMock
-
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
     ctrl._db.editor.validate_yaml = AsyncMock(


### PR DESCRIPTION
# What does this implement/fix?

Second of the audit follow-ups to #404 — the never-generate-invalid-configs principle, applied to `devices/clone`.

`clone_device` does leaf-line rewrites (`name` / `friendly_name` / `api.encryption.key`) on the source YAML and writes the result via exclusive-create. None of those rewrites reshape the YAML's structure, so cloning an invalid source produces an equally invalid clone. The user then has *two* unflashable YAMLs on disk to clean up: every downstream operation (rename, edit_friendly_name, install) refuses the clone via its own pre-flight check, and the user has to manually delete it before they can move on.

This PR runs the rewritten YAML through `_validate_rewritten_yaml_or_raise` between the api-key rewrite and the exclusive-create write. Validation failure raises `INVALID_ARGS` with the editor's actual errors so the user can fix the source's schema issues and retry. The same boot-window guard the create / edit_friendly_name paths already have is in place — when `self._db.editor` is None (early during dashboard startup), the clone proceeds without validation rather than refusing every clone for the lifetime of the process.

Two new tests:
- `test_clone_device_rejects_when_rewritten_yaml_does_not_validate` — pins the validation-failure path and confirms neither the source is touched nor the target lands on disk.
- `test_clone_device_skips_validation_when_editor_unavailable` — pins the editor-None boot-window guard.

**Related issue or feature (if applicable):**

- follow-up to #404 / #405

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
