### PR TITLE
Document the pr-workflow skill in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,12 @@ toggle in the official ESPHome container and Home Assistant add-on.
   the right release-notes section:
   `breaking-change`, `new-feature`, `enhancement`, `bugfix`,
   `refactor`, `docs`, `maintenance`, `ci`, `dependencies`.
-  CI enforces this via `.github/workflows/pr-labels.yaml`.
+  CI enforces this via `.github/workflows/pr-labels.yaml`. The
+  full template is in `.github/PULL_REQUEST_TEMPLATE.md`; the
+  `pr-workflow` skill (under `.claude/skills/pr-workflow/`)
+  walks through filling it in — branch off `origin/main`, tick
+  exactly one Types-of-changes box, pass the body via
+  `--body-file` so the template's backticks aren't shell-escaped.
 - Pre-commit runs ruff (lint + format), codespell, yaml/json/python
   checks. Failures auto-fix where possible, then the commit needs to
   be re-staged.


### PR DESCRIPTION
# What does this implement/fix?

The `pr-workflow` skill at `.claude/skills/pr-workflow/`
already encodes the project's PR conventions (branch from
`origin/main`, fill the full template, tick exactly one
Types-of-changes box, pass the body via `--body-file` so the
template's backticks survive shell quoting), and the frontend
sibling repo's `CLAUDE.md` already references its own copy of
the skill at line 159. The backend's `CLAUDE.md` was the
asymmetry — the skill is present in the repo but never
pointed at from the canonical orientation file, so a future
LLM session would need to discover it by listing
`.claude/skills/` rather than from CLAUDE.md.

This PR adds a short reference in the Commit / PR conventions
section so the skill is the discoverable entry point for "I'm
about to open a PR." The conventions list still spells out the
release-notes labels (the skill assumes you know which one fits
the change you're shipping) but defers the mechanical "how do I
drive `gh pr create` correctly" details to the skill itself.

No code changes; CLAUDE.md only.

**Related issue or feature (if applicable):**

- Parity with the frontend sibling repo's `CLAUDE.md`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
