### PR TITLE
Promote id / *_id children of multi_value=True parents off Advanced

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -3475,13 +3475,23 @@ def _promote_multi_value_keys(entries: list[dict]) -> None:
     def visit(entry: dict, _path: tuple[str, ...]) -> None:
         if not entry.get("multi_value") or entry.get("type") != "nested":
             return
-        for child in entry.get("config_entries") or []:
+        inner = entry.get("config_entries") or []
+        mutated = False
+        for child in inner:
             is_own_id = child["key"] == "id" and child.get("type") == "id"
             if not (is_own_id or child["key"].endswith("_id")):
                 continue
+            mutated = True
             child["advanced"] = False
             if is_own_id:
                 child["required"] = True
+        # Demoting from advanced changes ``_sort_entries``' sort key
+        # (non-advanced first, then by ``_IMPORTANT_KEY_ORDER``), so
+        # an advanced sibling like ``comment`` would otherwise stay
+        # ahead of the now-non-advanced ``id``. Re-sort to keep the
+        # form's ordering invariant.
+        if mutated:
+            entry["config_entries"] = _sort_entries(inner)
 
     _walk_catalog_entries(entries, visit)
 

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -3481,10 +3481,18 @@ def _promote_multi_value_keys(entries: list[dict]) -> None:
             is_own_id = child["key"] == "id" and child.get("type") == "id"
             if not (is_own_id or child["key"].endswith("_id")):
                 continue
-            mutated = True
-            child["advanced"] = False
-            if is_own_id:
+            # Flip the ``mutated`` flag only when a flag actually
+            # changes — if a future upstream-schema release already
+            # marks ``id`` non-advanced + required we'd otherwise
+            # re-sort a list that's already correct, potentially
+            # disturbing an order the schema authors picked
+            # deliberately.
+            if child.get("advanced"):
+                child["advanced"] = False
+                mutated = True
+            if is_own_id and not child.get("required"):
                 child["required"] = True
+                mutated = True
         # Demoting from advanced changes ``_sort_entries``' sort key
         # (non-advanced first, then by ``_IMPORTANT_KEY_ORDER``), so
         # an advanced sibling like ``comment`` would otherwise stay

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -3455,47 +3455,35 @@ def _promote_multi_value_keys(entries: list[dict]) -> None:
     """
     Promote ``id`` / ``*_id`` children off Advanced for list rows.
 
-    Acts on ``id`` and ``id``-shaped (``area_id``, ``device_id``,
-    ``mqtt_id``, …) children of ``multi_value=True`` parents:
+    Acts on ``id`` and ``*_id`` children of ``multi_value=True``
+    NESTED parents (``esphome.devices``, ``esphome.areas``, …):
     demotes them off the Advanced toggle, and promotes the
-    parent's own ``id`` to *required*.
+    parent's own ``id`` to *required*. ``_id`` references
+    (``area_id``) stay optional — a device with no area is a
+    valid config; a device with no id is not.
 
-    The upstream schema marks own-id fields advanced (auto-generated
-    is the common case for top-level components like ``sensor.dht``)
-    and leaves cross-references nullable. For repeatable nested
-    mappings (``esphome.devices``, ``esphome.areas``) that's wrong:
-    the id is the cross-reference primary key, the user MUST set it
-    for any other field to point at the row, and ``area_id`` on a
-    device is what links the device to its area. Without this fix
-    the visual editor's nested-list renderer hides those fields
-    behind the Advanced toggle, so a fresh row from the Add button
+    The upstream schema marks own-id fields advanced because
+    ESPHome's id system auto-generates one for top-level
+    components like ``sensor.dht``. For repeatable nested
+    mappings the id IS the cross-reference primary key — without
+    it nothing else can point at the row — so the visual editor
+    needs it on the main form, not behind the Advanced toggle.
+    Without this fix a fresh row from the renderer's Add button
     looks like it accepts only ``name`` (issue #434).
-
-    Acts in-place on entries marked ``multi_value=True`` and
-    recurses into any deeper nested entries so future schema shapes
-    inherit the same treatment without a script change.
     """
 
-    def walk(items: list[dict]) -> None:
-        for entry in items:
-            inner = entry.get("config_entries") or []
-            if entry.get("multi_value") and entry.get("type") == "nested":
-                for child in inner:
-                    is_own_id = child["key"] == "id" and child.get("type") == "id"
-                    is_ref_id = child["key"].endswith("_id") and not is_own_id
-                    if is_own_id or is_ref_id:
-                        child["advanced"] = False
-                    # Own ``id`` is the cross-reference primary key —
-                    # without it nothing else can point at this row,
-                    # so promote to required. ``_id`` references stay
-                    # optional (a device with no area is valid; a
-                    # device with no id is not).
-                    if is_own_id:
-                        child["required"] = True
-            if inner:
-                walk(inner)
+    def visit(entry: dict, _path: tuple[str, ...]) -> None:
+        if not entry.get("multi_value") or entry.get("type") != "nested":
+            return
+        for child in entry.get("config_entries") or []:
+            is_own_id = child["key"] == "id" and child.get("type") == "id"
+            if not (is_own_id or child["key"].endswith("_id")):
+                continue
+            child["advanced"] = False
+            if is_own_id:
+                child["required"] = True
 
-    walk(entries)
+    _walk_catalog_entries(entries, visit)
 
 
 def _load_unit_of_measurement_options() -> list[dict[str, str]]:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1603,6 +1603,7 @@ def build_component_entry(
     _apply_field_ranges(config_entries, introspection.get("field_ranges") or {})
     _apply_refined_types(config_entries, introspection.get("refined_types") or {})
     _apply_unit_of_measurement_options(config_entries)
+    _promote_multi_value_keys(config_entries)
 
     return {
         "id": component_id,
@@ -3444,6 +3445,53 @@ def _apply_unit_of_measurement_options(entries: list[dict]) -> None:
                 entry["options"] = options
                 entry["allow_custom_value"] = True
             inner = entry.get("config_entries")
+            if inner:
+                walk(inner)
+
+    walk(entries)
+
+
+def _promote_multi_value_keys(entries: list[dict]) -> None:
+    """
+    Promote ``id`` / ``*_id`` children off Advanced for list rows.
+
+    Acts on ``id`` and ``id``-shaped (``area_id``, ``device_id``,
+    ``mqtt_id``, …) children of ``multi_value=True`` parents:
+    demotes them off the Advanced toggle, and promotes the
+    parent's own ``id`` to *required*.
+
+    The upstream schema marks own-id fields advanced (auto-generated
+    is the common case for top-level components like ``sensor.dht``)
+    and leaves cross-references nullable. For repeatable nested
+    mappings (``esphome.devices``, ``esphome.areas``) that's wrong:
+    the id is the cross-reference primary key, the user MUST set it
+    for any other field to point at the row, and ``area_id`` on a
+    device is what links the device to its area. Without this fix
+    the visual editor's nested-list renderer hides those fields
+    behind the Advanced toggle, so a fresh row from the Add button
+    looks like it accepts only ``name`` (issue #434).
+
+    Acts in-place on entries marked ``multi_value=True`` and
+    recurses into any deeper nested entries so future schema shapes
+    inherit the same treatment without a script change.
+    """
+
+    def walk(items: list[dict]) -> None:
+        for entry in items:
+            inner = entry.get("config_entries") or []
+            if entry.get("multi_value") and entry.get("type") == "nested":
+                for child in inner:
+                    is_own_id = child["key"] == "id" and child.get("type") == "id"
+                    is_ref_id = child["key"].endswith("_id") and not is_own_id
+                    if is_own_id or is_ref_id:
+                        child["advanced"] = False
+                    # Own ``id`` is the cross-reference primary key —
+                    # without it nothing else can point at this row,
+                    # so promote to required. ``_id`` references stay
+                    # optional (a device with no area is valid; a
+                    # device with no id is not).
+                    if is_own_id:
+                        child["required"] = True
             if inner:
                 walk(inner)
 

--- a/tests/test_sync_components_multi_value_keys.py
+++ b/tests/test_sync_components_multi_value_keys.py
@@ -179,6 +179,29 @@ def test_re_sorts_children_so_demoted_id_lands_before_advanced_siblings() -> Non
     assert keys.index("id") < keys.index("comment")
 
 
+def test_does_not_re_sort_when_children_already_correct() -> None:
+    # If a future upstream-schema release ships ``id`` already
+    # non-advanced + required, we shouldn't re-sort — the schema
+    # authors may have picked a different order on purpose.
+    # The walker still visits the entry but bails before flipping
+    # any flag, so ``_sort_entries`` doesn't run.
+    original_order = [
+        _entry(key="comment", type="string", advanced=True),
+        _entry(key="name", type="string", required=True),
+        _entry(key="id", type="id", required=True, advanced=False),
+    ]
+    entries = [
+        _entry(
+            key="areas",
+            type="nested",
+            multi_value=True,
+            config_entries=list(original_order),
+        ),
+    ]
+    _promote_multi_value_keys(entries)
+    assert entries[0]["config_entries"] == original_order
+
+
 def test_does_not_re_sort_when_no_promotion_happened() -> None:
     # Walking past a multi_value entry without any promotable
     # children shouldn't disturb the existing order — that's

--- a/tests/test_sync_components_multi_value_keys.py
+++ b/tests/test_sync_components_multi_value_keys.py
@@ -150,8 +150,54 @@ def test_does_not_touch_non_id_children() -> None:
         ),
     ]
     _promote_multi_value_keys(entries)
-    name_child = entries[0]["config_entries"][0]
+    name_child = next(c for c in entries[0]["config_entries"] if c["key"] == "name")
     assert name_child["advanced"] is True
+
+
+def test_re_sorts_children_so_demoted_id_lands_before_advanced_siblings() -> None:
+    # ``_sort_entries`` puts non-advanced entries first, then sorts
+    # within each group by ``_IMPORTANT_KEY_ORDER``. Demoting ``id``
+    # from advanced leaves it stranded behind a still-advanced
+    # sibling like ``comment`` if we don't re-sort. The frontend
+    # renders ``config_entries`` in list order, so the row would
+    # surface ``Comment (Advanced)`` ahead of ``ID``.
+    entries = [
+        _entry(
+            key="areas",
+            type="nested",
+            multi_value=True,
+            config_entries=[
+                _entry(key="name", type="string", required=True),
+                _entry(key="comment", type="string", advanced=True),
+                _entry(key="id", type="id", required=False, advanced=True),
+            ],
+        ),
+    ]
+    _promote_multi_value_keys(entries)
+    keys = [c["key"] for c in entries[0]["config_entries"]]
+    # ``id`` (now non-advanced) must precede ``comment`` (still advanced).
+    assert keys.index("id") < keys.index("comment")
+
+
+def test_does_not_re_sort_when_no_promotion_happened() -> None:
+    # Walking past a multi_value entry without any promotable
+    # children shouldn't disturb the existing order — that's
+    # owned by ``_sort_entries`` upstream and should stay
+    # idempotent here.
+    original_order = [
+        _entry(key="z_late", type="string"),
+        _entry(key="a_early", type="string"),
+    ]
+    entries = [
+        _entry(
+            key="rows",
+            type="nested",
+            multi_value=True,
+            config_entries=list(original_order),
+        ),
+    ]
+    _promote_multi_value_keys(entries)
+    assert entries[0]["config_entries"] == original_order
 
 
 def test_handles_list_with_no_multi_value_entries() -> None:

--- a/tests/test_sync_components_multi_value_keys.py
+++ b/tests/test_sync_components_multi_value_keys.py
@@ -1,0 +1,162 @@
+"""Tests for the ``_promote_multi_value_keys`` catalog post-process.
+
+The post-process demotes ``id`` / ``*_id`` children of
+``multi_value=True`` parents from Advanced to the main form, and
+promotes the parent's own ``id`` to required (since cross-references
+depend on it).
+
+The upstream schema marks ``esphome.areas[].id`` and
+``esphome.devices[].id`` as advanced + optional because ESPHome's id
+system can auto-generate one. For repeatable nested mappings the
+user is expected to set the id by hand — it's the key other rows
+reference (a device's ``area_id`` points at an ``esphome.areas``
+row's ``id``). Without this fix the visual editor's nested-list
+renderer hides those fields behind the Advanced toggle, so a fresh
+row from the Add button looks like it accepts only ``name``
+(issue #434).
+"""
+
+from __future__ import annotations
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _promote_multi_value_keys,
+)
+
+
+def _entry(**kwargs: object) -> dict:
+    """Build a config-entry dict with sensible defaults.
+
+    Lets tests focus on the fields under test instead of repeating
+    boilerplate.
+    """
+    base = {
+        "key": "x",
+        "type": "string",
+        "required": False,
+        "advanced": False,
+        "multi_value": False,
+        "config_entries": None,
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_promotes_own_id_to_required_and_not_advanced() -> None:
+    entries = [
+        _entry(
+            key="areas",
+            type="nested",
+            multi_value=True,
+            config_entries=[
+                _entry(key="name", type="string", required=True),
+                _entry(key="id", type="id", required=False, advanced=True),
+            ],
+        ),
+    ]
+    _promote_multi_value_keys(entries)
+    id_child = entries[0]["config_entries"][1]
+    assert id_child["required"] is True
+    assert id_child["advanced"] is False
+    # Sibling untouched.
+    name_child = entries[0]["config_entries"][0]
+    assert name_child["required"] is True
+
+
+def test_demotes_underscore_id_references_without_marking_required() -> None:
+    # ``area_id`` on a device row references an area but the user
+    # may legitimately leave it blank. Drop ``advanced`` so the
+    # field is reachable without the Advanced toggle, but don't
+    # force it required.
+    entries = [
+        _entry(
+            key="devices",
+            type="nested",
+            multi_value=True,
+            config_entries=[
+                _entry(key="id", type="id", required=False, advanced=True),
+                _entry(key="area_id", type="id", required=False, advanced=True),
+            ],
+        ),
+    ]
+    _promote_multi_value_keys(entries)
+    id_child, area_child = entries[0]["config_entries"]
+    assert id_child["required"] is True  # own id IS promoted
+    assert id_child["advanced"] is False
+    assert area_child["required"] is False  # ref id stays optional
+    assert area_child["advanced"] is False
+
+
+def test_leaves_single_value_nested_entries_alone() -> None:
+    # Non-multi_value parents (regular ``key: { … }`` shape) keep
+    # the upstream schema's advanced/required markings. ``ap.id``
+    # on ``wifi.ap`` should still be auto-generated and advanced.
+    entries = [
+        _entry(
+            key="ap",
+            type="nested",
+            multi_value=False,
+            config_entries=[
+                _entry(key="id", type="id", required=False, advanced=True),
+            ],
+        ),
+    ]
+    _promote_multi_value_keys(entries)
+    id_child = entries[0]["config_entries"][0]
+    assert id_child["required"] is False
+    assert id_child["advanced"] is True
+
+
+def test_recurses_into_nested_multi_value_descendants() -> None:
+    # The walker should reach a ``multi_value=True`` entry that's
+    # nested inside another nested entry. Future schema shapes
+    # may surface a list-of-mappings under a non-list parent.
+    entries = [
+        _entry(
+            key="outer",
+            type="nested",
+            multi_value=False,
+            config_entries=[
+                _entry(
+                    key="rows",
+                    type="nested",
+                    multi_value=True,
+                    config_entries=[
+                        _entry(key="id", type="id", required=False, advanced=True),
+                    ],
+                ),
+            ],
+        ),
+    ]
+    _promote_multi_value_keys(entries)
+    deep_id = entries[0]["config_entries"][0]["config_entries"][0]
+    assert deep_id["required"] is True
+    assert deep_id["advanced"] is False
+
+
+def test_does_not_touch_non_id_children() -> None:
+    # Only ``id`` / ``*_id`` keys are eligible. A ``name`` child
+    # marked advanced (unlikely but possible) should keep its
+    # markings — we don't want to flatten the entire item to the
+    # main form.
+    entries = [
+        _entry(
+            key="areas",
+            type="nested",
+            multi_value=True,
+            config_entries=[
+                _entry(key="name", type="string", advanced=True, required=True),
+                _entry(key="id", type="id", required=False, advanced=True),
+            ],
+        ),
+    ]
+    _promote_multi_value_keys(entries)
+    name_child = entries[0]["config_entries"][0]
+    assert name_child["advanced"] is True
+
+
+def test_handles_list_with_no_multi_value_entries() -> None:
+    entries = [_entry(key="ssid", type="string", required=True)]
+    # No multi_value entries; helper should be a no-op.
+    _promote_multi_value_keys(entries)
+    assert entries[0]["required"] is True
+    assert entries[0]["advanced"] is False


### PR DESCRIPTION
# What does this implement/fix?

User-reported bug on the visual editor's nested-list renderer (esphome/device-builder-frontend#230 / issue #434): clicking the Add button on `esphome.areas` or `esphome.devices` rendered a row with only a `Name` field. The `id` (and `area_id` on devices) only appeared after toggling Advanced.

Root cause: the upstream schema marks `esphome.areas[].id` and `esphome.devices[].id` as `advanced=True` and optional because ESPHome's id-system can auto-generate one — true for top-level components like `sensor.dht` where the id is rarely user-typed, wrong for repeatable nested mappings where the id IS the cross-reference primary key (`area_id: kitchen_area` points at an area's `id`).

`_promote_multi_value_keys` post-processes the catalog: any `multi_value=True` NESTED entry has its `id` / `*_id` children demoted from advanced. The parent's own `id` is also promoted to required (without it, nothing else can point at this row). `_id`-suffixed reference fields (`area_id`) stay optional — a device with no area is a valid config; a device with no id is not.

Generic by design — runs over every `multi_value=True` entry in the catalog so future repeatable-mapping schemas (e.g. a future packages-style list) inherit the same correctness without a script change.

The catalog itself isn't included here per project convention — nightly sync regenerates it. Tested locally by patching the in-tree `components.json` with the same logic.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#434 (frontend follow-on to esphome/device-builder-frontend#230)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#230

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
