### PR TITLE
Add per-sub-field platform gating to ConfigEntry catalog

### DIFF
--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -294,6 +294,24 @@ class ConfigEntry(DataClassORJSONMixin):
     # commonly used there).
     platform_defaults: dict[str, ConfigPrimitive] | None = None
 
+    # Target chips this field is valid on. Empty list means "all
+    # platforms" (the common case). Non-empty restricts the field
+    # to the named chips — e.g. ``sensor.debug.psram`` is
+    # ``["esp32"]`` because PSRAM stats only exist on ESP32 with
+    # PSRAM-enabled variants, and ``sensor.debug.fragmentation``
+    # is ``["esp8266"]`` because heap-fragmentation reporting is
+    # ESP8266-specific. The form renderer hides entries whose
+    # ``supported_platforms`` is non-empty and doesn't include
+    # the device's target chip; a preemptive filter beats the
+    # current behaviour where the user fills the field, compiles,
+    # and then sees a "doesn't apply on this platform" error well
+    # after they've left the dialog. Sibling-but-different from
+    # the catalog-entry-level ``supported_platforms`` on
+    # :class:`ComponentCatalogEntry` (that one gates the *whole
+    # component*; this one gates a single config entry within an
+    # otherwise platform-portable component).
+    supported_platforms: list[str] = field(default_factory=list)
+
     # === value constraints ===
 
     # Constrains the value to a fixed set of choices. When populated the

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1598,6 +1598,7 @@ def build_component_entry(
     _apply_platform_defaults(config_entries, introspection.get("platform_defaults") or {})
     _apply_refined_types(config_entries, introspection.get("refined_types") or {})
     _apply_unit_of_measurement_options(config_entries)
+    _apply_field_platform_overrides(component_id, config_entries)
 
     return {
         "id": component_id,
@@ -3133,6 +3134,68 @@ def _apply_platform_defaults(
             pd = platform_defaults.get(sub_path)
             if pd:
                 entry["platform_defaults"] = pd
+            inner = entry.get("config_entries")
+            if inner:
+                walk(inner, sub_path)
+
+    walk(entries, ())
+
+
+# Per-(component_id, *path) override for ``ConfigEntry.supported_platforms``
+# — fields that are valid only on a subset of the platforms the
+# *component* runs on. The schema bundle doesn't carry this signal
+# in a uniform way (some fields live behind ``cv.SplitDefault``,
+# others behind component-side ``if CORE.is_esp32`` branches that
+# the schema dump can't see), so we maintain a small explicit map
+# until upstream surfaces it. Keep the list short and targeted —
+# every entry is a workaround for a foot-gun a user actually hit
+# in the visual editor (compile failing because they filled in a
+# field their MCU doesn't support).
+#
+# Path format: ``(component_id, *parent_keys, field_key)``. For
+# ``sensor.debug.psram`` the path is
+# ``("sensor.debug", "psram")`` because ``psram`` is a top-level
+# entry under the ``sensor.debug`` component (one of the optional
+# nested sub-sensors). Sub-fields nested deeper (e.g. the
+# ``name`` inside ``psram``) inherit the parent's gate at render
+# time on the frontend; we don't repeat the entry per child.
+_FIELD_PLATFORM_OVERRIDES: dict[tuple[str, ...], list[str]] = {
+    # Heap fragmentation reporting is ESP8266-only; the upstream
+    # debug component's fragmentation sub-sensor is wrapped in a
+    # ``CORE.is_esp8266`` guard at codegen time.
+    ("sensor.debug", "fragmentation"): ["esp8266"],
+    # PSRAM stats only make sense on ESP32 variants with PSRAM
+    # support enabled. The upstream component checks
+    # ``CORE.is_esp32`` at codegen and refuses on ESP8266 / RP2040
+    # / etc. Keeping the gate at the catalog level means the form
+    # never offers the field on the wrong board, instead of the
+    # current "fill it in, compile fails three minutes later"
+    # foot-gun (issue #417).
+    ("sensor.debug", "psram"): ["esp32"],
+}
+
+
+def _apply_field_platform_overrides(
+    component_id: str,
+    entries: list[dict],
+) -> None:
+    """Stamp ``supported_platforms`` onto fields listed in the override map.
+
+    The schema bundle doesn't reliably surface per-field platform
+    constraints (they're often hidden behind component-side
+    ``CORE.is_esp32`` branches that don't show up in the static
+    dump), so we maintain a small explicit override list. The
+    frontend's form renderer hides entries whose
+    ``supported_platforms`` is non-empty and doesn't include the
+    device's target chip.
+    """
+
+    def walk(items: list[dict], path: tuple[str, ...]) -> None:
+        for entry in items:
+            sub_path = (*path, entry["key"])
+            override = _FIELD_PLATFORM_OVERRIDES.get((component_id, *sub_path))
+            if override:
+                entry["supported_platforms"] = list(override)
             inner = entry.get("config_entries")
             if inner:
                 walk(inner, sub_path)

--- a/tests/test_sync_components_field_platform_overrides.py
+++ b/tests/test_sync_components_field_platform_overrides.py
@@ -1,0 +1,124 @@
+"""Unit tests for ``_FIELD_PLATFORM_OVERRIDES`` in ``script/sync_components.py``.
+
+The schema bundle doesn't reliably capture per-field platform
+constraints — the upstream debug component's ``psram`` /
+``fragmentation`` sub-sensors live behind ``CORE.is_esp32`` /
+``CORE.is_esp8266`` branches at codegen time that don't surface
+in the static schema dump. Issue #417 walked through the foot-gun:
+the form happily lets a user fill in PSRAM stats on an ESP8266
+board, then compile fails three minutes later with a
+"doesn't apply on this platform" error.
+
+The fix is a small explicit override list in the sync script
+that stamps ``ConfigEntry.supported_platforms`` onto the affected
+fields. The frontend's form renderer reads that and hides the
+entry on incompatible boards.
+
+Pin the override shape here so a future sync-script edit can't
+quietly regress to "no platform gate" and reintroduce the
+foot-gun.
+"""
+
+from __future__ import annotations
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _FIELD_PLATFORM_OVERRIDES,
+    _apply_field_platform_overrides,
+)
+
+
+def test_psram_is_gated_to_esp32() -> None:
+    """``sensor.debug.psram`` is ESP32-only.
+
+    PSRAM stats only exist on ESP32 variants with PSRAM enabled —
+    the upstream component refuses on ESP8266 / RP2040 / etc. via
+    a ``CORE.is_esp32`` guard at codegen. The static schema
+    doesn't capture this, so we override here.
+    """
+    assert _FIELD_PLATFORM_OVERRIDES[("sensor.debug", "psram")] == ["esp32"]
+
+
+def test_fragmentation_is_gated_to_esp8266() -> None:
+    """``sensor.debug.fragmentation`` is ESP8266-only.
+
+    Heap fragmentation reporting is ESP8266-specific in upstream
+    debug. The schema bundle doesn't carry the gate; we do.
+    """
+    assert _FIELD_PLATFORM_OVERRIDES[("sensor.debug", "fragmentation")] == ["esp8266"]
+
+
+def test_apply_stamps_supported_platforms_on_top_level_field() -> None:
+    """The walker stamps the override onto the matching entry."""
+    entries = [
+        {"key": "free", "config_entries": []},
+        {"key": "psram", "config_entries": []},
+        {"key": "loop_time", "config_entries": []},
+    ]
+    _apply_field_platform_overrides("sensor.debug", entries)
+    by_key = {e["key"]: e for e in entries}
+    # ``psram`` gets the override.
+    assert by_key["psram"]["supported_platforms"] == ["esp32"]
+    # Sibling fields without overrides stay untouched (no
+    # ``supported_platforms`` key set, which the model defaults to
+    # an empty list — meaning "all platforms").
+    assert "supported_platforms" not in by_key["free"]
+    assert "supported_platforms" not in by_key["loop_time"]
+
+
+def test_apply_walks_nested_paths() -> None:
+    """Nested entries are reachable via the ``(component, *path)`` key.
+
+    Today's overrides only target top-level entries, but the
+    walker supports nested paths so future entries can target
+    deeper fields without restructuring the override map. Pin a
+    synthetic nested case so a refactor that flattened the walk
+    fails loudly.
+    """
+    # Synthetic component-side hook for the test only.
+    _FIELD_PLATFORM_OVERRIDES[("test.synthetic", "outer", "inner")] = ["rp2040"]
+    try:
+        entries = [
+            {
+                "key": "outer",
+                "config_entries": [
+                    {"key": "inner", "config_entries": []},
+                    {"key": "sibling", "config_entries": []},
+                ],
+            },
+        ]
+        _apply_field_platform_overrides("test.synthetic", entries)
+        inner = entries[0]["config_entries"][0]
+        sibling = entries[0]["config_entries"][1]
+        assert inner["supported_platforms"] == ["rp2040"]
+        assert "supported_platforms" not in sibling
+    finally:
+        del _FIELD_PLATFORM_OVERRIDES[("test.synthetic", "outer", "inner")]
+
+
+def test_apply_is_a_no_op_on_unrelated_component() -> None:
+    """Walking a component without overrides leaves entries unchanged."""
+    entries = [
+        {"key": "ssid", "config_entries": []},
+        {"key": "password", "config_entries": []},
+    ]
+    before = [dict(e) for e in entries]
+    _apply_field_platform_overrides("wifi", entries)
+    assert entries == before
+
+
+def test_apply_preserves_existing_entry_state() -> None:
+    """Stamping ``supported_platforms`` doesn't disturb other fields."""
+    entries = [
+        {
+            "key": "psram",
+            "type": "nested",
+            "label": "PSRAM",
+            "config_entries": [{"key": "name"}],
+        },
+    ]
+    _apply_field_platform_overrides("sensor.debug", entries)
+    assert entries[0]["supported_platforms"] == ["esp32"]
+    # Other keys preserved.
+    assert entries[0]["type"] == "nested"
+    assert entries[0]["label"] == "PSRAM"
+    assert entries[0]["config_entries"] == [{"key": "name"}]


### PR DESCRIPTION
# What does this implement/fix?

Backend half of esphome/device-builder#417 — per-sub-field platform gating for the visual editor.

The schema bundle doesn't reliably surface per-field platform constraints. The upstream `debug` sensor's `psram` and `fragmentation` sub-sensors live behind `CORE.is_esp32` / `CORE.is_esp8266` branches at codegen time that don't show up in the static schema dump. Today the visual editor happily lets a user fill in `sensor.debug.psram` on an ESP8266 board, then they watch the compile fail three minutes later with a "doesn't apply on this platform" error well after they've left the dialog.

The fix: add a `supported_platforms` field to `ConfigEntry` (sibling-but-different from the existing `ComponentCatalogEntry.supported_platforms` — that one gates the *whole component*; this one gates a single config entry within an otherwise platform-portable component), plus a small explicit override map in `script/sync_components.py` keyed on `(component_id, *path)`. The walker supports nested paths so future entries can target deeper fields without restructuring the map.

**Starter overrides:**
- `("sensor.debug", "psram") → ["esp32"]` — PSRAM stats are ESP32-only with PSRAM-enabled variants
- `("sensor.debug", "fragmentation") → ["esp8266"]` — heap-fragmentation reporting is ESP8266-specific

The wire contract is "empty list = all platforms" (the common case), "non-empty = restrict to listed chips." The model default is `field(default_factory=list)` so existing serialized payloads stay compatible without a migration.

The frontend half (companion PR — drafted separately) reads `supported_platforms` in the form renderer and hides entries whose target chip isn't listed. Until that lands the field is dormant — no behaviour change for existing users.

**Why a hand-curated map and not a schema-side signal.** The platform branches in upstream debug aren't a schema construct; they're imperative codegen guards. Surfacing them through the schema bundle would require an upstream design change (PR/issue not yet filed). The override list is small and targeted — every entry is a workaround for a foot-gun a user actually hit. We can drop the override list once upstream surfaces the gates uniformly.

**Tests.** 6 new tests in `tests/test_sync_components_field_platform_overrides.py`:
- Pin both starter override values (regression-proof against silent map edits)
- Walker stamps the override on a top-level field and leaves siblings untouched
- Walker reaches nested paths via a synthetic test-only entry
- No-op on components without overrides
- Stamping doesn't disturb other entry fields (`type`, `label`, `config_entries`)

`components.json` is **not** regenerated in this PR — the sync script supports the new override but the next nightly catalog sync will pick it up. Doing the regeneration in this PR would mix the schema sync with the override addition and make the diff much harder to review.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#417 (backend half — frontend companion PR pending)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD — to be opened next>

The new `ConfigEntry.supported_platforms` field is the wire contract; the frontend reads it in the form renderer to hide entries whose target chip isn't in the list. Until the FE PR ships the field is dormant.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
