### PR TITLE
Document the Noise XX pairing flow in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,6 +191,17 @@ Pairing is a two-human action: an offloader-side user picks a discovered receive
 
 The cryptographic primitives are `Noise_XX_25519_ChaChaPoly_SHA256` (mutual identity exchange + forward secrecy) over a dedicated peer-link TCP listener (default port 6058, separate from the dashboard UI port). Each dashboard holds a long-lived X25519 keypair as its peer-link identity, persisted at `<config_dir>/.device-builder-peer-link-key.bin` (0o600); `pin_sha256` is the lowercase-hex SHA-256 of the static pubkey.
 
+The numbered phases:
+
+1. **Discovery** — both dashboards advertise on mDNS (`_esphomebuilder._tcp.local`); TXT carries `peer_link_port` + `pin_sha256`.
+2. **Receiver opens pairing window** — admin navigates to the Pairing requests screen; the frontend calls `set_pairing_window` with `open=true`; the backend flips an in-process deadline and fires `pairing_window_changed`. The window closes automatically on screen-unmount or user-idle timeout.
+3. **Preview pair (intent=preview)** — three Noise XX handshake messages. The offloader captures the receiver's static pubkey from the handshake transcript and surfaces `pin_sha256` to the user; no application data crosses the wire.
+4. **OOB pin verification** — human-mediated. The user compares the pin shown on the offloader UI against the receiver UI's Build server card.
+5. **Pair request (intent=pair_request)** — fresh Noise XX with payload `{label, dashboard_id}`. If the pairing window is open, the receiver creates a PENDING `StoredPeer` row, fires `pair_request_received`, and returns `intent_response=pending`. If the window is closed, it returns `intent_response=no_pairing_window` without creating a row.
+6. **Receiver admin approves** — admin OOB-confirms the offloader's pin, clicks Accept; the receiver flips the row to APPROVED and fires `pair_status_changed`.
+7. **Offloader observes approval (5s polling)** — while the offloader's local row is pending, its frontend polls `list_pool`; the offloader backend opens a fresh Noise WS with `intent=pair_status` and writes the response back into the local row.
+8. **Subsequent real-build sessions** — `intent=peer_link`. **Not gated by the pairing window**; paired peers connect anytime. The receiver looks up the offloader's static-pubkey-hash against its `StoredPeer` table; an APPROVED match returns `intent_response=ok` and the session stays open for application messages.
+
 ```mermaid
 sequenceDiagram
     autonumber
@@ -200,57 +211,42 @@ sequenceDiagram
     participant RF as Receiver frontend
     participant RU as Receiver admin
 
-    Note over OF,RU: 1. Discovery (mDNS, advertised by both)
-    Note right of OB: _esphomebuilder._tcp.local TXT carries peer_link_port + pin_sha256
+    RU->>RF: open Pairing requests screen
+    RF->>RB: set_pairing_window open=true
+    RB-->>RF: pairing_window_changed expires_in=300
 
-    Note over OF,RU: 2. Receiver opens pairing window
-    RU->>RF: navigate to Pairing requests screen
-    RF->>RB: set_pairing_window({open true})
-    RB-->>RF: pairing_window_changed (open true, expires_in 300s)
-    Note right of RB: window is in-process; closes on screen-unmount or user-idle timeout
+    OF->>OB: preview_pair
+    OB->>RB: Noise XX msg1 intent=preview
+    RB->>OB: Noise XX msg2 responder pubkey
+    OB->>RB: Noise XX msg3 finish
+    OB-->>OF: pin_sha256
 
-    Note over OF,RU: 3. Preview pair (Noise XX, intent=preview)
-    OF->>OB: preview_pair({hostname, port})
-    OB->>RB: Noise XX msg1 (intent=preview)
-    RB->>OB: Noise XX msg2 (carries responder static pubkey)
-    OB->>RB: Noise XX msg3 (handshake complete; WS closes)
-    OB-->>OF: {pin_sha256}
-    Note right of OB: pubkey captured from handshake transcript; no application data
+    Note over OF,RF: OOB pin verification
 
-    Note over OF,RU: 4. OOB pin verification (human-mediated)
-    Note over OF,RF: User compares pin on offloader UI against receiver UI's Build server card
-
-    Note over OF,RU: 5. Pair request (Noise XX, intent=pair_request)
-    OF->>OB: request_pair({pin_sha256, label, ...})
-    OB->>RB: fresh Noise XX (intent=pair_request, payload {label, dashboard_id})
+    OF->>OB: request_pair
+    OB->>RB: Noise XX intent=pair_request
     alt pairing window open
-        RB->>RB: create StoredPeer (status=PENDING)
+        RB->>RB: create StoredPeer PENDING
         RB-->>RF: pair_request_received
         RB-->>OB: intent_response=pending
-        OB-->>OF: persisted StoredPairing (status=pending)
     else window closed
         RB-->>OB: intent_response=no_pairing_window
-        OB-->>OF: error; ask receiver admin to open the screen
     end
 
-    Note over OF,RU: 6. Receiver admin approves
-    RU->>RF: OOB-confirm offloader's pin, click Accept
-    RF->>RB: approve_peer({dashboard_id})
-    RB->>RB: status PENDING -> APPROVED
-    RB-->>RF: pair_status_changed (approved)
+    RU->>RF: OOB-confirm pin, click Accept
+    RF->>RB: approve_peer
+    RB->>RB: PENDING to APPROVED
+    RB-->>RF: pair_status_changed approved
 
-    Note over OF,RU: 7. Offloader observes approval (5s polling)
-    loop while local row pending
+    loop while pending
         OF->>OB: list_pool
-        OB->>RB: Noise XX (intent=pair_status)
+        OB->>RB: Noise XX intent=pair_status
         RB-->>OB: status
     end
-    OB-->>OF: row updated to paired
+    OB-->>OF: paired
 
-    Note over OF,RU: 8. Subsequent real-build sessions (NOT gated by pairing window)
-    OB->>RB: Noise XX (intent=peer_link)
-    RB->>RB: lookup pubkey hash -> APPROVED StoredPeer
-    RB-->>OB: intent_response=ok; session continues
+    OB->>RB: Noise XX intent=peer_link
+    RB-->>OB: intent_response=ok
 ```
 
 **Why two Noise handshakes for one pairing.** The preview handshake (step 3) captures the receiver's static pubkey for OOB display *before* the offloader has decided to trust this receiver; the WS closes immediately, no application data crosses the wire. The pair-request handshake (step 5) is a fresh handshake that re-binds the OOB-confirmed pin (defends against TOCTOU between preview and confirm: if the pubkey-hash on the second handshake doesn't match `pin_sha256` from preview, the offloader aborts). Re-handshakes are cheap because Noise's setup cost is negligible at this cadence (pair flows are rare, not a hot path).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,64 +194,63 @@ The cryptographic primitives are `Noise_XX_25519_ChaChaPoly_SHA256` (mutual iden
 ```mermaid
 sequenceDiagram
     autonumber
-    participant OF as Offloader<br/>frontend
-    participant OB as Offloader<br/>backend
-    participant RB as Receiver<br/>backend
-    participant RF as Receiver<br/>frontend
-    participant RU as Receiver<br/>admin
+    participant OF as Offloader frontend
+    participant OB as Offloader backend
+    participant RB as Receiver backend
+    participant RF as Receiver frontend
+    participant RU as Receiver admin
 
     Note over OF,RU: 1. Discovery (mDNS, advertised by both)
-    Note right of OB: _esphomebuilder._tcp.local TXT:<br/>peer_link_port + pin_sha256
+    Note right of OB: _esphomebuilder._tcp.local TXT carries peer_link_port + pin_sha256
 
     Note over OF,RU: 2. Receiver opens pairing window
     RU->>RF: navigate to Pairing requests screen
-    RF->>RB: set_pairing_window({open: true})
-    RB-->>RF: pairing_window_changed<br/>{open: true, expires_in: 300s}
-    Note right of RB: in-process deadline; closes on<br/>screen-unmount or user-idle timeout
+    RF->>RB: set_pairing_window({open true})
+    RB-->>RF: pairing_window_changed (open true, expires_in 300s)
+    Note right of RB: window is in-process; closes on screen-unmount or user-idle timeout
 
-    Note over OF,RU: 3. Preview pair (Noise XX, intent="preview")
+    Note over OF,RU: 3. Preview pair (Noise XX, intent=preview)
     OF->>OB: preview_pair({hostname, port})
-    OB->>RB: Noise XX msg1 (intent="preview")
+    OB->>RB: Noise XX msg1 (intent=preview)
     RB->>OB: Noise XX msg2 (carries responder static pubkey)
     OB->>RB: Noise XX msg3 (handshake complete; WS closes)
     OB-->>OF: {pin_sha256}
-    Note right of OB: pubkey captured from handshake<br/>transcript; no application data
+    Note right of OB: pubkey captured from handshake transcript; no application data
 
     Note over OF,RU: 4. OOB pin verification (human-mediated)
-    Note over OF,RF: User compares pin on offloader UI<br/>against receiver UI's "Build server" card
+    Note over OF,RF: User compares pin on offloader UI against receiver UI's Build server card
 
-    Note over OF,RU: 5. Pair request (Noise XX, intent="pair_request")
+    Note over OF,RU: 5. Pair request (Noise XX, intent=pair_request)
     OF->>OB: request_pair({pin_sha256, label, ...})
-    OB->>RB: fresh Noise XX (intent="pair_request",<br/>payload={label, dashboard_id})
+    OB->>RB: fresh Noise XX (intent=pair_request, payload {label, dashboard_id})
     alt pairing window open
-        RB->>RB: create StoredPeer<br/>(status=PENDING)
+        RB->>RB: create StoredPeer (status=PENDING)
         RB-->>RF: pair_request_received
-        RB-->>OB: intent_response="pending"
-        OB-->>OF: persisted StoredPairing<br/>(status=pending)
+        RB-->>OB: intent_response=pending
+        OB-->>OF: persisted StoredPairing (status=pending)
     else window closed
-        RB-->>OB: intent_response="no_pairing_window"
-        OB-->>OF: error: ask receiver admin<br/>to open the screen
+        RB-->>OB: intent_response=no_pairing_window
+        OB-->>OF: error; ask receiver admin to open the screen
     end
 
     Note over OF,RU: 6. Receiver admin approves
     RU->>RF: OOB-confirm offloader's pin, click Accept
     RF->>RB: approve_peer({dashboard_id})
-    RB->>RB: status PENDING → APPROVED
-    RB-->>RF: pair_status_changed(approved)
+    RB->>RB: status PENDING -> APPROVED
+    RB-->>RF: pair_status_changed (approved)
 
     Note over OF,RU: 7. Offloader observes approval (5s polling)
     loop while local row pending
         OF->>OB: list_pool
-        OB->>RB: Noise XX (intent="pair_status")
+        OB->>RB: Noise XX (intent=pair_status)
         RB-->>OB: status
     end
-    OB-->>OF: row updated to "paired"
+    OB-->>OF: row updated to paired
 
-    Note over OF,RU: 8. Subsequent real-build sessions
-    Note right of OB: NOT gated by pairing window;<br/>paired peers connect anytime
-    OB->>RB: Noise XX (intent="peer_link")
-    RB->>RB: lookup pubkey hash → APPROVED StoredPeer
-    RB-->>OB: intent_response="ok"; session continues
+    Note over OF,RU: 8. Subsequent real-build sessions (NOT gated by pairing window)
+    OB->>RB: Noise XX (intent=peer_link)
+    RB->>RB: lookup pubkey hash -> APPROVED StoredPeer
+    RB-->>OB: intent_response=ok; session continues
 ```
 
 **Why two Noise handshakes for one pairing.** The preview handshake (step 3) captures the receiver's static pubkey for OOB display *before* the offloader has decided to trust this receiver; the WS closes immediately, no application data crosses the wire. The pair-request handshake (step 5) is a fresh handshake that re-binds the OOB-confirmed pin (defends against TOCTOU between preview and confirm: if the pubkey-hash on the second handshake doesn't match `pin_sha256` from preview, the offloader aborts). Re-handshakes are cheap because Noise's setup cost is negligible at this cadence (pair flows are rare, not a hot path).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -183,7 +183,84 @@ The 15-character RFC 6335 §5.1 cap on service-type labels is why the new type i
 
 ## Remote build
 
-Receiver-side surface for the remote-build offload feature (issue #106). The dashboard can play *receiver* (lend its CPU to other dashboards) and *offloader* (delegate compiles to a paired receiver) — phases 3a–3c land the receiver half; offloader-side pairing + peer-link work is phase 4+ and not yet shipped.
+Receiver-side surface for the remote-build offload feature (issue #106). The dashboard can play *receiver* (lend its CPU to other dashboards) and *offloader* (delegate compiles to a paired receiver). Phases 3a–3c landed the receiver half against a bearer-token auth model that is now being torn out and replaced by the Noise XX peer-link described below; phase 4a-r1 is in flight. Bullets further down ("Second TCP listener", "Middleware stack", "Token store", "First-use binding") describe the currently-shipped bearer machinery that phase 4a-r2 deletes wholesale.
+
+### Pairing auth flow (Noise XX, phase 4 target)
+
+Pairing is a two-human action: an offloader-side user picks a discovered receiver and clicks Pair; a receiver-side admin sees the request in an inbox and OOB-confirms the offloader's identity before approving. Out-of-band pin verification defeats a LAN MITM at first contact (the only window where pinning hasn't established trust yet); the **pairing window** narrows when new requests are even accepted (only while the receiver-side admin is on the Pairing requests screen) so an idle receiver doesn't accumulate inbox noise from arbitrary LAN scanners. Already-approved peers connect anytime for real builds; the window only gates new pair_requests.
+
+The cryptographic primitives are `Noise_XX_25519_ChaChaPoly_SHA256` (mutual identity exchange + forward secrecy) over a dedicated peer-link TCP listener (default port 6058, separate from the dashboard UI port). Each dashboard holds a long-lived X25519 keypair as its peer-link identity, persisted at `<config_dir>/.device-builder-peer-link-key.bin` (0o600); `pin_sha256` is the lowercase-hex SHA-256 of the static pubkey.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant OF as Offloader<br/>frontend
+    participant OB as Offloader<br/>backend
+    participant RB as Receiver<br/>backend
+    participant RF as Receiver<br/>frontend
+    participant RU as Receiver<br/>admin
+
+    Note over OF,RU: 1. Discovery (mDNS, advertised by both)
+    Note right of OB: _esphomebuilder._tcp.local TXT:<br/>peer_link_port + pin_sha256
+
+    Note over OF,RU: 2. Receiver opens pairing window
+    RU->>RF: navigate to Pairing requests screen
+    RF->>RB: set_pairing_window({open: true})
+    RB-->>RF: pairing_window_changed<br/>{open: true, expires_in: 300s}
+    Note right of RB: in-process deadline; closes on<br/>screen-unmount or user-idle timeout
+
+    Note over OF,RU: 3. Preview pair (Noise XX, intent="preview")
+    OF->>OB: preview_pair({hostname, port})
+    OB->>RB: Noise XX msg1 (intent="preview")
+    RB->>OB: Noise XX msg2 (carries responder static pubkey)
+    OB->>RB: Noise XX msg3 (handshake complete; WS closes)
+    OB-->>OF: {pin_sha256}
+    Note right of OB: pubkey captured from handshake<br/>transcript; no application data
+
+    Note over OF,RU: 4. OOB pin verification (human-mediated)
+    Note over OF,RF: User compares pin on offloader UI<br/>against receiver UI's "Build server" card
+
+    Note over OF,RU: 5. Pair request (Noise XX, intent="pair_request")
+    OF->>OB: request_pair({pin_sha256, label, ...})
+    OB->>RB: fresh Noise XX (intent="pair_request",<br/>payload={label, dashboard_id})
+    alt pairing window open
+        RB->>RB: create StoredPeer<br/>(status=PENDING)
+        RB-->>RF: pair_request_received
+        RB-->>OB: intent_response="pending"
+        OB-->>OF: persisted StoredPairing<br/>(status=pending)
+    else window closed
+        RB-->>OB: intent_response="no_pairing_window"
+        OB-->>OF: error: ask receiver admin<br/>to open the screen
+    end
+
+    Note over OF,RU: 6. Receiver admin approves
+    RU->>RF: OOB-confirm offloader's pin, click Accept
+    RF->>RB: approve_peer({dashboard_id})
+    RB->>RB: status PENDING → APPROVED
+    RB-->>RF: pair_status_changed(approved)
+
+    Note over OF,RU: 7. Offloader observes approval (5s polling)
+    loop while local row pending
+        OF->>OB: list_pool
+        OB->>RB: Noise XX (intent="pair_status")
+        RB-->>OB: status
+    end
+    OB-->>OF: row updated to "paired"
+
+    Note over OF,RU: 8. Subsequent real-build sessions
+    Note right of OB: NOT gated by pairing window;<br/>paired peers connect anytime
+    OB->>RB: Noise XX (intent="peer_link")
+    RB->>RB: lookup pubkey hash → APPROVED StoredPeer
+    RB-->>OB: intent_response="ok"; session continues
+```
+
+**Why two Noise handshakes for one pairing.** The preview handshake (step 3) captures the receiver's static pubkey for OOB display *before* the offloader has decided to trust this receiver; the WS closes immediately, no application data crosses the wire. The pair-request handshake (step 5) is a fresh handshake that re-binds the OOB-confirmed pin (defends against TOCTOU between preview and confirm: if the pubkey-hash on the second handshake doesn't match `pin_sha256` from preview, the offloader aborts). Re-handshakes are cheap because Noise's setup cost is negligible at this cadence (pair flows are rare, not a hot path).
+
+**Why polling instead of a long-held WS.** The offloader's `request_pair` returns immediately with `pending`; the offloader's frontend polls `list_pool` every 5s while a pending row is visible. The alternative (a long-held WS frame waiting for the admin to click Accept) fails on idle timeouts (load-balancer, HA addon ingress, offloader process restart) and forces the receiver to track stale connections across approval. Polling makes each interaction self-contained; a 2s server-side debounce on the offloader backend caches the receiver-side status to prevent cross-tab amplification.
+
+**Identity rotation.** The peer-link X25519 keypair has its own rotation lifecycle (`rotate_peer_link_identity`), independent of the phase-3a Ed25519 cert. Rotating the 3a cert does NOT change the X25519 pubkey; only `rotate_peer_link_identity` does. When an admin rotates, the `dashboard_id` stays stable but `pin_sha256` changes; every paired peer sees a `pin_mismatch` event on the next handshake and has to re-pair (this is the desired behaviour for "operator suspects compromise"). The separate-keypair design was decided during PR #472 review: the alternative (deriving X25519 from Ed25519 via libsodium-style `crypto_sign_ed25519_sk_to_curve25519`) adds non-trivial code for no benefit pre-release, and an implicit cascade would hide a security-relevant rotation event behind a routine cert renewal.
+
+### Currently-shipped bearer machinery (slated for deletion in 4a-r2)
 
 **Second TCP listener.** When `_remote_build.enabled` is `true`, `DeviceBuilder` binds a third aiohttp `TCPSite` on `--remote-build-port` (default 6055) over TLS, served with the cert from `helpers/dashboard_identity`. Disabled by default; the listener doesn't bind at all when the toggle is off (a sidecar `enabled=false` skip beats default-deny 404s — nothing to probe). This sits alongside the public + ingress sites from the Authentication section: HA-addon mode with remote-build enabled binds three listeners on three different ports, each with its own middleware stack.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,13 +193,15 @@ The cryptographic primitives are `Noise_XX_25519_ChaChaPoly_SHA256` (mutual iden
 
 The numbered phases:
 
-1. **Discovery** — both dashboards advertise on mDNS (`_esphomebuilder._tcp.local`); TXT carries `peer_link_port` + `pin_sha256`.
-2. **Receiver opens pairing window** — admin navigates to the Pairing requests screen; the frontend calls `set_pairing_window` with `open=true`; the backend flips an in-process deadline and fires `pairing_window_changed`. The window closes automatically on screen-unmount or user-idle timeout.
+All WS commands below use the `remote_build/` namespace and all events use the `remote_build_` prefix (matching the existing convention in `docs/API.md` and `models/common.py`); the diagram further down strips both for readability.
+
+1. **Discovery** — both dashboards advertise on mDNS (`_esphomebuilder._tcp.local`); the post-pivot TXT carries `peer_link_port` + `pin_sha256`. (Currently-shipped TXT advertises `remote_build_port` + `pin_sha256` instead, where `remote_build_port` points at the about-to-be-removed 6055 HTTPS listener; the rename to `peer_link_port` lands with phase 4a-r2.)
+2. **Receiver opens pairing window** — admin navigates to the Pairing requests screen; the frontend calls `remote_build/set_pairing_window` with `open=true`; the backend flips an in-process deadline and fires `remote_build_pairing_window_changed`. The window closes automatically on screen-unmount or user-idle timeout.
 3. **Preview pair (intent=preview)** — three Noise XX handshake messages. The offloader captures the receiver's static pubkey from the handshake transcript and surfaces `pin_sha256` to the user; no application data crosses the wire.
 4. **OOB pin verification** — human-mediated. The user compares the pin shown on the offloader UI against the receiver UI's Build server card.
-5. **Pair request (intent=pair_request)** — fresh Noise XX with payload `{label, dashboard_id}`. If the pairing window is open, the receiver creates a PENDING `StoredPeer` row, fires `pair_request_received`, and returns `intent_response=pending`. If the window is closed, it returns `intent_response=no_pairing_window` without creating a row.
-6. **Receiver admin approves** — admin OOB-confirms the offloader's pin, clicks Accept; the receiver flips the row to APPROVED and fires `pair_status_changed`.
-7. **Offloader observes approval (5s polling)** — while the offloader's local row is pending, its frontend polls `list_pool`; the offloader backend opens a fresh Noise WS with `intent=pair_status` and writes the response back into the local row.
+5. **Pair request (intent=pair_request)** — fresh Noise XX with payload `{label, dashboard_id}`. If the pairing window is open, the receiver creates a PENDING `StoredPeer` row, fires `remote_build_pair_request_received`, and returns `intent_response=pending`. If the window is closed, it returns `intent_response=no_pairing_window` without creating a row.
+6. **Receiver admin approves** — admin OOB-confirms the offloader's pin, clicks Accept; the receiver `remote_build/approve_peer` flips the row to APPROVED and fires `remote_build_pair_status_changed`.
+7. **Offloader observes approval (5s polling)** — while the offloader's local row is pending, its frontend polls `remote_build/list_pool`; the offloader backend opens a fresh Noise WS with `intent=pair_status` and writes the response back into the local row.
 8. **Subsequent real-build sessions** — `intent=peer_link`. **Not gated by the pairing window**; paired peers connect anytime. The receiver looks up the offloader's static-pubkey-hash against its `StoredPeer` table; an APPROVED match returns `intent_response=ok` and the session stays open for application messages.
 
 ```mermaid


### PR DESCRIPTION
# What does this implement/fix?

Adds a Mermaid sequence diagram + supporting prose to `docs/ARCHITECTURE.md` covering the phase-4 target auth shape from issue #106's pivot. The current section describes the bearer-token flow that 4a-r2 is about to delete; without this PR, anyone reading the architecture doc has to cross-reference issue #106's wall of design-choice text to understand how pairing actually works post-pivot.

## What's in this PR

The diagram walks through the 8-phase pairing flow:

1. **Discovery** — mDNS service advertise on both sides; TXT carries `peer_link_port` + `pin_sha256`.
2. **Receiver opens pairing window** — `set_pairing_window({open: true})` on screen-mount, fires `pairing_window_changed` with the live deadline.
3. **Preview pair** — Noise XX with `intent="preview"`; captures the receiver's static X25519 pubkey from the handshake transcript, no application data, WS closes.
4. **OOB pin verification** — human-mediated, the entire reason the diagram has 5 actors instead of 2.
5. **Pair request** — fresh Noise XX with `intent="pair_request"` carrying `{label, dashboard_id}`; gated by the pairing window (returns `no_pairing_window` if closed); on accept, creates a `PENDING` `StoredPeer` row + fires `pair_request_received`.
6. **Receiver admin approves** — `approve_peer({dashboard_id})` flips `PENDING` → `APPROVED`, fires `pair_status_changed(approved)`.
7. **Offloader observes approval** — 5s polling via `list_pool` (each tick is a self-contained Noise handshake with `intent="pair_status"`); 2s server-side debounce prevents cross-tab amplification.
8. **Real builds** — `intent="peer_link"` against the approved `StoredPeer`; **NOT gated by the pairing window** (paired peers connect anytime).

Plus three explanatory paragraphs the diagram alone can't carry:

- **Why two Noise handshakes for one pairing** — preview captures the pubkey *before* trust is established, pair_request re-binds against the OOB-confirmed pin to defend against TOCTOU between preview and confirm.
- **Why polling rather than a long-held WS** — idle timeouts (load-balancer, HA addon ingress, offloader process restarts) break long-held connections; polling makes each interaction self-contained.
- **Identity rotation lifecycle** — peer-link X25519 keypair has its own rotation independent of the 3a Ed25519 cert; rotating the 3a cert does NOT change the X25519 pubkey. The separate-keypair design was decided during PR #472 review (rejected libsodium-style `crypto_sign_ed25519_sk_to_curve25519` derivation: adds non-trivial code for no benefit pre-release, and the implicit cascade hides a security-relevant rotation event behind a routine cert renewal).

The existing bearer-flow bullets stay in place under a new heading "Currently-shipped bearer machinery (slated for deletion in 4a-r2)" so the doc still accurately describes what's running on main today.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation only — `docs`
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump

## Frontend coordination

- [x] No frontend change needed.

## Checklist

- [x] Pre-commit hooks pass.
- [x] No code changes; pure documentation.
- [x] Mermaid renders on GitHub (sequence diagrams are GH-native; no extension required).

## Notes for reviewers

- The diagram intentionally compresses the Noise handshake to "msg1 / msg2 / msg3" rather than spelling out the X25519 + ChaCha20-Poly1305 wire details — those are in issue #106 design choice (h) for anyone who wants the bytes-level shape. The architecture doc's job is to convey *the trust model*, not to re-derive the cryptography.
- The `alt pairing window open / window closed` block in step 5 is the load-bearing piece the diagram captures that the prose elsewhere only hints at — the window gate is what makes the protocol active rather than passive.
- The "Currently-shipped bearer machinery" heading is a deliberate signal to future readers: when 4a-r2 ships, that whole subsection comes out as one diff, no per-bullet untangling needed.

## Related

- Tracking issue: esphome/device-builder#106 (phase 4a-r1 + 4a-r2 + 4a-o + 4b-2 + 4b-3 all reference this flow).
- Implementation slices in flight: esphome/device-builder#472 (Noise framing helper, merged), esphome/device-builder#473 (X25519 identity helper, in review).
