### PR TITLE
Skip api/ota for boards without a network component (fixes H2 wizard)

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -101,6 +101,20 @@ _FALLBACK_WIFI_FIRST_PLATFORMS: frozenset[str] = frozenset(
     {"esp8266", "bk72xx", "rtl87xx", "ln882x", "libretiny"}
 )
 
+# TODO comment block emitted by ``generate_device_yaml`` for
+# no-Wi-Fi boards (H2 / P4 / plain Pico / etc.) instead of
+# ``api:`` + ``ota:``. Lifted to module scope so the generator
+# can ``lines.extend`` rather than five inline ``lines.append``
+# calls — keeps the function under PLR0915's statement budget.
+_NO_NETWORK_TODO_LINES: tuple[str, ...] = (
+    "# This board has no native Wi-Fi. ESPHome's ``api:`` and",
+    "# ``ota:`` components both require a ``network``",
+    "# component — configure ``openthread:`` / ``ethernet:`` /",
+    "# ``esp32_hosted:`` to suit your setup, then add ``api:``",
+    "# and ``ota:`` blocks once the network is ready.",
+    "",
+)
+
 
 def _fallback_has_native_wifi(
     *, platform: str, board: str | None = None, variant: str | None = None
@@ -245,32 +259,40 @@ def generate_device_yaml(
     lines.append("logger:")
     lines.append("")
 
-    # Home Assistant API — unique encryption key per device
-    api_key = base64.b64encode(secrets.token_bytes(32)).decode()
-    lines.append("api:")
-    lines.append("  encryption:")
-    lines.append(f'    key: "{api_key}"')
-    lines.append("")
-
-    # OTA
-    lines.append("ota:")
-    lines.append("  - platform: esphome")
-    lines.append("")
-
-    # Wi-Fi: prefer the manifest's explicit claim, fall back to a
-    # platform/variant/board-aware inference for boards whose hardware
-    # block omits ``connectivity`` entirely. The prior shape defaulted
-    # empty connectivity to Wi-Fi — correct for the typical S2/S3/C3/C6
-    # / ESP8266 / Pico W board, but it silently generated a ``wifi:``
-    # block ESPHome rejects at compile time for ESP32-H2 / ESP32-P4
-    # (no Wi-Fi PHY) and for the plain RP2040 / RP2350 chips (only the
-    # Pico W / Pico 2 W variants ship a CYW43). The inference asks
-    # ESPHome's own ``NO_WIFI_VARIANTS`` and ``rp2040.boards.BOARDS``
-    # so a future no-Wi-Fi variant or new RP2040 wifi board flows
-    # through without a coordinated edit here.
+    # Wi-Fi decision — used both for the ``wifi:`` block below and to
+    # gate ``api:`` / ``ota:`` (both DEPENDENCIES=["network"], so
+    # they can't compile on a board without a network component
+    # auto-loaded by ``wifi:`` / ``ethernet:`` / ``openthread:`` /
+    # ``host:``). Prefer the manifest's explicit ``connectivity``
+    # claim, fall back to a platform/variant/board-aware inference
+    # for boards whose hardware block omits ``connectivity``
+    # entirely. The inference asks ESPHome's own ``NO_WIFI_VARIANTS``
+    # / ``rp2040.boards.BOARDS`` so a future no-Wi-Fi variant or new
+    # RP2040 Wi-Fi board flows through without a coordinated edit
+    # here.
     connectivity = [c.value for c in board.hardware.connectivity] if board.hardware else []
     has_wifi = "wifi" in connectivity if connectivity else _infer_native_wifi(board)
+
     if has_wifi:
+        # Home Assistant API — unique encryption key per device.
+        # Skipped on no-Wi-Fi boards because ``api:`` requires a
+        # ``network`` component (DEPENDENCIES=["network"]) and the
+        # wizard doesn't emit ``ethernet:`` / ``openthread:`` /
+        # ``host:`` for non-Wi-Fi boards. Validation would otherwise
+        # reject the generated config with
+        # "Component api requires component network." — see ``ota``
+        # below for the same reasoning.
+        api_key = base64.b64encode(secrets.token_bytes(32)).decode()
+        lines.append("api:")
+        lines.append("  encryption:")
+        lines.append(f'    key: "{api_key}"')
+        lines.append("")
+
+        # OTA — same network dependency as ``api:`` above.
+        lines.append("ota:")
+        lines.append("  - platform: esphome")
+        lines.append("")
+
         lines.append("wifi:")
         if ssid:
             lines.append(f"  ssid: {ssid}")
@@ -279,6 +301,17 @@ def generate_device_yaml(
             lines.append("  ssid: !secret wifi_ssid")
             lines.append("  password: !secret wifi_password")
         lines.append("")
+    else:
+        # No native Wi-Fi → leave a TODO so the user knows what they
+        # need to configure before adding ``api:`` / ``ota:``. Both
+        # require a ``network`` component to compile, and the right
+        # network for these boards depends on the user's setup
+        # (``openthread:`` for H2, ``ethernet:`` for P4 with a
+        # co-processor, ``esp32_hosted:`` for either with a Wi-Fi
+        # daughterboard, etc.). Emitting a placeholder block would
+        # bake an arbitrary choice into the generated YAML; a
+        # commented-out hint lets the user pick.
+        lines.extend(_NO_NETWORK_TODO_LINES)
 
     return "\n".join(lines)
 

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -755,6 +755,58 @@ def test_generate_yaml_omits_wifi_for_esp32h2_without_explicit_connectivity() ->
     assert "wifi:" not in yaml
 
 
+def test_generate_yaml_omits_api_and_ota_for_no_wifi_board() -> None:
+    """No-Wi-Fi board → no top-level ``api:`` and no top-level ``ota:`` block.
+
+    Both components declare ``DEPENDENCIES=["network"]``, and the
+    wizard doesn't emit a ``network``-providing component
+    (``ethernet:`` / ``openthread:`` / ``host:``) for non-Wi-Fi
+    boards. Without this guard the generated YAML fails validation
+    with "Component api requires component network." for every H2 /
+    P4 / plain Pico the user picks. Pin the omission so a
+    regression that re-enabled the unconditional emit shows up
+    here. Match against the line-anchored top-level form rather
+    than a bare substring — the TODO comment mentions ``api:`` /
+    ``ota:`` in backticks so naive ``"api:" not in yaml`` would
+    false-positive on the guidance text.
+    """
+    board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32H2)
+    yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
+    lines = yaml.splitlines()
+    assert "api:" not in lines
+    assert "ota:" not in lines
+
+
+def test_generate_yaml_no_wifi_board_emits_network_todo_comment() -> None:
+    """Wizard leaves a hint pointing the user at network options.
+
+    When ``api:`` / ``ota:`` are skipped the user might not realise
+    why; the comment block names the candidate network components
+    (``openthread:`` / ``ethernet:`` / ``esp32_hosted:``) so they
+    have a starting point. Pin a couple of stable substrings so a
+    rewording that drops the guidance entirely surfaces here.
+    """
+    board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32H2)
+    yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
+    assert "no native Wi-Fi" in yaml
+    assert "network" in yaml
+
+
+def test_generate_yaml_keeps_api_and_ota_for_wifi_board() -> None:
+    """Wi-Fi board → ``api:`` and ``ota:`` blocks both still emitted.
+
+    The no-network guard above must not regress the happy path —
+    every ESP32 / ESP8266 / Pico-W config keeps the api +
+    encryption + ota blocks the wizard always produced.
+    """
+    board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32C3)
+    yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
+    lines = yaml.splitlines()
+    assert "api:" in lines
+    assert "ota:" in lines
+    assert "  - platform: esphome" in yaml
+
+
 def test_generate_yaml_emits_wifi_for_esp32c3_without_explicit_connectivity() -> None:
     """ESP32-C3 with no connectivity claim → ``wifi:`` block emitted.
 


### PR DESCRIPTION
# What does this implement/fix?

Creating an ESP32-H2 device through the basic-setup wizard rejected with `Cannot create — config doesn't validate: Component api requires component network.` The wizard emitted `api:` + `ota:` blocks unconditionally, but both declare `DEPENDENCIES=["network"]` and the wizard only auto-loads `network` via the `wifi:` block — so every no-Wi-Fi board (H2, P4, plain Pico, Pico 2, Seeed XIAO RP2040, Waveshare RP2040 Zero) failed to validate before the user could even open the editor.

Gate `api:` / `ota:` emission on the same `has_wifi` decision the `wifi:` block already uses. No-Wi-Fi boards now produce a minimal compileable config (`esphome:` / platform / `logger:` only) plus a `# TODO` comment block guiding the user toward the right network component for their setup:

```
# This board has no native Wi-Fi. ESPHome's ``api:`` and
# ``ota:`` components both require a ``network``
# component — configure ``openthread:`` / ``ethernet:`` /
# ``esp32_hosted:`` to suit your setup, then add ``api:``
# and ``ota:`` blocks once the network is ready.
```

Comment-over-commented-out-blocks because emitting a placeholder `ethernet:` / `openthread:` would bake an arbitrary choice into the generated YAML — H2 wants OpenThread, P4 wants ESP-Hosted, an Ethernet-shielded board wants `ethernet:` — and the user is the one with the right answer.

The Wi-Fi happy path is unchanged: every ESP32 / ESP8266 / Pico-W config keeps the `api:` (with per-device encryption key) + `ota: - platform: esphome` + `wifi:` blocks the wizard always produced.

**Related issue or feature (if applicable):**

- fixes the user-reported "Failed to create device for Generic ESP32-H2 Board: Component api requires component network."

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
