### PR TITLE
Treat populated TXT without api_encryption as authoritative removal

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -1296,28 +1296,48 @@ class DeviceStateMonitor:
             self.apply_config_hash(device_name, config_hash)
         if mac := props.get("mac"):
             self.apply_mac_address(device_name, mac)
-        # Apply api_encryption ONLY when the TXT key is actually
-        # present in this announcement (value can be empty — that's
-        # the meaningful "device confirmed plaintext" signal). When
-        # the TXT key is absent we keep the device's current value
-        # as the last-known truth: a transient / fragmented mDNS
-        # re-announcement that omits the TXT used to overwrite a
-        # previously-truthy ``api_encryption_active`` with ``""``,
-        # flipping the dashboard's lock indicator to "mismatch" /
-        # "pending" and prompting the user to reinstall a device
-        # that was actually fine. Tri-state on the model side
-        # (``"…"`` / ``""`` / ``None``) already encodes
-        # "confirmed-encrypted / confirmed-plaintext / unknown"; the
-        # apply path was conflating "TXT absent in *this*
-        # announcement" with "TXT absent on the device", which is
-        # only true once we observe the absence directly. Older
-        # firmwares that never broadcast the TXT remain at the
-        # ``None`` initial — the frontend's ``getEncryptionState``
-        # falls back to the YAML's ``api_encrypted`` flag in that
-        # case, which is the right behaviour.
-        api_encryption = props.get("api_encryption")
-        if api_encryption is not None:
-            self.apply_api_encryption(device_name, api_encryption)
+        # api_encryption tri-state semantics on this announce:
+        #
+        # * Key present with truthy value (``Noise_...``):
+        #   encryption confirmed live → apply with that string.
+        #
+        # * Key present with bare-key / ``api_encryption=`` empty
+        #   value (zeroconf collapses both to ``None`` in
+        #   ``decoded_properties``): device explicitly broadcast
+        #   "no key" → apply with ``""``. The pre-fix code used
+        #   ``props.get("api_encryption") is not None`` which
+        #   dropped this case onto the floor; with the explicit
+        #   ``in props`` check it now flows through.
+        #
+        # * Key absent AND the announce carried other content
+        #   (``version`` / ``mac`` / ``config_hash`` / ...): the
+        #   firmware was rebuilt without encryption and is
+        #   re-announcing its real new state. Apply with ``""``
+        #   so the dashboard's encryption indicator follows the
+        #   wire instead of staying frozen on a stale truthy
+        #   value. ESPHome's TXT broadcasts are atomic per
+        #   announce — there's no fragmentation shape that would
+        #   carry ``version`` but drop ``api_encryption`` — so a
+        #   TXT with content but no encryption key IS
+        #   authoritative for "encryption was removed."
+        #
+        # * Key absent AND props is empty (no other keys either):
+        #   preserve. This is the cache-eviction /
+        #   truly-empty-fragment shape the original guard was
+        #   written for; a non-content announce shouldn't
+        #   overwrite a previously-truthy state and prompt an
+        #   unnecessary reinstall.
+        #
+        # Older firmwares that never broadcast the TXT keep the
+        # ``None`` initial value — the frontend's
+        # ``getEncryptionState`` falls back to the YAML's
+        # ``api_encrypted`` flag in that case, which is the right
+        # behaviour.
+        if "api_encryption" in props:
+            value = props["api_encryption"]
+            self.apply_api_encryption(device_name, value if isinstance(value, str) else "")
+        elif props:
+            self.apply_api_encryption(device_name, "")
 
     async def _ping_loop(self) -> None:
         # First sweep after the short bootstrap window — gives mDNS a

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -165,18 +165,25 @@ VersionChangeCallback = Callable[[str, str], None]
 ConfigHashChangeCallback = Callable[[str, str], None]
 
 # Callback fired when the mDNS ``api_encryption`` TXT record reports a
-# different value than last seen. Empty string means the TXT key was
-# *present in the announcement* with an empty value — i.e. the device
-# is explicitly broadcasting plaintext API. A non-empty value (e.g.
-# ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) confirms encryption is
-# live on the device.
+# different value than last seen.
 #
-# The "no signal" case (mDNS seen but TXT key absent in this
-# announcement, or no mDNS seen at all) never fires this callback —
-# the apply path at ``_apply_service_info`` gates on the key being
-# present in ``props`` so a quiet re-announce doesn't clobber a
-# previously-confirmed value. The device controller keeps that state
-# as ``None`` to mean "trust whatever the YAML says".
+#   * Non-empty (e.g. ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) →
+#     encryption confirmed live on the device.
+#   * Empty string → device is explicitly broadcasting plaintext.
+#     Two wire shapes land here: TXT carrying the
+#     ``api_encryption`` key with an empty / bare value (zeroconf
+#     collapses both to ``None`` and the apply path normalises to
+#     ``""``), AND a content-bearing TXT that omits the key
+#     entirely (firmware was rebuilt without encryption — the
+#     omission inside an otherwise-populated announce is
+#     authoritative for "encryption was removed").
+#
+# The "no signal" case (no mDNS seen, or a truly empty re-announce
+# with no other TXT keys) never fires this callback — the apply
+# path at ``_apply_service_info`` only treats key-absence as
+# authoritative when the announce carried other content. The
+# device controller keeps that state as ``None`` to mean "trust
+# whatever the YAML says".
 ApiEncryptionChangeCallback = Callable[[str, str], None]
 
 # Callback fired when the mDNS ``mac`` TXT record reports a different
@@ -798,21 +805,33 @@ class DeviceStateMonitor:
         """
         Record the device's broadcast API encryption status.
 
-        Empty string means the mDNS announcement explicitly carried
-        an empty ``api_encryption`` TXT — the device is confirming
-        plaintext API. A non-empty value (e.g.
-        ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) confirms encryption
-        is active.
+        Non-empty value (e.g. ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``)
+        confirms encryption is active. Empty string is the
+        plaintext-confirmed signal, fired by ``_apply_service_info``
+        in two wire shapes:
 
-        Callers must NOT translate "TXT key absent in this
-        announcement" into ``""`` — that conflates a transient quiet
-        re-announce with a real plaintext confirmation, which clobbers
-        the last-known truthy value and trips the frontend's
-        "reinstall to apply" prompt. ``_apply_service_info`` gates on
-        the TXT key being present in ``props`` so absence skips the
-        call entirely; the device's ``api_encryption_active`` stays
-        ``None`` (or whatever was last confirmed) until a real
-        observation lands.
+        1. TXT carries the ``api_encryption`` key with an empty /
+           bare value (``api_encryption=`` or just ``api_encryption``
+           — zeroconf collapses both to ``None`` and the apply path
+           normalises to ``""``).
+
+        2. TXT carries other content (``version`` / ``mac`` /
+           ``config_hash`` / ...) but the ``api_encryption`` key is
+           absent. ESPHome firmware emits TXT atomically per
+           announce, so the omission of the key inside an
+           otherwise-populated TXT IS authoritative for "encryption
+           was removed."
+
+        Callers must NOT translate "no TXT content at all" into
+        ``""`` — that conflates a transient cache-eviction /
+        truly-empty fragment with a real plaintext confirmation,
+        which would clobber the last-known truthy value and trip
+        the frontend's "reinstall to apply" prompt.
+        ``_apply_service_info`` only fires the empty-string apply
+        when the announce carried other content; the truly-empty
+        case skips the call entirely so the device's
+        ``api_encryption_active`` stays ``None`` (or whatever was
+        last confirmed) until a real observation lands.
 
         Returns True when the value actually changed and the change
         was forwarded to the callback.

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -597,6 +597,103 @@ async def test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none(
         await _stop_and_drain(monitor)
 
 
+@pytest.mark.asyncio
+async def test_dispatch_added_api_encryption_absent_with_other_content_clears_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TXT carries other keys but ``api_encryption`` is missing → confirm plaintext.
+
+    The firmware was rebuilt without encryption and is
+    re-announcing its real new state. ESPHome's TXT broadcasts
+    are atomic per announce — there's no fragmentation shape
+    that would carry ``version`` / ``mac`` / ``config_hash``
+    but drop only ``api_encryption`` — so the absence of the
+    key inside an otherwise-populated TXT IS authoritative for
+    "encryption was removed."
+
+    Pre-fix: the old guard ``if api_encryption is not None``
+    treated this case identically to a transient empty-fragment
+    (no apply, previous truthy value preserved). The result
+    was a stale lock indicator that stayed green long after
+    the device's firmware was downgraded to plaintext.
+    """
+    truthy = "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+    device = _device(api_encryption_active=truthy)
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    # Real-shaped TXT: version/mac/config_hash present, but
+    # ``api_encryption`` absent. ESPHome firmware that was
+    # rebuilt without encryption broadcasts exactly this shape.
+    fake_info.decoded_properties = {
+        "version": "2026.4.0",
+        "mac": "aabbccddeeff",
+        "config_hash": "abc12345",
+    }
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        # Wire authoritatively says no encryption — flip to
+        # confirmed-plaintext so the lock indicator follows.
+        assert device.api_encryption_active == ""
+    finally:
+        await _stop_and_drain(monitor)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_added_api_encryption_bare_key_pushes_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare-key TXT (``api_encryption`` with no ``=`` value) → confirm plaintext.
+
+    zeroconf collapses bare keys (``foo``) and empty-value
+    entries (``foo=``) to the same ``None`` in
+    ``decoded_properties``. Both shapes are how ESPHome firmware
+    broadcasts "I have the key in my TXT but the value slot
+    is empty" — the documented confirmed-plaintext signal.
+
+    Pre-fix: ``props.get(...) is not None`` returned False for
+    ``None`` so the apply was skipped — a latent bug where the
+    confirmed-plaintext signal wasn't actually flowing through.
+    Now the explicit ``in props`` check catches the key
+    presence and treats the ``None`` value as the empty-string
+    plaintext signal.
+    """
+    truthy = "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+    device = _device(api_encryption_active=truthy)
+    monitor, _callbacks = _make_monitor([device])
+
+    fake_info = MagicMock()
+    fake_info.load_from_cache.return_value = True
+    fake_info.parsed_scoped_addresses = lambda _mode: []
+    # Mirror what zeroconf actually returns for ``api_encryption=``
+    # or bare ``api_encryption``: the key is present in the dict
+    # but the value is ``None``.
+    fake_info.decoded_properties = {"api_encryption": None}
+    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    try:
+        dispatch(
+            monitor._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Added,
+        )
+        assert device.api_encryption_active == ""
+    finally:
+        await _stop_and_drain(monitor)
+
+
 # ---------------------------------------------------------------------------
 # Defense-in-depth: TXT-absent / TXT-empty must preserve the device's
 # last-known value for every mDNS-derived field that doesn't have an


### PR DESCRIPTION
# What does this implement/fix?

The mDNS apply path's previous guard `if api_encryption is not
None` treated three semantically distinct cases identically —
all three landing as "no apply, preserve previous value":

1. **Truly empty TXT broadcast** (fragmented / cache-eviction
   announce; preserving the previous value was correct here).
2. **Bare-key / empty-value TXT entry** (`api_encryption` with
   no `=` value, or `api_encryption=` with empty value —
   zeroconf collapses both shapes to `None` in
   `decoded_properties`). Documented intent: "confirmed
   plaintext." Actual behavior: silently dropped onto the
   floor.
3. **Populated TXT carrying other content but NOT `api_encryption`**.
   Firmware was rebuilt without encryption and is re-announcing
   its real new state, but the lock indicator stayed frozen on
   the previously-truthy value.

ESPHome firmware emits TXT broadcasts atomically per announce —
there's no fragmentation shape that carries `version` / `mac` /
`config_hash` but drops only `api_encryption`. So a TXT with
content but no encryption key IS authoritative for "encryption
was removed."

## What this PR does

Replaces the single `is not None` guard with explicit branching:

```python
if "api_encryption" in props:
    value = props["api_encryption"]
    self.apply_api_encryption(
        device_name, value if isinstance(value, str) else ""
    )
elif props:
    self.apply_api_encryption(device_name, "")
# else: empty TXT → preserve (transient/fragmented announce)
```

Four cases:

| TXT shape | `decoded_properties` | Action |
|---|---|---|
| `api_encryption=Noise_...` | `{"api_encryption": "Noise_..."}` | Apply `"Noise_..."` |
| `api_encryption=` (empty) or bare | `{"api_encryption": None}` | Apply `""` (was a no-op; **fixes a latent bug**) |
| Other keys present, no `api_encryption` | `{"version": "...", "mac": "...", ...}` | Apply `""` (**new authoritative removal**) |
| Empty `decoded_properties` | `{}` | No apply (preserve, cache-eviction safety) |

## Why the safety net stays

The "empty TXT preserves" branch keeps the protection the
original guard was written for: a router/repeater serving a
stale cached TXT, an mDNS reflector that drops payload, or a
zeroconf cache-eviction edge case. None of those carry real
content; the apply skips and the previously-truthy state
survives. ESPHome firmware itself never emits a real
content-bearing announce missing `api_encryption` unless that
key was genuinely removed from the build, which is the
authoritative case.

## Tests

Two new tests pin the new branches:

* `test_dispatch_added_api_encryption_absent_with_other_content_clears_to_empty`
  — TXT carries `version`/`mac`/`config_hash` but no
  `api_encryption`; `api_encryption_active` flips from a
  previously-truthy `"Noise_..."` to `""`.

* `test_dispatch_added_api_encryption_bare_key_pushes_empty_string`
  — TXT carries `{"api_encryption": None}` (bare-key shape);
  flips truthy to `""`. Closes the latent bug where the
  confirmed-plaintext signal wasn't actually flowing through.

Three pre-existing tests still pass unchanged:

* `test_dispatch_added_with_explicit_empty_api_encryption_pushes_empty_string`
  — synthesized `{"api_encryption": ""}` (real zeroconf would
  produce `None` for that wire shape, but this also exercises
  the `str` branch of the new code).
* `test_dispatch_added_without_api_encryption_txt_preserves_last_known`
  — empty `decoded_properties` preserves a truthy value.
* `test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none`
  — empty `decoded_properties` keeps `None` at `None`.

2333 backend tests pass, ruff clean.

## Why this PR is separate

#466 already shipped the truth-on-the-wire `api_encrypted` fold-in
for the YAML-says-no / wire-says-yes direction. This PR closes
the symmetric YAML-says-yes / wire-says-no direction at the
apply-path layer. Splitting the two keeps each PR's blast radius
small and the test suites focused on one tri-state arm at a
time.

**Related issue or feature (if applicable):**

- Follow-up to #466 / #469 (the issue #437 fix series).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

The frontend's `getEncryptionState` already handles the
`api_encryption_active = ""` confirmed-plaintext case correctly
(produces `"mismatch"` / `"pending"` per the four-state lock
indicator); this PR just makes that case actually fire when the
wire reports it.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
