### PR TITLE
Extract long-form pin schema in sync_components (fixes #420)

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1919,6 +1919,63 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
 
 
 @cache
+def _pin_long_form_mode_flags(schema_dir: Path) -> tuple[str, ...]:
+    """Return the mode-flag keys present in the bundle's pin schema.
+
+    Cached read of ``esp32.json``'s ``pin.schema.config_vars.mode.schema``
+    so a sync run with hundreds of pin entries pays the bundle parse
+    once. Returns a tuple (immutable) so cache reuse can't leak
+    mutations the way a shared dict / list could — the actual
+    ``ConfigEntry`` dicts are built fresh on each call to
+    ``_pin_long_form_extras``.
+
+    Returns ``()`` for any unexpected bundle shape (file missing,
+    non-JSON, JSON that parses to non-dict at any level along the
+    ``esp32.pin.schema.config_vars.mode.schema.config_vars`` path).
+    The caller treats an empty return as "skip the long-form
+    extras", so pin entries fall back to the short-form picker
+    rather than crashing the sync.
+    """
+    try:
+        esp32_data = json.loads((schema_dir / "esp32.json").read_text())
+    except (FileNotFoundError, ValueError, OSError):
+        return ()
+    if not isinstance(esp32_data, dict):
+        return ()
+    node: Any = esp32_data
+    for key in ("esp32", "pin", "schema", "config_vars", "mode", "schema", "config_vars"):
+        if not isinstance(node, dict):
+            return ()
+        node = node.get(key)
+    if not isinstance(node, dict):
+        return ()
+    common_modes = ("input", "output", "pullup", "pulldown", "open_drain")
+    return tuple(flag for flag in common_modes if flag in node)
+
+
+@cache
+def _pin_long_form_has_inverted(schema_dir: Path) -> bool:
+    """Whether the bundle's pin schema declares an ``inverted`` field.
+
+    Cached for the same reason as ``_pin_long_form_mode_flags`` —
+    one bundle parse per sync run. Returns ``False`` on any
+    unexpected shape so the caller drops the field rather than
+    emitting one the bundle didn't claim.
+    """
+    try:
+        esp32_data = json.loads((schema_dir / "esp32.json").read_text())
+    except (FileNotFoundError, ValueError, OSError):
+        return False
+    if not isinstance(esp32_data, dict):
+        return False
+    node: Any = esp32_data
+    for key in ("esp32", "pin", "schema", "config_vars"):
+        if not isinstance(node, dict):
+            return False
+        node = node.get(key)
+    return isinstance(node, dict) and "inverted" in node
+
+
 def _pin_long_form_extras(schema_dir: Path) -> tuple[dict, ...]:
     """Return nested ConfigEntry dicts for the pin schema's long form.
 
@@ -1940,36 +1997,27 @@ def _pin_long_form_extras(schema_dir: Path) -> tuple[dict, ...]:
     field on a pin shared across components can't be resolved
     here.
 
-    Cached so a sync run with hundreds of pin entries pays the
-    bundle read once. ``schema_dir`` is the cache key; a fresh
-    ``ensure_schema`` call returns a different directory and the
-    cache invalidates naturally.
+    The bundle parse is cached one level down (in
+    ``_pin_long_form_mode_flags`` / ``_pin_long_form_has_inverted``)
+    so the file read happens once per sync. *This* function builds
+    the ``ConfigEntry`` dicts fresh on every call — downstream
+    sync passes mutate ``config_entries`` in place, so a shared
+    cache would let one component's edit leak into every other
+    pin field. The cost of rebuilding is six dicts per pin entry,
+    which is dwarfed by the rest of the sync work.
     """
-    try:
-        esp32_data = json.loads((schema_dir / "esp32.json").read_text())
-    except (FileNotFoundError, ValueError, OSError):
-        # Bundle missing the platform schema — skip the long-form
-        # extras rather than crashing the whole sync. Pin entries
-        # render as the short-form picker, same as today.
-        return ()
-    pin_block = esp32_data.get("esp32", {}).get("pin", {}) or {}
-    pin_cvs = pin_block.get("schema", {}).get("config_vars", {}) or {}
-
+    flags = _pin_long_form_mode_flags(schema_dir)
     extras: list[dict] = []
-
-    mode_subs = (pin_cvs.get("mode", {}) or {}).get("schema", {}).get("config_vars", {}) or {}
-    common_modes = ("input", "output", "pullup", "pulldown", "open_drain")
-    mode_children = [
-        _synthesise_long_form_extra(
-            key=flag,
-            type_="boolean",
-            default_value=False,
-            description=f"Set the {_key_to_label(flag).lower()} mode flag.",
-        )
-        for flag in common_modes
-        if flag in mode_subs
-    ]
-    if mode_children:
+    if flags:
+        mode_children = [
+            _synthesise_long_form_extra(
+                key=flag,
+                type_="boolean",
+                default_value=False,
+                description=f"Set the {_key_to_label(flag).lower()} mode flag.",
+            )
+            for flag in flags
+        ]
         extras.append(
             _synthesise_long_form_extra(
                 key="mode",
@@ -1983,8 +2031,7 @@ def _pin_long_form_extras(schema_dir: Path) -> tuple[dict, ...]:
                 config_entries=mode_children,
             )
         )
-
-    if "inverted" in pin_cvs:
+    if _pin_long_form_has_inverted(schema_dir):
         extras.append(
             _synthesise_long_form_extra(
                 key="inverted",
@@ -1997,7 +2044,6 @@ def _pin_long_form_extras(schema_dir: Path) -> tuple[dict, ...]:
                 ),
             )
         )
-
     return tuple(extras)
 
 

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1903,10 +1903,148 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
         # avoids accidentally exposing deeply technical groups.
         if inner and _all_inner_advanced(inner):
             entry["advanced"] = True
+    elif entry_type == "pin":
+        # Attach the long-form pin schema (mode flags + inverted) so
+        # the editor can render an "Advanced" disclosure under every
+        # pin field. Without this the visual editor only supports
+        # the short ``pin: GPIO5`` form, which blocks configurations
+        # like ``pin: { number: GPIO5, mode: { input: true, pullup:
+        # true } }`` (issue #420).
+        entry["config_entries"] = list(_pin_long_form_extras(schema_dir)) or None
     else:
         entry["config_entries"] = None
 
     return entry
+
+
+@cache
+def _pin_long_form_extras(schema_dir: Path) -> tuple[dict, ...]:
+    """Return nested ConfigEntry dicts for the pin schema's long form.
+
+    ESPHome's pin schema accepts both ``pin: GPIO5`` (the short form
+    our existing pin picker handles) and ``pin: { number: GPIO5,
+    mode: { input: true, pullup: true }, inverted: true }``. Today's
+    catalog flat-maps ``type: pin`` to a leaf entry, so the visual
+    editor can't drive the long form at all.
+
+    Read the long-form fields from ``esp32.json``'s
+    ``pin.schema.config_vars`` — ESP32's schema is the most complete
+    of the bundled platforms and includes every common field. The
+    common subset (``mode`` + ``inverted``) applies to every
+    platform that has a pin schema (esp32, esp8266, rp2040, nrf52,
+    host); platform-specific extras (``drive_strength`` on ESP32
+    only, ``analog`` mode on esp8266/rp2040/nrf52/host) are
+    intentionally excluded for first cut — the catalog entries
+    are component-keyed, not platform-keyed, so a per-platform
+    field on a pin shared across components can't be resolved
+    here.
+
+    Cached so a sync run with hundreds of pin entries pays the
+    bundle read once. ``schema_dir`` is the cache key; a fresh
+    ``ensure_schema`` call returns a different directory and the
+    cache invalidates naturally.
+    """
+    try:
+        esp32_data = json.loads((schema_dir / "esp32.json").read_text())
+    except (FileNotFoundError, ValueError, OSError):
+        # Bundle missing the platform schema — skip the long-form
+        # extras rather than crashing the whole sync. Pin entries
+        # render as the short-form picker, same as today.
+        return ()
+    pin_block = esp32_data.get("esp32", {}).get("pin", {}) or {}
+    pin_cvs = pin_block.get("schema", {}).get("config_vars", {}) or {}
+
+    extras: list[dict] = []
+
+    mode_subs = (pin_cvs.get("mode", {}) or {}).get("schema", {}).get("config_vars", {}) or {}
+    common_modes = ("input", "output", "pullup", "pulldown", "open_drain")
+    mode_children = [
+        _synthesise_long_form_extra(
+            key=flag,
+            type_="boolean",
+            default_value=False,
+            description=f"Set the {_key_to_label(flag).lower()} mode flag.",
+        )
+        for flag in common_modes
+        if flag in mode_subs
+    ]
+    if mode_children:
+        extras.append(
+            _synthesise_long_form_extra(
+                key="mode",
+                type_="nested",
+                default_value=None,
+                description=(
+                    "Pin mode flags (input / output / pullup / pulldown / "
+                    "open_drain). Combine flags as needed — e.g. input + "
+                    "pullup for a button pulled to VCC."
+                ),
+                config_entries=mode_children,
+            )
+        )
+
+    if "inverted" in pin_cvs:
+        extras.append(
+            _synthesise_long_form_extra(
+                key="inverted",
+                type_="boolean",
+                default_value=False,
+                description=(
+                    "Invert the logical level. ``true`` swaps high/low "
+                    "in software so an active-low button reads as "
+                    "active when grounded."
+                ),
+            )
+        )
+
+    return tuple(extras)
+
+
+def _synthesise_long_form_extra(
+    *,
+    key: str,
+    type_: str,
+    default_value: Any,
+    description: str,
+    config_entries: list[dict] | None = None,
+) -> dict:
+    """Build a ConfigEntry-shaped dict for a synthesised long-form pin field.
+
+    Mirrors the shape ``_convert_field`` produces but with the small
+    set of fields the long-form pin extras actually need; the rest
+    default to safe values so the consumer can treat synthesised and
+    schema-derived entries uniformly. Marked ``advanced=True`` —
+    the long-form fields are an opt-in disclosure under the pin
+    picker, never on the main form.
+    """
+    return {
+        "key": key,
+        "type": type_,
+        "label": _key_to_label(key),
+        "description": description,
+        "required": False,
+        "default_value": default_value,
+        "options": None,
+        "allow_custom_value": False,
+        "range": None,
+        "display_format": None,
+        "multi_value": False,
+        "templatable": False,
+        "depends_on": None,
+        "depends_on_value": None,
+        "depends_on_value_not": None,
+        "depends_on_component": None,
+        "references_component": None,
+        "pin_features": [],
+        "pin_mode": None,
+        "advanced": True,
+        "hidden": False,
+        "help_link": None,
+        "translation_key": None,
+        "translation_params": None,
+        "platform_type": None,
+        "config_entries": config_entries,
+    }
 
 
 def _build_map_value_template(

--- a/tests/test_sync_components_pin_long_form.py
+++ b/tests/test_sync_components_pin_long_form.py
@@ -1,0 +1,207 @@
+"""Tests for the long-form pin schema attached by ``_pin_long_form_extras``.
+
+ESPHome's pin schema accepts both ``pin: GPIO5`` (the short form
+the existing pin picker handles) and the long form
+``pin: { number: GPIO5, mode: { input: true, pullup: true },
+inverted: true }``. Without nested config_entries on every
+``type: pin`` catalog entry the visual editor can't drive the
+long form — issue #420.
+
+These tests pin:
+
+- ``_pin_long_form_extras`` extracts ``mode`` (with the standard
+  five flag children) and ``inverted`` from ``esp32.json``'s
+  pin schema.
+- ``_convert_field`` attaches the extras as nested
+  ``config_entries`` on every ``type: pin`` entry it produces.
+- The bundle-missing fallback returns ``()`` so a sync against a
+  truncated bundle doesn't crash.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _convert_field,
+    _pin_long_form_extras,
+)
+
+# Minimal esp32.json shape covering the fields ``_pin_long_form_extras``
+# reads. Mirrors the actual bundle structure — top-level ``esp32`` key,
+# ``pin.schema.config_vars``, with ``mode`` carrying its own nested
+# ``schema.config_vars`` of mode-flag booleans. Keep this in sync with
+# the bundle if upstream restructures the pin definition.
+_ESP32_PIN_BUNDLE: dict = {
+    "esp32": {
+        "pin": {
+            "schema": {
+                "config_vars": {
+                    "number": {"key": "Required"},
+                    "mode": {
+                        "default": "{}",
+                        "key": "Optional",
+                        "modes": [],
+                        "schema": {
+                            "config_vars": {
+                                "input": {"default": "False", "key": "Optional", "type": "boolean"},
+                                "output": {
+                                    "default": "False",
+                                    "key": "Optional",
+                                    "type": "boolean",
+                                },
+                                "pullup": {
+                                    "default": "False",
+                                    "key": "Optional",
+                                    "type": "boolean",
+                                },
+                                "pulldown": {
+                                    "default": "False",
+                                    "key": "Optional",
+                                    "type": "boolean",
+                                },
+                                "open_drain": {
+                                    "default": "False",
+                                    "key": "Optional",
+                                    "type": "boolean",
+                                },
+                            },
+                        },
+                        "type": "pin",
+                    },
+                    "inverted": {
+                        "default": "False",
+                        "key": "Optional",
+                        "type": "boolean",
+                    },
+                    "drive_strength": {
+                        "default": "20mA",
+                        "key": "Optional",
+                        "type": "enum",
+                    },
+                },
+            },
+            "type": "schema",
+        },
+    },
+}
+
+
+@pytest.fixture
+def schema_dir(tmp_path: Path) -> Path:
+    """``schema_dir`` containing a stub ``esp32.json`` with the pin block.
+
+    Cleared cache so each test run sees the test fixture rather than
+    a previous test's bundle. ``_pin_long_form_extras`` is
+    ``@cache``-decorated for production efficiency (the pin block
+    gets read once per sync run, attached to ~hundreds of entries),
+    so tests that vary the bundle content have to invalidate it
+    explicitly.
+    """
+    (tmp_path / "esp32.json").write_text(json.dumps(_ESP32_PIN_BUNDLE))
+    _pin_long_form_extras.cache_clear()
+    return tmp_path
+
+
+def test_pin_long_form_extras_extracts_mode_and_inverted(schema_dir: Path) -> None:
+    """``mode`` (nested + 5 flag booleans) and ``inverted`` (boolean) emitted.
+
+    Pins the canonical shape so a refactor that drops one of the
+    flag children, flips the mode wrapper to a flat structure, or
+    accidentally bubbles ``drive_strength`` (an ESP32-only extra
+    that doesn't apply to other platforms' pin schemas) surfaces
+    here.
+    """
+    extras = _pin_long_form_extras(schema_dir)
+
+    assert [e["key"] for e in extras] == ["mode", "inverted"]
+
+    mode = extras[0]
+    assert mode["type"] == "nested"
+    assert mode["advanced"] is True
+    assert [c["key"] for c in mode["config_entries"]] == [
+        "input",
+        "output",
+        "pullup",
+        "pulldown",
+        "open_drain",
+    ]
+    for child in mode["config_entries"]:
+        assert child["type"] == "boolean"
+        assert child["default_value"] is False
+        assert child["advanced"] is True
+
+    inverted = extras[1]
+    assert inverted["type"] == "boolean"
+    assert inverted["default_value"] is False
+    assert inverted["advanced"] is True
+
+
+def test_pin_long_form_extras_skips_platform_specific_drive_strength(
+    schema_dir: Path,
+) -> None:
+    """ESP32's ``drive_strength`` does not leak into the synthesised extras.
+
+    Catalog entries are component-keyed, not platform-keyed — a
+    ``binary_sensor.gpio.pin`` config var renders the same on
+    every platform. ESP32-specific fields like ``drive_strength``
+    would render but do nothing on esp8266 / rp2040 / nrf52 /
+    host configs, which is worse than not exposing them.
+    """
+    extras = _pin_long_form_extras(schema_dir)
+
+    keys = {e["key"] for e in extras}
+    assert "drive_strength" not in keys
+
+
+def test_pin_long_form_extras_returns_empty_when_bundle_missing(
+    tmp_path: Path,
+) -> None:
+    """No ``esp32.json`` in the bundle → empty tuple, not a crash.
+
+    Defensive against a truncated / corrupt bundle. The pin
+    entries fall back to the short-form picker (today's
+    behaviour); the sync run completes normally.
+    """
+    _pin_long_form_extras.cache_clear()
+    extras = _pin_long_form_extras(tmp_path)
+    assert extras == ()
+
+
+def test_convert_field_attaches_long_form_extras_to_pin_entries(
+    schema_dir: Path,
+) -> None:
+    """A ``type: pin`` config_var lands with the long-form extras nested.
+
+    End-to-end check that ``_convert_field`` actually wires
+    ``_pin_long_form_extras`` into the produced entry — without
+    this the catalog stays short-form-only and the visual editor
+    bug behind issue #420 persists.
+    """
+    raw = {"key": "Required", "modes": ["input"], "type": "pin"}
+    entry = _convert_field("pin", raw, schema_dir)
+
+    assert entry is not None
+    assert entry["type"] == "pin"
+    assert entry["config_entries"] is not None
+    assert [e["key"] for e in entry["config_entries"]] == ["mode", "inverted"]
+
+
+def test_convert_field_does_not_attach_pin_extras_to_non_pin_entries(
+    schema_dir: Path,
+) -> None:
+    """Non-pin fields keep their existing ``config_entries`` shape (None / nested).
+
+    The pin extras are scoped to ``type: pin`` only — a regression
+    that flooded every entry with the long-form pin fields would
+    break every other field's editor.
+    """
+    raw = {"key": "Required", "type": "string"}
+    entry = _convert_field("name", raw, schema_dir)
+
+    assert entry is not None
+    assert entry["type"] == "string"
+    assert entry["config_entries"] is None

--- a/tests/test_sync_components_pin_long_form.py
+++ b/tests/test_sync_components_pin_long_form.py
@@ -28,6 +28,8 @@ import pytest
 from script.sync_components import (  # type: ignore[import-not-found]
     _convert_field,
     _pin_long_form_extras,
+    _pin_long_form_has_inverted,
+    _pin_long_form_mode_flags,
 )
 
 # Minimal esp32.json shape covering the fields ``_pin_long_form_extras``
@@ -94,15 +96,16 @@ _ESP32_PIN_BUNDLE: dict = {
 def schema_dir(tmp_path: Path) -> Path:
     """``schema_dir`` containing a stub ``esp32.json`` with the pin block.
 
-    Cleared cache so each test run sees the test fixture rather than
-    a previous test's bundle. ``_pin_long_form_extras`` is
-    ``@cache``-decorated for production efficiency (the pin block
-    gets read once per sync run, attached to ~hundreds of entries),
-    so tests that vary the bundle content have to invalidate it
-    explicitly.
+    Clears the bundle-parse caches so each test sees this fixture's
+    bundle rather than a previous test's. ``_pin_long_form_mode_flags``
+    / ``_pin_long_form_has_inverted`` are ``@cache``-decorated for
+    production efficiency (the pin block gets parsed once per sync
+    run, even though hundreds of pin entries query it); tests that
+    vary the bundle content have to invalidate them explicitly.
     """
     (tmp_path / "esp32.json").write_text(json.dumps(_ESP32_PIN_BUNDLE))
-    _pin_long_form_extras.cache_clear()
+    _pin_long_form_mode_flags.cache_clear()
+    _pin_long_form_has_inverted.cache_clear()
     return tmp_path
 
 
@@ -166,9 +169,50 @@ def test_pin_long_form_extras_returns_empty_when_bundle_missing(
     entries fall back to the short-form picker (today's
     behaviour); the sync run completes normally.
     """
-    _pin_long_form_extras.cache_clear()
+    _pin_long_form_mode_flags.cache_clear()
+    _pin_long_form_has_inverted.cache_clear()
     extras = _pin_long_form_extras(tmp_path)
     assert extras == ()
+
+
+@pytest.mark.parametrize(
+    "malformed_payload",
+    [
+        # Top-level isn't a dict (a JSON-decodable value but the
+        # wrong shape).
+        "null",
+        "[]",
+        '"not-an-object"',
+        "42",
+        # Top-level dict but ``esp32`` key carries the wrong type.
+        '{"esp32": null}',
+        '{"esp32": []}',
+        # ``esp32.pin`` non-dict.
+        '{"esp32": {"pin": "string-value"}}',
+        # ``esp32.pin.schema.config_vars.mode`` non-dict — the
+        # path-walk should fail closed mid-traversal.
+        '{"esp32": {"pin": {"schema": {"config_vars": {"mode": []}}}}}',
+        # Outright invalid JSON.
+        "{not json",
+    ],
+)
+def test_pin_long_form_extras_returns_empty_for_malformed_bundle(
+    tmp_path: Path,
+    malformed_payload: str,
+) -> None:
+    """Bundle present but malformed → empty tuple, not an AttributeError.
+
+    Defensive against a partial download, a future schema-shape
+    change that breaks our path expectations, or a hand-edited
+    bundle in a developer cache. The sync should keep running and
+    fall back to short-form pin entries; an ``AttributeError`` on
+    a chained ``.get()`` call against a non-dict node would crash
+    the whole catalog regen.
+    """
+    (tmp_path / "esp32.json").write_text(malformed_payload)
+    _pin_long_form_mode_flags.cache_clear()
+    _pin_long_form_has_inverted.cache_clear()
+    assert _pin_long_form_extras(tmp_path) == ()
 
 
 def test_convert_field_attaches_long_form_extras_to_pin_entries(
@@ -205,3 +249,38 @@ def test_convert_field_does_not_attach_pin_extras_to_non_pin_entries(
     assert entry is not None
     assert entry["type"] == "string"
     assert entry["config_entries"] is None
+
+
+def test_pin_long_form_extras_returns_fresh_dicts_per_call(
+    schema_dir: Path,
+) -> None:
+    """Each call rebuilds the dicts so downstream mutation can't cross-leak.
+
+    Sync passes after ``_convert_field`` modify ``config_entries``
+    in place (description rewrites, sub-field defaults, etc.). If
+    ``_pin_long_form_extras`` returned shared dict instances, a
+    mutation on one component's pin entry would silently affect
+    every other pin entry across the whole catalog.
+
+    Mutating the first call's structures must not change the
+    second call's identity / shape.
+    """
+    first = _pin_long_form_extras(schema_dir)
+    second = _pin_long_form_extras(schema_dir)
+
+    # Top-level dicts — fresh objects.
+    assert first[0] is not second[0]
+    assert first[1] is not second[1]
+    # Nested mode-children list — fresh objects too (the leak risk
+    # is highest here; sync passes commonly walk into nested
+    # children).
+    assert first[0]["config_entries"][0] is not second[0]["config_entries"][0]
+
+    # Stress-test: mutate first call's structures, second call
+    # must come back clean.
+    first[0]["config_entries"].append({"injected": True})
+    first[0]["description"] = "MUTATED"
+
+    third = _pin_long_form_extras(schema_dir)
+    assert all("injected" not in c for c in third[0]["config_entries"])
+    assert third[0]["description"] != "MUTATED"


### PR DESCRIPTION
# What does this implement/fix?

ESPHome's pin schema accepts both shapes:

```yaml
# Short form — the only thing today's visual editor supports
pin: GPIO5

# Long form — what the user in #420 needs (pullup), and what
# every gpio-input config with debounce / pull / inversion needs
pin:
  number: GPIO5
  mode:
    input: true
    pullup: true
  inverted: true
```

The catalog flat-mapped `type: pin` to a leaf `ConfigEntryType.PIN`, which the frontend renders as a single GPIO picker. Configurations needing a pull-up resistor, an inverted level, or any other long-form field were impossible to drive from the wizard — users had to drop into raw YAML mode for every gpio sensor / output / switch / light.

Read the long-form fields from the schema bundle's `esp32.json` pin block and attach them as nested `config_entries` on every `type: pin` entry. The common subset — `mode` (an input/output/pullup/pulldown/open_drain map) + `inverted` — applies to every platform that ships a pin schema in the bundle (`esp32`, `esp8266`, `rp2040`, `nrf52`, `host`).

**Excluded from first cut:**

- Platform-specific extras (`drive_strength` on ESP32, `analog` mode on esp8266 / rp2040 / nrf52 / host). Catalog entries are component-keyed, not platform-keyed — a `binary_sensor.gpio.pin` config var renders the same on every platform, so a field that only applies to one would render but do nothing on the others. Clean per-platform resolution is a follow-up.
- `allow_other_uses` (rare advanced flag, deferred).

**Frontend coordination:** PIN entries today render as a single GPIO picker. The frontend needs to learn to render an "Advanced" disclosure under PIN entries when `config_entries` is non-empty, and to emit the long-form YAML when any nested field is set. Companion PR coming.

Backend can ship without the frontend support — the catalog gains the data; the editor still renders the short form until the frontend lands. No regression for existing manifests / flows.

**Related issue or feature (if applicable):**

- fixes #420

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#<TBD — coming next>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
