### PR TITLE
Advertise dashboard on mDNS as _esphomebuilder._tcp.local. (#106 phase 1)

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -452,6 +452,19 @@ class DeviceStateMonitor:
                 _LOGGER.debug("zeroconf close failed", exc_info=True)
             self._zeroconf = None
 
+    @property
+    def zeroconf(self) -> AsyncEsphomeZeroconf | None:
+        """
+        The mDNS responder powering device discovery, or ``None``.
+
+        Exposed so the dashboard's own ``_esphomebuilder._tcp.local.``
+        advertiser can reuse the same instance instead of opening a
+        second responder. Returns ``None`` when zeroconf failed to
+        start (port held by avahi / ``mDNSResponder``); callers are
+        expected to skip their advertise in that case.
+        """
+        return self._zeroconf
+
     def set_reachability(self, tracker: ReachabilityTracker) -> None:
         """Wire (or rewire) the per-signal freshness tracker.
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -23,6 +23,7 @@ from esphome import const
 from esphome.components.dashboard_import import import_config
 from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
+from esphome.zeroconf import AsyncEsphomeZeroconf
 
 from ...helpers.api import CommandError, api_command
 from ...helpers.build_size import coerce_sidecar_int
@@ -239,7 +240,7 @@ class DevicesController:
         )
 
     @property
-    def zeroconf(self) -> Any:
+    def zeroconf(self) -> AsyncEsphomeZeroconf | None:
         """
         The mDNS responder owned by the state monitor, or ``None``.
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -238,6 +238,18 @@ class DevicesController:
             on_ip_change=self._state_monitor.apply_ip,
         )
 
+    @property
+    def zeroconf(self) -> Any:
+        """
+        The mDNS responder owned by the state monitor, or ``None``.
+
+        Surfaced so the dashboard's own ``_esphomebuilder._tcp.local.``
+        advertiser can reuse the existing instance instead of standing
+        up a second responder. ``None`` when zeroconf failed to start —
+        callers skip their advertise.
+        """
+        return self._state_monitor.zeroconf
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -18,9 +18,11 @@ from pathlib import Path
 from typing import Any
 
 from aiohttp import web
+from esphome.const import __version__ as esphome_version
 
 from .api.legacy import create_legacy_routes
 from .api.ws import create_ws_routes
+from .constants import __version__ as server_version
 from .controllers.auth import AuthController
 from .controllers.automations import AutomationsController
 from .controllers.boards import BoardCatalog
@@ -32,6 +34,7 @@ from .controllers.firmware import FirmwareController
 from .controllers.labels import LabelsController
 from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.auth import auth_middleware
+from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware
 from .helpers.subscriber_presence import SubscriberPresence
@@ -198,6 +201,13 @@ class DeviceBuilder:
         self.editor: EditorController | None = None
         self.labels: LabelsController | None = None
 
+        # mDNS advertise — populated in start() once we know zeroconf
+        # is up. Optional: a zeroconf-bind failure leaves this None
+        # and dashboard discovery just doesn't happen for this
+        # process (device discovery, the load-bearing mDNS feature,
+        # has the same fail-soft contract).
+        self._dashboard_advertiser: DashboardAdvertiser | None = None
+
         # Command registry — populated from controllers
         self.command_handlers: dict[str, CommandHandler] = {}
 
@@ -252,6 +262,37 @@ class DeviceBuilder:
         await self.firmware.start()
         await self.editor.start()
 
+        # Advertise this dashboard on mDNS so peer dashboards (and
+        # the future ESPHome Desktop welcome screen) can discover it.
+        # Reuses the state monitor's zeroconf instance so the
+        # responder count stays at one per process.
+        #
+        # Skipped in two cases:
+        #   * Zeroconf failed to bind — device discovery already
+        #     fails soft here, the advertise follows the same rule.
+        #   * HA addon — by default the addon container's port 6052
+        #     is not exposed to the LAN (ingress-only on 8099) AND
+        #     mDNS announcements would carry the container's docker
+        #     IP rather than the host's, so a peer that found the
+        #     listing couldn't connect anyway. A future setting can
+        #     opt back in once we know how to expose the addon's
+        #     host port deliberately.
+        zeroconf = self.devices.zeroconf
+        if zeroconf is None:
+            _LOGGER.debug("Skipping dashboard mDNS advertise: zeroconf is unavailable")
+        elif self.settings.on_ha_addon:
+            _LOGGER.debug(
+                "Skipping dashboard mDNS advertise: running as HA addon "
+                "(ingress-only; port 6052 not LAN-reachable)"
+            )
+        else:
+            self._dashboard_advertiser = DashboardAdvertiser(
+                port=self.settings.port,
+                server_version=server_version,
+                esphome_version=esphome_version,
+            )
+            await self._dashboard_advertiser.register(zeroconf)
+
         # Collect command handlers from all controllers
         for controller in (
             self.auth,
@@ -292,6 +333,11 @@ class DeviceBuilder:
             task.cancel()
         if self._background_tasks:
             await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        # Withdraw the mDNS advertise BEFORE devices.stop() closes
+        # the zeroconf socket the responder is using.
+        if self._dashboard_advertiser is not None:
+            await self._dashboard_advertiser.unregister()
+            self._dashboard_advertiser = None
         if self.devices is not None:
             await self.devices.stop()
         if self.editor is not None:

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -154,6 +154,7 @@ def _local_addresses() -> list[str]:
        method handles that for production use; tests that call this
        function synchronously off the loop don't need to.
     """
+    seen: set[str] = set()
     out: list[str] = []
     for adapter in ifaddr.get_adapters():
         if _is_loopback_adapter(adapter):
@@ -171,13 +172,21 @@ def _local_addresses() -> list[str]:
                 continue
             if parsed.is_loopback or parsed.is_link_local:
                 continue
+            # De-duplicate while preserving discovery order: an IP
+            # bound to multiple adapters (e.g. a primary + an alias
+            # on the same NIC) would otherwise appear twice in the
+            # advertise and trigger spurious ``refresh`` updates if
+            # the duplicate flickers in/out between enumerations.
+            if addr_str in seen:
+                continue
+            seen.add(addr_str)
             out.append(addr_str)
     return out
 
 
 def _default_hostname() -> str:
     """
-    System mDNS hostname for the ``hostname`` TXT field.
+    System mDNS hostname for the ``ServiceInfo.server`` SRV target.
 
     Returns ``socket.gethostname()`` with ``.local`` appended when
     the result has no dot. Doesn't use ``socket.getfqdn()``: on
@@ -378,7 +387,7 @@ class DashboardAdvertiser:
         Re-runs :func:`_local_addresses` (via the executor — see
         :meth:`register`), compares the result against the address
         list that's currently on the wire, and calls
-        :meth:`AsyncZeroconf.async_update_service` only when the
+        :meth:`AsyncEsphomeZeroconf.async_update_service` only when the
         sorted sets differ. The no-op return path keeps callers
         free to invoke this on a tick / interface-change event
         without flooding the network with unchanged updates.

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -325,6 +325,48 @@ class DashboardAdvertiser:
             self._esphome_version,
         )
 
+    async def refresh(self) -> bool:
+        """
+        Re-publish the advertise if the local-address set has changed.
+
+        Re-runs :func:`_local_addresses` (via the executor — see
+        :meth:`register`), compares the result against the address
+        list that's currently on the wire, and calls
+        :meth:`AsyncZeroconf.async_update_service` only when the
+        sorted sets differ. The no-op return path keeps callers
+        free to invoke this on a tick / interface-change event
+        without flooding the network with unchanged updates.
+
+        Returns ``True`` if a re-publish actually fired, ``False``
+        when the cached and freshly-enumerated address sets matched
+        (or when the advertiser isn't currently registered, in
+        which case there's nothing to refresh against).
+        """
+        info = self._info
+        zeroconf = self._zeroconf
+        if info is None or zeroconf is None:
+            return False
+        loop = asyncio.get_running_loop()
+        new_addresses = await loop.run_in_executor(None, _local_addresses)
+        # Compare normalized sets so the order ifaddr returns
+        # interfaces in (which can shift between calls on some
+        # platforms) doesn't trigger a spurious re-publish.
+        if sorted(new_addresses) == sorted(info.parsed_addresses()):
+            return False
+        new_info = self.build_service_info(new_addresses)
+        try:
+            await zeroconf.async_update_service(new_info)
+        except Exception:
+            _LOGGER.debug("Dashboard advertise refresh failed", exc_info=True)
+            return False
+        self._info = new_info
+        _LOGGER.debug(
+            "Refreshed dashboard advertise — addresses changed (%d → %d)",
+            len(info.parsed_addresses()),
+            len(new_addresses),
+        )
+        return True
+
     async def unregister(self) -> None:
         """
         Withdraw the service.

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -59,6 +59,17 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_TYPE = "_esphomebuilder._tcp.local."
 
+# Cadence at which the advertiser polls ``_local_addresses`` for
+# changes and re-publishes via ``async_update_service`` if the set
+# differs from what's currently on the wire. Five minutes balances
+# "DHCP renewal / WiFi reconnect should be picked up before a peer's
+# pairing breaks for too long" against "don't burn CPU walking
+# adapters every minute". Refresh is a no-op when the address set
+# hasn't changed (see :meth:`DashboardAdvertiser.refresh`), so the
+# steady-state cost is one ``ifaddr.get_adapters`` call per tick
+# with zero wire traffic.
+_REFRESH_INTERVAL_SECONDS = 300
+
 
 def _default_friendly_name() -> str:
     """
@@ -224,6 +235,12 @@ class DashboardAdvertiser:
         self._esphome_version = esphome_version
         self._info: ServiceInfo | None = None
         self._zeroconf: AsyncEsphomeZeroconf | None = None
+        # Background tick that calls :meth:`refresh` on
+        # ``_REFRESH_INTERVAL_SECONDS`` so DHCP renewals / WiFi
+        # reconnects pick up new addresses without a dashboard
+        # restart. Started in :meth:`register`, cancelled in
+        # :meth:`unregister`.
+        self._refresh_task: asyncio.Task[None] | None = None
 
     @property
     def service_type(self) -> str:
@@ -324,6 +341,35 @@ class DashboardAdvertiser:
             self._port,
             self._esphome_version,
         )
+        self._refresh_task = asyncio.create_task(
+            self._refresh_loop(), name="dashboard-advertise-refresh"
+        )
+
+    async def _refresh_loop(self) -> None:
+        """
+        Background task that polls :meth:`refresh` on a fixed cadence.
+
+        Sleeps ``_REFRESH_INTERVAL_SECONDS`` between checks. Exits
+        cleanly on cancellation (the ``CancelledError`` raised by
+        :func:`asyncio.sleep` propagates out of the loop and the
+        task finishes) so :meth:`unregister` can drain it without
+        special handling.
+
+        Refresh exceptions are caught and logged at debug level —
+        a transient zeroconf glitch shouldn't kill the whole
+        refresh loop and leave the advertise stuck on stale
+        addresses until the dashboard restarts. The next tick
+        retries.
+        """
+        while True:
+            await asyncio.sleep(_REFRESH_INTERVAL_SECONDS)
+            try:
+                await self.refresh()
+            except Exception:
+                _LOGGER.debug(
+                    "Dashboard advertise refresh tick raised; will retry next interval",
+                    exc_info=True,
+                )
 
     async def refresh(self) -> bool:
         """
@@ -377,8 +423,26 @@ class DashboardAdvertiser:
         """
         info = self._info
         zeroconf = self._zeroconf
+        refresh_task = self._refresh_task
         self._info = None
         self._zeroconf = None
+        self._refresh_task = None
+        # Cancel the periodic refresh first so a tick already in
+        # flight can't race the ``async_unregister_service`` call
+        # below (refresh's ``async_update_service`` after we tore
+        # down would either fail or race with the unregister).
+        # Always drain — even an already-``done`` task may have
+        # ended with an exception we want to surface to the
+        # debug log instead of dropping silently.
+        if refresh_task is not None:
+            if not refresh_task.done():
+                refresh_task.cancel()
+            try:
+                await refresh_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                _LOGGER.debug("Dashboard advertise refresh task drain failed", exc_info=True)
         if info is None or zeroconf is None:
             return
         try:

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -15,14 +15,22 @@ alternative that fits. Parallels the existing ``_esphomelib._tcp.local.``
 device service type so a packet capture shows both ESPHome surfaces
 in the same ``_esphome*`` namespace.
 
-The TXT record carries everything a peer needs to make the
-already-discovered/eventually-paired decision without first opening
-an HTTP connection: the dashboard's own version (``server_version``),
-the ``esphome`` library version it would compile against
-(``esphome_version``), a human label (``name``), and the system's
-mDNS hostname (``hostname``). Listing peers in a UI then takes one
-zeroconf browser; pairing / token exchange / version-mismatch
-warnings come in later phases.
+The TXT record carries the two version fields a peer can't derive
+from the browse response on its own:
+
+* ``server_version`` — this dashboard's own package version, so a
+  peer can flag a release-skew warning before pairing.
+* ``esphome_version`` — the ``esphome`` library version this
+  dashboard would compile against, so the version-mismatch warning
+  in phase 7 can fire on the listing page rather than waiting for
+  an upload to come back with a surprise build.
+
+A friendly label and the host's mDNS name are *not* in TXT — both
+are already on the wire. python-zeroconf exposes the service
+instance name (the leftmost label of the published name, e.g.
+``MacBook-Pro``) and the SRV record's target (the FQDN, e.g.
+``MacBook-Pro.local.``) directly on the resolved ``ServiceInfo``;
+duplicating them in TXT just bloats the packet.
 
 The advertise reuses the existing ``AsyncEsphomeZeroconf`` instance
 owned by :class:`~esphome_device_builder.controllers._device_state_monitor.DeviceStateMonitor`
@@ -140,11 +148,14 @@ class DashboardAdvertiser:
         register/unregister cycle.
         """
         instance = f"{self._name}.{SERVICE_TYPE}"
+        # TXT carries only what isn't already on the wire. The
+        # service-instance label (``self._name``) and the SRV
+        # target (``server`` below) are returned by every browse;
+        # peers read them directly off ``ServiceInfo.name`` /
+        # ``ServiceInfo.server`` rather than parsing TXT.
         properties = {
             "server_version": self._server_version,
             "esphome_version": self._esphome_version,
-            "name": self._name,
-            "hostname": self._hostname,
         }
         # ``server`` is the SRV record's target. Zeroconf appends
         # ``.local.`` if missing; pass the FQDN through as-is so a

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -1,0 +1,210 @@
+"""
+Publish the dashboard's own ``_esphomebuilder._tcp.local.`` service.
+
+Phase 1 of the remote-build offload feature (issue #106). Dashboards
+that browse this service type can list every other dashboard reachable
+on the LAN — used by the eventual "Remote build" settings page on the
+offloader and by the ESPHome Desktop welcome screen's "we found a
+dashboard, want to connect?" detection.
+
+The service-type label is ``_esphomebuilder`` rather than the
+``_esphomedashboard`` named in the original design proposal: RFC
+6335 §5.1 caps the label at 15 characters, ``esphomedashboard`` is
+16, and ``esphomebuilder`` (14) is the closest project-identifying
+alternative that fits. Parallels the existing ``_esphomelib._tcp.local.``
+device service type so a packet capture shows both ESPHome surfaces
+in the same ``_esphome*`` namespace.
+
+The TXT record carries everything a peer needs to make the
+already-discovered/eventually-paired decision without first opening
+an HTTP connection: the dashboard's own version (``server_version``),
+the ``esphome`` library version it would compile against
+(``esphome_version``), a human label (``name``), and the system's
+mDNS hostname (``hostname``). Listing peers in a UI then takes one
+zeroconf browser; pairing / token exchange / version-mismatch
+warnings come in later phases.
+
+The advertise reuses the existing ``AsyncEsphomeZeroconf`` instance
+owned by :class:`~esphome_device_builder.controllers._device_state_monitor.DeviceStateMonitor`
+so the dashboard ships one mDNS responder per process. When that
+zeroconf failed to start (e.g. the port is held by avahi /
+``mDNSResponder`` and we couldn't bind), the advertise is a no-op
+rather than a hard failure — device discovery is the load-bearing
+mDNS feature; the dashboard advertise is a nice-to-have.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from typing import TYPE_CHECKING
+
+from zeroconf import ServiceInfo
+
+if TYPE_CHECKING:
+    from zeroconf.asyncio import AsyncZeroconf
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_TYPE = "_esphomebuilder._tcp.local."
+
+
+def _default_friendly_name() -> str:
+    """
+    Best-effort friendly label for the dashboard host.
+
+    Uses the leftmost label of ``socket.gethostname()`` so a host
+    that returns ``desktop.local`` advertises as ``desktop`` (the
+    full FQDN goes in the ``hostname`` TXT field separately). Falls
+    back to ``"esphome-dashboard"`` when the system can't report
+    a hostname at all.
+    """
+    raw = socket.gethostname() or ""
+    label = raw.split(".", 1)[0].strip()
+    return label or "esphome-dashboard"
+
+
+def _default_hostname() -> str:
+    """
+    System mDNS hostname for the ``hostname`` TXT field.
+
+    Returns ``socket.gethostname()`` with ``.local`` appended when
+    the result has no dot. Doesn't use ``socket.getfqdn()``: on
+    macOS that resolver can return the reverse-DNS arpa form (e.g.
+    ``...ip6.arpa``) when reverse lookup fails, which is worse
+    than no hostname at all.
+    """
+    raw = (socket.gethostname() or "").strip()
+    if not raw:
+        return ""
+    if "." in raw:
+        return raw
+    return f"{raw}.local"
+
+
+class DashboardAdvertiser:
+    """
+    Publish the dashboard's ``_esphomedashboard._tcp.local.`` service.
+
+    Constructed once per :class:`DeviceBuilder` lifetime. The
+    :meth:`register` / :meth:`unregister` pair runs from the
+    dashboard's start / stop hooks. Idempotent on both sides — calling
+    ``register`` twice (or ``unregister`` without a prior register) is
+    safe and logged at debug level.
+    """
+
+    def __init__(
+        self,
+        *,
+        port: int,
+        server_version: str,
+        esphome_version: str,
+        name: str | None = None,
+        hostname: str | None = None,
+    ) -> None:
+        """
+        Capture the static fields used in the published ``ServiceInfo``.
+
+        ``port`` is the dashboard's HTTP listen port — what a peer
+        connects to once it's chosen this advertisement from a
+        browse. ``name`` defaults to the system hostname's leftmost
+        label (used as both the friendly TXT field and the mDNS
+        instance name); ``hostname`` defaults to the FQDN.
+        """
+        friendly = (name or "").strip() or _default_friendly_name()
+        host = (hostname or "").strip() or _default_hostname()
+        self._port = int(port)
+        self._name = friendly
+        self._hostname = host
+        self._server_version = server_version
+        self._esphome_version = esphome_version
+        self._info: ServiceInfo | None = None
+        self._zeroconf: AsyncZeroconf | None = None
+
+    @property
+    def service_type(self) -> str:
+        """The mDNS service type this advertiser publishes under."""
+        return SERVICE_TYPE
+
+    @property
+    def registered(self) -> bool:
+        """True between a successful :meth:`register` and :meth:`unregister`."""
+        return self._info is not None
+
+    def build_service_info(self) -> ServiceInfo:
+        """
+        Construct the ``ServiceInfo`` that will be published on register.
+
+        Exposed (rather than inlined into :meth:`register`) so tests
+        can introspect the payload without driving the full zeroconf
+        register/unregister cycle.
+        """
+        instance = f"{self._name}.{SERVICE_TYPE}"
+        properties = {
+            "server_version": self._server_version,
+            "esphome_version": self._esphome_version,
+            "name": self._name,
+            "hostname": self._hostname,
+        }
+        # ``server`` is the SRV record's target. Zeroconf appends
+        # ``.local.`` if missing; pass the FQDN through as-is so a
+        # host already advertising e.g. ``desktop.local`` keeps the
+        # same answer it does for every other service.
+        server = self._hostname if self._hostname.endswith(".") else f"{self._hostname}."
+        return ServiceInfo(
+            SERVICE_TYPE,
+            instance,
+            port=self._port,
+            properties=properties,
+            server=server,
+        )
+
+    async def register(self, zeroconf: AsyncZeroconf) -> None:
+        """
+        Publish the service via *zeroconf*.
+
+        ``allow_name_change=True`` lets python-zeroconf disambiguate
+        two dashboards on the same hostname (rare in practice, but
+        the rename-on-conflict cost is one register call so the
+        protection is essentially free).
+        """
+        if self._info is not None:
+            _LOGGER.debug("Dashboard advertise already registered; skipping")
+            return
+        info = self.build_service_info()
+        try:
+            await zeroconf.async_register_service(info, allow_name_change=True)
+        except Exception:
+            _LOGGER.exception(
+                "Failed to advertise dashboard on %s — peer discovery disabled",
+                SERVICE_TYPE,
+            )
+            return
+        self._info = info
+        self._zeroconf = zeroconf
+        _LOGGER.info(
+            "Advertising dashboard on %s as %r (port %d, esphome %s)",
+            SERVICE_TYPE,
+            info.name,
+            self._port,
+            self._esphome_version,
+        )
+
+    async def unregister(self) -> None:
+        """
+        Withdraw the service.
+
+        No-op when never registered or already unregistered. Failures
+        are logged but not re-raised so dashboard shutdown stays clean
+        even if the zeroconf socket is already gone.
+        """
+        info = self._info
+        zeroconf = self._zeroconf
+        self._info = None
+        self._zeroconf = None
+        if info is None or zeroconf is None:
+            return
+        try:
+            await zeroconf.async_unregister_service(info)
+        except Exception:
+            _LOGGER.debug("Dashboard advertise unregister failed", exc_info=True)

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -43,10 +43,13 @@ mDNS feature; the dashboard advertise is a nice-to-have.
 
 from __future__ import annotations
 
+import asyncio
+import ipaddress
 import logging
 import socket
 from typing import TYPE_CHECKING
 
+import ifaddr
 from zeroconf import ServiceInfo
 
 if TYPE_CHECKING:
@@ -70,6 +73,89 @@ def _default_friendly_name() -> str:
     raw = socket.gethostname() or ""
     label = raw.split(".", 1)[0].strip()
     return label or "esphome-dashboard"
+
+
+def _is_loopback_adapter(adapter: ifaddr.Adapter) -> bool:
+    """
+    Return ``True`` when *adapter* is the host's loopback interface.
+
+    Matches by interface name (``lo`` / ``lo0``) rather than by
+    inspecting individual addresses: macOS configures ``fe80::1``
+    on ``lo0``, which is a real link-local address as far as
+    :mod:`ipaddress` is concerned (``is_loopback`` returns ``False``,
+    ``is_link_local`` returns ``True``) but routes to nothing
+    useful — advertising it would be misleading. Filtering the
+    interface out wholesale catches every loopback IP in one
+    place.
+    """
+    name = (adapter.name or "").lower()
+    nice = (adapter.nice_name or "").lower()
+    return name.startswith("lo") or "loopback" in nice
+
+
+def _local_addresses() -> list[str]:
+    """
+    Return the IPv4 / IPv6 addresses to advertise.
+
+    Enumerates every adapter via :mod:`ifaddr` (already a
+    python-zeroconf dependency) and returns the bare addresses as
+    plain strings suitable for :class:`~zeroconf.ServiceInfo`'s
+    ``parsed_addresses`` keyword. Drops three classes of addresses
+    that would land on the wire but never help a peer:
+
+    * **Loopback interfaces.** Filtering by interface (``lo`` /
+      ``lo0``) catches macOS's ``fe80::1``-on-``lo0`` link-local
+      that wouldn't be caught by an ``ip.is_loopback`` check alone.
+    * **Loopback IPs on non-loopback interfaces.** Defense in depth
+      for hosts where the OS aliases ``127.0.0.1`` onto a real
+      interface for some reason.
+    * **IPv6 link-local addresses** (``fe80::/10``). Useless once
+      the scope_id is dropped, which the mDNS wire format requires
+      — a peer receiving a bare ``fe80::xxx`` has no way to know
+      which interface to send the packet out on. Hosts with many
+      virtual interfaces (VPN, awdl, utun*) carry a dozen link-
+      local addresses that just inflate the announcement without
+      adding reachability.
+
+    Setting ``parsed_addresses`` explicitly is what fixes the
+    "127.0.0.1 / ::1 / fe80::1 only" advertise we saw on macOS:
+    when ``ServiceInfo`` is constructed with no addresses, peers
+    fall back to A/AAAA lookups against the SRV target. On macOS
+    that lookup is answered by ``mDNSResponder``, which can drop
+    to loopback while the system's network state is in flux.
+    Publishing the addresses ourselves takes that path out of the
+    loop.
+
+    .. note::
+
+       :func:`ifaddr.get_adapters` does blocking I/O — reads
+       ``/proc/net`` on Linux, calls ``GetAdaptersAddresses`` on
+       Windows. Async callers must run this via
+       :meth:`asyncio.AbstractEventLoop.run_in_executor` rather
+       than calling it directly on the event loop. The
+       :class:`DashboardAdvertiser`'s :meth:`~DashboardAdvertiser.register`
+       method handles that for production use; tests that call this
+       function synchronously off the loop don't need to.
+    """
+    out: list[str] = []
+    for adapter in ifaddr.get_adapters():
+        if _is_loopback_adapter(adapter):
+            continue
+        for ip in adapter.ips:
+            # ``ifaddr.IP.ip`` is a ``str`` for IPv4 and a 3-tuple
+            # ``(addr, flowinfo, scope_id)`` for IPv6. The ServiceInfo
+            # wire format only carries the bare address — drop the
+            # tuple framing.
+            raw = ip.ip
+            addr_str = raw[0] if isinstance(raw, tuple) else raw
+            try:
+                parsed = ipaddress.ip_address(addr_str)
+            except ValueError:
+                continue
+            if parsed.is_loopback or parsed.is_link_local:
+                continue
+            out.append(addr_str)
+    return out
 
 
 def _default_hostname() -> str:
@@ -139,14 +225,23 @@ class DashboardAdvertiser:
         """True between a successful :meth:`register` and :meth:`unregister`."""
         return self._info is not None
 
-    def build_service_info(self) -> ServiceInfo:
+    def build_service_info(self, addresses: list[str] | None = None) -> ServiceInfo:
         """
         Construct the ``ServiceInfo`` that will be published on register.
+
+        *addresses* is the list of IP strings to publish in the A /
+        AAAA records. ``None`` (the default) calls
+        :func:`_local_addresses` synchronously, which is convenient
+        for tests but does blocking I/O — :meth:`register` resolves
+        the list via :meth:`asyncio.AbstractEventLoop.run_in_executor`
+        and passes it in explicitly, keeping the event loop clean.
 
         Exposed (rather than inlined into :meth:`register`) so tests
         can introspect the payload without driving the full zeroconf
         register/unregister cycle.
         """
+        if addresses is None:
+            addresses = _local_addresses()
         instance = f"{self._name}.{SERVICE_TYPE}"
         # TXT carries only what isn't already on the wire. The
         # service-instance label (``self._name``) and the SRV
@@ -162,12 +257,17 @@ class DashboardAdvertiser:
         # host already advertising e.g. ``desktop.local`` keeps the
         # same answer it does for every other service.
         server = self._hostname if self._hostname.endswith(".") else f"{self._hostname}."
+        # Publishing the host's addresses explicitly avoids relying
+        # on the receiver's A/AAAA lookup against ``server``, which
+        # on macOS can return loopback while mDNSResponder is in a
+        # transient state. See ``_local_addresses``.
         return ServiceInfo(
             SERVICE_TYPE,
             instance,
             port=self._port,
             properties=properties,
             server=server,
+            parsed_addresses=addresses,
         )
 
     async def register(self, zeroconf: AsyncZeroconf) -> None:
@@ -178,11 +278,20 @@ class DashboardAdvertiser:
         two dashboards on the same hostname (rare in practice, but
         the rename-on-conflict cost is one register call so the
         protection is essentially free).
+
+        Address enumeration runs in the default executor:
+        :func:`ifaddr.get_adapters` does blocking syscalls, which
+        would trip blockbuster on Linux and stall the loop in
+        production. The result is passed into
+        :meth:`build_service_info` so the rest of the construction
+        stays sync.
         """
         if self._info is not None:
             _LOGGER.debug("Dashboard advertise already registered; skipping")
             return
-        info = self.build_service_info()
+        loop = asyncio.get_running_loop()
+        addresses = await loop.run_in_executor(None, _local_addresses)
+        info = self.build_service_info(addresses)
         try:
             await zeroconf.async_register_service(info, allow_name_change=True)
         except Exception:

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -53,7 +53,7 @@ import ifaddr
 from zeroconf import ServiceInfo
 
 if TYPE_CHECKING:
-    from zeroconf.asyncio import AsyncZeroconf
+    from esphome.zeroconf import AsyncEsphomeZeroconf
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,10 +65,12 @@ def _default_friendly_name() -> str:
     Best-effort friendly label for the dashboard host.
 
     Uses the leftmost label of ``socket.gethostname()`` so a host
-    that returns ``desktop.local`` advertises as ``desktop`` (the
-    full FQDN goes in the ``hostname`` TXT field separately). Falls
-    back to ``"esphome-dashboard"`` when the system can't report
-    a hostname at all.
+    that returns ``desktop.local`` advertises as ``desktop`` (this
+    label is what becomes the mDNS service-instance name, i.e. the
+    bit before ``._esphomebuilder._tcp.local.``; the FQDN is
+    carried separately as the ``ServiceInfo.server`` SRV target).
+    Falls back to ``"esphome-dashboard"`` when the system can't
+    report a hostname at all.
     """
     raw = socket.gethostname() or ""
     label = raw.split(".", 1)[0].strip()
@@ -109,13 +111,17 @@ def _local_addresses() -> list[str]:
     * **Loopback IPs on non-loopback interfaces.** Defense in depth
       for hosts where the OS aliases ``127.0.0.1`` onto a real
       interface for some reason.
-    * **IPv6 link-local addresses** (``fe80::/10``). Useless once
-      the scope_id is dropped, which the mDNS wire format requires
-      — a peer receiving a bare ``fe80::xxx`` has no way to know
-      which interface to send the packet out on. Hosts with many
-      virtual interfaces (VPN, awdl, utun*) carry a dozen link-
-      local addresses that just inflate the announcement without
-      adding reachability.
+    * **Link-local addresses** — both IPv6 (``fe80::/10``) and
+      IPv4 (``169.254.0.0/16``). IPv6 link-local is useless once
+      the scope_id is dropped (which the mDNS wire format
+      requires) — a peer receiving a bare ``fe80::xxx`` has no way
+      to know which interface to send the packet out on. IPv4
+      link-local (APIPA) only appears when DHCP has failed; a
+      dashboard advertising itself on ``169.254.x.x`` would just
+      attract pairings that immediately break the next time DHCP
+      comes back. Hosts with many virtual interfaces (VPN, awdl,
+      utun*) can carry a dozen link-local addresses that just
+      inflate the announcement without adding reachability.
 
     Setting ``parsed_addresses`` explicitly is what fixes the
     "127.0.0.1 / ::1 / fe80::1 only" advertise we saw on macOS:
@@ -178,7 +184,7 @@ def _default_hostname() -> str:
 
 class DashboardAdvertiser:
     """
-    Publish the dashboard's ``_esphomedashboard._tcp.local.`` service.
+    Publish the dashboard's ``_esphomebuilder._tcp.local.`` service.
 
     Constructed once per :class:`DeviceBuilder` lifetime. The
     :meth:`register` / :meth:`unregister` pair runs from the
@@ -202,8 +208,12 @@ class DashboardAdvertiser:
         ``port`` is the dashboard's HTTP listen port — what a peer
         connects to once it's chosen this advertisement from a
         browse. ``name`` defaults to the system hostname's leftmost
-        label (used as both the friendly TXT field and the mDNS
-        instance name); ``hostname`` defaults to the FQDN.
+        label and is used as the mDNS service-instance name (the
+        bit before ``._esphomebuilder._tcp.local.``). ``hostname``
+        defaults to the system's mDNS hostname and lands in the SRV
+        record's target. Neither is duplicated in TXT — peers read
+        them off ``ServiceInfo.name`` / ``ServiceInfo.server`` for
+        free.
         """
         friendly = (name or "").strip() or _default_friendly_name()
         host = (hostname or "").strip() or _default_hostname()
@@ -213,7 +223,7 @@ class DashboardAdvertiser:
         self._server_version = server_version
         self._esphome_version = esphome_version
         self._info: ServiceInfo | None = None
-        self._zeroconf: AsyncZeroconf | None = None
+        self._zeroconf: AsyncEsphomeZeroconf | None = None
 
     @property
     def service_type(self) -> str:
@@ -255,8 +265,13 @@ class DashboardAdvertiser:
         # ``server`` is the SRV record's target. Zeroconf appends
         # ``.local.`` if missing; pass the FQDN through as-is so a
         # host already advertising e.g. ``desktop.local`` keeps the
-        # same answer it does for every other service.
-        server = self._hostname if self._hostname.endswith(".") else f"{self._hostname}."
+        # same answer it does for every other service. When
+        # ``_default_hostname`` returned ``""`` (rare — minimal
+        # containers / blank ``gethostname``), fall back to the
+        # friendly name + ``.local`` so the SRV target is a valid
+        # name rather than the bare ``.``.
+        host = self._hostname or f"{self._name}.local"
+        server = host if host.endswith(".") else f"{host}."
         # Publishing the host's addresses explicitly avoids relying
         # on the receiver's A/AAAA lookup against ``server``, which
         # on macOS can return loopback while mDNSResponder is in a
@@ -270,7 +285,7 @@ class DashboardAdvertiser:
             parsed_addresses=addresses,
         )
 
-    async def register(self, zeroconf: AsyncZeroconf) -> None:
+    async def register(self, zeroconf: AsyncEsphomeZeroconf) -> None:
         """
         Publish the service via *zeroconf*.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,17 +21,21 @@ import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from blockbuster import blockbuster_ctx
 from esphome.core import CORE
 
+from esphome_device_builder.controllers._device_mqtt_coordinator import (
+    DeviceMqttCoordinator,
+)
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.models import AdoptableDevice, Device, DeviceState, EventType
 
@@ -280,6 +284,64 @@ def make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MakeSettin
         return settings
 
     return _make
+
+
+# ---------------------------------------------------------------------------
+# Hermetic ``DeviceBuilder.start()`` — stubs network / subprocess surfaces
+# so any test that wants a fully-wired DeviceBuilder (lifecycle smoke,
+# mDNS-advertise wiring, command-registry walks) doesn't depend on a
+# real esphome install / ICMP / MQTT / multicast bind.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _hermetic_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the network / subprocess surfaces so ``DeviceBuilder.start()`` runs hermetically.
+
+    - ``_find_esphome_cmd`` returns a fake invocation so the resolver
+      doesn't depend on a real esphome install.
+    - ``_verify_esphome_importable`` short-circuits to ``(True, "")``
+      so the firmware controller's startup probe doesn't spawn a
+      15-second subprocess.
+    - ``DeviceStateMonitor.start/stop`` are AsyncMocks at the class
+      level so any instance constructed by ``DevicesController``
+      picks them up. ``_zeroconf`` stays at its ``None`` default,
+      which the dashboard-advertise wiring treats as "skip".
+    - ``DeviceMqttCoordinator.reconcile/stop`` are AsyncMocks for the
+      same reason — production opens a paho broker connection.
+    - ``BoardCatalog.load`` / ``ComponentCatalog.load`` are no-oped
+      because they do synchronous ``Path.glob`` walks of the
+      bundled definitions tree — under blockbuster (Linux CI) the
+      ``ScandirIterator`` calls fail event-loop checks. Wiring
+      (``BoardCatalog()`` construction + ``@api_command`` decorator
+      collection) still runs, so the tests still pin the
+      controller-attr and command-handler contract; the catalog's
+      *contents* are exercised in the catalog-specific tests.
+    - ``FirmwareController._load_jobs`` is AsyncMock'd so the
+      controller's startup doesn't try to read jobs from disk.
+    """
+    fake_cmd = ["python", "-m", "esphome"]
+    for module in (
+        "esphome_device_builder.controllers.firmware.controller",
+        "esphome_device_builder.controllers.editor",
+        "esphome_device_builder.controllers.devices.controller",
+    ):
+        monkeypatch.setattr(f"{module}._find_esphome_cmd", lambda: fake_cmd)
+    monkeypatch.setattr(FirmwareController, "_load_jobs", AsyncMock())
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.firmware.controller._verify_esphome_importable",
+        AsyncMock(return_value=(True, "")),
+    )
+    monkeypatch.setattr(DeviceStateMonitor, "start", AsyncMock())
+    monkeypatch.setattr(DeviceStateMonitor, "stop", AsyncMock())
+    monkeypatch.setattr(DeviceMqttCoordinator, "reconcile", AsyncMock())
+    monkeypatch.setattr(DeviceMqttCoordinator, "stop", AsyncMock())
+    monkeypatch.setattr(BoardCatalog, "load", lambda self: None)
+    monkeypatch.setattr(ComponentCatalog, "load", lambda self: None)
+    # ``CORE`` is a process-global; without restoration via
+    # monkeypatch a leaked ``config_path`` poisons sibling tests in
+    # the same xdist worker.
+    monkeypatch.setattr(CORE, "config_path", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -16,6 +16,7 @@ multicast listener; the integration test uses the same
 
 from __future__ import annotations
 
+import asyncio
 import socket
 from unittest.mock import AsyncMock, MagicMock
 
@@ -24,11 +25,13 @@ import pytest
 from esphome_device_builder import device_builder as db_module
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.device_builder import DeviceBuilder
+from esphome_device_builder.helpers import dashboard_advertise
 from esphome_device_builder.helpers.dashboard_advertise import (
     SERVICE_TYPE,
     DashboardAdvertiser,
     _default_friendly_name,
     _default_hostname,
+    _local_addresses,
 )
 
 
@@ -76,6 +79,14 @@ def test_default_hostname_keeps_dotted(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _default_hostname() == "desktop.lan"
 
 
+def test_default_hostname_returns_empty_when_gethostname_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blank ``gethostname`` (rare but seen on minimal containers) yields ``""``."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "")
+    assert _default_hostname() == ""
+
+
 def test_default_hostname_does_not_use_getfqdn(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     The default-hostname path must NOT route through ``socket.getfqdn``.
@@ -93,6 +104,109 @@ def test_default_hostname_does_not_use_getfqdn(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr(socket, "getfqdn", _boom)
     assert _default_hostname() == "host.local"
+
+
+# ---------------------------------------------------------------------------
+# _local_addresses — adapter enumeration / filtering
+# ---------------------------------------------------------------------------
+
+
+def _adapter(name: str, *, nice_name: str | None = None, ips: list[object]) -> object:
+    """Build a stand-in for an ``ifaddr.Adapter`` with the fields we read."""
+    ip_objs = [
+        type(
+            "IP",
+            (),
+            {
+                "ip": raw,
+                "network_prefix": 0,
+                "nice_name": "",
+                "is_IPv4": isinstance(raw, str),
+                "is_IPv6": isinstance(raw, tuple),
+            },
+        )()
+        for raw in ips
+    ]
+    return type(
+        "Adapter",
+        (),
+        {
+            "name": name,
+            "nice_name": nice_name or name,
+            "ips": ip_objs,
+            "index": 0,
+        },
+    )()
+
+
+def test_local_addresses_filters_loopback_interface(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole loopback interface is dropped, including its link-locals."""
+    adapters = [
+        _adapter(
+            "lo0",
+            ips=["127.0.0.1", ("::1", 0, 0), ("fe80::1", 0, 1)],
+        ),
+        _adapter("en0", ips=["192.168.1.10"]),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    assert _local_addresses() == ["192.168.1.10"]
+
+
+def test_local_addresses_filters_loopback_by_nice_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-``lo*`` adapter name still gets dropped if Windows-style 'Loopback'."""
+    adapters = [
+        _adapter(
+            "\\Device\\NPF_Loopback", nice_name="Loopback Pseudo-Interface", ips=["127.0.0.1"]
+        ),
+        _adapter("Ethernet", ips=["10.0.0.5"]),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    assert _local_addresses() == ["10.0.0.5"]
+
+
+def test_local_addresses_drops_link_local_ipv6(monkeypatch: pytest.MonkeyPatch) -> None:
+    """IPv6 link-local (``fe80::/10``) is dropped — wire can't carry scope_id."""
+    adapters = [
+        _adapter(
+            "en0",
+            ips=[
+                "192.168.1.10",
+                ("fe80::1234:5678:abcd:ef00", 0, 4),
+                ("2001:db8::1", 0, 0),
+                ("fdc8:d776:7cca:46ed::1", 0, 0),  # ULA — kept
+            ],
+        ),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    result = _local_addresses()
+    assert "192.168.1.10" in result
+    assert "2001:db8::1" in result
+    assert "fdc8:d776:7cca:46ed::1" in result
+    assert all("fe80" not in addr for addr in result)
+
+
+def test_local_addresses_drops_loopback_ip_on_real_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defense in depth: a 127.x address aliased onto a real interface is dropped."""
+    adapters = [
+        _adapter("en0", ips=["192.168.1.10", "127.0.0.1"]),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    assert _local_addresses() == ["192.168.1.10"]
+
+
+def test_local_addresses_skips_unparseable_strings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Garbage from a flaky adapter doesn't blow up the whole walk."""
+    adapters = [
+        _adapter("en0", ips=["192.168.1.10", "not-an-ip"]),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    assert _local_addresses() == ["192.168.1.10"]
+
+
+def test_local_addresses_returns_empty_when_no_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No adapters at all — return an empty list, not a crash."""
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: [])
+    assert _local_addresses() == []
 
 
 # ---------------------------------------------------------------------------
@@ -123,8 +237,14 @@ def test_build_service_info_populates_txt_and_server() -> None:
 def test_build_service_info_keeps_trailing_dot_on_explicit_fqdn() -> None:
     """An already-trailing-dot hostname round-trips unchanged."""
     advertiser = _make_advertiser(name="green", hostname="green.local.")
-    info = advertiser.build_service_info()
+    info = advertiser.build_service_info(addresses=[])
     assert info.server == "green.local."
+
+
+def test_service_type_property_is_canonical() -> None:
+    """The ``service_type`` accessor returns the module-level constant."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    assert advertiser.service_type == SERVICE_TYPE
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +260,8 @@ def _make_zeroconf_mock() -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_register_calls_async_register_service() -> None:
+async def test_register_calls_async_register_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dashboard_advertise, "_local_addresses", lambda: ["192.168.1.10"])
     advertiser = _make_advertiser(name="green", hostname="green.local")
     zc = _make_zeroconf_mock()
     await advertiser.register(zc)
@@ -151,6 +272,38 @@ async def test_register_calls_async_register_service() -> None:
     assert info.type == SERVICE_TYPE
     assert info.port == 6052
     assert kwargs.get("allow_name_change") is True
+    # Pin the executor-fetched addresses landed on the published info.
+    assert info.parsed_addresses() == ["192.168.1.10"]
+
+
+@pytest.mark.asyncio
+async def test_register_runs_address_enumeration_in_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``_local_addresses`` must run on a thread, not the event loop.
+
+    ``ifaddr.get_adapters`` does blocking I/O (``/proc/net`` on Linux,
+    Win32 calls on Windows). Calling it directly on the loop would
+    stall every concurrent request and trip blockbuster on Linux CI.
+    Verify by spying on the loop's ``run_in_executor`` to confirm
+    the helper is dispatched there.
+    """
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+
+    loop = asyncio.get_running_loop()
+    real_run_in_executor = loop.run_in_executor
+    captured: list[object] = []
+
+    def _spy(executor: object, func: object, *args: object) -> object:
+        captured.append(func)
+        return real_run_in_executor(executor, func, *args)
+
+    monkeypatch.setattr(loop, "run_in_executor", _spy)
+    await advertiser.register(zc)
+    # ``_local_addresses`` is the function we expect on the executor.
+    assert dashboard_advertise._local_addresses in captured
 
 
 @pytest.mark.asyncio

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -164,14 +164,22 @@ def test_local_addresses_filters_loopback_by_nice_name(monkeypatch: pytest.Monke
     assert _local_addresses() == ["10.0.0.5"]
 
 
-def test_local_addresses_drops_link_local_ipv6(monkeypatch: pytest.MonkeyPatch) -> None:
-    """IPv6 link-local (``fe80::/10``) is dropped — wire can't carry scope_id."""
+def test_local_addresses_drops_link_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Both IPv4 and IPv6 link-local addresses are dropped.
+
+    IPv6 ``fe80::/10`` is unreachable once the scope_id is stripped
+    by the wire format. IPv4 ``169.254.0.0/16`` (APIPA) only shows
+    up when DHCP has failed — advertising it just attracts pairings
+    that immediately break the next time DHCP comes back.
+    """
     adapters = [
         _adapter(
             "en0",
             ips=[
                 "192.168.1.10",
-                ("fe80::1234:5678:abcd:ef00", 0, 4),
+                "169.254.7.7",  # IPv4 APIPA — dropped
+                ("fe80::1234:5678:abcd:ef00", 0, 4),  # IPv6 link-local — dropped
                 ("2001:db8::1", 0, 0),
                 ("fdc8:d776:7cca:46ed::1", 0, 0),  # ULA — kept
             ],
@@ -182,6 +190,7 @@ def test_local_addresses_drops_link_local_ipv6(monkeypatch: pytest.MonkeyPatch) 
     assert "192.168.1.10" in result
     assert "2001:db8::1" in result
     assert "fdc8:d776:7cca:46ed::1" in result
+    assert "169.254.7.7" not in result
     assert all("fe80" not in addr for addr in result)
 
 
@@ -245,6 +254,28 @@ def test_service_type_property_is_canonical() -> None:
     """The ``service_type`` accessor returns the module-level constant."""
     advertiser = _make_advertiser(name="green", hostname="green.local")
     assert advertiser.service_type == SERVICE_TYPE
+
+
+def test_build_service_info_falls_back_when_hostname_is_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Blank hostname → SRV target derived from the friendly name.
+
+    When ``socket.gethostname`` is blank (minimal containers,
+    misconfigured systems), ``_default_hostname`` returns ``""``.
+    Without a fallback, ``build_service_info`` would set
+    ``server="."`` — an invalid SRV target that python-zeroconf
+    rejects at register time. Pin the recovery so the advertise
+    still produces a valid record on degraded hosts.
+    """
+    monkeypatch.setattr(socket, "gethostname", lambda: "")
+    # Both inherit the ``""`` from gethostname; ``_default_friendly_name``
+    # rescues with ``"esphome-dashboard"`` and we want SRV target to
+    # follow.
+    advertiser = DashboardAdvertiser(port=6052, server_version="1.0", esphome_version="2026.5.0")
+    info = advertiser.build_service_info(addresses=[])
+    assert info.server == "esphome-dashboard.local."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -108,11 +108,13 @@ def test_build_service_info_populates_txt_and_server() -> None:
     assert info.port == 6052
     # ServiceInfo encodes properties as bytes; decode to compare.
     decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    # TXT carries only the version fields that aren't already
+    # implied by the browse response. Friendly name and hostname
+    # come from ``info.name`` and ``info.server`` instead — pinned
+    # below so a future refactor doesn't quietly add them back.
     assert decoded == {
         "server_version": "1.2.3",
         "esphome_version": "2026.5.0",
-        "name": "green",
-        "hostname": "green.local",
     }
     # ``server`` is always trailing-dotted so zeroconf doesn't double-suffix it.
     assert info.server == "green.local."

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -213,6 +213,27 @@ def test_local_addresses_skips_unparseable_strings(monkeypatch: pytest.MonkeyPat
     assert _local_addresses() == ["192.168.1.10"]
 
 
+def test_local_addresses_deduplicates_repeated_ips(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    The same IP appearing on multiple adapters lands in the result once.
+
+    A duplicate would inflate the published A/AAAA list and worse,
+    if the duplicate flickered between two enumerations (one
+    interface up, the other down) the sorted set comparison in
+    ``refresh`` would see "different" and fire a spurious update.
+    Pin the dedup so refresh stays a true no-op when nothing
+    actually changed.
+    """
+    adapters = [
+        _adapter("en0", ips=["192.168.1.10"]),
+        _adapter("en1", ips=["192.168.1.10", "10.0.0.5"]),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    result = _local_addresses()
+    assert result == ["192.168.1.10", "10.0.0.5"]
+    assert len(result) == len(set(result))
+
+
 def test_local_addresses_returns_empty_when_no_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
     """No adapters at all — return an empty list, not a crash."""
     monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: [])
@@ -698,6 +719,11 @@ async def test_device_builder_constructs_advertiser_when_zeroconf_present(
     settings.on_ha_addon = False
     settings.port = 6052
     db = DeviceBuilder(settings)
+    # Seed ``adv`` to ``None`` so the ``finally`` block can guard
+    # against a failure in ``db.start()`` that would otherwise leave
+    # ``adv`` unbound and mask the real assertion error with an
+    # ``UnboundLocalError`` at teardown.
+    adv: object | None = None
     try:
         await db.start()
         assert len(instances) == 1
@@ -709,4 +735,5 @@ async def test_device_builder_constructs_advertiser_when_zeroconf_present(
         assert "esphome_version" in adv.kwargs  # type: ignore[attr-defined]
     finally:
         await db.stop()
-        adv.unregister.assert_awaited_once()  # type: ignore[attr-defined]
+        if adv is not None:
+            adv.unregister.assert_awaited_once()  # type: ignore[attr-defined]

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -1,0 +1,315 @@
+"""
+Tests for the dashboard's own ``_esphomebuilder._tcp.local.`` mDNS advertise.
+
+Covers the helper in isolation (TXT shape, default name / hostname
+derivation, idempotent register / unregister, fail-soft on zeroconf
+errors) plus the wiring through ``DeviceBuilder.start()`` /
+``stop()`` (advertise registers when zeroconf is up, skips when
+zeroconf is ``None``, unregisters before the responder is closed).
+
+The helper level uses an ``AsyncMock`` for ``async_register_service``
+/ ``async_unregister_service`` so we can assert call counts and
+inspect the ``ServiceInfo`` argument without standing up a real
+multicast listener; the integration test uses the same
+``_hermetic_lifecycle`` fixture as ``test_device_builder_lifecycle.py``.
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder import device_builder as db_module
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.device_builder import DeviceBuilder
+from esphome_device_builder.helpers.dashboard_advertise import (
+    SERVICE_TYPE,
+    DashboardAdvertiser,
+    _default_friendly_name,
+    _default_hostname,
+)
+
+
+def _make_advertiser(
+    *,
+    name: str | None = None,
+    hostname: str | None = None,
+    port: int = 6052,
+) -> DashboardAdvertiser:
+    return DashboardAdvertiser(
+        port=port,
+        server_version="1.2.3",
+        esphome_version="2026.5.0",
+        name=name,
+        hostname=hostname,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default-name helpers
+# ---------------------------------------------------------------------------
+
+
+def test_default_friendly_name_strips_dotted_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mac-style ``desktop.local`` from gethostname yields ``desktop``."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "desktop.local")
+    assert _default_friendly_name() == "desktop"
+
+
+def test_default_friendly_name_falls_back_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty/whitespace hostname falls back to a stable string."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "")
+    assert _default_friendly_name() == "esphome-dashboard"
+
+
+def test_default_hostname_appends_local_when_no_dot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare ``desktop`` becomes ``desktop.local`` for the TXT field."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "desktop")
+    assert _default_hostname() == "desktop.local"
+
+
+def test_default_hostname_keeps_dotted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hostname with a dot is trusted as already-FQDN-ish."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "desktop.lan")
+    assert _default_hostname() == "desktop.lan"
+
+
+def test_default_hostname_does_not_use_getfqdn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    The default-hostname path must NOT route through ``socket.getfqdn``.
+
+    On macOS that resolver can return the reverse-DNS arpa form (e.g.
+    a long ``...ip6.arpa`` string) when reverse lookup fails, which
+    would land in the published TXT record. Pin the implementation
+    so a future refactor doesn't reintroduce the call.
+    """
+    monkeypatch.setattr(socket, "gethostname", lambda: "host")
+
+    def _boom() -> str:
+        msg = "getfqdn must not be called in this code path"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(socket, "getfqdn", _boom)
+    assert _default_hostname() == "host.local"
+
+
+# ---------------------------------------------------------------------------
+# build_service_info
+# ---------------------------------------------------------------------------
+
+
+def test_build_service_info_populates_txt_and_server() -> None:
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    info = advertiser.build_service_info()
+    assert info.type == SERVICE_TYPE
+    assert info.name == f"green.{SERVICE_TYPE}"
+    assert info.port == 6052
+    # ServiceInfo encodes properties as bytes; decode to compare.
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert decoded == {
+        "server_version": "1.2.3",
+        "esphome_version": "2026.5.0",
+        "name": "green",
+        "hostname": "green.local",
+    }
+    # ``server`` is always trailing-dotted so zeroconf doesn't double-suffix it.
+    assert info.server == "green.local."
+
+
+def test_build_service_info_keeps_trailing_dot_on_explicit_fqdn() -> None:
+    """An already-trailing-dot hostname round-trips unchanged."""
+    advertiser = _make_advertiser(name="green", hostname="green.local.")
+    info = advertiser.build_service_info()
+    assert info.server == "green.local."
+
+
+# ---------------------------------------------------------------------------
+# register / unregister lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _make_zeroconf_mock() -> MagicMock:
+    zc = MagicMock()
+    zc.async_register_service = AsyncMock()
+    zc.async_unregister_service = AsyncMock()
+    return zc
+
+
+@pytest.mark.asyncio
+async def test_register_calls_async_register_service() -> None:
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    assert advertiser.registered is True
+    zc.async_register_service.assert_awaited_once()
+    args, kwargs = zc.async_register_service.call_args
+    info = args[0]
+    assert info.type == SERVICE_TYPE
+    assert info.port == 6052
+    assert kwargs.get("allow_name_change") is True
+
+
+@pytest.mark.asyncio
+async def test_register_is_idempotent() -> None:
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    await advertiser.register(zc)
+    # Second register is a no-op — exactly one call regardless.
+    zc.async_register_service.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_register_failure_clears_state() -> None:
+    """A zeroconf register-side error leaves the advertiser unregistered.
+
+    Subsequent ``unregister`` calls should be no-ops (no spurious
+    ``async_unregister_service`` against a never-registered info)
+    and the dashboard's shutdown path stays clean.
+    """
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    zc.async_register_service.side_effect = RuntimeError("zeroconf is sad")
+    await advertiser.register(zc)
+    assert advertiser.registered is False
+    await advertiser.unregister()
+    zc.async_unregister_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unregister_calls_async_unregister_service() -> None:
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    await advertiser.unregister()
+    assert advertiser.registered is False
+    zc.async_unregister_service.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unregister_without_register_is_noop() -> None:
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    await advertiser.unregister()
+    assert advertiser.registered is False
+
+
+@pytest.mark.asyncio
+async def test_unregister_swallows_zeroconf_errors() -> None:
+    """A teardown-time zeroconf failure must not surface to the caller."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    zc.async_unregister_service.side_effect = RuntimeError("socket already closed")
+    await advertiser.register(zc)
+    await advertiser.unregister()  # must not raise
+    assert advertiser.registered is False
+
+
+# ---------------------------------------------------------------------------
+# DeviceBuilder integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_device_builder_skips_advertise_when_zeroconf_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    make_settings,
+    _hermetic_lifecycle,
+) -> None:
+    """Zeroconf failed to bind → advertise is skipped, no construction.
+
+    The hermetic-lifecycle fixture stubs ``DeviceStateMonitor.start``
+    to a no-op, so ``_zeroconf`` stays ``None`` (matches the
+    production "port 5353 was held" failure mode). The advertise
+    branch must short-circuit cleanly without surfacing an error.
+    """
+    constructed: list[object] = []
+
+    class _FakeAdvertiser:
+        def __init__(self, **kwargs: object) -> None:
+            constructed.append(kwargs)
+            self.register = AsyncMock()
+            self.unregister = AsyncMock()
+
+    monkeypatch.setattr(db_module, "DashboardAdvertiser", _FakeAdvertiser)
+
+    db = DeviceBuilder(make_settings(with_core_path=True))
+    try:
+        await db.start()
+    finally:
+        await db.stop()
+
+    assert constructed == [], "advertise must skip when zeroconf is None"
+
+
+@pytest.mark.asyncio
+async def test_device_builder_skips_advertise_in_ha_addon_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    make_settings,
+    _hermetic_lifecycle,
+) -> None:
+    """``on_ha_addon=True`` → advertise is skipped even with zeroconf up.
+
+    Mocks the state monitor's ``zeroconf`` accessor to return a live
+    object so the only thing standing between ``start()`` and a
+    ``DashboardAdvertiser`` construction is the addon-mode guard.
+    """
+    constructed: list[object] = []
+
+    class _FakeAdvertiser:
+        def __init__(self, **kwargs: object) -> None:
+            constructed.append(kwargs)
+            self.register = AsyncMock()
+            self.unregister = AsyncMock()
+
+    monkeypatch.setattr(db_module, "DashboardAdvertiser", _FakeAdvertiser)
+    monkeypatch.setattr(DeviceStateMonitor, "zeroconf", property(lambda self: MagicMock()))
+
+    settings = make_settings(with_core_path=True)
+    settings.on_ha_addon = True
+    db = DeviceBuilder(settings)
+    try:
+        await db.start()
+    finally:
+        await db.stop()
+
+    assert constructed == [], "advertise must be skipped in HA addon mode"
+
+
+@pytest.mark.asyncio
+async def test_device_builder_constructs_advertiser_when_zeroconf_present(
+    monkeypatch: pytest.MonkeyPatch,
+    make_settings,
+    _hermetic_lifecycle,
+) -> None:
+    """Non-addon mode + zeroconf up → advertise is registered and unregistered."""
+    fake_zc = MagicMock()
+    instances: list[object] = []
+
+    class _FakeAdvertiser:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            self.register = AsyncMock()
+            self.unregister = AsyncMock()
+            instances.append(self)
+
+    monkeypatch.setattr(db_module, "DashboardAdvertiser", _FakeAdvertiser)
+    monkeypatch.setattr(DeviceStateMonitor, "zeroconf", property(lambda self: fake_zc))
+
+    settings = make_settings(with_core_path=True)
+    settings.on_ha_addon = False
+    settings.port = 6052
+    db = DeviceBuilder(settings)
+    try:
+        await db.start()
+        assert len(instances) == 1
+        adv = instances[0]
+        adv.register.assert_awaited_once_with(fake_zc)  # type: ignore[attr-defined]
+        # Constructor sees the configured port + the right version fields.
+        assert adv.kwargs["port"] == 6052  # type: ignore[attr-defined]
+        assert "server_version" in adv.kwargs  # type: ignore[attr-defined]
+        assert "esphome_version" in adv.kwargs  # type: ignore[attr-defined]
+    finally:
+        await db.stop()
+        adv.unregister.assert_awaited_once()  # type: ignore[attr-defined]

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -17,6 +17,7 @@ multicast listener; the integration test uses the same
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import socket
 from unittest.mock import AsyncMock, MagicMock
 
@@ -363,6 +364,137 @@ async def test_register_failure_clears_state() -> None:
     assert advertiser.registered is False
     await advertiser.unregister()
     zc.async_unregister_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_register_starts_refresh_loop_task() -> None:
+    """``register`` spawns a named background task that drives the refresh tick."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    task = advertiser._refresh_task
+    try:
+        assert task is not None
+        assert not task.done()
+        assert task.get_name() == "dashboard-advertise-refresh"
+    finally:
+        await advertiser.unregister()
+
+
+@pytest.mark.asyncio
+async def test_refresh_loop_invokes_refresh_on_each_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Refresh is invoked once per ``_REFRESH_INTERVAL_SECONDS`` tick.
+
+    The 5-minute sleep is patched to a tiny value so the test can
+    observe two ticks without sitting around for ten minutes.
+    """
+    monkeypatch.setattr(dashboard_advertise, "_REFRESH_INTERVAL_SECONDS", 0.01)
+    refresh_count = 0
+
+    async def _counted_refresh(self: object) -> bool:
+        nonlocal refresh_count
+        refresh_count += 1
+        return False
+
+    monkeypatch.setattr(DashboardAdvertiser, "refresh", _counted_refresh)
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    try:
+        # Two ticks of 0.01s each — yield until refresh has been
+        # called at least twice or 1s elapses (whichever first).
+        for _ in range(100):
+            if refresh_count >= 2:
+                break
+            await asyncio.sleep(0.02)
+        assert refresh_count >= 2
+    finally:
+        await advertiser.unregister()
+
+
+@pytest.mark.asyncio
+async def test_refresh_loop_survives_refresh_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient refresh failure must not kill the periodic loop."""
+    monkeypatch.setattr(dashboard_advertise, "_REFRESH_INTERVAL_SECONDS", 0.01)
+    calls = 0
+
+    async def _raising_refresh(self: object) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            msg = "transient zeroconf glitch"
+            raise RuntimeError(msg)
+        return False
+
+    monkeypatch.setattr(DashboardAdvertiser, "refresh", _raising_refresh)
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    try:
+        for _ in range(100):
+            if calls >= 2:
+                break
+            await asyncio.sleep(0.02)
+        # First tick raised, second tick still ran — loop is alive.
+        assert calls >= 2
+        assert advertiser._refresh_task is not None
+        assert not advertiser._refresh_task.done()
+    finally:
+        await advertiser.unregister()
+
+
+@pytest.mark.asyncio
+async def test_unregister_cancels_refresh_loop() -> None:
+    """``unregister`` drains the periodic-refresh task before tearing down."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    task = advertiser._refresh_task
+    assert task is not None
+    await advertiser.unregister()
+    assert task.done()
+    assert advertiser._refresh_task is None
+
+
+@pytest.mark.asyncio
+async def test_unregister_swallows_refresh_task_exception() -> None:
+    """
+    Drain a refresh task that ended in a non-``CancelledError`` exception.
+
+    A refresh-task that ended with a non-``CancelledError`` exception
+    is drained quietly so dashboard shutdown stays clean.
+
+    The production refresh loop catches its own exceptions, so this
+    branch only fires if something replaces the task with one that
+    doesn't — defense in depth, pinned with an explicit test.
+    """
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+
+    async def _failing() -> None:
+        msg = "task blew up"
+        raise RuntimeError(msg)
+
+    # Replace the running refresh task with one that ends in a
+    # non-CancelledError exception. Cancel the original first so it
+    # doesn't leak.
+    if advertiser._refresh_task is not None:
+        advertiser._refresh_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await advertiser._refresh_task
+    advertiser._refresh_task = asyncio.create_task(_failing())
+    # Give the failing task a tick to actually finish.
+    await asyncio.sleep(0)
+
+    # Must not raise.
+    await advertiser.unregister()
+    assert advertiser._refresh_task is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -287,6 +287,7 @@ def _make_zeroconf_mock() -> MagicMock:
     zc = MagicMock()
     zc.async_register_service = AsyncMock()
     zc.async_unregister_service = AsyncMock()
+    zc.async_update_service = AsyncMock()
     return zc
 
 
@@ -379,6 +380,84 @@ async def test_unregister_without_register_is_noop() -> None:
     advertiser = _make_advertiser(name="green", hostname="green.local")
     await advertiser.unregister()
     assert advertiser.registered is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_skips_when_addresses_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Calling ``refresh`` when ``_local_addresses`` hasn't changed is a no-op.
+
+    Avoids spamming the network with an announcement when the
+    interface set is stable. The contract is "only refresh if
+    something actually changed".
+    """
+    monkeypatch.setattr(dashboard_advertise, "_local_addresses", lambda: ["192.168.1.10"])
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    zc.async_update_service.reset_mock()
+
+    changed = await advertiser.refresh()
+
+    assert changed is False
+    zc.async_update_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_refresh_publishes_via_update_service_when_addresses_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Address-set change → ``async_update_service`` fires with the new info.
+
+    Uses the proper update API (not unregister + re-register) so peers
+    that have the existing record cached see a single record-change
+    rather than a removal followed by a re-add.
+    """
+    addresses = ["192.168.1.10"]
+    monkeypatch.setattr(dashboard_advertise, "_local_addresses", lambda: list(addresses))
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    zc.async_update_service.reset_mock()
+    zc.async_register_service.reset_mock()
+
+    # DHCP renewal flips the address.
+    addresses[:] = ["192.168.1.42", "fdc8::1"]
+    changed = await advertiser.refresh()
+
+    assert changed is True
+    zc.async_update_service.assert_awaited_once()
+    zc.async_register_service.assert_not_awaited()
+    new_info = zc.async_update_service.call_args.args[0]
+    assert sorted(new_info.parsed_addresses()) == sorted(["192.168.1.42", "fdc8::1"])
+
+
+@pytest.mark.asyncio
+async def test_refresh_is_noop_when_not_registered() -> None:
+    """``refresh()`` before ``register()`` is a no-op (no zeroconf to talk to)."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    assert await advertiser.refresh() is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_swallows_update_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A zeroconf update-side error doesn't surface to the caller."""
+    addresses = ["192.168.1.10"]
+    monkeypatch.setattr(dashboard_advertise, "_local_addresses", lambda: list(addresses))
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    zc.async_update_service.side_effect = RuntimeError("update failed")
+
+    addresses[:] = ["192.168.1.42"]
+    changed = await advertiser.refresh()
+
+    # Update fired, but the wrapper caught the error and returned False;
+    # the cached info stays at the pre-update value so a future retry
+    # still sees the change.
+    assert changed is False
+    zc.async_update_service.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_builder_lifecycle.py
+++ b/tests/test_device_builder_lifecycle.py
@@ -18,90 +18,12 @@ loads and the command-handler registration walk.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
 
 import pytest
-from esphome.core import CORE
 
-from esphome_device_builder.controllers._device_mqtt_coordinator import (
-    DeviceMqttCoordinator,
-)
-from esphome_device_builder.controllers._device_state_monitor import (
-    DeviceStateMonitor,
-)
-from esphome_device_builder.controllers.boards import BoardCatalog
-from esphome_device_builder.controllers.components import ComponentCatalog
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.device_builder import DeviceBuilder
 
 from .conftest import MakeSettingsFactory
-
-
-@pytest.fixture
-def _hermetic_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub the network / subprocess surfaces so the smoke test runs hermetically.
-
-    - ``_find_esphome_cmd`` returns a fake invocation so the resolver
-      doesn't depend on a real esphome install.
-    - ``_verify_esphome_importable`` short-circuits to ``(True, "")``
-      so the firmware controller's startup probe doesn't spawn a
-      15-second subprocess.
-    - ``DeviceStateMonitor.start/stop`` are AsyncMocks at the class
-      level so any instance constructed by ``DevicesController``
-      picks them up.
-    - ``DeviceMqttCoordinator.reconcile/stop`` are AsyncMocks for the
-      same reason — production opens a paho broker connection.
-    - ``BoardCatalog.load`` / ``ComponentCatalog.load`` are no-oped
-      because they do synchronous ``Path.glob`` walks of the
-      bundled definitions tree — under blockbuster (Linux CI) the
-      ``ScandirIterator`` calls fail event-loop checks. Wiring
-      (``BoardCatalog()`` construction + ``@api_command`` decorator
-      collection) still runs, so the tests still pin the
-      controller-attr and command-handler contract; the catalog's
-      *contents* are exercised in the catalog-specific tests.
-    """
-    fake_cmd = ["python", "-m", "esphome"]
-    for module in (
-        "esphome_device_builder.controllers.firmware.controller",
-        "esphome_device_builder.controllers.editor",
-        "esphome_device_builder.controllers.devices.controller",
-    ):
-        monkeypatch.setattr(f"{module}._find_esphome_cmd", lambda: fake_cmd)
-    monkeypatch.setattr(
-        FirmwareController,
-        "_load_jobs",
-        AsyncMock(),
-    )
-    # ``_verify_esphome_importable`` lives at module scope inside
-    # ``firmware.controller``; the firmware ``start()`` imports the
-    # name from there.
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.controller._verify_esphome_importable",
-        AsyncMock(return_value=(True, "")),
-    )
-
-    # Patch the methods on the *classes* so any instance constructed
-    # by ``start()`` picks them up — production ``DevicesController``
-    # instantiates the monitors in its ``__init__``.
-    monkeypatch.setattr(DeviceStateMonitor, "start", AsyncMock())
-    monkeypatch.setattr(DeviceStateMonitor, "stop", AsyncMock())
-    monkeypatch.setattr(DeviceMqttCoordinator, "reconcile", AsyncMock())
-    monkeypatch.setattr(DeviceMqttCoordinator, "stop", AsyncMock())
-
-    # Skip the disk walks. The catalog instances still get
-    # constructed (so ``boards`` / ``components`` controller attrs
-    # are populated) and their ``@api_command`` methods are still
-    # picked up by ``collect_api_commands``; the only thing we lose
-    # is the YAML/JSON loading work, which is covered separately.
-    monkeypatch.setattr(BoardCatalog, "load", lambda self: None)
-    monkeypatch.setattr(ComponentCatalog, "load", lambda self: None)
-
-    # ``CORE`` is a process-global; without restoration via
-    # monkeypatch a leaked ``config_path`` poisons sibling tests in
-    # the same xdist worker (e.g. anything that probes
-    # ``CORE.config_dir`` to discriminate "set up" from "fresh").
-    monkeypatch.setattr(CORE, "config_path", None)
-
 
 # ---------------------------------------------------------------------------
 # Pre-start state


### PR DESCRIPTION
# What does this implement/fix?

Phase 1 of the remote-build offload feature in #106. Every dashboard now publishes itself on mDNS as `_esphomebuilder._tcp.local.` (RFC 6335 §5.1 caps service-type labels at 15 chars; `esphomedashboard` is 16, `esphomebuilder` is 14 and parallels the existing `_esphomelib._tcp.local.` device service type — issue body updated to capture the rename + reason). Peers that browse this type can list every other dashboard reachable on the LAN, and the future ESPHome Desktop welcome screen can pre-select a discovered server.

The TXT record carries only `server_version` and `esphome_version` — the friendly label and FQDN are already on the wire (service-instance name + SRV target), no need to duplicate them.

The advertise reuses the `AsyncEsphomeZeroconf` instance owned by `DeviceStateMonitor` so the dashboard ships one mDNS responder per process; new `zeroconf` accessors on `DeviceStateMonitor` and `DevicesController` surface it without reaching into private state. Skipped in two cases:

- **Zeroconf failed to bind** — matches the device-discovery fail-soft contract.
- **HA addon mode** — port 6052 isn't LAN-exposed by default and the announcement would carry the container's docker IP, so a peer that found the listing couldn't connect anyway.

Addresses are explicitly published via `parsed_addresses`. Letting zeroconf fall back to the receiver's A/AAAA lookup against the SRV target turned out to be flaky on macOS — when `mDNSResponder` is in a transient state, `host.local` can resolve to loopback only. We enumerate local interfaces via `ifaddr.get_adapters` (run in the default executor — it does blocking I/O), filter out the whole loopback interface plus IPv6 link-local addresses (the wire can't carry the scope_id), and pass the rest in. Mirrors Home Assistant's pattern in `homeassistant/components/zeroconf`.

The `_hermetic_lifecycle` fixture moves from `test_device_builder_lifecycle.py` to `tests/conftest.py` so the new `test_dashboard_advertise.py` integration tests can share it without reaching into a sibling test module.

**Related issue or feature (if applicable):**

- Phase 1 of #106

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Frontend coordination

- [x] No frontend change needed

Future phases of #106 will need a settings page (paired hosts, tokens) on the frontend; phase 1 is backend-only.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. *(Deferred to phase 2 — the architecture doc gets a remote-build section once the API surface lands.)*

## Test plan

- [x] `pytest tests/test_dashboard_advertise.py tests/test_device_builder_lifecycle.py` — 32 passed
- [x] `pytest --cov=esphome_device_builder.helpers.dashboard_advertise` — 100% on the new helper
- [x] Pre-commit ruff lint + format clean on all touched files
- [x] Manual: `dns-sd -B _esphomebuilder._tcp` on macOS shows the advertisement with `server_version` / `esphome_version` TXT and the host's LAN IPs in A / AAAA (no loopback).
- [ ] Manual: `avahi-browse -r _esphomebuilder._tcp` on Linux
- [ ] Manual: confirm HA-addon-mode skip via `--ha-addon` CLI flag

## Out of scope (future phases per #106)

- Phase 2: `remote_build/list_hosts` browse + frontend stub
- Phase 3+: token CRUD, pairing, bundle upload, version-mismatch warning UI
