### PR TITLE
Add remote-build peer discovery + settings scaffolding (#106 phase 2)

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -27,7 +27,7 @@ from ..constants import __version__ as server_version
 from ..helpers.api import CommandError, api_command
 from ..helpers.auth import hash_password
 from ..helpers.json import JSONDecodeError, dumps_indent, loads
-from ..models import ErrorCode, Label, UserPreferences
+from ..models import ErrorCode, Label, RemoteBuildSettings, UserPreferences
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
@@ -38,6 +38,7 @@ _DASHBOARD_SENTINEL_FILE = "___DASHBOARD_SENTINEL___.yaml"
 _METADATA_FILE = ".device-builder.json"
 _PREFS_KEY = "_preferences"
 _LABELS_KEY = "_labels"
+_REMOTE_BUILD_KEY = "_remote_build"
 
 
 # ---------------------------------------------------------------------------
@@ -504,6 +505,29 @@ def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
     """Save user preferences to disk."""
     with metadata_transaction(config_dir) as data:
         data[_PREFS_KEY] = prefs.to_dict()
+
+
+def load_remote_build_settings(config_dir: Path) -> RemoteBuildSettings:
+    """
+    Load the receiver-side remote-build settings.
+
+    Returns defaults (``enabled=False``) when the metadata file is
+    missing or the ``_remote_build`` key isn't present. A
+    deserialisation failure also falls back to defaults rather than
+    crashing dashboard startup — a corrupted settings blob shouldn't
+    take down the whole receiver.
+    """
+    raw = _load_metadata(config_dir).get(_REMOTE_BUILD_KEY, {})
+    try:
+        return RemoteBuildSettings.from_dict(raw)
+    except Exception:
+        return RemoteBuildSettings()
+
+
+def save_remote_build_settings(config_dir: Path, settings: RemoteBuildSettings) -> None:
+    """Persist the receiver-side remote-build settings."""
+    with metadata_transaction(config_dir) as data:
+        data[_REMOTE_BUILD_KEY] = settings.to_dict()
 
 
 def _decode_labels(raw: Any) -> list[Label]:

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1,0 +1,236 @@
+"""
+Remote-build feature — peer dashboard discovery + settings.
+
+Phase 2 of issue #106. Browses ``_esphomebuilder._tcp.local.`` to
+list other dashboards reachable on the LAN, and persists the
+receiver-side ``enabled`` master switch the rest of the feature
+will gate behind in phase 3.
+
+Phase 2 stops at discovery + settings storage:
+
+* No HTTP / WS endpoints under ``/remote-build/v1/*`` yet (phase 3
+  lands the auth middleware + cert).
+* No pairing or peer-link WS yet (phase 4 / phase 5).
+* The ``enabled`` setting is persisted but not wired to any
+  endpoint registration — flipping it currently has no observable
+  effect beyond round-tripping in the settings UI. That's
+  deliberate scaffolding so phase 3+ have a place to plug in.
+
+Browser uses the existing ``AsyncEsphomeZeroconf`` instance owned by
+:class:`~esphome_device_builder.controllers._device_state_monitor.DeviceStateMonitor`
+— the dashboard ships one mDNS responder per process, and this
+controller adds a second :class:`~zeroconf.asyncio.AsyncServiceBrowser`
+on the same instance for the new service type. The state monitor's
+own browsers (``_esphomelib._tcp.local.`` for devices,
+``_http._tcp.local.`` for adoptable web UIs) are unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from zeroconf import ServiceStateChange
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
+
+from ..helpers.api import api_command
+from ..helpers.dashboard_advertise import SERVICE_TYPE
+from ..models import RemoteBuildPeer, RemoteBuildSettings
+from .config import load_remote_build_settings, save_remote_build_settings
+
+if TYPE_CHECKING:
+    from ..device_builder import DeviceBuilder
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _decode_txt_value(raw: bytes | None) -> str:
+    """Decode a TXT value as UTF-8, falling back to the empty string."""
+    if not raw:
+        return ""
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return ""
+
+
+def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPeer:
+    """
+    Build a :class:`RemoteBuildPeer` from a resolved ``AsyncServiceInfo``.
+
+    Keeps the parsing in one place so ``_apply_service_info`` and
+    the cache-hit branch produce identical shapes.
+    """
+    properties = info.properties or {}
+    server_version = _decode_txt_value(properties.get(b"server_version"))
+    esphome_version = _decode_txt_value(properties.get(b"esphome_version"))
+    # ``info.name`` comes back as ``<instance>.<service_type>``; we
+    # only want the leftmost label as the friendly name.
+    instance = (info.name or name).split(".", 1)[0]
+    server = info.server or ""
+    return RemoteBuildPeer(
+        name=instance,
+        hostname=server,
+        port=info.port or 0,
+        addresses=info.parsed_addresses() or [],
+        server_version=server_version,
+        esphome_version=esphome_version,
+    )
+
+
+class RemoteBuildController:
+    """
+    Discover peer dashboards and own the receiver-side settings.
+
+    Constructed once in :meth:`DeviceBuilder.start`. The browser
+    lifetime is tied to :meth:`start` / :meth:`stop`; the controller's
+    own start happens after :class:`DevicesController.start` so the
+    shared zeroconf instance is already up.
+    """
+
+    def __init__(self, device_builder: DeviceBuilder) -> None:
+        self._db = device_builder
+        self._browser: AsyncServiceBrowser | None = None
+        self._peers: dict[str, RemoteBuildPeer] = {}
+        # Strong refs for fire-and-forget resolve tasks so the
+        # garbage collector can't reap them mid-await.
+        self._tasks: set[asyncio.Task[None]] = set()
+        # The mDNS service-instance name our own ``DashboardAdvertiser``
+        # publishes — captured at start so we can filter our own
+        # broadcast out of the discovered list. ``None`` when the
+        # advertiser was skipped (HA addon mode, zeroconf failed) —
+        # in that case there's nothing to filter.
+        self._own_instance_name: str | None = None
+
+    async def start(self) -> None:
+        """
+        Wire the browser onto the shared zeroconf and capture self-name.
+
+        No-op when zeroconf failed to start — peer discovery is a
+        nice-to-have, not load-bearing, and the controller stays in
+        a "no peers, never will be" state until the next dashboard
+        restart. Same fail-soft contract as
+        :class:`DashboardAdvertiser`.
+        """
+        if self._db.devices is None:
+            _LOGGER.debug("RemoteBuildController.start called before devices controller")
+            return
+        zeroconf = self._db.devices.zeroconf
+        if zeroconf is None:
+            _LOGGER.debug("zeroconf unavailable — remote-build discovery disabled")
+            return
+        # Capture own service-instance name so our own advertise
+        # doesn't show up in ``list_hosts``.
+        advertiser = self._db._dashboard_advertiser
+        if advertiser is not None and advertiser.registered:
+            info = advertiser._info
+            if info is not None:
+                self._own_instance_name = info.name
+        self._browser = AsyncServiceBrowser(
+            zeroconf.zeroconf,
+            [SERVICE_TYPE],
+            handlers=[self._on_service_state_change],
+        )
+
+    async def stop(self) -> None:
+        """Cancel the browser and drain in-flight resolve tasks."""
+        if self._browser is not None:
+            try:
+                await self._browser.async_cancel()
+            except Exception:
+                _LOGGER.debug("remote-build browser cancel failed", exc_info=True)
+            self._browser = None
+        for task in self._tasks:
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+            self._tasks.clear()
+        self._peers.clear()
+
+    # ------------------------------------------------------------------
+    # mDNS plumbing
+    # ------------------------------------------------------------------
+
+    def _on_service_state_change(
+        self,
+        zeroconf: Any,
+        service_type: str,
+        name: str,
+        state_change: ServiceStateChange,
+    ) -> None:
+        """
+        Browser callback — resolve the service info and update the peer map.
+
+        Filters our own service-instance name so the advertise we
+        publish doesn't show up in ``list_hosts``. ``Removed`` events
+        delete the peer immediately; ``Added`` / ``Updated`` resolve
+        either from the zeroconf cache (sync) or via a fire-and-forget
+        task (async).
+        """
+        if name == self._own_instance_name:
+            return
+        if state_change == ServiceStateChange.Removed:
+            self._peers.pop(name, None)
+            return
+        info = AsyncServiceInfo(service_type, name)
+        if info.load_from_cache(zeroconf):
+            self._peers[name] = _peer_from_service_info(name, info)
+            return
+        task = asyncio.create_task(self._resolve_and_apply(zeroconf, info, name))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _resolve_and_apply(self, zeroconf: Any, info: AsyncServiceInfo, name: str) -> None:
+        """Async resolve path for cache misses."""
+        try:
+            resolved = await info.async_request(zeroconf, timeout=3000)
+        except Exception:
+            _LOGGER.debug("Resolve failed for %s", name, exc_info=True)
+            return
+        if not resolved:
+            return
+        self._peers[name] = _peer_from_service_info(name, info)
+
+    # ------------------------------------------------------------------
+    # API surface
+    # ------------------------------------------------------------------
+
+    @api_command("remote_build/list_hosts")
+    async def list_hosts(self, **kwargs: Any) -> list[RemoteBuildPeer]:
+        """
+        Return every peer dashboard discovered on the LAN.
+
+        Snapshot of the browser's state — fresh for every call, no
+        caching. Empty when the browser hasn't seen any peers yet
+        (or when zeroconf failed to start). Phase 3+ will add
+        paired-or-not state to each row; phase 2 just returns the
+        raw discovery.
+        """
+        return list(self._peers.values())
+
+    @api_command("remote_build/get_settings")
+    async def get_settings(self, **kwargs: Any) -> RemoteBuildSettings:
+        """Return the receiver-side remote-build settings."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, load_remote_build_settings, self._db.settings.config_dir
+        )
+
+    @api_command("remote_build/set_settings")
+    async def set_settings(self, *, enabled: bool, **kwargs: Any) -> RemoteBuildSettings:
+        """
+        Persist the receiver-side remote-build settings.
+
+        Currently only ``enabled`` is settable; future phases add
+        knobs from the "Remote builder settings" section of the
+        design (artifact retention TTL, build target preference,
+        major-version-mismatch toggle, ...). Returns the
+        post-write value so the frontend can confirm the round-trip.
+        """
+        settings = RemoteBuildSettings(enabled=bool(enabled))
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, save_remote_build_settings, self._db.settings.config_dir, settings
+        )
+        return settings

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -31,7 +31,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
-from zeroconf import ServiceStateChange
+from zeroconf import IPVersion, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
 from ..helpers.api import CommandError, api_command
@@ -71,6 +71,14 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
 
     Keeps the parsing in one place so ``_apply_service_info`` and
     the cache-hit branch produce identical shapes.
+
+    Uses ``parsed_scoped_addresses(IPVersion.All)`` rather than
+    ``parsed_addresses()`` so IPv6 link-local entries keep their
+    ``%<interface>`` scope suffix. Without the scope, an
+    ``fe80::xxx`` address parses but isn't connectable — the OS
+    needs to know which interface to send the packet out on.
+    Mirrors the choice already made in
+    :class:`DeviceStateMonitor` (line 901).
     """
     properties = info.properties or {}
     server_version = _decode_txt_value(properties.get(b"server_version"))
@@ -83,7 +91,7 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
         name=instance,
         hostname=server,
         port=info.port or 0,
-        addresses=info.parsed_addresses() or [],
+        addresses=info.parsed_scoped_addresses(IPVersion.All) or [],
         server_version=server_version,
         esphome_version=esphome_version,
     )
@@ -131,12 +139,14 @@ class RemoteBuildController:
             _LOGGER.debug("zeroconf unavailable — remote-build discovery disabled")
             return
         # Capture own service-instance name so our own advertise
-        # doesn't show up in ``list_hosts``.
+        # doesn't show up in ``list_hosts``. Reads through the
+        # public ``service_instance_name`` accessor on
+        # ``DashboardAdvertiser`` rather than reaching into
+        # ``_info`` — keeps this controller decoupled from the
+        # advertiser's private layout.
         advertiser = self._db._dashboard_advertiser
-        if advertiser is not None and advertiser.registered:
-            info = advertiser._info
-            if info is not None:
-                self._own_instance_name = info.name
+        if advertiser is not None:
+            self._own_instance_name = advertiser.service_instance_name
         # Wrap browser construction so a zeroconf-side failure (e.g.
         # the underlying socket got torn down between
         # ``DeviceStateMonitor.start`` and now, or the cache is in an

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -34,15 +34,25 @@ from typing import TYPE_CHECKING, Any
 from zeroconf import ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
-from ..helpers.api import api_command
+from ..helpers.api import CommandError, api_command
 from ..helpers.dashboard_advertise import SERVICE_TYPE
-from ..models import RemoteBuildPeer, RemoteBuildSettings
+from ..models import ErrorCode, RemoteBuildPeer, RemoteBuildSettings
 from .config import load_remote_build_settings, save_remote_build_settings
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
 
 _LOGGER = logging.getLogger(__name__)
+
+# Timeout for the cache-miss resolve path. Longer than
+# ``DeviceStateMonitor._MDNS_RESOLVE_TIMEOUT_MS`` (2s) because peer
+# dashboards typically run on full hosts (laptop, desktop, addon
+# container) that may be a few hops further away on the LAN than
+# an ESPHome device, and the user-visible cost of a slow first
+# discovery is "the peer doesn't appear in Settings for a few
+# seconds" — not the device-state miss the shorter timeout
+# protects against.
+_RESOLVE_TIMEOUT_MS = 3000
 
 
 def _decode_txt_value(raw: bytes | None) -> str:
@@ -127,11 +137,20 @@ class RemoteBuildController:
             info = advertiser._info
             if info is not None:
                 self._own_instance_name = info.name
-        self._browser = AsyncServiceBrowser(
-            zeroconf.zeroconf,
-            [SERVICE_TYPE],
-            handlers=[self._on_service_state_change],
-        )
+        # Wrap browser construction so a zeroconf-side failure (e.g.
+        # the underlying socket got torn down between
+        # ``DeviceStateMonitor.start`` and now, or the cache is in an
+        # unexpected state) doesn't abort dashboard startup. Peer
+        # discovery is fail-soft — same contract as the advertise.
+        try:
+            self._browser = AsyncServiceBrowser(
+                zeroconf.zeroconf,
+                [SERVICE_TYPE],
+                handlers=[self._on_service_state_change],
+            )
+        except Exception:
+            _LOGGER.exception("Could not start remote-build browser — peer discovery disabled")
+            self._browser = None
 
     async def stop(self) -> None:
         """Cancel the browser and drain in-flight resolve tasks."""
@@ -184,7 +203,7 @@ class RemoteBuildController:
     async def _resolve_and_apply(self, zeroconf: Any, info: AsyncServiceInfo, name: str) -> None:
         """Async resolve path for cache misses."""
         try:
-            resolved = await info.async_request(zeroconf, timeout=3000)
+            resolved = await info.async_request(zeroconf, timeout=_RESOLVE_TIMEOUT_MS)
         except Exception:
             _LOGGER.debug("Resolve failed for %s", name, exc_info=True)
             return
@@ -227,8 +246,17 @@ class RemoteBuildController:
         design (artifact retention TTL, build target preference,
         major-version-mismatch toggle, ...). Returns the
         post-write value so the frontend can confirm the round-trip.
+
+        Validates ``enabled`` is strictly a ``bool`` rather than
+        coercing truthiness — a client sending the string ``"false"``
+        for example would otherwise persist as ``True``, which is
+        the opposite of what the user intended on a security-
+        sensitive toggle.
         """
-        settings = RemoteBuildSettings(enabled=bool(enabled))
+        if not isinstance(enabled, bool):
+            msg = "remote_build/set_settings: 'enabled' must be a boolean"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+        settings = RemoteBuildSettings(enabled=enabled)
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
             None, save_remote_build_settings, self._db.settings.config_dir, settings

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -32,6 +32,7 @@ from .controllers.devices import DevicesController
 from .controllers.editor import EditorController
 from .controllers.firmware import FirmwareController
 from .controllers.labels import LabelsController
+from .controllers.remote_build import RemoteBuildController
 from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.auth import auth_middleware
 from .helpers.dashboard_advertise import DashboardAdvertiser
@@ -200,6 +201,7 @@ class DeviceBuilder:
         self.firmware: FirmwareController | None = None
         self.editor: EditorController | None = None
         self.labels: LabelsController | None = None
+        self.remote_build: RemoteBuildController | None = None
 
         # mDNS advertise — populated in start() once we know zeroconf
         # is up. Optional: a zeroconf-bind failure leaves this None
@@ -258,6 +260,7 @@ class DeviceBuilder:
         self.firmware = FirmwareController(self)
         self.editor = EditorController(self)
         self.labels = LabelsController(self)
+        self.remote_build = RemoteBuildController(self)
         await self.devices.start()
         await self.firmware.start()
         await self.editor.start()
@@ -293,6 +296,16 @@ class DeviceBuilder:
             )
             await self._dashboard_advertiser.register(zeroconf)
 
+        # Phase 2 of the remote-build feature (issue #106): browse
+        # the same service type to surface peer dashboards.
+        # ``RemoteBuildController.start`` is itself a no-op when
+        # zeroconf is unavailable — same fail-soft contract as the
+        # advertise — so we don't gate it here. Started AFTER the
+        # advertiser so the browser can capture our own
+        # service-instance name and filter our broadcast out of the
+        # discovered list.
+        await self.remote_build.start()
+
         # Collect command handlers from all controllers
         for controller in (
             self.auth,
@@ -304,6 +317,7 @@ class DeviceBuilder:
             self.firmware,
             self.editor,
             self.labels,
+            self.remote_build,
         ):
             self.command_handlers.update(collect_api_commands(controller))
 
@@ -333,6 +347,11 @@ class DeviceBuilder:
             task.cancel()
         if self._background_tasks:
             await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        # Cancel the remote-build browser BEFORE devices.stop()
+        # closes the zeroconf socket the browser is using. Same
+        # ordering rule as the dashboard advertise just below.
+        if self.remote_build is not None:
+            await self.remote_build.stop()
         # Withdraw the mDNS advertise BEFORE devices.stop() closes
         # the zeroconf socket the responder is using.
         if self._dashboard_advertiser is not None:

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -261,6 +261,24 @@ class DashboardAdvertiser:
         """True between a successful :meth:`register` and :meth:`unregister`."""
         return self._info is not None
 
+    @property
+    def service_instance_name(self) -> str | None:
+        """
+        The published mDNS service-instance name, or ``None``.
+
+        Returns the fully-qualified instance name as zeroconf
+        registered it (e.g. ``MacBook-Pro._esphomebuilder._tcp.local.``,
+        or ``MacBook-Pro-2._esphomebuilder._tcp.local.`` after a
+        ``allow_name_change`` collision rename). ``None`` when the
+        advertiser hasn't registered yet — same shape callers
+        already use to gate other operations on ``registered``.
+
+        Public surface so peer-discovery code can filter our own
+        broadcast out of its discovered list without reaching into
+        the private :attr:`_info`.
+        """
+        return self._info.name if self._info is not None else None
+
     def build_service_info(self, addresses: list[str] | None = None) -> ServiceInfo:
         """
         Construct the ``ServiceInfo`` that will be published on register.

--- a/esphome_device_builder/models/__init__.py
+++ b/esphome_device_builder/models/__init__.py
@@ -8,3 +8,4 @@ from .devices import *  # noqa: F403
 from .firmware import *  # noqa: F403
 from .labels import *  # noqa: F403
 from .preferences import *  # noqa: F403
+from .remote_build import *  # noqa: F403

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1,0 +1,44 @@
+"""Remote-build feature models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+
+@dataclass
+class RemoteBuildSettings(DataClassORJSONMixin):
+    """
+    Receiver-side settings for the remote-build feature.
+
+    Stored in ``.device-builder.json`` under the ``_remote_build``
+    top-level key. ``enabled`` is the master switch — phase 3 will
+    gate ``/remote-build/v1/*`` route registration on it; phase 2
+    just persists the flag so the Settings UI has somewhere to
+    write.
+    """
+
+    enabled: bool = False
+
+
+@dataclass
+class RemoteBuildPeer(DataClassORJSONMixin):
+    """
+    A peer dashboard discovered via mDNS browse of ``_esphomebuilder._tcp.local.``.
+
+    Wire shape returned from ``remote_build/list_hosts``. ``name`` is
+    the mDNS service-instance name (the leftmost label, e.g.
+    ``desktop``); ``hostname`` is the SRV target (e.g. ``desktop.local.``).
+    Versions come from the TXT record. ``addresses`` is the parsed
+    A / AAAA list — what an offloader would actually connect to.
+    Phase 2 stops at discovery; pairing / connection / fingerprint
+    pinning lands in later phases.
+    """
+
+    name: str
+    hostname: str
+    port: int
+    addresses: list[str] = field(default_factory=list)
+    server_version: str = ""
+    esphome_version: str = ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.models import AdoptableDevice, Device, DeviceState, EventType
 
@@ -336,6 +337,13 @@ def _hermetic_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(DeviceStateMonitor, "stop", AsyncMock())
     monkeypatch.setattr(DeviceMqttCoordinator, "reconcile", AsyncMock())
     monkeypatch.setattr(DeviceMqttCoordinator, "stop", AsyncMock())
+    # Phase 2 of the remote-build feature wires a second mDNS browser
+    # behind ``RemoteBuildController.start``. The lifecycle tests use
+    # the same "stub start/stop on the class" trick to keep the
+    # smoke test hermetic — the per-controller test file
+    # ``test_remote_build_controller.py`` exercises the real browser.
+    monkeypatch.setattr(RemoteBuildController, "start", AsyncMock())
+    monkeypatch.setattr(RemoteBuildController, "stop", AsyncMock())
     monkeypatch.setattr(BoardCatalog, "load", lambda self: None)
     monkeypatch.setattr(ComponentCatalog, "load", lambda self: None)
     # ``CORE`` is a process-global; without restoration via

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -46,15 +46,17 @@ from esphome_device_builder.controllers.config import (
     labels_transaction,
     load_labels,
     load_preferences,
+    load_remote_build_settings,
     metadata_transaction,
     remove_device_metadata,
     save_labels,
     save_preferences,
+    save_remote_build_settings,
     set_device_labels,
     set_device_metadata,
 )
 from esphome_device_builder.helpers.api import CommandError
-from esphome_device_builder.models import ErrorCode, Label
+from esphome_device_builder.models import ErrorCode, Label, RemoteBuildSettings
 from esphome_device_builder.models.preferences import (
     DashboardView,
     Theme,
@@ -383,6 +385,39 @@ def test_load_preferences_returns_defaults_on_bad_data(tmp_path: Path) -> None:
     metadata_path.write_bytes(b'{"_preferences": {"unknown_field": 42}}')
 
     assert load_preferences(tmp_path) == UserPreferences()
+
+
+def test_load_remote_build_settings_returns_defaults_on_missing(tmp_path: Path) -> None:
+    """Fresh config dir → ``RemoteBuildSettings()`` with ``enabled=False``."""
+    assert load_remote_build_settings(tmp_path) == RemoteBuildSettings()
+
+
+def test_load_remote_build_settings_returns_defaults_on_bad_data(
+    tmp_path: Path,
+) -> None:
+    """Corrupted ``_remote_build`` blob → default object, not partial recovery.
+
+    Same fallback semantics as ``load_preferences``: an older
+    version's payload that doesn't deserialise under the current
+    mashumaro schema lands on defaults rather than crashing
+    dashboard startup. Pinning ``RemoteBuildSettings()`` keeps
+    the recovery shape stable so a future regression that
+    silently mutates the fallback would surface here.
+    """
+    # Use a payload mashumaro can't coerce — a list where a dict
+    # was expected. (A bare ``"not-a-bool"`` for ``enabled`` would
+    # silently coerce to truthy, masking the fallback path.)
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(b'{"_remote_build": [1, 2, 3]}')
+
+    assert load_remote_build_settings(tmp_path) == RemoteBuildSettings()
+
+
+def test_save_remote_build_settings_round_trip(tmp_path: Path) -> None:
+    """A non-default settings blob round-trips through save → load."""
+    settings = RemoteBuildSettings(enabled=True)
+    save_remote_build_settings(tmp_path, settings)
+    assert load_remote_build_settings(tmp_path) == settings
 
 
 def test_save_preferences_round_trip(tmp_path: Path) -> None:

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -648,6 +648,7 @@ async def test_device_builder_skips_advertise_when_zeroconf_unavailable(
         def __init__(self, **kwargs: object) -> None:
             constructed.append(kwargs)
             self.register = AsyncMock()
+            self.registered = False
             self.unregister = AsyncMock()
 
     monkeypatch.setattr(db_module, "DashboardAdvertiser", _FakeAdvertiser)
@@ -679,6 +680,7 @@ async def test_device_builder_skips_advertise_in_ha_addon_mode(
         def __init__(self, **kwargs: object) -> None:
             constructed.append(kwargs)
             self.register = AsyncMock()
+            self.registered = False
             self.unregister = AsyncMock()
 
     monkeypatch.setattr(db_module, "DashboardAdvertiser", _FakeAdvertiser)
@@ -709,6 +711,7 @@ async def test_device_builder_constructs_advertiser_when_zeroconf_present(
         def __init__(self, **kwargs: object) -> None:
             self.kwargs = kwargs
             self.register = AsyncMock()
+            self.registered = False
             self.unregister = AsyncMock()
             instances.append(self)
 

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -278,6 +278,35 @@ def test_service_type_property_is_canonical() -> None:
     assert advertiser.service_type == SERVICE_TYPE
 
 
+def test_service_instance_name_returns_none_before_register() -> None:
+    """``service_instance_name`` is ``None`` until ``register()`` succeeds."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    assert advertiser.service_instance_name is None
+
+
+@pytest.mark.asyncio
+async def test_service_instance_name_returns_published_name_after_register(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Post-``register``, the accessor returns what zeroconf published.
+
+    Public surface so peer-discovery code (the
+    ``RemoteBuildController`` browser) can filter our own
+    broadcast out of its discovered list without reaching into
+    the private ``_info`` attribute.
+    """
+    monkeypatch.setattr(dashboard_advertise, "_local_addresses", lambda: ["192.168.1.10"])
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    try:
+        assert advertiser.service_instance_name == f"green.{SERVICE_TYPE}"
+    finally:
+        await advertiser.unregister()
+    assert advertiser.service_instance_name is None
+
+
 def test_build_service_info_falls_back_when_hostname_is_blank(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -46,7 +46,7 @@ def _fake_service_info(
     info.name = f"{name}.{SERVICE_TYPE}"
     info.server = server
     info.port = port
-    info.parsed_addresses = MagicMock(return_value=list(addresses or []))
+    info.parsed_scoped_addresses = MagicMock(return_value=list(addresses or []))
     info.properties = {
         b"server_version": server_version.encode("utf-8"),
         b"esphome_version": esphome_version.encode("utf-8"),
@@ -106,6 +106,22 @@ def test_peer_from_service_info_carries_all_addresses() -> None:
     info = _fake_service_info(addresses=["192.168.1.10", "fdc8::1"])
     peer = _peer_from_service_info(f"desktop.{SERVICE_TYPE}", info)
     assert peer.addresses == ["192.168.1.10", "fdc8::1"]
+
+
+def test_peer_from_service_info_preserves_ipv6_scope() -> None:
+    """
+    IPv6 link-local addresses keep their ``%<interface>`` scope.
+
+    ``parsed_addresses()`` strips the scope suffix; without it
+    ``fe80::xxx`` parses but isn't connectable — the OS doesn't
+    know which interface to send the packet out on. This test
+    pins the choice of ``parsed_scoped_addresses(IPVersion.All)``
+    so a future refactor can't quietly switch back.
+    """
+    info = _fake_service_info(addresses=["fe80::1%en0", "192.168.1.10"])
+    peer = _peer_from_service_info(f"desktop.{SERVICE_TYPE}", info)
+    assert "fe80::1%en0" in peer.addresses
+    assert "192.168.1.10" in peer.addresses
 
 
 def test_peer_from_service_info_handles_missing_txt_keys() -> None:
@@ -278,7 +294,8 @@ async def test_start_captures_own_instance_name(monkeypatch: pytest.MonkeyPatch)
     A registered advertiser's instance name lands in ``_own_instance_name``.
 
     The browser would otherwise pick up our own broadcast and list
-    ourselves as a peer — pin the self-filter wiring.
+    ourselves as a peer — pin the self-filter wiring through the
+    public ``service_instance_name`` accessor.
     """
     fake_browser = MagicMock()
     fake_browser.async_cancel = AsyncMock()
@@ -288,11 +305,8 @@ async def test_start_captures_own_instance_name(monkeypatch: pytest.MonkeyPatch)
     )
     controller = _make_controller()
     controller._db.devices.zeroconf = MagicMock()
-    own_info = MagicMock()
-    own_info.name = f"self.{SERVICE_TYPE}"
     advertiser = MagicMock()
-    advertiser.registered = True
-    advertiser._info = own_info
+    advertiser.service_instance_name = f"self.{SERVICE_TYPE}"
     controller._db._dashboard_advertiser = advertiser
 
     await controller.start()
@@ -315,7 +329,10 @@ async def test_start_skips_self_capture_when_advertiser_unregistered(
     controller = _make_controller()
     controller._db.devices.zeroconf = MagicMock()
     advertiser = MagicMock()
-    advertiser.registered = False
+    # ``service_instance_name`` returns ``None`` when the
+    # advertiser isn't registered (skipped in HA addon mode or
+    # zeroconf failed to bind).
+    advertiser.service_instance_name = None
     controller._db._dashboard_advertiser = advertiser
 
     await controller.start()

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1,0 +1,394 @@
+"""
+Tests for the phase-2 remote-build controller.
+
+Covers the helper that turns ``AsyncServiceInfo`` into
+``RemoteBuildPeer`` plus the WS commands (``list_hosts`` /
+``get_settings`` / ``set_settings``). The browser plumbing itself
+(``_on_service_state_change``, the resolve task) is exercised by
+fabricating ``ServiceStateChange`` events and ``AsyncServiceInfo``
+objects directly — no real multicast listener.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from zeroconf import ServiceStateChange
+
+from esphome_device_builder.controllers.remote_build import (
+    RemoteBuildController,
+    _decode_txt_value,
+    _peer_from_service_info,
+)
+from esphome_device_builder.helpers.dashboard_advertise import SERVICE_TYPE
+from esphome_device_builder.models import RemoteBuildPeer, RemoteBuildSettings
+
+# ---------------------------------------------------------------------------
+# Helpers used by the tests
+# ---------------------------------------------------------------------------
+
+
+def _fake_service_info(
+    *,
+    name: str = "desktop",
+    server: str = "desktop.local.",
+    port: int = 6052,
+    addresses: list[str] | None = None,
+    server_version: str = "1.2.3",
+    esphome_version: str = "2026.5.0",
+) -> MagicMock:
+    """Build a stand-in for ``AsyncServiceInfo`` carrying the fields we read."""
+    info = MagicMock()
+    info.name = f"{name}.{SERVICE_TYPE}"
+    info.server = server
+    info.port = port
+    info.parsed_addresses = MagicMock(return_value=list(addresses or []))
+    info.properties = {
+        b"server_version": server_version.encode("utf-8"),
+        b"esphome_version": esphome_version.encode("utf-8"),
+    }
+    return info
+
+
+def _make_controller(*, config_dir: Any = None) -> RemoteBuildController:
+    db = MagicMock()
+    db.devices = MagicMock()
+    db.devices.zeroconf = None
+    db._dashboard_advertiser = None
+    db.settings = MagicMock()
+    db.settings.config_dir = config_dir
+    return RemoteBuildController(db)
+
+
+# ---------------------------------------------------------------------------
+# _decode_txt_value
+# ---------------------------------------------------------------------------
+
+
+def test_decode_txt_value_handles_none() -> None:
+    assert _decode_txt_value(None) == ""
+
+
+def test_decode_txt_value_handles_empty_bytes() -> None:
+    assert _decode_txt_value(b"") == ""
+
+
+def test_decode_txt_value_decodes_utf8() -> None:
+    assert _decode_txt_value(b"2026.5.0") == "2026.5.0"
+
+
+def test_decode_txt_value_falls_back_on_invalid_utf8() -> None:
+    """A non-utf8 TXT value yields ``""`` instead of raising."""
+    assert _decode_txt_value(b"\xff\xff") == ""
+
+
+# ---------------------------------------------------------------------------
+# _peer_from_service_info
+# ---------------------------------------------------------------------------
+
+
+def test_peer_from_service_info_extracts_instance_label() -> None:
+    """The peer's ``name`` is the leftmost label of the service-instance name."""
+    info = _fake_service_info(name="desktop")
+    peer = _peer_from_service_info(f"desktop.{SERVICE_TYPE}", info)
+    assert peer.name == "desktop"
+    assert peer.hostname == "desktop.local."
+    assert peer.port == 6052
+    assert peer.server_version == "1.2.3"
+    assert peer.esphome_version == "2026.5.0"
+
+
+def test_peer_from_service_info_carries_all_addresses() -> None:
+    info = _fake_service_info(addresses=["192.168.1.10", "fdc8::1"])
+    peer = _peer_from_service_info(f"desktop.{SERVICE_TYPE}", info)
+    assert peer.addresses == ["192.168.1.10", "fdc8::1"]
+
+
+def test_peer_from_service_info_handles_missing_txt_keys() -> None:
+    """A peer that didn't broadcast version TXT yields empty version strings."""
+    info = _fake_service_info()
+    info.properties = {}
+    peer = _peer_from_service_info(f"desktop.{SERVICE_TYPE}", info)
+    assert peer.server_version == ""
+    assert peer.esphome_version == ""
+
+
+# ---------------------------------------------------------------------------
+# Browser callback semantics
+# ---------------------------------------------------------------------------
+
+
+def test_on_service_state_change_filters_own_advertise() -> None:
+    """Our own service-instance name never lands in ``_peers``."""
+    controller = _make_controller()
+    controller._own_instance_name = f"self.{SERVICE_TYPE}"
+    zeroconf = MagicMock()
+    controller._on_service_state_change(
+        zeroconf, SERVICE_TYPE, f"self.{SERVICE_TYPE}", ServiceStateChange.Added
+    )
+    assert controller._peers == {}
+
+
+def test_on_service_state_change_removed_drops_peer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``Removed`` event clears the peer entry immediately."""
+    controller = _make_controller()
+    controller._peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
+        name="desktop", hostname="desktop.local.", port=6052
+    )
+    controller._on_service_state_change(
+        MagicMock(), SERVICE_TYPE, f"desktop.{SERVICE_TYPE}", ServiceStateChange.Removed
+    )
+    assert controller._peers == {}
+
+
+def test_on_service_state_change_uses_cache_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cache-hit resolves the peer synchronously without spawning a task."""
+    controller = _make_controller()
+    fake_info = _fake_service_info(name="desktop")
+    fake_info.load_from_cache = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.AsyncServiceInfo",
+        MagicMock(return_value=fake_info),
+    )
+    zeroconf = MagicMock()
+    controller._on_service_state_change(
+        zeroconf, SERVICE_TYPE, f"desktop.{SERVICE_TYPE}", ServiceStateChange.Added
+    )
+    assert f"desktop.{SERVICE_TYPE}" in controller._peers
+    assert controller._peers[f"desktop.{SERVICE_TYPE}"].name == "desktop"
+    # No async resolve task was spawned.
+    assert controller._tasks == set()
+
+
+# ---------------------------------------------------------------------------
+# WS commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_hosts_returns_snapshot_of_peers() -> None:
+    controller = _make_controller()
+    controller._peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
+        name="desktop", hostname="desktop.local.", port=6052
+    )
+    controller._peers[f"laptop.{SERVICE_TYPE}"] = RemoteBuildPeer(
+        name="laptop", hostname="laptop.local.", port=6052
+    )
+    result = await controller.list_hosts()
+    assert {peer.name for peer in result} == {"desktop", "laptop"}
+
+
+@pytest.mark.asyncio
+async def test_list_hosts_empty_when_no_peers() -> None:
+    controller = _make_controller()
+    assert await controller.list_hosts() == []
+
+
+@pytest.mark.asyncio
+async def test_get_settings_defaults_when_unset(tmp_path: Any) -> None:
+    """A fresh dashboard with no metadata returns ``enabled=False``."""
+    controller = _make_controller(config_dir=tmp_path)
+    settings = await controller.get_settings()
+    assert settings == RemoteBuildSettings(enabled=False)
+
+
+@pytest.mark.asyncio
+async def test_set_settings_round_trips(tmp_path: Any) -> None:
+    """Setting ``enabled=True`` persists and is read back by ``get_settings``."""
+    controller = _make_controller(config_dir=tmp_path)
+    written = await controller.set_settings(enabled=True)
+    assert written == RemoteBuildSettings(enabled=True)
+    read = await controller.get_settings()
+    assert read == RemoteBuildSettings(enabled=True)
+
+
+@pytest.mark.asyncio
+async def test_set_settings_coerces_truthy_values(tmp_path: Any) -> None:
+    """Anything truthy is normalised to ``True`` (mirrors ``bool(enabled)``)."""
+    controller = _make_controller(config_dir=tmp_path)
+    written = await controller.set_settings(enabled=1)  # type: ignore[arg-type]
+    assert written.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle no-op paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_skips_when_devices_controller_missing() -> None:
+    """``start`` is a no-op when ``DevicesController`` hasn't been set."""
+    db = MagicMock()
+    db.devices = None
+    controller = RemoteBuildController(db)
+    await controller.start()
+    assert controller._browser is None
+
+
+@pytest.mark.asyncio
+async def test_start_skips_when_zeroconf_unavailable() -> None:
+    """``start`` is a no-op when zeroconf failed to bind."""
+    controller = _make_controller()
+    controller._db.devices.zeroconf = None
+    await controller.start()
+    assert controller._browser is None
+
+
+@pytest.mark.asyncio
+async def test_start_captures_own_instance_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A registered advertiser's instance name lands in ``_own_instance_name``.
+
+    The browser would otherwise pick up our own broadcast and list
+    ourselves as a peer — pin the self-filter wiring.
+    """
+    fake_browser = MagicMock()
+    fake_browser.async_cancel = AsyncMock()
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        MagicMock(return_value=fake_browser),
+    )
+    controller = _make_controller()
+    controller._db.devices.zeroconf = MagicMock()
+    own_info = MagicMock()
+    own_info.name = f"self.{SERVICE_TYPE}"
+    advertiser = MagicMock()
+    advertiser.registered = True
+    advertiser._info = own_info
+    controller._db._dashboard_advertiser = advertiser
+
+    await controller.start()
+    assert controller._own_instance_name == f"self.{SERVICE_TYPE}"
+    assert controller._browser is fake_browser
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_skips_self_capture_when_advertiser_unregistered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unregistered advertiser (HA addon mode etc.) leaves the filter empty."""
+    fake_browser = MagicMock()
+    fake_browser.async_cancel = AsyncMock()
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        MagicMock(return_value=fake_browser),
+    )
+    controller = _make_controller()
+    controller._db.devices.zeroconf = MagicMock()
+    advertiser = MagicMock()
+    advertiser.registered = False
+    controller._db._dashboard_advertiser = advertiser
+
+    await controller.start()
+    assert controller._own_instance_name is None
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_skips_self_capture_when_no_advertiser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An entirely-absent advertiser (zeroconf-down branch) is fine."""
+    fake_browser = MagicMock()
+    fake_browser.async_cancel = AsyncMock()
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        MagicMock(return_value=fake_browser),
+    )
+    controller = _make_controller()
+    controller._db.devices.zeroconf = MagicMock()
+    controller._db._dashboard_advertiser = None
+
+    await controller.start()
+    assert controller._own_instance_name is None
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_swallows_browser_cancel_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A teardown-time browser-cancel failure is logged but not raised."""
+    fake_browser = MagicMock()
+    fake_browser.async_cancel = AsyncMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        MagicMock(return_value=fake_browser),
+    )
+    controller = _make_controller()
+    controller._db.devices.zeroconf = MagicMock()
+    await controller.start()
+    await controller.stop()  # must not raise
+    assert controller._browser is None
+
+
+@pytest.mark.asyncio
+async def test_on_service_state_change_spawns_resolve_task_on_cache_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cache-miss queues the async resolve task and tracks it in ``_tasks``."""
+    controller = _make_controller()
+    fake_info = _fake_service_info(name="desktop")
+    fake_info.load_from_cache = MagicMock(return_value=False)
+    fake_info.async_request = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.AsyncServiceInfo",
+        MagicMock(return_value=fake_info),
+    )
+    zeroconf = MagicMock()
+    controller._on_service_state_change(
+        zeroconf, SERVICE_TYPE, f"desktop.{SERVICE_TYPE}", ServiceStateChange.Added
+    )
+    # Drain the resolve task and verify the peer landed.
+    pending = list(controller._tasks)
+    assert len(pending) == 1
+    await asyncio.gather(*pending)
+    assert f"desktop.{SERVICE_TYPE}" in controller._peers
+    assert controller._tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_apply_swallows_errors() -> None:
+    """A resolve-side exception leaves the peer map untouched."""
+    controller = _make_controller()
+    fake_info = _fake_service_info(name="desktop")
+    fake_info.async_request = AsyncMock(side_effect=RuntimeError("network down"))
+    await controller._resolve_and_apply(MagicMock(), fake_info, f"desktop.{SERVICE_TYPE}")
+    assert controller._peers == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_apply_skips_when_resolution_returns_false() -> None:
+    """An ``async_request`` that returns ``False`` (timeout) doesn't add a peer."""
+    controller = _make_controller()
+    fake_info = _fake_service_info(name="desktop")
+    fake_info.async_request = AsyncMock(return_value=False)
+    await controller._resolve_and_apply(MagicMock(), fake_info, f"desktop.{SERVICE_TYPE}")
+    assert controller._peers == {}
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_resolve_tasks() -> None:
+    """In-flight resolve tasks are cancelled and the set is cleared."""
+    controller = _make_controller()
+    started = asyncio.Event()
+
+    async def _slow() -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(_slow())
+    controller._tasks.add(task)
+    # Yield so the task body actually begins; otherwise ``cancel``
+    # fires against a never-started task and the test isn't
+    # exercising the drain.
+    await started.wait()
+    await controller.stop()
+    assert task.done()
+    assert controller._tasks == set()

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -23,8 +23,9 @@ from esphome_device_builder.controllers.remote_build import (
     _decode_txt_value,
     _peer_from_service_info,
 )
+from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.dashboard_advertise import SERVICE_TYPE
-from esphome_device_builder.models import RemoteBuildPeer, RemoteBuildSettings
+from esphome_device_builder.models import ErrorCode, RemoteBuildPeer, RemoteBuildSettings
 
 # ---------------------------------------------------------------------------
 # Helpers used by the tests
@@ -208,11 +209,22 @@ async def test_set_settings_round_trips(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_settings_coerces_truthy_values(tmp_path: Any) -> None:
-    """Anything truthy is normalised to ``True`` (mirrors ``bool(enabled)``)."""
+async def test_set_settings_rejects_non_bool(tmp_path: Any) -> None:
+    """
+    Non-boolean ``enabled`` raises ``INVALID_ARGS``, doesn't coerce.
+
+    A client sending the string ``"false"`` would coerce to truthy
+    under a permissive ``bool()`` cast and silently flip the
+    security-sensitive toggle on. Strict ``isinstance`` check
+    closes that gap.
+    """
     controller = _make_controller(config_dir=tmp_path)
-    written = await controller.set_settings(enabled=1)  # type: ignore[arg-type]
-    assert written.enabled is True
+    with pytest.raises(CommandError) as exc:
+        await controller.set_settings(enabled="false")  # type: ignore[arg-type]
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+    # No write happened — disk still at default.
+    settings = await controller.get_settings()
+    assert settings.enabled is False
 
 
 # ---------------------------------------------------------------------------
@@ -236,6 +248,27 @@ async def test_start_skips_when_zeroconf_unavailable() -> None:
     controller = _make_controller()
     controller._db.devices.zeroconf = None
     await controller.start()
+    assert controller._browser is None
+
+
+@pytest.mark.asyncio
+async def test_start_swallows_browser_construction_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Browser construction failure leaves the controller in a no-peer state.
+
+    Peer discovery is fail-soft — same contract as the advertise.
+    A zeroconf-side error during ``AsyncServiceBrowser`` init must
+    not crash dashboard startup.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        MagicMock(side_effect=RuntimeError("zeroconf socket gone")),
+    )
+    controller = _make_controller()
+    controller._db.devices.zeroconf = MagicMock()
+    await controller.start()  # must not raise
     assert controller._browser is None
 
 


### PR DESCRIPTION
# What does this implement/fix?

Phase 2 of the remote-build offload feature in #106. Backend wiring for peer dashboard discovery + the receiver-side `enabled` master switch, scaffolded so phase 3+ have an API surface and Settings home to plug into.

**Discovery**

- New `RemoteBuildController` browses `_esphomebuilder._tcp.local.` on the same `AsyncEsphomeZeroconf` instance the state monitor already owns (one mDNS responder per process).
- Captures our own service-instance name from the running `DashboardAdvertiser` and filters it out of the discovered list — dashboard doesn't appear as a peer to itself.
- Cache-hit resolution is sync; cache-miss spawns a fire-and-forget resolve task tracked in a set so the GC can't reap it mid-await.
- Same fail-soft contract as phase 1: zeroconf failed to bind → controller no-ops cleanly until the next dashboard restart.

**Settings**

- New `_remote_build` top-level key in the metadata sidecar holding a single `enabled` boolean (off by default). Persistent across restarts via the same `metadata_transaction` plumbing `_preferences` / `_labels` use.
- `RemoteBuildSettings` dataclass mirrors the storage shape; a deserialisation failure falls back to defaults rather than crashing dashboard startup.
- Phase 2 only **persists** the flag. Phase 3 wires the auth middleware + cert + route registration to it. Flipping it now is a no-op the frontend Settings UI can write to without observable side effects — that's the deliberate scaffolding.

**WS commands**

- `remote_build/list_hosts` — snapshot of discovered peers as `RemoteBuildPeer` rows (name, hostname, port, addresses, version fields from TXT).
- `remote_build/get_settings` / `remote_build/set_settings` — read / write the `enabled` flag.

**Related issue or feature (if applicable):**

- Phase 2 of #106

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

Companion frontend PR adds the empty-state Settings → Remote builder section + the master toggle: esphome/device-builder-frontend#234. The discovered-peers list there only needs `remote_build/list_hosts` once it lands; settings round-trip through the two new commands.

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#234

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
