### PR TITLE
Add mDNS TXT records to reachability snapshot

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -614,9 +614,25 @@ class DeviceStateMonitor:
                 # the upstream ``api_encryption`` tri-state already
                 # uses for "device confirmed plaintext" — see issue
                 # #437.
+                #
+                # Build the dict with sorted keys so the wire output
+                # is order-stable across snapshots. zeroconf's
+                # ``decoded_properties`` preserves insertion order
+                # from the raw TXT bytes, which can shift when a
+                # device re-announces (or zeroconf rebuilds the
+                # cached entry) without any of the values actually
+                # changing. A naive insertion-order pass would
+                # surface those reorderings as "different"
+                # snapshots — bloating the per-device subscription
+                # stream and forcing dedupe layers to compare dicts
+                # set-wise instead of structurally. Sorting once
+                # here keeps the wire deterministic and lets
+                # downstream consumers compare with plain
+                # equality / ``JSON.stringify``.
+                decoded = info.decoded_properties
                 txt_records = {
-                    key: value if isinstance(value, str) else ""
-                    for key, value in info.decoded_properties.items()
+                    key: decoded[key] if isinstance(decoded[key], str) else ""
+                    for key in sorted(decoded)
                     if isinstance(key, str)
                 }
         return MdnsCacheInfo(

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -19,6 +19,7 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import Callable
+from functools import lru_cache
 from operator import attrgetter
 from typing import Any
 
@@ -216,10 +217,51 @@ def _http_url_from_service_info(device_name: str, info: AsyncServiceInfo) -> str
     return f"http://{host}{'' if port == 80 else f':{port}'}"
 
 
-def _decode_mdns_txt_records(
-    txt_dns_records: list[Any],
-    service_name: str,
-) -> dict[str, str]:
+@lru_cache(maxsize=256)
+def _decode_txt_bytes_to_sorted_pairs(txt_bytes: bytes) -> tuple[tuple[str, str], ...]:
+    """
+    Bytes-keyed memoised TXT decode — the reusable hot path.
+
+    The reachability snapshot fires on every observation; for a
+    50-device fleet with the drawer open that's ~50 calls/sec
+    against a ``DNSText`` cache where each device's TXT bytes
+    rarely change between firmware flashes. The decode itself
+    (``ServiceInfo.text`` setter → ``decoded_properties`` →
+    sort + filter) costs about an allocation-heavy 50µs per call;
+    keying on the immutable raw bytes turns 49 of every 50 of
+    those calls into hash-table lookups.
+
+    Returns an immutable ``tuple[tuple[str, str], ...]`` rather
+    than a dict so a downstream caller mutating the result can't
+    poison subsequent cache hits. Callers materialise a fresh
+    dict via ``dict(pairs)``.
+
+    Bytes are content-addressed: two devices broadcasting
+    byte-identical TXT payloads share a cache entry, which is
+    correct (the decoded output is the same).
+
+    ``maxsize=256`` covers fleet sizes well past the typical
+    tens-to-low-hundreds, with headroom for a device that
+    re-broadcasts a slightly different TXT payload (firmware
+    upgrade, ``config_hash`` change) without immediately
+    evicting another device's stable entry. Still bounded so a
+    long-running dashboard with rotating device names can't grow
+    the cache without limit.
+    """
+    # ``service_name`` is required by the ctor but doesn't affect
+    # ``set_text`` parsing — pass a placeholder so the cache key
+    # stays bytes-only.
+    info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"_decode.{_ESPHOME_SERVICE_TYPE}")
+    info.text = txt_bytes
+    decoded = info.decoded_properties
+    return tuple(
+        (key, decoded[key] if isinstance(decoded[key], str) else "")
+        for key in sorted(decoded)
+        if isinstance(key, str)
+    )
+
+
+def _decode_mdns_txt_records(txt_dns_records: list[Any]) -> dict[str, str]:
     """
     Decode the freshest cached ``DNSText`` record into a sorted ``key=value`` dict.
 
@@ -250,6 +292,12 @@ def _decode_mdns_txt_records(
     consumers dedupe with plain equality / ``JSON.stringify``
     instead of comparing dicts set-wise.
 
+    The actual bytes-to-dict decode is delegated to
+    ``_decode_txt_bytes_to_sorted_pairs`` so consecutive calls
+    with the same TXT bytes reuse the cached result — typical
+    for a stable fleet where each device's TXT rarely changes
+    between firmware flashes.
+
     Returns ``{}`` when no TXT records are passed or the freshest
     record's ``text`` attribute is missing / not bytes-like.
     """
@@ -259,14 +307,7 @@ def _decode_mdns_txt_records(
     txt_bytes = latest_txt.text
     if not isinstance(txt_bytes, (bytes, bytearray)):
         return {}
-    info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, service_name)
-    info.text = bytes(txt_bytes)
-    decoded = info.decoded_properties
-    return {
-        key: decoded[key] if isinstance(decoded[key], str) else ""
-        for key in sorted(decoded)
-        if isinstance(key, str)
-    }
+    return dict(_decode_txt_bytes_to_sorted_pairs(bytes(txt_bytes)))
 
 
 def device_name_from_service(service_name: str) -> str:
@@ -639,7 +680,7 @@ class DeviceStateMonitor:
         return MdnsCacheInfo(
             age_seconds=age_s,
             ttl_remaining_seconds=ttl_remaining_s,
-            txt_records=_decode_mdns_txt_records(txt_dns_records, service_name),
+            txt_records=_decode_mdns_txt_records(txt_dns_records),
         )
 
     def _apply_resolved_addresses(

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -256,7 +256,7 @@ def _decode_mdns_txt_records(
     if not txt_dns_records:
         return {}
     latest_txt = max(txt_dns_records, key=attrgetter("created"))
-    txt_bytes = getattr(latest_txt, "text", None)
+    txt_bytes = latest_txt.text
     if not isinstance(txt_bytes, (bytes, bytearray)):
         return {}
     info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, service_name)

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -216,6 +216,59 @@ def _http_url_from_service_info(device_name: str, info: AsyncServiceInfo) -> str
     return f"http://{host}{'' if port == 80 else f':{port}'}"
 
 
+def _decode_mdns_txt_records(
+    txt_dns_records: list[Any],
+    service_name: str,
+) -> dict[str, str]:
+    """
+    Decode the freshest cached ``DNSText`` record into a sorted ``key=value`` dict.
+
+    Reuses ``ServiceInfo.text`` setter so we get zeroconf's canonical
+    RFC-6763 split (length-prefixed UTF-8 entries → ``key=value``
+    pairs) and ``decoded_properties`` for the UTF-8 decode +
+    bad-bytes-to-``None`` handling. Skips ``load_from_cache`` so
+    tests can stub the cache with a ``MagicMock``: that helper's
+    strict ``DNSCache`` isinstance check would crash the test path,
+    and the only thing we need from the cache here is the
+    already-fetched TXT bytes.
+
+    Empty / bare-key handling: zeroconf collapses both bare keys
+    (``foo`` with no ``=``) and empty-value entries (``foo=`` with
+    ``=`` but no value) to the same ``None`` in
+    ``decoded_properties``. The diagnostic value is the same in
+    both cases — the user wants to see that the key IS present
+    even if the value is empty — so we surface those as ``""``
+    rather than dropping them. The empty string is the signal the
+    upstream ``api_encryption`` tri-state already uses for "device
+    confirmed plaintext" (issue #437) and the whole point of the
+    debug collapsible is to make those advertisements observable.
+
+    Order stability: zeroconf preserves the bytes-order of the
+    raw TXT entries, which can shift on a fresh announce or when
+    the cache rebuilds an entry. We sort by key so the wire
+    output is deterministic across snapshots, letting downstream
+    consumers dedupe with plain equality / ``JSON.stringify``
+    instead of comparing dicts set-wise.
+
+    Returns ``{}`` when no TXT records are passed or the freshest
+    record's ``text`` attribute is missing / not bytes-like.
+    """
+    if not txt_dns_records:
+        return {}
+    latest_txt = max(txt_dns_records, key=attrgetter("created"))
+    txt_bytes = getattr(latest_txt, "text", None)
+    if not isinstance(txt_bytes, (bytes, bytearray)):
+        return {}
+    info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, service_name)
+    info.text = bytes(txt_bytes)
+    decoded = info.decoded_properties
+    return {
+        key: decoded[key] if isinstance(decoded[key], str) else ""
+        for key in sorted(decoded)
+        if isinstance(key, str)
+    }
+
+
 def device_name_from_service(service_name: str) -> str:
     """Extract the device name from an mDNS service-instance name.
 
@@ -583,62 +636,10 @@ class DeviceStateMonitor:
         # — that would turn "108 seconds remaining" into 0.108
         # and render as "TTL: 0s".
         ttl_remaining_s = max(0.0, float(latest.get_remaining_ttl(now_ms)))
-        # Decode the TXT key/value pairs straight off the cached
-        # ``DNSText`` records for the drawer's debug collapsible.
-        # Reuses ``ServiceInfo.text`` setter so we get zeroconf's
-        # canonical RFC-6763 split (length-prefixed UTF-8 entries
-        # → ``key=value`` pairs) and ``decoded_properties`` for the
-        # UTF-8 decode + bad-bytes-to-``None`` handling. We skip
-        # ``load_from_cache`` here because production passes a
-        # real Zeroconf and tests stub the cache with a
-        # ``MagicMock`` — ``load_from_cache``'s strict
-        # ``DNSCache`` isinstance check would crash the test
-        # path, and the only thing we need from the cache is the
-        # already-fetched TXT bytes.
-        txt_records: dict[str, str] = {}
-        if txt_dns_records:
-            latest_txt = max(txt_dns_records, key=attrgetter("created"))
-            txt_bytes = getattr(latest_txt, "text", None)
-            if isinstance(txt_bytes, (bytes, bytearray)):
-                info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, service_name)
-                info.text = bytes(txt_bytes)
-                # ``decoded_properties`` is ``dict[str, str | None]``.
-                # ``None`` covers BOTH "bare key, no ``=``" and
-                # "``key=`` with an empty value" — zeroconf collapses
-                # the two — but the diagnostic value is the same:
-                # the user wants to see that the key IS present,
-                # even if the value is empty. Render those as
-                # ``""`` on the wire so they show up in the drawer
-                # as a key with an empty value rather than vanishing
-                # entirely. The empty-string is exactly the signal
-                # the upstream ``api_encryption`` tri-state already
-                # uses for "device confirmed plaintext" — see issue
-                # #437.
-                #
-                # Build the dict with sorted keys so the wire output
-                # is order-stable across snapshots. zeroconf's
-                # ``decoded_properties`` preserves insertion order
-                # from the raw TXT bytes, which can shift when a
-                # device re-announces (or zeroconf rebuilds the
-                # cached entry) without any of the values actually
-                # changing. A naive insertion-order pass would
-                # surface those reorderings as "different"
-                # snapshots — bloating the per-device subscription
-                # stream and forcing dedupe layers to compare dicts
-                # set-wise instead of structurally. Sorting once
-                # here keeps the wire deterministic and lets
-                # downstream consumers compare with plain
-                # equality / ``JSON.stringify``.
-                decoded = info.decoded_properties
-                txt_records = {
-                    key: decoded[key] if isinstance(decoded[key], str) else ""
-                    for key in sorted(decoded)
-                    if isinstance(key, str)
-                }
         return MdnsCacheInfo(
             age_seconds=age_s,
             ttl_remaining_seconds=ttl_remaining_s,
-            txt_records=txt_records,
+            txt_records=_decode_mdns_txt_records(txt_dns_records, service_name),
         )
 
     def _apply_resolved_addresses(

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -602,14 +602,22 @@ class DeviceStateMonitor:
             if isinstance(txt_bytes, (bytes, bytearray)):
                 info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, service_name)
                 info.text = bytes(txt_bytes)
-                # ``decoded_properties`` is ``dict[str, str | None]``
-                # — drop ``None`` values (key without ``=``) so they
-                # don't surface as JSON ``null`` on the wire; the
-                # drawer would render those as empty rows anyway.
+                # ``decoded_properties`` is ``dict[str, str | None]``.
+                # ``None`` covers BOTH "bare key, no ``=``" and
+                # "``key=`` with an empty value" — zeroconf collapses
+                # the two — but the diagnostic value is the same:
+                # the user wants to see that the key IS present,
+                # even if the value is empty. Render those as
+                # ``""`` on the wire so they show up in the drawer
+                # as a key with an empty value rather than vanishing
+                # entirely. The empty-string is exactly the signal
+                # the upstream ``api_encryption`` tri-state already
+                # uses for "device confirmed plaintext" — see issue
+                # #437.
                 txt_records = {
-                    key: value
+                    key: value if isinstance(value, str) else ""
                     for key, value in info.decoded_properties.items()
-                    if isinstance(key, str) and isinstance(value, str)
+                    if isinstance(key, str)
                 }
         return MdnsCacheInfo(
             age_seconds=age_s,

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -546,10 +546,11 @@ class DeviceStateMonitor:
             return None
         cache = self._zeroconf.zeroconf.cache
         service_name = f"{name}.{_ESPHOME_SERVICE_TYPE}"
+        txt_dns_records = list(cache.get_all_by_details(service_name, _TYPE_TXT, _CLASS_IN))
         records: list[Any] = [
             *self._get_address_records(name),
             *cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN),
-            *cache.get_all_by_details(service_name, _TYPE_TXT, _CLASS_IN),
+            *txt_dns_records,
         ]
         # PTR is owned by the type-domain (``_esphomelib._tcp.local.``)
         # and carries the service-instance as its ``alias`` —
@@ -582,7 +583,39 @@ class DeviceStateMonitor:
         # — that would turn "108 seconds remaining" into 0.108
         # and render as "TTL: 0s".
         ttl_remaining_s = max(0.0, float(latest.get_remaining_ttl(now_ms)))
-        return MdnsCacheInfo(age_seconds=age_s, ttl_remaining_seconds=ttl_remaining_s)
+        # Decode the TXT key/value pairs straight off the cached
+        # ``DNSText`` records for the drawer's debug collapsible.
+        # Reuses ``ServiceInfo.text`` setter so we get zeroconf's
+        # canonical RFC-6763 split (length-prefixed UTF-8 entries
+        # → ``key=value`` pairs) and ``decoded_properties`` for the
+        # UTF-8 decode + bad-bytes-to-``None`` handling. We skip
+        # ``load_from_cache`` here because production passes a
+        # real Zeroconf and tests stub the cache with a
+        # ``MagicMock`` — ``load_from_cache``'s strict
+        # ``DNSCache`` isinstance check would crash the test
+        # path, and the only thing we need from the cache is the
+        # already-fetched TXT bytes.
+        txt_records: dict[str, str] = {}
+        if txt_dns_records:
+            latest_txt = max(txt_dns_records, key=attrgetter("created"))
+            txt_bytes = getattr(latest_txt, "text", None)
+            if isinstance(txt_bytes, (bytes, bytearray)):
+                info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, service_name)
+                info.text = bytes(txt_bytes)
+                # ``decoded_properties`` is ``dict[str, str | None]``
+                # — drop ``None`` values (key without ``=``) so they
+                # don't surface as JSON ``null`` on the wire; the
+                # drawer would render those as empty rows anyway.
+                txt_records = {
+                    key: value
+                    for key, value in info.decoded_properties.items()
+                    if isinstance(key, str) and isinstance(value, str)
+                }
+        return MdnsCacheInfo(
+            age_seconds=age_s,
+            ttl_remaining_seconds=ttl_remaining_s,
+            txt_records=txt_records,
+        )
 
     def _apply_resolved_addresses(
         self, name: str, addresses: list[str] | BaseException | None

--- a/esphome_device_builder/controllers/_reachability_tracker.py
+++ b/esphome_device_builder/controllers/_reachability_tracker.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from ..models import DeviceState
 
@@ -63,7 +63,8 @@ ObservationCallback = Callable[[str], None]
 
 @dataclass(frozen=True, slots=True)
 class MdnsCacheInfo:
-    """Truthful mDNS freshness derived from the zeroconf cache.
+    """
+    Truthful mDNS freshness derived from the zeroconf cache.
 
     ``age_seconds`` is the elapsed time since the device's most
     recent ``_esphomelib._tcp.local.`` SRV record was received,
@@ -78,10 +79,24 @@ class MdnsCacheInfo:
     fresh announce. The drawer surfaces it beside the row so the
     user can see whether the device is "due to re-announce" or
     "missed several windows already."
+
+    ``txt_records`` is the parsed ``key -> value`` pairs from the
+    device's ``TXT`` record at ``<name>._esphomelib._tcp.local.``
+    — the same payload the dashboard already mines for
+    ``version`` / ``config_hash`` / ``mac`` / ``api_encryption``.
+    Surfaced wholesale to the drawer so the user can see exactly
+    what the device is broadcasting (debugging "why is the
+    dashboard reading the wrong version?" / "did my OTA actually
+    refresh the TXT?"). Empty mapping when no TXT is cached or
+    every value failed UTF-8 decode. Keys we couldn't decode are
+    dropped silently — the dashboard already trusts
+    ``decoded_properties`` for the live-apply path, so this
+    matches that contract.
     """
 
     age_seconds: float
     ttl_remaining_seconds: float
+    txt_records: dict[str, str] = field(default_factory=dict)
 
 
 # Reads the mDNS cache for a device name and returns the freshness
@@ -215,11 +230,22 @@ class ReachabilityTracker:
 
         mdns_age: float | None = None
         mdns_ttl_remaining: float | None = None
+        # ``None`` means "no TXT data" so the drawer can hide the
+        # debug section entirely; an empty dict would render the
+        # collapsible header with zero rows, which is just visual
+        # noise. Distinct from ``{}`` which is "TXT was present
+        # but had no decodable keys" (vanishingly rare in practice).
+        mdns_txt_records: dict[str, str] | None = None
         if self._mdns_cache_reader is not None:
             info = self._mdns_cache_reader(name)
             if info is not None:
                 mdns_age = info.age_seconds
                 mdns_ttl_remaining = info.ttl_remaining_seconds
+                # Send a fresh dict on the wire — the cache reader
+                # may hand us a reference into a cached structure;
+                # don't let downstream mutation reach back into
+                # zeroconf's internals.
+                mdns_txt_records = dict(info.txt_records) if info.txt_records else None
 
         return {
             "device": name,
@@ -228,6 +254,7 @@ class ReachabilityTracker:
             "ip": ip,
             "mdns_last_seen_seconds_ago": mdns_age,
             "mdns_ttl_remaining_seconds": mdns_ttl_remaining,
+            "mdns_txt_records": mdns_txt_records,
             "ping_last_seen_seconds_ago": _ago(self._ping_last_seen.get(name)),
             "mqtt_last_seen_seconds_ago": _ago(self._mqtt_last_seen.get(name)),
             "ping_rtt_ms": self._ping_rtt_ms.get(name),

--- a/esphome_device_builder/controllers/_reachability_tracker.py
+++ b/esphome_device_builder/controllers/_reachability_tracker.py
@@ -87,11 +87,31 @@ class MdnsCacheInfo:
     Surfaced wholesale to the drawer so the user can see exactly
     what the device is broadcasting (debugging "why is the
     dashboard reading the wrong version?" / "did my OTA actually
-    refresh the TXT?"). Empty mapping when no TXT is cached or
-    every value failed UTF-8 decode. Keys we couldn't decode are
-    dropped silently — the dashboard already trusts
-    ``decoded_properties`` for the live-apply path, so this
-    matches that contract.
+    refresh the TXT?").
+
+    Bare keys (``foo`` with no ``=``), empty-value entries
+    (``foo=``), and entries whose value failed UTF-8 decode all
+    surface as ``""``-valued keys — zeroconf collapses the three
+    cases to a single ``None`` in ``decoded_properties`` and the
+    diagnostic value is the same regardless ("the key IS being
+    broadcast, even if there's nothing useful on the right-hand
+    side"). The empty string is the same signal the upstream
+    ``api_encryption`` tri-state already uses for "device
+    confirmed plaintext" (issue #437). Keys themselves are
+    dropped only when they fail UTF-8 decode (zeroconf surfaces
+    those as non-string keys in ``decoded_properties``); we
+    mirror the live-apply path's contract there.
+
+    Order is alphabetical by key — the decode pass sorts the
+    output so the wire format is deterministic across consecutive
+    snapshots regardless of zeroconf's bytes-order, which lets
+    downstream consumers compare with plain equality /
+    ``JSON.stringify`` instead of comparing dicts set-wise.
+
+    Empty mapping when no TXT record is cached at all (or the
+    cached record's bytes are missing); the snapshot serialiser
+    upstream maps ``{}`` to ``None`` on the wire so the drawer
+    hides the section entirely.
     """
 
     age_seconds: float

--- a/esphome_device_builder/controllers/_reachability_tracker.py
+++ b/esphome_device_builder/controllers/_reachability_tracker.py
@@ -230,11 +230,13 @@ class ReachabilityTracker:
 
         mdns_age: float | None = None
         mdns_ttl_remaining: float | None = None
-        # ``None`` means "no TXT data" so the drawer can hide the
-        # debug section entirely; an empty dict would render the
-        # collapsible header with zero rows, which is just visual
-        # noise. Distinct from ``{}`` which is "TXT was present
-        # but had no decodable keys" (vanishingly rare in practice).
+        # ``None`` means "no TXT data the drawer should render". An
+        # empty dict would let the renderer mount a chevron with
+        # zero rows, which is just visual noise — so we collapse
+        # *both* "no TXT cached" and "TXT cached but every key
+        # decoded to nothing useful" to ``None`` here. The
+        # frontend hides the section entirely with a single
+        # null-check.
         mdns_txt_records: dict[str, str] | None = None
         if self._mdns_cache_reader is not None:
             info = self._mdns_cache_reader(name)

--- a/tests/test_reachability_tracker.py
+++ b/tests/test_reachability_tracker.py
@@ -54,6 +54,7 @@ def test_snapshot_empty_returns_all_nulls() -> None:
         "ip": "",
         "mdns_last_seen_seconds_ago": None,
         "mdns_ttl_remaining_seconds": None,
+        "mdns_txt_records": None,
         "ping_last_seen_seconds_ago": None,
         "mqtt_last_seen_seconds_ago": None,
         "ping_rtt_ms": None,
@@ -85,6 +86,54 @@ def test_snapshot_mdns_null_when_cache_reader_returns_none() -> None:
     snap = _snapshot(tracker)
     assert snap["mdns_last_seen_seconds_ago"] is None
     assert snap["mdns_ttl_remaining_seconds"] is None
+    assert snap["mdns_txt_records"] is None
+
+
+def test_snapshot_includes_txt_records_when_present() -> None:
+    """
+    TXT records on the wire let the drawer show a debug collapsible.
+
+    Pin the wire shape: a non-empty ``txt_records`` mapping on the
+    ``MdnsCacheInfo`` round-trips through the snapshot dict as a
+    fresh ``dict[str, str]``, so a downstream caller mutating the
+    serialised dict can't poke back into the cache.
+    """
+    info = MdnsCacheInfo(
+        age_seconds=1.0,
+        ttl_remaining_seconds=119.0,
+        txt_records={
+            "version": "2025.4.0",
+            "config_hash": "5a94a12d",
+            "mac": "aabbccddeeff",
+        },
+    )
+    tracker = ReachabilityTracker(mdns_cache_reader={"kitchen": info}.get)
+
+    snap = _snapshot(tracker)
+    assert snap["mdns_txt_records"] == {
+        "version": "2025.4.0",
+        "config_hash": "5a94a12d",
+        "mac": "aabbccddeeff",
+    }
+    # Wire-side dict is a copy: mutating it doesn't reach the
+    # cached info object the next snapshot will read.
+    snap["mdns_txt_records"]["version"] = "tampered"  # type: ignore[index]
+    assert info.txt_records["version"] == "2025.4.0"
+
+
+def test_snapshot_drops_empty_txt_records_to_none() -> None:
+    """Empty ``txt_records`` → ``None`` on the wire so the drawer hides the debug section.
+
+    A collapsible header with zero rows is just visual noise; the
+    ``None`` distinction lets the renderer skip rendering the
+    section entirely.
+    """
+    info = MdnsCacheInfo(age_seconds=1.0, ttl_remaining_seconds=119.0, txt_records={})
+    tracker = ReachabilityTracker(mdns_cache_reader={"kitchen": info}.get)
+
+    snap = _snapshot(tracker)
+    assert snap["mdns_last_seen_seconds_ago"] == 1.0
+    assert snap["mdns_txt_records"] is None
 
 
 def test_observe_records_ping_and_mqtt_stamps() -> None:

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -32,11 +32,12 @@ import pytest
 from zeroconf import (
     DNSAddress,
     DNSPointer,
+    DNSText,
     ServiceStateChange,
     Zeroconf,
     current_time_millis,
 )
-from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR
+from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR, _TYPE_TXT
 
 import esphome_device_builder.controllers._device_state_monitor as state_monitor_module
 from esphome_device_builder.controllers._device_state_monitor import (
@@ -451,6 +452,98 @@ def test_get_mdns_cache_info_picks_latest_across_record_types() -> None:
         assert info is not None
         # PTR (5s ago) is fresher than A (110s ago) → PTR wins.
         assert info.age_seconds == pytest.approx(5.0, abs=0.5)
+    finally:
+        zc.close()
+
+
+def test_get_mdns_cache_info_decodes_txt_records() -> None:
+    """
+    Cached ``DNSText`` → parsed ``key=value`` mapping for the drawer.
+
+    The drawer's "show TXT records" debug collapsible needs the
+    decoded key/value pairs the device actually broadcast, not the
+    raw RFC-6763 length-prefixed bytes. Pin the round-trip via a
+    real ``Zeroconf`` cache: the monitor reads the cached
+    ``DNSText`` record, hands its bytes to ``ServiceInfo.text``,
+    and surfaces ``decoded_properties`` filtered to ``str``-valued
+    entries (drop ``None``-valued bare keys so they don't show up
+    as empty rows in the UI).
+    """
+    zc = Zeroconf(interfaces=["127.0.0.1"])
+    try:
+        # RFC-6763 length-prefixed TXT entries. ``decoded_properties``
+        # already handles UTF-8 decode + ``None`` for bad bytes; we
+        # just need to make sure the bytes-to-dict path runs.
+        txt_entries = [
+            b"version=2025.4.0",
+            b"config_hash=5a94a12d",
+            b"mac=aabbccddeeff",
+            b"api_encryption=Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+        ]
+        txt_payload = b"".join(bytes([len(e)]) + e for e in txt_entries)
+        txt_rec = DNSText(
+            name="kitchen._esphomelib._tcp.local.",
+            type_=_TYPE_TXT,
+            class_=_CLASS_IN,
+            ttl=120,
+            text=txt_payload,
+            created=current_time_millis() - 2_000,
+        )
+        # An A record so ``records`` is non-empty (otherwise the
+        # method returns ``None`` before the TXT path runs).
+        a_rec = DNSAddress(
+            name="kitchen.local.",
+            type_=_TYPE_A,
+            class_=_CLASS_IN,
+            ttl=120,
+            address=socket.inet_aton("10.0.0.42"),
+            created=current_time_millis() - 2_000,
+        )
+        zc.cache.async_add_records([a_rec, txt_rec])
+
+        monitor = _make_monitor([_make_device()], None)
+        monitor._zeroconf = MagicMock(zeroconf=zc)
+
+        info = monitor.get_mdns_cache_info("kitchen")
+        assert info is not None
+        assert info.txt_records == {
+            "version": "2025.4.0",
+            "config_hash": "5a94a12d",
+            "mac": "aabbccddeeff",
+            "api_encryption": "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+        }
+    finally:
+        zc.close()
+
+
+def test_get_mdns_cache_info_no_txt_records_returns_empty_mapping() -> None:
+    """
+    Address records present but no TXT → ``txt_records == {}``.
+
+    The drawer's snapshot serialiser maps an empty mapping to
+    ``None`` on the wire (so the debug collapsible stays hidden);
+    this test pins the upstream half — the monitor itself
+    distinguishes "no TXT cached" from "TXT cached but empty"
+    only at this granularity.
+    """
+    zc = Zeroconf(interfaces=["127.0.0.1"])
+    try:
+        a_rec = DNSAddress(
+            name="kitchen.local.",
+            type_=_TYPE_A,
+            class_=_CLASS_IN,
+            ttl=120,
+            address=socket.inet_aton("10.0.0.42"),
+            created=current_time_millis() - 2_000,
+        )
+        zc.cache.async_add_records([a_rec])
+
+        monitor = _make_monitor([_make_device()], None)
+        monitor._zeroconf = MagicMock(zeroconf=zc)
+
+        info = monitor.get_mdns_cache_info("kitchen")
+        assert info is not None
+        assert info.txt_records == {}
     finally:
         zc.close()
 

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -518,6 +518,90 @@ def test_get_mdns_cache_info_decodes_txt_records() -> None:
         zc.close()
 
 
+def test_get_mdns_cache_info_sorts_txt_records_for_wire_stability() -> None:
+    """
+    Identical TXT content in any input order produces the same dict.
+
+    The reachability subscription pushes one snapshot per
+    observation. If the backend's TXT decode walked the cached
+    bytes in the order zeroconf decoded them — which can shift
+    on a fresh announce, or if zeroconf rebuilds the cached
+    entry — every reorder would surface as a "different"
+    snapshot. Downstream consumers (dedupe layers, the
+    frontend's per-device renderer) would either churn or have
+    to compare dicts set-wise. Sorting at the source keeps the
+    wire deterministic. Pin the contract via two devices whose
+    TXT byte payloads carry the same key/value pairs in
+    different orders and assert ``info.txt_records`` round-trips
+    to the same dict.
+    """
+    zc = Zeroconf(interfaces=["127.0.0.1"])
+    try:
+        # Same payload, different bytes order. After decoding
+        # both should land in the same dict shape on the wire.
+        ascending = b"".join(
+            bytes([len(e)]) + e
+            for e in (
+                b"api_encryption=Noise",
+                b"config_hash=abc",
+                b"mac=aa",
+                b"version=1",
+            )
+        )
+        descending = b"".join(
+            bytes([len(e)]) + e
+            for e in (
+                b"version=1",
+                b"mac=aa",
+                b"config_hash=abc",
+                b"api_encryption=Noise",
+            )
+        )
+
+        a_rec = DNSAddress(
+            name="kitchen.local.",
+            type_=_TYPE_A,
+            class_=_CLASS_IN,
+            ttl=120,
+            address=socket.inet_aton("10.0.0.42"),
+            created=current_time_millis() - 2_000,
+        )
+        zc.cache.async_add_records([a_rec])
+        monitor = _make_monitor([_make_device()], None)
+        monitor._zeroconf = MagicMock(zeroconf=zc)
+
+        snapshots: list[dict[str, str]] = []
+        for payload, age_offset in ((ascending, 4_000), (descending, 1_000)):
+            txt_rec = DNSText(
+                name="kitchen._esphomelib._tcp.local.",
+                type_=_TYPE_TXT,
+                class_=_CLASS_IN,
+                ttl=120,
+                text=payload,
+                created=current_time_millis() - age_offset,
+            )
+            zc.cache.async_add_records([txt_rec])
+            info = monitor.get_mdns_cache_info("kitchen")
+            assert info is not None
+            snapshots.append(dict(info.txt_records))
+
+        # Both decoded snapshots are byte-identical when iterated
+        # — same keys, same values, same order. Without the sort
+        # they'd carry the bytes-order from the raw TXT payload
+        # and the second snapshot would differ from the first.
+        assert snapshots[0] == snapshots[1]
+        assert list(snapshots[0].items()) == list(snapshots[1].items())
+        # And they're actually sorted, not just stable.
+        assert list(snapshots[0]) == [
+            "api_encryption",
+            "config_hash",
+            "mac",
+            "version",
+        ]
+    finally:
+        zc.close()
+
+
 def test_get_mdns_cache_info_keeps_empty_value_keys_visible() -> None:
     """
     Bare keys and ``key=`` empty-value entries surface as ``""``.

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -42,6 +42,7 @@ from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR, _TYPE_TXT
 import esphome_device_builder.controllers._device_state_monitor as state_monitor_module
 from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
+    _decode_txt_bytes_to_sorted_pairs,
 )
 from esphome_device_builder.controllers._reachability_tracker import (
     MdnsCacheInfo,
@@ -658,6 +659,55 @@ def test_get_mdns_cache_info_keeps_empty_value_keys_visible() -> None:
         }
     finally:
         zc.close()
+
+
+def test_decode_txt_bytes_to_sorted_pairs_caches_by_bytes() -> None:
+    """
+    Repeat calls with identical bytes hit the LRU cache, not the decoder.
+
+    The reachability snapshot fires on every observation; for a
+    50-device fleet that's potentially ~50 calls/sec into the
+    decoder. Each device's TXT bytes rarely change between
+    firmware flashes, so the bytes are a near-perfect cache key.
+    Pin the contract: a second call with the same ``bytes``
+    object lands in the cache (``hits`` advances, ``misses``
+    doesn't) and returns the same tuple instance — and a caller
+    can't poison the cache by mutating their dict copy of the
+    tuple, because the cached tuple is itself immutable.
+    """
+    txt_payload = b"".join(
+        bytes([len(e)]) + e for e in (b"version=1", b"mac=aa", b"api_encryption=Noise")
+    )
+    # Reset the cache so previous tests' entries don't shift the
+    # hit / miss counts we're asserting on.
+    _decode_txt_bytes_to_sorted_pairs.cache_clear()
+
+    first = _decode_txt_bytes_to_sorted_pairs(txt_payload)
+    second = _decode_txt_bytes_to_sorted_pairs(txt_payload)
+
+    # Same tuple instance — the cache returned the memoised value.
+    assert first is second
+    # Sorted, with empty-value preserved as ``""``.
+    assert first == (
+        ("api_encryption", "Noise"),
+        ("mac", "aa"),
+        ("version", "1"),
+    )
+
+    info = _decode_txt_bytes_to_sorted_pairs.cache_info()
+    assert info.misses == 1
+    assert info.hits == 1
+
+    # A different payload misses cache; identical-content bytes
+    # objects with different identity still hit (cache key is
+    # value-equality on bytes, not identity).
+    other = b"".join(bytes([len(e)]) + e for e in (b"foo=bar",))
+    _decode_txt_bytes_to_sorted_pairs(other)
+    assert _decode_txt_bytes_to_sorted_pairs.cache_info().misses == 2
+
+    same_content_different_object = bytes(txt_payload)  # forces a new bytes object
+    third = _decode_txt_bytes_to_sorted_pairs(same_content_different_object)
+    assert third is first  # value-equal bytes hit the same cache slot
 
 
 def test_get_mdns_cache_info_no_txt_records_returns_empty_mapping() -> None:

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -465,9 +465,11 @@ def test_get_mdns_cache_info_decodes_txt_records() -> None:
     raw RFC-6763 length-prefixed bytes. Pin the round-trip via a
     real ``Zeroconf`` cache: the monitor reads the cached
     ``DNSText`` record, hands its bytes to ``ServiceInfo.text``,
-    and surfaces ``decoded_properties`` filtered to ``str``-valued
-    entries (drop ``None``-valued bare keys so they don't show up
-    as empty rows in the UI).
+    and surfaces ``decoded_properties`` as ``str``-valued entries
+    (collapsing zeroconf's ``None`` — which covers both bare keys
+    and empty values — to ``""`` so the user can still see the
+    key is present, which is the meaningful diagnostic for the
+    ``api_encryption`` tri-state).
     """
     zc = Zeroconf(interfaces=["127.0.0.1"])
     try:
@@ -511,6 +513,64 @@ def test_get_mdns_cache_info_decodes_txt_records() -> None:
             "config_hash": "5a94a12d",
             "mac": "aabbccddeeff",
             "api_encryption": "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+        }
+    finally:
+        zc.close()
+
+
+def test_get_mdns_cache_info_keeps_empty_value_keys_visible() -> None:
+    """
+    Bare keys and ``key=`` empty-value entries surface as ``""``.
+
+    zeroconf's ``decoded_properties`` collapses both ``foo`` (no
+    ``=``) and ``foo=`` (with ``=`` but empty value) to ``None``
+    — there's no public API to tell them apart. For the drawer's
+    debug view the diagnostic value is the same: the user wants
+    to see that the key IS being broadcast, even if the value is
+    empty. Pin that those entries surface as ``""`` rather than
+    being silently dropped — this is the signal the
+    ``api_encryption`` tri-state already uses for "device
+    confirmed plaintext" (issue #437) and the whole point of the
+    debug collapsible is to make those advertisements visible.
+    """
+    zc = Zeroconf(interfaces=["127.0.0.1"])
+    try:
+        # ``api_encryption=`` is the canonical empty-value case
+        # (device confirmed plaintext); ``bare_flag`` covers the
+        # other shape zeroconf collapses to the same ``None``.
+        txt_entries = [
+            b"version=2025.4.0",
+            b"api_encryption=",
+            b"bare_flag",
+        ]
+        txt_payload = b"".join(bytes([len(e)]) + e for e in txt_entries)
+        txt_rec = DNSText(
+            name="kitchen._esphomelib._tcp.local.",
+            type_=_TYPE_TXT,
+            class_=_CLASS_IN,
+            ttl=120,
+            text=txt_payload,
+            created=current_time_millis() - 2_000,
+        )
+        a_rec = DNSAddress(
+            name="kitchen.local.",
+            type_=_TYPE_A,
+            class_=_CLASS_IN,
+            ttl=120,
+            address=socket.inet_aton("10.0.0.42"),
+            created=current_time_millis() - 2_000,
+        )
+        zc.cache.async_add_records([a_rec, txt_rec])
+
+        monitor = _make_monitor([_make_device()], None)
+        monitor._zeroconf = MagicMock(zeroconf=zc)
+
+        info = monitor.get_mdns_cache_info("kitchen")
+        assert info is not None
+        assert info.txt_records == {
+            "version": "2025.4.0",
+            "api_encryption": "",
+            "bare_flag": "",
         }
     finally:
         zc.close()


### PR DESCRIPTION
# What does this implement/fix?

The drawer's "Reachability" section already shows when each
channel last heard from the device, but offered no visibility
into *what* the device is broadcasting. Operators debugging "why
is the dashboard reading the wrong version?" / "did my OTA
refresh the `api_encryption` advertisement?" / "is the device
still announcing the same `mac` after the rebuild?" had to drop
to `avahi-browse` or `dns-sd` to read the TXT records by hand.

Extends `MdnsCacheInfo` with a `txt_records: dict[str, str]`
field and threads it through `ReachabilityTracker.snapshot` as
`mdns_txt_records` on the per-device WS event. The monitor
decodes the cached `DNSText` bytes via zeroconf's
`ServiceInfo.text` setter (the canonical RFC-6763 length-prefixed
split path) and reads `decoded_properties` filtered to
`str`-valued entries — keys whose TXT bytes failed UTF-8 decode
(zeroconf surfaces those as `None` in `decoded_properties`) drop
out so they don't surface as JSON `null` on the wire and pollute
the rendered list with empty rows.

Empty mappings normalise to `None` at the snapshot layer so the
frontend can hide its (incoming) "show TXT records" section with
a single null-check, no separate "is split available" flag
needed. The wire-side dict is also a fresh copy, so a downstream
caller mutating the serialised dict can't poke back into
zeroconf's cached state.

**Empty-value keys stay visible.** zeroconf's
`decoded_properties` collapses both bare keys (`foo` with no
`=`) and empty-value keys (`foo=` with `=` but no value) to the
same `None` — there's no public API to tell them apart. We
surface those entries as `""` so the key stays visible in the
diagnostic view: `api_encryption=` is the canonical
"device-confirmed-plaintext" signal (issue #437) and the whole
point of the debug collapsible is to make those advertisements
observable.

**TXT keys are sorted on the wire.** zeroconf preserves
insertion order from the raw bytes, which can shift on a fresh
announce or when the cache rebuilds an entry. Sorting keeps
consecutive snapshots byte-identical for content-equivalent
inputs, so downstream consumers can dedupe with plain
equality / `JSON.stringify` instead of comparing dicts
set-wise.

The companion frontend PR consumes the new field to render a
chevron-collapsible under the mDNS reachability row. The wire is
forward+backward compatible during the rollout: older frontends
just ignore the new field, and an older backend's omission lands
as `None` on the new frontend's optional type.

Three new tracker tests pin the snapshot wire shape — `None`
when no records, a fresh-copy round-trip for the populated path,
and the empty-dict-to-`None` normalisation. Two new
state-monitor integration tests use a real `Zeroconf` cache with
an injected `DNSText` record to pin the bytes-to-dict decode and
the empty-cache fallthrough.

**Related issue or feature (if applicable):**

- Diagnostic helper for #437 ("incorrect api->encryption status
  on preview dashboard"). The TXT collapsible surfaces the live
  ``api_encryption`` advertisement straight off the device's
  mDNS announce, so a user reproducing #437 can see at a glance
  what the firmware is actually broadcasting (truthy / empty
  string / absent) versus what the dashboard chose to display.
  Doesn't fix the bug — root cause appears to be on the
  config-resolution side, not the mDNS read — but makes the
  state observable so the bug is debuggable.
- Surfaces existing mDNS TXT data already broadcast by ESPHome
  firmware so the drawer's reachability section can offer a
  one-glance debug view without an external mDNS browser.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#233

The frontend PR consumes `mdns_txt_records` to render a chevron
collapsible under the mDNS row in the device drawer's
reachability section. Both PRs are written so either can ship
first: the new field is optional on the frontend type, and an
older frontend simply ignores the extra wire field.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
