### PR TITLE
Fold mDNS truth into api_encrypted (closes #437)

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -19,11 +19,12 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from esphome import const
 from esphome.components.dashboard_import import import_config
 from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 from esphome.zeroconf import AsyncEsphomeZeroconf
+
+from esphome import const
 
 from ...helpers.api import CommandError, api_command
 from ...helpers.build_size import coerce_sidecar_int
@@ -2624,7 +2625,7 @@ class DevicesController:
             self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 
     def _on_api_encryption_change(self, name: str, encryption: str) -> None:
-        """
+        r"""
         Apply the API-encryption state observed via mDNS.
 
         Stores the broadcast value (or empty string for "TXT absent —
@@ -2632,11 +2633,31 @@ class DevicesController:
         four-state lock indicator reads this together with
         ``api_encrypted`` to distinguish active / pending-flash /
         mismatch / plaintext.
+
+        Also folds the wire signal into ``api_encrypted`` itself when
+        a truthy cipher string arrives. ESPHome's compile pipeline
+        runs the Jinja preprocessor over packages before YAML parsing
+        (``api: |\n  # set ns = ...  ${ns.cfg}``); the dashboard's
+        ``yaml_util.load_yaml`` doesn't, so the scan-time YAML pass
+        can come back ``api_encrypted=False`` for a fully-encrypted
+        device (issue #437). The live broadcast is the truthful
+        signal — promoting ``api_encrypted`` here closes the gap for
+        non-frontend consumers (HA integration, table-row menu
+        gating, the ``Show API key`` affordance) that otherwise hide
+        encryption-aware affordances on a YAML-detection miss. The
+        symmetric "wire confirms plaintext" case (empty-string
+        broadcast) deliberately doesn't *clear* ``api_encrypted`` —
+        a wire-says-no while YAML-says-yes is the legitimate
+        "mismatch" / "pending" shape the existing state machine
+        already handles.
         """
         for device in self._devices_by_name(name):
-            if device.api_encryption_active == encryption:
+            wire_promotes_encrypted = bool(encryption) and not device.api_encrypted
+            if device.api_encryption_active == encryption and not wire_promotes_encrypted:
                 continue
             device.api_encryption_active = encryption
+            if wire_promotes_encrypted:
+                device.api_encrypted = True
             self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
 
     def _on_config_hash_change(self, name: str, config_hash: str) -> None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -19,12 +19,11 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+from esphome import const
 from esphome.components.dashboard_import import import_config
 from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON, ext_storage_path, ignored_devices_storage_path
 from esphome.zeroconf import AsyncEsphomeZeroconf
-
-from esphome import const
 
 from ...helpers.api import CommandError, api_command
 from ...helpers.build_size import coerce_sidecar_int

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -16,10 +16,9 @@ import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from esphome import const, yaml_util
 from esphome.const import CONF_PACKAGES
 from esphome.storage_json import StorageJSON, ext_storage_path
-
-from esphome import const, yaml_util
 
 # Prefer the central dispatcher landing in esphome/esphome#16300
 # so we depend on a stable upstream API rather than reaching into

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -16,9 +16,10 @@ import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from esphome import const, yaml_util
 from esphome.const import CONF_PACKAGES
 from esphome.storage_json import StorageJSON, ext_storage_path
+
+from esphome import const, yaml_util
 
 # Prefer the central dispatcher landing in esphome/esphome#16300
 # so we depend on a stable upstream API rather than reaching into
@@ -896,9 +897,29 @@ def load_device_from_storage(
     ethernet_mac, bluetooth_mac = derive_interface_macs(
         mac_address, target_platform, loaded_integrations
     )
-    api_encrypted = get_api_encryption_block(
-        resolved_config
-    ) is not None or yaml_has_api_encryption(yaml_content)
+    # ``api_encrypted`` mirrors the same union shape as ``api_enabled``:
+    #
+    #   1. Resolved YAML config — primary source for local
+    #      ``!include`` / package-merged encryption blocks.
+    #   2. Raw-text scan — keeps the indicator stable mid-edit
+    #      when ``yaml_util.load_yaml`` fails on an invalid draft.
+    #   3. Live mDNS broadcast (``api_encryption_active`` truthy)
+    #      — authoritative when the YAML pass diverges from the
+    #      running firmware. ESPHome's compile pipeline runs the
+    #      Jinja preprocessor over packages before YAML parsing
+    #      (``api: |\n  # set ns = ...  ${ns.cfg}``), the
+    #      dashboard's ``yaml_util.load_yaml`` doesn't, so the
+    #      YAML pass can come back ``False`` for a fully-
+    #      encrypted device. The wire signal is the truthful
+    #      one; without this the dashboard mislabels the device
+    #      as plaintext (issue #437) and hides the
+    #      "Show API key" affordance even though encryption is
+    #      live on the firmware.
+    api_encrypted = (
+        get_api_encryption_block(resolved_config) is not None
+        or yaml_has_api_encryption(yaml_content)
+        or bool(api_encryption_active)
+    )
     return Device(
         name=name,
         friendly_name=friendly_name,

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -101,22 +101,44 @@ class Device(DataClassORJSONMixin):
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
-    # Native API surface flags — drive the lock-icon indicator in the
-    # device list. ``api_enabled`` is True when the resolved YAML
-    # carries a top-level ``api:`` block; ``api_encrypted`` adds the
-    # inner ``encryption:`` check.
+    # Native API surface flags — drive the lock-icon indicator in
+    # the device list. Both fields are computed in
+    # ``helpers.device_yaml.load_device_from_storage`` as the
+    # union of multiple signals; ``True`` if any of them fires.
+    # The union shape is what makes the indicator stable across
+    # mid-edit drafts, packages-only ``api:`` blocks, and
+    # configurations whose YAML resolution diverges from the
+    # actual compiled firmware.
     #
-    # Both come from the resolved YAML config so ``!include`` /
-    # packages are followed. ``api_encrypted`` ALSO folds in the
-    # live mDNS broadcast (``api_encryption_active`` truthy) so a
-    # configuration whose YAML resolves through ESPHome's Jinja
-    # preprocessor (``api: |\n  # set ... ${ns.cfg}``) — which the
-    # dashboard's ``yaml_util.load_yaml`` doesn't run — still
-    # surfaces as encrypted once the firmware announces (issue
-    # #437). The truthful "encryption is on right now" signal is
-    # the wire; the YAML pass is a useful first approximation that
-    # fails open for any preprocessor feature the dashboard
-    # doesn't reproduce.
+    # ``api_enabled`` — the device exposes a Native API at all:
+    #   1. Resolved YAML has a top-level ``api:`` block (handles
+    #      local ``!include`` / package contents).
+    #   2. Raw-text scan has an ``^api:`` line (keeps the flag
+    #      stable mid-edit when ``yaml_util.load_yaml`` fails on
+    #      an invalid draft).
+    #   3. ``StorageJSON.loaded_integrations`` from the last
+    #      successful compile lists ``api`` (catches remote
+    #      ``dashboard_import`` packages whose YAML resolution
+    #      requires a ``git clone`` the dashboard doesn't run).
+    #
+    # ``api_encrypted`` — the device's Native API runs Noise
+    # encryption:
+    #   1. Resolved YAML has an ``api: encryption:`` block.
+    #   2. Raw-text scan matches the same shape (the ``api:`` /
+    #      ``encryption:`` indented pair).
+    #   3. Live mDNS broadcast is a truthy cipher string
+    #      (``api_encryption_active``). Authoritative when the
+    #      YAML pass diverges from the compiled firmware — e.g.
+    #      ESPHome's Jinja-templated packages
+    #      (``api: |\n  # set ... ${ns.cfg}``), which the
+    #      dashboard's ``yaml_util.load_yaml`` doesn't run but
+    #      ESPHome's compile pipeline does (issue #437).
+    #
+    # Symmetric "wire confirms plaintext" (empty-string mDNS
+    # broadcast) deliberately doesn't *clear* ``api_encrypted`` —
+    # the four-state lock indicator already encodes
+    # YAML-yes / wire-no as ``"mismatch"`` / ``"pending"``, not
+    # as a flatten-to-False signal.
     #
     # The actual key is fetched on demand via
     # ``devices/get_api_key``.

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -103,10 +103,23 @@ class Device(DataClassORJSONMixin):
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
     # Native API surface flags — drive the lock-icon indicator in the
     # device list. ``api_enabled`` is True when the resolved YAML
-    # carries a top-level ``api:`` block; ``api_encrypted`` only adds
-    # the inner ``encryption:`` check. Both come from the resolved
-    # config so ``!include`` / packages are followed; the actual key
-    # is fetched on demand via ``devices/get_api_key``.
+    # carries a top-level ``api:`` block; ``api_encrypted`` adds the
+    # inner ``encryption:`` check.
+    #
+    # Both come from the resolved YAML config so ``!include`` /
+    # packages are followed. ``api_encrypted`` ALSO folds in the
+    # live mDNS broadcast (``api_encryption_active`` truthy) so a
+    # configuration whose YAML resolves through ESPHome's Jinja
+    # preprocessor (``api: |\n  # set ... ${ns.cfg}``) — which the
+    # dashboard's ``yaml_util.load_yaml`` doesn't run — still
+    # surfaces as encrypted once the firmware announces (issue
+    # #437). The truthful "encryption is on right now" signal is
+    # the wire; the YAML pass is a useful first approximation that
+    # fails open for any preprocessor feature the dashboard
+    # doesn't reproduce.
+    #
+    # The actual key is fetched on demand via
+    # ``devices/get_api_key``.
     api_enabled: bool = False
     api_encrypted: bool = False
     # Encryption status as observed from the device's

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1393,3 +1393,64 @@ def test_load_device_without_previous_defaults_api_encryption_active_to_none(
     device = load_device_from_storage(yaml_path)
 
     assert device.api_encryption_active is None
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_api_encrypted_falls_back_to_wire_signal(tmp_path: Path) -> None:
+    """A truthy ``api_encryption_active`` carry-forward promotes ``api_encrypted=True``.
+
+    Issue #437: a config that wires encryption via ESPHome's
+    Jinja-templated packages leaves the dashboard's
+    ``yaml_util.load_yaml`` pass with ``api_encrypted=False``
+    because the dashboard doesn't run the Jinja preprocessor.
+    The live mDNS broadcast does carry the cipher because the
+    firmware really IS running encryption — fold that into
+    ``api_encrypted`` at scan time so the flag matches the
+    truth-on-the-wire even after a fresh reload throws away the
+    previous in-memory ``api_encrypted`` value.
+
+    Drives the scan path (not the mDNS-callback path covered by
+    ``test_on_api_encryption_change_promotes_api_encrypted_when_yaml_missed_it``)
+    by setting ``previous.api_encryption_active`` to a cipher
+    string and reloading; the YAML itself has no ``encryption:``
+    block so the YAML signal still says false.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    # No ``api: encryption:`` here — pure plaintext-looking YAML.
+    yaml_path.write_text("esphome:\n  name: kitchen\napi:\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    previous = load_device_from_storage(yaml_path)
+    assert previous.api_encrypted is False  # YAML signal alone says no
+    previous.api_encryption_active = "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+
+    reloaded = load_device_from_storage(yaml_path, previous=previous)
+
+    assert reloaded.api_encrypted is True
+    assert reloaded.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_api_encrypted_stays_false_for_plaintext_wire(tmp_path: Path) -> None:
+    """``api_encryption_active=""`` (confirmed plaintext) doesn't flip ``api_encrypted``.
+
+    The empty-string is the "TXT seen, key absent → device
+    confirmed plaintext" tri-state signal. Combined with a YAML
+    that doesn't declare encryption, the device is unambiguously
+    plaintext — the wire-fold-in must not promote
+    ``api_encrypted`` just because ``api_encryption_active`` is
+    non-null. Pins the boundary between the two falsy values
+    (``None`` and ``""``) so future logic that treats them
+    interchangeably gets caught here.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\napi:\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    previous = load_device_from_storage(yaml_path)
+    previous.api_encryption_active = ""  # mDNS confirmed plaintext
+
+    reloaded = load_device_from_storage(yaml_path, previous=previous)
+
+    assert reloaded.api_encrypted is False
+    assert reloaded.api_encryption_active == ""

--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -138,13 +138,106 @@ async def test_on_api_encryption_change_records_empty_string() -> None:
 
 @pytest.mark.asyncio
 async def test_on_api_encryption_change_skips_when_same() -> None:
-    """No-op when the in-memory device already has the announced value."""
-    device = _device(api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+    """No-op when the in-memory device already has the announced value AND ``api_encrypted`` agrees.
+
+    Both halves matter: the YAML signal (``api_encrypted=True``)
+    and the wire signal (truthy ``api_encryption_active``) have
+    to be in agreement before we suppress the bus event. Without
+    the second half, a device whose YAML pass missed the
+    encryption (issue #437) but whose wire signal already
+    reported the cipher would never get its ``api_encrypted``
+    flag promoted on subsequent identical broadcasts — the
+    handler would short-circuit before the promotion ran. The
+    next test pins the promote-on-mismatch path that requires
+    falling through this check.
+    """
+    device = _device(
+        api_encrypted=True,
+        api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+    )
     controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
 
     assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_on_api_encryption_change_promotes_api_encrypted_when_yaml_missed_it() -> None:
+    """Truthy mDNS broadcast flips ``api_encrypted=True`` when YAML missed it.
+
+    Issue #437: a config that wires encryption via ESPHome's
+    Jinja-templated packages leaves the dashboard's YAML pass
+    with ``api_encrypted=False`` because ``yaml_util.load_yaml``
+    doesn't render Jinja. The live mDNS broadcast carries the
+    cipher because the firmware really IS running encryption —
+    promote ``api_encrypted`` so non-frontend consumers
+    (HA integration, table-row menu, "Show API key" gate) see
+    the truth.
+    """
+    device = _device(api_encrypted=False, api_encryption_active=None)
+    controller, captured = make_devices_controller_with_bus([device])
+
+    controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+
+    assert device.api_encrypted is True
+    assert device.api_encryption_active == "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_on_api_encryption_change_promotion_fires_even_when_active_unchanged() -> None:
+    """Repeat truthy broadcast still promotes ``api_encrypted`` if YAML scan reset it.
+
+    The atomic-save scanner pattern (see
+    ``DeviceScanner._set_device``) rebuilds devices on YAML
+    edits. If a YAML edit retriggers the scan and the YAML pass
+    still misses the encryption (the Jinja blind spot is
+    persistent across scans), ``api_encrypted`` resets to
+    False even though ``api_encryption_active`` is still the
+    cipher string. The next mDNS broadcast — which carries the
+    same cipher — must still re-promote, which means the
+    "skip when same" short-circuit can't apply when the YAML
+    side disagrees with the wire side.
+    """
+    device = _device(
+        api_encrypted=False,
+        api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+    )
+    controller, captured = make_devices_controller_with_bus([device])
+
+    controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+
+    assert device.api_encrypted is True
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_on_api_encryption_change_empty_does_not_clear_api_encrypted() -> None:
+    """Wire-confirmed-plaintext doesn't *demote* a YAML-claimed encryption.
+
+    ``api_encryption_active = ""`` is the "TXT seen, key absent
+    → device confirmed plaintext" tri-state signal. When the
+    YAML says encrypted but the wire says plaintext, the right
+    state is "mismatch" / "pending" (the user hasn't reflashed
+    yet), not "demote ``api_encrypted`` to False." The frontend
+    state machine already encodes that distinction; the
+    backend must not flatten it by clearing the flag.
+    """
+    device = _device(
+        api_encrypted=True,
+        api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+    )
+    controller, captured = make_devices_controller_with_bus([device])
+
+    controller._on_api_encryption_change("kitchen", "")
+
+    # ``api_encryption_active`` updated to the new (empty) value;
+    # ``api_encrypted`` stayed truthy (state machine handles the
+    # mismatch vs pending distinction from there).
+    assert device.api_encryption_active == ""
+    assert device.api_encrypted is True
+    assert len(captured) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Closes #437 — backend half. A fully-encrypted device showed the
open-lock indicator (and lost the "Show API key" affordance,
HA-integration encryption-aware paths, etc.) because the
dashboard's YAML pass missed the `api: encryption:` block on a
config that wires it via ESPHome's Jinja-templated packages.

## Why the YAML side missed it

The reporter's config:

```yaml
# common/api.yaml
api: |
  # set ns = namespace(cfg={})
  # if api_encryption_key is defined and api_encryption_key != ""
  # set ns.cfg = dict(ns.cfg, **{
      "encryption": {
        "key": api_encryption_key
      }
    })
  # endif
  ${ns.cfg}
```

ESPHome's compile pipeline runs the Jinja preprocessor over
packages **before** YAML parsing, so the firmware really gets
`api: encryption: key: <secret>`. The dashboard's
`yaml_util.load_yaml` does plain YAML + package merge with **no
Jinja step**, so `cfg["api"]` lands as the literal block-scalar
string `# set ns = namespace(cfg={}) ...`, the package merge
clobbers it with the dict-shaped `api: actions:` from another
package, and the YAML pass returns `api_encrypted: false`.

Verified end-to-end against the reporter's exact config (loader
run in-process):

```text
cfg["api"]                          → OrderedDict({"actions": [...]})
get_api_encryption_block(cfg)       → None
yaml_has_api_encryption(raw_text)   → False
api_encryption_active               → "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
```

## What this PR does

Fold the live mDNS broadcast into `api_encrypted` itself in two
places, so non-frontend consumers (HA integration, table-row
menu gating, the "Show API key" affordance) see the corrected
flag:

1. **Scan time** — `load_device_from_storage` ORs the YAML
   signal with `bool(previous.api_encryption_active)` so reloads
   carry the wire-derived flag forward instead of recomputing
   only from the (incorrect) YAML pass.

2. **mDNS callback** — `_on_api_encryption_change` promotes
   `api_encrypted=True` whenever a truthy cipher string arrives
   on a device whose YAML pass said False, and fires
   `DEVICE_UPDATED` so the dashboard re-renders. The
   short-circuit on `api_encryption_active == encryption` also
   requires `api_encrypted` to already be in agreement — without
   that second half a wire-says-yes / YAML-says-no device whose
   `api_encryption_active` already matched would never get the
   promotion on subsequent identical broadcasts (e.g. after the
   atomic-save scanner pattern resets the scan-time flag).

The symmetric "wire says plaintext" case (empty-string
broadcast) deliberately doesn't *clear* `api_encrypted` — a
wire-says-no while YAML-says-yes is the legitimate
"mismatch" / "pending" shape the existing four-state lock
indicator already encodes, not a flatten-to-False signal.

## Frontend companion

`esphome/device-builder-frontend#247` reorders
`getEncryptionState` so the same truth-on-the-wire short-circuit
applies to the rendered indicator regardless of the backend's
`api_encrypted`. Either PR alone fixes the visible indicator;
both together close the gap end-to-end — the backend-side fix
also unhides the "Show API key" menu item and the HA
integration's encryption-aware paths. Wire is forward+backward
compatible: an old frontend works against the new backend (the
fixed `api_encrypted` flag flows through the existing
`getEncryptionState` logic unchanged), and an old backend works
against the new frontend (frontend logic still honours mDNS
truth even if backend `api_encrypted` is wrong).

## Tests

Five focused tests covering the three new code paths:

* `test_load_device_api_encrypted_falls_back_to_wire_signal` —
  scan-time promotion via `previous.api_encryption_active`.
* `test_load_device_api_encrypted_stays_false_for_plaintext_wire`
  — boundary between the two falsy mDNS values (`None` and
  `""`); only truthy cipher strings flip the flag.
* `test_on_api_encryption_change_promotes_api_encrypted_when_yaml_missed_it`
  — mDNS-callback promotion on first observation.
* `test_on_api_encryption_change_promotion_fires_even_when_active_unchanged`
  — repeat broadcast still promotes when YAML scan reset
  `api_encrypted` (atomic-save scanner pattern).
* `test_on_api_encryption_change_empty_does_not_clear_api_encrypted`
  — wire-says-plaintext doesn't demote a YAML-claimed
  encryption.

Existing
`test_on_api_encryption_change_skips_when_same` updated to also
set `api_encrypted=True` so the no-op suppression still
short-circuits cleanly when both halves agree (rather than
falsely passing on the old single-field check).

2331 backend tests pass, ruff clean.

**Related issue or feature (if applicable):**

- closes #437

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#247

Both PRs are independently effective: the backend fix corrects
the `api_encrypted` flag for all consumers (frontend, HA
integration, menu gating); the frontend fix honours the live
wire signal in the indicator regardless of `api_encrypted`. The
wire is forward+backward compatible during rollout.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
