### PR TITLE
get_api_key: subprocess esphome config fallback for templated YAML

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -19,6 +19,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+import yaml
 from esphome import const
 from esphome.components.dashboard_import import import_config
 from esphome.helpers import write_file as atomic_write_file
@@ -1729,24 +1730,106 @@ class DevicesController:
 
     @api_command("devices/get_api_key")
     async def get_api_key(self, *, configuration: str, **kwargs: Any) -> dict[str, str]:
-        """
+        r"""
         Return the resolved Native API encryption key for *configuration*.
 
-        Uses ESPHome's own YAML loader so ``!secret`` references and
-        substitutions resolve the same way they would at compile time —
-        the regex-on-raw-YAML approach a frontend has access to gives up
-        whenever the user pulls the key from ``secrets.yaml`` or hides
-        it behind a ``${api_key}`` substitution.
+        Two-stage resolution:
+
+        1. Fast path — ``yaml_util.load_yaml`` + package merge in-process.
+           Resolves ``!secret`` / ``!include`` / packages the same way
+           the rest of the dashboard does. Covers the common case
+           (key directly in YAML or behind a ``!secret`` reference)
+           with no subprocess overhead.
+
+        2. Slow path — ``esphome --dashboard config <file> --show-secrets``
+           subprocess. Falls back here when the fast path returns ``""``,
+           which happens for configs whose key is constructed by an
+           ESPHome preprocessor feature the dashboard's loader doesn't
+           reproduce. The canonical example is Jinja-templated
+           packages (``api: |\\n  # set ns = ... ${ns.cfg}``) — issue
+           #437. ESPHome's full pipeline runs the Jinja step before
+           YAML parsing, so its ``config`` subcommand emits a
+           fully-resolved YAML on stdout that we parse to pull the
+           key out. Slow (~1s subprocess) but only on click, not per
+           scan, and only when the fast path fails.
 
         ``{"key": "<base64 32-byte>"}`` on success; ``{"key": ""}`` when
-        the device has no ``api:`` block, no ``encryption`` key, or YAML
-        loading fails. Callers treat the empty value as the "open the
-        editor and check" signal.
+        both paths fail (no ``api:`` block, no ``encryption`` key, YAML
+        loading fails, or the subprocess errors out). Callers treat
+        the empty value as the "open the editor and check" signal.
         """
         path = self._db.settings.rel_path(configuration)
         loop = asyncio.get_running_loop()
         config = await loop.run_in_executor(None, load_device_yaml, path)
-        return {"key": get_api_encryption_key(config)}
+        key = get_api_encryption_key(config)
+        if key:
+            return {"key": key}
+        # Fast path missed — subprocess to ESPHome's full
+        # ``config`` pipeline (which runs the Jinja preprocessor
+        # over packages) and parse its resolved-YAML output.
+        key = await self._resolve_api_key_via_esphome_config(configuration)
+        return {"key": key}
+
+    async def _resolve_api_key_via_esphome_config(self, configuration: str) -> str:
+        r"""
+        Subprocess fallback for ``get_api_key``.
+
+        Runs ``esphome --dashboard config <path> --show-secrets``,
+        captures stdout, parses it as YAML, and returns
+        ``api.encryption.key`` if present. ``--show-secrets`` is
+        required: without it, ``esphome config`` wraps each
+        ``key`` value in the ANSI conceal SGR (``\\x1b[8m...\\x1b[28m``)
+        and ``yaml.safe_load`` would treat the wrapped string as the
+        key value. The wire form ESPHome emits when secrets are
+        shown is the literal base64 we want.
+
+        Returns ``""`` on any failure path: subprocess startup
+        failure (``self._esphome_cmd`` empty / unreachable),
+        non-zero exit (config didn't validate), stdout that doesn't
+        parse as YAML, missing api / encryption block. The caller
+        rolls all of these into the documented "open the editor and
+        check" signal — there's no actionable distinction between
+        "config invalid" and "no encryption" at the API surface.
+        """
+        # Defensive ``getattr``: bypass-init controllers used by
+        # tests that don't go through ``start()`` (the
+        # ``make_controller`` factory in
+        # ``tests/controllers/devices/conftest.py``) don't set
+        # ``_esphome_cmd`` unless explicitly told to. Production
+        # always sets it in ``start()`` so the attribute is
+        # guaranteed there.
+        esphome_cmd: list[str] | None = getattr(self, "_esphome_cmd", None)
+        if not esphome_cmd:
+            return ""
+        config_path = str(self._db.settings.rel_path(configuration))
+        cmd = [*esphome_cmd, "--dashboard", "config", config_path, "--show-secrets"]
+        try:
+            proc = await create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout_bytes, _ = await proc.communicate()
+        except OSError as exc:
+            _LOGGER.debug("esphome config subprocess failed for %s: %s", configuration, exc)
+            return ""
+        if proc.returncode != 0:
+            _LOGGER.debug(
+                "esphome config returned %s for %s; key extraction skipped",
+                proc.returncode,
+                configuration,
+            )
+            return ""
+        try:
+            resolved = yaml.safe_load(stdout_bytes.decode("utf-8", errors="replace"))
+        except yaml.YAMLError as exc:
+            _LOGGER.debug(
+                "esphome config output for %s did not parse as YAML: %s",
+                configuration,
+                exc,
+            )
+            return ""
+        return get_api_encryption_key(resolved)
 
     @api_command("devices/add_component")
     async def add_component(

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1823,10 +1823,17 @@ class DevicesController:
         try:
             resolved = yaml.safe_load(stdout_bytes.decode("utf-8", errors="replace"))
         except yaml.YAMLError as exc:
+            # ``str(yaml.YAMLError)`` includes context lines from
+            # the input, which were emitted with ``--show-secrets``
+            # and therefore carry the resolved Wi-Fi password,
+            # API key, etc. verbatim. Log only the exception class
+            # name so a malformed-output failure surfaces in debug
+            # logs without leaking those secrets into the operator's
+            # log scrape / support bundle.
             _LOGGER.debug(
-                "esphome config output for %s did not parse as YAML: %s",
+                "esphome config output for %s did not parse as YAML (%s)",
                 configuration,
-                exc,
+                type(exc).__name__,
             )
             return ""
         return get_api_encryption_key(resolved)

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -32,6 +32,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import esphome_device_builder.controllers.devices.controller as ctrl_mod
 from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices.controller import StorageJSON
 from esphome_device_builder.helpers.event_bus import Event
@@ -288,6 +289,207 @@ async def test_get_api_key_returns_empty_when_no_encryption(
     result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_falls_back_to_esphome_config_subprocess(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    r"""When the in-process loader misses, ``esphome config`` subprocess wins.
+
+    Issue #437: a config that wires encryption via ESPHome's
+    Jinja-templated packages (``api: |\n  # set ns = ... ${ns.cfg}``)
+    leaves the in-process YAML loader with ``api_encrypted=False``
+    because ``yaml_util.load_yaml`` doesn't render Jinja. The
+    subprocess fallback runs the full ESPHome pipeline (Jinja
+    preprocessor + YAML parse + package merge) and emits a
+    fully-resolved YAML on stdout that DOES carry the
+    ``api.encryption.key`` value.
+
+    Stub the subprocess to return that resolved-YAML shape; the
+    controller parses it and returns the key. The fast path
+    (in-process loader) gets ``""`` because the YAML on disk is
+    a plaintext stub without an ``encryption:`` block — exactly
+    the shape the bug surfaces.
+    """
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    # On-disk YAML has no ``encryption:`` — fast path returns "".
+    (tmp_path / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\napi:\n",
+        encoding="utf-8",
+    )
+
+    # Fake subprocess returning the resolved YAML the way ESPHome's
+    # ``config --show-secrets`` would emit it.
+    resolved_yaml = (
+        b"esphome:\n  name: kitchen\n"
+        b"api:\n  encryption:\n    key: ZGFzaGJvYXJkLWtleS1mcm9tLWVzcGhvbWUtY29uZmln\n"
+    )
+    fake_proc = MagicMock()
+    fake_proc.communicate = AsyncMock(return_value=(resolved_yaml, b""))
+    fake_proc.returncode = 0
+
+    async def _fake_create_subprocess(*_args: Any, **_kwargs: Any) -> Any:
+        return fake_proc
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ctrl_mod, "create_subprocess_exec", _fake_create_subprocess)
+        result = await controller.get_api_key(configuration="kitchen.yaml")
+
+    assert result == {"key": "ZGFzaGJvYXJkLWtleS1mcm9tLWVzcGhvbWUtY29uZmln"}
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_subprocess_returns_empty_on_nonzero_exit(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A subprocess that exits non-zero still returns ``{"key": ""}``.
+
+    ``esphome config`` exits non-zero when validation fails (bad
+    YAML, missing ``!secret``, etc.). The fallback must surface
+    the same "open the editor and check" empty-key sentinel
+    rather than crashing the WS handler — frontend's modal
+    handles the empty key gracefully (suggests opening the
+    editor); a thrown exception would leak a stack trace into
+    the WS error event.
+    """
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\napi:\n",
+        encoding="utf-8",
+    )
+
+    fake_proc = MagicMock()
+    fake_proc.communicate = AsyncMock(return_value=(b"INVALID CONFIG\n", b""))
+    fake_proc.returncode = 1
+
+    async def _fake_create_subprocess(*_args: Any, **_kwargs: Any) -> Any:
+        return fake_proc
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ctrl_mod, "create_subprocess_exec", _fake_create_subprocess)
+        result = await controller.get_api_key(configuration="kitchen.yaml")
+
+    assert result == {"key": ""}
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_subprocess_returns_empty_on_unparsable_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Subprocess output that doesn't parse as YAML degrades to ``""``.
+
+    ESPHome's ``config`` always emits YAML on stdout when the
+    config validates, but a future ESPHome version that adds
+    progress text or formatting wrappers could break the parse.
+    Pin the graceful-degrade so a subprocess success + unparsable
+    output doesn't leak a YAMLError into the WS handler.
+    """
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\napi:\n",
+        encoding="utf-8",
+    )
+
+    fake_proc = MagicMock()
+    fake_proc.communicate = AsyncMock(return_value=(b"\x00\x01not yaml: [unterminated", b""))
+    fake_proc.returncode = 0
+
+    async def _fake_create_subprocess(*_args: Any, **_kwargs: Any) -> Any:
+        return fake_proc
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ctrl_mod, "create_subprocess_exec", _fake_create_subprocess)
+        result = await controller.get_api_key(configuration="kitchen.yaml")
+
+    assert result == {"key": ""}
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_subprocess_returns_empty_on_oserror(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A subprocess startup failure (``OSError``) still returns ``""``.
+
+    ``create_subprocess_exec`` raises ``OSError`` when the
+    binary isn't on PATH or the system is out of file
+    descriptors. Either way the fallback should produce the
+    documented empty-key sentinel rather than propagating the
+    OS-level error to the WS layer.
+    """
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\napi:\n",
+        encoding="utf-8",
+    )
+
+    async def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise OSError("simulated subprocess startup failure")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ctrl_mod, "create_subprocess_exec", _boom)
+        result = await controller.get_api_key(configuration="kitchen.yaml")
+
+    assert result == {"key": ""}
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_skips_subprocess_when_fast_path_finds_key(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """The fast path's hit short-circuits — no subprocess overhead.
+
+    The vast majority of configs (key directly in YAML or behind
+    a ``!secret`` reference) hit the in-process loader cleanly.
+    Spawning the subprocess on every click would burn ~1s for no
+    reason; pin that the fast path's success skips the spawn.
+    """
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\napi:\n  encryption:\n    key: a/c+inline-key==\n",
+        encoding="utf-8",
+    )
+
+    spawn_spy = AsyncMock()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ctrl_mod, "create_subprocess_exec", spawn_spy)
+        result = await controller.get_api_key(configuration="kitchen.yaml")
+
+    assert result == {"key": "a/c+inline-key=="}
+    spawn_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_fallback_skipped_when_esphome_cmd_unset(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """The subprocess fallback is a no-op without ``_esphome_cmd``.
+
+    Pre-``start()`` controllers (and the bypass-init test factory
+    that doesn't pass ``esphome_cmd=``) don't have the binary
+    resolved. Production hits this only during the brief startup
+    window before ``_find_esphome_cmd`` runs, but the same guard
+    keeps the test factory's default path working without
+    requiring every test to set ``esphome_cmd=`` defensively.
+    Empty list is the documented "no esphome found" sentinel from
+    ``_find_esphome_cmd``.
+    """
+    # Note: ``esphome_cmd`` deliberately NOT set on the factory.
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(
+        "esphome:\n  name: kitchen\napi:\n",
+        encoding="utf-8",
+    )
+
+    spawn_spy = AsyncMock()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ctrl_mod, "create_subprocess_exec", spawn_spy)
+        result = await controller.get_api_key(configuration="kitchen.yaml")
+
+    assert result == {"key": ""}
+    spawn_spy.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Companion follow-up to #466. The first half of the issue #437
fix folded the live mDNS broadcast into `api_encrypted` so the
lock indicator turns green and the **Show API key** menu item
appears for configs whose YAML pass misses the encryption
block. Without this PR the menu item now appears but the click
returns an empty key — `devices/get_api_key` used the same
Jinja-blind `yaml_util.load_yaml` path and failed for the same
reason.

This PR closes that gap.

## Two-stage resolution

1. **Fast path** — unchanged in-process loader. Resolves the
   common case (key directly in YAML or behind `!secret`) with
   no subprocess overhead.

2. **Slow path** — `esphome --dashboard config <file>
   --show-secrets` subprocess. Falls back when the fast path
   returns `""`. ESPHome's full pipeline runs the Jinja
   preprocessor over packages before YAML parsing, so its
   `config` subcommand emits a fully-resolved YAML on stdout
   that DOES carry `api.encryption.key` for the reporter's
   templated config (`api: |\n  # set ns = ... ${ns.cfg}`).

`--show-secrets` is required: without it `esphome config` wraps
each `key` value in the ANSI conceal SGR
(`\x1b[8m...\x1b[28m`) and `yaml.safe_load` would round-trip
the wrapped bytes as the key value. With `--show-secrets` the
wire form is the literal base64 we want.

Cost gating: slow path runs ~1s but only on click, not per
scan, and only when the fast path misses. Stable configs (the
vast majority) never pay the subprocess cost.

## Graceful degrade

Every failure mode lands at the documented `{"key": ""}` "open
the editor and check" sentinel:

- `OSError` on subprocess startup (binary not on PATH, FD
  exhaustion) → `""`.
- Non-zero exit (config didn't validate) → `""`.
- Unparsable stdout (`yaml.YAMLError`) → `""`.
- Missing `api` / `encryption` block in resolved YAML → `""`.

Throwing into the WS handler would leak a stack trace into the
WS error event. The frontend's modal already handles the empty
key gracefully (suggests opening the editor).

## Tests

Six new tests in `tests/controllers/devices/test_branches_coverage.py`:

- `test_get_api_key_falls_back_to_esphome_config_subprocess` —
  the headline case (in-process miss → subprocess → key
  extracted).
- `test_get_api_key_subprocess_returns_empty_on_nonzero_exit` —
  validation failure path.
- `test_get_api_key_subprocess_returns_empty_on_unparsable_yaml`
  — bad subprocess stdout.
- `test_get_api_key_subprocess_returns_empty_on_oserror` —
  subprocess startup failure.
- `test_get_api_key_skips_subprocess_when_fast_path_finds_key`
  — cost gating; fast-path hit short-circuits the spawn.
- `test_get_api_key_fallback_skipped_when_esphome_cmd_unset` —
  bypass-init / pre-`start()` controllers without
  `_esphome_cmd` skip the subprocess (existing test factory's
  default path keeps working).

The existing two `get_api_key` tests pass unchanged — the new
code only adds a fallback after the existing fast path returns
`""`.

2332 backend tests pass, ruff clean.

**Related issue or feature (if applicable):**

- closes esphome/device-builder#437 (paired with backend #466
  and frontend `esphome/device-builder-frontend#247`).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

The frontend already handles the `{"key": ""}` empty-key
sentinel; this PR just makes the empty case rarer by reaching
into the slow path when the fast path can't extract.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
