### PR TITLE
Accept user-uploaded YAML even when it doesn't validate

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -471,12 +471,23 @@ class DevicesController:
            the stub tells the user to swap the platform block if
            their hardware differs.
 
-        Whichever flow runs, the resulting YAML is validated through
-        ``EditorController``'s schema check before the file lands on
-        disk. Validation failures surface as ``INVALID_ARGS`` (the
-        user's ``file_content`` is unfixable from our side) or
-        ``INTERNAL_ERROR`` (one of the generators emitted an
-        invalid YAML — that's our bug to fix, not the user's).
+        The two *generated* flows (template, stub) run the result
+        through ``EditorController``'s schema check before the
+        file lands on disk — those are *our* outputs, so an
+        invalid one is our regression to fix and surfaces as
+        ``INTERNAL_ERROR``.
+
+        The user-upload flow deliberately skips validation. The
+        whole point of "upload an existing YAML" is to get a
+        config the user already has into the dashboard so they
+        can edit it; many real-world cases are configs from older
+        ESPHome versions whose components have since changed
+        schema, and refusing to write them would lock the user
+        out of the editor — the only place they can fix the YAML
+        in the first place. The next compile / install will
+        surface the actual schema errors with line numbers, which
+        is what the user wants when they're repairing an old
+        config.
 
         After writing, we always try to derive a board_id by parsing
         the resulting YAML's platform/board/variant fields and matching
@@ -519,18 +530,24 @@ class DevicesController:
             name, friendly, board, file_content, ssid, psk
         )
 
-        # Validate before write so an unflashable YAML never lands
-        # on disk. ``INVALID_ARGS`` for the user-supplied
-        # ``file_content`` branch (the user can fix their input);
-        # ``INTERNAL_ERROR`` for the two generator branches because
-        # an invalid template / stub is our regression and we want
-        # it routed to the issue tracker, not to the user.
-        await self._validate_rewritten_yaml_or_raise(
-            filename,
-            yaml_content,
-            action="create",
-            on_failure=ErrorCode.INVALID_ARGS if source == "user" else ErrorCode.INTERNAL_ERROR,
-        )
+        # Validate generated YAML before write so a regression in
+        # ``generate_device_yaml`` / ``generate_minimal_stub_yaml``
+        # surfaces as ``INTERNAL_ERROR`` (our bug to report) rather
+        # than landing an unflashable YAML on disk. User uploads
+        # are deliberately *not* validated here — the upload flow
+        # exists so users can bring an existing config (often from
+        # an older ESPHome version with since-changed component
+        # schemas) into the builder and repair it in the editor.
+        # Refusing the write would strand them; the next compile
+        # / install surfaces the real schema errors with line
+        # numbers, which is what they need to fix it.
+        if source != "user":
+            await self._validate_rewritten_yaml_or_raise(
+                filename,
+                yaml_content,
+                action="create",
+                on_failure=ErrorCode.INTERNAL_ERROR,
+            )
 
         # Derive board_id from YAML when not explicitly provided.
         # Mirrors the scanner's resolution chain: pio_board match first,

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -126,28 +126,31 @@ async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
-async def test_create_device_rejects_invalid_file_content(
+async def test_create_device_accepts_invalid_file_content_for_user_repair(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """User-supplied ``file_content`` that doesn't validate is refused.
+    """User uploads of schema-invalid YAML still land on disk.
 
-    The frontend's "import YAML" flow lets users paste arbitrary
-    text into the wizard. Without this guard a malformed paste
-    would land on disk, every downstream operation would refuse
-    it, and the user would have to delete the device and try
-    again. Surfacing the editor's actual errors gives them
-    something to fix.
+    The "upload YAML" flow exists so a user can bring an existing
+    config into the builder and repair it in the editor. Many
+    real-world cases are configs from older ESPHome versions
+    whose components have since changed schema — refusing the
+    upload would strand the user with no way to get the file in
+    front of the editor where they can fix it. Pin: even when
+    the (mocked) validator returns errors for the uploaded YAML,
+    the file still lands on disk and the scanner fires so the
+    device shows up in the dashboard for the user to edit.
+    Validation runs only on our generators (template / stub
+    branches) where an invalid output is *our* regression.
     """
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     boards = StubBoardLookups(ctrl)
     boards.find_by_pio_board_returns(None)
     boards.find_by_platform_variant_returns(None)
-    # File content that mirrors what the user's failing scenario
-    # would actually look like — esphome block with a name but no
-    # platform block at all, which the editor rejects with the
-    # mocked error below.
-    invalid_file_content = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
-    ctrl._db.editor.validate_yaml = AsyncMock(
+    # Mock the validator to return errors. We assert the
+    # upload succeeds anyway (validate_yaml should never be
+    # called for the user-upload branch).
+    validate = AsyncMock(
         return_value={
             "yaml_errors": [],
             "validation_errors": [
@@ -155,15 +158,72 @@ async def test_create_device_rejects_invalid_file_content(
             ],
         }
     )
+    ctrl._db.editor.validate_yaml = validate
+    invalid_file_content = "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
 
-    with pytest.raises(CommandError) as excinfo:
-        await ctrl.create_device(name="kitchen", file_content=invalid_file_content)
+    result = await ctrl.create_device(name="kitchen", file_content=invalid_file_content)
 
-    assert excinfo.value.code == ErrorCode.INVALID_ARGS
-    assert "required key not provided: a platform" in excinfo.value.message
-    # File never landed on disk.
-    assert not (tmp_path / "kitchen.yaml").exists()
-    assert ctrl._scanner.calls == []
+    assert result.configuration == "kitchen.yaml"
+    # File landed verbatim on disk so the user can open it in
+    # the editor.
+    assert (tmp_path / "kitchen.yaml").read_text("utf-8") == invalid_file_content
+    # Scanner nudged so the device shows up in ``devices/list``.
+    assert ctrl._scanner.calls == [("scan",)]
+    # Validator must NOT have been called for the upload branch.
+    validate.assert_not_called()
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_create_device_accepts_old_esphome_version_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A YAML using deprecated upstream syntax still uploads cleanly.
+
+    Concrete regression for the "I upgraded ESPHome and now my
+    config doesn't validate" scenario. The YAML below uses the
+    pre-2024 ``esp32: { board: ..., framework: { type: arduino } }``
+    flat shape and a deprecated ``esphome.platform: ESP32`` key
+    that current ESPHome rejects. Even with a validator that
+    flags multiple deprecation errors, the upload must succeed
+    so the user can open the file in the editor and fix it.
+    Without this acceptance the upload path would be useless for
+    its primary use case (importing legacy configs to repair).
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    boards = StubBoardLookups(ctrl)
+    boards.find_by_pio_board_returns(None)
+    boards.find_by_platform_variant_returns(None)
+    legacy_yaml = (
+        "esphome:\n"
+        "  name: old-device\n"
+        "  platform: ESP32\n"  # deprecated key
+        "  board: nodemcu-32s\n"  # deprecated location
+        "esp32:\n"
+        "  framework:\n"
+        "    type: arduino\n"
+        "    version: 2.0.5\n"
+        "wifi:\n"
+        "  ssid: !secret wifi_ssid\n"
+        "  password: !secret wifi_password\n"
+        "  use_address: 192.168.1.50\n"  # legacy field renamed in newer schema
+    )
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [
+                {"message": "[esphome] 'platform' has been deprecated"},
+                {"message": "[esphome] 'board' has been deprecated"},
+                {"message": "[esp32.framework] 'version' is no longer supported"},
+            ],
+        }
+    )
+
+    result = await ctrl.create_device(name="old-device", file_content=legacy_yaml)
+
+    assert result.configuration == "old-device.yaml"
+    written = (tmp_path / "old-device.yaml").read_text("utf-8")
+    assert written == legacy_yaml
+    assert ctrl._scanner.calls == [("scan",)]
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")


### PR DESCRIPTION
# What does this implement/fix?

Follow-up correction to #405. The upload path's validation is the wrong shape for the scenario it's most needed in.

The "Upload YAML" wizard option exists so a user can bring an existing config into the builder and edit it. A common real-world case is configs from older ESPHome versions whose components have since changed schema — the pre-2024 `esphome.platform` / `esphome.board` shape, or the renamed `wifi.use_address` field, or any component whose schema tightened between releases. After an `esphome` upgrade, those YAMLs no longer validate. The user comes to the dashboard specifically to *repair* them.

#405 validates user-uploaded YAML and refuses on schema errors. That refusal strands the user: the only place they can fix the YAML is the dashboard's editor, and we won't let the file land on disk for them to open. The upload path is useless for its primary purpose.

The never-generate-invalid-configs principle applies to *our* generators (`generate_device_yaml`, `generate_minimal_stub_yaml`) — not to YAMLs the user is bringing in. This PR drops the validation on the `file_content` branch only. The two generated branches (template, stub) still validate; an invalid output from those is a regression in our code that should surface as `INTERNAL_ERROR`.

Two tests pin the new contract:

- A generic case where the (mocked) validator returns errors but the upload lands anyway, with an explicit `validate.assert_not_called()` to pin that the upload branch doesn't even consult the validator.
- A concrete legacy-YAML regression: a config using the deprecated `esphome.platform` + `esphome.board` keys, the deprecated `esp32.framework.version` field, and the renamed `wifi.use_address` field. The mocked validator flags all three; the upload still lands so the user can fix the file in the editor.

**Related issue or feature (if applicable):**

- follow-up to #405

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
