### PR TITLE
Validate imported YAML; roll back on schema failure

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1851,9 +1851,7 @@ class DevicesController:
 
         try:
             content = await loop.run_in_executor(None, _read)
-            await self._validate_rewritten_yaml_or_raise(
-                configuration, content, action="import"
-            )
+            await self._validate_rewritten_yaml_or_raise(configuration, content, action="import")
         except BaseException:
             await loop.run_in_executor(None, _cleanup)
             raise

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1811,6 +1811,33 @@ class DevicesController:
             msg = f"Configuration {configuration} already exists"
             raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
 
+        # Validate the freshly-written YAML before announcing it.
+        # ``import_config`` produces a wizard-style YAML by
+        # construction, but a regression upstream — or a project
+        # whose ``packages:`` reference doesn't resolve cleanly
+        # against the current esphome / zeroconf state — would
+        # otherwise leave an unflashable YAML on disk that every
+        # downstream operation refuses. Read it back, validate,
+        # and on failure delete the YAML so we never surface a
+        # half-imported device. The window between
+        # ``import_config`` and the cleanup is short and the
+        # scanner only runs on poll (no inotify watcher), so the
+        # rollback is safe before ``self._scanner.scan()`` below.
+        def _read() -> str:
+            return path.read_text(encoding="utf-8")
+
+        content = await loop.run_in_executor(None, _read)
+        try:
+            await self._validate_rewritten_yaml_or_raise(
+                configuration, content, action="import"
+            )
+        except CommandError:
+            def _cleanup() -> None:
+                path.unlink(missing_ok=True)
+
+            await loop.run_in_executor(None, _cleanup)
+            raise
+
         # Picking up the new YAML is best-effort — if the scanner
         # hiccups (e.g. a transient stat error on a network mount),
         # the next periodic scan will catch it. We've already written

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1199,6 +1199,7 @@ class DevicesController:
         *,
         action: str,
         on_failure: ErrorCode = ErrorCode.INVALID_ARGS,
+        on_error_cleanup: Callable[[], None] | None = None,
     ) -> None:
         """
         Schema-validate *content* via the editor; raise if invalid.
@@ -1233,35 +1234,53 @@ class DevicesController:
         but report it. The error list is capped at three entries so
         a long error pile collapses to "first three + (+N more)"
         rather than overflowing the toast.
+
+        *on_error_cleanup* is a sync callback that runs in a
+        ``finally`` if validation didn't reach a clean success
+        (rejected, subprocess-wedged, anything). For commands that
+        write the YAML *before* calling this helper (currently
+        ``import_device``, where upstream ``import_config`` writes
+        unconditionally), the callback unlinks the half-imported
+        file so a retry doesn't trip ``FileExistsError``. Unset
+        for commands that haven't written yet (``create_device``,
+        ``clone_device``, ``edit_friendly_name``) — there's
+        nothing to roll back. Runs through ``run_in_executor`` so
+        ``blockbuster`` doesn't flag the sync syscall in tests.
         """
         editor = self._db.editor
         if editor is None:
             return
-        result = await editor.validate_yaml(configuration=configuration, content=content)
-        errors = [
-            *(err.get("message", "") for err in result.get("yaml_errors", [])),
-            *(err.get("message", "") for err in result.get("validation_errors", [])),
-        ]
-        errors = [msg for msg in errors if msg]
-        if not errors:
-            return
-        shown = errors[:3]
-        suffix = f" (+{len(errors) - len(shown)} more)" if len(errors) > len(shown) else ""
-        message_tail = (
-            ". Please report this with a redacted snippet of just the "
-            "esphome: / substitutions: blocks (strip Wi-Fi credentials, "
-            "API keys, and static IPs) so the dashboard generator can "
-            "be fixed."
-            if on_failure is ErrorCode.INTERNAL_ERROR
-            else ". Fix the errors in the editor and try again."
-        )
-        raise CommandError(
-            on_failure,
-            f"Can't {action} — config doesn't validate: "
-            + "; ".join(shown)
-            + suffix
-            + message_tail,
-        )
+        succeeded = False
+        try:
+            result = await editor.validate_yaml(configuration=configuration, content=content)
+            errors = [
+                *(err.get("message", "") for err in result.get("yaml_errors", [])),
+                *(err.get("message", "") for err in result.get("validation_errors", [])),
+            ]
+            errors = [msg for msg in errors if msg]
+            if not errors:
+                succeeded = True
+                return
+            shown = errors[:3]
+            suffix = f" (+{len(errors) - len(shown)} more)" if len(errors) > len(shown) else ""
+            message_tail = (
+                ". Please report this with a redacted snippet of just the "
+                "esphome: / substitutions: blocks (strip Wi-Fi credentials, "
+                "API keys, and static IPs) so the dashboard generator can "
+                "be fixed."
+                if on_failure is ErrorCode.INTERNAL_ERROR
+                else ". Fix the errors in the editor and try again."
+            )
+            raise CommandError(
+                on_failure,
+                f"Can't {action} — config doesn't validate: "
+                + "; ".join(shown)
+                + suffix
+                + message_tail,
+            )
+        finally:
+            if not succeeded and on_error_cleanup is not None:
+                await asyncio.get_running_loop().run_in_executor(None, on_error_cleanup)
 
     @api_command("devices/delete")
     async def delete_device(self, *, configuration: str, **kwargs: Any) -> None:
@@ -1830,19 +1849,15 @@ class DevicesController:
         # whose ``packages:`` reference doesn't resolve cleanly
         # against the current esphome / zeroconf state — would
         # otherwise leave an unflashable YAML on disk that every
-        # downstream operation refuses. Read it back, validate,
-        # and on *any* failure delete the YAML so we never surface
-        # a half-imported device. The window between
-        # ``import_config`` and the cleanup is short and the
-        # scanner only runs on poll (no inotify watcher), so the
-        # rollback is safe before ``self._scanner.scan()`` below.
-        # ``except BaseException`` (re-raising) catches the read's
-        # OSError, the validator subprocess's
-        # TimeoutError/RuntimeError/BrokenPipeError, and the
-        # validation helper's CommandError equally — without it a
-        # transient I/O error during validation would leak the
-        # half-imported YAML and trip ``FileExistsError`` on every
-        # retry.
+        # downstream operation refuses. Hand the helper an
+        # ``on_error_cleanup`` so any non-success path (validation
+        # rejection, validator subprocess wedged, ...) unlinks
+        # the half-imported file before re-raising — without it
+        # a retry would trip ``FileExistsError`` on the leftover
+        # YAML. The window between ``import_config`` and the
+        # cleanup is short and the scanner only runs on poll (no
+        # inotify watcher), so no half-imported device leaks
+        # into ``devices/list``.
         def _read() -> str:
             return path.read_text(encoding="utf-8")
 
@@ -1851,10 +1866,15 @@ class DevicesController:
 
         try:
             content = await loop.run_in_executor(None, _read)
-            await self._validate_rewritten_yaml_or_raise(configuration, content, action="import")
-        except BaseException:
+        except OSError:
+            # Transient FS error reading back what we just wrote
+            # via ``import_config``. Roll back so a retry doesn't
+            # see a leftover file.
             await loop.run_in_executor(None, _cleanup)
             raise
+        await self._validate_rewritten_yaml_or_raise(
+            configuration, content, action="import", on_error_cleanup=_cleanup
+        )
 
         # Picking up the new YAML is best-effort — if the scanner
         # hiccups (e.g. a transient stat error on a network mount),

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1280,7 +1280,19 @@ class DevicesController:
             )
         finally:
             if not succeeded and on_error_cleanup is not None:
-                await asyncio.get_running_loop().run_in_executor(None, on_error_cleanup)
+                # Swallow + log cleanup failures so a permission /
+                # FS error during rollback doesn't replace the
+                # original validation diagnostic (or the validator
+                # subprocess error) the caller is about to see. The
+                # leftover YAML is the lesser foot-gun here — the
+                # user can ``devices/delete`` it once they understand
+                # what failed.
+                try:
+                    await asyncio.get_running_loop().run_in_executor(
+                        None, on_error_cleanup
+                    )
+                except Exception:
+                    _LOGGER.exception("on_error_cleanup raised; original error preserved")
 
     @api_command("devices/delete")
     async def delete_device(self, *, configuration: str, **kwargs: Any) -> None:
@@ -1866,10 +1878,10 @@ class DevicesController:
 
         try:
             content = await loop.run_in_executor(None, _read)
-        except OSError:
-            # Transient FS error reading back what we just wrote
-            # via ``import_config``. Roll back so a retry doesn't
-            # see a leftover file.
+        except (OSError, UnicodeDecodeError):
+            # Transient FS error or non-UTF-8 bytes in what we
+            # just wrote via ``import_config``. Roll back either
+            # way so a retry doesn't see a leftover file.
             await loop.run_in_executor(None, _cleanup)
             raise
         await self._validate_rewritten_yaml_or_raise(

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1828,10 +1828,9 @@ class DevicesController:
 
         content = await loop.run_in_executor(None, _read)
         try:
-            await self._validate_rewritten_yaml_or_raise(
-                configuration, content, action="import"
-            )
+            await self._validate_rewritten_yaml_or_raise(configuration, content, action="import")
         except CommandError:
+
             def _cleanup() -> None:
                 path.unlink(missing_ok=True)
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1288,9 +1288,7 @@ class DevicesController:
                 # user can ``devices/delete`` it once they understand
                 # what failed.
                 try:
-                    await asyncio.get_running_loop().run_in_executor(
-                        None, on_error_cleanup
-                    )
+                    await asyncio.get_running_loop().run_in_executor(None, on_error_cleanup)
                 except Exception:
                     _LOGGER.exception("on_error_cleanup raised; original error preserved")
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1831,22 +1831,30 @@ class DevicesController:
         # against the current esphome / zeroconf state — would
         # otherwise leave an unflashable YAML on disk that every
         # downstream operation refuses. Read it back, validate,
-        # and on failure delete the YAML so we never surface a
-        # half-imported device. The window between
+        # and on *any* failure delete the YAML so we never surface
+        # a half-imported device. The window between
         # ``import_config`` and the cleanup is short and the
         # scanner only runs on poll (no inotify watcher), so the
         # rollback is safe before ``self._scanner.scan()`` below.
+        # ``except BaseException`` (re-raising) catches the read's
+        # OSError, the validator subprocess's
+        # TimeoutError/RuntimeError/BrokenPipeError, and the
+        # validation helper's CommandError equally — without it a
+        # transient I/O error during validation would leak the
+        # half-imported YAML and trip ``FileExistsError`` on every
+        # retry.
         def _read() -> str:
             return path.read_text(encoding="utf-8")
 
-        content = await loop.run_in_executor(None, _read)
+        def _cleanup() -> None:
+            path.unlink(missing_ok=True)
+
         try:
-            await self._validate_rewritten_yaml_or_raise(configuration, content, action="import")
-        except CommandError:
-
-            def _cleanup() -> None:
-                path.unlink(missing_ok=True)
-
+            content = await loop.run_in_executor(None, _read)
+            await self._validate_rewritten_yaml_or_raise(
+                configuration, content, action="import"
+            )
+        except BaseException:
             await loop.run_in_executor(None, _cleanup)
             raise
 

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -14,6 +14,7 @@ Covers two regressions discovered while wiring up the adoption flow:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
@@ -40,6 +41,28 @@ def _seed_import_state(controller: DevicesController) -> None:
     but the bypass-init factory leaves it unset.
     """
     controller.import_result = {}
+
+
+def _import_config_stub(
+    captured: dict[str, Any] | None = None,
+) -> Callable[..., None]:
+    """Stub for ``import_config`` that mirrors its on-disk write.
+
+    The real ``import_config`` writes a YAML to ``args[0]``. The
+    ``import_device`` post-write validation step then reads it
+    back, so a stub that only records call args trips the read
+    with ``FileNotFoundError``. This helper writes a minimal
+    valid YAML at the destination path and optionally records
+    the call args into *captured* (for tests that assert on
+    what got forwarded to upstream).
+    """
+
+    def _stub(*args: Any, **_kw: Any) -> None:
+        if captured is not None:
+            captured.setdefault("args", args)
+        args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8")
+
+    return _stub
 
 
 def test_import_config_resolves_at_import_time() -> None:
@@ -115,14 +138,7 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
     ``network`` field to ``import_config``.
     """
     captured: dict[str, Any] = {}
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *args, **_kw: (
-            captured.setdefault("args", args),
-            args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8"),
-        ),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub(captured))
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -168,14 +184,7 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
     the imported YAML got.
     """
     captured: dict[str, Any] = {}
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *args, **_kw: (
-            captured.setdefault("args", args),
-            args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8"),
-        ),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub(captured))
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -226,14 +235,7 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
     dashboard wrote.
     """
     captured: dict[str, Any] = {}
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *args, **_kw: (
-            captured.setdefault("args", args),
-            args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8"),
-        ),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub(captured))
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -308,13 +310,7 @@ async def test_import_device_rejects_when_imported_yaml_does_not_validate(
     project (or pick a different one) and retry without a
     leftover ``FileExistsError`` blocking them.
     """
-    from unittest.mock import AsyncMock
-
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *a, **_kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._db.editor.validate_yaml = AsyncMock(
@@ -354,11 +350,7 @@ async def test_import_device_skips_validation_when_editor_unavailable(
     lifetime of the process would be worse than landing the
     YAML and letting the next compile surface any schema issues.
     """
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *a, **_kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._db.editor = None

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -66,6 +66,9 @@ async def test_import_device_invokes_import_config_and_returns_path(
 
     def fake_import_config(*args: Any, **_kwargs: Any) -> None:
         captured["args"] = args
+        # ``import_config`` writes the YAML to disk; mirror that
+        # so the post-write validation step can read it back.
+        args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8")
 
     monkeypatch.setattr(devices_module, "import_config", fake_import_config)
     ctrl = make_controller(tmp_path, with_state_monitor=True)
@@ -113,7 +116,7 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
     """
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
-        devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
+        devices_module, "import_config", lambda *args, **_kw: (captured.setdefault('args', args), args[0].write_text(f'esphome:\n  name: {args[1]}\n', encoding='utf-8'))
     )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
@@ -161,7 +164,7 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
     """
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
-        devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
+        devices_module, "import_config", lambda *args, **_kw: (captured.setdefault('args', args), args[0].write_text(f'esphome:\n  name: {args[1]}\n', encoding='utf-8'))
     )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
@@ -214,7 +217,7 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
     """
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
-        devices_module, "import_config", lambda *args, **_kw: captured.setdefault("args", args)
+        devices_module, "import_config", lambda *args, **_kw: (captured.setdefault('args', args), args[0].write_text(f'esphome:\n  name: {args[1]}\n', encoding='utf-8'))
     )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
@@ -273,6 +276,92 @@ async def test_import_device_translates_file_exists_to_command_error(
     assert ctrl._scanner.calls == []
 
 
+async def test_import_device_rejects_when_imported_yaml_does_not_validate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Imported YAML failing schema validation is deleted + raises.
+
+    ``import_config`` produces a wizard-style YAML by construction,
+    but a regression upstream — or a project YAML whose
+    ``packages:`` reference doesn't resolve cleanly — would
+    otherwise leave an unflashable file on disk that every
+    downstream operation refuses. After ``import_config`` returns
+    we read the file back, validate, and on failure delete it
+    and surface the editor errors so the user can fix the source
+    project (or pick a different one) and retry without a
+    leftover ``FileExistsError`` blocking them.
+    """
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        devices_module,
+        "import_config",
+        lambda *a, **_kw: a[0].write_text(
+            f"esphome:\n  name: {a[1]}\n", encoding="utf-8"
+        ),
+    )
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [
+                {"message": "[esphome] required key not provided: a platform"},
+            ],
+        }
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.import_device(
+            name="kitchen",
+            project_name="x",
+            package_import_url="github://x",
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "required key not provided: a platform" in excinfo.value.message
+    # YAML rolled back so a retry doesn't trip ``FileExistsError``.
+    assert not (tmp_path / "kitchen.yaml").exists()
+    # Scanner must NOT have been notified of the half-imported device.
+    assert ctrl._scanner.calls == []
+
+
+async def test_import_device_skips_validation_when_editor_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Editor not yet started → import proceeds without validation.
+
+    Mirrors the boot-window guard the create / clone /
+    edit_friendly_name paths already have. If the editor
+    subprocess is unavailable, refusing every adoption for the
+    lifetime of the process would be worse than landing the
+    YAML and letting the next compile surface any schema issues.
+    """
+    monkeypatch.setattr(
+        devices_module,
+        "import_config",
+        lambda *a, **_kw: a[0].write_text(
+            f"esphome:\n  name: {a[1]}\n", encoding="utf-8"
+        ),
+    )
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    ctrl._db.editor = None
+
+    result = await ctrl.import_device(
+        name="kitchen",
+        project_name="x",
+        package_import_url="github://x",
+    )
+
+    assert result == {"configuration": "kitchen.yaml"}
+    assert (tmp_path / "kitchen.yaml").exists()
+
+
 async def test_import_device_returns_even_when_post_scan_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -285,7 +374,7 @@ async def test_import_device_returns_even_when_post_scan_fails(
     nothing being wrong. Best-effort scan; the periodic poll picks up
     whatever this attempt missed.
     """
-    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
+    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: a[0].write_text(f'esphome:\n  name: {a[1]}\n', encoding='utf-8'))
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._scanner.scan = AsyncMock(side_effect=RuntimeError("transient"))
@@ -313,7 +402,7 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     can't clobber it) and pulls the cached IP out of zeroconf so the
     new card has an address right away.
     """
-    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
+    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: a[0].write_text(f'esphome:\n  name: {a[1]}\n', encoding='utf-8'))
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor(
@@ -342,7 +431,7 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     make_controller: MakeControllerFactory,
 ) -> None:
     """No cached IP → state still flips ONLINE, just no apply_ip call."""
-    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
+    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: a[0].write_text(f'esphome:\n  name: {a[1]}\n', encoding='utf-8'))
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor()  # no cached addresses
@@ -374,7 +463,7 @@ async def test_import_device_drops_matching_import_result_entry(
     so we drop the right entry even when the user typed a different
     YAML name in the dialog.
     """
-    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: None)
+    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: a[0].write_text(f'esphome:\n  name: {a[1]}\n', encoding='utf-8'))
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     captured = capture_devices_events(ctrl, EventType.IMPORTABLE_DEVICE_REMOVED)

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -116,7 +116,12 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
     """
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
-        devices_module, "import_config", lambda *args, **_kw: (captured.setdefault('args', args), args[0].write_text(f'esphome:\n  name: {args[1]}\n', encoding='utf-8'))
+        devices_module,
+        "import_config",
+        lambda *args, **_kw: (
+            captured.setdefault("args", args),
+            args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8"),
+        ),
     )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
@@ -164,7 +169,12 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
     """
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
-        devices_module, "import_config", lambda *args, **_kw: (captured.setdefault('args', args), args[0].write_text(f'esphome:\n  name: {args[1]}\n', encoding='utf-8'))
+        devices_module,
+        "import_config",
+        lambda *args, **_kw: (
+            captured.setdefault("args", args),
+            args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8"),
+        ),
     )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
@@ -217,7 +227,12 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
     """
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
-        devices_module, "import_config", lambda *args, **_kw: (captured.setdefault('args', args), args[0].write_text(f'esphome:\n  name: {args[1]}\n', encoding='utf-8'))
+        devices_module,
+        "import_config",
+        lambda *args, **_kw: (
+            captured.setdefault("args", args),
+            args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8"),
+        ),
     )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
@@ -298,9 +313,7 @@ async def test_import_device_rejects_when_imported_yaml_does_not_validate(
     monkeypatch.setattr(
         devices_module,
         "import_config",
-        lambda *a, **_kw: a[0].write_text(
-            f"esphome:\n  name: {a[1]}\n", encoding="utf-8"
-        ),
+        lambda *a, **_kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
     )
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -344,9 +357,7 @@ async def test_import_device_skips_validation_when_editor_unavailable(
     monkeypatch.setattr(
         devices_module,
         "import_config",
-        lambda *a, **_kw: a[0].write_text(
-            f"esphome:\n  name: {a[1]}\n", encoding="utf-8"
-        ),
+        lambda *a, **_kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
     )
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -374,7 +385,11 @@ async def test_import_device_returns_even_when_post_scan_fails(
     nothing being wrong. Best-effort scan; the periodic poll picks up
     whatever this attempt missed.
     """
-    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: a[0].write_text(f'esphome:\n  name: {a[1]}\n', encoding='utf-8'))
+    monkeypatch.setattr(
+        devices_module,
+        "import_config",
+        lambda *a, **kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
+    )
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._scanner.scan = AsyncMock(side_effect=RuntimeError("transient"))
@@ -402,7 +417,11 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     can't clobber it) and pulls the cached IP out of zeroconf so the
     new card has an address right away.
     """
-    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: a[0].write_text(f'esphome:\n  name: {a[1]}\n', encoding='utf-8'))
+    monkeypatch.setattr(
+        devices_module,
+        "import_config",
+        lambda *a, **kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
+    )
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor(
@@ -431,7 +450,11 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     make_controller: MakeControllerFactory,
 ) -> None:
     """No cached IP → state still flips ONLINE, just no apply_ip call."""
-    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: a[0].write_text(f'esphome:\n  name: {a[1]}\n', encoding='utf-8'))
+    monkeypatch.setattr(
+        devices_module,
+        "import_config",
+        lambda *a, **kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
+    )
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor()  # no cached addresses
@@ -463,7 +486,11 @@ async def test_import_device_drops_matching_import_result_entry(
     so we drop the right entry even when the user typed a different
     YAML name in the dialog.
     """
-    monkeypatch.setattr(devices_module, "import_config", lambda *a, **kw: a[0].write_text(f'esphome:\n  name: {a[1]}\n', encoding='utf-8'))
+    monkeypatch.setattr(
+        devices_module,
+        "import_config",
+        lambda *a, **kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
+    )
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     captured = capture_devices_events(ctrl, EventType.IMPORTABLE_DEVICE_REMOVED)

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -86,14 +86,7 @@ async def test_import_device_invokes_import_config_and_returns_path(
 ) -> None:
     """Happy path: write the YAML, run a scan, return the configuration name."""
     captured: dict[str, Any] = {}
-
-    def fake_import_config(*args: Any, **_kwargs: Any) -> None:
-        captured["args"] = args
-        # ``import_config`` writes the YAML to disk; mirror that
-        # so the post-write validation step can read it back.
-        args[0].write_text(f"esphome:\n  name: {args[1]}\n", encoding="utf-8")
-
-    monkeypatch.setattr(devices_module, "import_config", fake_import_config)
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub(captured))
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
 
@@ -337,6 +330,38 @@ async def test_import_device_rejects_when_imported_yaml_does_not_validate(
     assert ctrl._scanner.calls == []
 
 
+async def test_import_device_rolls_back_on_validator_subprocess_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A non-CommandError failure from the validator still rolls the YAML back.
+
+    The validator subprocess can raise ``TimeoutError`` /
+    ``RuntimeError`` / ``BrokenPipeError`` (or even an
+    ``OSError`` from the post-write read) without going through
+    ``CommandError``. Without a broad ``except`` the rollback
+    would skip and the half-imported YAML would stick around,
+    tripping ``FileExistsError`` on every retry — exactly the
+    foot-gun this PR is meant to prevent.
+    """
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    ctrl._db.editor.validate_yaml = AsyncMock(side_effect=TimeoutError("subprocess wedged"))
+
+    with pytest.raises(TimeoutError):
+        await ctrl.import_device(
+            name="kitchen",
+            project_name="x",
+            package_import_url="github://x",
+        )
+
+    # YAML must be unlinked even though the failure wasn't a CommandError.
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert ctrl._scanner.calls == []
+
+
 async def test_import_device_skips_validation_when_editor_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -377,11 +402,7 @@ async def test_import_device_returns_even_when_post_scan_fails(
     nothing being wrong. Best-effort scan; the periodic poll picks up
     whatever this attempt missed.
     """
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *a, **kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._scanner.scan = AsyncMock(side_effect=RuntimeError("transient"))
@@ -409,11 +430,7 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     can't clobber it) and pulls the cached IP out of zeroconf so the
     new card has an address right away.
     """
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *a, **kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor(
@@ -442,11 +459,7 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     make_controller: MakeControllerFactory,
 ) -> None:
     """No cached IP → state still flips ONLINE, just no apply_ip call."""
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *a, **kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor()  # no cached addresses
@@ -478,11 +491,7 @@ async def test_import_device_drops_matching_import_result_entry(
     so we drop the right entry even when the user typed a different
     YAML name in the dialog.
     """
-    monkeypatch.setattr(
-        devices_module,
-        "import_config",
-        lambda *a, **kw: a[0].write_text(f"esphome:\n  name: {a[1]}\n", encoding="utf-8"),
-    )
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     captured = capture_devices_events(ctrl, EventType.IMPORTABLE_DEVICE_REMOVED)

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -52,9 +52,12 @@ def _import_config_stub(
     ``import_device`` post-write validation step then reads it
     back, so a stub that only records call args trips the read
     with ``FileNotFoundError``. This helper writes a minimal
-    valid YAML at the destination path and optionally records
-    the call args into *captured* (for tests that assert on
-    what got forwarded to upstream).
+    syntactically-valid YAML (parseable, but deliberately not
+    ESPHome-schema-valid — there's no platform block, so the
+    fake validator we mock around it is the source of pass/fail
+    truth) at the destination path and optionally records the
+    call args into *captured* (for tests that assert on what got
+    forwarded to upstream).
     """
 
     def _stub(*args: Any, **_kw: Any) -> None:
@@ -328,6 +331,89 @@ async def test_import_device_rejects_when_imported_yaml_does_not_validate(
     assert not (tmp_path / "kitchen.yaml").exists()
     # Scanner must NOT have been notified of the half-imported device.
     assert ctrl._scanner.calls == []
+
+
+async def test_import_device_rolls_back_on_unicode_decode_error_from_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Non-UTF-8 bytes in the freshly-written YAML still trigger rollback.
+
+    ``Path.read_text(encoding='utf-8')`` raises ``UnicodeDecodeError``
+    (which is *not* an ``OSError``) when ``import_config`` somehow
+    landed bytes that aren't valid UTF-8. Without an explicit
+    catch, the rollback would skip and the half-imported file
+    would block every retry with ``FileExistsError``.
+    """
+
+    def write_garbage(*args: Any, **_kw: Any) -> None:
+        # Write a byte that isn't a valid UTF-8 leading byte so
+        # ``read_text(encoding='utf-8')`` chokes on it.
+        args[0].write_bytes(b"\xff garbage")
+
+    monkeypatch.setattr(devices_module, "import_config", write_garbage)
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+
+    with pytest.raises(UnicodeDecodeError):
+        await ctrl.import_device(
+            name="kitchen",
+            project_name="x",
+            package_import_url="github://x",
+        )
+
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert ctrl._scanner.calls == []
+
+
+async def test_import_device_preserves_original_error_when_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A failing rollback doesn't replace the validation diagnostic.
+
+    If the YAML's permissions changed between write and cleanup
+    (``unlink`` raises ``PermissionError``), the user should
+    still see the actual validation rejection — not a confusing
+    "permission denied" trace from the rollback path. The
+    cleanup hook's exception is swallowed and logged; the
+    original ``CommandError`` propagates.
+    """
+    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [{"message": "[esphome] required key not provided: a platform"}],
+        }
+    )
+
+    # Make ``Path.unlink`` raise on the imported YAML so the
+    # cleanup hook's executor call surfaces an exception inside
+    # the helper's ``finally``.
+    real_unlink = Path.unlink
+
+    def boom_unlink(self: Path, *, missing_ok: bool = False) -> None:
+        if self.name == "kitchen.yaml":
+            raise PermissionError("rollback denied")
+        real_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", boom_unlink)
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.import_device(
+            name="kitchen",
+            project_name="x",
+            package_import_url="github://x",
+        )
+
+    # Original validation error survives — not a PermissionError
+    # from the rollback path.
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "required key not provided: a platform" in excinfo.value.message
 
 
 async def test_import_device_rolls_back_on_validator_subprocess_error(


### PR DESCRIPTION
# What does this implement/fix?

Third of the audit follow-ups to #404 — applies the never-generate-invalid-configs principle to `devices/import`.

`import_device` delegates the YAML write to upstream `esphome.components.dashboard_import.import_config` and then runs a scan. `import_config` produces wizard-style YAML by construction, but a regression upstream — or a project YAML whose `packages:` reference doesn't resolve cleanly against the current ESPHome state — would otherwise leave an unflashable file on disk that every downstream operation refuses. Worse, a retry would trip `FileExistsError` because the half-imported file is still there, blocking the user.

After `import_config` returns, this PR reads the YAML back through an executor hop and runs it through `_validate_rewritten_yaml_or_raise`. On validation failure, the file is unlinked and `INVALID_ARGS` is raised so the user sees the editor's actual errors and can retry against a different project (or wait for the upstream regression to be fixed) without a leftover blocker. The window between `import_config` and the cleanup is short and the scanner only runs on poll (no inotify watcher), so no half-imported device leaks into `devices/list`. Boot-window guard mirrors the other audited paths: `editor` is None → skip validation; the next compile will surface schema issues if any.

Existing import tests previously stubbed `import_config` as `lambda *a, **kw: None` because they only verified call shape and post-call state. With the new post-write read step those stubs need to actually land a YAML on disk; updated all of them to write a minimal `esphome:\n  name: <n>\n` so the read succeeds. Two new tests pin the validation-failure rollback path and the editor-unavailable boot-window guard.

**Related issue or feature (if applicable):**

- follow-up to #404 / #405 / #406

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
