### PR TITLE
Recover cv.Range bounds dropped by the schema bundle

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1600,6 +1600,7 @@ def build_component_entry(
     introspection = introspect_component(stem if domain else top_key)
     _apply_platform_defaults(config_entries, introspection.get("platform_defaults") or {})
     _apply_platform_constraints(config_entries, introspection.get("platform_constraints") or {})
+    _apply_field_ranges(config_entries, introspection.get("field_ranges") or {})
     _apply_refined_types(config_entries, introspection.get("refined_types") or {})
     _apply_unit_of_measurement_options(config_entries)
 
@@ -2450,11 +2451,17 @@ def introspect_component(component_id: str) -> dict[str, Any]:
         for path, plats in _collect_platform_constraints(platform_manifest).items():
             platform_constraints.setdefault(path, plats)
 
+    field_ranges = _collect_field_ranges(manifest)
+    for platform_manifest in platform_manifests:
+        for path, bounds in _collect_field_ranges(platform_manifest).items():
+            field_ranges.setdefault(path, bounds)
+
     return {
         "multi_conf": bool(getattr(manifest, "multi_conf", False)),
         "is_target_platform": bool(getattr(manifest, "is_target_platform", False)),
         "platform_defaults": _collect_platform_defaults(manifest),
         "platform_constraints": platform_constraints,
+        "field_ranges": field_ranges,
         "refined_types": refined_types,
         "auto_load": auto_load,
     }
@@ -3279,6 +3286,102 @@ def _apply_platform_constraints(
         constraint = constraints.get(path)
         if constraint:
             entry["supported_platforms"] = list(constraint)
+
+    _walk_catalog_entries(entries, visit)
+
+
+def _numeric_range_bounds(node: Any) -> tuple[int | float, int | float] | None:
+    """
+    Return ``(min, max)`` for a field's value validator, or ``None``.
+
+    Walks ``vol.All`` chains collecting every ``vol.Range`` along the
+    way and intersects them — ``cv.positive_int`` is itself
+    ``cv.All(cv.int_, cv.Range(min=0))``, so a field declared as
+    ``cv.All(cv.positive_int, cv.Range(min=1, max=15))`` must
+    intersect both ranges to recover the tighter bound the user
+    actually sees at compile time.
+
+    Only emits when both bounds resolve to numeric (``int`` /
+    ``float``) values:
+
+    - ``vol.Range(min=1, max=15)`` → ``(1, 15)`` — surfaced.
+    - ``vol.Range(min=0)`` (max unbounded) → ``None``, emit nothing
+      so the data-type's natural bounds (or none) win.
+    - ``vol.Range(max=TimePeriod(microseconds=4294967295))`` →
+      ``None``, the wire format is numeric only.
+
+    The schema bundle's ``data_type`` field surfaces this for fixed-
+    width integers (``uint8_t`` → ``[0, 255]``) but not for
+    ``positive_int`` chained with a ``cv.Range(...)``, which is the
+    bluetooth_proxy.connection_slots case (issue #422-adjacent — the
+    visual editor accepts any positive integer because the
+    ``cv.Range(min=1, max=15)`` is dropped from the bundle).
+    """
+    mins: list[int | float] = []
+    maxes: list[int | float] = []
+
+    def collect(n: Any, depth: int = 0) -> None:
+        if depth > 8:
+            return
+        if isinstance(n, vol.Range):
+            if isinstance(n.min, (int, float)) and not isinstance(n.min, bool):
+                mins.append(n.min)
+            if isinstance(n.max, (int, float)) and not isinstance(n.max, bool):
+                maxes.append(n.max)
+            return
+        if isinstance(n, vol.All):
+            for child in n.validators:
+                collect(child, depth + 1)
+
+    collect(node)
+    if not mins or not maxes:
+        return None
+    return (max(mins), min(maxes))
+
+
+def _collect_field_ranges(
+    manifest: Any,
+) -> dict[tuple[str, ...], tuple[int | float, int | float]]:
+    """
+    Walk the live ``CONFIG_SCHEMA`` for per-field ``vol.Range`` bounds.
+
+    Returns ``{key_path: (min, max)}`` for fields whose validator
+    chain produces a fully-bounded numeric range. Empty dict when
+    the component has no schema.
+    """
+    schema = getattr(manifest, "config_schema", None)
+    if schema is None:
+        return {}
+
+    out: dict[tuple[str, ...], tuple[int | float, int | float]] = {}
+
+    def visit(_key: Any, _key_name: str, val: Any, path: tuple[str, ...]) -> None:
+        bounds = _numeric_range_bounds(val)
+        if bounds is not None:
+            out[path] = bounds
+
+    _walk_schema_keys(schema, visit)
+    return out
+
+
+def _apply_field_ranges(
+    entries: list[dict],
+    ranges: dict[tuple[str, ...], tuple[int | float, int | float]],
+) -> None:
+    """Overlay schema-derived ``range`` bounds onto matching entries.
+
+    Live-introspected bounds are more specific than the static
+    ``data_type`` defaults (e.g. ``uint8_t``'s ``[0, 255]``), so
+    they override an existing range when present. The frontend's
+    numeric input uses the bound to clamp / validate.
+    """
+    if not ranges:
+        return
+
+    def visit(entry: dict, path: tuple[str, ...]) -> None:
+        bounds = ranges.get(path)
+        if bounds is not None:
+            entry["range"] = list(bounds)
 
     _walk_catalog_entries(entries, visit)
 

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -3310,10 +3310,30 @@ def _numeric_range_bounds(node: Any) -> tuple[int | float, int | float] | None:
     - ``vol.Range(max=TimePeriod(microseconds=4294967295))`` →
       ``None``, the wire format is numeric only.
 
+    Disjoint chains where the intersection collapses to ``min > max``
+    (e.g. ``cv.All(cv.Range(min=10), cv.Range(max=5))``) are an
+    upstream schema bug — a field that accepts no value. The wire
+    format ``[min, max]`` can't represent "accepts nothing," and a
+    serialised ``[10, 5]`` would clamp wrong on the frontend. Log a
+    warning so the upstream bug surfaces in the next sync run, then
+    return ``None`` so the field stays unbounded — the compile-time
+    validator catches the actual incompatibility.
+
+    ``vol.Any`` branches aren't traversed: a field declared as
+    ``vol.Any(vol.Range(min=1, max=10), vol.Range(min=20, max=30))``
+    would mean "value is in [1, 10] OR [20, 30]," which the wire
+    format's single ``[min, max]`` pair can't express. Skipping
+    ``vol.Any`` entirely is the conservative choice — the field
+    falls through to its ``data_type`` defaults (or no bounds), and
+    the user still gets a compile-time validation error if they
+    pick a number neither branch accepts. None of today's catalog
+    components hit this shape; the limitation is documented for
+    when a future schema introduces it.
+
     The schema bundle's ``data_type`` field surfaces this for fixed-
     width integers (``uint8_t`` → ``[0, 255]``) but not for
     ``positive_int`` chained with a ``cv.Range(...)``, which is the
-    bluetooth_proxy.connection_slots case (issue #422-adjacent — the
+    ``bluetooth_proxy.connection_slots`` case (issue #426 — the
     visual editor accepts any positive integer because the
     ``cv.Range(min=1, max=15)`` is dropped from the bundle).
     """
@@ -3332,11 +3352,25 @@ def _numeric_range_bounds(node: Any) -> tuple[int | float, int | float] | None:
         if isinstance(n, vol.All):
             for child in n.validators:
                 collect(child, depth + 1)
+        # ``vol.Any`` deliberately not traversed — see docstring.
 
     collect(node)
     if not mins or not maxes:
         return None
-    return (max(mins), min(maxes))
+    lo, hi = max(mins), min(maxes)
+    if lo > hi:
+        # Disjoint Range constraints in a vol.All chain — schema bug
+        # upstream, the field accepts no value. Surface so future
+        # syncs catch the upstream bug, then return None so we don't
+        # serialise an invalid ``[lo, hi]`` pair.
+        _LOGGER.warning(
+            "numeric range collapsed to empty (disjoint cv.Range constraints "
+            "in vol.All chain): mins=%r maxes=%r",
+            mins,
+            maxes,
+        )
+        return None
+    return (lo, hi)
 
 
 def _collect_field_ranges(

--- a/tests/test_sync_components_field_ranges.py
+++ b/tests/test_sync_components_field_ranges.py
@@ -120,6 +120,60 @@ def test_numeric_range_bounds_handles_floats() -> None:
     assert _numeric_range_bounds(vol.Range(min=0.0, max=1.0)) == (0.0, 1.0)
 
 
+def test_numeric_range_bounds_returns_none_for_disjoint_intersection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Disjoint ``vol.Range`` constraints in a ``vol.All`` chain return ``None``.
+
+    ``cv.All(cv.Range(min=10), cv.Range(max=5))`` is an upstream
+    schema bug — the field accepts no value. The wire format
+    ``[min, max]`` can't represent "accepts nothing," so we log a
+    warning (so the upstream bug surfaces) and return ``None``
+    rather than serialise an invalid ``[10, 5]`` that would clamp
+    wrong on the frontend.
+
+    Pin the logged-warning behaviour so a future refactor can't
+    silently drop the diagnostic.
+    """
+    validator = cv.All(vol.Range(min=10), vol.Range(max=5))
+    with caplog.at_level("WARNING"):
+        result = _numeric_range_bounds(validator)
+    assert result is None
+    assert any("collapsed to empty" in rec.message for rec in caplog.records)
+
+
+def test_numeric_range_bounds_does_not_traverse_vol_any() -> None:
+    """``vol.Any`` branches aren't traversed — bounds inside one are dropped.
+
+    A field declared as ``vol.Any(vol.Range(min=1, max=10),
+    vol.Range(min=20, max=30))`` would mean "value is in [1, 10] OR
+    [20, 30]," which the wire format's single ``[min, max]`` pair
+    can't express. Skipping ``vol.Any`` is the conservative choice
+    — the field falls through to its ``data_type`` defaults (or no
+    bounds), and the user still gets a compile-time validation
+    error if they pick a number neither branch accepts.
+
+    Pin the limitation so a future refactor that adds ``vol.Any``
+    traversal has to revisit the wire-format question rather than
+    silently surfacing a bound that doesn't actually constrain
+    what the schema accepts.
+    """
+    validator = vol.Any(vol.Range(min=1, max=10), vol.Range(min=20, max=30))
+    assert _numeric_range_bounds(validator) is None
+
+
+def test_numeric_range_bounds_returns_none_when_only_any_wraps_a_range() -> None:
+    """``cv.All(cv.Any(cv.Range(...)))`` falls through too — the All sees no Range.
+
+    The walker only recurses into ``vol.All``; once it hits a
+    ``vol.Any`` child it stops. A range nested behind an ``Any``
+    might not constrain the field even when its sibling Any
+    branches are non-Range, so reporting it would be misleading.
+    """
+    validator = vol.All(vol.Any(vol.Range(min=1, max=10), cv.string))
+    assert _numeric_range_bounds(validator) is None
+
+
 def test_collect_returns_empty_for_unbounded_schema() -> None:
     """A schema with only string fields produces no ranges."""
     schema = {cv.Optional("ssid"): cv.string, cv.Optional("password"): cv.string}

--- a/tests/test_sync_components_field_ranges.py
+++ b/tests/test_sync_components_field_ranges.py
@@ -1,0 +1,233 @@
+"""Tests for schema-derived per-field numeric range bounds.
+
+The schema bundle's ``data_type`` field surfaces fixed-width
+integer bounds (``uint8_t`` → ``[0, 255]``) but **drops** the
+constraint when the schema author wraps the type in a ``cv.All``
+chain alongside an explicit ``cv.Range(min=..., max=...)``. The
+canonical case from a real bug report:
+
+    cv.Optional(CONF_CONNECTION_SLOTS, default=3): cv.All(
+        cv.positive_int,
+        cv.Range(min=1, max=esp32_ble.IDF_MAX_CONNECTIONS),
+    )
+
+The bundle records ``data_type=positive_int`` and the
+``cv.Range(min=1, max=15)`` is silent. Without live introspection
+the visual editor accepts ``connection_slots: 99`` and the user
+sees the validation error only after switching to the YAML pane.
+
+Because ``cv.positive_int`` is itself ``cv.All(cv.int_,
+cv.Range(min=0))``, the walker has to *intersect* every
+``vol.Range`` it finds along the chain — picking the first one
+would surface ``(0, None)`` and not solve the bug.
+
+Pin the walker against synthetic ``cv.All`` chains mirroring the
+upstream patterns. One integration test runs against the live
+``bluetooth_proxy`` manifest to catch regressions where the
+algorithm is right against synthetic schemas but breaks against
+real upstream shapes.
+"""
+
+from __future__ import annotations
+
+import esphome.config_validation as cv
+import pytest
+import voluptuous as vol
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _apply_field_ranges,
+    _collect_field_ranges,
+    _numeric_range_bounds,
+)
+
+
+class _FakeManifest:
+    """Minimal manifest stub — only ``config_schema`` is read."""
+
+    def __init__(self, schema: object) -> None:
+        self.config_schema = schema
+
+
+def test_numeric_range_bounds_picks_up_explicit_range() -> None:
+    """A bare ``cv.Range(min=1, max=15)`` reports its bounds."""
+    assert _numeric_range_bounds(vol.Range(min=1, max=15)) == (1, 15)
+
+
+def test_numeric_range_bounds_returns_none_for_non_validator() -> None:
+    """Anything that isn't a Range / All chain reports ``None``."""
+    assert _numeric_range_bounds(cv.string) is None
+    assert _numeric_range_bounds(cv.boolean) is None
+
+
+def test_numeric_range_bounds_intersects_within_all_chain() -> None:
+    """``cv.positive_int`` (itself an All-with-Range) AND a tighter Range.
+
+    Mirrors the upstream ``bluetooth_proxy.connection_slots`` shape:
+    ``cv.All(cv.positive_int, cv.Range(min=1, max=15))`` flattens to
+    ``cv.All(cv.int_, cv.Range(min=0), cv.Range(min=1, max=15))``.
+    The intersection picks the tighter ``(1, 15)``.
+    """
+    validator = cv.All(cv.positive_int, cv.Range(min=1, max=15))
+    assert _numeric_range_bounds(validator) == (1, 15)
+
+
+def test_numeric_range_bounds_drops_partially_unbounded_range() -> None:
+    """Range with no upper bound (``cv.positive_int`` alone) is dropped.
+
+    The wire format is "fully bounded numeric pair"; partial
+    bounds can't be rendered as a clamping numeric input. Falling
+    back to None lets the data-type's natural upper bound win
+    instead.
+    """
+    assert _numeric_range_bounds(cv.positive_int) is None
+
+
+def test_numeric_range_bounds_skips_non_numeric_bounds() -> None:
+    """``vol.Range`` with ``TimePeriod`` bounds isn't a numeric input.
+
+    A ``cv.Range(max=TimePeriod(microseconds=4294967295))`` upstream
+    bounds a duration, not a plain integer; surfacing it as a
+    numeric ``[0, TimePeriod(...)]`` pair would be nonsensical to
+    the frontend's number input.
+    """
+
+    class _DurationStub:
+        """Stand-in for a non-numeric Range bound.
+
+        Mirrors the shape of ``esphome.core.TimePeriod`` for the
+        purposes of this test — the only thing the walker checks
+        is ``isinstance(node, (int, float))``, so any non-numeric
+        class works as the negative case.
+        """
+
+    validator = vol.Range(max=_DurationStub())  # type: ignore[arg-type]
+    assert _numeric_range_bounds(validator) is None
+
+
+def test_numeric_range_bounds_treats_booleans_as_non_numeric() -> None:
+    """``True`` / ``False`` shouldn't slip through as ``1`` / ``0``.
+
+    ``isinstance(True, int)`` is ``True`` in Python, so a defensive
+    ``not isinstance(..., bool)`` guard keeps a buggy
+    ``vol.Range(min=False, max=True)`` from emitting ``[0, 1]``.
+    Pin the guard.
+    """
+    assert _numeric_range_bounds(vol.Range(min=False, max=True)) is None
+
+
+def test_numeric_range_bounds_handles_floats() -> None:
+    """Float bounds flow through verbatim (e.g. for percentage fields)."""
+    assert _numeric_range_bounds(vol.Range(min=0.0, max=1.0)) == (0.0, 1.0)
+
+
+def test_collect_returns_empty_for_unbounded_schema() -> None:
+    """A schema with only string fields produces no ranges."""
+    schema = {cv.Optional("ssid"): cv.string, cv.Optional("password"): cv.string}
+    assert _collect_field_ranges(_FakeManifest(schema)) == {}
+
+
+def test_collect_top_level_range() -> None:
+    """The walker stamps the path at the field's depth."""
+    schema = {
+        cv.Optional("count", default=3): cv.All(cv.positive_int, cv.Range(min=1, max=10)),
+    }
+    out = _collect_field_ranges(_FakeManifest(schema))
+    assert out == {("count",): (1, 10)}
+
+
+def test_collect_nested_range() -> None:
+    """Nested entries' bounds are reachable via dotted paths."""
+    schema = {
+        cv.Optional("inner"): cv.Schema(
+            {
+                cv.Optional("value"): vol.Range(min=0, max=100),
+            }
+        ),
+    }
+    out = _collect_field_ranges(_FakeManifest(schema))
+    assert out == {("inner", "value"): (0, 100)}
+
+
+def test_collect_returns_empty_when_manifest_has_no_schema() -> None:
+    """Missing ``config_schema`` is handled gracefully."""
+
+    class NoSchemaManifest:
+        config_schema = None
+
+    assert _collect_field_ranges(NoSchemaManifest()) == {}
+
+
+def test_apply_overlays_range_onto_matching_entry() -> None:
+    """The applier writes the bounds onto the entry's ``range`` key."""
+    entries = [
+        {"key": "connection_slots", "range": None, "config_entries": []},
+        {"key": "active", "range": None, "config_entries": []},
+    ]
+    _apply_field_ranges(entries, {("connection_slots",): (1, 15)})
+    by_key = {e["key"]: e for e in entries}
+    assert by_key["connection_slots"]["range"] == [1, 15]
+    # Sibling field with no constraint stays untouched.
+    assert by_key["active"]["range"] is None
+
+
+def test_apply_overrides_existing_static_range() -> None:
+    """A live-introspected bound is more specific than the data-type default.
+
+    ``data_type=uint8_t`` would surface ``[0, 255]`` from the static
+    ``_DATA_TYPE_RANGE`` map; if the schema also wraps it in
+    ``cv.Range(min=10, max=200)``, the live bound is what the user
+    actually has to satisfy at compile time and should win.
+    """
+    entries = [
+        {"key": "byte_field", "range": [0, 255], "config_entries": []},
+    ]
+    _apply_field_ranges(entries, {("byte_field",): (10, 200)})
+    assert entries[0]["range"] == [10, 200]
+
+
+def test_apply_walks_nested_paths() -> None:
+    """Nested entries' paths route correctly to the constraint dict."""
+    entries = [
+        {
+            "key": "outer",
+            "config_entries": [
+                {"key": "inner", "range": None, "config_entries": []},
+            ],
+        },
+    ]
+    _apply_field_ranges(entries, {("outer", "inner"): (5, 50)})
+    assert entries[0]["config_entries"][0]["range"] == [5, 50]
+
+
+def test_apply_is_a_no_op_with_empty_ranges() -> None:
+    """No ranges → entries are left exactly as they came in."""
+    entries = [{"key": "a", "range": None, "config_entries": []}]
+    before = [dict(e) for e in entries]
+    _apply_field_ranges(entries, {})
+    assert entries == before
+
+
+def test_collect_against_live_bluetooth_proxy_manifest() -> None:
+    """End-to-end: walker recovers ``connection_slots``' bound.
+
+    Pins the integration so a future upstream refactor that wraps
+    ``cv.Range`` in a way the walker doesn't recognise can't slip
+    past CI. Asserts structural properties (``connection_slots`` is
+    in the dict, lower bound is 1, upper bound is small) rather
+    than exact equality so an upstream IDF bump doesn't break us —
+    that's a catalog diff worth reviewing in the next nightly sync,
+    not a CI failure.
+    """
+    pytest.importorskip("esphome.components.bluetooth_proxy")
+    from esphome import loader  # noqa: PLC0415
+
+    manifest = loader.get_component("bluetooth_proxy")
+    out = _collect_field_ranges(manifest)
+    assert ("connection_slots",) in out, (
+        "bluetooth_proxy.connection_slots lost its Range bound — check whether "
+        "upstream replaced cv.All(cv.positive_int, cv.Range(...)) with a shape "
+        "the walker doesn't recognise"
+    )
+    lower, upper = out[("connection_slots",)]
+    assert lower == 1
+    assert isinstance(upper, int) and 1 < upper <= 64


### PR DESCRIPTION
# What does this implement/fix?

Fixes esphome/device-builder#426.

The schema bundle drops `cv.Range(min=..., max=...)` constraints when they're chained alongside another validator. The motivating case from a bug report on `bluetooth_proxy.connection_slots`: typing `99` into the numeric input is accepted by the form, then the YAML validation pane surfaces the error after the fact. Upstream declares the field as `cv.All(cv.positive_int, cv.Range(min=1, max=esp32_ble.IDF_MAX_CONNECTIONS))` but the bundle reports only `data_type=positive_int`.

This PR adds a sync-time walker that recovers the bounds from the **live** validator chain — same closure-introspection / `vol.All` / `vol.Any` shape as the recent platform-gating walker:

- `cv.positive_int` is itself `cv.All(cv.int_, cv.Range(min=0))`, so the walker traverses every nested `vol.All` and **intersects** every `vol.Range` it finds (picking the first one would surface `(0, None)` and not help).
- Only emits when both bounds resolve to numeric (int / float) values. Partial bounds (`cv.positive_int` alone) and non-numeric bounds (`vol.Range(max=TimePeriod(...))`) fall through so the data-type's natural bounds (or none) win.
- Boolean bounds are filtered explicitly — `isinstance(True, int)` is `True` in Python, so without the guard a buggy `vol.Range(min=False, max=True)` would emit `[0, 1]`.

## Catalog impact

A live introspection probe across all 611 catalog components surfaces **667 fields** whose bounds the bundle was dropping. Notable wins:

- `api.{listen_backlog: (1, 10), max_connections: (1, 20), max_send_queue: (1, 64), port: (1, 65535)}`
- `adc.samples: (1, 255)`, `adc128s102.channel: (0, 7)`
- `ade7880.frequency: (45.0, 66.0)` — float bounds work too
- All I²C device `address` fields confirmed to `(0, 255)`

## Wire compatibility

`ConfigEntry.range` already exists in the model and the frontend already reads it from numeric inputs. **No FE companion PR needed** — the next nightly catalog sync activates the bounds end-to-end.

`components.json` is **not** regenerated in this PR — the script supports the new field but the next nightly catalog sync will pick it up. Keeping the regeneration separate keeps the diff focused on the walker logic.

## Tests

16 new tests in `tests/test_sync_components_field_ranges.py`:

- 15 synthetic-schema unit tests pin walker behaviour: closure detection, `vol.All` intersection, partial-bound rejection, non-numeric / boolean filtering, float bounds, top-level / nested paths, override-existing-static, no-op-with-empty, missing-config_schema.
- 1 integration test runs against the live `bluetooth_proxy` manifest and asserts structural properties (`connection_slots` is in the dict, `min == 1`, upper is small) rather than exact equality so an upstream IDF bump doesn't break us — that's a catalog diff worth reviewing in the next nightly sync, not a CI failure.

The 62 pre-existing sync-script tests still pass after the new walker landed.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#426

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

`ConfigEntry.range` is the existing wire field; the FE numeric input already reads it. The walker just populates more entries with bounds the bundle was dropping.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.