### PR TITLE
Audit edit_friendly_name validation; fix misleading 'Can't rename' verb

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1140,7 +1140,9 @@ class DevicesController:
         # rejected with the editor's actual errors instead of
         # silently landing on disk for an install that will never
         # take effect.
-        await self._validate_rewritten_yaml_or_raise(configuration, new_content, action="rename")
+        await self._validate_rewritten_yaml_or_raise(
+            configuration, new_content, action="update friendly name"
+        )
 
         # Atomic write — ``Path.write_text`` truncates the
         # destination before writing, so a crash mid-write leaves

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -401,6 +401,115 @@ async def test_edit_friendly_name_blocks_when_validation_fails(
     assert ctrl._scanner.calls == []
 
 
+async def test_edit_friendly_name_blocks_validation_failure_on_substitution_rewrite(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Validation runs on the substitution-redirect rewrite shape too.
+
+    When the source uses ``friendly_name: ${friendly_name}`` +
+    ``substitutions.friendly_name: …`` the editor rewrites the
+    *substitution definition*, not the leaf. Pin that the
+    pre-write validation runs against this rewritten shape with
+    the same errors-surfaced behaviour, so a regression that
+    skipped validation on this branch (e.g. an early-return that
+    only fired for the literal-leaf path) would fail loudly.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    yaml = (
+        "substitutions:\n"
+        "  friendly_name: AC Float Monitor\n"
+        "esphome:\n"
+        "  name: acmon\n"
+        "  friendly_name: ${friendly_name}\n"
+    )
+    (tmp_path / "acmon.yaml").write_text(yaml, "utf-8")
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [{"message": "[esp32] required key not provided: board"}],
+        }
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.edit_friendly_name(
+            configuration="acmon.yaml", new_friendly_name="Pump Watcher"
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "required key not provided: board" in excinfo.value.message
+    # Source unchanged — the rewrite was computed but the write
+    # never landed because validation refused.
+    assert (tmp_path / "acmon.yaml").read_text("utf-8") == yaml
+    assert ctrl._scanner.calls == []
+
+
+async def test_edit_friendly_name_blocks_validation_failure_on_prepend_path(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Validation runs on the prepend-new-block rewrite shape too.
+
+    When the source has no ``esphome:`` block (package-driven
+    config), the editor prepends a fresh block carrying just
+    ``friendly_name:``. Pin that pre-write validation runs on the
+    prepended YAML — a regression that skipped validation here
+    would let the user land an unflashable YAML even though the
+    other rewrite shapes refuse the same shape.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    yaml = "packages:\n  base: !include common/base.yaml\nesp32:\n  variant: ESP32\n"
+    (tmp_path / "kitchen.yaml").write_text(yaml, "utf-8")
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [{"message": "[esp32] required key not provided: board"}],
+        }
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.edit_friendly_name(
+            configuration="kitchen.yaml", new_friendly_name="Reading Lamp"
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "required key not provided: board" in excinfo.value.message
+    assert (tmp_path / "kitchen.yaml").read_text("utf-8") == yaml
+    assert ctrl._scanner.calls == []
+
+
+async def test_edit_friendly_name_validation_error_action_verb(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Error message uses an action verb that matches the operation.
+
+    The handler is ``edit_friendly_name``, not ``rename`` — a
+    leftover ``action="rename"`` would render "Can't rename —
+    config doesn't validate", confusing for a user who clicked
+    "save friendly name". Pin that the surfaced verb tracks
+    the actual operation.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [{"message": "[esp32] some error"}],
+        }
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.edit_friendly_name(
+            configuration="kitchen.yaml", new_friendly_name="Reading Lamp"
+        )
+
+    # The verb appears in the message; "rename" must not, since
+    # this isn't the rename handler.
+    assert "friendly name" in excinfo.value.message
+    assert "Can't rename" not in excinfo.value.message
+
+
 async def test_edit_friendly_name_caps_validation_error_list_in_message(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -432,9 +432,7 @@ async def test_edit_friendly_name_blocks_validation_failure_on_substitution_rewr
     )
 
     with pytest.raises(CommandError) as excinfo:
-        await ctrl.edit_friendly_name(
-            configuration="acmon.yaml", new_friendly_name="Pump Watcher"
-        )
+        await ctrl.edit_friendly_name(configuration="acmon.yaml", new_friendly_name="Pump Watcher")
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "required key not provided: board" in excinfo.value.message


### PR DESCRIPTION
# What does this implement/fix?

Final audit follow-up to #404 — closes the `edit_friendly_name` side of the never-generate-invalid-configs principle.

The handler already validated the rewritten YAML before write (added in #390), but two gaps turned up under audit:

**1. Misleading action verb.** The validator's error message threaded `action="rename"` from the call site, so a user clicking *"save friendly name"* would see `Can't rename — config doesn't validate: …` — wrong operation, confusing UX. Switched to `action="update friendly name"` so the surfaced verb tracks the actual handler.

**2. Coverage gap on rewrite shapes.** The existing validation-failure test (`test_edit_friendly_name_blocks_when_validation_fails`) only exercised the literal-leaf rewrite path. The handler also rewrites through substitution definitions and prepends new `esphome:` blocks for package-driven configs — both shapes go through the same validation step but the tests didn't pin that. A regression that short-circuited validation on either branch (e.g. an early return that only fired for the literal-leaf path) would have slipped past CI.

Two new tests cover the substitution-redirect and prepend-new-block paths against the same `validate_yaml`-mock-returns-errors fixture pattern, plus a small test pinning the corrected action verb. 25 tests pass on the suite.

**Related issue or feature (if applicable):**

- final follow-up to #404 / #390 / #405 / #406 / #407

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
