### PR TITLE
Document the user-supplied-content exception to validate-generators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,32 @@ in case anything has resurfaced.
   output through `editor.validate_yaml` (or the equivalent
   schema check) so the same shape can't reappear.
 
+  **Important exception — user-supplied content is *not* a
+  generator.** Don't apply this principle to YAMLs the user is
+  bringing into the dashboard via the wizard's "Upload YAML"
+  flow, drag-and-drop, paste-into-editor, or any other
+  user-typed entry point. The whole point of those entry points
+  is to land an existing config in the builder *so the user can
+  repair it in the editor*. The most common real-world case is
+  a YAML from an older ESPHome version whose components have
+  since changed schema (deprecated `esphome.platform` /
+  `esphome.board`, renamed fields like `wifi.use_address`,
+  components whose schema tightened across releases); refusing
+  the write strands the user with no way to get the file into
+  the editor in the first place. Validate *our* outputs
+  (`generate_device_yaml`, `generate_minimal_stub_yaml`,
+  `dashboard_import.import_config`, clone's leaf rewrites) but
+  pass user-supplied content through unchanged. PR #412
+  reverses #405's overzealous validation on `create_device`'s
+  `file_content` branch and pins the legacy-config
+  acceptance contract; if you ever feel the urge to add a
+  `_validate_*_or_raise` to a path whose content originated
+  from outside the dashboard, stop and check this exception
+  first. The next compile / install will surface real schema
+  errors with line numbers — that's what the user wants when
+  they're repairing an old config, not a "config doesn't
+  validate" up-front refusal.
+
 ## Things that have bitten us before
 
 When changing the sync script or catalog handling, watch for these:


### PR DESCRIPTION
# What does this implement/fix?

Doc companion to #412. Extends the "Never generate invalid configs" design-principles section (added in #404) with the user-supplied-content exception that #412 surfaces.

The principle in #404 was sound but lacked a carve-out: it ended up justifying #405's validation on `create_device`'s `file_content` branch, which strands users trying to import a legacy config to repair it in the editor. The canonical real-world case is a YAML from a pre-upgrade ESPHome release whose components have since changed schema — deprecated `esphome.platform` / `esphome.board`, renamed `wifi.use_address`, components whose schema tightened. Refusing the write blocks the user from getting the file into the only place they can fix it.

#412 reverses the validation on the upload path. This PR documents *why* so the same overzealous shape doesn't reappear in future PRs touching upload / paste / drag-and-drop entry points. The added paragraph spells out:

- Validate *our* outputs (`generate_device_yaml`, `generate_minimal_stub_yaml`, `dashboard_import.import_config`, clone's leaf rewrites).
- Pass user-supplied content through unchanged.
- The next compile / install surfaces the real schema errors with line numbers — that's what the user wants when repairing.
- Points at #412's tests as the canonical "old YAML uploads cleanly" fixtures.

Mirrors the wording from the corresponding feedback memory I keep across sessions so the doc and the agent's working memory stay aligned.

**Related issue or feature (if applicable):**

- doc companion to #412 (and follow-up to #404 / #405)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
