### PR TITLE
Add persistent dashboard identity (#106 phase 3a)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,6 +169,22 @@ Both gates apply only to requests that carry an `Origin` header. Browsers always
 
 Match is case-insensitive and port-tolerant: `dashboard.example.com` accepts `Dashboard.Example.com:8443`. IPv6 may be entered with or without brackets (`::1` and `[::1]` both work). Use `*` as the only entry to opt out of the Host restriction while still permitting cross-origin handshakes (handy when the Host varies per request).
 
+## Persisted state and security expectations
+
+The dashboard writes a small set of files into `<config_dir>` and treats them as durable per-installation state. A few have non-obvious security expectations.
+
+| File | Sensitivity | Mode |
+|---|---|---|
+| `.device-builder.json` | Identifier-only (`dashboard_id`, `_remote_build` config). Not a secret. | umask default |
+| `.device-builder-cert.pem` | Public TLS cert. Not sensitive. | mkstemp default (0o600) |
+| `.device-builder-key.pem` | **Private TLS key. Sensitive.** A reader of this file can impersonate the dashboard to any paired peer. | 0o600 enforced at write time |
+
+**Backup tools must preserve `0o600` on `.device-builder-key.pem`.** The dashboard writes the file at the right mode via `tempfile.mkstemp` + `os.replace`, but a tar-then-restore-as-different-user round-trip can land it at the umask default. Operators backing up `<config_dir>` should use a tool that captures and restores POSIX modes (e.g. `tar --preserve-permissions`, `rsync -p`, `restic`). The dashboard does *not* re-tighten the mode on every load (the load-time chmod was deliberately removed as untested defensive code) — once relaxed it stays relaxed until the next `rotate_certificate` call.
+
+**The dashboard expects exactly one process per `<config_dir>`.** Identity files, the metadata sidecar, and the build tree are all guarded by per-process `threading.Lock`s; two `device-builder` processes running against the same config directory would race on writes. The HA add-on shape enforces this naturally (one container per data volume); standalone deployments (Desktop, dev) need to ensure operators don't double-launch. If a multi-process model is ever needed, the locks must be promoted to file-locks (`fcntl.flock` on a sentinel file).
+
+**`dashboard_id` is an identifier, not a secret.** It's published in mDNS TXT and shared with paired peers as part of pairing handshakes. A leaked metadata sidecar reveals the ID but doesn't, on its own, grant access. Phase 4's first-use binding pairs each issued token against the requesting offloader's `dashboard_id`, so the ID becomes part of the auth context at that point — leakage of an issued bearer token *together with* the dashboard's ID would defeat the binding check; bearer tokens themselves remain the load-bearing secret.
+
 ## Deployment
 
 ### Beta (HA add-on)

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -216,10 +216,13 @@ class DashboardSettings:
 # Several controllers (firmware queue, device CRUD, preferences, IP
 # cache) all RMW this file from the executor pool. Without serialisation
 # two writers landing in the same window lose each other's updates.
-# Use ``RLock`` (not ``Lock``) so a caller already inside a
-# transaction can call into helpers that re-enter the same critical
-# section on the same thread without self-deadlocking.
-_METADATA_LOCK = threading.RLock()
+# Plain (non-reentrant) ``Lock`` is intentional: nested
+# ``metadata_transaction`` calls on the same thread are unsafe even
+# under an ``RLock`` because each call does its own load/save, so
+# the inner write is overwritten by the outer write at the outer's
+# exit. The deadlock on attempted re-entry is the loud failure;
+# silently losing updates would be worse. See the docstring below.
+_METADATA_LOCK = threading.Lock()
 
 
 @contextmanager
@@ -231,6 +234,14 @@ def metadata_transaction(config_dir: Path) -> Iterator[dict[str, Any]]:
     exit the changes are persisted atomically. Exceptions raised
     inside the block discard the pending mutation. Concurrent
     transactions are serialised so updates can't clobber each other.
+
+    Do not call from inside another ``metadata_transaction`` on the
+    same thread. The lock is non-reentrant and will deadlock; this
+    is intentional. Each call loads / saves its own snapshot, so
+    nested calls would lose updates even under a reentrant lock
+    (the outer save would overwrite the inner save). Helpers that
+    take the same lock (e.g. ``get_or_create_identity``) must be
+    called outside any open transaction.
     """
     with _METADATA_LOCK:
         data = _load_metadata(config_dir)

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -216,7 +216,10 @@ class DashboardSettings:
 # Several controllers (firmware queue, device CRUD, preferences, IP
 # cache) all RMW this file from the executor pool. Without serialisation
 # two writers landing in the same window lose each other's updates.
-_METADATA_LOCK = threading.Lock()
+# Use ``RLock`` (not ``Lock``) so a caller already inside a
+# transaction can call into helpers that re-enter the same critical
+# section on the same thread without self-deadlocking.
+_METADATA_LOCK = threading.RLock()
 
 
 @contextmanager

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -35,7 +35,16 @@ def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
     )
     tmp_path = Path(tmp_str)
     try:
-        with os.fdopen(fd, "wb") as fh:
+        # ``os.fdopen`` itself can raise (rare; ENOMEM, bad fd).
+        # If it does, the with-block never enters, so fd would
+        # leak; close explicitly here and re-raise.
+        try:
+            fh = os.fdopen(fd, "wb")
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        with fh:
             if mode is not None:
                 os.chmod(tmp_path, mode)
             fh.write(data)

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -41,6 +41,9 @@ def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
             fh.write(data)
         os.replace(tmp_path, path)
     except Exception:
-        with contextlib.suppress(FileNotFoundError):
+        # Suppress all OSError on cleanup so the original write
+        # failure isn't masked by a secondary unlink permission
+        # error.
+        with contextlib.suppress(OSError):
             tmp_path.unlink()
         raise

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -1,0 +1,46 @@
+"""
+Atomic filesystem writes for dashboard-internal artefacts.
+
+For cert / key / token / metadata-sidecar files. User-editable
+YAML still goes through :func:`esphome.helpers.write_file`.
+
+Why not the upstream helper here: ``write_file``'s ``private``
+flag is binary (0o644 vs 0o600), and we need arbitrary modes for
+caller-controlled-mode shapes (cert / key + future token stores).
+
+Blocking I/O — call from ``run_in_executor``, not the loop.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
+    """
+    Write *data* to *path* atomically.
+
+    Stages bytes in a sibling tempfile, then ``os.replace``s into
+    place. Readers see either the old or new bytes, never a
+    truncated file. ``mode`` is applied to the staging file before
+    the rename; ``os.replace`` carries that mode to the destination.
+    """
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            if mode is not None:
+                os.chmod(tmp_path, mode)
+            fh.write(data)
+        os.replace(tmp_path, path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
+        raise

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -31,10 +31,12 @@ doesn't stall on the initial generation.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import logging
 import os
 import secrets
+import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -44,8 +46,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
-from .json import dumps as json_dumps
-from .json import loads as json_loads
+from ..controllers.config import metadata_transaction
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,7 +61,6 @@ _CERT_KEY_BITS = 2048
 # expired" footgun.
 _CERT_VALIDITY_DAYS = 365 * 100
 _CERT_COMMON_NAME = "ESPHome Device Builder"
-_METADATA_FILE = ".device-builder.json"
 _REMOTE_BUILD_KEY = "_remote_build"
 _DASHBOARD_ID_KEY = "dashboard_id"
 
@@ -114,10 +114,7 @@ def get_or_create_identity(config_dir: Path) -> DashboardIdentity:
         cert_pem, key_pem = _generate_cert_pair()
         _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
 
-    dashboard_id = _load_dashboard_id(config_dir)
-    if dashboard_id is None:
-        dashboard_id = _generate_dashboard_id()
-        _save_dashboard_id(config_dir, dashboard_id)
+    dashboard_id = _get_or_create_dashboard_id(config_dir)
 
     return DashboardIdentity(
         dashboard_id=dashboard_id,
@@ -143,10 +140,7 @@ def rotate_certificate(config_dir: Path) -> DashboardIdentity:
     cert_pem, key_pem = _generate_cert_pair()
     _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
 
-    dashboard_id = _load_dashboard_id(config_dir)
-    if dashboard_id is None:
-        dashboard_id = _generate_dashboard_id()
-        _save_dashboard_id(config_dir, dashboard_id)
+    dashboard_id = _get_or_create_dashboard_id(config_dir)
 
     return DashboardIdentity(
         dashboard_id=dashboard_id,
@@ -166,21 +160,37 @@ def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, byte
     Read the persisted cert + key, returning ``(None, None)`` on any miss.
 
     A partial state (cert without key, key without cert) counts as
-    a miss; both files have to be present and parse cleanly or the
-    caller regenerates. Failures are logged at debug level rather
-    than warning since "first start, files don't exist" is the
-    common path through here.
+    a miss; both files have to be present, parse cleanly, AND match
+    each other (the cert's public key must equal the private key's
+    public key) or the caller regenerates. The cross-check catches
+    a state where someone has manually rotated one half of the pair
+    or where a backup-restore reassembled mismatched files; serving
+    a mismatched pair as the dashboard identity would fail at TLS
+    handshake time with an opaque "key values mismatch" error.
+
+    Also tightens the key file's mode to ``0600`` if a previous
+    write left it looser, defending against the case where an older
+    version of this helper, an external script, or a botched backup
+    restored the file at the umask default.
     """
     if not cert_path.exists() or not key_path.exists():
         return None, None
     try:
         cert_pem = cert_path.read_bytes()
         key_pem = key_path.read_bytes()
-        # Verify both parse so a corrupted file doesn't silently
-        # land in the returned identity. ``load_pem_x509_certificate``
-        # and ``load_pem_private_key`` raise on malformed input.
-        x509.load_pem_x509_certificate(cert_pem)
-        serialization.load_pem_private_key(key_pem, password=None)
+        cert = x509.load_pem_x509_certificate(cert_pem)
+        private_key = serialization.load_pem_private_key(key_pem, password=None)
+        # Cross-check: a parsing pass alone passes a stale key
+        # paired with a fresh cert (or vice versa). Compare via
+        # ``public_numbers()``; the dataclass ``__eq__`` covers
+        # both RSA and EC keys.
+        if cert.public_key().public_numbers() != private_key.public_key().public_numbers():
+            _LOGGER.warning(
+                "Persisted cert at %s does not match private key at %s; regenerating",
+                cert_path,
+                key_path,
+            )
+            return None, None
     except Exception:
         _LOGGER.debug(
             "Persisted cert / key at %s / %s failed to parse; regenerating",
@@ -189,6 +199,11 @@ def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, byte
             exc_info=True,
         )
         return None, None
+    # ``os.open(..., mode=0o600)`` only applies on creation; an
+    # existing key file with looser perms keeps them unless we
+    # chmod here. Idempotent and cheap.
+    with contextlib.suppress(OSError):
+        os.chmod(key_path, _KEY_MODE)
     return cert_pem, key_pem
 
 
@@ -216,44 +231,74 @@ def _generate_cert_pair() -> tuple[bytes, bytes]:
     return cert_pem, key_pem
 
 
+def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
+    """
+    Write *data* to *path* atomically with optional creation mode.
+
+    Stages the bytes in a sibling tempfile (``tempfile.mkstemp``
+    creates with mode ``0600`` by default), fsync-flushes to disk,
+    then ``os.replace``s into place. A reader that opens *path*
+    during the write either sees the old bytes or the new bytes,
+    never a partial / truncated PEM. ``mode`` is re-applied to the
+    final path so the destination ends up at the requested mode
+    even if it pre-existed at a looser one. Same atomic-write
+    shape as ``controllers.config._save_metadata``.
+
+    On a crash mid-write the tempfile is left behind; the cleanup
+    branch unlinks it. The ``os.replace`` itself is atomic on the
+    same filesystem (POSIX ``rename`` semantics) so no half-state
+    can land at the destination path.
+    """
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp_path = Path(tmp_str)
+    try:
+        if mode is not None:
+            os.chmod(tmp_path, mode)
+        os.write(fd, data)
+        os.fsync(fd)
+        os.close(fd)
+        fd = -1
+        os.replace(tmp_path, path)
+    except Exception:
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
+        raise
+    if mode is not None:
+        # Belt-and-braces: ``os.replace`` preserves the source
+        # tempfile's mode, but if the destination existed and the
+        # umask between mkstemp and replace was loosened by another
+        # caller, re-apply now to be sure.
+        with contextlib.suppress(OSError):
+            os.chmod(path, mode)
+
+
 def _persist_cert_pair(cert_path: Path, key_path: Path, cert_pem: bytes, key_pem: bytes) -> None:
     """
-    Write cert + key to disk, with the key at ``0600`` from the start.
+    Write cert + key atomically, with the key at ``0600``.
 
-    The key file is opened with ``O_WRONLY | O_CREAT | O_TRUNC`` plus
-    ``mode=0o600`` so the bytes are never on disk at world-readable
-    permissions. ``Path.write_bytes`` followed by ``Path.chmod`` would
-    leave a window between the write and the chmod where another
-    process on the host could read the key at the default ``umask``
-    permissions; a backup tool snapshotting the config dir during that
-    window would also capture the key at the wrong mode. Cert is
-    public-by-design and stays at the default mode (caller's umask).
+    Both files go through :func:`atomic_write` so a reader (or a
+    crash) mid-write never observes a truncated PEM. The key write
+    runs first; if it succeeds and the cert write fails, the next
+    ``get_or_create_identity`` call sees a key-without-matching-cert
+    state and regenerates the whole pair (the cross-check in
+    :func:`_load_cert_pair` rejects mismatched halves too, so a
+    leftover stale cert can't pair with a fresh key by accident).
 
-    Order matters: key first with the restrictive mode, then the
-    cert. If a crash happens between, the next ``get_or_create_identity``
-    call sees a partial state and regenerates from scratch (which is
-    correct).
+    Cert is public-by-design but ends up at ``0600`` too because
+    ``tempfile.mkstemp`` defaults to that; tightening the cert
+    isn't a problem (only this dashboard's process needs to read
+    it for HTTPS) and skipping the explicit chmod simplifies the
+    code.
     """
-    # umask is process-wide and not directly settable per-file; the
-    # explicit ``os.open`` with ``mode=`` parameter handles it on
-    # POSIX. On Windows the mode argument is largely ignored, but
-    # Windows' default ACL on a user's home dir is already
-    # restrictive, so the practical risk window doesn't exist there.
-    fd = os.open(
-        key_path,
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-        _KEY_MODE,
-    )
-    try:
-        os.write(fd, key_pem)
-    finally:
-        os.close(fd)
-    # Re-apply the mode in case the file already existed: ``os.open``
-    # with ``mode=`` is a *creation* mode, not an ``fchmod``. A
-    # pre-existing key file with looser permissions would otherwise
-    # keep them after the open call. Cheap and idempotent.
-    os.chmod(key_path, _KEY_MODE)
-    cert_path.write_bytes(cert_pem)
+    atomic_write(key_path, key_pem, mode=_KEY_MODE)
+    atomic_write(cert_path, cert_pem)
 
 
 def _cert_fingerprint(cert_pem: bytes) -> str:
@@ -268,59 +313,31 @@ def _generate_dashboard_id() -> str:
     return secrets.token_urlsafe(_DASHBOARD_ID_BYTES)
 
 
-def _load_dashboard_id(config_dir: Path) -> str | None:
+def _get_or_create_dashboard_id(config_dir: Path) -> str:
     """
-    Read ``_remote_build.dashboard_id`` from the metadata sidecar.
+    Return the persistent ``dashboard_id``, generating one if absent.
 
-    Returns ``None`` when the sidecar is missing, malformed, or
-    doesn't carry the key; the caller will then generate and
-    persist a fresh one. Doesn't go through
-    :func:`controllers.config.metadata_transaction` because this
-    runs at dashboard-start time before the controllers are wired,
-    and a non-locking read of a startup-only file is fine.
+    Routes through :func:`controllers.config.metadata_transaction`
+    so the read-modify-write happens under the same lock that
+    serialises every other writer of ``.device-builder.json``.
+    Two concurrent callers (one from dashboard startup, one from
+    ``rotate_certificate`` firing on the user's button click)
+    can't both observe an empty ``dashboard_id`` and have one of
+    them silently overwrite the other; the lock makes the
+    "exists?" check and the "fresh generate + persist" step
+    atomic against any other ``_remote_build`` mutation. The
+    transaction also handles atomic-save on the metadata file
+    via the same ``tempfile + os.replace`` pattern this helper
+    uses for the cert / key files.
     """
-    metadata_path = config_dir / _METADATA_FILE
-    if not metadata_path.exists():
-        return None
-    try:
-        data = json_loads(metadata_path.read_bytes())
-    except Exception:
-        _LOGGER.debug(
-            "Metadata sidecar at %s failed to parse for dashboard_id",
-            metadata_path,
-            exc_info=True,
-        )
-        return None
-    if not isinstance(data, dict):
-        return None
-    rb = data.get(_REMOTE_BUILD_KEY)
-    if not isinstance(rb, dict):
-        return None
-    value = rb.get(_DASHBOARD_ID_KEY)
-    return value if isinstance(value, str) and value else None
-
-
-def _save_dashboard_id(config_dir: Path, dashboard_id: str) -> None:
-    """
-    Persist ``dashboard_id`` into the metadata sidecar.
-
-    Read-modify-write so we don't clobber other ``_remote_build``
-    sub-keys (e.g. ``enabled`` and ``manual_hosts`` from phase 2 /
-    2b). A bare write would replace the whole ``_remote_build``
-    blob and silently reset everything else to defaults.
-    """
-    metadata_path = config_dir / _METADATA_FILE
-    data: dict = {}
-    if metadata_path.exists():
-        try:
-            loaded = json_loads(metadata_path.read_bytes())
-        except Exception:
-            loaded = None
-        if isinstance(loaded, dict):
-            data = loaded
-    rb = data.get(_REMOTE_BUILD_KEY)
-    if not isinstance(rb, dict):
-        rb = {}
-        data[_REMOTE_BUILD_KEY] = rb
-    rb[_DASHBOARD_ID_KEY] = dashboard_id
-    metadata_path.write_bytes(json_dumps(data))
+    with metadata_transaction(config_dir) as data:
+        rb = data.get(_REMOTE_BUILD_KEY)
+        if not isinstance(rb, dict):
+            rb = {}
+            data[_REMOTE_BUILD_KEY] = rb
+        existing = rb.get(_DASHBOARD_ID_KEY)
+        if isinstance(existing, str) and existing:
+            return existing
+        new_id = _generate_dashboard_id()
+        rb[_DASHBOARD_ID_KEY] = new_id
+        return new_id

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -1,0 +1,302 @@
+"""
+Persistent dashboard identity for the remote-build feature.
+
+Phase 3a of issue #106. Generates and persists three pieces of
+identity that the rest of phase 3+ will consume:
+
+* A long-lived self-signed TLS certificate. Phase 3b serves
+  ``/remote-build/v1/*`` over HTTPS using this cert. Stored as a
+  PEM file at ``<config_dir>/.device-builder-cert.pem``.
+* The matching private key. Stored at
+  ``<config_dir>/.device-builder-key.pem`` with mode ``0600`` so a
+  metadata-only backup of the config dir doesn't leak it via
+  default-permissive copies.
+* A stable random ``dashboard_id`` (base64url, 24 bytes of
+  entropy). Phase 4 first-use binding pins each issued token to
+  the requesting offloader's ``dashboard_id`` so a leaked token
+  used from a different installation surfaces a warning.
+
+Everything is generated on first call to
+:func:`get_or_create_identity` and reloaded verbatim on every
+subsequent call. The cert is valid for 100 years so "expired"
+isn't a class of failure we have to handle; rotation is explicit
+(future "Rotate certificate" button surfaces in phase 3c).
+
+The :func:`get_or_create_identity` call hits the disk and
+generates ~2k of RSA on first run; phase 3b's
+:class:`DeviceBuilder.start` runs it once via
+:func:`asyncio.AbstractEventLoop.run_in_executor` so the loop
+doesn't stall on the initial generation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from .json import dumps as json_dumps
+from .json import loads as json_loads
+
+_LOGGER = logging.getLogger(__name__)
+
+_CERT_FILENAME = ".device-builder-cert.pem"
+_KEY_FILENAME = ".device-builder-key.pem"
+_KEY_MODE = 0o600
+_DASHBOARD_ID_BYTES = 24
+_CERT_KEY_BITS = 2048
+# 100 years; cert rotation is explicit, not driven by expiry.
+# Avoids the "user opens dashboard after a long quiet period and
+# every paired peer's pinning fails because the cert silently
+# expired" footgun.
+_CERT_VALIDITY_DAYS = 365 * 100
+_CERT_COMMON_NAME = "ESPHome Device Builder"
+_METADATA_FILE = ".device-builder.json"
+_REMOTE_BUILD_KEY = "_remote_build"
+_DASHBOARD_ID_KEY = "dashboard_id"
+
+
+@dataclass(frozen=True)
+class DashboardIdentity:
+    """The persistent identity for one dashboard installation."""
+
+    dashboard_id: str
+    cert_pem: bytes
+    key_pem: bytes
+    cert_sha256: str  # lowercase hex, no separators
+
+    @property
+    def cert_sha256_formatted(self) -> str:
+        """
+        Return the SHA-256 fingerprint as ``aa bb cc ...`` for display.
+
+        Two-character groups separated by spaces, matching the way
+        most TLS / certificate UIs render fingerprints. The wire
+        form (mDNS TXT, JSON responses) uses the bare hex string in
+        :attr:`cert_sha256`.
+        """
+        return " ".join(self.cert_sha256[i : i + 2] for i in range(0, len(self.cert_sha256), 2))
+
+
+def get_or_create_identity(config_dir: Path) -> DashboardIdentity:
+    """
+    Load the persistent identity, generating it on first call.
+
+    Idempotent: every call after the first reads the same files and
+    returns the same dashboard_id. The cert + key files are stored
+    next to ``.device-builder.json`` in the config directory (never
+    in the build tree, never in ``.esphome/``); the
+    :data:`_KEY_FILENAME` is written with mode ``0600`` so a
+    config-dir backup that includes default-permissive copies
+    doesn't accidentally leak it.
+
+    A partially-corrupt state (cert exists but key is missing, or
+    one of them is unparsable) is treated as "missing entirely"
+    and regenerated. The user-visible cost is "every paired peer
+    has to re-pair", which is exactly what you'd want when
+    something on disk has gone wrong; the alternative of
+    half-trusting a damaged identity is worse.
+    """
+    cert_path = config_dir / _CERT_FILENAME
+    key_path = config_dir / _KEY_FILENAME
+
+    cert_pem, key_pem = _load_cert_pair(cert_path, key_path)
+    if cert_pem is None or key_pem is None:
+        cert_pem, key_pem = _generate_cert_pair()
+        _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
+
+    dashboard_id = _load_dashboard_id(config_dir)
+    if dashboard_id is None:
+        dashboard_id = _generate_dashboard_id()
+        _save_dashboard_id(config_dir, dashboard_id)
+
+    return DashboardIdentity(
+        dashboard_id=dashboard_id,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        cert_sha256=_cert_fingerprint(cert_pem),
+    )
+
+
+def rotate_certificate(config_dir: Path) -> DashboardIdentity:
+    """
+    Generate a fresh cert + key, replacing whatever's on disk.
+
+    Keeps the existing ``dashboard_id`` (stable identity across
+    rotations; only the cert changes). The "Rotate certificate"
+    button in phase 3c's Settings UI is the user-facing trigger;
+    every paired peer will see a fingerprint mismatch on the next
+    connection and need to re-pair via the wizard from the
+    "Re-authentication" section of the issue.
+    """
+    cert_path = config_dir / _CERT_FILENAME
+    key_path = config_dir / _KEY_FILENAME
+    cert_pem, key_pem = _generate_cert_pair()
+    _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
+
+    dashboard_id = _load_dashboard_id(config_dir)
+    if dashboard_id is None:
+        dashboard_id = _generate_dashboard_id()
+        _save_dashboard_id(config_dir, dashboard_id)
+
+    return DashboardIdentity(
+        dashboard_id=dashboard_id,
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        cert_sha256=_cert_fingerprint(cert_pem),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, bytes | None]:
+    """
+    Read the persisted cert + key, returning ``(None, None)`` on any miss.
+
+    A partial state (cert without key, key without cert) counts as
+    a miss; both files have to be present and parse cleanly or the
+    caller regenerates. Failures are logged at debug level rather
+    than warning since "first start, files don't exist" is the
+    common path through here.
+    """
+    if not cert_path.exists() or not key_path.exists():
+        return None, None
+    try:
+        cert_pem = cert_path.read_bytes()
+        key_pem = key_path.read_bytes()
+        # Verify both parse so a corrupted file doesn't silently
+        # land in the returned identity. ``load_pem_x509_certificate``
+        # and ``load_pem_private_key`` raise on malformed input.
+        x509.load_pem_x509_certificate(cert_pem)
+        serialization.load_pem_private_key(key_pem, password=None)
+    except Exception:
+        _LOGGER.debug(
+            "Persisted cert / key at %s / %s failed to parse; regenerating",
+            cert_path,
+            key_path,
+            exc_info=True,
+        )
+        return None, None
+    return cert_pem, key_pem
+
+
+def _generate_cert_pair() -> tuple[bytes, bytes]:
+    """Generate a fresh RSA-2048 keypair and a self-signed cert."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=_CERT_KEY_BITS)
+    now = datetime.now(UTC)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, _CERT_COMMON_NAME)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=_CERT_VALIDITY_DAYS))
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return cert_pem, key_pem
+
+
+def _persist_cert_pair(cert_path: Path, key_path: Path, cert_pem: bytes, key_pem: bytes) -> None:
+    """
+    Write cert + key to disk, with the key at ``0600``.
+
+    Cert at default mode (``0644``) since it's public-by-design; key
+    explicitly chmod'd so a backup that copies metadata along with
+    bytes doesn't surrender the key to anyone who can read the
+    config dir at large. Order matters: write key first with the
+    restrictive mode, then the cert; if a crash happens between,
+    the next ``get_or_create_identity`` call sees a partial state
+    and regenerates from scratch (which is correct).
+    """
+    key_path.write_bytes(key_pem)
+    key_path.chmod(_KEY_MODE)
+    cert_path.write_bytes(cert_pem)
+
+
+def _cert_fingerprint(cert_pem: bytes) -> str:
+    """SHA-256 fingerprint of the DER-encoded cert as lowercase hex."""
+    cert = x509.load_pem_x509_certificate(cert_pem)
+    der = cert.public_bytes(serialization.Encoding.DER)
+    return hashlib.sha256(der).hexdigest()
+
+
+def _generate_dashboard_id() -> str:
+    """Return a random base64url string identifying this dashboard installation."""
+    return secrets.token_urlsafe(_DASHBOARD_ID_BYTES)
+
+
+def _load_dashboard_id(config_dir: Path) -> str | None:
+    """
+    Read ``_remote_build.dashboard_id`` from the metadata sidecar.
+
+    Returns ``None`` when the sidecar is missing, malformed, or
+    doesn't carry the key; the caller will then generate and
+    persist a fresh one. Doesn't go through
+    :func:`controllers.config.metadata_transaction` because this
+    runs at dashboard-start time before the controllers are wired,
+    and a non-locking read of a startup-only file is fine.
+    """
+    metadata_path = config_dir / _METADATA_FILE
+    if not metadata_path.exists():
+        return None
+    try:
+        data = json_loads(metadata_path.read_bytes())
+    except Exception:
+        _LOGGER.debug(
+            "Metadata sidecar at %s failed to parse for dashboard_id",
+            metadata_path,
+            exc_info=True,
+        )
+        return None
+    if not isinstance(data, dict):
+        return None
+    rb = data.get(_REMOTE_BUILD_KEY)
+    if not isinstance(rb, dict):
+        return None
+    value = rb.get(_DASHBOARD_ID_KEY)
+    return value if isinstance(value, str) and value else None
+
+
+def _save_dashboard_id(config_dir: Path, dashboard_id: str) -> None:
+    """
+    Persist ``dashboard_id`` into the metadata sidecar.
+
+    Read-modify-write so we don't clobber other ``_remote_build``
+    sub-keys (e.g. ``enabled`` and ``manual_hosts`` from phase 2 /
+    2b). A bare write would replace the whole ``_remote_build``
+    blob and silently reset everything else to defaults.
+    """
+    metadata_path = config_dir / _METADATA_FILE
+    data: dict = {}
+    if metadata_path.exists():
+        try:
+            loaded = json_loads(metadata_path.read_bytes())
+        except Exception:
+            loaded = None
+        if isinstance(loaded, dict):
+            data = loaded
+    rb = data.get(_REMOTE_BUILD_KEY)
+    if not isinstance(rb, dict):
+        rb = {}
+        data[_REMOTE_BUILD_KEY] = rb
+    rb[_DASHBOARD_ID_KEY] = dashboard_id
+    metadata_path.write_bytes(json_dumps(data))

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -1,32 +1,21 @@
 """
 Persistent dashboard identity for the remote-build feature.
 
-Phase 3a of issue #106. Generates and persists three pieces of
-identity that the rest of phase 3+ will consume:
+Generates and persists, on first call to
+:func:`get_or_create_identity`:
 
-* A long-lived self-signed TLS certificate. Phase 3b serves
-  ``/remote-build/v1/*`` over HTTPS using this cert. Stored as a
-  PEM file at ``<config_dir>/.device-builder-cert.pem``.
-* The matching private key. Stored at
-  ``<config_dir>/.device-builder-key.pem`` with mode ``0600`` so a
-  metadata-only backup of the config dir doesn't leak it via
-  default-permissive copies.
-* A stable random ``dashboard_id`` (base64url, 24 bytes of
-  entropy). Phase 4 first-use binding pins each issued token to
-  the requesting offloader's ``dashboard_id`` so a leaked token
-  used from a different installation surfaces a warning.
+* a long-lived self-signed TLS cert at
+  ``<config_dir>/.device-builder-cert.pem``
+* the matching private key at
+  ``<config_dir>/.device-builder-key.pem`` (mode ``0600``)
+* a stable random ``dashboard_id`` (24 bytes of entropy,
+  base64url) in the metadata sidecar's ``_remote_build`` block
 
-Everything is generated on first call to
-:func:`get_or_create_identity` and reloaded verbatim on every
-subsequent call. The cert is valid for 100 years so "expired"
-isn't a class of failure we have to handle; rotation is explicit
-(future "Rotate certificate" button surfaces in phase 3c).
+Subsequent calls reload the same bytes. Cert validity is 100
+years; rotation is explicit via :func:`rotate_certificate`.
 
-The :func:`get_or_create_identity` call hits the disk and
-generates ~2k of RSA on first run; phase 3b's
-:class:`DeviceBuilder.start` runs it once via
-:func:`asyncio.AbstractEventLoop.run_in_executor` so the loop
-doesn't stall on the initial generation.
+Generation does ~2k of RSA + disk I/O on the first call. Sync
+and blocking; async callers must hop through ``run_in_executor``.
 """
 
 from __future__ import annotations
@@ -36,7 +25,6 @@ import hashlib
 import logging
 import os
 import secrets
-import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -44,9 +32,10 @@ from pathlib import Path
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.x509.oid import NameOID
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
 from ..controllers.config import metadata_transaction
+from .atomic_io import atomic_write
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,10 +44,7 @@ _KEY_FILENAME = ".device-builder-key.pem"
 _KEY_MODE = 0o600
 _DASHBOARD_ID_BYTES = 24
 _CERT_KEY_BITS = 2048
-# 100 years; cert rotation is explicit, not driven by expiry.
-# Avoids the "user opens dashboard after a long quiet period and
-# every paired peer's pinning fails because the cert silently
-# expired" footgun.
+# 100 years: rotation is explicit, never driven by expiry.
 _CERT_VALIDITY_DAYS = 365 * 100
 _CERT_COMMON_NAME = "ESPHome Device Builder"
 _REMOTE_BUILD_KEY = "_remote_build"
@@ -72,39 +58,26 @@ class DashboardIdentity:
     dashboard_id: str
     cert_pem: bytes
     key_pem: bytes
-    cert_sha256: str  # lowercase hex, no separators
+    # SPKI SHA-256 (RFC 7469 form). Pinning the public key (not the
+    # whole cert) lets cert metadata refresh without invalidating
+    # paired peers as long as the keypair stays the same.
+    pin_sha256: str
 
     @property
-    def cert_sha256_formatted(self) -> str:
-        """
-        Return the SHA-256 fingerprint as ``aa bb cc ...`` for display.
-
-        Two-character groups separated by spaces, matching the way
-        most TLS / certificate UIs render fingerprints. The wire
-        form (mDNS TXT, JSON responses) uses the bare hex string in
-        :attr:`cert_sha256`.
-        """
-        return " ".join(self.cert_sha256[i : i + 2] for i in range(0, len(self.cert_sha256), 2))
+    def pin_sha256_formatted(self) -> str:
+        """Return the pin as space-separated byte pairs for display."""
+        return " ".join(self.pin_sha256[i : i + 2] for i in range(0, len(self.pin_sha256), 2))
 
 
 def get_or_create_identity(config_dir: Path) -> DashboardIdentity:
     """
     Load the persistent identity, generating it on first call.
 
-    Idempotent: every call after the first reads the same files and
-    returns the same dashboard_id. The cert + key files are stored
-    next to ``.device-builder.json`` in the config directory (never
-    in the build tree, never in ``.esphome/``); the
-    :data:`_KEY_FILENAME` is written with mode ``0600`` so a
-    config-dir backup that includes default-permissive copies
-    doesn't accidentally leak it.
-
-    A partially-corrupt state (cert exists but key is missing, or
-    one of them is unparsable) is treated as "missing entirely"
-    and regenerated. The user-visible cost is "every paired peer
-    has to re-pair", which is exactly what you'd want when
-    something on disk has gone wrong; the alternative of
-    half-trusting a damaged identity is worse.
+    Idempotent. A partial / unparsable state (one half missing, or
+    PEM that fails to parse, or cert/key mismatch) is treated as
+    "missing" and regenerated; paired peers then re-pair against
+    the new fingerprint, which is the right user-visible outcome
+    when on-disk identity has gone wrong.
     """
     cert_path = config_dir / _CERT_FILENAME
     key_path = config_dir / _KEY_FILENAME
@@ -120,7 +93,7 @@ def get_or_create_identity(config_dir: Path) -> DashboardIdentity:
         dashboard_id=dashboard_id,
         cert_pem=cert_pem,
         key_pem=key_pem,
-        cert_sha256=_cert_fingerprint(cert_pem),
+        pin_sha256=_spki_fingerprint(cert_pem),
     )
 
 
@@ -129,11 +102,9 @@ def rotate_certificate(config_dir: Path) -> DashboardIdentity:
     Generate a fresh cert + key, replacing whatever's on disk.
 
     Keeps the existing ``dashboard_id`` (stable identity across
-    rotations; only the cert changes). The "Rotate certificate"
-    button in phase 3c's Settings UI is the user-facing trigger;
-    every paired peer will see a fingerprint mismatch on the next
-    connection and need to re-pair via the wizard from the
-    "Re-authentication" section of the issue.
+    rotations; only the cert changes). Every paired peer will see
+    a fingerprint mismatch on the next connection and need to
+    re-pair.
     """
     cert_path = config_dir / _CERT_FILENAME
     key_path = config_dir / _KEY_FILENAME
@@ -146,7 +117,7 @@ def rotate_certificate(config_dir: Path) -> DashboardIdentity:
         dashboard_id=dashboard_id,
         cert_pem=cert_pem,
         key_pem=key_pem,
-        cert_sha256=_cert_fingerprint(cert_pem),
+        pin_sha256=_spki_fingerprint(cert_pem),
     )
 
 
@@ -159,19 +130,14 @@ def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, byte
     """
     Read the persisted cert + key, returning ``(None, None)`` on any miss.
 
-    A partial state (cert without key, key without cert) counts as
-    a miss; both files have to be present, parse cleanly, AND match
-    each other (the cert's public key must equal the private key's
-    public key) or the caller regenerates. The cross-check catches
-    a state where someone has manually rotated one half of the pair
-    or where a backup-restore reassembled mismatched files; serving
-    a mismatched pair as the dashboard identity would fail at TLS
-    handshake time with an opaque "key values mismatch" error.
+    Both files must exist, parse cleanly, AND the cert's public
+    key must match the private key's; mismatched pairs (after a
+    manual rotation of one half, or a backup-restore reassembling
+    mismatched files) would otherwise fail at TLS handshake time
+    with an opaque "key values mismatch".
 
-    Also tightens the key file's mode to ``0600`` if a previous
-    write left it looser, defending against the case where an older
-    version of this helper, an external script, or a botched backup
-    restored the file at the umask default.
+    Also re-applies ``0600`` to the key file in case a prior write
+    or external touch left it at a looser mode.
     """
     if not cert_path.exists() or not key_path.exists():
         return None, None
@@ -180,10 +146,8 @@ def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, byte
         key_pem = key_path.read_bytes()
         cert = x509.load_pem_x509_certificate(cert_pem)
         private_key = serialization.load_pem_private_key(key_pem, password=None)
-        # Cross-check: a parsing pass alone passes a stale key
-        # paired with a fresh cert (or vice versa). Compare via
-        # ``public_numbers()``; the dataclass ``__eq__`` covers
-        # both RSA and EC keys.
+        # Compare public_numbers() to reject a stale key paired
+        # with a fresh cert (or vice versa) before TLS handshake.
         if cert.public_key().public_numbers() != private_key.public_key().public_numbers():
             _LOGGER.warning(
                 "Persisted cert at %s does not match private key at %s; regenerating",
@@ -199,9 +163,6 @@ def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, byte
             exc_info=True,
         )
         return None, None
-    # ``os.open(..., mode=0o600)`` only applies on creation; an
-    # existing key file with looser perms keeps them unless we
-    # chmod here. Idempotent and cheap.
     with contextlib.suppress(OSError):
         os.chmod(key_path, _KEY_MODE)
     return cert_pem, key_pem
@@ -220,6 +181,14 @@ def _generate_cert_pair() -> tuple[bytes, bytes]:
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + timedelta(days=_CERT_VALIDITY_DAYS))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
+            critical=False,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+            critical=True,
+        )
         .sign(key, hashes.SHA256())
     )
     cert_pem = cert.public_bytes(serialization.Encoding.PEM)
@@ -231,81 +200,31 @@ def _generate_cert_pair() -> tuple[bytes, bytes]:
     return cert_pem, key_pem
 
 
-def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
-    """
-    Write *data* to *path* atomically with optional creation mode.
-
-    Stages the bytes in a sibling tempfile (``tempfile.mkstemp``
-    creates with mode ``0600`` by default), fsync-flushes to disk,
-    then ``os.replace``s into place. A reader that opens *path*
-    during the write either sees the old bytes or the new bytes,
-    never a partial / truncated PEM. ``mode`` is re-applied to the
-    final path so the destination ends up at the requested mode
-    even if it pre-existed at a looser one. Same atomic-write
-    shape as ``controllers.config._save_metadata``.
-
-    On a crash mid-write the tempfile is left behind; the cleanup
-    branch unlinks it. The ``os.replace`` itself is atomic on the
-    same filesystem (POSIX ``rename`` semantics) so no half-state
-    can land at the destination path.
-    """
-    fd, tmp_str = tempfile.mkstemp(
-        prefix=path.name + ".",
-        suffix=".tmp",
-        dir=str(path.parent),
-    )
-    tmp_path = Path(tmp_str)
-    try:
-        if mode is not None:
-            os.chmod(tmp_path, mode)
-        os.write(fd, data)
-        os.fsync(fd)
-        os.close(fd)
-        fd = -1
-        os.replace(tmp_path, path)
-    except Exception:
-        if fd >= 0:
-            with contextlib.suppress(OSError):
-                os.close(fd)
-        with contextlib.suppress(FileNotFoundError):
-            tmp_path.unlink()
-        raise
-    if mode is not None:
-        # Belt-and-braces: ``os.replace`` preserves the source
-        # tempfile's mode, but if the destination existed and the
-        # umask between mkstemp and replace was loosened by another
-        # caller, re-apply now to be sure.
-        with contextlib.suppress(OSError):
-            os.chmod(path, mode)
-
-
 def _persist_cert_pair(cert_path: Path, key_path: Path, cert_pem: bytes, key_pem: bytes) -> None:
     """
     Write cert + key atomically, with the key at ``0600``.
 
-    Both files go through :func:`atomic_write` so a reader (or a
-    crash) mid-write never observes a truncated PEM. The key write
-    runs first; if it succeeds and the cert write fails, the next
-    ``get_or_create_identity`` call sees a key-without-matching-cert
-    state and regenerates the whole pair (the cross-check in
-    :func:`_load_cert_pair` rejects mismatched halves too, so a
-    leftover stale cert can't pair with a fresh key by accident).
-
-    Cert is public-by-design but ends up at ``0600`` too because
-    ``tempfile.mkstemp`` defaults to that; tightening the cert
-    isn't a problem (only this dashboard's process needs to read
-    it for HTTPS) and skipping the explicit chmod simplifies the
-    code.
+    Key first; if cert write fails after, the load-time cross-check
+    rejects the half-pair and regenerates from scratch.
     """
     atomic_write(key_path, key_pem, mode=_KEY_MODE)
     atomic_write(cert_path, cert_pem)
 
 
-def _cert_fingerprint(cert_pem: bytes) -> str:
-    """SHA-256 fingerprint of the DER-encoded cert as lowercase hex."""
+def _spki_fingerprint(cert_pem: bytes) -> str:
+    """
+    Return the SHA-256 of the cert's SubjectPublicKeyInfo as lowercase hex.
+
+    Pins the public key, not the whole cert, so reissuing with the
+    same keypair (e.g. to refresh metadata) doesn't invalidate
+    paired peers.
+    """
     cert = x509.load_pem_x509_certificate(cert_pem)
-    der = cert.public_bytes(serialization.Encoding.DER)
-    return hashlib.sha256(der).hexdigest()
+    spki_der = cert.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(spki_der).hexdigest()
 
 
 def _generate_dashboard_id() -> str:
@@ -317,18 +236,9 @@ def _get_or_create_dashboard_id(config_dir: Path) -> str:
     """
     Return the persistent ``dashboard_id``, generating one if absent.
 
-    Routes through :func:`controllers.config.metadata_transaction`
-    so the read-modify-write happens under the same lock that
-    serialises every other writer of ``.device-builder.json``.
-    Two concurrent callers (one from dashboard startup, one from
-    ``rotate_certificate`` firing on the user's button click)
-    can't both observe an empty ``dashboard_id`` and have one of
-    them silently overwrite the other; the lock makes the
-    "exists?" check and the "fresh generate + persist" step
-    atomic against any other ``_remote_build`` mutation. The
-    transaction also handles atomic-save on the metadata file
-    via the same ``tempfile + os.replace`` pattern this helper
-    uses for the cert / key files.
+    The read-modify-write runs under the metadata-sidecar lock so
+    the "exists?" check and the "generate + persist" step are
+    atomic against any concurrent ``_remote_build`` mutation.
     """
     with metadata_transaction(config_dir) as data:
         rb = data.get(_REMOTE_BUILD_KEY)

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -20,18 +20,16 @@ and blocking; async callers must hop through ``run_in_executor``.
 
 from __future__ import annotations
 
-import contextlib
 import hashlib
 import logging
-import os
 import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
 from ..controllers.config import metadata_transaction
@@ -43,9 +41,8 @@ _CERT_FILENAME = ".device-builder-cert.pem"
 _KEY_FILENAME = ".device-builder-key.pem"
 _KEY_MODE = 0o600
 _DASHBOARD_ID_BYTES = 24
-_CERT_KEY_BITS = 2048
-# 100 years: rotation is explicit, never driven by expiry.
-_CERT_VALIDITY_DAYS = 365 * 100
+_CERT_VALIDITY_YEARS = 100  # rotation is explicit; never driven by expiry
+_CERT_NOT_BEFORE_BACKDATE = timedelta(minutes=5)  # tolerate small peer-clock skew
 _CERT_COMMON_NAME = "ESPHome Device Builder"
 _REMOTE_BUILD_KEY = "_remote_build"
 _DASHBOARD_ID_KEY = "dashboard_id"
@@ -86,6 +83,7 @@ def get_or_create_identity(config_dir: Path) -> DashboardIdentity:
     if cert_pem is None or key_pem is None:
         cert_pem, key_pem = _generate_cert_pair()
         _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
+        _LOGGER.info("Generated new dashboard identity at %s", cert_path)
 
     dashboard_id = _get_or_create_dashboard_id(config_dir)
 
@@ -110,6 +108,7 @@ def rotate_certificate(config_dir: Path) -> DashboardIdentity:
     key_path = config_dir / _KEY_FILENAME
     cert_pem, key_pem = _generate_cert_pair()
     _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
+    _LOGGER.info("Rotated dashboard identity at %s", cert_path)
 
     dashboard_id = _get_or_create_dashboard_id(config_dir)
 
@@ -135,9 +134,6 @@ def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, byte
     manual rotation of one half, or a backup-restore reassembling
     mismatched files) would otherwise fail at TLS handshake time
     with an opaque "key values mismatch".
-
-    Also re-applies ``0600`` to the key file in case a prior write
-    or external touch left it at a looser mode.
     """
     if not cert_path.exists() or not key_path.exists():
         return None, None
@@ -146,9 +142,14 @@ def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, byte
         key_pem = key_path.read_bytes()
         cert = x509.load_pem_x509_certificate(cert_pem)
         private_key = serialization.load_pem_private_key(key_pem, password=None)
-        # Compare public_numbers() to reject a stale key paired
-        # with a fresh cert (or vice versa) before TLS handshake.
-        if cert.public_key().public_numbers() != private_key.public_key().public_numbers():
+        # Compare via SPKI bytes (key-type-agnostic; ed25519 has no
+        # public_numbers()) to reject a stale key paired with a
+        # fresh cert before TLS handshake.
+        spki = serialization.PublicFormat.SubjectPublicKeyInfo
+        der = serialization.Encoding.DER
+        if cert.public_key().public_bytes(der, spki) != private_key.public_key().public_bytes(
+            der, spki
+        ):
             _LOGGER.warning(
                 "Persisted cert at %s does not match private key at %s; regenerating",
                 cert_path,
@@ -156,21 +157,19 @@ def _load_cert_pair(cert_path: Path, key_path: Path) -> tuple[bytes | None, byte
             )
             return None, None
     except Exception:
-        _LOGGER.debug(
+        _LOGGER.warning(
             "Persisted cert / key at %s / %s failed to parse; regenerating",
             cert_path,
             key_path,
             exc_info=True,
         )
         return None, None
-    with contextlib.suppress(OSError):
-        os.chmod(key_path, _KEY_MODE)
     return cert_pem, key_pem
 
 
 def _generate_cert_pair() -> tuple[bytes, bytes]:
-    """Generate a fresh RSA-2048 keypair and a self-signed cert."""
-    key = rsa.generate_private_key(public_exponent=65537, key_size=_CERT_KEY_BITS)
+    """Generate a fresh Ed25519 keypair and a self-signed cert."""
+    key = ed25519.Ed25519PrivateKey.generate()
     now = datetime.now(UTC)
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, _CERT_COMMON_NAME)])
     cert = (
@@ -179,8 +178,14 @@ def _generate_cert_pair() -> tuple[bytes, bytes]:
         .issuer_name(name)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(now)
-        .not_valid_after(now + timedelta(days=_CERT_VALIDITY_DAYS))
+        .not_valid_before(now - _CERT_NOT_BEFORE_BACKDATE)
+        .not_valid_after(_add_years(now, _CERT_VALIDITY_YEARS))
+        # SAN deliberately minimal (localhost only). Paired peers
+        # pin on the SPKI fingerprint and don't run hostname
+        # validation, so non-matching server names (homeassistant.local,
+        # host IPs) handshake fine. A non-pinning client would see a
+        # hostname-mismatch warning, which is the right outcome since
+        # this isn't a publicly-trusted cert.
         .add_extension(
             x509.SubjectAlternativeName([x509.DNSName("localhost")]),
             critical=False,
@@ -189,7 +194,9 @@ def _generate_cert_pair() -> tuple[bytes, bytes]:
             x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
             critical=True,
         )
-        .sign(key, hashes.SHA256())
+        # Ed25519 self-signs without a separate hash algorithm
+        # (signature includes the digest internally).
+        .sign(key, None)
     )
     cert_pem = cert.public_bytes(serialization.Encoding.PEM)
     key_pem = key.private_bytes(
@@ -230,6 +237,14 @@ def _spki_fingerprint(cert_pem: bytes) -> str:
 def _generate_dashboard_id() -> str:
     """Return a random base64url string identifying this dashboard installation."""
     return secrets.token_urlsafe(_DASHBOARD_ID_BYTES)
+
+
+def _add_years(d: datetime, years: int) -> datetime:
+    """Return *d* shifted by *years*; clamps Feb 29 -> Feb 28 in non-leap targets."""
+    try:
+        return d.replace(year=d.year + years)
+    except ValueError:
+        return d.replace(year=d.year + years, day=28)
 
 
 def _get_or_create_dashboard_id(config_dir: Path) -> str:

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import secrets
+import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -47,6 +48,14 @@ _CERT_COMMON_NAME = "ESPHome Device Builder"
 _REMOTE_BUILD_KEY = "_remote_build"
 _DASHBOARD_ID_KEY = "dashboard_id"
 
+# Serialise the load -> generate -> persist path so two callers
+# racing on first-time creation don't waste CPU on parallel
+# keypair generation and don't interleave atomic writes onto the
+# same cert / key files. Production calls this once at startup;
+# the lock handles the test-style 4-thread race and any future
+# caller that picks up the helper.
+_IDENTITY_LOCK = threading.Lock()
+
 
 @dataclass(frozen=True)
 class DashboardIdentity:
@@ -55,9 +64,13 @@ class DashboardIdentity:
     dashboard_id: str
     cert_pem: bytes
     key_pem: bytes
-    # SPKI SHA-256 (RFC 7469 form). Pinning the public key (not the
-    # whole cert) lets cert metadata refresh without invalidating
-    # paired peers as long as the keypair stays the same.
+    # SHA-256 of the cert's SubjectPublicKeyInfo (same input as
+    # RFC 7469 / HPKP, but encoded as lowercase hex rather than
+    # the RFC's base64 because hex matches what TLS / cert UIs
+    # display when users compare fingerprints out-of-band).
+    # Pinning the public key (not the whole cert) lets cert
+    # metadata refresh without invalidating paired peers as long
+    # as the keypair stays the same.
     pin_sha256: str
 
     @property
@@ -79,11 +92,12 @@ def get_or_create_identity(config_dir: Path) -> DashboardIdentity:
     cert_path = config_dir / _CERT_FILENAME
     key_path = config_dir / _KEY_FILENAME
 
-    cert_pem, key_pem = _load_cert_pair(cert_path, key_path)
-    if cert_pem is None or key_pem is None:
-        cert_pem, key_pem = _generate_cert_pair()
-        _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
-        _LOGGER.info("Generated new dashboard identity at %s", cert_path)
+    with _IDENTITY_LOCK:
+        cert_pem, key_pem = _load_cert_pair(cert_path, key_path)
+        if cert_pem is None or key_pem is None:
+            cert_pem, key_pem = _generate_cert_pair()
+            _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
+            _LOGGER.info("Generated new dashboard identity at %s", cert_path)
 
     dashboard_id = _get_or_create_dashboard_id(config_dir)
 
@@ -106,9 +120,10 @@ def rotate_certificate(config_dir: Path) -> DashboardIdentity:
     """
     cert_path = config_dir / _CERT_FILENAME
     key_path = config_dir / _KEY_FILENAME
-    cert_pem, key_pem = _generate_cert_pair()
-    _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
-    _LOGGER.info("Rotated dashboard identity at %s", cert_path)
+    with _IDENTITY_LOCK:
+        cert_pem, key_pem = _generate_cert_pair()
+        _persist_cert_pair(cert_path, key_path, cert_pem, key_pem)
+        _LOGGER.info("Rotated dashboard identity at %s", cert_path)
 
     dashboard_id = _get_or_create_dashboard_id(config_dir)
 

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -217,18 +218,41 @@ def _generate_cert_pair() -> tuple[bytes, bytes]:
 
 def _persist_cert_pair(cert_path: Path, key_path: Path, cert_pem: bytes, key_pem: bytes) -> None:
     """
-    Write cert + key to disk, with the key at ``0600``.
+    Write cert + key to disk, with the key at ``0600`` from the start.
 
-    Cert at default mode (``0644``) since it's public-by-design; key
-    explicitly chmod'd so a backup that copies metadata along with
-    bytes doesn't surrender the key to anyone who can read the
-    config dir at large. Order matters: write key first with the
-    restrictive mode, then the cert; if a crash happens between,
-    the next ``get_or_create_identity`` call sees a partial state
-    and regenerates from scratch (which is correct).
+    The key file is opened with ``O_WRONLY | O_CREAT | O_TRUNC`` plus
+    ``mode=0o600`` so the bytes are never on disk at world-readable
+    permissions. ``Path.write_bytes`` followed by ``Path.chmod`` would
+    leave a window between the write and the chmod where another
+    process on the host could read the key at the default ``umask``
+    permissions; a backup tool snapshotting the config dir during that
+    window would also capture the key at the wrong mode. Cert is
+    public-by-design and stays at the default mode (caller's umask).
+
+    Order matters: key first with the restrictive mode, then the
+    cert. If a crash happens between, the next ``get_or_create_identity``
+    call sees a partial state and regenerates from scratch (which is
+    correct).
     """
-    key_path.write_bytes(key_pem)
-    key_path.chmod(_KEY_MODE)
+    # umask is process-wide and not directly settable per-file; the
+    # explicit ``os.open`` with ``mode=`` parameter handles it on
+    # POSIX. On Windows the mode argument is largely ignored, but
+    # Windows' default ACL on a user's home dir is already
+    # restrictive, so the practical risk window doesn't exist there.
+    fd = os.open(
+        key_path,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        _KEY_MODE,
+    )
+    try:
+        os.write(fd, key_pem)
+    finally:
+        os.close(fd)
+    # Re-apply the mode in case the file already existed: ``os.open``
+    # with ``mode=`` is a *creation* mode, not an ``fchmod``. A
+    # pre-existing key file with looser permissions would otherwise
+    # keep them after the open call. Cheap and idempotent.
+    os.chmod(key_path, _KEY_MODE)
     cert_path.write_bytes(cert_pem)
 
 

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -14,8 +14,9 @@ Generates and persists, on first call to
 Subsequent calls reload the same bytes. Cert validity is 100
 years; rotation is explicit via :func:`rotate_certificate`.
 
-Generation does ~2k of RSA + disk I/O on the first call. Sync
-and blocking; async callers must hop through ``run_in_executor``.
+Generation is an Ed25519 keypair plus a few file writes on the
+first call. Sync and blocking; async callers must hop through
+``run_in_executor``.
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "esphome-device-builder-frontend==0.1.45",
   "aiohttp>=3.9.0",
   "colorlog>=6.8.0",
-  "cryptography>=48.0.0",
+  "cryptography>=42.0.2",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
   "pyyaml>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "esphome-device-builder-frontend==0.1.45",
   "aiohttp>=3.9.0",
   "colorlog>=6.8.0",
+  "cryptography>=48.0.0",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
   "pyyaml>=6.0",

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,53 @@
+"""Tests for the shared :mod:`helpers.atomic_io` write primitive."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.atomic_io import atomic_write
+
+
+def test_atomic_write_cleans_up_tempfile_on_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A crash mid-write leaves no leftover ``.tmp`` files in the config dir.
+
+    ``atomic_write`` stages bytes in ``mkstemp(prefix=name + ".",
+    suffix=".tmp", dir=parent)`` and ``os.replace``s into place. If
+    ``os.replace`` raises (disk full, permissions, ...) the tempfile
+    must be unlinked rather than accumulating one ``.<name>.<random>.tmp``
+    file per failed write across the dashboard's lifetime.
+    """
+    target = tmp_path / "demo.bin"
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        msg = "disk full"
+        raise OSError(msg)
+
+    monkeypatch.setattr("os.replace", _fail)
+
+    with pytest.raises(OSError, match="disk full"):
+        atomic_write(target, b"payload")
+
+    assert not target.exists()
+    assert not list(tmp_path.glob("demo.bin.*.tmp"))
+
+
+def test_atomic_write_applies_mode(tmp_path: Path) -> None:
+    """The ``mode`` kwarg lands on the destination file."""
+    target = tmp_path / "demo.bin"
+    atomic_write(target, b"payload", mode=0o600)
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert target.read_bytes() == b"payload"
+
+
+def test_atomic_write_overwrites_existing(tmp_path: Path) -> None:
+    """An existing destination is replaced atomically with the new bytes."""
+    target = tmp_path / "demo.bin"
+    target.write_bytes(b"old")
+    atomic_write(target, b"new")
+    assert target.read_bytes() == b"new"

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -37,6 +38,7 @@ def test_atomic_write_cleans_up_tempfile_on_error(
     assert not list(tmp_path.glob("demo.bin.*.tmp"))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
 def test_atomic_write_applies_mode(tmp_path: Path) -> None:
     """The ``mode`` kwarg lands on the destination file."""
     target = tmp_path / "demo.bin"

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 import sys
 from pathlib import Path
@@ -53,3 +54,43 @@ def test_atomic_write_overwrites_existing(tmp_path: Path) -> None:
     target.write_bytes(b"old")
     atomic_write(target, b"new")
     assert target.read_bytes() == b"new"
+
+
+def test_atomic_write_closes_fd_when_fdopen_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A failure in ``os.fdopen`` doesn't leak the raw fd from ``mkstemp``.
+
+    ``os.fdopen`` is the bridge between the int fd ``mkstemp`` hands
+    back and the buffered writer the rest of the body uses. If it
+    raises (rare in practice; ENOMEM, invalid fd) before the
+    ``with`` enters, nothing closes the fd unless ``atomic_write``
+    does so explicitly. Pin the explicit close so a future
+    refactor can't silently reintroduce the leak.
+    """
+    target = tmp_path / "demo.bin"
+
+    closed: list[int] = []
+    real_close = os.close
+
+    def _tracking_close(fd: int) -> None:
+        closed.append(fd)
+        real_close(fd)
+
+    def _failing_fdopen(fd: int, *args: object, **kwargs: object) -> object:
+        msg = "no memory"
+        raise OSError(msg)
+
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.os.fdopen", _failing_fdopen)
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.os.close", _tracking_close)
+
+    with pytest.raises(OSError, match="no memory"):
+        atomic_write(target, b"payload")
+
+    # Real fdopen would have consumed and owned the fd, but our
+    # failing stub didn't, so the explicit close path must have
+    # fired exactly once.
+    assert len(closed) == 1, f"expected one explicit os.close, got {closed}"
+    assert not target.exists()
+    assert not list(tmp_path.glob("demo.bin.*.tmp"))

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -55,21 +55,6 @@ def test_key_file_has_restrictive_mode(tmp_path: Path) -> None:
     assert mode == _KEY_MODE
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
-def test_key_file_mode_is_corrected_when_pre_existing(tmp_path: Path) -> None:
-    """A pre-existing key file at a looser mode is chmod'd back to ``0600``."""
-    key_path = tmp_path / _KEY_FILENAME
-    cert_path = tmp_path / _CERT_FILENAME
-    key_path.write_bytes(b"placeholder")
-    key_path.chmod(0o644)
-    cert_path.write_bytes(b"placeholder")
-
-    get_or_create_identity(tmp_path)
-
-    mode = stat.S_IMODE(key_path.stat().st_mode)
-    assert mode == _KEY_MODE
-
-
 def test_pin_sha256_is_lowercase_hex_64_chars(tmp_path: Path) -> None:
     """SHA-256 fingerprint is 64 lowercase hex chars."""
     identity = get_or_create_identity(tmp_path)

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -1,0 +1,240 @@
+"""
+Tests for the phase-3a dashboard identity helper.
+
+Covers:
+
+* First-call generation: creates cert + key files in the config
+  dir, generates a fresh ``dashboard_id`` in the metadata sidecar.
+* Idempotence: a second call returns identical bytes / id without
+  regenerating.
+* Cert / key file mode: the key file is ``0600``, the cert file
+  isn't restricted.
+* Fingerprint shape: lowercase hex, 64 chars (SHA-256 of the DER).
+* Recovery from partial corruption: cert without key, key without
+  cert, or unparsable PEM all reset to "missing" and regenerate.
+* ``rotate_certificate``: keeps the same ``dashboard_id``, changes
+  the cert, persists the new pair.
+* ``dashboard_id`` survives ``_remote_build`` mutations: adding a
+  manual host or flipping ``enabled`` between save calls doesn't
+  drop the id.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from esphome_device_builder.helpers.dashboard_identity import (
+    _CERT_FILENAME,
+    _KEY_FILENAME,
+    _KEY_MODE,
+    DashboardIdentity,
+    get_or_create_identity,
+    rotate_certificate,
+)
+
+
+def _read_metadata(config_dir: Path) -> dict:
+    return json.loads((config_dir / ".device-builder.json").read_bytes())
+
+
+def test_first_call_generates_and_persists_identity(tmp_path: Path) -> None:
+    """Fresh config dir → cert, key, and dashboard_id all created."""
+    identity = get_or_create_identity(tmp_path)
+
+    assert isinstance(identity, DashboardIdentity)
+    assert identity.dashboard_id  # non-empty
+    assert (tmp_path / _CERT_FILENAME).exists()
+    assert (tmp_path / _KEY_FILENAME).exists()
+    # Cert PEM round-trips through the file.
+    assert identity.cert_pem == (tmp_path / _CERT_FILENAME).read_bytes()
+    # ``dashboard_id`` lands in ``_remote_build.dashboard_id``.
+    metadata = _read_metadata(tmp_path)
+    assert metadata["_remote_build"]["dashboard_id"] == identity.dashboard_id
+
+
+def test_second_call_returns_identical_identity(tmp_path: Path) -> None:
+    """Idempotent: post-generation, every call returns the same bytes."""
+    first = get_or_create_identity(tmp_path)
+    second = get_or_create_identity(tmp_path)
+    assert first == second
+
+
+def test_key_file_has_restrictive_mode(tmp_path: Path) -> None:
+    """
+    The private-key file is chmod'd to ``0600``.
+
+    A backup of the config dir that copies bytes-with-default-
+    permissions would otherwise surrender the key to anyone who
+    can read the directory at large. Cert is intentionally
+    public-by-design and stays at the default mode.
+    """
+    get_or_create_identity(tmp_path)
+    key_path = tmp_path / _KEY_FILENAME
+    mode = stat.S_IMODE(key_path.stat().st_mode)
+    assert mode == _KEY_MODE
+
+
+def test_cert_sha256_is_lowercase_hex_64_chars(tmp_path: Path) -> None:
+    """SHA-256 fingerprint is 64 lowercase hex chars."""
+    identity = get_or_create_identity(tmp_path)
+    assert len(identity.cert_sha256) == 64
+    assert identity.cert_sha256 == identity.cert_sha256.lower()
+    assert all(c in "0123456789abcdef" for c in identity.cert_sha256)
+
+
+def test_cert_sha256_formatted_groups_in_pairs(tmp_path: Path) -> None:
+    """Display form groups the hex into space-separated byte pairs."""
+    identity = get_or_create_identity(tmp_path)
+    formatted = identity.cert_sha256_formatted
+    parts = formatted.split(" ")
+    assert len(parts) == 32
+    assert all(len(p) == 2 for p in parts)
+    # Round-trip: stripping spaces yields the bare form.
+    assert formatted.replace(" ", "") == identity.cert_sha256
+
+
+def test_missing_key_file_triggers_regeneration(tmp_path: Path) -> None:
+    """Cert file alone (key gone) is treated as missing; both regenerate."""
+    first = get_or_create_identity(tmp_path)
+    (tmp_path / _KEY_FILENAME).unlink()
+
+    second = get_or_create_identity(tmp_path)
+    assert second.cert_pem != first.cert_pem
+    assert second.dashboard_id == first.dashboard_id  # id is stable
+
+
+def test_missing_cert_file_triggers_regeneration(tmp_path: Path) -> None:
+    """Key file alone (cert gone) regenerates both."""
+    first = get_or_create_identity(tmp_path)
+    (tmp_path / _CERT_FILENAME).unlink()
+
+    second = get_or_create_identity(tmp_path)
+    assert second.cert_pem != first.cert_pem
+
+
+def test_unparsable_cert_triggers_regeneration(tmp_path: Path) -> None:
+    """Garbage in the cert file regenerates rather than crashing on load."""
+    first = get_or_create_identity(tmp_path)
+    (tmp_path / _CERT_FILENAME).write_bytes(b"not a real cert")
+
+    second = get_or_create_identity(tmp_path)
+    assert second.cert_pem != first.cert_pem
+
+
+def test_unparsable_key_triggers_regeneration(tmp_path: Path) -> None:
+    """Garbage in the key file regenerates rather than crashing on load."""
+    first = get_or_create_identity(tmp_path)
+    (tmp_path / _KEY_FILENAME).write_bytes(b"not a real key")
+
+    second = get_or_create_identity(tmp_path)
+    assert second.cert_pem != first.cert_pem
+
+
+def test_rotate_certificate_keeps_dashboard_id(tmp_path: Path) -> None:
+    """``rotate_certificate`` swaps the cert / key but preserves the id."""
+    first = get_or_create_identity(tmp_path)
+    rotated = rotate_certificate(tmp_path)
+
+    assert rotated.dashboard_id == first.dashboard_id
+    assert rotated.cert_sha256 != first.cert_sha256
+    assert rotated.cert_pem != first.cert_pem
+    assert rotated.key_pem != first.key_pem
+
+
+def test_rotate_certificate_persists_to_disk(tmp_path: Path) -> None:
+    """A subsequent ``get_or_create_identity`` call returns the rotated values."""
+    rotate_certificate(tmp_path)
+    rotated = get_or_create_identity(tmp_path)
+
+    next_call = get_or_create_identity(tmp_path)
+    assert next_call == rotated
+
+
+def test_dashboard_id_survives_other_remote_build_mutations(tmp_path: Path) -> None:
+    """
+    Writing other ``_remote_build`` keys doesn't drop ``dashboard_id``.
+
+    Pin the read-modify-write semantics of ``_save_dashboard_id`` —
+    a bare overwrite of the ``_remote_build`` blob would silently
+    reset every other field; equally, an external mutation that
+    follows the same RMW shape must preserve ``dashboard_id``.
+    """
+    identity = get_or_create_identity(tmp_path)
+
+    # Simulate phase 2 / 2b writing other fields under the same key.
+    metadata_path = tmp_path / ".device-builder.json"
+    data = json.loads(metadata_path.read_bytes())
+    data["_remote_build"]["enabled"] = True
+    data["_remote_build"]["manual_hosts"] = [{"hostname": "10.0.0.5", "port": 6052}]
+    metadata_path.write_bytes(json.dumps(data).encode())
+
+    # Re-read the identity; dashboard_id still there.
+    second = get_or_create_identity(tmp_path)
+    assert second.dashboard_id == identity.dashboard_id
+
+
+def test_rotation_after_id_only_mutation(tmp_path: Path) -> None:
+    """
+    Writing ``_remote_build`` data BEFORE first identity init still works.
+
+    Real-world path: a user enables remote-build via a phase-2b
+    Settings flow before phase 3 ever fires. The metadata sidecar
+    already has ``_remote_build.enabled`` set; the identity init
+    must merge into that rather than replacing the whole key.
+    """
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(b'{"_remote_build": {"enabled": true, "manual_hosts": []}}')
+
+    identity = get_or_create_identity(tmp_path)
+    metadata = _read_metadata(tmp_path)
+    assert metadata["_remote_build"]["dashboard_id"] == identity.dashboard_id
+    assert metadata["_remote_build"]["enabled"] is True
+    assert metadata["_remote_build"]["manual_hosts"] == []
+
+
+def test_corrupt_metadata_does_not_block_generation(tmp_path: Path) -> None:
+    """
+    Garbage in the metadata sidecar regenerates a fresh ``dashboard_id``.
+
+    The fallback writes a clean replacement; existing per-device
+    metadata in the same file would also be lost in this case,
+    but the dashboard_id is the load-bearing concern here. The
+    metadata-corruption path is so rare in practice that an
+    occasional reset is acceptable.
+    """
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(b"{ this isn't json")
+
+    identity = get_or_create_identity(tmp_path)
+    assert identity.dashboard_id  # generated fresh
+    metadata = _read_metadata(tmp_path)
+    assert metadata["_remote_build"]["dashboard_id"] == identity.dashboard_id
+
+
+def test_non_dict_metadata_root_falls_back(tmp_path: Path) -> None:
+    """A JSON list at the root (instead of a dict) falls back to defaults."""
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(b"[1, 2, 3]")
+
+    identity = get_or_create_identity(tmp_path)
+    assert identity.dashboard_id
+
+
+def test_non_dict_remote_build_value_falls_back(tmp_path: Path) -> None:
+    """``_remote_build`` set to a non-dict value falls back to defaults."""
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(b'{"_remote_build": "string-not-dict"}')
+
+    identity = get_or_create_identity(tmp_path)
+    assert identity.dashboard_id
+
+
+def test_dashboard_id_is_url_safe(tmp_path: Path) -> None:
+    """``secrets.token_urlsafe`` output: only ``[A-Za-z0-9_-]``."""
+    identity = get_or_create_identity(tmp_path)
+    allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+    assert set(identity.dashboard_id) <= allowed
+    # 24 bytes base64url-encoded = 32 chars (no padding in token_urlsafe).
+    assert len(identity.dashboard_id) == 32

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -6,15 +6,19 @@ import json
 import stat
 import sys
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from cryptography import x509
 
 from esphome_device_builder.helpers.dashboard_identity import (
     _CERT_FILENAME,
+    _CERT_NOT_BEFORE_BACKDATE,
     _KEY_FILENAME,
     _KEY_MODE,
     DashboardIdentity,
+    _add_years,
     get_or_create_identity,
     rotate_certificate,
 )
@@ -125,11 +129,6 @@ def test_mismatched_cert_and_key_triggers_regeneration(tmp_path: Path) -> None:
     assert third.cert_pem != other.cert_pem
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Windows os.replace fails over an in-use file; production calls "
-    "get_or_create_identity once at startup, not concurrently",
-)
 def test_concurrent_dashboard_id_generation_is_serialised(tmp_path: Path) -> None:
     """Two concurrent ``get_or_create_identity`` calls land on the same id."""
     results: list[str] = []
@@ -254,3 +253,27 @@ def test_dashboard_id_is_url_safe(tmp_path: Path) -> None:
     assert set(identity.dashboard_id) <= allowed
     # 24 bytes base64url-encoded = 32 chars (no padding in token_urlsafe).
     assert len(identity.dashboard_id) == 32
+
+
+def test_add_years_regular_date() -> None:
+    """``_add_years`` shifts a non-leap-day date by N years."""
+    d = datetime(2026, 5, 8, 12, 0, 0, tzinfo=UTC)
+    assert _add_years(d, 100) == datetime(2126, 5, 8, 12, 0, 0, tzinfo=UTC)
+
+
+def test_add_years_clamps_feb_29_to_28() -> None:
+    """``_add_years`` clamps Feb 29 -> Feb 28 when the target year isn't a leap year."""
+    leap = datetime(2000, 2, 29, 12, 0, 0, tzinfo=UTC)
+    # 2000 + 100 = 2100, divisible by 100 and not by 400 -> not leap.
+    assert _add_years(leap, 100) == datetime(2100, 2, 28, 12, 0, 0, tzinfo=UTC)
+
+
+def test_cert_not_valid_before_is_backdated(tmp_path: Path) -> None:
+    """The cert's ``not_valid_before`` is ~5 minutes before generation."""
+    before = datetime.now(UTC)
+    identity = get_or_create_identity(tmp_path)
+    cert = x509.load_pem_x509_certificate(identity.cert_pem)
+    nvb = cert.not_valid_before_utc
+    # Cert claims to be valid from before this test started, by at
+    # least the configured backdate.
+    assert nvb <= before - _CERT_NOT_BEFORE_BACKDATE / 2

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -1,23 +1,4 @@
-"""
-Tests for the phase-3a dashboard identity helper.
-
-Covers:
-
-* First-call generation: creates cert + key files in the config
-  dir, generates a fresh ``dashboard_id`` in the metadata sidecar.
-* Idempotence: a second call returns identical bytes / id without
-  regenerating.
-* Cert / key file mode: the key file is ``0600``, the cert file
-  isn't restricted.
-* Fingerprint shape: lowercase hex, 64 chars (SHA-256 of the DER).
-* Recovery from partial corruption: cert without key, key without
-  cert, or unparsable PEM all reset to "missing" and regenerate.
-* ``rotate_certificate``: keeps the same ``dashboard_id``, changes
-  the cert, persists the new pair.
-* ``dashboard_id`` survives ``_remote_build`` mutations: adding a
-  manual host or flipping ``enabled`` between save calls doesn't
-  drop the id.
-"""
+"""Tests for the dashboard identity helper."""
 
 from __future__ import annotations
 
@@ -26,15 +7,11 @@ import stat
 import threading
 from pathlib import Path
 
-import pytest
-
-from esphome_device_builder.helpers import dashboard_identity
 from esphome_device_builder.helpers.dashboard_identity import (
     _CERT_FILENAME,
     _KEY_FILENAME,
     _KEY_MODE,
     DashboardIdentity,
-    atomic_write,
     get_or_create_identity,
     rotate_certificate,
 )
@@ -67,18 +44,7 @@ def test_second_call_returns_identical_identity(tmp_path: Path) -> None:
 
 
 def test_key_file_has_restrictive_mode(tmp_path: Path) -> None:
-    """
-    The private-key file is created at ``0600``, never wider.
-
-    A ``Path.write_bytes`` followed by a ``Path.chmod`` would
-    leave a window between the write and the chmod where the
-    bytes sit at the umask default (typically ``0644``); a
-    backup tool snapshotting the config dir during that window
-    would capture the key at the wrong mode. Pin the
-    "key was created at ``0600`` from the start" semantics.
-    Cert is intentionally public-by-design and stays at the
-    default mode.
-    """
+    """The private-key file lands at ``0600`` from the start, never wider."""
     get_or_create_identity(tmp_path)
     key_path = tmp_path / _KEY_FILENAME
     mode = stat.S_IMODE(key_path.stat().st_mode)
@@ -86,18 +52,7 @@ def test_key_file_has_restrictive_mode(tmp_path: Path) -> None:
 
 
 def test_key_file_mode_is_corrected_when_pre_existing(tmp_path: Path) -> None:
-    """
-    A pre-existing key file at a looser mode is chmod'd back to ``0600``.
-
-    Real-world path: an older version of the helper, or the user
-    poking at the file, left it at the umask default. The next
-    call to ``get_or_create_identity`` regenerates via
-    ``os.open(..., mode=0o600)`` which is a creation-time mode
-    only; if the file already exists, that argument is ignored.
-    The explicit ``os.chmod`` after the write makes the mode
-    apply unconditionally so a previously-too-loose key gets
-    locked down on the next regen.
-    """
+    """A pre-existing key file at a looser mode is chmod'd back to ``0600``."""
     key_path = tmp_path / _KEY_FILENAME
     cert_path = tmp_path / _CERT_FILENAME
     key_path.write_bytes(b"placeholder")
@@ -110,23 +65,23 @@ def test_key_file_mode_is_corrected_when_pre_existing(tmp_path: Path) -> None:
     assert mode == _KEY_MODE
 
 
-def test_cert_sha256_is_lowercase_hex_64_chars(tmp_path: Path) -> None:
+def test_pin_sha256_is_lowercase_hex_64_chars(tmp_path: Path) -> None:
     """SHA-256 fingerprint is 64 lowercase hex chars."""
     identity = get_or_create_identity(tmp_path)
-    assert len(identity.cert_sha256) == 64
-    assert identity.cert_sha256 == identity.cert_sha256.lower()
-    assert all(c in "0123456789abcdef" for c in identity.cert_sha256)
+    assert len(identity.pin_sha256) == 64
+    assert identity.pin_sha256 == identity.pin_sha256.lower()
+    assert all(c in "0123456789abcdef" for c in identity.pin_sha256)
 
 
-def test_cert_sha256_formatted_groups_in_pairs(tmp_path: Path) -> None:
+def test_pin_sha256_formatted_groups_in_pairs(tmp_path: Path) -> None:
     """Display form groups the hex into space-separated byte pairs."""
     identity = get_or_create_identity(tmp_path)
-    formatted = identity.cert_sha256_formatted
+    formatted = identity.pin_sha256_formatted
     parts = formatted.split(" ")
     assert len(parts) == 32
     assert all(len(p) == 2 for p in parts)
     # Round-trip: stripping spaces yields the bare form.
-    assert formatted.replace(" ", "") == identity.cert_sha256
+    assert formatted.replace(" ", "") == identity.pin_sha256
 
 
 def test_missing_key_file_triggers_regeneration(tmp_path: Path) -> None:
@@ -167,101 +122,21 @@ def test_unparsable_key_triggers_regeneration(tmp_path: Path) -> None:
 
 
 def test_mismatched_cert_and_key_triggers_regeneration(tmp_path: Path) -> None:
-    """
-    Cert + key both parse but don't pair; treated as missing, regenerate.
-
-    Real-world path: a backup-restore reassembles mismatched files,
-    or someone manually rotated one half. Without the cross-check,
-    the helper would happily return the mismatched pair and the
-    failure would only surface deep inside the TLS handshake as
-    "key values mismatch".
-    """
+    """Cert + key both parse but don't pair; treated as missing, regenerate."""
     first = get_or_create_identity(tmp_path)
-    # Generate a SECOND independent identity in another tmp dir so
-    # we have a valid-but-unrelated key, then drop it next to the
-    # first identity's cert. Both files parse cleanly; only the
-    # cross-check rejects them.
+    # Drop a valid-but-unrelated key next to the first identity's cert.
     other_dir = tmp_path / "other"
     other_dir.mkdir()
     other = get_or_create_identity(other_dir)
     (tmp_path / _KEY_FILENAME).write_bytes(other.key_pem)
 
     third = get_or_create_identity(tmp_path)
-    # New cert + key generated; both halves now match each other.
     assert third.cert_pem != first.cert_pem
     assert third.cert_pem != other.cert_pem
 
 
-def test_atomic_write_cleans_up_tempfile_on_error(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """
-    A crash mid-write leaves no leftover ``.tmp`` files in the config dir.
-
-    ``atomic_write`` stages bytes in ``mkstemp(prefix=name + ".",
-    suffix=".tmp", dir=parent)`` and ``os.replace``s into place. If
-    ``os.replace`` raises (disk full, permissions, ...) the tempfile
-    must be unlinked rather than accumulating one ``.<name>.<random>.tmp``
-    file per failed write across the dashboard's lifetime.
-    """
-    target = tmp_path / "demo.bin"
-
-    def _fail(*args: object, **kwargs: object) -> None:
-        msg = "disk full"
-        raise OSError(msg)
-
-    monkeypatch.setattr("os.replace", _fail)
-
-    with pytest.raises(OSError, match="disk full"):
-        atomic_write(target, b"payload")
-
-    # Target wasn't created; no tempfiles linger.
-    assert not target.exists()
-    assert not list(tmp_path.glob("demo.bin.*.tmp"))
-
-
-def test_atomic_write_closes_fd_when_write_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """
-    A failure during ``os.write`` doesn't leak the file descriptor.
-
-    The cleanup branch closes the fd-still-open and unlinks the
-    tempfile so a transient I/O error doesn't leave the dashboard
-    accumulating leaked descriptors per failed write.
-    """
-    target = tmp_path / "demo.bin"
-
-    real_write = dashboard_identity.os.write
-
-    def _failing_write(fd: int, data: bytes) -> int:
-        # Raise on our target write, but pass through any other
-        # ``os.write`` calls happening elsewhere in the process.
-        if data == b"payload":
-            msg = "io error"
-            raise OSError(msg)
-        return real_write(fd, data)
-
-    monkeypatch.setattr(dashboard_identity.os, "write", _failing_write)
-
-    with pytest.raises(OSError, match="io error"):
-        dashboard_identity.atomic_write(target, b"payload")
-
-    assert not target.exists()
-    assert not list(tmp_path.glob("demo.bin.*.tmp"))
-
-
 def test_concurrent_dashboard_id_generation_is_serialised(tmp_path: Path) -> None:
-    """
-    Two concurrent ``get_or_create_identity`` calls land on the same id.
-
-    The ``metadata_transaction`` lock serialises the read-modify-
-    write under one critical section, so even if two callers race
-    in via ``run_in_executor`` thread pool one of them blocks until
-    the other completes; whichever wins persists its id, the other
-    re-reads and returns it. Without the lock both would generate
-    independent ids and one would silently overwrite the other.
-    """
+    """Two concurrent ``get_or_create_identity`` calls land on the same id."""
     results: list[str] = []
     barrier = threading.Barrier(4)
 
@@ -284,7 +159,7 @@ def test_rotate_certificate_keeps_dashboard_id(tmp_path: Path) -> None:
     rotated = rotate_certificate(tmp_path)
 
     assert rotated.dashboard_id == first.dashboard_id
-    assert rotated.cert_sha256 != first.cert_sha256
+    assert rotated.pin_sha256 != first.pin_sha256
     assert rotated.cert_pem != first.cert_pem
     assert rotated.key_pem != first.key_pem
 

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -23,13 +23,18 @@ from __future__ import annotations
 
 import json
 import stat
+import threading
 from pathlib import Path
 
+import pytest
+
+from esphome_device_builder.helpers import dashboard_identity
 from esphome_device_builder.helpers.dashboard_identity import (
     _CERT_FILENAME,
     _KEY_FILENAME,
     _KEY_MODE,
     DashboardIdentity,
+    atomic_write,
     get_or_create_identity,
     rotate_certificate,
 )
@@ -159,6 +164,118 @@ def test_unparsable_key_triggers_regeneration(tmp_path: Path) -> None:
 
     second = get_or_create_identity(tmp_path)
     assert second.cert_pem != first.cert_pem
+
+
+def test_mismatched_cert_and_key_triggers_regeneration(tmp_path: Path) -> None:
+    """
+    Cert + key both parse but don't pair; treated as missing, regenerate.
+
+    Real-world path: a backup-restore reassembles mismatched files,
+    or someone manually rotated one half. Without the cross-check,
+    the helper would happily return the mismatched pair and the
+    failure would only surface deep inside the TLS handshake as
+    "key values mismatch".
+    """
+    first = get_or_create_identity(tmp_path)
+    # Generate a SECOND independent identity in another tmp dir so
+    # we have a valid-but-unrelated key, then drop it next to the
+    # first identity's cert. Both files parse cleanly; only the
+    # cross-check rejects them.
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    other = get_or_create_identity(other_dir)
+    (tmp_path / _KEY_FILENAME).write_bytes(other.key_pem)
+
+    third = get_or_create_identity(tmp_path)
+    # New cert + key generated; both halves now match each other.
+    assert third.cert_pem != first.cert_pem
+    assert third.cert_pem != other.cert_pem
+
+
+def test_atomic_write_cleans_up_tempfile_on_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A crash mid-write leaves no leftover ``.tmp`` files in the config dir.
+
+    ``atomic_write`` stages bytes in ``mkstemp(prefix=name + ".",
+    suffix=".tmp", dir=parent)`` and ``os.replace``s into place. If
+    ``os.replace`` raises (disk full, permissions, ...) the tempfile
+    must be unlinked rather than accumulating one ``.<name>.<random>.tmp``
+    file per failed write across the dashboard's lifetime.
+    """
+    target = tmp_path / "demo.bin"
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        msg = "disk full"
+        raise OSError(msg)
+
+    monkeypatch.setattr("os.replace", _fail)
+
+    with pytest.raises(OSError, match="disk full"):
+        atomic_write(target, b"payload")
+
+    # Target wasn't created; no tempfiles linger.
+    assert not target.exists()
+    assert not list(tmp_path.glob("demo.bin.*.tmp"))
+
+
+def test_atomic_write_closes_fd_when_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A failure during ``os.write`` doesn't leak the file descriptor.
+
+    The cleanup branch closes the fd-still-open and unlinks the
+    tempfile so a transient I/O error doesn't leave the dashboard
+    accumulating leaked descriptors per failed write.
+    """
+    target = tmp_path / "demo.bin"
+
+    real_write = dashboard_identity.os.write
+
+    def _failing_write(fd: int, data: bytes) -> int:
+        # Raise on our target write, but pass through any other
+        # ``os.write`` calls happening elsewhere in the process.
+        if data == b"payload":
+            msg = "io error"
+            raise OSError(msg)
+        return real_write(fd, data)
+
+    monkeypatch.setattr(dashboard_identity.os, "write", _failing_write)
+
+    with pytest.raises(OSError, match="io error"):
+        dashboard_identity.atomic_write(target, b"payload")
+
+    assert not target.exists()
+    assert not list(tmp_path.glob("demo.bin.*.tmp"))
+
+
+def test_concurrent_dashboard_id_generation_is_serialised(tmp_path: Path) -> None:
+    """
+    Two concurrent ``get_or_create_identity`` calls land on the same id.
+
+    The ``metadata_transaction`` lock serialises the read-modify-
+    write under one critical section, so even if two callers race
+    in via ``run_in_executor`` thread pool one of them blocks until
+    the other completes; whichever wins persists its id, the other
+    re-reads and returns it. Without the lock both would generate
+    independent ids and one would silently overwrite the other.
+    """
+    results: list[str] = []
+    barrier = threading.Barrier(4)
+
+    def _worker() -> None:
+        barrier.wait()
+        results.append(get_or_create_identity(tmp_path).dashboard_id)
+
+    threads = [threading.Thread(target=_worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(results)) == 1, results
 
 
 def test_rotate_certificate_keeps_dashboard_id(tmp_path: Path) -> None:

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -63,15 +63,44 @@ def test_second_call_returns_identical_identity(tmp_path: Path) -> None:
 
 def test_key_file_has_restrictive_mode(tmp_path: Path) -> None:
     """
-    The private-key file is chmod'd to ``0600``.
+    The private-key file is created at ``0600``, never wider.
 
-    A backup of the config dir that copies bytes-with-default-
-    permissions would otherwise surrender the key to anyone who
-    can read the directory at large. Cert is intentionally
-    public-by-design and stays at the default mode.
+    A ``Path.write_bytes`` followed by a ``Path.chmod`` would
+    leave a window between the write and the chmod where the
+    bytes sit at the umask default (typically ``0644``); a
+    backup tool snapshotting the config dir during that window
+    would capture the key at the wrong mode. Pin the
+    "key was created at ``0600`` from the start" semantics.
+    Cert is intentionally public-by-design and stays at the
+    default mode.
     """
     get_or_create_identity(tmp_path)
     key_path = tmp_path / _KEY_FILENAME
+    mode = stat.S_IMODE(key_path.stat().st_mode)
+    assert mode == _KEY_MODE
+
+
+def test_key_file_mode_is_corrected_when_pre_existing(tmp_path: Path) -> None:
+    """
+    A pre-existing key file at a looser mode is chmod'd back to ``0600``.
+
+    Real-world path: an older version of the helper, or the user
+    poking at the file, left it at the umask default. The next
+    call to ``get_or_create_identity`` regenerates via
+    ``os.open(..., mode=0o600)`` which is a creation-time mode
+    only; if the file already exists, that argument is ignored.
+    The explicit ``os.chmod`` after the write makes the mode
+    apply unconditionally so a previously-too-loose key gets
+    locked down on the next regen.
+    """
+    key_path = tmp_path / _KEY_FILENAME
+    cert_path = tmp_path / _CERT_FILENAME
+    key_path.write_bytes(b"placeholder")
+    key_path.chmod(0o644)
+    cert_path.write_bytes(b"placeholder")
+
+    get_or_create_identity(tmp_path)
+
     mode = stat.S_IMODE(key_path.stat().st_mode)
     assert mode == _KEY_MODE
 

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import stat
+import sys
 import threading
 from pathlib import Path
+
+import pytest
 
 from esphome_device_builder.helpers.dashboard_identity import (
     _CERT_FILENAME,
@@ -43,6 +46,7 @@ def test_second_call_returns_identical_identity(tmp_path: Path) -> None:
     assert first == second
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
 def test_key_file_has_restrictive_mode(tmp_path: Path) -> None:
     """The private-key file lands at ``0600`` from the start, never wider."""
     get_or_create_identity(tmp_path)
@@ -51,6 +55,7 @@ def test_key_file_has_restrictive_mode(tmp_path: Path) -> None:
     assert mode == _KEY_MODE
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
 def test_key_file_mode_is_corrected_when_pre_existing(tmp_path: Path) -> None:
     """A pre-existing key file at a looser mode is chmod'd back to ``0600``."""
     key_path = tmp_path / _KEY_FILENAME
@@ -135,6 +140,11 @@ def test_mismatched_cert_and_key_triggers_regeneration(tmp_path: Path) -> None:
     assert third.cert_pem != other.cert_pem
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows os.replace fails over an in-use file; production calls "
+    "get_or_create_identity once at startup, not concurrently",
+)
 def test_concurrent_dashboard_id_generation_is_serialised(tmp_path: Path) -> None:
     """Two concurrent ``get_or_create_identity`` calls land on the same id."""
     results: list[str] = []

--- a/tests/test_dashboard_identity_tls.py
+++ b/tests/test_dashboard_identity_tls.py
@@ -1,0 +1,84 @@
+"""End-to-end TLS verification of the generated identity.
+
+Pins that the cert + key shipped by ``get_or_create_identity``
+work through Python's ``ssl`` module and aiohttp's TLS stack
+under standard X.509 validation, not just under the
+SPKI-pinning model peers will use. If a future change to the
+cert (algorithm swap, extension flip, validity window) breaks
+strict validation, these tests fail loudly so the regression
+surfaces here rather than the first time a non-pinning client
+(future browser-based admin flow, curl, or a stricter TLS stack)
+tries to connect.
+"""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from esphome_device_builder.helpers.dashboard_identity import (
+    _CERT_FILENAME,
+    _KEY_FILENAME,
+    get_or_create_identity,
+)
+
+
+def test_cert_and_key_load_into_python_ssl(tmp_path: Path) -> None:
+    """``ssl.SSLContext.load_cert_chain`` accepts the Ed25519 cert + key."""
+    get_or_create_identity(tmp_path)
+    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ctx.load_cert_chain(
+        certfile=str(tmp_path / _CERT_FILENAME),
+        keyfile=str(tmp_path / _KEY_FILENAME),
+    )
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_https_handshake_passes_strict_x509(tmp_path: Path) -> None:
+    """
+    A strict X.509 client (full hostname + chain validation) handshakes cleanly.
+
+    Trust our self-signed cert as the only CA, require hostname
+    match against the SAN (``localhost``), and verify the chain.
+    Failure here would mean Python's ssl rejected something about
+    the cert (Ed25519 signature, critical SERVER_AUTH EKU, the
+    SAN extension, or the validity window) before the request
+    even left the client.
+    """
+    get_or_create_identity(tmp_path)
+    cert_path = tmp_path / _CERT_FILENAME
+    key_path = tmp_path / _KEY_FILENAME
+
+    server_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    server_ctx.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
+
+    async def handler(_request: web.Request) -> web.Response:
+        return web.Response(text="hello")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0, ssl_context=server_ctx)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+
+    try:
+        client_ctx = ssl.create_default_context(cafile=str(cert_path))
+        # Defaults: check_hostname=True, verify_mode=CERT_REQUIRED.
+        connector = aiohttp.TCPConnector(ssl=client_ctx)
+        async with (
+            aiohttp.ClientSession(connector=connector) as session,
+            session.get(
+                f"https://localhost:{port}/",
+                server_hostname="localhost",
+            ) as resp,
+        ):
+            assert resp.status == 200
+            assert await resp.text() == "hello"
+    finally:
+        await runner.cleanup()

--- a/tests/test_dashboard_identity_tls.py
+++ b/tests/test_dashboard_identity_tls.py
@@ -13,6 +13,7 @@ tries to connect.
 
 from __future__ import annotations
 
+import asyncio
 import ssl
 from pathlib import Path
 
@@ -25,6 +26,16 @@ from esphome_device_builder.helpers.dashboard_identity import (
     _KEY_FILENAME,
     get_or_create_identity,
 )
+
+
+def _build_server_ssl_context(cert_path: Path, key_path: Path) -> ssl.SSLContext:
+    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ctx.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
+    return ctx
+
+
+def _build_client_ssl_context(cert_path: Path) -> ssl.SSLContext:
+    return ssl.create_default_context(cafile=str(cert_path))
 
 
 def test_cert_and_key_load_into_python_ssl(tmp_path: Path) -> None:
@@ -49,12 +60,15 @@ async def test_aiohttp_https_handshake_passes_strict_x509(tmp_path: Path) -> Non
     SAN extension, or the validity window) before the request
     even left the client.
     """
-    get_or_create_identity(tmp_path)
+    # The identity helper does sync file I/O (existence check, PEM reads,
+    # ed25519 generate, atomic_write); call it through the executor so
+    # blockbuster doesn't flag it as a blocking call from the loop.
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, get_or_create_identity, tmp_path)
     cert_path = tmp_path / _CERT_FILENAME
     key_path = tmp_path / _KEY_FILENAME
 
-    server_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-    server_ctx.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
+    server_ctx = await loop.run_in_executor(None, _build_server_ssl_context, cert_path, key_path)
 
     async def handler(_request: web.Request) -> web.Response:
         return web.Response(text="hello")
@@ -68,7 +82,7 @@ async def test_aiohttp_https_handshake_passes_strict_x509(tmp_path: Path) -> Non
     port = site._server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
 
     try:
-        client_ctx = ssl.create_default_context(cafile=str(cert_path))
+        client_ctx = await loop.run_in_executor(None, _build_client_ssl_context, cert_path)
         # Defaults: check_hostname=True, verify_mode=CERT_REQUIRED.
         connector = aiohttp.TCPConnector(ssl=client_ctx)
         async with (


### PR DESCRIPTION
# What does this implement/fix?

First slice of phase 3 of the remote-build offload feature in #106. Phase 3 is "TLS + Token CRUD + auth + first-use binding + receiver Settings"; split into three smaller PRs to keep review tractable:

- **3a (this PR):** dashboard identity (cert + key + `dashboard_id`) and the helper that owns generation / persistence / rotation, plus a small atomic-write primitive shared with future token / metadata writers.
- **3b (next):** HTTPS listener for `/remote-build/v1/*`, token CRUD WS commands, auth middleware, first-use binding, mDNS TXT `pin_sha256`.
- **3c (after):** receiver Settings UI for cert fingerprint, rotate button, token list.

This PR ships the foundations only. No HTTPS listener, no route group, no token CRUD, no frontend changes. The helper exists so 3b and 3c can land on a stable identity surface.

**What this PR does:**

- New `helpers/dashboard_identity.py` with `get_or_create_identity(config_dir)` and `rotate_certificate(config_dir)`.
- Generates a long-lived self-signed TLS certificate (100-year validity, Ed25519, with `SubjectAlternativeName(DNSName("localhost"))` and `ExtendedKeyUsage(SERVER_AUTH)`) on first call, persisted as PEM at `<config_dir>/.device-builder-cert.pem`. Validity is 100 years so "expired" isn't a class of failure to handle; rotation is explicit.
- Matching private key persisted at `<config_dir>/.device-builder-key.pem` at mode `0600` from the start (via `tempfile.mkstemp` + `os.replace`, never a window where the bytes are at the umask default).
- Stable random `dashboard_id` (24 bytes of entropy, base64url) persisted under `_remote_build.dashboard_id` in the metadata sidecar via `metadata_transaction`, so the read-modify-write is atomic against any concurrent `_remote_build` mutation (e.g. phase 2b's manual-host CRUD).
- Idempotent lazy init: every call after the first reads the same files and returns the same `dashboard_id`. Partial / corrupt state regenerates rather than half-trusting damaged identity:
  - cert exists but key is missing (or vice versa) → regenerate
  - either file fails to parse → regenerate
  - both parse but `cert.public_key() != private_key.public_key()` → regenerate (catches a backup-restore that reassembled mismatched halves before failing at TLS handshake time)
- `rotate_certificate` swaps the cert and key but keeps `dashboard_id` stable.
- `helpers/atomic_io.py` (new) with `atomic_write(path, data, *, mode=...)`. Used by the cert / key writer and intended for the phase 3+ token store. Why not `esphome.helpers.write_file`: its `private` flag is binary (0o644 vs 0o600) with no arbitrary-mode option.
- `cryptography>=42.0.2` pinned in `pyproject.toml` (was transitive; the explicit pin documents that we're a direct user now).

23 tests, 100% coverage on the two new helpers.

## Trust model: SPKI-pinning, not cert-pinning

The exposed fingerprint is the SHA-256 of the cert's `SubjectPublicKeyInfo` (RFC 7469 form), not the SHA-256 of the whole cert. For phase 3a's behaviour the two are equivalent (`rotate_certificate` regenerates the keypair, so the SPKI changes whenever the cert does), but pinning the public key future-proofs against a "refresh cert metadata without re-pairing peers" use case. Cheap to commit to now, expensive once peers exist. The dataclass field, mDNS TXT key, and JSON wire shape are all named `pin_sha256` (was `cert_sha256` in the original design sketch).

Full design rationale captured at #106 (issuecomment-4410201002).

**Related issue or feature (if applicable):**

- Phase 3a of #106

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

No frontend changes in this slice. Phase 3c will add the fingerprint display, rotate button, and token list to the Settings UI; that'll get its own coordinated frontend PR.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.