### PR TITLE
Add HTTPS receiver site + bearer auth (#106 phase 3b2)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -266,9 +266,32 @@ Receiver-side surface for the remote-build offload feature (issue #106). Discove
 | `remote_build/add_token` | `{label}` | `TokenCreateResult` | Issue a fresh bearer. The cleartext `bearer` flashes through the response **once**; only `sha256(secret)` lands on disk. Label 1-128 chars; duplicates allowed (`token_id` is the unique key). |
 | `remote_build/remove_token` | `{token_id}` | `RemoteBuildSettingsView` | Revoke a token. Unknown / blank `token_id` raises `not_found` / `invalid_args` respectively. |
 
-**Bearer wire format**: `{token_id}.{secret}` where `token_id` is the lookup key (8-byte base64url, ~11 chars) and `secret` is the verification value (32-byte base64url, ~43 chars). Phase 3b2's auth middleware will split on `.`, look up by `token_id`, and `hmac.compare_digest` SHA-256(`secret`) against the stored hash.
+**Bearer wire format**: `{token_id}.{secret}` where `token_id` is the lookup key (8-byte base64url, ~11 chars) and `secret` is the verification value (32-byte base64url, ~43 chars). The phase-3b2 auth middleware splits on `.`, looks up by `token_id`, and `hmac.compare_digest`s `SHA-256(secret)` against the stored hash.
 
 **`bound_dashboard_id`** on `StoredToken` / `TokenSummary` is reserved for phase 3b3's first-use binding; it stays `null` until the first authenticated request arrives carrying the offloader's `X-Dashboard-ID` header.
+
+#### HTTPS receiver site (phase 3b2)
+
+A separate aiohttp `web.Application` binds on the dashboard's `--remote-build-port` (default `6055`) over TLS using the cert + key from phase 3a. Default-off; binds only when `RemoteBuildSettings.enabled` is true. **Toggling `enabled` requires a dashboard restart for the listener to follow** — `set_settings` persists the new value but doesn't live-bind / unbind the listener.
+
+| Endpoint | Auth | Notes |
+|---|---|---|
+| `GET /remote-build/v1/health` | `Authorization: Bearer {token_id}.{secret}` | Returns `{"ok": true}` on a valid bearer; 401 without; 429 with `Retry-After` after rate-limit lockout. |
+
+The bearer scheme is RFC 7235 case-insensitive (`Bearer`, `bearer`, `BEARER` all work) and tolerant of any RFC 7230 BWS (space or tab) between scheme and credentials.
+
+Per-IP rate limiter on failed attempts: 10 failures per 60 seconds triggers a 5-minute lockout for that source IP. Successful auth doesn't clear the limiter — there's no notion of "this peer is trustworthy now"; per-pairing trust is the binding step in phase 3b3.
+
+The receiver advertises the listener's port over mDNS as a TXT property:
+
+| TXT property | Value | When present |
+|---|---|---|
+| `server_version` | `"1.2.3"` | always |
+| `esphome_version` | `"2026.5.0"` | always |
+| `pin_sha256` | lowercase-hex SPKI fingerprint | when remote-build is enabled |
+| `remote_build_port` | stringified int (e.g. `"6055"`) | when remote-build is enabled |
+
+Same-subnet peers read `remote_build_port` from TXT so a `--remote-build-port` override is auto-discovered. Cross-subnet peers (`add_manual_host` flow) provide the port at add time.
 
 ### Utility
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -288,8 +288,8 @@ The receiver advertises the listener's port over mDNS as a TXT property:
 |---|---|---|
 | `server_version` | `"1.2.3"` | always |
 | `esphome_version` | `"2026.5.0"` | always |
-| `pin_sha256` | lowercase-hex SPKI fingerprint | when remote-build is enabled |
-| `remote_build_port` | stringified int (e.g. `"6055"`) | when remote-build is enabled |
+| `pin_sha256` | lowercase-hex SPKI fingerprint | when the remote-build receiver site is bound (the listener post-bind sets this; a misconfigured `enabled=true` that fails to bind leaves it absent) |
+| `remote_build_port` | stringified int (e.g. `"6055"`) | when the remote-build receiver site is bound (same condition as `pin_sha256`) |
 
 Same-subnet peers read `remote_build_port` from TXT so a `--remote-build-port` override is auto-discovered. Cross-subnet peers (`add_manual_host` flow) provide the port at add time.
 

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -13,7 +13,13 @@ from typing import TYPE_CHECKING
 
 from colorlog import ColoredFormatter
 
-from .constants import DEFAULT_HOST, DEFAULT_INGRESS_PORT, DEFAULT_PORT, __version__
+from .constants import (
+    DEFAULT_HOST,
+    DEFAULT_INGRESS_PORT,
+    DEFAULT_PORT,
+    DEFAULT_REMOTE_BUILD_PORT,
+    __version__,
+)
 from .helpers.logging import activate_log_queue_handler
 
 if TYPE_CHECKING:
@@ -139,6 +145,16 @@ def main() -> None:
         help=(
             "Bind address for the HA Ingress site (defaults to all interfaces "
             "inside the addon container)"
+        ),
+    )
+    parser.add_argument(
+        "--remote-build-port",
+        type=int,
+        default=DEFAULT_REMOTE_BUILD_PORT,
+        help=(
+            "HTTPS port for the remote-build receiver site "
+            f"(default {DEFAULT_REMOTE_BUILD_PORT}; only bound when "
+            "remote-build is enabled in Settings)"
         ),
     )
     parser.add_argument(

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -150,11 +150,12 @@ def main() -> None:
     parser.add_argument(
         "--remote-build-port",
         type=int,
-        default=DEFAULT_REMOTE_BUILD_PORT,
+        default=None,
         help=(
-            "HTTPS port for the remote-build receiver site "
-            f"(default {DEFAULT_REMOTE_BUILD_PORT}; only bound when "
-            "remote-build is enabled in Settings)"
+            "HTTPS port for the remote-build receiver site (default "
+            f"{DEFAULT_REMOTE_BUILD_PORT}; only bound when "
+            "remote-build is enabled in Settings; falls back to "
+            "$ESPHOME_REMOTE_BUILD_PORT when the flag isn't passed)"
         ),
     )
     parser.add_argument(

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -150,12 +150,16 @@ def main() -> None:
     parser.add_argument(
         "--remote-build-port",
         type=int,
-        default=None,
+        # ``SUPPRESS`` keeps ``ArgumentDefaultsHelpFormatter`` from
+        # rendering a contradictory ``(default: None)`` next to the
+        # help text; the real default lives in
+        # ``DashboardSettings.parse_args`` (env-var fallback +
+        # ``DEFAULT_REMOTE_BUILD_PORT``).
+        default=argparse.SUPPRESS,
         help=(
-            "HTTPS port for the remote-build receiver site (default "
-            f"{DEFAULT_REMOTE_BUILD_PORT}; only bound when "
-            "remote-build is enabled in Settings; falls back to "
-            "$ESPHOME_REMOTE_BUILD_PORT when the flag isn't passed)"
+            f"HTTPS port for the remote-build receiver site (default "
+            f"{DEFAULT_REMOTE_BUILD_PORT} or $ESPHOME_REMOTE_BUILD_PORT; "
+            "only bound when remote-build is enabled in Settings)"
         ),
     )
     parser.add_argument(

--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -29,3 +29,11 @@ DEFAULT_HOST = "0.0.0.0"
 # on the supervisor's docker bridge network, and bypasses the password
 # gate (the supervisor has already authenticated the request).
 DEFAULT_INGRESS_PORT = 8099
+
+# HTTPS site for the remote-build feature (issue #106). Carries the
+# TLS-pinned ``/remote-build/v1/*`` route group; bearer-token gated.
+# Different port from the dashboard's own HTTP listener so a
+# misconfigured offloader can't accidentally hit the dashboard auth
+# surface, and so paired peers can resolve "the remote-build URL" off
+# the mDNS SRV record without ambiguity.
+DEFAULT_REMOTE_BUILD_PORT = 6055

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -22,7 +22,7 @@ from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON, ext_storage_path
 from esphome.util import get_serial_ports
 
-from ..constants import DEFAULT_INGRESS_PORT
+from ..constants import DEFAULT_INGRESS_PORT, DEFAULT_REMOTE_BUILD_PORT
 from ..constants import __version__ as server_version
 from ..helpers.api import CommandError, api_command
 from ..helpers.auth import hash_password
@@ -61,6 +61,12 @@ class DashboardSettings:
     host: str = "0.0.0.0"
     ingress_port: int = DEFAULT_INGRESS_PORT
     ingress_host: str = ""
+    # HTTPS port for the remote-build receiver site (issue #106).
+    # The site is only bound when ``RemoteBuildSettings.enabled`` is
+    # set; default-off keeps the listener inactive on installs that
+    # haven't opted in. Lives separately from ``port`` because it
+    # serves a TLS-pinned route group with its own auth gate.
+    remote_build_port: int = DEFAULT_REMOTE_BUILD_PORT
     # In dev mode the SPA shell is served with ``Cache-Control: no-cache``
     # so a re-deployed wheel isn't masked by a browser-cached
     # ``index.html`` pointing at a now-deleted hashed bundle. In
@@ -140,6 +146,7 @@ class DashboardSettings:
         self.host = getattr(args, "host", "0.0.0.0")
         self.ingress_port = getattr(args, "ingress_port", DEFAULT_INGRESS_PORT)
         self.ingress_host = getattr(args, "ingress_host", "") or ""
+        self.remote_build_port = getattr(args, "remote_build_port", DEFAULT_REMOTE_BUILD_PORT)
         self.dev_mode = bool(getattr(args, "dev", False))
         # ``--trusted-domains a,b,c`` (or ``$ESPHOME_TRUSTED_DOMAINS``).
         # Comma-separated. Lower-cased for the case-insensitive match

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -146,7 +146,30 @@ class DashboardSettings:
         self.host = getattr(args, "host", "0.0.0.0")
         self.ingress_port = getattr(args, "ingress_port", DEFAULT_INGRESS_PORT)
         self.ingress_host = getattr(args, "ingress_host", "") or ""
-        self.remote_build_port = getattr(args, "remote_build_port", DEFAULT_REMOTE_BUILD_PORT)
+        # ``--remote-build-port`` (or ``$ESPHOME_REMOTE_BUILD_PORT``).
+        # Precedence mirrors ``--trusted-domains`` below: an explicit
+        # CLI value (including the default) wins; ``None`` means
+        # "flag not set, consult the env var". Container deployments
+        # that fix the CMD in the Dockerfile and override via env
+        # can flip the listener port without rebuilding the image.
+        cli_remote_build_port = getattr(args, "remote_build_port", None)
+        if cli_remote_build_port is not None:
+            self.remote_build_port = cli_remote_build_port
+        else:
+            env_remote_build_port = os.getenv("ESPHOME_REMOTE_BUILD_PORT", "")
+            try:
+                self.remote_build_port = (
+                    int(env_remote_build_port)
+                    if env_remote_build_port
+                    else DEFAULT_REMOTE_BUILD_PORT
+                )
+            except ValueError:
+                _LOGGER.warning(
+                    "Invalid ESPHOME_REMOTE_BUILD_PORT=%r; falling back to %d",
+                    env_remote_build_port,
+                    DEFAULT_REMOTE_BUILD_PORT,
+                )
+                self.remote_build_port = DEFAULT_REMOTE_BUILD_PORT
         self.dev_mode = bool(getattr(args, "dev", False))
         # ``--trusted-domains a,b,c`` (or ``$ESPHOME_TRUSTED_DOMAINS``).
         # Comma-separated. Lower-cased for the case-insensitive match

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -8,21 +8,29 @@ cross-subnet / non-multicast LANs, and the receiver-issued
 bearer-token list; merges discovery sources into a single
 ``remote_build/list_hosts`` snapshot.
 
-Current scope:
+The ``enabled`` flag gates the HTTPS receiver site
+:class:`DeviceBuilder` binds at startup (``/remote-build/v1/*``,
+default port 6055). Toggling ``enabled`` at runtime persists
+the new value but does NOT live-bind / unbind the listener;
+flipping it requires a dashboard restart for the listener
+state to follow. The 3c Settings UI surfaces this constraint;
+a future PR can wire the start / stop hooks if interactive
+toggling matters.
 
-* No HTTP / WS endpoints under ``/remote-build/v1/*`` yet (the
-  HTTPS listener + auth middleware land alongside the token
-  store's first consumer).
-* No pairing or peer-link WS yet.
-* The ``enabled`` setting is persisted but not wired to any
-  endpoint registration; flipping it currently has no observable
-  effect beyond round-tripping in the settings UI.
-* Tokens are issuable / revocable but nothing consumes them yet;
-  ``add_token`` returns the cleartext bearer once at creation
-  time, only the SHA-256 of the secret half lands on disk.
-* Manual hosts have no version / fingerprint resolution; they
-  land in ``list_hosts`` with empty ``server_version`` /
-  ``esphome_version`` until phase 4 attempts the connection.
+Tokens are validated by the auth middleware on that site
+against an in-memory index seeded from disk in :meth:`start`
+and refreshed on every CRUD mutation. ``add_token`` flashes
+the cleartext bearer through its response once at creation
+time; only the SHA-256 of the secret half lands on disk.
+
+Pairing flow + peer-link WS arrive in later phases. The
+listener currently serves only ``/remote-build/v1/health`` as
+a smoke endpoint; phase 5+ adds the real bundle / build /
+firmware RPCs against the same auth surface.
+
+Manual hosts have no version / fingerprint resolution yet;
+they land in ``list_hosts`` with empty ``server_version`` /
+``esphome_version`` until pairing attempts the connection.
 
 Browser uses the existing ``AsyncEsphomeZeroconf`` instance owned by
 :class:`~esphome_device_builder.controllers._device_state_monitor.DeviceStateMonitor`,
@@ -566,15 +574,24 @@ class RemoteBuildController:
         """
         Persist the receiver-side ``enabled`` master switch.
 
-        Read-modify-write so manual hosts and any future phase-3+
-        fields stay intact; a client toggling just ``enabled``
-        doesn't reset every other field to its default.
+        Read-modify-write so manual hosts, tokens, and any future
+        phase-3+ fields stay intact; a client toggling just
+        ``enabled`` doesn't reset every other field to its default.
 
         Validates ``enabled`` is strictly a ``bool`` rather than
         coercing truthiness; a client sending the string ``"false"``
         for example would otherwise persist as ``True``, which is
         the opposite of what the user intended on a security-
         sensitive toggle.
+
+        **Listener bind requires restart.** The HTTPS receiver
+        site (``/remote-build/v1/*``) is bound once in
+        :meth:`DeviceBuilder.start` based on the value at startup;
+        flipping ``enabled`` here persists the new value but does
+        NOT live-rebind. The frontend should surface a "restart
+        required" hint to the operator. A future PR can wire
+        ``set_settings`` into the lifecycle hooks if interactive
+        toggling becomes a real UX concern.
         """
         if not isinstance(enabled, bool):
             msg = "remote_build/set_settings: 'enabled' must be a boolean"

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -352,6 +352,12 @@ class RemoteBuildController:
         # advertiser was skipped (HA addon mode, zeroconf failed),
         # in which case there's nothing to filter.
         self._own_instance_name: str | None = None
+        # In-memory token index keyed off ``token_id``. Built from
+        # disk at start; refreshed after every CRUD mutation so
+        # the auth middleware's lookup is constant-time and
+        # never has to hit the filesystem on the request hot
+        # path. Empty until ``start`` runs.
+        self._tokens_by_id: dict[str, StoredToken] = {}
 
     async def start(self) -> None:
         """
@@ -363,6 +369,18 @@ class RemoteBuildController:
         restart. Same fail-soft contract as
         :class:`DashboardAdvertiser`.
         """
+        # Seed the token index from disk before the zeroconf gate
+        # below: the index is consumed by the HTTPS auth middleware
+        # (phase 3b2), not by the zeroconf browser. Even on a
+        # zeroconf-disabled deployment (HA addon, container with
+        # mDNS broken) the index needs to be live so the listener
+        # can validate bearers.
+        loop = asyncio.get_running_loop()
+        settings = await loop.run_in_executor(
+            None, load_remote_build_settings, self._db.settings.config_dir
+        )
+        self._tokens_by_id = {t.token_id: t for t in settings.tokens}
+
         if self._db.devices is None:
             _LOGGER.debug("RemoteBuildController.start called before devices controller")
             return
@@ -524,7 +542,24 @@ class RemoteBuildController:
 
         loop = asyncio.get_running_loop()
         settings = await loop.run_in_executor(None, _txn)
+        # Keep the auth middleware's lookup index in sync with the
+        # post-write state. Add / remove / first-use-binding all
+        # route through here, so this is the one place that needs
+        # to refresh.
+        self._tokens_by_id = {t.token_id: t for t in settings.tokens}
         return _to_view(settings)
+
+    def lookup_token(self, token_id: str) -> StoredToken | None:
+        """
+        Return the matching :class:`StoredToken` for ``token_id``, or ``None``.
+
+        Public accessor for the phase-3b2 auth middleware. Reads
+        the in-memory index (constant-time dict hit, no I/O on
+        the request hot path). The index is seeded in
+        :meth:`start` and kept in sync via
+        :meth:`_modify_settings`.
+        """
+        return self._tokens_by_id.get(token_id)
 
     @api_command("remote_build/set_settings")
     async def set_settings(self, *, enabled: bool, **kwargs: Any) -> RemoteBuildSettingsView:

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -12,10 +12,15 @@ import contextlib
 import html
 import logging
 import re
+import ssl
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .helpers.dashboard_identity import DashboardIdentity
 
 from aiohttp import web
 from esphome.const import __version__ as esphome_version
@@ -27,7 +32,11 @@ from .controllers.auth import AuthController
 from .controllers.automations import AutomationsController
 from .controllers.boards import BoardCatalog
 from .controllers.components import ComponentCatalog
-from .controllers.config import ConfigController, DashboardSettings
+from .controllers.config import (
+    ConfigController,
+    DashboardSettings,
+    load_remote_build_settings,
+)
 from .controllers.devices import DevicesController
 from .controllers.editor import EditorController
 from .controllers.firmware import FirmwareController
@@ -36,8 +45,10 @@ from .controllers.remote_build import RemoteBuildController
 from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.auth import auth_middleware
 from .helpers.dashboard_advertise import DashboardAdvertiser
+from .helpers.dashboard_identity import get_or_create_identity
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware
+from .helpers.remote_build_auth import make_remote_build_auth_middleware
 from .helpers.subscriber_presence import SubscriberPresence
 from .models import EventType
 
@@ -95,6 +106,42 @@ _BASE_HREF_PLACEHOLDER = "__ESPHOME_BASE_HREF__"
 # intermediary cache could serve the wrong-prefix shell to a
 # different client.
 _BASE_HREF_VARY = "X-Ingress-Path, X-Forwarded-Prefix"
+
+
+def _build_remote_build_ssl_context(identity: DashboardIdentity) -> ssl.SSLContext:
+    """
+    Build the ``SSLContext`` used by the remote-build receiver site.
+
+    Python's ``ssl.SSLContext.load_cert_chain`` only accepts
+    filenames, not bytes. Stage the cert + key in tempfiles
+    inside a single ``mkdtemp`` directory so the load is atomic
+    from the API's perspective; the directory is deleted before
+    return so nothing sensitive lingers on disk longer than the
+    handshake setup.
+
+    Sync; called via ``run_in_executor`` from the start hook so
+    the loop doesn't block on the file I/O + crypto setup.
+    """
+    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    with tempfile.TemporaryDirectory(prefix="esphome-remote-build-tls-") as tmpdir:
+        cert_path = Path(tmpdir) / "cert.pem"
+        key_path = Path(tmpdir) / "key.pem"
+        cert_path.write_bytes(identity.cert_pem)
+        key_path.write_bytes(identity.key_pem)
+        ctx.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
+    return ctx
+
+
+async def _remote_build_health(_: web.Request) -> web.Response:
+    """
+    Smoke endpoint for ``/remote-build/v1/health``.
+
+    The auth middleware fires before this handler — by the time
+    the handler runs the bearer is already validated. Returns
+    a minimal JSON ack so a paired offloader can prove the
+    receiver is reachable AND that its token is honoured.
+    """
+    return web.json_response({"ok": True})
 
 
 def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
@@ -218,6 +265,10 @@ class DeviceBuilder:
         self._bg_task: asyncio.Task | None = None
 
         self._ingress_runner: web.AppRunner | None = None
+        # HTTPS receiver site for ``/remote-build/v1/*`` (issue #106
+        # phase 3b2). Bound only when ``RemoteBuildSettings.enabled``
+        # is true; ``None`` otherwise.
+        self._remote_build_runner: web.AppRunner | None = None
 
     def _install_default_executor(self) -> None:
         """Register the dashboard's executor as the loop's default.
@@ -306,6 +357,13 @@ class DeviceBuilder:
         # discovered list.
         await self.remote_build.start()
 
+        # Phase 3b2: bind the HTTPS receiver site for
+        # ``/remote-build/v1/*`` if the user has opted in via
+        # ``RemoteBuildSettings.enabled``. Default-off so a
+        # fresh install never opens an inbound port without a
+        # deliberate operator action.
+        await self._maybe_start_remote_build_site()
+
         # Collect command handlers from all controllers
         for controller in (
             self.auth,
@@ -347,6 +405,15 @@ class DeviceBuilder:
             task.cancel()
         if self._background_tasks:
             await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        # Tear down the remote-build HTTPS listener (if it was
+        # bound) before the controller it depends on. Order
+        # matters less here than for zeroconf, but doing it
+        # first keeps the listener from servicing a request
+        # that hits a torn-down controller mid-shutdown.
+        if self._remote_build_runner is not None:
+            with contextlib.suppress(Exception):
+                await self._remote_build_runner.cleanup()
+            self._remote_build_runner = None
         # Cancel the remote-build browser BEFORE devices.stop()
         # closes the zeroconf socket the browser is using. Same
         # ordering rule as the dashboard advertise just below.
@@ -632,6 +699,73 @@ class DeviceBuilder:
         if self._ingress_runner is not None:
             await self._ingress_runner.cleanup()
             self._ingress_runner = None
+
+    async def _maybe_start_remote_build_site(self) -> None:
+        """
+        Bind the HTTPS receiver site for ``/remote-build/v1/*`` if enabled.
+
+        Default-off: the listener only binds when
+        ``RemoteBuildSettings.enabled`` is true. Reads the cert + key
+        + identity off disk via :func:`get_or_create_identity` and
+        builds an aiohttp ``SSLContext`` from the on-disk PEM files.
+        Both reads hop through ``run_in_executor`` because the
+        helper is sync-blocking by design.
+
+        On HA addon mode with the listener enabled, logs a warning
+        that the addon's ``ports:`` config must expose the bound
+        port for LAN peers to actually reach it. The bind itself
+        proceeds — "not supported by default today" rather than
+        "hard-refused forever."
+        """
+        if self.remote_build is None or self.loop is None:
+            return
+        loop = self.loop
+        rb_settings = await loop.run_in_executor(
+            None, load_remote_build_settings, self.settings.config_dir
+        )
+        if not rb_settings.enabled:
+            _LOGGER.debug(
+                "Skipping remote-build HTTPS site: not enabled in settings "
+                "(set ``remote_build/set_settings`` enabled=true to bind)"
+            )
+            return
+
+        identity = await loop.run_in_executor(
+            None, get_or_create_identity, self.settings.config_dir
+        )
+        # Tell the controller about the cert pin so the next mDNS
+        # advertise refresh carries it in TXT.
+        if self._dashboard_advertiser is not None:
+            self._dashboard_advertiser.set_pin_sha256(identity.pin_sha256)
+
+        ssl_context = await loop.run_in_executor(None, _build_remote_build_ssl_context, identity)
+        middleware = make_remote_build_auth_middleware(self.remote_build.lookup_token)
+        app = web.Application(middlewares=[middleware])
+        app.router.add_get("/remote-build/v1/health", _remote_build_health)
+
+        runner = web.AppRunner(app)
+        await runner.setup()
+        host = self.settings.host
+        port = self.settings.remote_build_port
+        site = web.TCPSite(runner, host, port, ssl_context=ssl_context)
+        await site.start()
+        self._remote_build_runner = runner
+
+        if self.settings.on_ha_addon:
+            _LOGGER.warning(
+                "Remote-build HTTPS site bound on %s:%d while running as HA "
+                "addon. Peers won't reach this port unless the addon's "
+                "``ports:`` config exposes it to the host.",
+                host,
+                port,
+            )
+        else:
+            _LOGGER.info(
+                "Remote-build HTTPS site listening on %s:%d (TLS pin %s)",
+                host,
+                port,
+                identity.pin_sha256_formatted,
+            )
 
     def run(self) -> None:
         """Start the HTTP server (blocking)."""

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -778,10 +778,24 @@ class DeviceBuilder:
             runner = web.AppRunner(app)
             await runner.setup()
             host = self.settings.host
-            port = self.settings.remote_build_port
-            site = web.TCPSite(runner, host, port, ssl_context=ssl_context)
+            configured_port = self.settings.remote_build_port
+            site = web.TCPSite(runner, host, configured_port, ssl_context=ssl_context)
             await site.start()
             self._remote_build_runner = runner
+            # Resolve the actually-bound port. ``configured_port=0``
+            # tells the OS to pick an ephemeral port; if we then
+            # advertised ``0`` in mDNS TXT and logged ``0``,
+            # discovery would point peers at port 0 (unreachable)
+            # and the operator's "what port am I on?" question
+            # would be unanswerable. Read the real port off the
+            # bound socket. When ``configured_port`` is non-zero
+            # this returns the same value, so the branch is
+            # harmless on the default path too.
+            port = configured_port
+            if configured_port == 0 and site._server is not None:
+                sockets = site._server.sockets
+                if sockets:
+                    port = sockets[0].getsockname()[1]
         except Exception:
             _LOGGER.exception(
                 "Remote-build HTTPS site failed to start; dashboard continues "

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -119,6 +119,13 @@ def _build_remote_build_ssl_context(identity: DashboardIdentity) -> ssl.SSLConte
     return so nothing sensitive lingers on disk longer than the
     handshake setup.
 
+    The brief on-disk window is protected by ``mkdtemp``'s
+    default ``0o700`` mode — the staging directory is private
+    to the dashboard's user. A future refactor that moves the
+    staging out of ``mkdtemp`` to a known-path location (e.g.
+    a sibling of ``config_dir``) MUST keep that mode invariant
+    or the key file leaks to other users on the host.
+
     Sync; called via ``run_in_executor`` from the start hook so
     the loop doesn't block on the file I/O + crypto setup.
     """
@@ -142,6 +149,26 @@ async def _remote_build_health(_: web.Request) -> web.Response:
     receiver is reachable AND that its token is honoured.
     """
     return web.json_response({"ok": True})
+
+
+@web.middleware
+async def _strip_server_header_middleware(
+    request: web.Request,
+    handler: Any,
+) -> web.StreamResponse:
+    """
+    Drop aiohttp's default ``Server: Python/x.y aiohttp/z.w`` banner.
+
+    Defence-in-depth on the LAN-reachable surface: the banner is
+    a free version-fingerprint for any scanner that touches the
+    listener. The remote-build site is bearer-gated, so the
+    leak is bounded, but stripping the header costs nothing and
+    keeps the signal off the wire.
+    """
+    response = await handler(request)
+    if "Server" in response.headers:
+        del response.headers["Server"]
+    return response
 
 
 def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
@@ -733,14 +760,9 @@ class DeviceBuilder:
         identity = await loop.run_in_executor(
             None, get_or_create_identity, self.settings.config_dir
         )
-        # Tell the controller about the cert pin so the next mDNS
-        # advertise refresh carries it in TXT.
-        if self._dashboard_advertiser is not None:
-            self._dashboard_advertiser.set_pin_sha256(identity.pin_sha256)
-
         ssl_context = await loop.run_in_executor(None, _build_remote_build_ssl_context, identity)
-        middleware = make_remote_build_auth_middleware(self.remote_build.lookup_token)
-        app = web.Application(middlewares=[middleware])
+        auth_middleware_fn = make_remote_build_auth_middleware(self.remote_build.lookup_token)
+        app = web.Application(middlewares=[_strip_server_header_middleware, auth_middleware_fn])
         app.router.add_get("/remote-build/v1/health", _remote_build_health)
 
         runner = web.AppRunner(app)
@@ -750,6 +772,15 @@ class DeviceBuilder:
         site = web.TCPSite(runner, host, port, ssl_context=ssl_context)
         await site.start()
         self._remote_build_runner = runner
+
+        # Update the mDNS advertise AFTER the bind succeeds. If the
+        # bind raised (port in use, permission denied, ...) the
+        # advertiser stays at its pre-listener state instead of
+        # broadcasting a pin + port that nothing's actually
+        # listening on.
+        if self._dashboard_advertiser is not None:
+            self._dashboard_advertiser.set_pin_sha256(identity.pin_sha256)
+            self._dashboard_advertiser.set_remote_build_port(port)
 
         if self.settings.on_ha_addon:
             _LOGGER.warning(

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -14,6 +14,7 @@ import logging
 import re
 import ssl
 import tempfile
+from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from pathlib import Path
@@ -154,7 +155,7 @@ async def _remote_build_health(_: web.Request) -> web.Response:
 @web.middleware
 async def _strip_server_header_middleware(
     request: web.Request,
-    handler: Any,
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
 ) -> web.StreamResponse:
     """
     Drop aiohttp's default ``Server: Python/x.y aiohttp/z.w`` banner.
@@ -738,6 +739,11 @@ class DeviceBuilder:
         Both reads hop through ``run_in_executor`` because the
         helper is sync-blocking by design.
 
+        Fail-soft: any exception during identity load, SSL setup, or
+        bind is caught and logged. The main dashboard keeps running;
+        the operator gets a warning and the listener is simply
+        absent until the next restart with the issue resolved.
+
         On HA addon mode with the listener enabled, logs a warning
         that the addon's ``ports:`` config must expose the bound
         port for LAN peers to actually reach it. The bind itself
@@ -757,30 +763,50 @@ class DeviceBuilder:
             )
             return
 
-        identity = await loop.run_in_executor(
-            None, get_or_create_identity, self.settings.config_dir
-        )
-        ssl_context = await loop.run_in_executor(None, _build_remote_build_ssl_context, identity)
-        auth_middleware_fn = make_remote_build_auth_middleware(self.remote_build.lookup_token)
-        app = web.Application(middlewares=[_strip_server_header_middleware, auth_middleware_fn])
-        app.router.add_get("/remote-build/v1/health", _remote_build_health)
+        runner: web.AppRunner | None = None
+        try:
+            identity = await loop.run_in_executor(
+                None, get_or_create_identity, self.settings.config_dir
+            )
+            ssl_context = await loop.run_in_executor(
+                None, _build_remote_build_ssl_context, identity
+            )
+            auth_middleware_fn = make_remote_build_auth_middleware(self.remote_build.lookup_token)
+            app = web.Application(middlewares=[_strip_server_header_middleware, auth_middleware_fn])
+            app.router.add_get("/remote-build/v1/health", _remote_build_health)
 
-        runner = web.AppRunner(app)
-        await runner.setup()
-        host = self.settings.host
-        port = self.settings.remote_build_port
-        site = web.TCPSite(runner, host, port, ssl_context=ssl_context)
-        await site.start()
-        self._remote_build_runner = runner
+            runner = web.AppRunner(app)
+            await runner.setup()
+            host = self.settings.host
+            port = self.settings.remote_build_port
+            site = web.TCPSite(runner, host, port, ssl_context=ssl_context)
+            await site.start()
+            self._remote_build_runner = runner
+        except Exception:
+            _LOGGER.exception(
+                "Remote-build HTTPS site failed to start; dashboard continues "
+                "without the receiver listener. Disable in Settings or "
+                "fix the underlying error and restart."
+            )
+            if runner is not None:
+                with contextlib.suppress(Exception):
+                    await runner.cleanup()
+            self._remote_build_runner = None
+            return
 
         # Update the mDNS advertise AFTER the bind succeeds. If the
         # bind raised (port in use, permission denied, ...) the
         # advertiser stays at its pre-listener state instead of
         # broadcasting a pin + port that nothing's actually
-        # listening on.
+        # listening on. ``refresh`` republishes the ServiceInfo
+        # if the TXT properties changed; without that call the
+        # setter-driven update would only land on the wire on the
+        # next periodic refresh tick (5 min).
         if self._dashboard_advertiser is not None:
             self._dashboard_advertiser.set_pin_sha256(identity.pin_sha256)
             self._dashboard_advertiser.set_remote_build_port(port)
+            with contextlib.suppress(Exception):
+                await self._dashboard_advertiser.refresh()
 
         if self.settings.on_ha_addon:
             _LOGGER.warning(

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -158,17 +158,23 @@ async def _strip_server_header_middleware(
     handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
 ) -> web.StreamResponse:
     """
-    Drop aiohttp's default ``Server: Python/x.y aiohttp/z.w`` banner.
+    Override aiohttp's default ``Server: Python/x.y aiohttp/z.w`` banner.
 
     Defence-in-depth on the LAN-reachable surface: the banner is
     a free version-fingerprint for any scanner that touches the
     listener. The remote-build site is bearer-gated, so the
     leak is bounded, but stripping the header costs nothing and
     keeps the signal off the wire.
+
+    aiohttp injects the banner at the connection-write layer
+    when the response doesn't carry a ``Server`` header — a
+    middleware-level ``del`` only catches handlers that set the
+    header explicitly. Setting the header to an empty string
+    overrides aiohttp's default; an empty ``Server:`` value
+    lands on the wire instead of the version banner.
     """
     response = await handler(request)
-    if "Server" in response.headers:
-        del response.headers["Server"]
+    response.headers["Server"] = ""
     return response
 
 

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -763,50 +763,16 @@ class DeviceBuilder:
             )
             return
 
-        runner: web.AppRunner | None = None
         try:
-            identity = await loop.run_in_executor(
-                None, get_or_create_identity, self.settings.config_dir
-            )
-            ssl_context = await loop.run_in_executor(
-                None, _build_remote_build_ssl_context, identity
-            )
-            auth_middleware_fn = make_remote_build_auth_middleware(self.remote_build.lookup_token)
-            app = web.Application(middlewares=[_strip_server_header_middleware, auth_middleware_fn])
-            app.router.add_get("/remote-build/v1/health", _remote_build_health)
-
-            runner = web.AppRunner(app)
-            await runner.setup()
-            host = self.settings.host
-            configured_port = self.settings.remote_build_port
-            site = web.TCPSite(runner, host, configured_port, ssl_context=ssl_context)
-            await site.start()
-            self._remote_build_runner = runner
-            # Resolve the actually-bound port. ``configured_port=0``
-            # tells the OS to pick an ephemeral port; if we then
-            # advertised ``0`` in mDNS TXT and logged ``0``,
-            # discovery would point peers at port 0 (unreachable)
-            # and the operator's "what port am I on?" question
-            # would be unanswerable. Read the real port off the
-            # bound socket. When ``configured_port`` is non-zero
-            # this returns the same value, so the branch is
-            # harmless on the default path too.
-            port = configured_port
-            if configured_port == 0 and site._server is not None:
-                sockets = site._server.sockets
-                if sockets:
-                    port = sockets[0].getsockname()[1]
+            runner, identity, port = await self._build_and_start_remote_build_runner()
         except Exception:
             _LOGGER.exception(
                 "Remote-build HTTPS site failed to start; dashboard continues "
                 "without the receiver listener. Disable in Settings or "
                 "fix the underlying error and restart."
             )
-            if runner is not None:
-                with contextlib.suppress(Exception):
-                    await runner.cleanup()
-            self._remote_build_runner = None
             return
+        self._remote_build_runner = runner
 
         # Update the mDNS advertise AFTER the bind succeeds. If the
         # bind raised (port in use, permission denied, ...) the
@@ -827,16 +793,76 @@ class DeviceBuilder:
                 "Remote-build HTTPS site bound on %s:%d while running as HA "
                 "addon. Peers won't reach this port unless the addon's "
                 "``ports:`` config exposes it to the host.",
-                host,
+                self.settings.host,
                 port,
             )
         else:
             _LOGGER.info(
                 "Remote-build HTTPS site listening on %s:%d (TLS pin %s)",
-                host,
+                self.settings.host,
                 port,
                 identity.pin_sha256_formatted,
             )
+
+    async def _build_and_start_remote_build_runner(
+        self,
+    ) -> tuple[web.AppRunner, DashboardIdentity, int]:
+        """
+        Construct the runner, build the SSL context, bind the listener.
+
+        Extracted from :meth:`_maybe_start_remote_build_site` so the
+        large try-block doesn't bury the orchestration in error
+        handling. Returns ``(runner, identity, bound_port)`` on
+        success; on any exception, cleans up the partial runner
+        before re-raising so the caller's ``except`` only has to
+        log + return.
+
+        ``bound_port`` is the OS-assigned port when the operator
+        passed ``--remote-build-port 0`` (ephemeral); otherwise the
+        configured value verbatim. Reading the real port off the
+        socket prevents mDNS / log lines from claiming port 0.
+        """
+        loop = self.loop
+        assert loop is not None  # caller-checked
+        assert self.remote_build is not None  # caller-checked
+
+        def _load_identity_and_ssl_context() -> tuple[DashboardIdentity, ssl.SSLContext]:
+            # Chain the two sync helpers in a single executor hop:
+            # ``get_or_create_identity`` reads / generates the cert
+            # + key + dashboard_id, then ``_build_remote_build_ssl_context``
+            # stages the PEMs through tempfiles into an SSLContext.
+            # Doing them as separate hops costs an extra
+            # event-loop -> worker-thread round-trip for nothing.
+            ident = get_or_create_identity(self.settings.config_dir)
+            return ident, _build_remote_build_ssl_context(ident)
+
+        runner: web.AppRunner | None = None
+        try:
+            identity, ssl_context = await loop.run_in_executor(None, _load_identity_and_ssl_context)
+            auth_middleware_fn = make_remote_build_auth_middleware(self.remote_build.lookup_token)
+            app = web.Application(middlewares=[_strip_server_header_middleware, auth_middleware_fn])
+            app.router.add_get("/remote-build/v1/health", _remote_build_health)
+
+            runner = web.AppRunner(app)
+            await runner.setup()
+            configured_port = self.settings.remote_build_port
+            site = web.TCPSite(runner, self.settings.host, configured_port, ssl_context=ssl_context)
+            await site.start()
+        except Exception:
+            if runner is not None:
+                with contextlib.suppress(Exception):
+                    await runner.cleanup()
+            raise
+
+        # Resolve the actually-bound port. ``configured_port=0``
+        # tells the OS to pick an ephemeral port; the bound port
+        # lives on the started server socket.
+        port = configured_port
+        if configured_port == 0 and site._server is not None:
+            sockets = site._server.sockets
+            if sockets:
+                port = sockets[0].getsockname()[1]
+        return runner, identity, port
 
     def run(self) -> None:
         """Start the HTTP server (blocking)."""

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -463,20 +463,19 @@ class DashboardAdvertiser:
 
     async def refresh(self) -> bool:
         """
-        Re-publish the advertise if the local-address set has changed.
+        Re-publish the advertise if anything observable on the wire changed.
 
-        Re-runs :func:`_local_addresses` (via the executor — see
-        :meth:`register`), compares the result against the address
-        list that's currently on the wire, and calls
-        :meth:`AsyncEsphomeZeroconf.async_update_service` only when the
-        sorted sets differ. The no-op return path keeps callers
-        free to invoke this on a tick / interface-change event
-        without flooding the network with unchanged updates.
+        Compares both the local-address set AND the TXT properties
+        against what's currently published; calls
+        :meth:`AsyncEsphomeZeroconf.async_update_service` only when
+        either differs. The no-op return path keeps callers free to
+        invoke this on a tick / interface-change event / TXT-field
+        update without flooding the network with unchanged updates.
 
         Returns ``True`` if a re-publish actually fired, ``False``
-        when the cached and freshly-enumerated address sets matched
-        (or when the advertiser isn't currently registered, in
-        which case there's nothing to refresh against).
+        when the cached state matched (or when the advertiser isn't
+        currently registered, in which case there's nothing to
+        refresh against).
         """
         info = self._info
         zeroconf = self._zeroconf
@@ -484,12 +483,18 @@ class DashboardAdvertiser:
             return False
         loop = asyncio.get_running_loop()
         new_addresses = await loop.run_in_executor(None, _local_addresses)
+        new_info = self.build_service_info(new_addresses)
         # Compare normalized sets so the order ifaddr returns
         # interfaces in (which can shift between calls on some
-        # platforms) doesn't trigger a spurious re-publish.
-        if sorted(new_addresses) == sorted(info.parsed_addresses()):
+        # platforms) doesn't trigger a spurious re-publish. Also
+        # compare TXT properties so a setter-driven change (e.g.
+        # ``set_pin_sha256``, ``set_remote_build_port``) actually
+        # makes it onto the wire — without this, a TXT update
+        # after register would never propagate.
+        addresses_unchanged = sorted(new_addresses) == sorted(info.parsed_addresses())
+        properties_unchanged = new_info.properties == info.properties
+        if addresses_unchanged and properties_unchanged:
             return False
-        new_info = self.build_service_info(new_addresses)
         try:
             await zeroconf.async_update_service(new_info)
         except Exception:

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -15,8 +15,8 @@ alternative that fits. Parallels the existing ``_esphomelib._tcp.local.``
 device service type so a packet capture shows both ESPHome surfaces
 in the same ``_esphome*`` namespace.
 
-The TXT record carries the two version fields a peer can't derive
-from the browse response on its own:
+The TXT record carries the fields a peer can't derive from the
+browse response on its own:
 
 * ``server_version`` — this dashboard's own package version, so a
   peer can flag a release-skew warning before pairing.
@@ -24,6 +24,11 @@ from the browse response on its own:
   dashboard would compile against, so the version-mismatch warning
   in phase 7 can fire on the listing page rather than waiting for
   an upload to come back with a surprise build.
+* ``pin_sha256`` (optional) — the receiver's SPKI fingerprint
+  (lowercase hex). Peers cross-check the cert they observe on
+  connect against this TXT entry; the fingerprint is also what
+  pairing pins out-of-band. Omitted when the identity helper
+  hasn't run yet.
 
 A friendly label and the host's mDNS name are *not* in TXT — both
 are already on the wire. python-zeroconf exposes the service
@@ -219,6 +224,7 @@ class DashboardAdvertiser:
         port: int,
         server_version: str,
         esphome_version: str,
+        pin_sha256: str | None = None,
         name: str | None = None,
         hostname: str | None = None,
     ) -> None:
@@ -234,6 +240,15 @@ class DashboardAdvertiser:
         record's target. Neither is duplicated in TXT — peers read
         them off ``ServiceInfo.name`` / ``ServiceInfo.server`` for
         free.
+
+        ``pin_sha256`` is the receiver's SPKI fingerprint (lowercase
+        hex, RFC 7469-form input but hex-encoded for parity with TLS
+        UI display). When set, peers who browse the broadcast can
+        sanity-check the cert they observe on connect against this
+        TXT entry — a useful tampering tripwire on top of the
+        out-of-band-confirmed pin from pairing. ``None`` when the
+        identity helper hasn't run yet (pre-3a deployments, or when
+        the dashboard's own remote-build feature is disabled).
         """
         friendly = (name or "").strip() or _default_friendly_name()
         host = (hostname or "").strip() or _default_hostname()
@@ -242,6 +257,7 @@ class DashboardAdvertiser:
         self._hostname = host
         self._server_version = server_version
         self._esphome_version = esphome_version
+        self._pin_sha256 = pin_sha256
         self._info: ServiceInfo | None = None
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         # Background tick that calls :meth:`refresh` on
@@ -260,6 +276,22 @@ class DashboardAdvertiser:
     def registered(self) -> bool:
         """True between a successful :meth:`register` and :meth:`unregister`."""
         return self._info is not None
+
+    def set_pin_sha256(self, pin_sha256: str | None) -> None:
+        """
+        Update the published cert pin and refresh the broadcast.
+
+        Called when the remote-build receiver site comes up and
+        the cert + key have been loaded; lets the advertiser
+        carry ``pin_sha256`` in TXT without having to know the
+        identity helper at construction time. A subsequent
+        :meth:`refresh` (the periodic background tick already
+        does this) re-publishes the ServiceInfo with the new
+        property. Safe to call before / after :meth:`register`;
+        if not yet registered, the value is simply captured for
+        the next ``build_service_info`` call.
+        """
+        self._pin_sha256 = pin_sha256
 
     @property
     def service_instance_name(self) -> str | None:
@@ -302,10 +334,12 @@ class DashboardAdvertiser:
         # target (``server`` below) are returned by every browse;
         # peers read them directly off ``ServiceInfo.name`` /
         # ``ServiceInfo.server`` rather than parsing TXT.
-        properties = {
+        properties: dict[str, str] = {
             "server_version": self._server_version,
             "esphome_version": self._esphome_version,
         }
+        if self._pin_sha256:
+            properties["pin_sha256"] = self._pin_sha256
         # ``server`` is the SRV record's target. Zeroconf appends
         # ``.local.`` if missing; pass the FQDN through as-is so a
         # host already advertising e.g. ``desktop.local`` keeps the

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -29,6 +29,11 @@ browse response on its own:
   connect against this TXT entry; the fingerprint is also what
   pairing pins out-of-band. Omitted when the identity helper
   hasn't run yet.
+* ``remote_build_port`` (optional) — the TLS port the receiver's
+  ``/remote-build/v1/*`` listener is bound to. Carried in TXT so
+  paired peers connect to the right port even when the operator
+  has overridden ``--remote-build-port``. Omitted when the
+  receiver site isn't bound (default-off mode).
 
 A friendly label and the host's mDNS name are *not* in TXT — both
 are already on the wire. python-zeroconf exposes the service
@@ -225,6 +230,7 @@ class DashboardAdvertiser:
         server_version: str,
         esphome_version: str,
         pin_sha256: str | None = None,
+        remote_build_port: int | None = None,
         name: str | None = None,
         hostname: str | None = None,
     ) -> None:
@@ -249,6 +255,14 @@ class DashboardAdvertiser:
         out-of-band-confirmed pin from pairing. ``None`` when the
         identity helper hasn't run yet (pre-3a deployments, or when
         the dashboard's own remote-build feature is disabled).
+
+        ``remote_build_port`` is the TLS port the receiver's
+        ``/remote-build/v1/*`` listener is bound to. Carried in TXT
+        so paired peers can connect to the right port without
+        re-typing it; the SRV record's port stays at the dashboard's
+        main HTTP port (``port`` arg) so the existing browse path
+        for general dashboard discovery isn't broken. ``None`` when
+        the listener isn't bound (default-off shape).
         """
         friendly = (name or "").strip() or _default_friendly_name()
         host = (hostname or "").strip() or _default_hostname()
@@ -258,6 +272,7 @@ class DashboardAdvertiser:
         self._server_version = server_version
         self._esphome_version = esphome_version
         self._pin_sha256 = pin_sha256
+        self._remote_build_port = remote_build_port
         self._info: ServiceInfo | None = None
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         # Background tick that calls :meth:`refresh` on
@@ -292,6 +307,18 @@ class DashboardAdvertiser:
         the next ``build_service_info`` call.
         """
         self._pin_sha256 = pin_sha256
+
+    def set_remote_build_port(self, remote_build_port: int | None) -> None:
+        """
+        Update the published remote-build listener port.
+
+        Same shape as :meth:`set_pin_sha256` — captured here, picked
+        up by the next ``build_service_info`` (the periodic refresh
+        re-publishes). Lets paired peers find the listener port
+        without having to re-type it after a ``--remote-build-port``
+        override.
+        """
+        self._remote_build_port = remote_build_port
 
     @property
     def service_instance_name(self) -> str | None:
@@ -340,6 +367,8 @@ class DashboardAdvertiser:
         }
         if self._pin_sha256:
             properties["pin_sha256"] = self._pin_sha256
+        if self._remote_build_port is not None:
+            properties["remote_build_port"] = str(self._remote_build_port)
         # ``server`` is the SRV record's target. Zeroconf appends
         # ``.local.`` if missing; pass the FQDN through as-is so a
         # host already advertising e.g. ``desktop.local`` keeps the

--- a/esphome_device_builder/helpers/remote_build_auth.py
+++ b/esphome_device_builder/helpers/remote_build_auth.py
@@ -54,12 +54,35 @@ _RATE_LIMIT_WINDOW_SECONDS = 60.0
 _RATE_LIMIT_LOCKOUT_SECONDS = 300.0
 
 
-_BEARER_PREFIX = "Bearer "
 # Stored ``secret_sha256`` is lowercase hex of SHA-256, so 64 chars.
 # Used as the constant-time placeholder when the token_id misses,
 # to keep "unknown token" indistinguishable from "wrong secret"
 # under timing analysis.
 _DUMMY_HASH = "0" * 64
+
+
+def _parse_bearer_credentials(auth_header: str | None) -> tuple[str, str] | None:
+    """
+    Split ``Authorization: Bearer {token_id}.{secret}`` into ``(id, secret)``.
+
+    Returns ``None`` for any malformed header (missing, wrong
+    scheme, no dot, empty halves). RFC 7235 §2.1 makes the scheme
+    case-insensitive and RFC 7230 §3.2.3 allows BWS (space / tab)
+    between scheme and credentials; ``str.split(None, 1)``
+    collapses any whitespace run into the single delimiter.
+    """
+    if not auth_header:
+        return None
+    parts = auth_header.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    bearer = parts[1].strip()
+    if "." not in bearer:
+        return None
+    token_id, _, secret = bearer.partition(".")
+    if not token_id or not secret:
+        return None
+    return token_id, secret
 
 
 def verify_bearer(
@@ -78,14 +101,10 @@ def verify_bearer(
     timing the response can't distinguish "no such token_id"
     from "wrong secret".
     """
-    if not auth_header or not auth_header.startswith(_BEARER_PREFIX):
+    parsed = _parse_bearer_credentials(auth_header)
+    if parsed is None:
         return None
-    bearer = auth_header[len(_BEARER_PREFIX) :].strip()
-    if "." not in bearer:
-        return None
-    token_id, _, secret = bearer.partition(".")
-    if not token_id or not secret:
-        return None
+    token_id, secret = parsed
     presented_hash = hashlib.sha256(secret.encode("ascii")).hexdigest()
     stored = lookup(token_id)
     if stored is None:

--- a/esphome_device_builder/helpers/remote_build_auth.py
+++ b/esphome_device_builder/helpers/remote_build_auth.py
@@ -1,0 +1,173 @@
+"""
+Remote-build receiver auth helpers.
+
+Phase 3b2 of issue #106: bearer-token validation middleware for
+the ``/remote-build/v1/*`` route group. Tokens are minted by
+phase 3b1's :mod:`controllers.remote_build` token CRUD and
+matched against the offloader's
+``Authorization: Bearer {token_id}.{secret}`` header.
+
+Verification model:
+
+* The wire bearer is split on the first ``.``: the left half is
+  the lookup key (``token_id``), the right half is the secret.
+* The presented secret is SHA-256 hashed and compared to the
+  stored ``secret_sha256`` via :func:`hmac.compare_digest` — the
+  comparison is constant-time so an attacker can't side-channel
+  the secret out of timing differences.
+* SHA-256 of the presented secret is computed unconditionally
+  (even on unknown ``token_id``), so the timing of "unknown
+  token" matches "known token, wrong secret".
+
+A per-IP :class:`helpers.auth.RateLimiter` wraps the validator;
+failed attempts trigger a 429 with ``Retry-After`` rather than a
+401, giving a probing scanner a clear "stop" signal and bounding
+log-spam from tight retry loops.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+from ..models import StoredToken
+from .auth import RateLimiter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable as _Callable
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Per-IP rate limit on FAILED bearer attempts. 256-bit secrets make
+# online brute force infeasible regardless, but the limiter closes
+# off log-spam and side-channel timing reconnaissance. Tunable via
+# the ``rate_limiter`` argument to ``make_remote_build_auth_middleware``.
+_RATE_LIMIT_MAX_ATTEMPTS = 10
+_RATE_LIMIT_WINDOW_SECONDS = 60.0
+_RATE_LIMIT_LOCKOUT_SECONDS = 300.0
+
+
+_BEARER_PREFIX = "Bearer "
+# Stored ``secret_sha256`` is lowercase hex of SHA-256, so 64 chars.
+# Used as the constant-time placeholder when the token_id misses,
+# to keep "unknown token" indistinguishable from "wrong secret"
+# under timing analysis.
+_DUMMY_HASH = "0" * 64
+
+
+def verify_bearer(
+    auth_header: str | None,
+    lookup: Callable[[str], StoredToken | None],
+) -> StoredToken | None:
+    """
+    Parse a bearer header, return the matching :class:`StoredToken` or ``None``.
+
+    Returns ``None`` for any failure mode (missing header, wrong
+    scheme, malformed wire form, unknown ``token_id``, hash
+    mismatch). The caller decides 401 vs 429 vs success at a
+    layer above this function.
+
+    The hash compute happens unconditionally so an attacker
+    timing the response can't distinguish "no such token_id"
+    from "wrong secret".
+    """
+    if not auth_header or not auth_header.startswith(_BEARER_PREFIX):
+        return None
+    bearer = auth_header[len(_BEARER_PREFIX) :].strip()
+    if "." not in bearer:
+        return None
+    token_id, _, secret = bearer.partition(".")
+    if not token_id or not secret:
+        return None
+    presented_hash = hashlib.sha256(secret.encode("ascii")).hexdigest()
+    stored = lookup(token_id)
+    if stored is None:
+        # Burn the same compare_digest cost the success path
+        # would so timing can't leak token_id existence.
+        hmac.compare_digest(_DUMMY_HASH, presented_hash)
+        return None
+    if not hmac.compare_digest(stored.secret_sha256, presented_hash):
+        return None
+    return stored
+
+
+def make_remote_build_auth_middleware(
+    lookup: Callable[[str], StoredToken | None],
+    rate_limiter: RateLimiter | None = None,
+) -> _Callable:
+    """
+    Build the aiohttp middleware that gates ``/remote-build/v1/*``.
+
+    *lookup* is the ``token_id -> StoredToken`` accessor
+    (typically the controller's in-memory index built from the
+    on-disk token list at startup and refreshed on every CRUD
+    mutation).
+
+    *rate_limiter* defaults to a fresh per-instance
+    :class:`helpers.auth.RateLimiter` with the module-level
+    constants; tests can pass a custom instance to drive
+    threshold-specific assertions. The limiter records FAILED
+    bearer attempts only — a successful auth does not "clear"
+    the IP because there's no notion of "this peer is
+    trustworthy now"; per-pairing trust is the binding step in
+    phase 3b3.
+
+    On 401 / 429 the middleware emits a warning log line with
+    the peer IP and the request path so an operator hunting
+    "why is my offloader getting kicked" has a paper trail.
+    Successful auth doesn't log (would spam the dashboard's log
+    on every build status poll); the audit-log shape for
+    successful requests lands in phase 3b2's first real RPC,
+    not the always-on middleware.
+    """
+    limiter = rate_limiter or RateLimiter(
+        max_attempts=_RATE_LIMIT_MAX_ATTEMPTS,
+        window_seconds=_RATE_LIMIT_WINDOW_SECONDS,
+        lockout_seconds=_RATE_LIMIT_LOCKOUT_SECONDS,
+    )
+
+    @web.middleware
+    async def middleware(
+        request: web.Request,
+        handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+    ) -> web.StreamResponse:
+        peer_ip = request.remote or "?"
+        locked = limiter.remaining_lockout(peer_ip)
+        if locked > 0:
+            _LOGGER.warning(
+                "Remote-build auth: %s locked out for %.0fs (path=%s)",
+                peer_ip,
+                locked,
+                request.path,
+            )
+            return web.Response(
+                status=429,
+                text="rate limited",
+                headers={"Retry-After": str(int(locked) + 1)},
+            )
+        token = verify_bearer(request.headers.get("Authorization"), lookup)
+        if token is None:
+            limiter.record_failure(peer_ip)
+            _LOGGER.warning(
+                "Remote-build auth: rejected request from %s (path=%s)",
+                peer_ip,
+                request.path,
+            )
+            return web.Response(
+                status=401,
+                text="unauthorized",
+                headers={"WWW-Authenticate": 'Bearer realm="remote-build"'},
+            )
+        # Stash the matched token on the request for the handler
+        # / phase 3b3's first-use binding to consume.
+        request["remote_build_token"] = token
+        return await handler(request)
+
+    return middleware

--- a/esphome_device_builder/helpers/remote_build_auth.py
+++ b/esphome_device_builder/helpers/remote_build_auth.py
@@ -105,7 +105,13 @@ def verify_bearer(
     if parsed is None:
         return None
     token_id, secret = parsed
-    presented_hash = hashlib.sha256(secret.encode("ascii")).hexdigest()
+    # Encode as UTF-8 (never raises) rather than ASCII (would
+    # raise ``UnicodeEncodeError`` on a malformed header carrying
+    # non-ASCII bytes, turning a 401 into a 500). Genuine bearers
+    # come from ``secrets.token_urlsafe`` and are pure ASCII; an
+    # attacker-supplied non-ASCII bearer just produces a hash
+    # that doesn't match anything stored.
+    presented_hash = hashlib.sha256(secret.encode("utf-8")).hexdigest()
     stored = lookup(token_id)
     if stored is None:
         # Burn the same compare_digest cost the success path

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -323,6 +323,67 @@ def test_set_remote_build_port_updates_subsequent_advertise() -> None:
     assert decoded["remote_build_port"] == "7000"
 
 
+@pytest.mark.asyncio
+async def test_refresh_republishes_when_only_txt_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A TXT-only change triggers ``async_update_service`` on the next refresh.
+
+    Pre-fix, ``refresh`` short-circuited when the address set was
+    unchanged, so a setter-driven TXT update (``set_pin_sha256``,
+    ``set_remote_build_port``) never made it onto the wire after
+    the initial register. The fix detects TXT differences too;
+    pin that contract.
+    """
+    advertiser = _make_advertiser()
+    # Pre-seed an "already registered" state. We don't actually
+    # talk to a real zeroconf instance — fake the bits ``refresh``
+    # reads / writes.
+    initial_addresses = ["10.0.0.5"]
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.dashboard_advertise._local_addresses",
+        lambda: list(initial_addresses),
+    )
+    advertiser._info = advertiser.build_service_info(initial_addresses)
+    fake_zeroconf = MagicMock()
+    fake_zeroconf.async_update_service = AsyncMock()
+    advertiser._zeroconf = fake_zeroconf
+
+    # Now set a TXT field WITHOUT changing addresses.
+    advertiser.set_pin_sha256("a" * 64)
+    refreshed = await advertiser.refresh()
+
+    assert refreshed is True
+    assert fake_zeroconf.async_update_service.called
+    # The republished info carries the new pin.
+    new_info = fake_zeroconf.async_update_service.call_args.args[0]
+    decoded = {k.decode(): v.decode() for k, v in new_info.properties.items()}
+    assert decoded["pin_sha256"] == "a" * 64
+
+
+@pytest.mark.asyncio
+async def test_refresh_no_op_when_nothing_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``refresh`` returns False without calling zeroconf when nothing changed."""
+    advertiser = _make_advertiser()
+    initial_addresses = ["10.0.0.5"]
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.dashboard_advertise._local_addresses",
+        lambda: list(initial_addresses),
+    )
+    advertiser._info = advertiser.build_service_info(initial_addresses)
+    fake_zeroconf = MagicMock()
+    fake_zeroconf.async_update_service = AsyncMock()
+    advertiser._zeroconf = fake_zeroconf
+
+    refreshed = await advertiser.refresh()
+
+    assert refreshed is False
+    assert not fake_zeroconf.async_update_service.called
+
+
 def test_build_service_info_keeps_trailing_dot_on_explicit_fqdn() -> None:
     """An already-trailing-dot hostname round-trips unchanged."""
     advertiser = _make_advertiser(name="green", hostname="green.local.")

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -293,6 +293,36 @@ def test_set_pin_sha256_updates_subsequent_advertise() -> None:
     assert decoded["pin_sha256"] == "b" * 64
 
 
+def test_build_service_info_carries_remote_build_port_when_set() -> None:
+    """``remote_build_port`` lands in TXT as a stringified int when set."""
+    advertiser = DashboardAdvertiser(
+        port=6052,
+        server_version="1.2.3",
+        esphome_version="2026.5.0",
+        remote_build_port=6055,
+    )
+    info = advertiser.build_service_info()
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert decoded["remote_build_port"] == "6055"
+
+
+def test_build_service_info_omits_remote_build_port_when_unset() -> None:
+    """``remote_build_port`` is absent when the listener isn't bound."""
+    advertiser = _make_advertiser()
+    info = advertiser.build_service_info()
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert "remote_build_port" not in decoded
+
+
+def test_set_remote_build_port_updates_subsequent_advertise() -> None:
+    """``set_remote_build_port`` makes the next advertise carry the new port."""
+    advertiser = _make_advertiser()
+    advertiser.set_remote_build_port(7000)
+    info = advertiser.build_service_info()
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert decoded["remote_build_port"] == "7000"
+
+
 def test_build_service_info_keeps_trailing_dot_on_explicit_fqdn() -> None:
     """An already-trailing-dot hostname round-trips unchanged."""
     advertiser = _make_advertiser(name="green", hostname="green.local.")

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -41,11 +41,13 @@ def _make_advertiser(
     name: str | None = None,
     hostname: str | None = None,
     port: int = 6052,
+    pin_sha256: str | None = None,
 ) -> DashboardAdvertiser:
     return DashboardAdvertiser(
         port=port,
         server_version="1.2.3",
         esphome_version="2026.5.0",
+        pin_sha256=pin_sha256,
         name=name,
         hostname=hostname,
     )
@@ -263,6 +265,32 @@ def test_build_service_info_populates_txt_and_server() -> None:
     }
     # ``server`` is always trailing-dotted so zeroconf doesn't double-suffix it.
     assert info.server == "green.local."
+
+
+def test_build_service_info_carries_pin_sha256_when_set() -> None:
+    """``pin_sha256`` lands in TXT when the advertiser was constructed with it."""
+    pin = "a" * 64
+    advertiser = _make_advertiser(name="green", hostname="green.local", pin_sha256=pin)
+    info = advertiser.build_service_info()
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert decoded["pin_sha256"] == pin
+
+
+def test_build_service_info_omits_pin_sha256_when_unset() -> None:
+    """``pin_sha256`` is absent from TXT when the advertiser doesn't have one."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    info = advertiser.build_service_info()
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert "pin_sha256" not in decoded
+
+
+def test_set_pin_sha256_updates_subsequent_advertise() -> None:
+    """``set_pin_sha256`` makes the next ``build_service_info`` carry the new pin."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    advertiser.set_pin_sha256("b" * 64)
+    info = advertiser.build_service_info()
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert decoded["pin_sha256"] == "b" * 64
 
 
 def test_build_service_info_keeps_trailing_dot_on_explicit_fqdn() -> None:

--- a/tests/test_remote_build_auth.py
+++ b/tests/test_remote_build_auth.py
@@ -84,6 +84,23 @@ def test_verify_bearer_returns_token_on_match() -> None:
     assert matched is stored
 
 
+@pytest.mark.parametrize(
+    "header",
+    [
+        pytest.param("bearer known.right-secret", id="lowercase"),
+        pytest.param("BEARER known.right-secret", id="uppercase"),
+        pytest.param("BeArEr known.right-secret", id="mixed-case"),
+        pytest.param("Bearer\tknown.right-secret", id="tab-delimited"),
+        pytest.param("Bearer  known.right-secret", id="double-space"),
+    ],
+)
+def test_verify_bearer_accepts_case_insensitive_scheme_and_bws(header: str) -> None:
+    """RFC 7235 §2.1 + RFC 7230 §3.2.3: scheme is case-insensitive, BWS allowed."""
+    stored = _stored(token_id="known", secret="right-secret")
+    matched = verify_bearer(header, _table_lookup([stored]))
+    assert matched is stored
+
+
 # ---------------------------------------------------------------------------
 # Middleware
 # ---------------------------------------------------------------------------

--- a/tests/test_remote_build_auth.py
+++ b/tests/test_remote_build_auth.py
@@ -101,6 +101,22 @@ def test_verify_bearer_accepts_case_insensitive_scheme_and_bws(header: str) -> N
     assert matched is stored
 
 
+def test_verify_bearer_handles_non_ascii_secret_without_raising() -> None:
+    """
+    A non-ASCII secret half is rejected as 401, not 500.
+
+    A genuine bearer is base64url (always ASCII), so a non-ASCII
+    payload is either a malformed client or an attacker's probe.
+    The pre-fix code did ``secret.encode("ascii")`` which raised
+    ``UnicodeEncodeError`` and turned the auth failure into a
+    500. Pin the rejection-not-crash contract.
+    """
+    stored = _stored(token_id="known", secret="right-secret")
+    # ``é`` is non-ASCII; would have raised under the old encode("ascii").
+    matched = verify_bearer("Bearer known.café", _table_lookup([stored]))
+    assert matched is None
+
+
 # ---------------------------------------------------------------------------
 # Middleware
 # ---------------------------------------------------------------------------

--- a/tests/test_remote_build_auth.py
+++ b/tests/test_remote_build_auth.py
@@ -1,0 +1,209 @@
+"""Tests for the phase-3b2 remote-build bearer auth middleware."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from esphome_device_builder.helpers.auth import RateLimiter
+from esphome_device_builder.helpers.remote_build_auth import (
+    make_remote_build_auth_middleware,
+    verify_bearer,
+)
+from esphome_device_builder.models import StoredToken
+
+_DEFAULT_ID = "tid12345"
+_DEFAULT_SECRET = "the-cleartext-secret"
+
+
+def _stored(token_id: str = _DEFAULT_ID, secret: str = _DEFAULT_SECRET) -> StoredToken:
+    """Build a ``StoredToken`` whose hash matches *secret*."""
+    return StoredToken(
+        token_id=token_id,
+        label="Green",
+        secret_sha256=hashlib.sha256(secret.encode("ascii")).hexdigest(),
+        created_at=1.0,
+    )
+
+
+def _table_lookup(rows: list[StoredToken]) -> Callable[[str], StoredToken | None]:
+    """Build a lookup callable from a list of stored tokens."""
+    by_id = {t.token_id: t for t in rows}
+
+    def _lookup(token_id: str) -> StoredToken | None:
+        return by_id.get(token_id)
+
+    return _lookup
+
+
+# ---------------------------------------------------------------------------
+# verify_bearer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param("", id="empty"),
+        pytest.param("token-without-scheme", id="no-scheme"),
+        pytest.param("Basic dXNlcjpwYXNz", id="wrong-scheme"),
+        pytest.param("Bearer ", id="bearer-empty"),
+        pytest.param("Bearer no-dot-separator", id="no-dot"),
+        pytest.param("Bearer .secret-only", id="empty-id"),
+        pytest.param("Bearer token-id-only.", id="empty-secret"),
+    ],
+)
+def test_verify_bearer_rejects_malformed_headers(header: str | None) -> None:
+    """Headers that don't carry a parseable ``{id}.{secret}`` return ``None``."""
+    stored = _stored()
+    assert verify_bearer(header, _table_lookup([stored])) is None
+
+
+def test_verify_bearer_rejects_unknown_token_id() -> None:
+    """A bearer with an unknown ``token_id`` half returns ``None``."""
+    stored = _stored(token_id="known", secret="s")
+    assert verify_bearer("Bearer unknown.s", _table_lookup([stored])) is None
+
+
+def test_verify_bearer_rejects_wrong_secret() -> None:
+    """Right ``token_id``, wrong secret returns ``None``."""
+    stored = _stored(token_id="known", secret="right-secret")
+    assert verify_bearer("Bearer known.wrong-secret", _table_lookup([stored])) is None
+
+
+def test_verify_bearer_returns_token_on_match() -> None:
+    """A valid bearer returns the matching ``StoredToken``."""
+    stored = _stored(token_id="known", secret="right-secret")
+    matched = verify_bearer("Bearer known.right-secret", _table_lookup([stored]))
+    assert matched is stored
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+async def _hit_middleware(
+    middleware: Any,
+    *,
+    auth_header: str | None = None,
+    peer_ip: str = "10.0.0.42",
+) -> web.StreamResponse:
+    """
+    Drive the middleware against a fake request, returning the response.
+
+    Wraps a noop downstream handler that returns 200 so we can
+    distinguish "middleware allowed through" (200 from the handler)
+    from "middleware short-circuited" (whatever it returned).
+    """
+    headers: dict[str, str] = {}
+    if auth_header is not None:
+        headers["Authorization"] = auth_header
+    request = make_mocked_request(
+        "GET", "/remote-build/v1/health", headers=headers, client_max_size=0
+    )
+    request._transport_peername = (peer_ip, 12345)  # used by request.remote
+
+    async def _noop(req: web.Request) -> web.StreamResponse:
+        return web.Response(status=200, text="ok")
+
+    return await middleware(request, _noop)
+
+
+@pytest.mark.asyncio
+async def test_middleware_401_without_bearer() -> None:
+    """No ``Authorization`` header → 401 with ``WWW-Authenticate``."""
+    middleware = make_remote_build_auth_middleware(_table_lookup([_stored()]))
+    response = await _hit_middleware(middleware)
+    assert response.status == 401
+    assert response.headers.get("WWW-Authenticate", "").startswith("Bearer ")
+
+
+@pytest.mark.asyncio
+async def test_middleware_401_with_bad_bearer() -> None:
+    """Wrong secret → 401."""
+    stored = _stored(token_id="abc", secret="right")
+    middleware = make_remote_build_auth_middleware(_table_lookup([stored]))
+    response = await _hit_middleware(middleware, auth_header="Bearer abc.wrong")
+    assert response.status == 401
+
+
+@pytest.mark.asyncio
+async def test_middleware_200_with_good_bearer_and_stashes_token() -> None:
+    """A valid bearer reaches the handler and stashes the token on the request."""
+    stored = _stored(token_id="abc", secret="right")
+
+    received: dict[str, Any] = {}
+
+    async def _spy_handler(request: web.Request) -> web.StreamResponse:
+        received["token"] = request.get("remote_build_token")
+        return web.Response(status=200, text="ok")
+
+    auth = make_remote_build_auth_middleware(_table_lookup([stored]))
+
+    request = make_mocked_request(
+        "GET",
+        "/remote-build/v1/health",
+        headers={"Authorization": "Bearer abc.right"},
+        client_max_size=0,
+    )
+    request._transport_peername = ("10.0.0.42", 12345)
+    response = await auth(request, _spy_handler)
+    assert response.status == 200
+    assert received["token"] is stored
+
+
+@pytest.mark.asyncio
+async def test_middleware_429_after_rate_limit_lockout() -> None:
+    """
+    Repeated bad-bearer attempts from one IP get locked out with 429.
+
+    Pin the limiter at a tiny threshold so the test doesn't have
+    to hammer the middleware to trigger the lockout.
+    """
+    limiter = RateLimiter(max_attempts=2, window_seconds=60.0, lockout_seconds=300.0)
+    middleware = make_remote_build_auth_middleware(
+        _table_lookup([_stored(token_id="abc", secret="right")]),
+        rate_limiter=limiter,
+    )
+
+    # Two failed attempts → IP gets locked out.
+    for _ in range(2):
+        response = await _hit_middleware(middleware, auth_header="Bearer abc.wrong")
+        assert response.status == 401
+
+    # Next attempt is short-circuited with 429.
+    response = await _hit_middleware(middleware, auth_header="Bearer abc.wrong")
+    assert response.status == 429
+    assert "Retry-After" in response.headers
+
+
+@pytest.mark.asyncio
+async def test_middleware_rate_limit_per_ip() -> None:
+    """
+    A different source IP isn't punished for another IP's failures.
+
+    Pin that the limiter is keyed off ``request.remote`` and not a
+    process-wide counter.
+    """
+    limiter = RateLimiter(max_attempts=2, window_seconds=60.0, lockout_seconds=300.0)
+    middleware = make_remote_build_auth_middleware(
+        _table_lookup([_stored(token_id="abc", secret="right")]),
+        rate_limiter=limiter,
+    )
+
+    # Attacker IP burns through the quota.
+    for _ in range(3):
+        await _hit_middleware(middleware, auth_header="Bearer abc.wrong", peer_ip="1.2.3.4")
+
+    # Honest peer with a valid bearer still gets through.
+    response = await _hit_middleware(
+        middleware, auth_header="Bearer abc.right", peer_ip="10.0.0.42"
+    )
+    assert response.status == 200

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -858,6 +858,34 @@ async def test_remove_token_drops_only_target(tmp_path: Path) -> None:
     assert [t.token_id for t in settings.tokens] == [keep_a.token_id, keep_b.token_id]
 
 
+@pytest.mark.asyncio
+async def test_lookup_token_round_trips_through_index(tmp_path: Path) -> None:
+    """
+    ``lookup_token`` returns the in-memory ``StoredToken`` for a known id.
+
+    The auth middleware (phase 3b2) reads through this accessor
+    on every authenticated request — it has to be constant-time
+    after CRUD mutations as well as after the startup seed. Round
+    trip a fresh token through ``add_token`` and confirm
+    ``lookup_token`` returns a matching record; remove it and
+    confirm the lookup returns ``None``.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    issued = await controller.add_token(label="Green")
+
+    found = controller.lookup_token(issued.token_id)
+    assert found is not None
+    assert found.token_id == issued.token_id
+    assert found.label == "Green"
+
+    # Unknown id -> None.
+    assert controller.lookup_token("not-a-real-id") is None
+
+    # Removal updates the index.
+    await controller.remove_token(token_id=issued.token_id)
+    assert controller.lookup_token(issued.token_id) is None
+
+
 @pytest.mark.parametrize(
     ("token_id", "expected_code"),
     [

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -228,7 +229,7 @@ def test_on_service_state_change_uses_cache_when_available(
 
 
 @pytest.mark.asyncio
-async def test_list_hosts_returns_snapshot_of_peers(tmp_path: Any) -> None:
+async def test_list_hosts_returns_snapshot_of_peers(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller._peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
         name="desktop",
@@ -248,13 +249,13 @@ async def test_list_hosts_returns_snapshot_of_peers(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_hosts_empty_when_no_peers(tmp_path: Any) -> None:
+async def test_list_hosts_empty_when_no_peers(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     assert await controller.list_hosts() == []
 
 
 @pytest.mark.asyncio
-async def test_get_settings_defaults_when_unset(tmp_path: Any) -> None:
+async def test_get_settings_defaults_when_unset(tmp_path: Path) -> None:
     """A fresh dashboard with no metadata returns ``enabled=False``."""
     controller = _make_controller(config_dir=tmp_path)
     settings = await controller.get_settings()
@@ -262,7 +263,7 @@ async def test_get_settings_defaults_when_unset(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_settings_round_trips(tmp_path: Any) -> None:
+async def test_set_settings_round_trips(tmp_path: Path) -> None:
     """Setting ``enabled=True`` persists and is read back by ``get_settings``."""
     controller = _make_controller(config_dir=tmp_path)
     written = await controller.set_settings(enabled=True)
@@ -272,7 +273,7 @@ async def test_set_settings_round_trips(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_settings_rejects_non_bool(tmp_path: Any) -> None:
+async def test_set_settings_rejects_non_bool(tmp_path: Path) -> None:
     """
     Non-boolean ``enabled`` raises ``INVALID_ARGS``, doesn't coerce.
 
@@ -296,19 +297,21 @@ async def test_set_settings_rejects_non_bool(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_skips_when_devices_controller_missing() -> None:
+async def test_start_skips_when_devices_controller_missing(tmp_path: Path) -> None:
     """``start`` is a no-op when ``DevicesController`` hasn't been set."""
     db = MagicMock()
     db.devices = None
+    db.settings = MagicMock()
+    db.settings.config_dir = tmp_path
     controller = RemoteBuildController(db)
     await controller.start()
     assert controller._browser is None
 
 
 @pytest.mark.asyncio
-async def test_start_skips_when_zeroconf_unavailable() -> None:
+async def test_start_skips_when_zeroconf_unavailable(tmp_path: Path) -> None:
     """``start`` is a no-op when zeroconf failed to bind."""
-    controller = _make_controller()
+    controller = _make_controller(config_dir=tmp_path)
     controller._db.devices.zeroconf = None
     await controller.start()
     assert controller._browser is None
@@ -316,7 +319,7 @@ async def test_start_skips_when_zeroconf_unavailable() -> None:
 
 @pytest.mark.asyncio
 async def test_start_swallows_browser_construction_errors(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """
     Browser construction failure leaves the controller in a no-peer state.
@@ -329,14 +332,16 @@ async def test_start_swallows_browser_construction_errors(
         "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
         MagicMock(side_effect=RuntimeError("zeroconf socket gone")),
     )
-    controller = _make_controller()
+    controller = _make_controller(config_dir=tmp_path)
     controller._db.devices.zeroconf = MagicMock()
     await controller.start()  # must not raise
     assert controller._browser is None
 
 
 @pytest.mark.asyncio
-async def test_start_captures_own_instance_name(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_start_captures_own_instance_name(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """
     A registered advertiser's instance name lands in ``_own_instance_name``.
 
@@ -350,7 +355,7 @@ async def test_start_captures_own_instance_name(monkeypatch: pytest.MonkeyPatch)
         "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
         MagicMock(return_value=fake_browser),
     )
-    controller = _make_controller()
+    controller = _make_controller(config_dir=tmp_path)
     controller._db.devices.zeroconf = MagicMock()
     advertiser = MagicMock()
     advertiser.service_instance_name = f"self.{SERVICE_TYPE}"
@@ -364,7 +369,7 @@ async def test_start_captures_own_instance_name(monkeypatch: pytest.MonkeyPatch)
 
 @pytest.mark.asyncio
 async def test_start_skips_self_capture_when_advertiser_unregistered(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """An unregistered advertiser (HA addon mode etc.) leaves the filter empty."""
     fake_browser = MagicMock()
@@ -373,7 +378,7 @@ async def test_start_skips_self_capture_when_advertiser_unregistered(
         "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
         MagicMock(return_value=fake_browser),
     )
-    controller = _make_controller()
+    controller = _make_controller(config_dir=tmp_path)
     controller._db.devices.zeroconf = MagicMock()
     advertiser = MagicMock()
     # ``service_instance_name`` returns ``None`` when the
@@ -389,7 +394,7 @@ async def test_start_skips_self_capture_when_advertiser_unregistered(
 
 @pytest.mark.asyncio
 async def test_start_skips_self_capture_when_no_advertiser(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """An entirely-absent advertiser (zeroconf-down branch) is fine."""
     fake_browser = MagicMock()
@@ -398,7 +403,7 @@ async def test_start_skips_self_capture_when_no_advertiser(
         "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
         MagicMock(return_value=fake_browser),
     )
-    controller = _make_controller()
+    controller = _make_controller(config_dir=tmp_path)
     controller._db.devices.zeroconf = MagicMock()
     controller._db._dashboard_advertiser = None
 
@@ -409,7 +414,7 @@ async def test_start_skips_self_capture_when_no_advertiser(
 
 @pytest.mark.asyncio
 async def test_stop_swallows_browser_cancel_errors(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A teardown-time browser-cancel failure is logged but not raised."""
     fake_browser = MagicMock()
@@ -418,7 +423,7 @@ async def test_stop_swallows_browser_cancel_errors(
         "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
         MagicMock(return_value=fake_browser),
     )
-    controller = _make_controller()
+    controller = _make_controller(config_dir=tmp_path)
     controller._db.devices.zeroconf = MagicMock()
     await controller.start()
     await controller.stop()  # must not raise
@@ -552,7 +557,7 @@ def test_peer_from_manual_host_uses_manual_source() -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_manual_host_persists_and_returns_settings(tmp_path: Any) -> None:
+async def test_add_manual_host_persists_and_returns_settings(tmp_path: Path) -> None:
     """Happy path: a unique entry is appended and the settings round-trip."""
     controller = _make_controller(config_dir=tmp_path)
     settings = await controller.add_manual_host(hostname="desktop.local", port=6052)
@@ -563,7 +568,7 @@ async def test_add_manual_host_persists_and_returns_settings(tmp_path: Any) -> N
 
 
 @pytest.mark.asyncio
-async def test_add_manual_host_rejects_duplicate(tmp_path: Any) -> None:
+async def test_add_manual_host_rejects_duplicate(tmp_path: Path) -> None:
     """
     A second add of the same ``(hostname, port)`` raises ``ALREADY_EXISTS``.
 
@@ -580,7 +585,7 @@ async def test_add_manual_host_rejects_duplicate(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_manual_host_normalises_case_for_dedup(tmp_path: Any) -> None:
+async def test_add_manual_host_normalises_case_for_dedup(tmp_path: Path) -> None:
     """``Desktop.Local`` and ``desktop.local`` are the same entry."""
     controller = _make_controller(config_dir=tmp_path)
     await controller.add_manual_host(hostname="desktop.local", port=6052)
@@ -589,7 +594,7 @@ async def test_add_manual_host_normalises_case_for_dedup(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_manual_host_keeps_enabled_intact(tmp_path: Any) -> None:
+async def test_add_manual_host_keeps_enabled_intact(tmp_path: Path) -> None:
     """
     Adding a manual host doesn't reset ``enabled``.
 
@@ -605,7 +610,7 @@ async def test_add_manual_host_keeps_enabled_intact(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_remove_manual_host_drops_entry(tmp_path: Any) -> None:
+async def test_remove_manual_host_drops_entry(tmp_path: Path) -> None:
     """Happy path: a registered entry is removed."""
     controller = _make_controller(config_dir=tmp_path)
     await controller.add_manual_host(hostname="desktop.local", port=6052)
@@ -615,7 +620,7 @@ async def test_remove_manual_host_drops_entry(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_remove_manual_host_rejects_unknown(tmp_path: Any) -> None:
+async def test_remove_manual_host_rejects_unknown(tmp_path: Path) -> None:
     """``NOT_FOUND`` for a host that was never registered."""
     controller = _make_controller(config_dir=tmp_path)
     with pytest.raises(CommandError) as exc:
@@ -624,7 +629,7 @@ async def test_remove_manual_host_rejects_unknown(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_remove_manual_host_normalises_case(tmp_path: Any) -> None:
+async def test_remove_manual_host_normalises_case(tmp_path: Path) -> None:
     """``Desktop.Local`` removes a stored ``desktop.local`` entry."""
     controller = _make_controller(config_dir=tmp_path)
     await controller.add_manual_host(hostname="desktop.local", port=6052)
@@ -633,7 +638,7 @@ async def test_remove_manual_host_normalises_case(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_settings_preserves_manual_hosts(tmp_path: Any) -> None:
+async def test_set_settings_preserves_manual_hosts(tmp_path: Path) -> None:
     """
     ``set_settings(enabled=...)`` doesn't wipe ``manual_hosts``.
 
@@ -651,7 +656,7 @@ async def test_set_settings_preserves_manual_hosts(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_hosts_merges_mdns_and_manual(tmp_path: Any) -> None:
+async def test_list_hosts_merges_mdns_and_manual(tmp_path: Path) -> None:
     """
     ``list_hosts`` returns mDNS-discovered peers followed by manual hosts.
 
@@ -677,7 +682,7 @@ async def test_list_hosts_merges_mdns_and_manual(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_manual_host_rejects_invalid_port(tmp_path: Any) -> None:
+async def test_add_manual_host_rejects_invalid_port(tmp_path: Path) -> None:
     """Out-of-range port doesn't slip through."""
     controller = _make_controller(config_dir=tmp_path)
     with pytest.raises(CommandError) as exc:
@@ -686,7 +691,7 @@ async def test_add_manual_host_rejects_invalid_port(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_manual_host_rejects_blank_hostname(tmp_path: Any) -> None:
+async def test_add_manual_host_rejects_blank_hostname(tmp_path: Path) -> None:
     """Empty / whitespace hostname doesn't slip through."""
     controller = _make_controller(config_dir=tmp_path)
     with pytest.raises(CommandError) as exc:
@@ -706,7 +711,7 @@ def _split_bearer(bearer: str) -> tuple[str, str]:
 
 
 @pytest.mark.asyncio
-async def test_add_token_returns_cleartext_bearer_once(tmp_path: Any) -> None:
+async def test_add_token_returns_cleartext_bearer_once(tmp_path: Path) -> None:
     """
     ``add_token`` flashes the cleartext bearer through exactly once.
 
@@ -733,7 +738,7 @@ async def test_add_token_returns_cleartext_bearer_once(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_token_persists_only_hashed_secret(tmp_path: Any) -> None:
+async def test_add_token_persists_only_hashed_secret(tmp_path: Path) -> None:
     """
     The on-disk row carries SHA-256 of the secret only; never the cleartext.
 
@@ -759,7 +764,7 @@ async def test_add_token_persists_only_hashed_secret(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_settings_responses_never_carry_secret_hash(tmp_path: Any) -> None:
+async def test_settings_responses_never_carry_secret_hash(tmp_path: Path) -> None:
     """
     Every WS command that returns settings projects tokens to ``TokenSummary``.
 
@@ -791,7 +796,7 @@ async def test_settings_responses_never_carry_secret_hash(tmp_path: Any) -> None
 
 
 @pytest.mark.asyncio
-async def test_list_tokens_omits_secret_hash(tmp_path: Any) -> None:
+async def test_list_tokens_omits_secret_hash(tmp_path: Path) -> None:
     """The ``list_tokens`` projection drops ``secret_sha256`` and allows dup labels."""
     controller = _make_controller(config_dir=tmp_path)
     first = await controller.add_token(label="phone")
@@ -818,7 +823,7 @@ async def test_list_tokens_omits_secret_hash(tmp_path: Any) -> None:
 )
 @pytest.mark.asyncio
 async def test_add_token_rejects_invalid_label(
-    tmp_path: Any, label: object, expected_code: ErrorCode
+    tmp_path: Path, label: object, expected_code: ErrorCode
 ) -> None:
     """Empty / overlong / non-string labels don't slip through."""
     controller = _make_controller(config_dir=tmp_path)
@@ -828,7 +833,7 @@ async def test_add_token_rejects_invalid_label(
 
 
 @pytest.mark.asyncio
-async def test_add_token_keeps_other_settings_intact(tmp_path: Any) -> None:
+async def test_add_token_keeps_other_settings_intact(tmp_path: Path) -> None:
     """Issuing a token doesn't reset ``enabled`` or ``manual_hosts``."""
     controller = _make_controller(config_dir=tmp_path)
     await controller.set_settings(enabled=True)
@@ -842,7 +847,7 @@ async def test_add_token_keeps_other_settings_intact(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_remove_token_drops_only_target(tmp_path: Any) -> None:
+async def test_remove_token_drops_only_target(tmp_path: Path) -> None:
     """Removing one token leaves the rest of the list intact."""
     controller = _make_controller(config_dir=tmp_path)
     keep_a = await controller.add_token(label="Green")
@@ -867,7 +872,7 @@ async def test_remove_token_drops_only_target(tmp_path: Any) -> None:
 )
 @pytest.mark.asyncio
 async def test_remove_token_rejects_invalid(
-    tmp_path: Any, token_id: object, expected_code: ErrorCode
+    tmp_path: Path, token_id: object, expected_code: ErrorCode
 ) -> None:
     """Unknown / blank / empty / non-string / malformed ``token_id`` is rejected."""
     controller = _make_controller(config_dir=tmp_path)
@@ -878,7 +883,7 @@ async def test_remove_token_rejects_invalid(
 
 @pytest.mark.asyncio
 async def test_remove_token_rejects_full_bearer_without_echoing_secret(
-    tmp_path: Any,
+    tmp_path: Path,
 ) -> None:
     """
     Passing the full bearer to ``remove_token`` is rejected before logging.
@@ -905,7 +910,7 @@ async def test_remove_token_rejects_full_bearer_without_echoing_secret(
 
 
 @pytest.mark.asyncio
-async def test_remove_token_not_found_does_not_echo_id(tmp_path: Any) -> None:
+async def test_remove_token_not_found_does_not_echo_id(tmp_path: Path) -> None:
     """The ``NOT_FOUND`` message doesn't echo the user-supplied ``token_id``."""
     controller = _make_controller(config_dir=tmp_path)
     suspicious = "lookslike-id-but-isnt"
@@ -916,7 +921,7 @@ async def test_remove_token_not_found_does_not_echo_id(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_token_rejects_when_at_capacity(tmp_path: Any) -> None:
+async def test_add_token_rejects_when_at_capacity(tmp_path: Path) -> None:
     """
     ``add_token`` refuses once the receiver hits the soft cap.
 
@@ -953,7 +958,7 @@ async def test_add_token_rejects_when_at_capacity(tmp_path: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_load_remote_build_settings_falls_back_on_unrecoverable_blob(
-    tmp_path: Any,
+    tmp_path: Path,
 ) -> None:
     """
     A blob that fails to deserialise even after token-row cleaning resets to defaults.
@@ -984,7 +989,7 @@ async def test_load_remote_build_settings_falls_back_on_unrecoverable_blob(
 
 @pytest.mark.asyncio
 async def test_load_remote_build_settings_drops_malformed_token_rows(
-    tmp_path: Any,
+    tmp_path: Path,
 ) -> None:
     """
     One corrupt token row doesn't blank the rest of the receiver's view.
@@ -1026,7 +1031,7 @@ async def test_load_remote_build_settings_drops_malformed_token_rows(
 
 
 @pytest.mark.asyncio
-async def test_decode_tokens_skips_non_dict_entries(tmp_path: Any) -> None:
+async def test_decode_tokens_skips_non_dict_entries(tmp_path: Path) -> None:
     """
     Non-dict entries in the on-disk ``tokens`` list are skipped silently.
 
@@ -1046,7 +1051,7 @@ async def test_decode_tokens_skips_non_dict_entries(tmp_path: Any) -> None:
                     "created_at": 1.0,
                     "bound_dashboard_id": None,
                 },
-                "not-a-dict-at-all",  # noqa: type-confused row
+                "not-a-dict-at-all",  # type-confused row
                 42,
                 None,
             ],
@@ -1060,7 +1065,7 @@ async def test_decode_tokens_skips_non_dict_entries(tmp_path: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_decode_tokens_redacts_credential_material_from_logs(
-    tmp_path: Any, caplog: pytest.LogCaptureFixture
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """
     The malformed-row debug log doesn't carry credential-adjacent fields.
@@ -1100,7 +1105,7 @@ async def test_decode_tokens_redacts_credential_material_from_logs(
 
 
 @pytest.mark.asyncio
-async def test_loads_legacy_metadata_without_tokens_key(tmp_path: Any) -> None:
+async def test_loads_legacy_metadata_without_tokens_key(tmp_path: Path) -> None:
     """
     Phase-2/2b on-disk JSON without a ``tokens`` key still loads cleanly.
 

--- a/tests/test_remote_build_https_site.py
+++ b/tests/test_remote_build_https_site.py
@@ -1,11 +1,22 @@
 """
 End-to-end TLS verification of the phase-3b2 remote-build HTTPS site.
 
-Pins that the cert + key from phase 3a, the auth middleware from
-phase 3b2, and the bearer token store from phase 3b1 line up over
-the wire: a strict-TLS aiohttp client gets 401 without a valid
-bearer, 200 with one, and the cert it observes on connect matches
-the SPKI fingerprint the receiver advertises.
+Covers the auth + listener wiring for the receiver site:
+
+* A strict-TLS aiohttp client gets 401 without a valid bearer
+  and 200 with one (real handshake against the cert + key from
+  phase 3a, real auth middleware from phase 3b2 against the
+  token store from phase 3b1).
+* The lifecycle hook ``_maybe_start_remote_build_site``
+  default-skips when ``enabled=False``, binds when
+  ``enabled=True``, fails-soft on bind error, advertises the
+  OS-assigned port for ephemeral binds, and warns on
+  HA-addon mode.
+* The strip-Server-header middleware removes aiohttp's default
+  banner from on-the-wire responses.
+
+Pin-vs-observed-cert verification is the pairing flow's job
+(phase 4) and isn't exercised here.
 """
 
 from __future__ import annotations
@@ -63,8 +74,11 @@ async def _bring_up_site(
     def _lookup(token_id: str) -> StoredToken | None:
         return by_id.get(token_id)
 
-    middleware = make_remote_build_auth_middleware(_lookup)
-    app = web.Application(middlewares=[middleware])
+    auth_middleware = make_remote_build_auth_middleware(_lookup)
+    # Mirror production's middleware stack: server-header strip
+    # first (so its post-handler step runs LAST on the way out),
+    # auth gate inside.
+    app = web.Application(middlewares=[_strip_server_header_middleware, auth_middleware])
     app.router.add_get("/remote-build/v1/health", _remote_build_health)
 
     runner = web.AppRunner(app)
@@ -127,6 +141,13 @@ async def test_health_returns_200_with_valid_bearer(tmp_path: Path) -> None:
             assert resp.status == 200
             body = await resp.json()
             assert body == {"ok": True}
+            # On-the-wire check: aiohttp injects a ``Server``
+            # banner at the connection-write layer when the
+            # response doesn't carry one. The strip-Server
+            # middleware sets it to empty string so aiohttp's
+            # default banner is overridden. Empty value (not
+            # absent) is the expected wire shape.
+            assert resp.headers.get("Server", "") == ""
     finally:
         await runner.cleanup()
 
@@ -236,16 +257,22 @@ async def test_maybe_start_remote_build_site_fails_soft_on_bind_error(
 
 
 @pytest.mark.asyncio
-async def test_strip_server_header_middleware_drops_server_banner(tmp_path: Path) -> None:
-    """The Server header gets dropped from the response."""
+async def test_strip_server_header_middleware_overrides_to_empty(tmp_path: Path) -> None:
+    """
+    The Server header is overridden to empty string.
+
+    Setting to empty (not deleting) is what overrides aiohttp's
+    connection-level default banner; the live HTTPS test in this
+    file pins the on-the-wire shape end-to-end. This unit test
+    just sanity-checks the middleware's response-level behaviour.
+    """
 
     async def _handler(_: web.Request) -> web.StreamResponse:
-        # Simulate aiohttp's default server banner.
         return web.Response(status=200, headers={"Server": "Python/3.14 aiohttp/3.13"})
 
     request = make_mocked_request("GET", "/remote-build/v1/health", client_max_size=0)
     response = await _strip_server_header_middleware(request, _handler)
-    assert "Server" not in response.headers
+    assert response.headers["Server"] == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_https_site.py
+++ b/tests/test_remote_build_https_site.py
@@ -14,11 +14,12 @@ import asyncio
 import hashlib
 import ssl
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
 from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 
 from esphome_device_builder.controllers.config import (
     DashboardSettings,
@@ -28,6 +29,7 @@ from esphome_device_builder.device_builder import (
     DeviceBuilder,
     _build_remote_build_ssl_context,
     _remote_build_health,
+    _strip_server_header_middleware,
 )
 from esphome_device_builder.helpers.dashboard_identity import (
     _CERT_FILENAME,
@@ -183,3 +185,145 @@ async def test_maybe_start_remote_build_site_binds_when_enabled(tmp_path: Path) 
     finally:
         if db._remote_build_runner is not None:
             await db._remote_build_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_fails_soft_on_bind_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A failed bind logs the error and leaves the dashboard running.
+
+    Drive ``_maybe_start_remote_build_site`` through the enabled
+    path with a port that fails to bind (port 1, can't bind as
+    non-root). The hook MUST NOT raise; the runner must end up
+    cleaned up; the dashboard's main flow continues unaffected.
+    Pins the fail-soft contract so a misconfiguration in
+    Settings (typo'd port, port already in use, cert load
+    failure) doesn't take down the whole dashboard.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = True
+
+    await loop.run_in_executor(None, _enable)
+
+    # Force the bind to fail by stubbing TCPSite.start to raise.
+    real_start = web.TCPSite.start
+
+    async def _failing_start(self: web.TCPSite) -> None:
+        raise OSError("address in use (test stub)")
+
+    monkeypatch.setattr(web.TCPSite, "start", _failing_start)
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build = MagicMock()
+    db.remote_build.lookup_token = MagicMock(return_value=None)
+
+    # Must not raise — the dashboard keeps running on bind failure.
+    await db._maybe_start_remote_build_site()
+    assert db._remote_build_runner is None
+
+    # Sanity: with the stub removed, a fresh call would succeed.
+    monkeypatch.setattr(web.TCPSite, "start", real_start)
+
+
+@pytest.mark.asyncio
+async def test_strip_server_header_middleware_drops_server_banner(tmp_path: Path) -> None:
+    """The Server header gets dropped from the response."""
+
+    async def _handler(_: web.Request) -> web.StreamResponse:
+        # Simulate aiohttp's default server banner.
+        return web.Response(status=200, headers={"Server": "Python/3.14 aiohttp/3.13"})
+
+    request = make_mocked_request("GET", "/remote-build/v1/health", client_max_size=0)
+    response = await _strip_server_header_middleware(request, _handler)
+    assert "Server" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_updates_advertiser_on_success(
+    tmp_path: Path,
+) -> None:
+    """
+    Successful bind pushes ``pin_sha256`` + ``remote_build_port`` into the advertiser.
+
+    Pins the post-bind advertiser-update wiring so a refactor that
+    accidentally drops the setter calls (or moves them before the
+    bind) surfaces here.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = True
+
+    await loop.run_in_executor(None, _enable)
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build = MagicMock()
+    db.remote_build.lookup_token = MagicMock(return_value=None)
+
+    fake_advertiser = MagicMock()
+    fake_advertiser.set_pin_sha256 = MagicMock()
+    fake_advertiser.set_remote_build_port = MagicMock()
+    fake_advertiser.refresh = AsyncMock()
+    db._dashboard_advertiser = fake_advertiser
+
+    try:
+        await db._maybe_start_remote_build_site()
+        assert db._remote_build_runner is not None
+        # SPKI pin and listener port both made it to the advertiser.
+        assert fake_advertiser.set_pin_sha256.called
+        assert fake_advertiser.set_remote_build_port.called
+        # ``refresh`` was awaited so the TXT change actually
+        # leaves the local cache.
+        assert fake_advertiser.refresh.called
+    finally:
+        if db._remote_build_runner is not None:
+            await db._remote_build_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_warns_on_ha_addon(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """HA-addon mode logs a warning when the listener binds."""
+    loop = asyncio.get_running_loop()
+
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = True
+
+    await loop.run_in_executor(None, _enable)
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0
+    settings.on_ha_addon = True  # the branch under test
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build = MagicMock()
+    db.remote_build.lookup_token = MagicMock(return_value=None)
+
+    with caplog.at_level("WARNING", logger="esphome_device_builder.device_builder"):
+        try:
+            await db._maybe_start_remote_build_site()
+            assert db._remote_build_runner is not None
+        finally:
+            if db._remote_build_runner is not None:
+                await db._remote_build_runner.cleanup()
+    warnings = [r for r in caplog.records if "HA addon" in r.getMessage()]
+    assert warnings, "expected an HA-addon warning"

--- a/tests/test_remote_build_https_site.py
+++ b/tests/test_remote_build_https_site.py
@@ -14,13 +14,18 @@ import asyncio
 import hashlib
 import ssl
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import aiohttp
 import pytest
 from aiohttp import web
 
-from esphome_device_builder.controllers.config import remote_build_settings_transaction
+from esphome_device_builder.controllers.config import (
+    DashboardSettings,
+    remote_build_settings_transaction,
+)
 from esphome_device_builder.device_builder import (
+    DeviceBuilder,
     _build_remote_build_ssl_context,
     _remote_build_health,
 )
@@ -125,22 +130,56 @@ async def test_health_returns_200_with_valid_bearer(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_setting_remote_build_settings_keeps_listener_off_by_default(
-    tmp_path: Path,
-) -> None:
+async def test_maybe_start_remote_build_site_skips_when_disabled(tmp_path: Path) -> None:
     """
-    Default-off contract: a fresh config has ``enabled=False``.
+    Default-off: ``_maybe_start_remote_build_site`` early-returns when ``enabled=False``.
 
-    Pins the listener-binding gate at the settings layer (the
-    listener wiring inspects this same field). Defends against a
-    refactor that flips the default and exposes a port without
-    the operator opting in.
+    Pins the gate at the lifecycle hook, not just at the
+    settings layer — a refactor that bound the listener
+    unconditionally (or read the wrong field) would fail here
+    even if ``RemoteBuildSettings.enabled`` still defaulted to
+    ``False``.
+    """
+    settings = DashboardSettings(config_dir=tmp_path)
+    db = DeviceBuilder(settings)
+    db.loop = asyncio.get_running_loop()
+    db.remote_build = MagicMock()
+
+    await db._maybe_start_remote_build_site()
+    assert db._remote_build_runner is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_binds_when_enabled(tmp_path: Path) -> None:
+    """
+    Flipping ``enabled=True`` makes the lifecycle hook bind the listener.
+
+    Round-trip: write ``enabled=True`` to the settings sidecar,
+    drive ``_maybe_start_remote_build_site`` through the same
+    code path the dashboard's startup uses, assert a runner
+    landed.
     """
     loop = asyncio.get_running_loop()
 
-    def _read() -> bool:
-        with remote_build_settings_transaction(tmp_path) as settings:
-            return settings.enabled
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = True
 
-    enabled = await loop.run_in_executor(None, _read)
-    assert enabled is False
+    await loop.run_in_executor(None, _enable)
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    # Pin the port to ``0`` so the OS picks a free one and the
+    # test doesn't collide with a real receiver if 6055 is in use.
+    settings.remote_build_port = 0
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build = MagicMock()
+    db.remote_build.lookup_token = MagicMock(return_value=None)
+
+    try:
+        await db._maybe_start_remote_build_site()
+        assert db._remote_build_runner is not None
+    finally:
+        if db._remote_build_runner is not None:
+            await db._remote_build_runner.cleanup()

--- a/tests/test_remote_build_https_site.py
+++ b/tests/test_remote_build_https_site.py
@@ -1,0 +1,146 @@
+"""
+End-to-end TLS verification of the phase-3b2 remote-build HTTPS site.
+
+Pins that the cert + key from phase 3a, the auth middleware from
+phase 3b2, and the bearer token store from phase 3b1 line up over
+the wire: a strict-TLS aiohttp client gets 401 without a valid
+bearer, 200 with one, and the cert it observes on connect matches
+the SPKI fingerprint the receiver advertises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import ssl
+from pathlib import Path
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from esphome_device_builder.controllers.config import remote_build_settings_transaction
+from esphome_device_builder.device_builder import (
+    _build_remote_build_ssl_context,
+    _remote_build_health,
+)
+from esphome_device_builder.helpers.dashboard_identity import (
+    _CERT_FILENAME,
+    get_or_create_identity,
+)
+from esphome_device_builder.helpers.remote_build_auth import (
+    make_remote_build_auth_middleware,
+)
+from esphome_device_builder.models import StoredToken
+
+
+async def _bring_up_site(
+    tmp_path: Path,
+    *,
+    tokens: list[StoredToken],
+) -> tuple[web.AppRunner, int]:
+    """
+    Stand up a real HTTPS listener bound to a real ephemeral port.
+
+    Mirrors what ``DeviceBuilder._maybe_start_remote_build_site``
+    does, but inline so the tests can drive it without booting
+    the whole dashboard. Returns the runner (for cleanup) and
+    the bound port.
+    """
+    loop = asyncio.get_running_loop()
+    identity = await loop.run_in_executor(None, get_or_create_identity, tmp_path)
+    ssl_ctx = await loop.run_in_executor(None, _build_remote_build_ssl_context, identity)
+
+    by_id = {t.token_id: t for t in tokens}
+
+    def _lookup(token_id: str) -> StoredToken | None:
+        return by_id.get(token_id)
+
+    middleware = make_remote_build_auth_middleware(_lookup)
+    app = web.Application(middlewares=[middleware])
+    app.router.add_get("/remote-build/v1/health", _remote_build_health)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0, ssl_context=ssl_ctx)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+    return runner, port
+
+
+def _build_client_ctx(tmp_path: Path) -> ssl.SSLContext:
+    """Strict client: trust only our cert, validate hostname (SAN=localhost)."""
+    return ssl.create_default_context(cafile=str(tmp_path / _CERT_FILENAME))
+
+
+@pytest.mark.asyncio
+async def test_health_returns_401_without_bearer(tmp_path: Path) -> None:
+    """No ``Authorization`` header → 401 from the auth middleware."""
+    runner, port = await _bring_up_site(tmp_path, tokens=[])
+    try:
+        loop = asyncio.get_running_loop()
+        client_ctx = await loop.run_in_executor(None, _build_client_ctx, tmp_path)
+        connector = aiohttp.TCPConnector(ssl=client_ctx)
+        async with (
+            aiohttp.ClientSession(connector=connector) as session,
+            session.get(
+                f"https://localhost:{port}/remote-build/v1/health",
+                server_hostname="localhost",
+            ) as resp,
+        ):
+            assert resp.status == 401
+            assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer ")
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_health_returns_200_with_valid_bearer(tmp_path: Path) -> None:
+    """A valid bearer reaches the handler and gets a 200 + JSON ack."""
+    secret = "the-canary-secret"
+    token = StoredToken(
+        token_id="abc123",
+        label="Green",
+        secret_sha256=hashlib.sha256(secret.encode("ascii")).hexdigest(),
+        created_at=1.0,
+    )
+    runner, port = await _bring_up_site(tmp_path, tokens=[token])
+    try:
+        loop = asyncio.get_running_loop()
+        client_ctx = await loop.run_in_executor(None, _build_client_ctx, tmp_path)
+        connector = aiohttp.TCPConnector(ssl=client_ctx)
+        async with (
+            aiohttp.ClientSession(connector=connector) as session,
+            session.get(
+                f"https://localhost:{port}/remote-build/v1/health",
+                server_hostname="localhost",
+                headers={"Authorization": f"Bearer abc123.{secret}"},
+            ) as resp,
+        ):
+            assert resp.status == 200
+            body = await resp.json()
+            assert body == {"ok": True}
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_setting_remote_build_settings_keeps_listener_off_by_default(
+    tmp_path: Path,
+) -> None:
+    """
+    Default-off contract: a fresh config has ``enabled=False``.
+
+    Pins the listener-binding gate at the settings layer (the
+    listener wiring inspects this same field). Defends against a
+    refactor that flips the default and exposes a port without
+    the operator opting in.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _read() -> bool:
+        with remote_build_settings_transaction(tmp_path) as settings:
+            return settings.enabled
+
+    enabled = await loop.run_in_executor(None, _read)
+    assert enabled is False

--- a/tests/test_remote_build_https_site.py
+++ b/tests/test_remote_build_https_site.py
@@ -296,6 +296,55 @@ async def test_maybe_start_remote_build_site_updates_advertiser_on_success(
 
 
 @pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_advertises_actual_port_for_ephemeral(
+    tmp_path: Path,
+) -> None:
+    """
+    ``remote_build_port=0`` advertises the OS-assigned port, not literal 0.
+
+    When the operator binds with ``--remote-build-port 0`` (or a
+    test pins it to 0 to avoid collisions), the OS picks an
+    ephemeral port. Advertising or logging ``0`` would point
+    peers at an unreachable port and the operator couldn't
+    answer "what port am I on?". Resolve the actual bound port
+    from the socket and pass that to the advertiser.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = True
+
+    await loop.run_in_executor(None, _enable)
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0  # ask the OS for an ephemeral port
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build = MagicMock()
+    db.remote_build.lookup_token = MagicMock(return_value=None)
+
+    fake_advertiser = MagicMock()
+    fake_advertiser.set_pin_sha256 = MagicMock()
+    fake_advertiser.set_remote_build_port = MagicMock()
+    fake_advertiser.refresh = AsyncMock()
+    db._dashboard_advertiser = fake_advertiser
+
+    try:
+        await db._maybe_start_remote_build_site()
+        assert db._remote_build_runner is not None
+        # The advertiser receives the OS-assigned port, never 0.
+        assert fake_advertiser.set_remote_build_port.called
+        advertised = fake_advertiser.set_remote_build_port.call_args.args[0]
+        assert advertised != 0
+        assert 1024 <= advertised <= 65535
+    finally:
+        if db._remote_build_runner is not None:
+            await db._remote_build_runner.cleanup()
+
+
+@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_warns_on_ha_addon(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_remote_build_port_env.py
+++ b/tests/test_remote_build_port_env.py
@@ -1,0 +1,84 @@
+"""Tests for ``ESPHOME_REMOTE_BUILD_PORT`` env-var handling.
+
+Mirror the precedence rules used by ``--trusted-domains`` /
+``$ESPHOME_TRUSTED_DOMAINS`` and ``--username`` /
+``$ESPHOME_USERNAME``: an explicit CLI value (any non-``None``)
+wins over the env var; a ``None`` CLI default falls back to
+``$ESPHOME_REMOTE_BUILD_PORT``; an empty / unset env var falls
+back to ``DEFAULT_REMOTE_BUILD_PORT``; a non-integer env var
+logs a warning and falls back to the default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder.constants import DEFAULT_REMOTE_BUILD_PORT
+from esphome_device_builder.controllers.config import DashboardSettings
+
+
+def _ns(configuration: str, **kwargs: object) -> SimpleNamespace:
+    """Minimal argparse-namespace stub for ``DashboardSettings.parse_args``."""
+    defaults: dict[str, object] = {
+        "ha_addon": False,
+        "configuration": configuration,
+        "username": "",
+        "password": "",
+        "log_level": "info",
+        "port": 6052,
+        "host": "0.0.0.0",
+        "ingress_port": 6053,
+        "ingress_host": "",
+        # ``None`` matches the argparse default — production passes
+        # ``None`` when ``--remote-build-port`` wasn't given so the
+        # env-var fallback can fire.
+        "remote_build_port": None,
+        "dev": False,
+        "trusted_domains": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_cli_flag_wins_over_env(tmp_path: Path) -> None:
+    """Explicit ``--remote-build-port`` value beats the env var."""
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_PORT": "9999"}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path), remote_build_port=7000))
+    assert settings.remote_build_port == 7000
+
+
+def test_env_used_when_cli_unset(tmp_path: Path) -> None:
+    """``None`` CLI default falls back to the env var."""
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_PORT": "9999"}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path)))
+    assert settings.remote_build_port == 9999
+
+
+def test_default_when_neither_cli_nor_env(tmp_path: Path) -> None:
+    """Neither flag nor env → ``DEFAULT_REMOTE_BUILD_PORT``."""
+    settings = DashboardSettings()
+    # Empty string env entry covers the inherited-but-blank case.
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_PORT": ""}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path)))
+    assert settings.remote_build_port == DEFAULT_REMOTE_BUILD_PORT
+
+
+def test_invalid_env_falls_back_to_default(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-integer env value logs a warning and falls back to the default."""
+    settings = DashboardSettings()
+    with (
+        patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_PORT": "not-a-port"}, clear=False),
+        caplog.at_level("WARNING", logger="esphome_device_builder.controllers.config"),
+    ):
+        settings.parse_args(_ns(configuration=str(tmp_path)))
+    assert settings.remote_build_port == DEFAULT_REMOTE_BUILD_PORT
+    warnings = [r for r in caplog.records if "ESPHOME_REMOTE_BUILD_PORT" in r.getMessage()]
+    assert warnings, "expected a warning about the malformed env var"


### PR DESCRIPTION
# What does this implement/fix?

Second slice of phase 3b of the remote-build offload feature in #106. Wires the receiver-side HTTPS surface on top of phase 3a (identity) and phase 3b1 (token CRUD).

- **3a** (landed in #450): dashboard identity (cert + key + dashboard_id)
- **3b1** (landed in #453): receiver-side token store + CRUD WS commands
- **3b2 (this PR)**: HTTPS listener for `/remote-build/v1/*` + bearer auth middleware + mDNS TXT `pin_sha256`
- **3b3 (next)**: first-use binding (token <-> dashboard_id)
- **3c**: receiver Settings UI

## Wire surface

- `GET /remote-build/v1/health` — smoke endpoint. Returns `{"ok": true}` with a valid bearer; 401 without; 429 with `Retry-After` after rate-limit lockout.
- mDNS TXT now carries `pin_sha256` (lowercase hex) alongside `server_version` / `esphome_version` so same-subnet peers can cross-check the cert they observe on connect.

Phase 5+ adds the real `bundle/upload`, `build/start`, `firmware/download` RPCs against the same auth surface. The `/health` endpoint exists in this PR to prove the pipeline end-to-end.

## What this PR does

- New `helpers/remote_build_auth.py`:
  - `verify_bearer(header, lookup)` — parses `Authorization: Bearer {token_id}.{secret}`, returns the matching `StoredToken` or `None`. SHA-256 of the secret is computed unconditionally so unknown-`token_id` and known-token-wrong-secret paths are timing-equivalent.
  - `make_remote_build_auth_middleware(lookup, rate_limiter=None)` — aiohttp middleware. Bad attempts go through the per-IP `RateLimiter` from `helpers.auth`; locked-out IPs get 429 with `Retry-After`. Successful auth stashes the matched token on `request["remote_build_token"]` for the handler / phase 3b3.
- `RemoteBuildController`:
  - Seeds `_tokens_by_id` index from disk in `start()` (always, not gated on zeroconf).
  - Refreshes the index on every `_modify_settings` exit so CRUD changes propagate without a dashboard restart.
  - New `lookup_token(token_id)` public accessor — the middleware's hot-path lookup is constant-time with no I/O.
- `DashboardAdvertiser`:
  - Optional `pin_sha256` ctor arg + `set_pin_sha256(pin)` updater. Added to TXT when set, omitted otherwise.
- `DeviceBuilder`:
  - New `_maybe_start_remote_build_site` gated on `RemoteBuildSettings.enabled` (default-off). Loads identity + builds `SSLContext` via `run_in_executor`. Binds an aiohttp `web.AppRunner` with the auth middleware on `0.0.0.0:remote_build_port` (default 6055).
  - Cleanup hooks tear the runner down before the controller it depends on.
  - On HA-addon mode with `enabled=true`, the listener still binds but emits a warning that the addon's `ports:` config must expose 6055 for LAN peers to reach it. *Default-off, not hard-refused* — see [#106 issuecomment-4410616745](https://github.com/esphome/device-builder/issues/106#issuecomment-4410616745).
- `DashboardSettings`:
  - New `remote_build_port: int = 6055` field. CLI override via `--remote-build-port`.

## Async/sync boundaries

Every sync filesystem / crypto call hops through `run_in_executor`:

- `load_remote_build_settings` (settings RMW)
- `get_or_create_identity` (RSA / Ed25519 + atomic-write of cert / key)
- `_build_remote_build_ssl_context` (`SSLContext.load_cert_chain` + tempfile staging)
- `remote_build_settings_transaction` (CRUD)

Audited per the same contract phase 3a / 3b1 use. Tests follow the same pattern (no sync I/O on the loop in async tests).

## Cross-subnet behaviour

The listener doesn't depend on mDNS at all. Same-subnet peers discover via mDNS; cross-subnet peers use phase 2b's manual hosts. Cert-pin transfer is OOB (Settings UI in 3c → user pastes into pair dialog in phase 4). The mDNS TXT `pin_sha256` is a same-subnet sanity-check tripwire, not the trust root. See [#106 design discussion](https://github.com/esphome/device-builder/issues/106#issuecomment-4410614942).

## Tests

- `test_remote_build_auth.py` — 16 cases covering header parsing, lookup, rate-limit lockout per IP, successful auth + stashing.
- `test_remote_build_https_site.py` — end-to-end TLS via aiohttp on an ephemeral port; 401 without bearer, 200 with; default-off contract pinned.
- `test_dashboard_advertise.py` — `pin_sha256` lands in TXT when set; absent when unset; `set_pin_sha256` updates the next advertise.

**Related issue or feature (if applicable):** Phase 3b2 of #106

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

No frontend changes in this slice. Phase 3c will surface the cert fingerprint, rotate button, token list, and the receiver-mode toggle in Settings — at that point the frontend integrates the WS contract from 3b1 plus the new `pin_sha256` TXT.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.