### PR TITLE
Add receiver-side token CRUD (#106 phase 3b1)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -251,20 +251,20 @@ Renaming or recoloring a label leaves device assignments untouched — devices r
 
 > Controller: [`RemoteBuildController`](../esphome_device_builder/controllers/remote_build.py)
 >
-> Models: [`RemoteBuildSettings`](../esphome_device_builder/models/remote_build.py), [`RemoteBuildPeer`](../esphome_device_builder/models/remote_build.py), [`ManualHost`](../esphome_device_builder/models/remote_build.py), [`StoredToken`](../esphome_device_builder/models/remote_build.py), [`TokenSummary`](../esphome_device_builder/models/remote_build.py), [`TokenCreateResult`](../esphome_device_builder/models/remote_build.py)
+> Models: [`RemoteBuildSettingsView`](../esphome_device_builder/models/remote_build.py), [`RemoteBuildPeer`](../esphome_device_builder/models/remote_build.py), [`ManualHost`](../esphome_device_builder/models/remote_build.py), [`TokenSummary`](../esphome_device_builder/models/remote_build.py), [`TokenCreateResult`](../esphome_device_builder/models/remote_build.py)
 
 Receiver-side surface for the remote-build offload feature (issue #106). Discovers peer dashboards via mDNS (`_esphomebuilder._tcp.local.`), lets the user add manual peers for cross-subnet LANs, and issues bearer tokens that paired offloaders present to the receiver's HTTPS listener (the listener itself lands in phase 3b2). Settings persist in `.device-builder.json` under `_remote_build`.
 
 | Command | Args | Response | Description |
 |---------|------|----------|-------------|
 | `remote_build/list_hosts` | — | `[RemoteBuildPeer]` | Discovered (`source=mdns`) and manually-added (`source=manual`) peer dashboards merged into one list. |
-| `remote_build/get_settings` | — | `RemoteBuildSettings` | Read the receiver-side settings (enabled, manual_hosts, tokens). |
-| `remote_build/set_settings` | `{enabled}` | `RemoteBuildSettings` | Persist the master switch. Strict-bool; rejects truthy strings. |
-| `remote_build/add_manual_host` | `{hostname, port}` | `RemoteBuildSettings` | Add a manual peer for cross-subnet / non-mDNS LANs. Hostname normalised to lowercase. Duplicate `(hostname, port)` raises `already_exists`. |
-| `remote_build/remove_manual_host` | `{hostname, port}` | `RemoteBuildSettings` | Remove a manual peer. Unknown pair raises `not_found`. |
+| `remote_build/get_settings` | — | `RemoteBuildSettingsView` | Read the receiver-side settings (enabled, manual_hosts, tokens). |
+| `remote_build/set_settings` | `{enabled}` | `RemoteBuildSettingsView` | Persist the master switch. Strict-bool; rejects truthy strings. |
+| `remote_build/add_manual_host` | `{hostname, port}` | `RemoteBuildSettingsView` | Add a manual peer for cross-subnet / non-mDNS LANs. Hostname normalised to lowercase. Duplicate `(hostname, port)` raises `already_exists`. |
+| `remote_build/remove_manual_host` | `{hostname, port}` | `RemoteBuildSettingsView` | Remove a manual peer. Unknown pair raises `not_found`. |
 | `remote_build/list_tokens` | — | `[TokenSummary]` | Issued bearer tokens, projected to omit the secret hash. |
 | `remote_build/add_token` | `{label}` | `TokenCreateResult` | Issue a fresh bearer. The cleartext `bearer` flashes through the response **once**; only `sha256(secret)` lands on disk. Label 1-128 chars; duplicates allowed (`token_id` is the unique key). |
-| `remote_build/remove_token` | `{token_id}` | `RemoteBuildSettings` | Revoke a token. Unknown / blank `token_id` raises `not_found` / `invalid_args` respectively. |
+| `remote_build/remove_token` | `{token_id}` | `RemoteBuildSettingsView` | Revoke a token. Unknown / blank `token_id` raises `not_found` / `invalid_args` respectively. |
 
 **Bearer wire format**: `{token_id}.{secret}` where `token_id` is the lookup key (8-byte base64url, ~11 chars) and `secret` is the verification value (32-byte base64url, ~43 chars). Phase 3b2's auth middleware will split on `.`, look up by `token_id`, and `hmac.compare_digest` SHA-256(`secret`) against the stored hash.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -247,6 +247,29 @@ User-defined chips (name + optional `#rrggbb` color) that can be assigned to dev
 
 Renaming or recoloring a label leaves device assignments untouched — devices reference labels by id, not by name. The frontend is expected to subscribe to `subscribe_events`, fetch the catalog once via `labels/list`, then resolve ids → name + color at render time.
 
+### Remote Build
+
+> Controller: [`RemoteBuildController`](../esphome_device_builder/controllers/remote_build.py)
+>
+> Models: [`RemoteBuildSettings`](../esphome_device_builder/models/remote_build.py), [`RemoteBuildPeer`](../esphome_device_builder/models/remote_build.py), [`ManualHost`](../esphome_device_builder/models/remote_build.py), [`StoredToken`](../esphome_device_builder/models/remote_build.py), [`TokenSummary`](../esphome_device_builder/models/remote_build.py), [`TokenCreateResult`](../esphome_device_builder/models/remote_build.py)
+
+Receiver-side surface for the remote-build offload feature (issue #106). Discovers peer dashboards via mDNS (`_esphomebuilder._tcp.local.`), lets the user add manual peers for cross-subnet LANs, and issues bearer tokens that paired offloaders present to the receiver's HTTPS listener (the listener itself lands in phase 3b2). Settings persist in `.device-builder.json` under `_remote_build`.
+
+| Command | Args | Response | Description |
+|---------|------|----------|-------------|
+| `remote_build/list_hosts` | — | `[RemoteBuildPeer]` | Discovered (`source=mdns`) and manually-added (`source=manual`) peer dashboards merged into one list. |
+| `remote_build/get_settings` | — | `RemoteBuildSettings` | Read the receiver-side settings (enabled, manual_hosts, tokens). |
+| `remote_build/set_settings` | `{enabled}` | `RemoteBuildSettings` | Persist the master switch. Strict-bool; rejects truthy strings. |
+| `remote_build/add_manual_host` | `{hostname, port}` | `RemoteBuildSettings` | Add a manual peer for cross-subnet / non-mDNS LANs. Hostname normalised to lowercase. Duplicate `(hostname, port)` raises `already_exists`. |
+| `remote_build/remove_manual_host` | `{hostname, port}` | `RemoteBuildSettings` | Remove a manual peer. Unknown pair raises `not_found`. |
+| `remote_build/list_tokens` | — | `[TokenSummary]` | Issued bearer tokens, projected to omit the secret hash. |
+| `remote_build/add_token` | `{label}` | `TokenCreateResult` | Issue a fresh bearer. The cleartext `bearer` flashes through the response **once**; only `sha256(secret)` lands on disk. Label 1-128 chars; duplicates allowed (`token_id` is the unique key). |
+| `remote_build/remove_token` | `{token_id}` | `RemoteBuildSettings` | Revoke a token. Unknown / blank `token_id` raises `not_found` / `invalid_args` respectively. |
+
+**Bearer wire format**: `{token_id}.{secret}` where `token_id` is the lookup key (8-byte base64url, ~11 chars) and `secret` is the verification value (32-byte base64url, ~43 chars). Phase 3b2's auth middleware will split on `.`, look up by `token_id`, and `hmac.compare_digest` SHA-256(`secret`) against the stored hash.
+
+**`bound_dashboard_id`** on `StoredToken` / `TokenSummary` is reserved for phase 3b3's first-use binding; it stays `null` until the first authenticated request arrives carrying the offloader's `X-Dashboard-ID` header.
+
 ### Utility
 
 | Command | Args | Response | Description |

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -27,7 +27,7 @@ from ..constants import __version__ as server_version
 from ..helpers.api import CommandError, api_command
 from ..helpers.auth import hash_password
 from ..helpers.json import JSONDecodeError, dumps_indent, loads
-from ..models import ErrorCode, Label, RemoteBuildSettings, UserPreferences
+from ..models import ErrorCode, Label, RemoteBuildSettings, StoredToken, UserPreferences
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
@@ -532,21 +532,64 @@ def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
         data[_PREFS_KEY] = prefs.to_dict()
 
 
+def _decode_tokens(raw: Any) -> list[StoredToken]:
+    """
+    Parse the on-disk ``_remote_build.tokens`` list, dropping malformed rows.
+
+    Mirrors :func:`_decode_labels`: one bad entry shouldn't blank
+    every other token from the receiver's view, since the operator
+    would lose access to all paired peers until disk repair. Each
+    row is validated independently; a row that fails to round-trip
+    through :class:`StoredToken` is skipped with a debug log.
+    """
+    if not isinstance(raw, list):
+        return []
+    out: list[StoredToken] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            out.append(StoredToken.from_dict(entry))
+        except Exception as err:
+            _LOGGER.debug("Skipping malformed token entry %r: %s", entry, err)
+    return out
+
+
+def _settings_from_raw(raw: Any) -> RemoteBuildSettings:
+    """
+    Decode a ``_remote_build`` blob with row-level token tolerance.
+
+    The whole-blob fallback is preserved for corrupt
+    ``manual_hosts`` / ``enabled`` (those fields are atomic and a
+    schema break should reset to defaults loudly), but tokens
+    decode row-by-row so one bad token row doesn't disconnect
+    every paired peer.
+    """
+    if not isinstance(raw, dict):
+        return RemoteBuildSettings()
+    # Pre-clean the tokens list so mashumaro's all-or-nothing
+    # ``from_dict`` doesn't refuse the whole blob over one bad row.
+    cleaned: dict[str, Any] = {
+        **raw,
+        "tokens": [t.to_dict() for t in _decode_tokens(raw.get("tokens"))],
+    }
+    try:
+        return RemoteBuildSettings.from_dict(cleaned)
+    except Exception:
+        return RemoteBuildSettings()
+
+
 def load_remote_build_settings(config_dir: Path) -> RemoteBuildSettings:
     """
     Load the receiver-side remote-build settings.
 
     Returns defaults (``enabled=False``) when the metadata file is
-    missing or the ``_remote_build`` key isn't present. A
-    deserialisation failure also falls back to defaults rather than
-    crashing dashboard startup — a corrupted settings blob shouldn't
-    take down the whole receiver.
+    missing or the ``_remote_build`` key isn't present. Token rows
+    that fail to round-trip are dropped individually (see
+    :func:`_decode_tokens`); a wholly malformed blob falls back to
+    defaults rather than crashing dashboard startup.
     """
-    raw = _load_metadata(config_dir).get(_REMOTE_BUILD_KEY, {})
-    try:
-        return RemoteBuildSettings.from_dict(raw)
-    except Exception:
-        return RemoteBuildSettings()
+    return _settings_from_raw(_load_metadata(config_dir).get(_REMOTE_BUILD_KEY, {}))
 
 
 def save_remote_build_settings(config_dir: Path, settings: RemoteBuildSettings) -> None:
@@ -577,11 +620,7 @@ def remote_build_settings_transaction(
     change.
     """
     with metadata_transaction(config_dir) as data:
-        raw = data.get(_REMOTE_BUILD_KEY, {})
-        try:
-            settings = RemoteBuildSettings.from_dict(raw)
-        except Exception:
-            settings = RemoteBuildSettings()
+        settings = _settings_from_raw(data.get(_REMOTE_BUILD_KEY, {}))
         yield settings
         data[_REMOTE_BUILD_KEY] = settings.to_dict()
 

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -541,6 +541,13 @@ def _decode_tokens(raw: Any) -> list[StoredToken]:
     would lose access to all paired peers until disk repair. Each
     row is validated independently; a row that fails to round-trip
     through :class:`StoredToken` is skipped with a debug log.
+
+    The skip log only carries the non-sensitive ``token_id`` (the
+    public lookup key, never a secret), not the full entry dict.
+    A hand-edited sidecar could carry credential-adjacent fields
+    (e.g. an operator pasted the cleartext secret into the wrong
+    field by mistake), and ``%r``-dumping the whole row would
+    surface that material in logs / log shippers.
     """
     if not isinstance(raw, list):
         return []
@@ -551,7 +558,11 @@ def _decode_tokens(raw: Any) -> list[StoredToken]:
         try:
             out.append(StoredToken.from_dict(entry))
         except Exception as err:
-            _LOGGER.debug("Skipping malformed token entry %r: %s", entry, err)
+            safe_id = entry.get("token_id")
+            safe_id_repr = (
+                safe_id if isinstance(safe_id, str) and len(safe_id) <= 64 else "<unknown>"
+            )
+            _LOGGER.debug("Skipping malformed token entry (token_id=%s): %s", safe_id_repr, err)
     return out
 
 

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import re
 import secrets
 import time
 from collections.abc import Callable
@@ -185,6 +186,21 @@ _TOKEN_SECRET_BYTES = 32
 # (kitchen)" style labels.
 _TOKEN_LABEL_MAX = 128
 
+# ``secrets.token_urlsafe`` emits the base64url alphabet only;
+# any other character means the caller is sending something that
+# isn't a token_id (most likely the full bearer or a typo). Cap
+# the length at a generous 64 to defend against a runaway
+# request body.
+_TOKEN_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_TOKEN_ID_MAX_CHARS = 64
+
+# Soft cap on the receiver-side token list so a misbehaving
+# frontend looping ``add_token`` can't grow the metadata file
+# unboundedly. 100 is well above any realistic
+# pairings-per-receiver count and gives the UI a clean upper
+# bound to render.
+_MAX_TOKENS = 100
+
 
 def _validate_label(raw: object) -> str:
     """
@@ -213,9 +229,17 @@ def _validate_token_id(raw: object) -> str:
     """
     Validate a user-supplied token_id (e.g. for ``remove_token``).
 
-    Just shape-checks the input; the actual existence check happens
-    in the mutator under the metadata lock so the look-up and the
-    delete are atomic.
+    Shape-checks only; the existence check happens in the mutator
+    under the metadata lock so look-up and delete are atomic.
+
+    Also rejects values containing ``.``: the bearer wire form is
+    ``{token_id}.{secret}``, so a value with a dot is most likely
+    the full bearer mistakenly passed instead of the id half. The
+    error path serialises validation messages back over the WS,
+    and rejecting before the value lands in any error message
+    keeps the cleartext secret out of logs / DevTools / frontend
+    telemetry. The format check (base64url-only, length cap)
+    catches typos too.
     """
     if not isinstance(raw, str):
         msg = "token: 'token_id' must be a string"
@@ -223,6 +247,18 @@ def _validate_token_id(raw: object) -> str:
     trimmed = raw.strip()
     if not trimmed:
         msg = "token: 'token_id' must not be empty"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if "." in trimmed:
+        # Specifically don't echo ``trimmed`` back: it might be a
+        # full bearer, in which case the secret half is in this
+        # variable.
+        msg = "token: 'token_id' must be the id half only, not the full bearer"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if len(trimmed) > _TOKEN_ID_MAX_CHARS:
+        msg = f"token: 'token_id' must be at most {_TOKEN_ID_MAX_CHARS} characters"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if not _TOKEN_ID_PATTERN.fullmatch(trimmed):
+        msg = "token: 'token_id' must contain base64url characters only"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return trimmed
 
@@ -598,6 +634,12 @@ class RemoteBuildController:
         created_at = time.time()
 
         def _add(settings: RemoteBuildSettings) -> None:
+            if len(settings.tokens) >= _MAX_TOKENS:
+                msg = (
+                    f"token list at capacity ({_MAX_TOKENS}); "
+                    "remove an unused token before issuing a new one"
+                )
+                raise CommandError(ErrorCode.INVALID_ARGS, msg)
             settings.tokens.append(
                 StoredToken(
                     token_id=token_id,
@@ -632,7 +674,11 @@ class RemoteBuildController:
         def _remove(settings: RemoteBuildSettings) -> None:
             kept = [token for token in settings.tokens if token.token_id != clean_id]
             if len(kept) == len(settings.tokens):
-                msg = f"token {clean_id} is not registered"
+                # Don't echo ``clean_id`` (or any user-supplied
+                # input) here: validation rejects bearers up
+                # front, but the principle is to keep credential-
+                # adjacent input out of error messages by default.
+                msg = "token is not registered"
                 raise CommandError(ErrorCode.NOT_FOUND, msg)
             settings.tokens = kept
 

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -525,6 +525,36 @@ class RemoteBuildController:
 
         return await self._modify_settings(_add)
 
+    @api_command("remote_build/remove_manual_host")
+    async def remove_manual_host(
+        self, *, hostname: str, port: int, **kwargs: Any
+    ) -> RemoteBuildSettings:
+        """
+        Remove a previously-added manual peer.
+
+        Hostname normalisation matches :meth:`add_manual_host` so a
+        case-different removal request finds the entry. A
+        non-existent ``(hostname, port)`` pair raises
+        ``NOT_FOUND`` so the caller knows the operation was a no-op
+        rather than silently succeeding (matters for the
+        Settings UI: "Removed Foo" toast vs no feedback).
+        """
+        host = _validate_hostname(hostname)
+        port_num = _validate_port(port)
+
+        def _remove(settings: RemoteBuildSettings) -> None:
+            kept = [
+                entry
+                for entry in settings.manual_hosts
+                if not (entry.hostname == host and entry.port == port_num)
+            ]
+            if len(kept) == len(settings.manual_hosts):
+                msg = f"manual host {host}:{port_num} is not registered"
+                raise CommandError(ErrorCode.NOT_FOUND, msg)
+            settings.manual_hosts = kept
+
+        return await self._modify_settings(_remove)
+
     # ------------------------------------------------------------------
     # Token CRUD (phase 3b1)
     # ------------------------------------------------------------------
@@ -605,35 +635,5 @@ class RemoteBuildController:
                 msg = f"token {clean_id} is not registered"
                 raise CommandError(ErrorCode.NOT_FOUND, msg)
             settings.tokens = kept
-
-        return await self._modify_settings(_remove)
-
-    @api_command("remote_build/remove_manual_host")
-    async def remove_manual_host(
-        self, *, hostname: str, port: int, **kwargs: Any
-    ) -> RemoteBuildSettings:
-        """
-        Remove a previously-added manual peer.
-
-        Hostname normalisation matches :meth:`add_manual_host` so a
-        case-different removal request finds the entry. A
-        non-existent ``(hostname, port)`` pair raises
-        ``NOT_FOUND`` so the caller knows the operation was a no-op
-        rather than silently succeeding (matters for the
-        Settings UI: "Removed Foo" toast vs no feedback).
-        """
-        host = _validate_hostname(hostname)
-        port_num = _validate_port(port)
-
-        def _remove(settings: RemoteBuildSettings) -> None:
-            kept = [
-                entry
-                for entry in settings.manual_hosts
-                if not (entry.hostname == host and entry.port == port_num)
-            ]
-            if len(kept) == len(settings.manual_hosts):
-                msg = f"manual host {host}:{port_num} is not registered"
-                raise CommandError(ErrorCode.NOT_FOUND, msg)
-            settings.manual_hosts = kept
 
         return await self._modify_settings(_remove)

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1,22 +1,25 @@
 """
-Remote-build feature; peer dashboard discovery + settings.
+Remote-build feature; peer dashboard discovery + settings + tokens.
 
-Phase 2 / 2b of issue #106. Browses ``_esphomebuilder._tcp.local.``
-to list other dashboards reachable on the LAN; persists the
-receiver-side ``enabled`` master switch (phase 2) and the
-user-supplied manual-host list for cross-subnet / non-multicast
-LANs (phase 2b); merges both sources into a single
+Browses ``_esphomebuilder._tcp.local.`` to list other dashboards
+reachable on the LAN; persists the receiver-side ``enabled``
+master switch, the user-supplied manual-host list for
+cross-subnet / non-multicast LANs, and the receiver-issued
+bearer-token list; merges discovery sources into a single
 ``remote_build/list_hosts`` snapshot.
 
-Phase 2 / 2b stops at discovery + settings storage:
+Current scope:
 
-* No HTTP / WS endpoints under ``/remote-build/v1/*`` yet (phase 3
-  lands the auth middleware + cert).
-* No pairing or peer-link WS yet (phase 4 / phase 5).
+* No HTTP / WS endpoints under ``/remote-build/v1/*`` yet (the
+  HTTPS listener + auth middleware land alongside the token
+  store's first consumer).
+* No pairing or peer-link WS yet.
 * The ``enabled`` setting is persisted but not wired to any
   endpoint registration; flipping it currently has no observable
-  effect beyond round-tripping in the settings UI. That's
-  deliberate scaffolding so phase 3+ have a place to plug in.
+  effect beyond round-tripping in the settings UI.
+* Tokens are issuable / revocable but nothing consumes them yet;
+  ``add_token`` returns the cleartext bearer once at creation
+  time, only the SHA-256 of the secret half lands on disk.
 * Manual hosts have no version / fingerprint resolution; they
   land in ``list_hosts`` with empty ``server_version`` /
   ``esphome_version`` until phase 4 attempts the connection.
@@ -33,7 +36,10 @@ own browsers (``_esphomelib._tcp.local.`` for devices,
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
+import secrets
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -48,6 +54,9 @@ from ..models import (
     RemoteBuildPeer,
     RemoteBuildPeerSource,
     RemoteBuildSettings,
+    StoredToken,
+    TokenCreateResult,
+    TokenSummary,
 )
 from .config import load_remote_build_settings, remote_build_settings_transaction
 
@@ -156,6 +165,92 @@ def _validate_hostname(raw: object) -> str:
         msg = "manual host: 'hostname' must not be empty"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return trimmed
+
+
+# Wire format for the bearer token presented by the offloader is
+# ``{token_id}.{secret}``. Splitting on the dot gives the receiver
+# constant-time lookup by ``token_id`` (no scanning the whole list)
+# plus the secret to verify against the stored hash. 8 random
+# bytes for the id keeps it short enough to type if a user ever
+# has to and large enough to make the lookup table effectively
+# unguessable on its own; 32 random bytes for the secret matches
+# the entropy of a typical session token. Both are base64url so
+# the wire form has no shell-quoting hazards.
+_TOKEN_ID_BYTES = 8
+_TOKEN_SECRET_BYTES = 32
+
+# Cap label length to keep ``list_tokens`` payloads bounded and
+# prevent a misbehaving frontend from accidentally storing a
+# multi-megabyte string. Generous enough for "Green dashboard
+# (kitchen)" style labels.
+_TOKEN_LABEL_MAX = 128
+
+
+def _validate_label(raw: object) -> str:
+    """
+    Normalise a user-entered token label to a stripped, length-bounded form.
+
+    Rejects non-string, empty / whitespace-only, and too-long
+    inputs with :class:`CommandError(INVALID_ARGS)`. Duplicate
+    labels are NOT rejected: ``token_id`` is the unique key, and
+    a user might legitimately want two tokens both labelled
+    "Green" (different machines or different purposes).
+    """
+    if not isinstance(raw, str):
+        msg = "token: 'label' must be a string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    trimmed = raw.strip()
+    if not trimmed:
+        msg = "token: 'label' must not be empty"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if len(trimmed) > _TOKEN_LABEL_MAX:
+        msg = f"token: 'label' must be at most {_TOKEN_LABEL_MAX} characters"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return trimmed
+
+
+def _validate_token_id(raw: object) -> str:
+    """
+    Validate a user-supplied token_id (e.g. for ``remove_token``).
+
+    Just shape-checks the input; the actual existence check happens
+    in the mutator under the metadata lock so the look-up and the
+    delete are atomic.
+    """
+    if not isinstance(raw, str):
+        msg = "token: 'token_id' must be a string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    trimmed = raw.strip()
+    if not trimmed:
+        msg = "token: 'token_id' must not be empty"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return trimmed
+
+
+def _generate_token() -> tuple[str, str, str]:
+    """
+    Mint a fresh ``(token_id, secret, secret_sha256)`` triple.
+
+    ``token_id`` and ``secret`` are independent base64url strings
+    drawn from :func:`secrets.token_urlsafe`. The cleartext bearer
+    the caller hands to the offloader is ``{token_id}.{secret}``;
+    only ``secret_sha256`` lands on disk so a snapshot of
+    ``.device-builder.json`` can't be replayed as a valid bearer.
+    """
+    token_id = secrets.token_urlsafe(_TOKEN_ID_BYTES)
+    secret = secrets.token_urlsafe(_TOKEN_SECRET_BYTES)
+    secret_sha256 = hashlib.sha256(secret.encode("ascii")).hexdigest()
+    return token_id, secret, secret_sha256
+
+
+def _summarise_token(token: StoredToken) -> TokenSummary:
+    """Project a :class:`StoredToken` to its public-facing :class:`TokenSummary`."""
+    return TokenSummary(
+        token_id=token.token_id,
+        label=token.label,
+        created_at=token.created_at,
+        bound_dashboard_id=token.bound_dashboard_id,
+    )
 
 
 def _validate_port(raw: object) -> int:
@@ -429,6 +524,89 @@ class RemoteBuildController:
             settings.manual_hosts.append(ManualHost(hostname=host, port=port_num))
 
         return await self._modify_settings(_add)
+
+    # ------------------------------------------------------------------
+    # Token CRUD (phase 3b1)
+    # ------------------------------------------------------------------
+
+    @api_command("remote_build/list_tokens")
+    async def list_tokens(self, **kwargs: Any) -> list[TokenSummary]:
+        """
+        Return every issued bearer token, by ``TokenSummary``.
+
+        ``TokenSummary`` rows never carry the secret hash; the
+        cleartext bearer flashes through ``add_token``'s response
+        once at create time and isn't recoverable from disk after
+        that. The frontend renders the token_id + label + bound
+        dashboard_id (if any) so the operator can audit which
+        peers are paired.
+        """
+        loop = asyncio.get_running_loop()
+        settings = await loop.run_in_executor(
+            None, load_remote_build_settings, self._db.settings.config_dir
+        )
+        return [_summarise_token(token) for token in settings.tokens]
+
+    @api_command("remote_build/add_token")
+    async def add_token(self, *, label: str, **kwargs: Any) -> TokenCreateResult:
+        """
+        Issue a fresh bearer token under the given label.
+
+        Returns :class:`TokenCreateResult` with the cleartext
+        ``bearer`` field; that's the ONE chance the user has to
+        copy the cleartext to the offloader. A subsequent
+        ``list_tokens`` returns ``TokenSummary`` rows that don't
+        carry the secret. If the operator loses the bearer, the
+        only recovery is to remove the token and issue a new one.
+
+        Duplicate labels are allowed (``token_id`` is the unique
+        key); a user may legitimately want two tokens both
+        labelled "Green" or "phone".
+        """
+        clean_label = _validate_label(label)
+        token_id, secret, secret_sha256 = _generate_token()
+        created_at = time.time()
+
+        def _add(settings: RemoteBuildSettings) -> None:
+            settings.tokens.append(
+                StoredToken(
+                    token_id=token_id,
+                    label=clean_label,
+                    secret_sha256=secret_sha256,
+                    created_at=created_at,
+                )
+            )
+
+        await self._modify_settings(_add)
+        return TokenCreateResult(
+            token_id=token_id,
+            label=clean_label,
+            created_at=created_at,
+            bearer=f"{token_id}.{secret}",
+        )
+
+    @api_command("remote_build/remove_token")
+    async def remove_token(self, *, token_id: str, **kwargs: Any) -> RemoteBuildSettings:
+        """
+        Revoke a previously-issued token.
+
+        Removing a bound token immediately disconnects the
+        offloader it's paired to: the next request the offloader
+        sends presents a token_id the receiver no longer
+        recognises and gets a 401. A non-existent ``token_id``
+        raises ``NOT_FOUND`` so the caller knows the call was a
+        no-op.
+        """
+        clean_id = _validate_token_id(token_id)
+
+        def _remove(settings: RemoteBuildSettings) -> None:
+            kept = [token for token in settings.tokens if token.token_id != clean_id]
+            if len(kept) == len(settings.tokens):
+                msg = f"token {clean_id} is not registered"
+                raise CommandError(ErrorCode.NOT_FOUND, msg)
+            settings.tokens = kept
+
+        return await self._modify_settings(_remove)
 
     @api_command("remote_build/remove_manual_host")
     async def remove_manual_host(

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -55,6 +55,7 @@ from ..models import (
     RemoteBuildPeer,
     RemoteBuildPeerSource,
     RemoteBuildSettings,
+    RemoteBuildSettingsView,
     StoredToken,
     TokenCreateResult,
     TokenSummary,
@@ -169,14 +170,18 @@ def _validate_hostname(raw: object) -> str:
 
 
 # Wire format for the bearer token presented by the offloader is
-# ``{token_id}.{secret}``. Splitting on the dot gives the receiver
-# constant-time lookup by ``token_id`` (no scanning the whole list)
-# plus the secret to verify against the stored hash. 8 random
-# bytes for the id keeps it short enough to type if a user ever
-# has to and large enough to make the lookup table effectively
-# unguessable on its own; 32 random bytes for the secret matches
-# the entropy of a typical session token. Both are base64url so
-# the wire form has no shell-quoting hazards.
+# ``{token_id}.{secret}``. Splitting on the dot lets the receiver
+# look up the candidate row by ``token_id`` (a future in-memory
+# index keyed off this field, built once at startup, gives O(1)
+# verification; the on-disk persistence is a list, but the hot
+# path doesn't scan it). The secret half is then compared
+# against ``StoredToken.secret_sha256`` via
+# ``hmac.compare_digest``. 8 random bytes for the id keeps it
+# short enough to type if a user ever has to and large enough
+# that the id alone reveals nothing usable; 32 random bytes for
+# the secret matches the entropy of a typical session token.
+# Both halves are base64url so the wire form has no
+# shell-quoting hazards.
 _TOKEN_ID_BYTES = 8
 _TOKEN_SECRET_BYTES = 32
 
@@ -286,6 +291,22 @@ def _summarise_token(token: StoredToken) -> TokenSummary:
         label=token.label,
         created_at=token.created_at,
         bound_dashboard_id=token.bound_dashboard_id,
+    )
+
+
+def _to_view(settings: RemoteBuildSettings) -> RemoteBuildSettingsView:
+    """
+    Project a :class:`RemoteBuildSettings` to its wire :class:`RemoteBuildSettingsView`.
+
+    Drops ``secret_sha256`` from each token row. Every controller
+    method that returns settings to a client routes through here
+    so the stored hash never leaves the server, even when a CRUD
+    response also touches the tokens list.
+    """
+    return RemoteBuildSettingsView(
+        enabled=settings.enabled,
+        manual_hosts=list(settings.manual_hosts),
+        tokens=[_summarise_token(t) for t in settings.tokens],
     )
 
 
@@ -466,16 +487,17 @@ class RemoteBuildController:
         ]
 
     @api_command("remote_build/get_settings")
-    async def get_settings(self, **kwargs: Any) -> RemoteBuildSettings:
-        """Return the receiver-side remote-build settings."""
+    async def get_settings(self, **kwargs: Any) -> RemoteBuildSettingsView:
+        """Return the receiver-side remote-build settings (wire view)."""
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
+        settings = await loop.run_in_executor(
             None, load_remote_build_settings, self._db.settings.config_dir
         )
+        return _to_view(settings)
 
     async def _modify_settings(
         self, mutator: Callable[[RemoteBuildSettings], None]
-    ) -> RemoteBuildSettings:
+    ) -> RemoteBuildSettingsView:
         """
         Run ``mutator`` against the current settings and persist the result.
 
@@ -484,7 +506,8 @@ class RemoteBuildController:
         so two concurrent callers can't both read the same starting
         value and have the second save wipe the first's change.
         Runs in the default executor since the transaction does
-        blocking JSON I/O.
+        blocking JSON I/O. Returns the wire view so the response
+        leaving this method can never carry ``secret_sha256``.
 
         ``mutator`` is invoked with the freshly-loaded settings
         and is expected to mutate it in place. A
@@ -500,10 +523,11 @@ class RemoteBuildController:
                 return settings
 
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, _txn)
+        settings = await loop.run_in_executor(None, _txn)
+        return _to_view(settings)
 
     @api_command("remote_build/set_settings")
-    async def set_settings(self, *, enabled: bool, **kwargs: Any) -> RemoteBuildSettings:
+    async def set_settings(self, *, enabled: bool, **kwargs: Any) -> RemoteBuildSettingsView:
         """
         Persist the receiver-side ``enabled`` master switch.
 
@@ -533,7 +557,7 @@ class RemoteBuildController:
     @api_command("remote_build/add_manual_host")
     async def add_manual_host(
         self, *, hostname: str, port: int, **kwargs: Any
-    ) -> RemoteBuildSettings:
+    ) -> RemoteBuildSettingsView:
         """
         Add a manually-entered peer for cross-subnet / non-mDNS LANs.
 
@@ -564,7 +588,7 @@ class RemoteBuildController:
     @api_command("remote_build/remove_manual_host")
     async def remove_manual_host(
         self, *, hostname: str, port: int, **kwargs: Any
-    ) -> RemoteBuildSettings:
+    ) -> RemoteBuildSettingsView:
         """
         Remove a previously-added manual peer.
 
@@ -658,7 +682,7 @@ class RemoteBuildController:
         )
 
     @api_command("remote_build/remove_token")
-    async def remove_token(self, *, token_id: str, **kwargs: Any) -> RemoteBuildSettings:
+    async def remove_token(self, *, token_id: str, **kwargs: Any) -> RemoteBuildSettingsView:
         """
         Revoke a previously-issued token.
 

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -105,20 +105,38 @@ class TokenCreateResult(DataClassORJSONMixin):
 @dataclass
 class RemoteBuildSettings(DataClassORJSONMixin):
     """
-    Receiver-side settings for the remote-build feature.
+    Receiver-side settings for the remote-build feature (storage shape).
 
     Stored in ``.device-builder.json`` under the ``_remote_build``
-    top-level key. ``enabled`` is the master switch that phase 3
-    will gate ``/remote-build/v1/*`` route registration on. Phase
-    2 just persists the flag so the Settings UI has somewhere to
-    write. ``manual_hosts`` is the user-supplied peer list (see
-    :class:`ManualHost`). ``tokens`` is the receiver-issued bearer
-    list (see :class:`StoredToken`); only hashes land on disk.
+    top-level key. ``tokens`` carries :class:`StoredToken` rows
+    *with* the ``secret_sha256`` hash; this is the on-disk /
+    in-process shape only and MUST NOT be serialised over the
+    wire. Use :class:`RemoteBuildSettingsView` (or the
+    ``_summarise_token`` projection) for any response that leaves
+    the server.
     """
 
     enabled: bool = False
     manual_hosts: list[ManualHost] = field(default_factory=list)
     tokens: list[StoredToken] = field(default_factory=list)
+
+
+@dataclass
+class RemoteBuildSettingsView(DataClassORJSONMixin):
+    """
+    Wire view of :class:`RemoteBuildSettings`.
+
+    Returned from every WS command that exposes settings to a
+    client. Identical to :class:`RemoteBuildSettings` except
+    ``tokens`` is a list of :class:`TokenSummary` (no
+    ``secret_sha256``), so issuing or removing tokens via the
+    CRUD methods can't accidentally leak the stored hash back to
+    the frontend through the response shape.
+    """
+
+    enabled: bool = False
+    manual_hosts: list[ManualHost] = field(default_factory=list)
+    tokens: list[TokenSummary] = field(default_factory=list)
 
 
 @dataclass

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -40,6 +40,69 @@ class ManualHost(DataClassORJSONMixin):
 
 
 @dataclass
+class StoredToken(DataClassORJSONMixin):
+    """
+    A receiver-side issued bearer token, persisted by hash.
+
+    Cleartext is the wire form ``{token_id}.{secret}``; only
+    ``secret_sha256`` lands on disk. ``token_id`` is the lookup key
+    (constant-time table hit), ``secret_sha256`` is what the
+    middleware compares against the bearer's secret half via
+    ``hmac.compare_digest``.
+
+    ``bound_dashboard_id`` starts ``None`` and is filled in by the
+    phase-3b3 first-use binding the first time an authenticated
+    request arrives carrying a peer's ``X-Dashboard-ID``. After
+    that, requests presenting the same token but a different
+    dashboard_id are rejected as 403.
+    """
+
+    token_id: str
+    label: str
+    secret_sha256: str
+    created_at: float
+    bound_dashboard_id: str | None = None
+
+
+@dataclass
+class TokenSummary(DataClassORJSONMixin):
+    """
+    Public-facing token row for ``remote_build/list_tokens``.
+
+    Mirrors :class:`StoredToken` but drops ``secret_sha256``: the
+    stored hash isn't sensitive in the same way the cleartext is,
+    but exposing it would let a network attacker who's already
+    seen the on-disk metadata match candidate cleartext bearers
+    against the wire shape, so the frontend has no business
+    reading it.
+    """
+
+    token_id: str
+    label: str
+    created_at: float
+    bound_dashboard_id: str | None = None
+
+
+@dataclass
+class TokenCreateResult(DataClassORJSONMixin):
+    """
+    Response from ``remote_build/add_token``.
+
+    The cleartext ``bearer`` flashes through this response exactly
+    once at creation time; subsequent ``list_tokens`` calls return
+    :class:`TokenSummary` rows that never carry the secret. The
+    frontend is expected to show ``bearer`` to the user with a
+    copy-to-clipboard control and stop displaying it once the
+    dialog is dismissed.
+    """
+
+    token_id: str
+    label: str
+    created_at: float
+    bearer: str
+
+
+@dataclass
 class RemoteBuildSettings(DataClassORJSONMixin):
     """
     Receiver-side settings for the remote-build feature.
@@ -49,11 +112,13 @@ class RemoteBuildSettings(DataClassORJSONMixin):
     will gate ``/remote-build/v1/*`` route registration on. Phase
     2 just persists the flag so the Settings UI has somewhere to
     write. ``manual_hosts`` is the user-supplied peer list (see
-    :class:`ManualHost`).
+    :class:`ManualHost`). ``tokens`` is the receiver-issued bearer
+    list (see :class:`StoredToken`); only hashes land on disk.
     """
 
     enabled: bool = False
     manual_hosts: list[ManualHost] = field(default_factory=list)
+    tokens: list[StoredToken] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1026,6 +1026,39 @@ async def test_load_remote_build_settings_drops_malformed_token_rows(
 
 
 @pytest.mark.asyncio
+async def test_decode_tokens_skips_non_dict_entries(tmp_path: Any) -> None:
+    """
+    Non-dict entries in the on-disk ``tokens`` list are skipped silently.
+
+    A hand-edited (or just type-confused) sidecar might land a
+    string or null in the tokens list. The decoder skips those
+    without raising and without invoking ``StoredToken.from_dict``
+    (which would raise on a non-dict). Good rows still load.
+    """
+    await _seed_metadata(
+        tmp_path,
+        {
+            "tokens": [
+                {
+                    "token_id": "good1",
+                    "label": "Green",
+                    "secret_sha256": "a" * 64,
+                    "created_at": 1.0,
+                    "bound_dashboard_id": None,
+                },
+                "not-a-dict-at-all",  # noqa: type-confused row
+                42,
+                None,
+            ],
+        },
+    )
+
+    controller = _make_controller(config_dir=tmp_path)
+    settings = await controller.get_settings()
+    assert [t.token_id for t in settings.tokens] == ["good1"]
+
+
+@pytest.mark.asyncio
 async def test_decode_tokens_redacts_credential_material_from_logs(
     tmp_path: Any, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -20,7 +20,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from zeroconf import ServiceStateChange
 
-from esphome_device_builder.controllers.config import remote_build_settings_transaction
+from esphome_device_builder.controllers.config import (
+    load_remote_build_settings,
+    remote_build_settings_transaction,
+)
 from esphome_device_builder.controllers.remote_build import (
     _MAX_TOKENS,
     RemoteBuildController,
@@ -37,7 +40,7 @@ from esphome_device_builder.models import (
     ManualHost,
     RemoteBuildPeer,
     RemoteBuildPeerSource,
-    RemoteBuildSettings,
+    RemoteBuildSettingsView,
     StoredToken,
 )
 
@@ -250,7 +253,7 @@ async def test_get_settings_defaults_when_unset(tmp_path: Any) -> None:
     """A fresh dashboard with no metadata returns ``enabled=False``."""
     controller = _make_controller(config_dir=tmp_path)
     settings = await controller.get_settings()
-    assert settings == RemoteBuildSettings(enabled=False)
+    assert settings == RemoteBuildSettingsView(enabled=False)
 
 
 @pytest.mark.asyncio
@@ -258,9 +261,9 @@ async def test_set_settings_round_trips(tmp_path: Any) -> None:
     """Setting ``enabled=True`` persists and is read back by ``get_settings``."""
     controller = _make_controller(config_dir=tmp_path)
     written = await controller.set_settings(enabled=True)
-    assert written == RemoteBuildSettings(enabled=True)
+    assert written == RemoteBuildSettingsView(enabled=True)
     read = await controller.get_settings()
-    assert read == RemoteBuildSettings(enabled=True)
+    assert read == RemoteBuildSettingsView(enabled=True)
 
 
 @pytest.mark.asyncio
@@ -726,18 +729,59 @@ async def test_add_token_returns_cleartext_bearer_once(tmp_path: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_add_token_persists_only_hashed_secret(tmp_path: Any) -> None:
-    """The on-disk row carries SHA-256 of the secret only; never the cleartext."""
+    """
+    The on-disk row carries SHA-256 of the secret only; never the cleartext.
+
+    Inspects the on-disk shape via ``load_remote_build_settings``
+    (storage form, ``StoredToken`` rows with ``secret_sha256``)
+    rather than ``get_settings`` (wire form,
+    :class:`RemoteBuildSettingsView` with hashes stripped). The
+    storage form is the place to assert the hash is the only
+    representation that lands on disk.
+    """
     controller = _make_controller(config_dir=tmp_path)
     result = await controller.add_token(label="Green")
     _, secret = _split_bearer(result.bearer)
 
-    settings = await controller.get_settings()
-    assert len(settings.tokens) == 1
-    stored = settings.tokens[0]
+    on_disk = load_remote_build_settings(tmp_path)
+    assert len(on_disk.tokens) == 1
+    stored = on_disk.tokens[0]
     assert stored.token_id == result.token_id
     assert stored.secret_sha256 == hashlib.sha256(secret.encode("ascii")).hexdigest()
     assert secret not in stored.secret_sha256
     assert stored.bound_dashboard_id is None
+
+
+@pytest.mark.asyncio
+async def test_settings_responses_never_carry_secret_hash(tmp_path: Any) -> None:
+    """
+    Every WS command that returns settings projects tokens to ``TokenSummary``.
+
+    ``RemoteBuildSettings`` is the storage shape; ``RemoteBuildSettingsView``
+    is the wire shape. A regression that returned the storage shape
+    over the WS would leak ``secret_sha256`` to the frontend on
+    every CRUD response (set_settings, add_manual_host,
+    remove_manual_host, remove_token, get_settings). Pin that
+    none of the wire returns expose the field.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    issued = await controller.add_token(label="Green")
+
+    # Every method that returns settings to the wire.
+    responses = [
+        await controller.get_settings(),
+        await controller.set_settings(enabled=True),
+        await controller.add_manual_host(hostname="desktop.local", port=6052),
+        await controller.remove_manual_host(hostname="desktop.local", port=6052),
+        await controller.remove_token(token_id=issued.token_id),
+    ]
+    for response in responses:
+        # ``RemoteBuildSettingsView.tokens`` is ``list[TokenSummary]``;
+        # neither the dataclass nor the dict-form should carry
+        # ``secret_sha256``.
+        for entry in response.tokens:
+            assert not hasattr(entry, "secret_sha256")
+        assert "secret_sha256" not in response.to_dict()["tokens"].__repr__()
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -952,6 +952,37 @@ async def test_add_token_rejects_when_at_capacity(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_load_remote_build_settings_falls_back_on_unrecoverable_blob(
+    tmp_path: Any,
+) -> None:
+    """
+    A blob that fails to deserialise even after token-row cleaning resets to defaults.
+
+    Token-row tolerance handles the common case (one bad token
+    didn't disconnect every peer); but a wholly malformed blob
+    (e.g. ``manual_hosts`` set to a non-list, ``enabled`` set to
+    a list, etc.) still falls back to the empty defaults rather
+    than crashing dashboard startup. Pin the rescue branch.
+    """
+    await _seed_metadata(
+        tmp_path,
+        {
+            # Type errors mashumaro rejects: ``manual_hosts`` must
+            # be a list, ``enabled`` must be a bool. The
+            # token-row pre-clean can't save this.
+            "enabled": "definitely-not-a-bool",
+            "manual_hosts": "definitely-not-a-list",
+        },
+    )
+    controller = _make_controller(config_dir=tmp_path)
+    settings = await controller.get_settings()
+    # All fields back to defaults; the dashboard didn't crash.
+    assert settings.enabled is False
+    assert settings.manual_hosts == []
+    assert settings.tokens == []
+
+
+@pytest.mark.asyncio
 async def test_load_remote_build_settings_drops_malformed_token_rows(
     tmp_path: Any,
 ) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -790,14 +791,46 @@ async def test_remove_token_drops_only_target(tmp_path: Any) -> None:
         pytest.param("ghost123", ErrorCode.NOT_FOUND, id="unknown-id"),
         pytest.param("   ", ErrorCode.INVALID_ARGS, id="blank-id"),
         pytest.param("", ErrorCode.INVALID_ARGS, id="empty-id"),
+        pytest.param(123, ErrorCode.INVALID_ARGS, id="non-string-int"),
+        pytest.param(None, ErrorCode.INVALID_ARGS, id="non-string-none"),
     ],
 )
 @pytest.mark.asyncio
 async def test_remove_token_rejects_invalid(
-    tmp_path: Any, token_id: str, expected_code: ErrorCode
+    tmp_path: Any, token_id: object, expected_code: ErrorCode
 ) -> None:
-    """Unknown / blank / empty ``token_id`` is rejected with the right code."""
+    """Unknown / blank / empty / non-string ``token_id`` is rejected."""
     controller = _make_controller(config_dir=tmp_path)
     with pytest.raises(CommandError) as exc:
-        await controller.remove_token(token_id=token_id)
+        await controller.remove_token(token_id=token_id)  # type: ignore[arg-type]
     assert exc.value.code == expected_code
+
+
+@pytest.mark.asyncio
+async def test_loads_legacy_metadata_without_tokens_key(tmp_path: Any) -> None:
+    """
+    Phase-2/2b on-disk JSON without a ``tokens`` key still loads cleanly.
+
+    Mashumaro + the ``default_factory=list`` on ``RemoteBuildSettings.tokens``
+    is what bridges the version skew. A future refactor that
+    accidentally tightens ``from_dict`` would break this contract
+    silently — every existing install would lose its
+    ``manual_hosts`` and ``enabled`` on first boot. Pin it.
+    """
+    legacy_path = tmp_path / ".device-builder.json"
+    legacy_path.write_bytes(
+        json.dumps(
+            {
+                "_remote_build": {
+                    "enabled": True,
+                    "manual_hosts": [{"hostname": "desktop.local", "port": 6052}],
+                    # Note: no ``tokens`` key — what phase 2b shipped.
+                },
+            }
+        ).encode()
+    )
+    controller = _make_controller(config_dir=tmp_path)
+    settings = await controller.get_settings()
+    assert settings.enabled is True
+    assert settings.manual_hosts == [ManualHost(hostname="desktop.local", port=6052)]
+    assert settings.tokens == []

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -81,19 +81,24 @@ def _make_controller(*, config_dir: Any = None) -> RemoteBuildController:
     return RemoteBuildController(db)
 
 
-def _seed_metadata(config_dir: Any, remote_build: dict) -> None:
+async def _seed_metadata(config_dir: Any, remote_build: dict) -> None:
     """
     Seed ``<config_dir>/.device-builder.json`` with a ``_remote_build`` blob.
 
     Single place to write a hand-crafted on-disk state from a
     test, used by the legacy-compat and corrupt-row tests so the
-    JSON shape lives in one place. Runtime tests that go through
-    the real CRUD API use ``remote_build_settings_transaction``
-    directly (also a single helper, owned by ``controllers.config``).
+    JSON shape lives in one place. Hops to the executor because
+    the file write is sync I/O and blockbuster (Linux CI) flags
+    sync I/O from inside an async test as a real bug.
     """
-    (config_dir / ".device-builder.json").write_bytes(
-        json.dumps({"_remote_build": remote_build}).encode()
-    )
+    loop = asyncio.get_running_loop()
+
+    def _write() -> None:
+        (config_dir / ".device-builder.json").write_bytes(
+            json.dumps({"_remote_build": remote_build}).encode()
+        )
+
+    await loop.run_in_executor(None, _write)
 
 
 # ---------------------------------------------------------------------------
@@ -743,7 +748,8 @@ async def test_add_token_persists_only_hashed_secret(tmp_path: Any) -> None:
     result = await controller.add_token(label="Green")
     _, secret = _split_bearer(result.bearer)
 
-    on_disk = load_remote_build_settings(tmp_path)
+    loop = asyncio.get_running_loop()
+    on_disk = await loop.run_in_executor(None, load_remote_build_settings, tmp_path)
     assert len(on_disk.tokens) == 1
     stored = on_disk.tokens[0]
     assert stored.token_id == result.token_id
@@ -917,18 +923,25 @@ async def test_add_token_rejects_when_at_capacity(tmp_path: Any) -> None:
     Defends against a runaway frontend looping ``add_token`` and
     growing the metadata sidecar unboundedly. Pre-seed the disk
     state with the cap's worth of tokens so the test doesn't have
-    to actually mint 100 ed25519-strength secrets.
+    to actually mint 100 ed25519-strength secrets. Seed via
+    ``run_in_executor`` because the transaction does sync I/O
+    that blockbuster (Linux CI) flags from inside an async test.
     """
-    with remote_build_settings_transaction(tmp_path) as settings:
-        for i in range(_MAX_TOKENS):
-            settings.tokens.append(
-                StoredToken(
-                    token_id=f"id{i:04d}",
-                    label=f"pre-{i}",
-                    secret_sha256="0" * 64,
-                    created_at=0.0,
+
+    def _seed_at_capacity() -> None:
+        with remote_build_settings_transaction(tmp_path) as settings:
+            for i in range(_MAX_TOKENS):
+                settings.tokens.append(
+                    StoredToken(
+                        token_id=f"id{i:04d}",
+                        label=f"pre-{i}",
+                        secret_sha256="0" * 64,
+                        created_at=0.0,
+                    )
                 )
-            )
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, _seed_at_capacity)
 
     controller = _make_controller(config_dir=tmp_path)
     with pytest.raises(CommandError) as exc:
@@ -950,7 +963,7 @@ async def test_load_remote_build_settings_drops_malformed_token_rows(
     would lose every paired peer until manual repair. The good rows
     must still load.
     """
-    _seed_metadata(
+    await _seed_metadata(
         tmp_path,
         {
             "enabled": True,
@@ -992,7 +1005,7 @@ async def test_loads_legacy_metadata_without_tokens_key(tmp_path: Any) -> None:
     silently — every existing install would lose its
     ``manual_hosts`` and ``enabled`` on first boot. Pin it.
     """
-    _seed_metadata(
+    await _seed_metadata(
         tmp_path,
         {
             "enabled": True,

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1026,6 +1026,47 @@ async def test_load_remote_build_settings_drops_malformed_token_rows(
 
 
 @pytest.mark.asyncio
+async def test_decode_tokens_redacts_credential_material_from_logs(
+    tmp_path: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    The malformed-row debug log doesn't carry credential-adjacent fields.
+
+    A hand-edited sidecar could land a cleartext secret in the
+    wrong field by mistake; the row-skip log MUST NOT echo the
+    full entry dict back, only the non-sensitive ``token_id``.
+    Captures ``%r``-dump regressions before they ship.
+    """
+    cleartext_marker = "PASTED-CLEARTEXT-SECRET-DO-NOT-LOG"
+    await _seed_metadata(
+        tmp_path,
+        {
+            "tokens": [
+                {
+                    "token_id": "rowid",
+                    "label": "Broken",
+                    # Missing ``secret_sha256`` -> from_dict raises.
+                    # Add a fake field with the canary string so a
+                    # ``%r``-dump of the whole entry would reveal it.
+                    "leaked_field": cleartext_marker,
+                },
+            ],
+        },
+    )
+
+    controller = _make_controller(config_dir=tmp_path)
+    with caplog.at_level("DEBUG", logger="esphome_device_builder.controllers.config"):
+        await controller.get_settings()
+
+    skip_logs = [r for r in caplog.records if "Skipping malformed token entry" in r.getMessage()]
+    assert skip_logs, "expected at least one skip log"
+    for record in skip_logs:
+        assert cleartext_marker not in record.getMessage()
+    # The token_id (public lookup key) is fine to log.
+    assert any("rowid" in r.getMessage() for r in skip_logs)
+
+
+@pytest.mark.asyncio
 async def test_loads_legacy_metadata_without_tokens_key(tmp_path: Any) -> None:
     """
     Phase-2/2b on-disk JSON without a ``tokens`` key still loads cleanly.

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -12,6 +12,7 @@ objects directly — no real multicast listener.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -664,3 +665,139 @@ async def test_add_manual_host_rejects_blank_hostname(tmp_path: Any) -> None:
     with pytest.raises(CommandError) as exc:
         await controller.add_manual_host(hostname="   ", port=6052)
     assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+# ---------------------------------------------------------------------------
+# Token CRUD (phase 3b1)
+# ---------------------------------------------------------------------------
+
+
+def _split_bearer(bearer: str) -> tuple[str, str]:
+    """Return ``(token_id, secret)`` from a wire bearer."""
+    token_id, secret = bearer.split(".", 1)
+    return token_id, secret
+
+
+@pytest.mark.asyncio
+async def test_add_token_returns_cleartext_bearer_once(tmp_path: Any) -> None:
+    """
+    ``add_token`` flashes the cleartext bearer through exactly once.
+
+    Also pins the wire form (``{token_id}.{secret}``) and that
+    both halves are high-entropy distinct values across calls;
+    a refactor that swapped to a counter or a label-derived id
+    would fail here.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    first = await controller.add_token(label="Green dashboard")
+    second = await controller.add_token(label="Green dashboard")
+
+    assert first.label == "Green dashboard"
+    assert first.created_at > 0
+    # Wire form: ``{token_id}.{secret}`` with both halves substantial.
+    fid, fsecret = _split_bearer(first.bearer)
+    sid, ssecret = _split_bearer(second.bearer)
+    assert fid == first.token_id
+    assert sid == second.token_id
+    # Two calls give distinct high-entropy values everywhere.
+    assert fid != sid
+    assert fsecret != ssecret
+    assert len(fid) >= 8 and len(fsecret) >= 40
+
+
+@pytest.mark.asyncio
+async def test_add_token_persists_only_hashed_secret(tmp_path: Any) -> None:
+    """The on-disk row carries SHA-256 of the secret only; never the cleartext."""
+    controller = _make_controller(config_dir=tmp_path)
+    result = await controller.add_token(label="Green")
+    _, secret = _split_bearer(result.bearer)
+
+    settings = await controller.get_settings()
+    assert len(settings.tokens) == 1
+    stored = settings.tokens[0]
+    assert stored.token_id == result.token_id
+    assert stored.secret_sha256 == hashlib.sha256(secret.encode("ascii")).hexdigest()
+    assert secret not in stored.secret_sha256
+    assert stored.bound_dashboard_id is None
+
+
+@pytest.mark.asyncio
+async def test_list_tokens_omits_secret_hash(tmp_path: Any) -> None:
+    """The ``list_tokens`` projection drops ``secret_sha256`` and allows dup labels."""
+    controller = _make_controller(config_dir=tmp_path)
+    first = await controller.add_token(label="phone")
+    second = await controller.add_token(label="phone")
+    assert first.token_id != second.token_id  # token_id is the unique key
+
+    summaries = await controller.list_tokens()
+    assert [s.label for s in summaries] == ["phone", "phone"]
+    for summary in summaries:
+        assert not hasattr(summary, "secret_sha256")
+        assert summary.bound_dashboard_id is None
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_code"),
+    [
+        pytest.param("", ErrorCode.INVALID_ARGS, id="empty"),
+        pytest.param("   ", ErrorCode.INVALID_ARGS, id="whitespace-only"),
+        pytest.param("\t\n", ErrorCode.INVALID_ARGS, id="tabs-newlines"),
+        pytest.param("x" * 200, ErrorCode.INVALID_ARGS, id="overlong"),
+        pytest.param(123, ErrorCode.INVALID_ARGS, id="non-string-int"),
+        pytest.param(None, ErrorCode.INVALID_ARGS, id="non-string-none"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_add_token_rejects_invalid_label(
+    tmp_path: Any, label: object, expected_code: ErrorCode
+) -> None:
+    """Empty / overlong / non-string labels don't slip through."""
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.add_token(label=label)  # type: ignore[arg-type]
+    assert exc.value.code == expected_code
+
+
+@pytest.mark.asyncio
+async def test_add_token_keeps_other_settings_intact(tmp_path: Any) -> None:
+    """Issuing a token doesn't reset ``enabled`` or ``manual_hosts``."""
+    controller = _make_controller(config_dir=tmp_path)
+    await controller.set_settings(enabled=True)
+    await controller.add_manual_host(hostname="desktop.local", port=6052)
+    await controller.add_token(label="Green")
+
+    settings = await controller.get_settings()
+    assert settings.enabled is True
+    assert settings.manual_hosts == [ManualHost(hostname="desktop.local", port=6052)]
+    assert len(settings.tokens) == 1
+
+
+@pytest.mark.asyncio
+async def test_remove_token_drops_only_target(tmp_path: Any) -> None:
+    """Removing one token leaves the rest of the list intact."""
+    controller = _make_controller(config_dir=tmp_path)
+    keep_a = await controller.add_token(label="Green")
+    target = await controller.add_token(label="Laptop")
+    keep_b = await controller.add_token(label="Phone")
+
+    settings = await controller.remove_token(token_id=target.token_id)
+    assert [t.token_id for t in settings.tokens] == [keep_a.token_id, keep_b.token_id]
+
+
+@pytest.mark.parametrize(
+    ("token_id", "expected_code"),
+    [
+        pytest.param("ghost123", ErrorCode.NOT_FOUND, id="unknown-id"),
+        pytest.param("   ", ErrorCode.INVALID_ARGS, id="blank-id"),
+        pytest.param("", ErrorCode.INVALID_ARGS, id="empty-id"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_remove_token_rejects_invalid(
+    tmp_path: Any, token_id: str, expected_code: ErrorCode
+) -> None:
+    """Unknown / blank / empty ``token_id`` is rejected with the right code."""
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.remove_token(token_id=token_id)
+    assert exc.value.code == expected_code

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -20,7 +20,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from zeroconf import ServiceStateChange
 
+from esphome_device_builder.controllers.config import remote_build_settings_transaction
 from esphome_device_builder.controllers.remote_build import (
+    _MAX_TOKENS,
     RemoteBuildController,
     _decode_txt_value,
     _peer_from_manual_host,
@@ -36,6 +38,7 @@ from esphome_device_builder.models import (
     RemoteBuildPeer,
     RemoteBuildPeerSource,
     RemoteBuildSettings,
+    StoredToken,
 )
 
 # ---------------------------------------------------------------------------
@@ -73,6 +76,21 @@ def _make_controller(*, config_dir: Any = None) -> RemoteBuildController:
     db.settings = MagicMock()
     db.settings.config_dir = config_dir
     return RemoteBuildController(db)
+
+
+def _seed_metadata(config_dir: Any, remote_build: dict) -> None:
+    """
+    Seed ``<config_dir>/.device-builder.json`` with a ``_remote_build`` blob.
+
+    Single place to write a hand-crafted on-disk state from a
+    test, used by the legacy-compat and corrupt-row tests so the
+    JSON shape lives in one place. Runtime tests that go through
+    the real CRUD API use ``remote_build_settings_transaction``
+    directly (also a single helper, owned by ``controllers.config``).
+    """
+    (config_dir / ".device-builder.json").write_bytes(
+        json.dumps({"_remote_build": remote_build}).encode()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -793,17 +811,130 @@ async def test_remove_token_drops_only_target(tmp_path: Any) -> None:
         pytest.param("", ErrorCode.INVALID_ARGS, id="empty-id"),
         pytest.param(123, ErrorCode.INVALID_ARGS, id="non-string-int"),
         pytest.param(None, ErrorCode.INVALID_ARGS, id="non-string-none"),
+        pytest.param("not!base64", ErrorCode.INVALID_ARGS, id="non-base64url-chars"),
+        pytest.param("a" * 65, ErrorCode.INVALID_ARGS, id="overlong"),
     ],
 )
 @pytest.mark.asyncio
 async def test_remove_token_rejects_invalid(
     tmp_path: Any, token_id: object, expected_code: ErrorCode
 ) -> None:
-    """Unknown / blank / empty / non-string ``token_id`` is rejected."""
+    """Unknown / blank / empty / non-string / malformed ``token_id`` is rejected."""
     controller = _make_controller(config_dir=tmp_path)
     with pytest.raises(CommandError) as exc:
         await controller.remove_token(token_id=token_id)  # type: ignore[arg-type]
     assert exc.value.code == expected_code
+
+
+@pytest.mark.asyncio
+async def test_remove_token_rejects_full_bearer_without_echoing_secret(
+    tmp_path: Any,
+) -> None:
+    """
+    Passing the full bearer to ``remove_token`` is rejected before logging.
+
+    The bearer wire form is ``{token_id}.{secret}``. If a frontend
+    bug or operator typo passes the whole bearer instead of the id
+    half, the cleartext secret would land in the error message and
+    propagate over the WS into browser DevTools / frontend
+    telemetry. The validator rejects on ``.`` and the rejection
+    message must NOT echo the secret back.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    issued = await controller.add_token(label="Green")
+    full_bearer = issued.bearer  # ``{token_id}.{secret}``
+    secret = full_bearer.split(".", 1)[1]
+
+    with pytest.raises(CommandError) as exc:
+        await controller.remove_token(token_id=full_bearer)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+    # The whole point of the check: the secret half must not appear
+    # anywhere in the error message.
+    assert secret not in str(exc.value)
+    assert full_bearer not in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_remove_token_not_found_does_not_echo_id(tmp_path: Any) -> None:
+    """The ``NOT_FOUND`` message doesn't echo the user-supplied ``token_id``."""
+    controller = _make_controller(config_dir=tmp_path)
+    suspicious = "lookslike-id-but-isnt"
+    with pytest.raises(CommandError) as exc:
+        await controller.remove_token(token_id=suspicious)
+    assert exc.value.code == ErrorCode.NOT_FOUND
+    assert suspicious not in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_add_token_rejects_when_at_capacity(tmp_path: Any) -> None:
+    """
+    ``add_token`` refuses once the receiver hits the soft cap.
+
+    Defends against a runaway frontend looping ``add_token`` and
+    growing the metadata sidecar unboundedly. Pre-seed the disk
+    state with the cap's worth of tokens so the test doesn't have
+    to actually mint 100 ed25519-strength secrets.
+    """
+    with remote_build_settings_transaction(tmp_path) as settings:
+        for i in range(_MAX_TOKENS):
+            settings.tokens.append(
+                StoredToken(
+                    token_id=f"id{i:04d}",
+                    label=f"pre-{i}",
+                    secret_sha256="0" * 64,
+                    created_at=0.0,
+                )
+            )
+
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.add_token(label="overflow")
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+    # Cap message names the limit so the operator can act.
+    assert str(_MAX_TOKENS) in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_load_remote_build_settings_drops_malformed_token_rows(
+    tmp_path: Any,
+) -> None:
+    """
+    One corrupt token row doesn't blank the rest of the receiver's view.
+
+    Mirrors the labels-row-by-row contract. Without it, an operator
+    who hand-edited the sidecar (or hit an in-flight schema change)
+    would lose every paired peer until manual repair. The good rows
+    must still load.
+    """
+    _seed_metadata(
+        tmp_path,
+        {
+            "enabled": True,
+            "tokens": [
+                {
+                    "token_id": "good1",
+                    "label": "Green",
+                    "secret_sha256": "a" * 64,
+                    "created_at": 1.0,
+                    "bound_dashboard_id": None,
+                },
+                # Missing required ``secret_sha256`` field.
+                {"token_id": "bad1", "label": "Broken", "created_at": 2.0},
+                {
+                    "token_id": "good2",
+                    "label": "Laptop",
+                    "secret_sha256": "b" * 64,
+                    "created_at": 3.0,
+                    "bound_dashboard_id": None,
+                },
+            ],
+        },
+    )
+
+    controller = _make_controller(config_dir=tmp_path)
+    settings = await controller.get_settings()
+    assert settings.enabled is True
+    assert [t.token_id for t in settings.tokens] == ["good1", "good2"]
 
 
 @pytest.mark.asyncio
@@ -817,17 +948,13 @@ async def test_loads_legacy_metadata_without_tokens_key(tmp_path: Any) -> None:
     silently — every existing install would lose its
     ``manual_hosts`` and ``enabled`` on first boot. Pin it.
     """
-    legacy_path = tmp_path / ".device-builder.json"
-    legacy_path.write_bytes(
-        json.dumps(
-            {
-                "_remote_build": {
-                    "enabled": True,
-                    "manual_hosts": [{"hostname": "desktop.local", "port": 6052}],
-                    # Note: no ``tokens`` key — what phase 2b shipped.
-                },
-            }
-        ).encode()
+    _seed_metadata(
+        tmp_path,
+        {
+            "enabled": True,
+            "manual_hosts": [{"hostname": "desktop.local", "port": 6052}],
+            # Note: no ``tokens`` key — what phase 2b shipped.
+        },
     )
     controller = _make_controller(config_dir=tmp_path)
     settings = await controller.get_settings()


### PR DESCRIPTION
# What does this implement/fix?

First slice of phase 3b of the remote-build offload feature in #106. Phase 3 ships in three pieces:

- **3a** (landed in #450): dashboard identity (cert + key + dashboard_id)
- **3b1 (this PR)**: receiver-side token store + CRUD WS commands
- **3b2 (next)**: HTTPS listener for `/remote-build/v1/*` + bearer auth middleware + mDNS TXT `pin_sha256`
- **3b3**: first-use binding (token <-> dashboard_id)
- **3c**: receiver Settings UI consuming all of the above

This PR ships token issuance / revocation only. No HTTPS listener, no auth surface, no consumer for the tokens yet. The frontend can start integrating against the WS contract immediately.

**What this PR does:**

- New `StoredToken` model persisted under `_remote_build.tokens` in the metadata sidecar. Carries `token_id` (lookup key), `label`, `secret_sha256` (only the hash on disk), `created_at`, and `bound_dashboard_id` (reserved for phase 3b3, defaults `None`).
- New `TokenSummary` (public-facing list projection, never carries the hash) and `TokenCreateResult` (carries the cleartext bearer once at create time).
- `RemoteBuildSettings` gains a `tokens: list[StoredToken]` field with a default-factory; backwards-compatible with the on-disk JSON shape phase 2 / 2b shipped (mashumaro's `from_dict` ignores the missing key).
- Three new WS commands on `RemoteBuildController`:
  - `remote_build/list_tokens` -> `list[TokenSummary]`
  - `remote_build/add_token(label)` -> `TokenCreateResult` with cleartext `bearer`
  - `remote_build/remove_token(token_id)` -> updated `RemoteBuildSettings`
- Validation: blank / overlong / non-string labels rejected as `INVALID_ARGS`; unknown `token_id` on remove is `NOT_FOUND`; blank `token_id` is `INVALID_ARGS`.

## Wire format

Bearer = `{token_id}.{secret}`:

- `token_id`: 8 random bytes, base64url-encoded (~11 chars). Lookup key, constant-time table hit.
- `secret`: 32 random bytes, base64url-encoded (~43 chars). Verified by `hmac.compare_digest` against the stored SHA-256 hash.

Only the SHA-256 of `secret` lands on disk. The cleartext bearer flashes through `add_token`'s response exactly once at creation; standard "show secret once" UX for issued credentials. If the operator loses the bearer, the only recovery is to remove and re-issue.

Duplicate labels are allowed (`token_id` is the unique key); a user might legitimately want two tokens both labelled "Green". Label length is capped at 128 chars so a misbehaving frontend can't store megabytes.

## Topology

The receiver side of the auth model. The same dashboard can issue tokens to N offloaders (N×M many-to-many; see #106 issuecomment-4410460536 for the full topology design). Each (offloader, receiver) pairing gets its own token; tokens are NOT shared across pairings. Verification is O(1) via the `token_id` prefix.

23 new tests, parametrized for the bad-input cases.

**Related issue or feature (if applicable):**

- Phase 3b1 of #106

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

No frontend changes in this slice. Phase 3c will add the token-list / generate / revoke UI to Settings. The WS contract is stable as of this PR; frontend can start integrating immediately.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.