### PR TITLE
Surface directly-referenced integrations on the device model

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -544,6 +544,72 @@ def config_has_top_level_block(config: dict | None, key: str) -> bool:
     return isinstance(config, dict) and key in config
 
 
+def extract_directly_referenced_integrations(
+    config: dict | None,
+) -> list[str]:
+    """
+    Return the sorted list of directly-written integration names.
+
+    Walks a resolved device config and pulls out top-level keys
+    plus platform stems from ``- platform: <name>`` (or single-form
+    ``platform: <name>``) references.
+
+    The complement of this set against ``StorageJSON.loaded_integrations``
+    is the auto-loaded dependency chain (``md5`` pulled in by WPA2
+    password hashing, ``mdns`` by ``api``, ``web_server_base`` by
+    ``web_server``, ``voltage_sampler`` by ADC sensors, …). The
+    frontend's device-drawer uses the split to surface direct
+    integrations as the primary list and tuck auto-loaded ones
+    behind a collapsible — see issue #422.
+
+    Resolved config (``!include`` / packages expanded) is the right
+    source: a package the user imported counts as direct (they
+    chose the package), while integrations the platform infrastructure
+    auto-loads as dependencies of those imports are indirect.
+    Returns ``[]`` for ``None`` (resolved-parse failed) so the
+    frontend falls through to the flat-list rendering.
+
+    Two YAML shapes carry platform refs:
+
+    1. List-of-platforms (the common case)::
+
+        sensor:
+          - platform: bme280_i2c
+          - platform: dht
+
+       → adds ``sensor`` (top-level key) plus ``bme280_i2c`` and
+       ``dht`` (each item's ``platform`` value).
+
+    2. Single-platform dict (``ota`` / ``mqtt`` historically)::
+
+        ota:
+          platform: esphome
+
+       → adds ``ota`` plus ``esphome``.
+
+    Non-string ``platform:`` values (templated lambdas, malformed
+    drafts) are skipped silently rather than emitting garbage names.
+    """
+    if not isinstance(config, dict):
+        return []
+    out: set[str] = set()
+    for key, value in config.items():
+        if not isinstance(key, str):
+            continue
+        out.add(key)
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    platform = item.get("platform")
+                    if isinstance(platform, str) and platform:
+                        out.add(platform)
+        elif isinstance(value, dict):
+            platform = value.get("platform")
+            if isinstance(platform, str) and platform:
+                out.add(platform)
+    return sorted(out)
+
+
 def parse_esphome_meta(  # noqa: PLR0912
     yaml_content: str,
 ) -> tuple[str | None, str | None, str | None, str | None]:
@@ -793,6 +859,18 @@ def load_device_from_storage(
         target_platform = detect_platform_from_yaml(path)
 
     loaded_integrations = sorted(storage.loaded_integrations) if storage else []
+    # Subset of loaded_integrations the user directly wrote — top-
+    # level keys + ``- platform:`` stems. Frontend's device-drawer
+    # splits the loaded list into "direct" (these) and "indirect"
+    # (the rest, all auto-loaded dependencies). Resolved config is
+    # the right source so package contents are direct (the user
+    # imported them); falls back to the empty list when resolved
+    # config is unavailable so the frontend can render the flat
+    # loaded list as a graceful degrade. Issue #422.
+    user_referenced = set(extract_directly_referenced_integrations(resolved_config))
+    directly_referenced_integrations = [
+        name for name in loaded_integrations if name in user_referenced
+    ]
     # ``api_enabled`` / ``api_encrypted`` get the union of every signal
     # we have:
     #   1. Resolved YAML config — catches local ``api:`` blocks pulled
@@ -850,6 +928,7 @@ def load_device_from_storage(
         expected_config_hash=expected_config_hash,
         deployed_config_hash=deployed_config_hash,
         loaded_integrations=loaded_integrations,
+        directly_referenced_integrations=directly_referenced_integrations,
         state=state,
         has_pending_changes=has_pending,
         update_available=update_available,

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -81,6 +81,22 @@ class Device(DataClassORJSONMixin):
     # "compile succeeded but device still runs older firmware".
     deployed_config_hash: str = ""
     loaded_integrations: list[str] = field(default_factory=list)  # from StorageJSON after compile
+    # Subset of ``loaded_integrations`` the user directly wrote in
+    # YAML — top-level keys (``api:``, ``wifi:``, ``sensor:``) plus
+    # the platform stems from ``- platform: <name>`` references
+    # (``gpio`` under ``binary_sensor``, ``homeassistant`` /
+    # ``sntp`` under ``time``, ``esphome`` under ``ota``). Anything
+    # in ``loaded_integrations`` but NOT here is auto-loaded as a
+    # dependency (``md5`` from WPA2 password hashing, ``mdns``
+    # from ``api``, ``web_server_base`` from ``web_server``,
+    # ``voltage_sampler`` from ADC sensors, etc.). Computed from
+    # the resolved YAML at storage-load time so packages /
+    # ``!include`` contents count as direct (the user imported
+    # them; auto-loaded dependencies of those imports are still
+    # indirect). Empty list when the YAML couldn't be resolved
+    # (mid-edit drafts) — frontend falls back to rendering the
+    # whole ``loaded_integrations`` list flat.
+    directly_referenced_integrations: list[str] = field(default_factory=list)
     state: DeviceState = DeviceState.UNKNOWN
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     update_available: bool = False  # True if compiled with older ESPHome version

--- a/tests/test_directly_referenced_integrations.py
+++ b/tests/test_directly_referenced_integrations.py
@@ -1,0 +1,202 @@
+r"""Tests for ``extract_directly_referenced_integrations``.
+
+Backs the issue #422 fix — the device-drawer's "Loaded
+Integrations" panel was rendering both user-typed and auto-loaded
+integrations together, cluttering the sidebar for any
+non-trivial config. Splitting the list needs an authoritative
+"the user wrote this" signal; this helper produces that signal
+from the resolved YAML config.
+
+The complementary "auto-loaded" set is computed downstream as
+``loaded_integrations \ directly_referenced_integrations``, so
+correctness here is what determines whether a given chip lands
+in the visible "Direct" bucket vs the collapsed "Auto-loaded"
+bucket on the frontend.
+"""
+
+from __future__ import annotations
+
+from esphome_device_builder.helpers.device_yaml import (
+    extract_directly_referenced_integrations,
+)
+
+
+def test_extracts_top_level_keys() -> None:
+    """Every top-level key the user wrote counts as direct."""
+    config = {
+        "esphome": {"name": "x"},
+        "esp32": {"board": "nodemcu-32s"},
+        "wifi": {"ssid": "x"},
+        "api": {},
+    }
+    assert extract_directly_referenced_integrations(config) == [
+        "api",
+        "esp32",
+        "esphome",
+        "wifi",
+    ]
+
+
+def test_extracts_platform_stems_from_list() -> None:
+    """``- platform: <name>`` entries under a list-shaped block.
+
+    The common case for ``binary_sensor`` / ``sensor`` / ``switch``
+    / ``time`` / ``button`` / etc.: each list item is a dict with a
+    ``platform`` key naming the integration to load. All platform
+    stems land in the direct set alongside the parent key.
+    """
+    config = {
+        "binary_sensor": [{"platform": "gpio", "name": "Pan Water"}],
+        "button": [{"platform": "restart", "name": "Restart"}],
+        "time": [
+            {"platform": "homeassistant", "id": "ha_time"},
+            {"platform": "sntp", "id": "sntp_time"},
+        ],
+    }
+    assert extract_directly_referenced_integrations(config) == [
+        "binary_sensor",
+        "button",
+        "gpio",
+        "homeassistant",
+        "restart",
+        "sntp",
+        "time",
+    ]
+
+
+def test_extracts_platform_stem_from_single_dict() -> None:
+    """``ota: platform: esphome`` (single-platform dict shape).
+
+    A handful of components — historically ``ota``, ``mqtt`` —
+    accept a single platform/transport without the wrapping list.
+    The extractor handles both shapes so the user's intent is
+    captured the same way regardless of which form their YAML
+    uses.
+    """
+    config = {"ota": {"platform": "esphome"}}
+    assert extract_directly_referenced_integrations(config) == ["esphome", "ota"]
+
+
+def test_real_world_acfloatmonitor32_yaml() -> None:
+    """End-to-end shape from a real device YAML (issue #422 example).
+
+    The user pasted a real ``acfloatmonitor32`` config; running
+    that through the extractor must produce the exact direct set
+    we documented in the issue thread, so the frontend's
+    direct/indirect split matches user expectations on this
+    canonical case. (The actual ``loaded_integrations`` from a
+    compile of this device adds the auto-loaded chain on top —
+    ``md5``, ``mdns``, ``network``, ``preferences``, ``safe_mode``,
+    ``sha256``, ``socket``, ``watchdog``, etc. — which the
+    frontend buckets as indirect.)
+    """
+    config = {
+        "esp32_ble_tracker": {"scan_parameters": {"active": False}},
+        "bluetooth_proxy": {"active": True},
+        "substitutions": {"devicename": "acfloatmonitor32"},
+        "esphome": {"name": "$devicename"},
+        "esp32": {"board": "esp32-poe-iso"},
+        "ethernet": {"type": "LAN8720"},
+        "logger": {"level": "DEBUG"},
+        "api": {"id": "api_server", "encryption": {"key": "..."}},
+        "ota": {"platform": "esphome"},
+        "binary_sensor": [{"platform": "gpio", "name": "Pan Water"}],
+        "button": [{"platform": "restart", "name": "Restart"}],
+        "time": [
+            {"platform": "homeassistant", "id": "homeassistant_time"},
+            {"platform": "sntp", "id": "sntp_time"},
+        ],
+    }
+    # ``esphome`` appears as both a top-level key AND as
+    # ``ota.platform``, but the extractor dedupes via a set before
+    # sorting — landing once in the result.
+    assert extract_directly_referenced_integrations(config) == [
+        "api",
+        "binary_sensor",
+        "bluetooth_proxy",
+        "button",
+        "esp32",
+        "esp32_ble_tracker",
+        "esphome",
+        "ethernet",
+        "gpio",
+        "homeassistant",
+        "logger",
+        "ota",
+        "restart",
+        "sntp",
+        "substitutions",
+        "time",
+    ]
+
+
+def test_returns_empty_list_for_none_config() -> None:
+    """Resolved-config parse failure → empty list (graceful degrade).
+
+    When the YAML can't be parsed (mid-edit drafts, missing
+    secrets, malformed YAML), ``load_device_yaml`` returns
+    ``None``. The frontend reads an empty
+    ``directly_referenced_integrations`` as "I don't know what's
+    direct" and falls back to rendering the flat
+    ``loaded_integrations`` list, instead of false-bucketing
+    everything as indirect.
+    """
+    assert extract_directly_referenced_integrations(None) == []
+
+
+def test_returns_empty_list_for_non_dict_config() -> None:
+    """Defensive — a malformed loader handing in a list / scalar."""
+    assert extract_directly_referenced_integrations([1, 2, 3]) == []  # type: ignore[arg-type]
+    assert extract_directly_referenced_integrations("not a config") == []  # type: ignore[arg-type]
+
+
+def test_skips_non_string_keys_and_platforms() -> None:
+    """
+    Skip non-string keys and non-string platform values.
+
+    Defensive against weird parses: non-string keys are skipped (a
+    YAML mapping with int keys is technically valid but doesn't
+    map to any ESPHome integration), and ``platform: <lambda>``
+    or other non-string values don't bleed garbage names into the
+    direct set.
+    """
+    config: dict = {
+        "sensor": [
+            {"platform": "valid_platform"},
+            {"platform": 42},  # not a string — skip
+            {"platform": ""},  # empty — skip
+            {"platform": None},  # none — skip
+        ],
+        # Single-platform dict with non-string platform — skip
+        "weird": {"platform": ["templated"]},
+    }
+    assert extract_directly_referenced_integrations(config) == [
+        "sensor",
+        "valid_platform",
+        "weird",
+    ]
+
+
+def test_top_level_block_with_no_platform_field() -> None:
+    """
+    Top-level dicts without a ``platform`` key add only the parent.
+
+    No synthesised platform stem when the value isn't a list of
+    platforms or a single-platform dict.
+    """
+    config = {
+        "wifi": {"ssid": "x", "password": "y"},
+        "logger": {"level": "DEBUG"},
+    }
+    assert extract_directly_referenced_integrations(config) == ["logger", "wifi"]
+
+
+def test_empty_value_blocks_still_count() -> None:
+    """``api:`` with no body is still a direct reference.
+
+    Bare ``api:`` is the canonical opt-in to the Native API even
+    without an inner ``encryption:`` / ``id:``. The empty-value
+    case must not get filtered out.
+    """
+    config = {"api": None, "logger": None}
+    assert extract_directly_referenced_integrations(config) == ["api", "logger"]


### PR DESCRIPTION
# What does this implement/fix?

Backend half of issue #422. The device-drawer's "Loaded
Integrations" panel renders `StorageJSON.loaded_integrations` as
a flat list — every component upstream ESPHome resolved during
the compile, mixing user-typed top-level blocks (`api`, `wifi`,
`sensor`) with auto-loaded transitive dependencies (`md5` from
WPA2 password hashing, `mdns` from `api`, `web_server_base` from
`web_server`, `voltage_sampler` from ADC sensors). Large configs
accumulate enough auto-loads that the panel becomes visually
noisy and the user-meaningful entries get lost in it.

Adds a `directly_referenced_integrations` field on `Device`
populated from the resolved YAML at storage-load time:

- **Top-level keys** (`esphome:`, `esp32:`, `api:`, `wifi:`,
  `sensor:`, …) — anything the user wrote as a top-level block,
  including blocks pulled in via `!include` or packages (the
  user chose those imports, so their contents are direct).
- **Platform stems from `- platform: <name>` references** under
  list-shaped sections (`gpio` under `binary_sensor`,
  `homeassistant` / `sntp` under `time`, `bme280_i2c` under
  `sensor`) AND from the single-platform dict shape
  (`ota: platform: esphome`).

The complement against `loaded_integrations` is exactly the
auto-loaded dependency chain — that's what the frontend buckets
into a collapsible secondary list. Empty list when the resolved
config can't be parsed (mid-edit drafts, missing secrets) so
the frontend falls back to the existing flat-list rendering as
a graceful degrade.

`extract_directly_referenced_integrations` is exposed as a
public helper on `device_yaml.py` next to
`config_has_top_level_block`, with 9 unit tests pinning every
shape: top-level only, list-of-platforms, single-platform dict,
the issue reporter's real `acfloatmonitor32` YAML,
`None` / non-dict graceful degrade, non-string key / platform
filter, empty-value top-level blocks, and the dedupe path where
a name appears as both a top-level key and a platform stem
(`ota: platform: esphome` + `esphome:`).

**Related issue or feature (if applicable):**

- fixes #422 (backend half)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD>

The new `directly_referenced_integrations` field is consumed by
the device-drawer's "Loaded Integrations" panel — the frontend
PR splits the existing flat list into a primary "Direct" group
(intersection with this field) and a collapsible "Auto-loaded
dependencies" group (the remainder of `loaded_integrations`).
Frontend PR will land on the device-builder-frontend repo.

Until the frontend PR lands, the new field is an additive no-op
on the wire — older frontends ignore unknown fields, and the
existing `loaded_integrations` rendering continues to work
unchanged.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
