### PR TITLE
Add manual host entry for cross-subnet peers (#106 phase 2b)

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -530,6 +530,37 @@ def save_remote_build_settings(config_dir: Path, settings: RemoteBuildSettings) 
         data[_REMOTE_BUILD_KEY] = settings.to_dict()
 
 
+@contextmanager
+def remote_build_settings_transaction(
+    config_dir: Path,
+) -> Iterator[RemoteBuildSettings]:
+    """
+    Atomic read-modify-write context for the remote-build settings.
+
+    Yields the current :class:`RemoteBuildSettings` (defaults if
+    missing or corrupt). Mutate it in place; on a clean exit the
+    changes are persisted under the same ``metadata_transaction``
+    lock, so the whole RMW is atomic against concurrent
+    transactions. Exceptions raised inside the block discard the
+    pending mutation.
+
+    Use this whenever an operation "depends on the current state
+    to compute the next state" — add / remove a manual host, flip
+    ``enabled`` while preserving the rest. A bare ``load + save``
+    pair is racy because two concurrent callers can both read the
+    same starting value and the second save wipes the first's
+    change.
+    """
+    with metadata_transaction(config_dir) as data:
+        raw = data.get(_REMOTE_BUILD_KEY, {})
+        try:
+            settings = RemoteBuildSettings.from_dict(raw)
+        except Exception:
+            settings = RemoteBuildSettings()
+        yield settings
+        data[_REMOTE_BUILD_KEY] = settings.to_dict()
+
+
 def _decode_labels(raw: Any) -> list[Label]:
     """Parse the on-disk ``_labels`` list, dropping malformed entries."""
     if not isinstance(raw, list):

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -545,7 +545,7 @@ def remote_build_settings_transaction(
     pending mutation.
 
     Use this whenever an operation "depends on the current state
-    to compute the next state" — add / remove a manual host, flip
+    to compute the next state": add / remove a manual host, flip
     ``enabled`` while preserving the rest. A bare ``load + save``
     pair is racy because two concurrent callers can both read the
     same starting value and the second save wipes the first's

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1,5 +1,5 @@
 """
-Remote-build feature — peer dashboard discovery + settings.
+Remote-build feature; peer dashboard discovery + settings.
 
 Phase 2 / 2b of issue #106. Browses ``_esphomebuilder._tcp.local.``
 to list other dashboards reachable on the LAN; persists the
@@ -14,16 +14,16 @@ Phase 2 / 2b stops at discovery + settings storage:
   lands the auth middleware + cert).
 * No pairing or peer-link WS yet (phase 4 / phase 5).
 * The ``enabled`` setting is persisted but not wired to any
-  endpoint registration — flipping it currently has no observable
+  endpoint registration; flipping it currently has no observable
   effect beyond round-tripping in the settings UI. That's
   deliberate scaffolding so phase 3+ have a place to plug in.
-* Manual hosts have no version / fingerprint resolution — they
+* Manual hosts have no version / fingerprint resolution; they
   land in ``list_hosts`` with empty ``server_version`` /
   ``esphome_version`` until phase 4 attempts the connection.
 
 Browser uses the existing ``AsyncEsphomeZeroconf`` instance owned by
-:class:`~esphome_device_builder.controllers._device_state_monitor.DeviceStateMonitor`
-— the dashboard ships one mDNS responder per process, and this
+:class:`~esphome_device_builder.controllers._device_state_monitor.DeviceStateMonitor`,
+so the dashboard ships one mDNS responder per process and this
 controller adds a second :class:`~zeroconf.asyncio.AsyncServiceBrowser`
 on the same instance for the new service type. The state monitor's
 own browsers (``_esphomelib._tcp.local.`` for devices,
@@ -62,7 +62,7 @@ _LOGGER = logging.getLogger(__name__)
 # container) that may be a few hops further away on the LAN than
 # an ESPHome device, and the user-visible cost of a slow first
 # discovery is "the peer doesn't appear in Settings for a few
-# seconds" — not the device-state miss the shorter timeout
+# seconds"; not the device-state miss the shorter timeout
 # protects against.
 _RESOLVE_TIMEOUT_MS = 3000
 
@@ -87,7 +87,7 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
     Uses ``parsed_scoped_addresses(IPVersion.All)`` rather than
     ``parsed_addresses()`` so IPv6 link-local entries keep their
     ``%<interface>`` scope suffix. Without the scope, an
-    ``fe80::xxx`` address parses but isn't connectable — the OS
+    ``fe80::xxx`` address parses but isn't connectable; the OS
     needs to know which interface to send the packet out on.
     Mirrors the choice already made in
     :class:`DeviceStateMonitor` (line 901).
@@ -114,7 +114,7 @@ def _peer_from_manual_host(entry: ManualHost) -> RemoteBuildPeer:
     """
     Build a :class:`RemoteBuildPeer` from a stored :class:`ManualHost`.
 
-    Manual hosts skip resolution — phase 2b just surfaces the
+    Manual hosts skip resolution; phase 2b just surfaces the
     user-entered ``(hostname, port)`` so the frontend can render
     the row alongside mDNS-discovered ones. Phase 4 attempts the
     actual connection and fills the version fields.
@@ -138,7 +138,7 @@ def _validate_hostname(raw: object) -> str:
 
     Rejects non-string and empty / whitespace-only input with
     :class:`CommandError(INVALID_ARGS)`. Lowercase normalisation
-    matches the duplicate-check semantics — hostnames are
+    matches the duplicate-check semantics; hostnames are
     case-insensitive per RFC 1035 §2.3.3, so ``Desktop.local`` and
     ``desktop.local`` should be the same entry. Phase 4 attempts
     the actual connection (and discovers DNS / TLS validity); phase
@@ -161,7 +161,7 @@ def _validate_port(raw: object) -> int:
     Validate a user-entered port number.
 
     ``bool`` is rejected even though ``isinstance(True, int)`` is
-    true — accepting ``True`` for a port number is a footgun
+    true; accepting ``True`` for a port number is a footgun
     (silently coerces to 1, which IANA reserves for tcpmux).
     Range is the IANA-registered ephemeral plus
     well-known: 1-65535.
@@ -193,17 +193,17 @@ class RemoteBuildController:
         # garbage collector can't reap them mid-await.
         self._tasks: set[asyncio.Task[None]] = set()
         # The mDNS service-instance name our own ``DashboardAdvertiser``
-        # publishes — captured at start so we can filter our own
+        # publishes; captured at start so we can filter our own
         # broadcast out of the discovered list. ``None`` when the
-        # advertiser was skipped (HA addon mode, zeroconf failed) —
-        # in that case there's nothing to filter.
+        # advertiser was skipped (HA addon mode, zeroconf failed),
+        # in which case there's nothing to filter.
         self._own_instance_name: str | None = None
 
     async def start(self) -> None:
         """
         Wire the browser onto the shared zeroconf and capture self-name.
 
-        No-op when zeroconf failed to start — peer discovery is a
+        No-op when zeroconf failed to start; peer discovery is a
         nice-to-have, not load-bearing, and the controller stays in
         a "no peers, never will be" state until the next dashboard
         restart. Same fail-soft contract as
@@ -214,13 +214,13 @@ class RemoteBuildController:
             return
         zeroconf = self._db.devices.zeroconf
         if zeroconf is None:
-            _LOGGER.debug("zeroconf unavailable — remote-build discovery disabled")
+            _LOGGER.debug("zeroconf unavailable; remote-build discovery disabled")
             return
         # Capture own service-instance name so our own advertise
         # doesn't show up in ``list_hosts``. Reads through the
         # public ``service_instance_name`` accessor on
         # ``DashboardAdvertiser`` rather than reaching into
-        # ``_info`` — keeps this controller decoupled from the
+        # ``_info``; keeps this controller decoupled from the
         # advertiser's private layout.
         advertiser = self._db._dashboard_advertiser
         if advertiser is not None:
@@ -229,7 +229,7 @@ class RemoteBuildController:
         # the underlying socket got torn down between
         # ``DeviceStateMonitor.start`` and now, or the cache is in an
         # unexpected state) doesn't abort dashboard startup. Peer
-        # discovery is fail-soft — same contract as the advertise.
+        # discovery is fail-soft; same contract as the advertise.
         try:
             self._browser = AsyncServiceBrowser(
                 zeroconf.zeroconf,
@@ -237,7 +237,7 @@ class RemoteBuildController:
                 handlers=[self._on_service_state_change],
             )
         except Exception:
-            _LOGGER.exception("Could not start remote-build browser — peer discovery disabled")
+            _LOGGER.exception("Could not start remote-build browser; peer discovery disabled")
             self._browser = None
 
     async def stop(self) -> None:
@@ -267,7 +267,7 @@ class RemoteBuildController:
         state_change: ServiceStateChange,
     ) -> None:
         """
-        Browser callback — resolve the service info and update the peer map.
+        Browser callback; resolve the service info and update the peer map.
 
         Filters our own service-instance name so the advertise we
         publish doesn't show up in ``list_hosts``. ``Removed`` events
@@ -319,7 +319,7 @@ class RemoteBuildController:
         Manual hosts are placed AFTER mDNS hits so the UI's
         primary content is the auto-discovered list. A
         manually-added entry that's also reachable via mDNS shows
-        up twice for now (once per source) — phase 4's pairing
+        up twice for now (once per source); phase 4's pairing
         flow will introduce the deduplication logic alongside the
         actual connection attempt.
         """
@@ -347,8 +347,8 @@ class RemoteBuildController:
         Run ``mutator`` against the current settings and persist the result.
 
         Wraps :func:`remote_build_settings_transaction` so the
-        whole read-modify-write happens under the metadata lock —
-        two concurrent callers can't both read the same starting
+        whole read-modify-write happens under the metadata lock,
+        so two concurrent callers can't both read the same starting
         value and have the second save wipe the first's change.
         Runs in the default executor since the transaction does
         blocking JSON I/O.
@@ -357,7 +357,7 @@ class RemoteBuildController:
         and is expected to mutate it in place. A
         :class:`CommandError` raised inside the mutator (e.g.
         duplicate-detection on add) propagates out and discards
-        the pending write — same exception-on-discard contract as
+        the pending write; same exception-on-discard contract as
         :func:`metadata_transaction`.
         """
 
@@ -375,11 +375,11 @@ class RemoteBuildController:
         Persist the receiver-side ``enabled`` master switch.
 
         Read-modify-write so manual hosts and any future phase-3+
-        fields stay intact — a client toggling just ``enabled``
+        fields stay intact; a client toggling just ``enabled``
         doesn't reset every other field to its default.
 
         Validates ``enabled`` is strictly a ``bool`` rather than
-        coercing truthiness — a client sending the string ``"false"``
+        coercing truthiness; a client sending the string ``"false"``
         for example would otherwise persist as ``True``, which is
         the opposite of what the user intended on a security-
         sensitive toggle.
@@ -406,10 +406,11 @@ class RemoteBuildController:
 
         Validates ``hostname`` (non-empty string, normalised to
         lowercase per RFC 1035 §2.3.3) and ``port`` (integer,
-        1-65535). Rejects duplicates by ``(hostname, port)`` —
-        adding the same pair twice raises ``INVALID_ARGS`` rather
-        than silently no-op'ing so the user gets feedback that the
-        entry already existed.
+        1-65535). Rejects duplicates by ``(hostname, port)``:
+        adding the same pair twice raises ``ALREADY_EXISTS`` so
+        the frontend can render a "this dashboard is already in
+        your list" message without string-matching the details
+        field.
 
         Returns the post-write settings so the caller can re-render
         the manual-hosts list without a separate ``get_settings``
@@ -422,7 +423,7 @@ class RemoteBuildController:
             for entry in settings.manual_hosts:
                 if entry.hostname == host and entry.port == port_num:
                     msg = f"manual host {host}:{port_num} is already registered"
-                    raise CommandError(ErrorCode.INVALID_ARGS, msg)
+                    raise CommandError(ErrorCode.ALREADY_EXISTS, msg)
             settings.manual_hosts.append(ManualHost(hostname=host, port=port_num))
 
         return await self._modify_settings(_add)

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1,12 +1,14 @@
 """
 Remote-build feature — peer dashboard discovery + settings.
 
-Phase 2 of issue #106. Browses ``_esphomebuilder._tcp.local.`` to
-list other dashboards reachable on the LAN, and persists the
-receiver-side ``enabled`` master switch the rest of the feature
-will gate behind in phase 3.
+Phase 2 / 2b of issue #106. Browses ``_esphomebuilder._tcp.local.``
+to list other dashboards reachable on the LAN; persists the
+receiver-side ``enabled`` master switch (phase 2) and the
+user-supplied manual-host list for cross-subnet / non-multicast
+LANs (phase 2b); merges both sources into a single
+``remote_build/list_hosts`` snapshot.
 
-Phase 2 stops at discovery + settings storage:
+Phase 2 / 2b stops at discovery + settings storage:
 
 * No HTTP / WS endpoints under ``/remote-build/v1/*`` yet (phase 3
   lands the auth middleware + cert).
@@ -15,6 +17,9 @@ Phase 2 stops at discovery + settings storage:
   endpoint registration — flipping it currently has no observable
   effect beyond round-tripping in the settings UI. That's
   deliberate scaffolding so phase 3+ have a place to plug in.
+* Manual hosts have no version / fingerprint resolution — they
+  land in ``list_hosts`` with empty ``server_version`` /
+  ``esphome_version`` until phase 4 attempts the connection.
 
 Browser uses the existing ``AsyncEsphomeZeroconf`` instance owned by
 :class:`~esphome_device_builder.controllers._device_state_monitor.DeviceStateMonitor`
@@ -29,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from zeroconf import IPVersion, ServiceStateChange
@@ -36,8 +42,14 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
 from ..helpers.api import CommandError, api_command
 from ..helpers.dashboard_advertise import SERVICE_TYPE
-from ..models import ErrorCode, RemoteBuildPeer, RemoteBuildSettings
-from .config import load_remote_build_settings, save_remote_build_settings
+from ..models import (
+    ErrorCode,
+    ManualHost,
+    RemoteBuildPeer,
+    RemoteBuildPeerSource,
+    RemoteBuildSettings,
+)
+from .config import load_remote_build_settings, remote_build_settings_transaction
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
@@ -91,10 +103,76 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
         name=instance,
         hostname=server,
         port=info.port or 0,
+        source=RemoteBuildPeerSource.MDNS,
         addresses=info.parsed_scoped_addresses(IPVersion.All) or [],
         server_version=server_version,
         esphome_version=esphome_version,
     )
+
+
+def _peer_from_manual_host(entry: ManualHost) -> RemoteBuildPeer:
+    """
+    Build a :class:`RemoteBuildPeer` from a stored :class:`ManualHost`.
+
+    Manual hosts skip resolution — phase 2b just surfaces the
+    user-entered ``(hostname, port)`` so the frontend can render
+    the row alongside mDNS-discovered ones. Phase 4 attempts the
+    actual connection and fills the version fields.
+
+    ``name`` is the hostname verbatim (rather than the leftmost
+    label) so an IP-only entry still reads sensibly in the UI;
+    the frontend can render a "Manual" badge to distinguish it
+    from an mDNS-discovered row.
+    """
+    return RemoteBuildPeer(
+        name=entry.hostname,
+        hostname=entry.hostname,
+        port=entry.port,
+        source=RemoteBuildPeerSource.MANUAL,
+    )
+
+
+def _validate_hostname(raw: object) -> str:
+    """
+    Normalise a user-entered hostname to its canonical lowercase form.
+
+    Rejects non-string and empty / whitespace-only input with
+    :class:`CommandError(INVALID_ARGS)`. Lowercase normalisation
+    matches the duplicate-check semantics — hostnames are
+    case-insensitive per RFC 1035 §2.3.3, so ``Desktop.local`` and
+    ``desktop.local`` should be the same entry. Phase 4 attempts
+    the actual connection (and discovers DNS / TLS validity); phase
+    2b just stores the string the user entered so phase-4-style
+    feedback isn't blocked behind an "is this resolvable now?"
+    pre-flight that would fail on offline laptops.
+    """
+    if not isinstance(raw, str):
+        msg = "manual host: 'hostname' must be a string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    trimmed = raw.strip().lower()
+    if not trimmed:
+        msg = "manual host: 'hostname' must not be empty"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return trimmed
+
+
+def _validate_port(raw: object) -> int:
+    """
+    Validate a user-entered port number.
+
+    ``bool`` is rejected even though ``isinstance(True, int)`` is
+    true — accepting ``True`` for a port number is a footgun
+    (silently coerces to 1, which IANA reserves for tcpmux).
+    Range is the IANA-registered ephemeral plus
+    well-known: 1-65535.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        msg = "manual host: 'port' must be an integer"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if not 1 <= raw <= 65535:
+        msg = "manual host: 'port' must be between 1 and 65535"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return raw
 
 
 class RemoteBuildController:
@@ -228,15 +306,31 @@ class RemoteBuildController:
     @api_command("remote_build/list_hosts")
     async def list_hosts(self, **kwargs: Any) -> list[RemoteBuildPeer]:
         """
-        Return every peer dashboard discovered on the LAN.
+        Return every peer dashboard known to this receiver.
 
-        Snapshot of the browser's state — fresh for every call, no
-        caching. Empty when the browser hasn't seen any peers yet
-        (or when zeroconf failed to start). Phase 3+ will add
-        paired-or-not state to each row; phase 2 just returns the
-        raw discovery.
+        Merges two sources into a single snapshot:
+
+        * mDNS-discovered peers from the browser (``source=MDNS``,
+          full version + address info).
+        * Manually-added peers from
+          ``_remote_build.manual_hosts`` (``source=MANUAL``, blank
+          version fields until phase 4 fills them in).
+
+        Manual hosts are placed AFTER mDNS hits so the UI's
+        primary content is the auto-discovered list. A
+        manually-added entry that's also reachable via mDNS shows
+        up twice for now (once per source) — phase 4's pairing
+        flow will introduce the deduplication logic alongside the
+        actual connection attempt.
         """
-        return list(self._peers.values())
+        loop = asyncio.get_running_loop()
+        settings = await loop.run_in_executor(
+            None, load_remote_build_settings, self._db.settings.config_dir
+        )
+        return [
+            *self._peers.values(),
+            *(_peer_from_manual_host(entry) for entry in settings.manual_hosts),
+        ]
 
     @api_command("remote_build/get_settings")
     async def get_settings(self, **kwargs: Any) -> RemoteBuildSettings:
@@ -246,16 +340,43 @@ class RemoteBuildController:
             None, load_remote_build_settings, self._db.settings.config_dir
         )
 
+    async def _modify_settings(
+        self, mutator: Callable[[RemoteBuildSettings], None]
+    ) -> RemoteBuildSettings:
+        """
+        Run ``mutator`` against the current settings and persist the result.
+
+        Wraps :func:`remote_build_settings_transaction` so the
+        whole read-modify-write happens under the metadata lock —
+        two concurrent callers can't both read the same starting
+        value and have the second save wipe the first's change.
+        Runs in the default executor since the transaction does
+        blocking JSON I/O.
+
+        ``mutator`` is invoked with the freshly-loaded settings
+        and is expected to mutate it in place. A
+        :class:`CommandError` raised inside the mutator (e.g.
+        duplicate-detection on add) propagates out and discards
+        the pending write — same exception-on-discard contract as
+        :func:`metadata_transaction`.
+        """
+
+        def _txn() -> RemoteBuildSettings:
+            with remote_build_settings_transaction(self._db.settings.config_dir) as settings:
+                mutator(settings)
+                return settings
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _txn)
+
     @api_command("remote_build/set_settings")
     async def set_settings(self, *, enabled: bool, **kwargs: Any) -> RemoteBuildSettings:
         """
-        Persist the receiver-side remote-build settings.
+        Persist the receiver-side ``enabled`` master switch.
 
-        Currently only ``enabled`` is settable; future phases add
-        knobs from the "Remote builder settings" section of the
-        design (artifact retention TTL, build target preference,
-        major-version-mismatch toggle, ...). Returns the
-        post-write value so the frontend can confirm the round-trip.
+        Read-modify-write so manual hosts and any future phase-3+
+        fields stay intact — a client toggling just ``enabled``
+        doesn't reset every other field to its default.
 
         Validates ``enabled`` is strictly a ``bool`` rather than
         coercing truthiness — a client sending the string ``"false"``
@@ -266,9 +387,72 @@ class RemoteBuildController:
         if not isinstance(enabled, bool):
             msg = "remote_build/set_settings: 'enabled' must be a boolean"
             raise CommandError(ErrorCode.INVALID_ARGS, msg)
-        settings = RemoteBuildSettings(enabled=enabled)
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None, save_remote_build_settings, self._db.settings.config_dir, settings
-        )
-        return settings
+
+        def _set(settings: RemoteBuildSettings) -> None:
+            settings.enabled = enabled
+
+        return await self._modify_settings(_set)
+
+    # ------------------------------------------------------------------
+    # Manual hosts (phase 2b)
+    # ------------------------------------------------------------------
+
+    @api_command("remote_build/add_manual_host")
+    async def add_manual_host(
+        self, *, hostname: str, port: int, **kwargs: Any
+    ) -> RemoteBuildSettings:
+        """
+        Add a manually-entered peer for cross-subnet / non-mDNS LANs.
+
+        Validates ``hostname`` (non-empty string, normalised to
+        lowercase per RFC 1035 §2.3.3) and ``port`` (integer,
+        1-65535). Rejects duplicates by ``(hostname, port)`` —
+        adding the same pair twice raises ``INVALID_ARGS`` rather
+        than silently no-op'ing so the user gets feedback that the
+        entry already existed.
+
+        Returns the post-write settings so the caller can re-render
+        the manual-hosts list without a separate ``get_settings``
+        round-trip.
+        """
+        host = _validate_hostname(hostname)
+        port_num = _validate_port(port)
+
+        def _add(settings: RemoteBuildSettings) -> None:
+            for entry in settings.manual_hosts:
+                if entry.hostname == host and entry.port == port_num:
+                    msg = f"manual host {host}:{port_num} is already registered"
+                    raise CommandError(ErrorCode.INVALID_ARGS, msg)
+            settings.manual_hosts.append(ManualHost(hostname=host, port=port_num))
+
+        return await self._modify_settings(_add)
+
+    @api_command("remote_build/remove_manual_host")
+    async def remove_manual_host(
+        self, *, hostname: str, port: int, **kwargs: Any
+    ) -> RemoteBuildSettings:
+        """
+        Remove a previously-added manual peer.
+
+        Hostname normalisation matches :meth:`add_manual_host` so a
+        case-different removal request finds the entry. A
+        non-existent ``(hostname, port)`` pair raises
+        ``NOT_FOUND`` so the caller knows the operation was a no-op
+        rather than silently succeeding (matters for the
+        Settings UI: "Removed Foo" toast vs no feedback).
+        """
+        host = _validate_hostname(hostname)
+        port_num = _validate_port(port)
+
+        def _remove(settings: RemoteBuildSettings) -> None:
+            kept = [
+                entry
+                for entry in settings.manual_hosts
+                if not (entry.hostname == host and entry.port == port_num)
+            ]
+            if len(kept) == len(settings.manual_hosts):
+                msg = f"manual host {host}:{port_num} is not registered"
+                raise CommandError(ErrorCode.NOT_FOUND, msg)
+            settings.manual_hosts = kept
+
+        return await self._modify_settings(_remove)

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -140,11 +140,13 @@ def _validate_hostname(raw: object) -> str:
     :class:`CommandError(INVALID_ARGS)`. Lowercase normalisation
     matches the duplicate-check semantics; hostnames are
     case-insensitive per RFC 1035 §2.3.3, so ``Desktop.local`` and
-    ``desktop.local`` should be the same entry. Phase 4 attempts
-    the actual connection (and discovers DNS / TLS validity); phase
-    2b just stores the string the user entered so phase-4-style
-    feedback isn't blocked behind an "is this resolvable now?"
-    pre-flight that would fail on offline laptops.
+    ``desktop.local`` should be the same entry. The stored form
+    is the trimmed, lowercased string (so two adds with different
+    casing collapse to one entry rather than registering twice).
+    Phase 4 attempts the actual connection (and discovers DNS /
+    TLS validity); phase 2b deliberately doesn't pre-flight an
+    "is this resolvable now?" check, which would fail on offline
+    laptops adding a peer for later.
     """
     if not isinstance(raw, str):
         msg = "manual host: 'hostname' must be a string"

--- a/esphome_device_builder/models/api.py
+++ b/esphome_device_builder/models/api.py
@@ -16,6 +16,7 @@ class ErrorCode(StrEnum):
     UNKNOWN_COMMAND = "unknown_command"
     INVALID_ARGS = "invalid_args"
     NOT_FOUND = "not_found"
+    ALREADY_EXISTS = "already_exists"
     INTERNAL_ERROR = "internal_error"
     NOT_AUTHENTICATED = "not_authenticated"
     RATE_LIMITED = "rate_limited"

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -3,8 +3,39 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+
+class RemoteBuildPeerSource(StrEnum):
+    """
+    How a peer dashboard ended up in :meth:`list_hosts`.
+
+    ``mdns`` — discovered via the `_esphomebuilder._tcp.local.`
+    browse. ``manual`` — added by the user via
+    `remote_build/add_manual_host` for cross-subnet / non-multicast
+    LANs where mDNS doesn't reach but L3 unicast does.
+    """
+
+    MDNS = "mdns"
+    MANUAL = "manual"
+
+
+@dataclass
+class ManualHost(DataClassORJSONMixin):
+    """
+    A user-supplied peer entry stored in the metadata sidecar.
+
+    Persisted under ``_remote_build.manual_hosts``; merged into
+    :meth:`list_hosts` output as a :class:`RemoteBuildPeer` row
+    with ``source=MANUAL`` and empty version fields. Phase 2b does
+    no version / fingerprint resolution — phase 4 attempts the
+    connection and fills the version fields in.
+    """
+
+    hostname: str
+    port: int
 
 
 @dataclass
@@ -16,29 +47,44 @@ class RemoteBuildSettings(DataClassORJSONMixin):
     top-level key. ``enabled`` is the master switch — phase 3 will
     gate ``/remote-build/v1/*`` route registration on it; phase 2
     just persists the flag so the Settings UI has somewhere to
-    write.
+    write. ``manual_hosts`` is the user-supplied peer list (see
+    :class:`ManualHost`).
     """
 
     enabled: bool = False
+    manual_hosts: list[ManualHost] = field(default_factory=list)
 
 
 @dataclass
 class RemoteBuildPeer(DataClassORJSONMixin):
     """
-    A peer dashboard discovered via mDNS browse of ``_esphomebuilder._tcp.local.``.
+    A peer dashboard known to this dashboard.
 
-    Wire shape returned from ``remote_build/list_hosts``. ``name`` is
-    the mDNS service-instance name (the leftmost label, e.g.
-    ``desktop``); ``hostname`` is the SRV target (e.g. ``desktop.local.``).
-    Versions come from the TXT record. ``addresses`` is the parsed
-    A / AAAA list — what an offloader would actually connect to.
-    Phase 2 stops at discovery; pairing / connection / fingerprint
-    pinning lands in later phases.
+    Wire shape returned from ``remote_build/list_hosts``. Two
+    sources land in the same row shape:
+
+    * ``source=MDNS`` — discovered via the
+      ``_esphomebuilder._tcp.local.`` browse. ``name`` is the
+      mDNS service-instance name (leftmost label, e.g.
+      ``desktop``); ``hostname`` is the SRV target (e.g.
+      ``desktop.local.``); ``addresses`` is the parsed A / AAAA
+      list with IPv6 scope preserved; versions come from TXT.
+    * ``source=MANUAL`` — user-supplied via
+      ``remote_build/add_manual_host``. ``name`` derived from the
+      hostname (leftmost label so the UI can render it consistently
+      with mDNS rows); ``hostname`` is the user-entered string;
+      ``port`` is the user-entered port; ``addresses`` is empty
+      and version fields are blank until phase 4 attempts the
+      connection.
+
+    Phase 2 stops at discovery + manual entry; pairing / connection
+    / fingerprint pinning lands in later phases.
     """
 
     name: str
     hostname: str
     port: int
+    source: RemoteBuildPeerSource
     addresses: list[str] = field(default_factory=list)
     server_version: str = ""
     esphome_version: str = ""

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -12,10 +12,11 @@ class RemoteBuildPeerSource(StrEnum):
     """
     How a peer dashboard ended up in :meth:`list_hosts`.
 
-    ``mdns`` — discovered via the `_esphomebuilder._tcp.local.`
-    browse. ``manual`` — added by the user via
-    `remote_build/add_manual_host` for cross-subnet / non-multicast
-    LANs where mDNS doesn't reach but L3 unicast does.
+    ``mdns``: discovered via the ``_esphomebuilder._tcp.local.``
+    browse. ``manual``: added by the user via
+    ``remote_build/add_manual_host`` for cross-subnet or
+    non-multicast LANs where mDNS doesn't reach but L3 unicast
+    does.
     """
 
     MDNS = "mdns"
@@ -30,7 +31,7 @@ class ManualHost(DataClassORJSONMixin):
     Persisted under ``_remote_build.manual_hosts``; merged into
     :meth:`list_hosts` output as a :class:`RemoteBuildPeer` row
     with ``source=MANUAL`` and empty version fields. Phase 2b does
-    no version / fingerprint resolution — phase 4 attempts the
+    no version / fingerprint resolution; phase 4 attempts the
     connection and fills the version fields in.
     """
 
@@ -44,9 +45,9 @@ class RemoteBuildSettings(DataClassORJSONMixin):
     Receiver-side settings for the remote-build feature.
 
     Stored in ``.device-builder.json`` under the ``_remote_build``
-    top-level key. ``enabled`` is the master switch — phase 3 will
-    gate ``/remote-build/v1/*`` route registration on it; phase 2
-    just persists the flag so the Settings UI has somewhere to
+    top-level key. ``enabled`` is the master switch that phase 3
+    will gate ``/remote-build/v1/*`` route registration on. Phase
+    2 just persists the flag so the Settings UI has somewhere to
     write. ``manual_hosts`` is the user-supplied peer list (see
     :class:`ManualHost`).
     """
@@ -63,19 +64,19 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     Wire shape returned from ``remote_build/list_hosts``. Two
     sources land in the same row shape:
 
-    * ``source=MDNS`` — discovered via the
+    * ``source=MDNS``: discovered via the
       ``_esphomebuilder._tcp.local.`` browse. ``name`` is the
       mDNS service-instance name (leftmost label, e.g.
       ``desktop``); ``hostname`` is the SRV target (e.g.
       ``desktop.local.``); ``addresses`` is the parsed A / AAAA
       list with IPv6 scope preserved; versions come from TXT.
-    * ``source=MANUAL`` — user-supplied via
+    * ``source=MANUAL``: user-supplied via
       ``remote_build/add_manual_host``. ``name`` is the full
       hostname verbatim (NOT the leftmost label) so an IP-only
       entry like ``192.168.1.10`` reads sensibly in the UI rather
-      than truncating to ``"192"``; ``hostname`` is the same
-      user-entered string, ``port`` is the user-entered port;
-      ``addresses`` is empty and version fields are blank until
+      than truncating to ``"192"``. ``hostname`` is the same
+      user-entered string, ``port`` is the user-entered port,
+      ``addresses`` is empty, and version fields are blank until
       phase 4 attempts the connection.
 
     Phase 2 stops at discovery + manual entry; pairing / connection

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -70,12 +70,13 @@ class RemoteBuildPeer(DataClassORJSONMixin):
       ``desktop.local.``); ``addresses`` is the parsed A / AAAA
       list with IPv6 scope preserved; versions come from TXT.
     * ``source=MANUAL`` — user-supplied via
-      ``remote_build/add_manual_host``. ``name`` derived from the
-      hostname (leftmost label so the UI can render it consistently
-      with mDNS rows); ``hostname`` is the user-entered string;
-      ``port`` is the user-entered port; ``addresses`` is empty
-      and version fields are blank until phase 4 attempts the
-      connection.
+      ``remote_build/add_manual_host``. ``name`` is the full
+      hostname verbatim (NOT the leftmost label) so an IP-only
+      entry like ``192.168.1.10`` reads sensibly in the UI rather
+      than truncating to ``"192"``; ``hostname`` is the same
+      user-entered string, ``port`` is the user-entered port;
+      ``addresses`` is empty and version fields are blank until
+      phase 4 attempts the connection.
 
     Phase 2 stops at discovery + manual entry; pairing / connection
     / fingerprint pinning lands in later phases.

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -48,6 +48,7 @@ from esphome_device_builder.controllers.config import (
     load_preferences,
     load_remote_build_settings,
     metadata_transaction,
+    remote_build_settings_transaction,
     remove_device_metadata,
     save_labels,
     save_preferences,
@@ -418,6 +419,39 @@ def test_save_remote_build_settings_round_trip(tmp_path: Path) -> None:
     settings = RemoteBuildSettings(enabled=True)
     save_remote_build_settings(tmp_path, settings)
     assert load_remote_build_settings(tmp_path) == settings
+
+
+def test_remote_build_settings_transaction_falls_back_on_bad_data(
+    tmp_path: Path,
+) -> None:
+    """Corrupted blob → the transaction yields defaults, not crashes."""
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(b'{"_remote_build": [1, 2, 3]}')
+
+    with remote_build_settings_transaction(tmp_path) as settings:
+        # Yielded value is the defaults; any mutation persists as
+        # the new canonical state, replacing the corrupt blob.
+        assert settings == RemoteBuildSettings()
+        settings.enabled = True
+
+    assert load_remote_build_settings(tmp_path) == RemoteBuildSettings(enabled=True)
+
+
+def test_remote_build_settings_transaction_discards_on_exception(
+    tmp_path: Path,
+) -> None:
+    """A raise inside the block drops the pending mutation."""
+    save_remote_build_settings(tmp_path, RemoteBuildSettings(enabled=False))
+
+    with (
+        pytest.raises(RuntimeError, match="boom"),
+        remote_build_settings_transaction(tmp_path) as settings,
+    ):
+        settings.enabled = True
+        raise RuntimeError("boom")
+
+    # Original pre-block state survives untouched.
+    assert load_remote_build_settings(tmp_path) == RemoteBuildSettings(enabled=False)
 
 
 def test_save_preferences_round_trip(tmp_path: Path) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -464,7 +464,7 @@ async def test_stop_drains_resolve_tasks() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Phase 2b — manual hosts
+# Phase 2b: manual hosts
 # ---------------------------------------------------------------------------
 
 
@@ -516,7 +516,7 @@ def test_peer_from_manual_host_uses_manual_source() -> None:
     assert peer.name == "192.168.1.10"
     assert peer.hostname == "192.168.1.10"
     assert peer.port == 6052
-    # Version fields stay blank — phase 4 fills them in via the
+    # Version fields stay blank; phase 4 fills them in via the
     # actual connection attempt.
     assert peer.server_version == ""
     assert peer.esphome_version == ""
@@ -537,16 +537,18 @@ async def test_add_manual_host_persists_and_returns_settings(tmp_path: Any) -> N
 @pytest.mark.asyncio
 async def test_add_manual_host_rejects_duplicate(tmp_path: Any) -> None:
     """
-    A second add of the same ``(hostname, port)`` raises ``INVALID_ARGS``.
+    A second add of the same ``(hostname, port)`` raises ``ALREADY_EXISTS``.
 
-    The user gets feedback that the entry already existed rather
-    than a silent no-op.
+    Distinct from ``INVALID_ARGS`` so the frontend can show a
+    "this dashboard is already in your list" message without
+    string-matching the details field. The user gets feedback
+    that the entry already existed rather than a silent no-op.
     """
     controller = _make_controller(config_dir=tmp_path)
     await controller.add_manual_host(hostname="desktop.local", port=6052)
     with pytest.raises(CommandError) as exc:
         await controller.add_manual_host(hostname="desktop.local", port=6052)
-    assert exc.value.code == ErrorCode.INVALID_ARGS
+    assert exc.value.code == ErrorCode.ALREADY_EXISTS
 
 
 @pytest.mark.asyncio
@@ -563,7 +565,7 @@ async def test_add_manual_host_keeps_enabled_intact(tmp_path: Any) -> None:
     """
     Adding a manual host doesn't reset ``enabled``.
 
-    Pin the read-modify-write semantics — without it,
+    Pin the read-modify-write semantics. Without it,
     ``set_settings(enabled=True)`` followed by
     ``add_manual_host(...)`` would silently flip ``enabled`` back
     to ``False``.

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -21,11 +21,20 @@ from zeroconf import ServiceStateChange
 from esphome_device_builder.controllers.remote_build import (
     RemoteBuildController,
     _decode_txt_value,
+    _peer_from_manual_host,
     _peer_from_service_info,
+    _validate_hostname,
+    _validate_port,
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.dashboard_advertise import SERVICE_TYPE
-from esphome_device_builder.models import ErrorCode, RemoteBuildPeer, RemoteBuildSettings
+from esphome_device_builder.models import (
+    ErrorCode,
+    ManualHost,
+    RemoteBuildPeer,
+    RemoteBuildPeerSource,
+    RemoteBuildSettings,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers used by the tests
@@ -153,7 +162,10 @@ def test_on_service_state_change_removed_drops_peer(monkeypatch: pytest.MonkeyPa
     """A ``Removed`` event clears the peer entry immediately."""
     controller = _make_controller()
     controller._peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
-        name="desktop", hostname="desktop.local.", port=6052
+        name="desktop",
+        hostname="desktop.local.",
+        port=6052,
+        source=RemoteBuildPeerSource.MDNS,
     )
     controller._on_service_state_change(
         MagicMock(), SERVICE_TYPE, f"desktop.{SERVICE_TYPE}", ServiceStateChange.Removed
@@ -188,21 +200,28 @@ def test_on_service_state_change_uses_cache_when_available(
 
 
 @pytest.mark.asyncio
-async def test_list_hosts_returns_snapshot_of_peers() -> None:
-    controller = _make_controller()
+async def test_list_hosts_returns_snapshot_of_peers(tmp_path: Any) -> None:
+    controller = _make_controller(config_dir=tmp_path)
     controller._peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
-        name="desktop", hostname="desktop.local.", port=6052
+        name="desktop",
+        hostname="desktop.local.",
+        port=6052,
+        source=RemoteBuildPeerSource.MDNS,
     )
     controller._peers[f"laptop.{SERVICE_TYPE}"] = RemoteBuildPeer(
-        name="laptop", hostname="laptop.local.", port=6052
+        name="laptop",
+        hostname="laptop.local.",
+        port=6052,
+        source=RemoteBuildPeerSource.MDNS,
     )
     result = await controller.list_hosts()
     assert {peer.name for peer in result} == {"desktop", "laptop"}
+    assert all(peer.source == RemoteBuildPeerSource.MDNS for peer in result)
 
 
 @pytest.mark.asyncio
-async def test_list_hosts_empty_when_no_peers() -> None:
-    controller = _make_controller()
+async def test_list_hosts_empty_when_no_peers(tmp_path: Any) -> None:
+    controller = _make_controller(config_dir=tmp_path)
     assert await controller.list_hosts() == []
 
 
@@ -442,3 +461,204 @@ async def test_stop_drains_resolve_tasks() -> None:
     await controller.stop()
     assert task.done()
     assert controller._tasks == set()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b — manual hosts
+# ---------------------------------------------------------------------------
+
+
+def test_validate_hostname_lowercases_and_strips() -> None:
+    """RFC 1035 §2.3.3: hostnames are case-insensitive."""
+    assert _validate_hostname("  Desktop.Local  ") == "desktop.local"
+
+
+def test_validate_hostname_rejects_non_string() -> None:
+    with pytest.raises(CommandError) as exc:
+        _validate_hostname(42)  # type: ignore[arg-type]
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_validate_hostname_rejects_empty() -> None:
+    with pytest.raises(CommandError) as exc:
+        _validate_hostname("   ")
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_validate_port_accepts_typical() -> None:
+    assert _validate_port(6052) == 6052
+
+
+def test_validate_port_rejects_non_int() -> None:
+    with pytest.raises(CommandError) as exc:
+        _validate_port("6052")  # type: ignore[arg-type]
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_validate_port_rejects_bool() -> None:
+    """``isinstance(True, int)`` is true, but coercing to 1 is a footgun."""
+    with pytest.raises(CommandError) as exc:
+        _validate_port(True)  # type: ignore[arg-type]
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.parametrize("port", [0, -1, 65536, 100000])
+def test_validate_port_rejects_out_of_range(port: int) -> None:
+    with pytest.raises(CommandError) as exc:
+        _validate_port(port)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_peer_from_manual_host_uses_manual_source() -> None:
+    """A manual entry's ``RemoteBuildPeer`` row reports ``source=MANUAL``."""
+    peer = _peer_from_manual_host(ManualHost(hostname="192.168.1.10", port=6052))
+    assert peer.source == RemoteBuildPeerSource.MANUAL
+    assert peer.name == "192.168.1.10"
+    assert peer.hostname == "192.168.1.10"
+    assert peer.port == 6052
+    # Version fields stay blank — phase 4 fills them in via the
+    # actual connection attempt.
+    assert peer.server_version == ""
+    assert peer.esphome_version == ""
+    assert peer.addresses == []
+
+
+@pytest.mark.asyncio
+async def test_add_manual_host_persists_and_returns_settings(tmp_path: Any) -> None:
+    """Happy path: a unique entry is appended and the settings round-trip."""
+    controller = _make_controller(config_dir=tmp_path)
+    settings = await controller.add_manual_host(hostname="desktop.local", port=6052)
+    assert settings.manual_hosts == [ManualHost(hostname="desktop.local", port=6052)]
+    # Round-trip: get_settings reflects the persisted state.
+    reread = await controller.get_settings()
+    assert reread.manual_hosts == settings.manual_hosts
+
+
+@pytest.mark.asyncio
+async def test_add_manual_host_rejects_duplicate(tmp_path: Any) -> None:
+    """
+    A second add of the same ``(hostname, port)`` raises ``INVALID_ARGS``.
+
+    The user gets feedback that the entry already existed rather
+    than a silent no-op.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    await controller.add_manual_host(hostname="desktop.local", port=6052)
+    with pytest.raises(CommandError) as exc:
+        await controller.add_manual_host(hostname="desktop.local", port=6052)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_add_manual_host_normalises_case_for_dedup(tmp_path: Any) -> None:
+    """``Desktop.Local`` and ``desktop.local`` are the same entry."""
+    controller = _make_controller(config_dir=tmp_path)
+    await controller.add_manual_host(hostname="desktop.local", port=6052)
+    with pytest.raises(CommandError):
+        await controller.add_manual_host(hostname="Desktop.Local", port=6052)
+
+
+@pytest.mark.asyncio
+async def test_add_manual_host_keeps_enabled_intact(tmp_path: Any) -> None:
+    """
+    Adding a manual host doesn't reset ``enabled``.
+
+    Pin the read-modify-write semantics — without it,
+    ``set_settings(enabled=True)`` followed by
+    ``add_manual_host(...)`` would silently flip ``enabled`` back
+    to ``False``.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    await controller.set_settings(enabled=True)
+    settings = await controller.add_manual_host(hostname="desktop.local", port=6052)
+    assert settings.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_remove_manual_host_drops_entry(tmp_path: Any) -> None:
+    """Happy path: a registered entry is removed."""
+    controller = _make_controller(config_dir=tmp_path)
+    await controller.add_manual_host(hostname="desktop.local", port=6052)
+    await controller.add_manual_host(hostname="laptop.local", port=6052)
+    settings = await controller.remove_manual_host(hostname="desktop.local", port=6052)
+    assert settings.manual_hosts == [ManualHost(hostname="laptop.local", port=6052)]
+
+
+@pytest.mark.asyncio
+async def test_remove_manual_host_rejects_unknown(tmp_path: Any) -> None:
+    """``NOT_FOUND`` for a host that was never registered."""
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.remove_manual_host(hostname="ghost.local", port=6052)
+    assert exc.value.code == ErrorCode.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_remove_manual_host_normalises_case(tmp_path: Any) -> None:
+    """``Desktop.Local`` removes a stored ``desktop.local`` entry."""
+    controller = _make_controller(config_dir=tmp_path)
+    await controller.add_manual_host(hostname="desktop.local", port=6052)
+    settings = await controller.remove_manual_host(hostname="Desktop.Local", port=6052)
+    assert settings.manual_hosts == []
+
+
+@pytest.mark.asyncio
+async def test_set_settings_preserves_manual_hosts(tmp_path: Any) -> None:
+    """
+    ``set_settings(enabled=...)`` doesn't wipe ``manual_hosts``.
+
+    The previous ``set_settings`` shape full-replaced the
+    serialised blob, which would have reset every field a client
+    didn't pass to its default. Pin the read-modify-write so a
+    toggle of ``enabled`` doesn't silently drop the user's
+    manual-host list.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    await controller.add_manual_host(hostname="desktop.local", port=6052)
+    settings = await controller.set_settings(enabled=True)
+    assert settings.enabled is True
+    assert settings.manual_hosts == [ManualHost(hostname="desktop.local", port=6052)]
+
+
+@pytest.mark.asyncio
+async def test_list_hosts_merges_mdns_and_manual(tmp_path: Any) -> None:
+    """
+    ``list_hosts`` returns mDNS-discovered peers followed by manual hosts.
+
+    Each row carries its origin in ``source``; mDNS rows are
+    placed first so the auto-discovered list is the primary
+    content.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
+        name="desktop",
+        hostname="desktop.local.",
+        port=6052,
+        source=RemoteBuildPeerSource.MDNS,
+    )
+    await controller.add_manual_host(hostname="10.0.0.5", port=6052)
+
+    result = await controller.list_hosts()
+    assert len(result) == 2
+    assert result[0].source == RemoteBuildPeerSource.MDNS
+    assert result[0].name == "desktop"
+    assert result[1].source == RemoteBuildPeerSource.MANUAL
+    assert result[1].name == "10.0.0.5"
+
+
+@pytest.mark.asyncio
+async def test_add_manual_host_rejects_invalid_port(tmp_path: Any) -> None:
+    """Out-of-range port doesn't slip through."""
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.add_manual_host(hostname="desktop.local", port=0)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_add_manual_host_rejects_blank_hostname(tmp_path: Any) -> None:
+    """Empty / whitespace hostname doesn't slip through."""
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.add_manual_host(hostname="   ", port=6052)
+    assert exc.value.code == ErrorCode.INVALID_ARGS


### PR DESCRIPTION
# What does this implement/fix?

Phase 2b of the remote-build offload feature in #106. Backend wiring for user-supplied peer entries: for cross-subnet / non-multicast LANs where mDNS doesn't reach but L3 unicast does. Frontend companion will land separately.

**Model**

- New `ManualHost` dataclass and `RemoteBuildPeerSource` enum (`MDNS` / `MANUAL`).
- `RemoteBuildPeer` gains a required `source` field so each row carries its origin.
- `RemoteBuildSettings` gains `manual_hosts: list[ManualHost]`.

**WS commands**

- `remote_build/add_manual_host` validates hostname (non-empty string, normalised to lowercase per RFC 1035 §2.3.3) and port (integer, 1-65535; `bool` rejected even though `isinstance(True, int)` is true). Rejects duplicates by `(hostname, port)` with `ALREADY_EXISTS` (a new error code added to the `ErrorCode` enum so the frontend can dispatch on it without string-matching the details field). Bad hostname or bad port still raises `INVALID_ARGS`.
- `remote_build/remove_manual_host` — same validation; raises `NOT_FOUND` when the entry isn't registered so the caller can distinguish "removed Foo" from "Foo wasn't there".
- `remote_build/list_hosts` now merges mDNS-discovered peers (placed first) with manual hosts. Manual rows have empty version / address fields until phase 4 attempts the connection.

**Atomicity**

- New `remote_build_settings_transaction` context manager in `config.py` runs read-modify-write under the same `metadata_transaction` lock that `_preferences` / `_labels` use. Prevents the "two concurrent adds load the same starting value, second save wipes the first" race that a bare `load + save` pair would have.
- New `RemoteBuildController._modify_settings(mutator)` helper wraps the sync transaction via `run_in_executor` and is the single place every mutating command (`set_settings`, `add_manual_host`, `remove_manual_host`) routes through — consolidates three near-identical load/mutate/save blocks into one. `set_settings` now read-modify-writes too, so toggling `enabled` no longer wipes `manual_hosts` (or any future phase-3+ field).

Phase 2b deliberately does no version / fingerprint resolution — manual entries land with empty version fields until phase 4 attempts the connection. The split from phase 2 keeps the mDNS browse code self-contained in #446 and lets the manual-entry UX iterate on its own PR.

**Related issue or feature (if applicable):**

- Phase 2b of #106

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

The companion frontend PR adds an "Add by IP / hostname" input to the Settings → Remote builder section + renders the merged peer list with a "Manual" badge for `source=MANUAL` rows. Backend lands first to nail the wire contract.

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number> *(coming separately)*

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

