### PR TITLE
README: document the shipped preview-toggle paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ pip install esphome-device-builder
 esphome-device-builder ~/esphome-configs
 ```
 
-Pass `--pre` to `pip install` to track the beta channel.
+For the beta channel, pass `--pre` to opt the resolver into
+prereleases — e.g. `pip install --pre esphome-device-builder` for a
+fresh install, or `pip install --upgrade --pre esphome-device-builder`
+to pull the newest beta on top of an existing install. `--pre` only
+opts the *current* command into prereleases; rerun the upgrade
+command to refresh.
 
 The server starts on `http://localhost:6052`. Run with `--help` for
 the full flag set.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,36 @@ managing automations, and pushing firmware updates.
 
 ## Try it
 
-The dashboard isn't yet wired into the ESPHome container or the Home Assistant
-add-on as an opt-in preview — that's coming soon. In the meantime:
+The dashboard ships as an **opt-in preview** in the official Home Assistant
+add-on and in [ESPHome Desktop](https://github.com/esphome/esphome-desktop).
+Pick the path that matches how you run ESPHome today:
 
-**Install from [PyPI](https://pypi.org/project/esphome-device-builder/):**
+### Home Assistant add-on
+
+Open the ESPHome add-on configuration (Stable, Beta, or Dev — all three
+carry the toggle), flip **Use new Device Builder Preview** on, and restart
+the add-on. The container's init step pip-installs the latest prerelease
+of `esphome-device-builder` and the supervisor service launches it instead
+of the classic dashboard. The toggle is reversible — turn it off + restart
+to fall back to the classic dashboard.
+
+The add-on's data layout stays the same (`/config/esphome/` for YAMLs,
+`/data/` for build artefacts) so flipping the toggle doesn't move or
+duplicate any state.
+
+### ESPHome Desktop (macOS / Windows / Linux)
+
+Install [ESPHome Desktop](https://github.com/esphome/esphome-desktop)
+v0.7.0 or later, then click the system-tray icon and pick **Backend →
+ESPHome Builder (stable)** or **ESPHome Builder (beta)**. The daemon
+restarts under the chosen backend and the tray badge updates to reflect
+which one is running. Switch back to **Classic ESPHome Dashboard** the
+same way.
+
+### Standalone (PyPI)
+
+For developers, headless servers, or anyone running outside the
+add-on / Desktop shapes:
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
@@ -26,10 +52,10 @@ pip install esphome-device-builder
 esphome-device-builder ~/esphome-configs
 ```
 
-To try a pre-release (beta), pass `--pre` to `pip install`.
+Pass `--pre` to `pip install` to track the beta channel.
 
-The server starts on `http://localhost:6052`. Run with `--help` for the
-full flag set.
+The server starts on `http://localhost:6052`. Run with `--help` for
+the full flag set.
 
 <details>
 <summary>Install from a GitHub release</summary>
@@ -50,7 +76,10 @@ esphome-device-builder ~/esphome-configs
 
 </details>
 
-**From source** (requires [uv](https://docs.astral.sh/uv/)):
+<details>
+<summary>From source (contributors)</summary>
+
+Requires [uv](https://docs.astral.sh/uv/):
 
 ```bash
 git clone https://github.com/esphome/device-builder
@@ -67,6 +96,8 @@ themselves stay `immutable` regardless. Skip `--dev` in production —
 the browser's default heuristic is fine when you're not rebuilding
 every few minutes.
 
+</details>
+
 ## Roadmap
 
 - ✅ Standalone backend with WS-first API, persistent compile queue, mDNS device discovery
@@ -75,7 +106,14 @@ every few minutes.
   (one intentional decline: the HA Supervisor `/auth` POST flow —
   the new backend's HA add-on path is ingress-only by design, see
   [issue #85](https://github.com/esphome/device-builder/issues/85))
-- 🚧 Beta toggle in the official ESPHome container and Home Assistant add-on
+- ✅ Opt-in preview toggle in the Home Assistant add-on
+  (`use_new_device_builder` config option, available on the Stable, Beta,
+  and Dev channels)
+- ✅ Backend selector in [ESPHome Desktop](https://github.com/esphome/esphome-desktop)
+  ≥ v0.7.0 (system tray → Backend)
+- 🚧 Same toggle in the standalone ESPHome Docker image
+  (`ghcr.io/esphome/esphome`) — currently only the HA-addon image carries
+  it
 - 🗺️ See the
   [project backlog](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder-dashboard%22)
   for in-progress work and what's planned next


### PR DESCRIPTION
# What does this implement/fix?

The HA-addon `use_new_device_builder` toggle and ESPHome Desktop's
backend selector both shipped while the README still said the
dashboard "isn't yet wired into the ESPHome container or the Home
Assistant add-on as an opt-in preview — that's coming soon."
This PR brings the README in line with what's actually shipped.

## Three install shapes documented

* **HA add-on** — flip the **Use new Device Builder Preview**
  toggle in the Stable / Beta / Dev addon configuration. The
  container's cont-init step pip-installs the latest prerelease
  of `esphome-device-builder` and the supervisor service
  launches `esphome-device-builder /config/esphome --ha-addon`
  instead of `esphome dashboard`. Reversible — turning the toggle
  back off + restarting falls back to the classic dashboard. Data
  layout stays identical (`/config/esphome/` for YAMLs, `/data/`
  for build artefacts) so flipping the toggle doesn't move or
  duplicate any state.

* **ESPHome Desktop** ≥ v0.7.0 — system-tray menu carries a
  **Backend** submenu with three radio options: Classic ESPHome
  Dashboard / ESPHome Builder (stable) / ESPHome Builder (beta).
  Picking a builder variant restarts the daemon under it and
  updates the tray badge.

* **Standalone (PyPI / source)** — unchanged for developers,
  headless servers, anyone running outside the add-on or Desktop
  shapes. Tucked the from-source recipe behind a `<details>`
  block since the PyPI path is the primary recommendation; the
  contents are otherwise the same.

## Roadmap

Flipped the single 🚧 line into:

* ✅ HA-addon toggle (`use_new_device_builder`, available on
  Stable / Beta / Dev channels).
* ✅ Backend selector in ESPHome Desktop ≥ v0.7.0.
* 🚧 Same toggle in the standalone `ghcr.io/esphome/esphome`
  Docker image — `cont-init.d/40-device-builder.sh` currently
  lives in `ha-addon-rootfs` only, so the plain container doesn't
  carry the toggle yet.

## Verification

Cross-referenced against:

* `home-assistant-addon` (`esphome` / `esphome-beta` /
  `esphome-dev`) — `config.yaml` carries `use_new_device_builder:
  bool?`, default `false`, with translation
  "Use new Device Builder Preview".
* `esphome` repo — `docker/ha-addon-rootfs/etc/cont-init.d/40-device-builder.sh`
  pip-installs the prerelease when the option is true; the
  `s6-overlay/s6-rc.d/esphome/run` service script branches on
  the same option to launch `esphome-device-builder` instead of
  `esphome dashboard`.
* `esphome-desktop` ≥ v0.7.0 — `src-tauri/src/settings/mod.rs`
  defines `Backend::{Classic, BuilderStable, BuilderBeta}`, and
  `src-tauri/src/tray/mod.rs` builds the **Backend** tray
  submenu around the same enum.

Docs-only; no code or test changes.

**Related issue or feature (if applicable):**

- N/A (documentation refresh).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
