### PR TITLE
Preserve acronyms in catalog labels (fixes #401)

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2263,9 +2263,145 @@ def _detect_platform_type(inner_schema: dict) -> str | None:
     return None
 
 
+# Tokens that should render upper-case in labels rather than the
+# Title-case ``str.title()`` produces. Limit this list to widely-
+# recognised technical acronyms and signal names — anything more
+# component-specific belongs in a per-component override (issue #401).
+_LABEL_ACRONYMS = frozenset(
+    {
+        # Bus / peripheral / pin signals
+        "ADC",
+        "BCLK",
+        "CS",
+        "DAC",
+        "DIO",
+        "DMA",
+        "EN",
+        "GPIO",
+        "HSYNC",
+        "I2C",
+        "INT",
+        "IO",
+        "IRQ",
+        "JTAG",
+        "LNA",
+        "LRCLK",
+        "MCLK",
+        "MISO",
+        "MOSI",
+        "PA",
+        "PCLK",
+        "PCNT",
+        "PWM",
+        "RMT",
+        "RST",
+        "RX",
+        "SCK",
+        "SCL",
+        "SCLK",
+        "SDA",
+        "SDO",
+        "SPI",
+        "TX",
+        "UART",
+        "USB",
+        "VSYNC",
+        # Networking
+        "AP",
+        "API",
+        "BSSID",
+        "DHCP",
+        "DNS",
+        "HTTP",
+        "HTTPS",
+        "IP",
+        "MAC",
+        "MQTT",
+        "NTP",
+        "OTA",
+        "QOS",
+        "SSID",
+        "SSL",
+        "TCP",
+        "TLS",
+        "UDP",
+        "URI",
+        "URL",
+        # Wireless / RF
+        "BLE",
+        "FSK",
+        "MSK",
+        "NFC",
+        "OOK",
+        "RF",
+        "RFID",
+        # Display / colour
+        "BGR",
+        "LCD",
+        "LED",
+        "OLED",
+        "RGB",
+        "RGBW",
+        "TFT",
+        "WRGB",
+        # Identifier / common
+        "CRC",
+        "CPU",
+        "ID",
+        "PID",
+        "PSRAM",
+        "RAM",
+        "UID",
+        "UUID",
+        "VID",
+        # Power / electrical
+        "AC",
+        "DC",
+        "GFCI",
+        "MPPT",
+        "PV",
+        "RMS",
+        # Sensors / air-quality
+        "CO",
+        "CO2",
+        "IR",
+        "NOX",
+        "PM",
+        "TVOC",
+        "UV",
+        "VOC",
+        # OpenTherm domain (used heavily in the climate catalog)
+        "CH",
+        "DHW",
+    }
+)
+
+# Match an alpha prefix followed by a digit cluster (``Dio0``,
+# ``Co2``) so we can upper-case acronym + digit tokens together.
+_TRAILING_DIGITS_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
+
+
 def _key_to_label(key: str) -> str:
-    """Turn a config-var key into a human-friendly label."""
-    return key.replace("_", " ").title()
+    """
+    Turn a config-var key into a human-friendly label for the visual editor.
+
+    Title-cases the key after replacing underscores with spaces, then
+    upper-cases any token (or alpha prefix of an alpha+digit token)
+    that matches a known technical acronym — so ``cs_pin`` renders
+    as ``CS Pin`` and ``dio0_pin`` as ``DIO0 Pin``.
+    """
+    titled = key.replace("_", " ").title()
+    tokens: list[str] = []
+    for tok in titled.split(" "):
+        if tok.upper() in _LABEL_ACRONYMS:
+            tokens.append(tok.upper())
+            continue
+        match = _TRAILING_DIGITS_RE.match(tok)
+        if match and match.group(1).upper() in _LABEL_ACRONYMS:
+            tokens.append(match.group(1).upper() + match.group(2))
+            continue
+        tokens.append(tok)
+    return " ".join(tokens)
 
 
 def _classify_advanced(key: str, *, required: bool, is_structural: bool) -> bool:

--- a/tests/test_sync_components_key_to_label.py
+++ b/tests/test_sync_components_key_to_label.py
@@ -1,0 +1,56 @@
+"""Tests for ``_key_to_label`` acronym handling in ``script/sync_components.py``.
+
+Plain ``str.title()`` Title-cases acronyms (``Cs Pin``, ``Ble Id``,
+``Mac Address``), which renders badly in the visual editor — issue
+#401. Pin the acronym + trailing-digit handling here so a regression
+to the old behaviour shows up as a failing test rather than as a
+diff in every form label after a re-sync.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from script.sync_components import _key_to_label  # type: ignore[import-not-found]
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        # Bare acronyms render upper-case.
+        ("id", "ID"),
+        ("ssid", "SSID"),
+        ("mqtt", "MQTT"),
+        ("uuid", "UUID"),
+        # Acronym + descriptive token.
+        ("cs_pin", "CS Pin"),
+        ("rst_pin", "RST Pin"),
+        ("pa_pin", "PA Pin"),
+        ("led_pin", "LED Pin"),
+        ("mosi_pin", "MOSI Pin"),
+        ("vsync_pin", "VSYNC Pin"),
+        ("rgb_order", "RGB Order"),
+        ("mac_address", "MAC Address"),
+        # Acronym + acronym (the ``..._id`` shape the issue calls out).
+        ("ble_id", "BLE ID"),
+        ("i2c_id", "I2C ID"),
+        ("spi_id", "SPI ID"),
+        ("uart_id", "UART ID"),
+        # Trailing-digit acronyms — alpha prefix is upper-cased,
+        # digits stay attached.
+        ("dio0_pin", "DIO0 Pin"),
+        ("co2_value", "CO2 Value"),
+        # Non-acronym tokens keep Title-case (regression guard against
+        # the acronym set leaking into ordinary words).
+        ("name", "Name"),
+        ("friendly_name", "Friendly Name"),
+        ("update_interval", "Update Interval"),
+        ("day_of_week", "Day Of Week"),
+        # Trailing digits on a non-acronym alpha prefix stay as-is —
+        # part numbers like ``bme680`` shouldn't accidentally get
+        # caught by the regex when ``BME`` isn't an acronym.
+        ("bme680_id", "Bme680 ID"),
+    ],
+)
+def test_key_to_label_handles_known_acronyms(key: str, expected: str) -> None:
+    assert _key_to_label(key) == expected


### PR DESCRIPTION
# What does this implement/fix?

Catalog labels rendered acronyms with `str.title()` — `cs_pin` →
`Cs Pin`, `ble_id` → `Ble Id`, `mac_address` → `Mac Address`,
`dio0_pin` → `Dio0 Pin`, etc. — across every form in the visual
editor.

Keep a small frozenset of known technical acronyms (bus / pin
signals, networking, RF, display, identifiers, …) and upper-case
matching tokens after the title pass. Alpha+digit tokens
(`dio0`, `co2`) are upper-cased too when the alpha prefix is a
known acronym, so part-number-style suffixes still don't render
as `Dio0`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/401

## Changes

- `script/sync_components.py`: add `_LABEL_ACRONYMS` set + trailing-
  digit regex, rewrite `_key_to_label` to upper-case acronym tokens.
- `tests/test_sync_components_key_to_label.py`: parametrised table
  covering the issue's examples plus regression guards (non-acronym
  Title-case stays unchanged, part numbers like `bme680` aren't
  caught by the digit regex when their prefix isn't an acronym).

The next nightly catalog re-sync will pick up the new labels — no
hand-edit to `components.json` here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] No frontend change needed