### PR TITLE
Add receiver-UI WS commands + pairing window (#106 phase 4a-r1 part 3)

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -500,10 +500,13 @@ class RemoteBuildController:
         # dashboard restart (which is fine; admins re-open the
         # screen and the window opens fresh).
         self._pairing_window_clients: dict[Any, float] = {}
-        # Background task that wakes at the next deadline and either
-        # re-sleeps (someone extended) or closes the window + fires
-        # the event (everyone aged out / closed).
-        self._pairing_window_task: asyncio.Task[None] | None = None
+        # TimerHandle scheduled for the latest-extend deadline. Cancelled
+        # and rescheduled on every set_pairing_window call so it always
+        # tracks the "next time we need to auto-close". When the handle
+        # fires, every client has aged out (any later extend would have
+        # cancelled it), so the callback just clears the dict and fires
+        # the close event. ``None`` when the window is closed.
+        self._pairing_window_handle: asyncio.TimerHandle | None = None
 
     async def start(self) -> None:
         """
@@ -571,10 +574,9 @@ class RemoteBuildController:
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
             self._tasks.clear()
-        if self._pairing_window_task is not None:
-            self._pairing_window_task.cancel()
-            await asyncio.gather(self._pairing_window_task, return_exceptions=True)
-            self._pairing_window_task = None
+        if self._pairing_window_handle is not None:
+            self._pairing_window_handle.cancel()
+            self._pairing_window_handle = None
         self._pairing_window_clients.clear()
         self._peers.clear()
 
@@ -1219,12 +1221,15 @@ class RemoteBuildController:
         was_open = self.is_pairing_window_open()
         if open:
             self._pairing_window_clients[client] = time.monotonic()
-            if self._pairing_window_task is None or self._pairing_window_task.done():
-                self._pairing_window_task = asyncio.create_task(self._run_pairing_window_task())
         else:
             self._pairing_window_clients.pop(client, None)
-        self._prune_stale_pairing_window_clients()
-        is_open = self.is_pairing_window_open()
+        # Cancel the existing handle and schedule a new one against
+        # the current latest-extend deadline. When the dict is empty
+        # (last client closed), no new handle is scheduled; this is
+        # what prevents a duplicate close event from a stale handle
+        # on the explicit-close path.
+        self._reschedule_pairing_window_close()
+        is_open = bool(self._pairing_window_clients)
 
         # Fire on state transitions, AND on every successful extend
         # (open=True with the window already open) so the frontend's
@@ -1276,36 +1281,46 @@ class RemoteBuildController:
             if extended_at >= cutoff
         }
 
-    async def _run_pairing_window_task(self) -> None:
+    def _reschedule_pairing_window_close(self) -> None:
         """
-        Sleep until the latest client's deadline; on wake, close or re-sleep.
+        Cancel any pending close handle and schedule a fresh one.
 
-        Tolerates extension: when any client extends while we're
-        sleeping, the new latest-extend timestamp pushes the deadline
-        out, our sleep wakes at the *old* deadline, sees the new
-        deadline still in the future, and re-sleeps. One task handles
-        arbitrary numbers of extensions across all clients; the cost
-        is one wasted wake per extension, negligible at the 30s
-        debounced extend cadence.
+        Called after every :meth:`set_pairing_window` mutation. The
+        handle always reflects the current latest-extend deadline,
+        so on every extend we cancel and reschedule rather than
+        letting an old handle wake up and re-check; this avoids the
+        duplicate-close-event class of bug where an old handle
+        would fire after an explicit close.
 
-        Closes the window (and fires the event) when the prune sweep
-        on wake finds no clients left.
+        When the client map is empty (the explicit-close case where
+        the last client just dropped out), no new handle is
+        scheduled and ``_pairing_window_handle`` stays ``None``.
         """
-        while True:
-            self._prune_stale_pairing_window_clients()
-            if not self._pairing_window_clients:
-                # Auto-closed: every client aged out. Fire the close
-                # event so the frontend can render "window expired".
-                self._fire_pairing_window_changed()
-                return
-            latest_extend = max(self._pairing_window_clients.values())
-            deadline = latest_extend + _PAIRING_WINDOW_DURATION_SECONDS
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                # Fell through pruning's epsilon window; loop back to
-                # re-sweep and close on the next iteration.
-                continue
-            await asyncio.sleep(remaining)
+        if self._pairing_window_handle is not None:
+            self._pairing_window_handle.cancel()
+            self._pairing_window_handle = None
+        self._prune_stale_pairing_window_clients()
+        if not self._pairing_window_clients:
+            return
+        latest_extend = max(self._pairing_window_clients.values())
+        remaining = max(0.0, latest_extend + _PAIRING_WINDOW_DURATION_SECONDS - time.monotonic())
+        loop = asyncio.get_running_loop()
+        self._pairing_window_handle = loop.call_later(remaining, self._on_pairing_window_deadline)
+
+    def _on_pairing_window_deadline(self) -> None:
+        """
+        Sync callback fired by the TimerHandle when the deadline lapses.
+
+        The handle was scheduled to the latest-extend deadline; if
+        any later extend had bumped the deadline, the handle would
+        have been cancelled and rescheduled, so by the time we run
+        every client has aged out. Clear the dict, fire the close
+        event, done. No re-check loop needed (which is the whole
+        point of TimerHandle vs an asyncio.sleep coroutine).
+        """
+        self._pairing_window_handle = None
+        self._pairing_window_clients.clear()
+        self._fire_pairing_window_changed()
 
 
 def _identity_view(identity: DashboardIdentity, *, listener_bound: bool) -> IdentityView:

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1120,10 +1120,7 @@ class RemoteBuildController:
             raise CommandError(ErrorCode.NOT_FOUND, msg)
 
         view = await self._modify_settings(_approve)
-        self._db.bus.fire(
-            EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED,
-            {"dashboard_id": clean_id, "status": "approved"},
-        )
+        self._fire_pair_status_changed(clean_id, "approved")
         return view
 
     @api_command("remote_build/remove_peer")
@@ -1165,10 +1162,7 @@ class RemoteBuildController:
 
         view = await self._modify_settings(_remove)
         if previous_status == PeerStatus.APPROVED:
-            self._db.bus.fire(
-                EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED,
-                {"dashboard_id": clean_id, "status": "removed"},
-            )
+            self._fire_pair_status_changed(clean_id, "removed")
         return view
 
     # ------------------------------------------------------------------
@@ -1252,15 +1246,44 @@ class RemoteBuildController:
         self._prune_stale_pairing_window_clients()
         return bool(self._pairing_window_clients)
 
-    def _pairing_window_state(self) -> PairingWindowState:
-        """Project the in-memory client map into a wire-shape response."""
+    def _pairing_window_remaining(self) -> float | None:
+        """
+        Seconds until the latest-extend deadline, or ``None`` if closed.
+
+        Single source of truth for the deadline math: prunes stale
+        clients first, then derives the remaining lifetime from the
+        most recent extend across all live clients. Consumed by both
+        the wire-projection (:meth:`_pairing_window_state`) and the
+        TimerHandle scheduler (:meth:`_reschedule_pairing_window_close`)
+        so they can't drift out of sync on the cutoff calculation.
+        """
         self._prune_stale_pairing_window_clients()
         if not self._pairing_window_clients:
-            return PairingWindowState(open=False, expires_in_seconds=None)
+            return None
         latest_extend = max(self._pairing_window_clients.values())
-        deadline = latest_extend + _PAIRING_WINDOW_DURATION_SECONDS
-        remaining = max(0.0, deadline - time.monotonic())
+        return max(0.0, latest_extend + _PAIRING_WINDOW_DURATION_SECONDS - time.monotonic())
+
+    def _pairing_window_state(self) -> PairingWindowState:
+        """Project the in-memory client map into a wire-shape response."""
+        remaining = self._pairing_window_remaining()
+        if remaining is None:
+            return PairingWindowState(open=False, expires_in_seconds=None)
         return PairingWindowState(open=True, expires_in_seconds=remaining)
+
+    def _fire_pair_status_changed(self, dashboard_id: str, status: str) -> None:
+        """
+        Fire ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` for a peer transition.
+
+        ``status`` is ``"approved"`` (from :meth:`approve_peer`) or
+        ``"removed"`` (from :meth:`remove_peer` of a previously-
+        APPROVED row). Mirrors :meth:`_fire_pairing_window_changed`
+        for shape; both methods are the named-intent boundary
+        between controller logic and the bus payload format.
+        """
+        self._db.bus.fire(
+            EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED,
+            {"dashboard_id": dashboard_id, "status": status},
+        )
 
     def _fire_pairing_window_changed(self) -> None:
         """Fire ``REMOTE_BUILD_PAIRING_WINDOW_CHANGED`` with the current state."""
@@ -1299,11 +1322,9 @@ class RemoteBuildController:
         if self._pairing_window_handle is not None:
             self._pairing_window_handle.cancel()
             self._pairing_window_handle = None
-        self._prune_stale_pairing_window_clients()
-        if not self._pairing_window_clients:
+        remaining = self._pairing_window_remaining()
+        if remaining is None:
             return
-        latest_extend = max(self._pairing_window_clients.values())
-        remaining = max(0.0, latest_extend + _PAIRING_WINDOW_DURATION_SECONDS - time.monotonic())
         loop = asyncio.get_running_loop()
         self._pairing_window_handle = loop.call_later(remaining, self._on_pairing_window_deadline)
 

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -53,7 +53,7 @@ import asyncio
 import logging
 import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Hashable
 from typing import TYPE_CHECKING, Any
 
 from esphome.const import __version__ as esphome_version
@@ -509,7 +509,7 @@ class RemoteBuildController:
         # open forever. State lives in-memory only and resets on
         # dashboard restart (which is fine; admins re-open the
         # screen and the window opens fresh).
-        self._pairing_window_clients: dict[Any, float] = {}
+        self._pairing_window_clients: dict[Hashable, float] = {}
         # TimerHandle scheduled for the latest-extend deadline. Cancelled
         # and rescheduled on every set_pairing_window call so it always
         # tracks the "next time we need to auto-close". When the handle
@@ -1187,7 +1187,7 @@ class RemoteBuildController:
         self,
         *,
         open: bool,  # noqa: A002 — wire format names this field "open"
-        client: Any,
+        client: Hashable,
         **kwargs: Any,
     ) -> PairingWindowState:
         """

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -69,10 +69,14 @@ from ..models import (
     EventType,
     IdentityView,
     ManualHost,
+    PairingWindowState,
+    PeerStatus,
+    PeerSummary,
     RemoteBuildPeer,
     RemoteBuildPeerSource,
     RemoteBuildSettings,
     RemoteBuildSettingsView,
+    StoredPeer,
     StoredToken,
     TokenSummary,
 )
@@ -93,6 +97,16 @@ _LOGGER = logging.getLogger(__name__)
 # seconds"; not the device-state miss the shorter timeout
 # protects against.
 _RESOLVE_TIMEOUT_MS = 3000
+
+# Default lifetime of a pairing window (seconds). The window opens
+# when the receiver-side Pairing requests screen mounts and
+# auto-closes after this much idle time. The frontend extends by
+# calling ``remote_build/set_pairing_window`` with ``open=true``
+# again on each user-activity tick (debounced to once per 30s on
+# the wire). Five minutes balances "long enough to OOB-confirm a
+# pin without rushing" against "short enough that an idle tab
+# isn't an attack surface". See issue #106 design choice (c).
+_PAIRING_WINDOW_DURATION_SECONDS = 300.0
 
 
 def _decode_txt_value(raw: bytes | None) -> str:
@@ -349,16 +363,59 @@ def _to_view(settings: RemoteBuildSettings) -> RemoteBuildSettingsView:
     """
     Project a :class:`RemoteBuildSettings` to its wire :class:`RemoteBuildSettingsView`.
 
-    Drops ``secret_sha256`` from each token row. Every controller
-    method that returns settings to a client routes through here
-    so the stored hash never leaves the server, even when a CRUD
-    response also touches the tokens list.
+    Drops ``secret_sha256`` from each token row and the raw
+    ``static_x25519_pub`` bytes from each peer row. Every
+    controller method that returns settings to a client routes
+    through here so the stored secrets never leave the server,
+    even when a CRUD response also touches the tokens or peers
+    list.
     """
     return RemoteBuildSettingsView(
         enabled=settings.enabled,
         manual_hosts=list(settings.manual_hosts),
         tokens=[_summarise_token(t) for t in settings.tokens],
+        peers=[_peer_summary(p) for p in settings.peers],
     )
+
+
+def _peer_summary(peer: StoredPeer) -> PeerSummary:
+    """Project a :class:`StoredPeer` to wire :class:`PeerSummary`.
+
+    Drops the raw ``static_x25519_pub`` bytes; ``pin_sha256`` is
+    the wire-friendly form UIs render for OOB-verification, and
+    the pubkey is only needed server-side to look up the peer
+    against an incoming Noise handshake.
+    """
+    return PeerSummary(
+        dashboard_id=peer.dashboard_id,
+        pin_sha256=peer.pin_sha256,
+        label=peer.label,
+        paired_at=peer.paired_at,
+        status=peer.status,
+    )
+
+
+def _validate_dashboard_id(raw: object) -> str:
+    """
+    Validate a user-supplied ``dashboard_id`` argument.
+
+    Same shape as the phase 3a / 3b3 ``X-Dashboard-ID`` header
+    contract: base64url alphabet, ≤ 64 chars, non-empty. Rejects
+    other shapes with ``INVALID_ARGS`` rather than silently
+    looking up nothing (which would yield a misleading
+    ``NOT_FOUND``).
+    """
+    if not isinstance(raw, str):
+        msg = "dashboard_id must be a string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    cleaned = raw.strip()
+    if not cleaned or len(cleaned) > 64 or not _DASHBOARD_ID_PATTERN.match(cleaned):
+        msg = "dashboard_id must be 1-64 base64url chars"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return cleaned
+
+
+_DASHBOARD_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _validate_port(raw: object) -> int:
@@ -421,6 +478,32 @@ class RemoteBuildController:
         # guarantees the check + set in :meth:`rotate_identity`
         # is atomic without an explicit lock.
         self._rotation_in_flight = False
+        # Pairing window state (issue #106 design choice (c)).
+        # The window narrows acceptance of ``intent="pair_request"``
+        # Noise frames so an idle receiver doesn't accumulate inbox
+        # noise from arbitrary LAN scanners. Already-approved peers
+        # are NOT gated by the window; they connect anytime via
+        # ``intent="peer_link"``.
+        #
+        # Refcounted by client so two browser tabs / two users with
+        # the Pairing requests screen open both keep the window open
+        # together. Each ``set_pairing_window(open=true)`` call adds
+        # the calling WS client to the map (or refreshes its
+        # last-extend timestamp); ``open=false`` removes it. The
+        # window is open iff the map has any client whose last-extend
+        # timestamp is within ``_PAIRING_WINDOW_DURATION_SECONDS``.
+        # Crashed / disconnected clients (no graceful ``open=false``)
+        # age out via the same timeout, so a one-tab close in a
+        # multi-tab session doesn't immediately close the window for
+        # the other tab, and a crashed tab doesn't keep the window
+        # open forever. State lives in-memory only and resets on
+        # dashboard restart (which is fine; admins re-open the
+        # screen and the window opens fresh).
+        self._pairing_window_clients: dict[Any, float] = {}
+        # Background task that wakes at the next deadline and either
+        # re-sleeps (someone extended) or closes the window + fires
+        # the event (everyone aged out / closed).
+        self._pairing_window_task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
         """
@@ -488,6 +571,11 @@ class RemoteBuildController:
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
             self._tasks.clear()
+        if self._pairing_window_task is not None:
+            self._pairing_window_task.cancel()
+            await asyncio.gather(self._pairing_window_task, return_exceptions=True)
+            self._pairing_window_task = None
+        self._pairing_window_clients.clear()
         self._peers.clear()
 
     # ------------------------------------------------------------------
@@ -978,6 +1066,246 @@ class RemoteBuildController:
             return _identity_view(identity, listener_bound=listener_bound)
         finally:
             self._rotation_in_flight = False
+
+    # ------------------------------------------------------------------
+    # Peer CRUD (phase 4a-r1 part 3) — receiver-UI surface for the
+    # Pairing requests inbox and the approved-peers list. The peer-link
+    # listener (phase 4a-r1 part 4) is the actual creator of PENDING
+    # rows; these commands are the receiver-side admin's UI surface for
+    # acting on them.
+    # ------------------------------------------------------------------
+
+    @api_command("remote_build/list_peers")
+    async def list_peers(self, **kwargs: Any) -> list[PeerSummary]:
+        """
+        Return every ``StoredPeer`` row, projected to wire shape.
+
+        Includes both PENDING (waiting for admin Accept) and APPROVED
+        (paired) rows; the wire view drops the raw ``static_x25519_pub``
+        bytes and exposes only ``pin_sha256``. The frontend filters by
+        ``status`` to render the inbox vs the paired list.
+        """
+        loop = asyncio.get_running_loop()
+        settings = await loop.run_in_executor(
+            None, load_remote_build_settings, self._db.settings.config_dir
+        )
+        return [_peer_summary(peer) for peer in settings.peers]
+
+    @api_command("remote_build/approve_peer")
+    async def approve_peer(self, *, dashboard_id: str, **kwargs: Any) -> RemoteBuildSettingsView:
+        """
+        Promote a PENDING peer to APPROVED.
+
+        Fires :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED` with
+        ``{dashboard_id, status: "approved"}``. The offloader observes
+        the flip via its own polling loop (phase 4a-o ``list_pool``).
+        ``NOT_FOUND`` if no peer with this ``dashboard_id`` exists;
+        ``INVALID_ARGS`` if the peer is already APPROVED (a duplicate
+        Accept click is almost always a UI race and the receiver
+        should not silently re-fire the event).
+        """
+        clean_id = _validate_dashboard_id(dashboard_id)
+
+        def _approve(settings: RemoteBuildSettings) -> None:
+            for peer in settings.peers:
+                if peer.dashboard_id == clean_id:
+                    if peer.status == PeerStatus.APPROVED:
+                        msg = f"peer is already approved: {clean_id}"
+                        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+                    peer.status = PeerStatus.APPROVED
+                    return
+            msg = f"no peer with dashboard_id: {clean_id}"
+            raise CommandError(ErrorCode.NOT_FOUND, msg)
+
+        view = await self._modify_settings(_approve)
+        self._db.bus.fire(
+            EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED,
+            {"dashboard_id": clean_id, "status": "approved"},
+        )
+        return view
+
+    @api_command("remote_build/remove_peer")
+    async def remove_peer(self, *, dashboard_id: str, **kwargs: Any) -> RemoteBuildSettingsView:
+        """
+        Delete a peer row (works on both PENDING and APPROVED).
+
+        Two semantically distinct outcomes share the same WS command:
+
+        * Removing a PENDING row is *rejection* — the row never
+          represented an established trust relationship, so this is
+          inbox cleanup. No event fires.
+        * Removing an APPROVED row is *revocation* — fires
+          :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED` with
+          ``{dashboard_id, status: "removed"}`` so the offloader's
+          polling loop sees the revocation and can surface a
+          ``peer_revoked`` UI alert (phase 4b-3).
+
+        ``NOT_FOUND`` if no peer with this ``dashboard_id`` exists.
+        """
+        clean_id = _validate_dashboard_id(dashboard_id)
+        # ``_modify_settings`` returns the view but doesn't tell us
+        # what the peer's status was *before* the remove; capture
+        # that in the mutator so the event-fire decision below has
+        # the right answer.
+        previous_status: PeerStatus | None = None
+
+        def _remove(settings: RemoteBuildSettings) -> None:
+            nonlocal previous_status
+            for peer in settings.peers:
+                if peer.dashboard_id == clean_id:
+                    previous_status = peer.status
+                    break
+            kept = [peer for peer in settings.peers if peer.dashboard_id != clean_id]
+            if len(kept) == len(settings.peers):
+                msg = f"no peer with dashboard_id: {clean_id}"
+                raise CommandError(ErrorCode.NOT_FOUND, msg)
+            settings.peers = kept
+
+        view = await self._modify_settings(_remove)
+        if previous_status == PeerStatus.APPROVED:
+            self._db.bus.fire(
+                EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED,
+                {"dashboard_id": clean_id, "status": "removed"},
+            )
+        return view
+
+    # ------------------------------------------------------------------
+    # Pairing window (phase 4a-r1 part 3) — in-process deadline that
+    # gates ``intent="pair_request"`` Noise frames at the listener
+    # (phase 4a-r1 part 4 consumes :meth:`is_pairing_window_open`).
+    # See issue #106 design choice (c).
+    # ------------------------------------------------------------------
+
+    @api_command("remote_build/set_pairing_window")
+    async def set_pairing_window(
+        self,
+        *,
+        open: bool,  # noqa: A002 — wire format names this field "open"
+        **kwargs: Any,
+    ) -> PairingWindowState:
+        """
+        Open, extend, or close the pairing window for the calling client.
+
+        Wire shape: ``{open: bool}``. Refcounted by WS client: each
+        ``open=true`` adds (or refreshes) the caller's entry in the
+        active-clients map; ``open=false`` removes it. The window is
+        open iff *any* client has a non-stale entry. The
+        receiver-side frontend calls this on screen-mount and on
+        each activity-driven extend tick (debounced to once per 30s
+        on the wire), and ``open=false`` on screen-unmount /
+        ``beforeunload``. An explicit "extend" / "still pairing?"
+        button in the UI is just another caller of ``open=true``;
+        no separate wire command is needed for it.
+
+        Fires :attr:`EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED` on
+        every state transition. Idempotent calls that don't change
+        state (close-while-already-closed; or close from a client
+        that wasn't extending while another client still is) do NOT
+        fire; the frontend renders countdown ticks client-side and
+        doesn't need a per-second fire.
+
+        Two-tab / two-user behaviour: window stays open as long as
+        at least one client is extending. A crashed tab ages out
+        naturally via the 5min idle timeout (no per-client
+        disconnect hook is needed); a graceful close from one tab
+        leaves the window open for the other tab. See issue #106
+        design choice (c).
+        """
+        if not isinstance(open, bool):
+            msg = "remote_build/set_pairing_window: 'open' must be a bool"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+
+        client = kwargs.get("client")
+        was_open = self.is_pairing_window_open()
+        if open:
+            self._pairing_window_clients[client] = time.monotonic()
+            if self._pairing_window_task is None or self._pairing_window_task.done():
+                self._pairing_window_task = asyncio.create_task(self._run_pairing_window_task())
+        else:
+            self._pairing_window_clients.pop(client, None)
+        self._prune_stale_pairing_window_clients()
+        is_open = self.is_pairing_window_open()
+
+        # Fire on state transitions, AND on every successful extend
+        # (open=True with the window already open) so the frontend's
+        # live countdown re-syncs against the bumped deadline. A
+        # spurious open=False from a non-extending client (no state
+        # change) doesn't fire.
+        if was_open != is_open or (open and is_open):
+            self._fire_pairing_window_changed()
+        return self._pairing_window_state()
+
+    def is_pairing_window_open(self) -> bool:
+        """
+        Return whether the pairing window is currently open.
+
+        Consumed by the peer-link listener (phase 4a-r1 part 4) to
+        gate ``intent="pair_request"`` Noise frames. A closed window
+        rejects the frame with ``intent_response=no_pairing_window``
+        and closes the WS without creating a row.
+        """
+        self._prune_stale_pairing_window_clients()
+        return bool(self._pairing_window_clients)
+
+    def _pairing_window_state(self) -> PairingWindowState:
+        """Project the in-memory client map into a wire-shape response."""
+        self._prune_stale_pairing_window_clients()
+        if not self._pairing_window_clients:
+            return PairingWindowState(open=False, expires_in_seconds=None)
+        latest_extend = max(self._pairing_window_clients.values())
+        deadline = latest_extend + _PAIRING_WINDOW_DURATION_SECONDS
+        remaining = max(0.0, deadline - time.monotonic())
+        return PairingWindowState(open=True, expires_in_seconds=remaining)
+
+    def _fire_pairing_window_changed(self) -> None:
+        """Fire ``REMOTE_BUILD_PAIRING_WINDOW_CHANGED`` with the current state."""
+        state = self._pairing_window_state()
+        self._db.bus.fire(
+            EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED,
+            {"open": state.open, "expires_in_seconds": state.expires_in_seconds},
+        )
+
+    def _prune_stale_pairing_window_clients(self) -> None:
+        """Drop client entries whose last-extend timestamp aged out."""
+        if not self._pairing_window_clients:
+            return
+        cutoff = time.monotonic() - _PAIRING_WINDOW_DURATION_SECONDS
+        self._pairing_window_clients = {
+            client: extended_at
+            for client, extended_at in self._pairing_window_clients.items()
+            if extended_at >= cutoff
+        }
+
+    async def _run_pairing_window_task(self) -> None:
+        """
+        Sleep until the latest client's deadline; on wake, close or re-sleep.
+
+        Tolerates extension: when any client extends while we're
+        sleeping, the new latest-extend timestamp pushes the deadline
+        out, our sleep wakes at the *old* deadline, sees the new
+        deadline still in the future, and re-sleeps. One task handles
+        arbitrary numbers of extensions across all clients; the cost
+        is one wasted wake per extension, negligible at the 30s
+        debounced extend cadence.
+
+        Closes the window (and fires the event) when the prune sweep
+        on wake finds no clients left.
+        """
+        while True:
+            self._prune_stale_pairing_window_clients()
+            if not self._pairing_window_clients:
+                # Auto-closed: every client aged out. Fire the close
+                # event so the frontend can render "window expired".
+                self._fire_pairing_window_changed()
+                return
+            latest_extend = max(self._pairing_window_clients.values())
+            deadline = latest_extend + _PAIRING_WINDOW_DURATION_SECONDS
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                # Fell through pruning's epsilon window; loop back to
+                # re-sweep and close on the next iteration.
+                continue
+            await asyncio.sleep(remaining)
 
 
 def _identity_view(identity: DashboardIdentity, *, listener_bound: bool) -> IdentityView:

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -63,7 +63,12 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 from ..constants import __version__ as server_version
 from ..helpers.api import CommandError, api_command
 from ..helpers.dashboard_advertise import SERVICE_TYPE
-from ..helpers.dashboard_identity import get_or_create_identity, rotate_certificate
+from ..helpers.dashboard_identity import (
+    DASHBOARD_ID_MAX_CHARS,
+    DASHBOARD_ID_PATTERN,
+    get_or_create_identity,
+    rotate_certificate,
+)
 from ..models import (
     ErrorCode,
     EventType,
@@ -399,23 +404,28 @@ def _validate_dashboard_id(raw: object) -> str:
     """
     Validate a user-supplied ``dashboard_id`` argument.
 
-    Same shape as the phase 3a / 3b3 ``X-Dashboard-ID`` header
-    contract: base64url alphabet, ≤ 64 chars, non-empty. Rejects
-    other shapes with ``INVALID_ARGS`` rather than silently
-    looking up nothing (which would yield a misleading
-    ``NOT_FOUND``).
+    Same alphabet and length cap as the phase 3a / 3b3 ``X-Dashboard-ID``
+    header contract; the regex + max-length live in
+    :mod:`helpers.dashboard_identity` so the WS-command path here
+    and the HTTP-header path in :mod:`helpers.remote_build_auth`
+    can't drift apart.
+
+    Rejects non-string / empty / oversized / non-base64url input
+    with ``INVALID_ARGS`` rather than silently looking up nothing
+    (which would yield a misleading ``NOT_FOUND``).
     """
     if not isinstance(raw, str):
         msg = "dashboard_id must be a string"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     cleaned = raw.strip()
-    if not cleaned or len(cleaned) > 64 or not _DASHBOARD_ID_PATTERN.match(cleaned):
-        msg = "dashboard_id must be 1-64 base64url chars"
+    if (
+        not cleaned
+        or len(cleaned) > DASHBOARD_ID_MAX_CHARS
+        or not DASHBOARD_ID_PATTERN.fullmatch(cleaned)
+    ):
+        msg = f"dashboard_id must be 1-{DASHBOARD_ID_MAX_CHARS} base64url chars"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return cleaned
-
-
-_DASHBOARD_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _validate_port(raw: object) -> int:
@@ -1177,7 +1187,7 @@ class RemoteBuildController:
         self,
         *,
         open: bool,  # noqa: A002 — wire format names this field "open"
-        client: Any = None,
+        client: Any,
         **kwargs: Any,
     ) -> PairingWindowState:
         """
@@ -1197,14 +1207,12 @@ class RemoteBuildController:
         ``client`` is the WS connection object that the dispatcher
         injects on every command call (see ``api/ws.py``); we use
         the connection itself as the refcount dict key, so two
-        browser tabs / two users get distinct entries. The
-        ``client=None`` default exists only for direct callers in
-        tests; in that path each test creates a fresh controller,
-        so falling under the same ``None`` bucket is harmless. A
-        future production code path that legitimately needs to
-        call this without a WS client should pass an explicit
-        hashable identity (a ``uuid.uuid4()`` works) rather than
-        relying on the default.
+        browser tabs / two users get distinct entries. Required
+        kwarg with no default: a missing ``client`` would silently
+        bucket every caller under the same key and break the
+        refcount, so we want the loud ``TypeError`` from a missing
+        kwarg instead. Tests pass a stand-in hashable (``"tab-1"``,
+        etc.) to simulate distinct clients.
 
         Fires :attr:`EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED` on
         every state transition. Idempotent calls that don't change

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1177,6 +1177,7 @@ class RemoteBuildController:
         self,
         *,
         open: bool,  # noqa: A002 — wire format names this field "open"
+        client: Any = None,
         **kwargs: Any,
     ) -> PairingWindowState:
         """
@@ -1192,6 +1193,18 @@ class RemoteBuildController:
         ``beforeunload``. An explicit "extend" / "still pairing?"
         button in the UI is just another caller of ``open=true``;
         no separate wire command is needed for it.
+
+        ``client`` is the WS connection object that the dispatcher
+        injects on every command call (see ``api/ws.py``); we use
+        the connection itself as the refcount dict key, so two
+        browser tabs / two users get distinct entries. The
+        ``client=None`` default exists only for direct callers in
+        tests; in that path each test creates a fresh controller,
+        so falling under the same ``None`` bucket is harmless. A
+        future production code path that legitimately needs to
+        call this without a WS client should pass an explicit
+        hashable identity (a ``uuid.uuid4()`` works) rather than
+        relying on the default.
 
         Fires :attr:`EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED` on
         every state transition. Idempotent calls that don't change
@@ -1211,7 +1224,6 @@ class RemoteBuildController:
             msg = "remote_build/set_pairing_window: 'open' must be a bool"
             raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
-        client = kwargs.get("client")
         was_open = self.is_pairing_window_open()
         if open:
             self._pairing_window_clients[client] = time.monotonic()

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
 import secrets
 import threading
 from dataclasses import dataclass
@@ -43,6 +44,21 @@ _CERT_FILENAME = ".device-builder-cert.pem"
 _KEY_FILENAME = ".device-builder-key.pem"
 _KEY_MODE = 0o600
 _DASHBOARD_ID_BYTES = 24
+
+# Public validation contract for ``dashboard_id`` strings on the
+# wire. ``dashboard_id`` is generated via
+# ``secrets.token_urlsafe(_DASHBOARD_ID_BYTES)`` (32 base64url
+# chars at the current 24-byte entropy size). The cap of 64
+# defends against runaway inputs without rejecting legitimate
+# values; the pattern catches probes carrying control bytes /
+# non-printables. Both consumers (``helpers/remote_build_auth``
+# for HTTP header parsing today; ``controllers/remote_build``
+# for WS-command argument validation in phase 4a-r1) import
+# these so a future entropy bump or alphabet change happens in
+# one place.
+DASHBOARD_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+DASHBOARD_ID_MAX_CHARS = 64
+
 _CERT_VALIDITY_YEARS = 100  # rotation is explicit; never driven by expiry
 _CERT_NOT_BEFORE_BACKDATE = timedelta(minutes=5)  # tolerate small peer-clock skew
 _CERT_COMMON_NAME = "ESPHome Device Builder"

--- a/esphome_device_builder/helpers/remote_build_auth.py
+++ b/esphome_device_builder/helpers/remote_build_auth.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
-import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -53,6 +52,7 @@ from aiohttp import web
 
 from ..models import StoredToken
 from .auth import RateLimiter
+from .dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
 
 if TYPE_CHECKING:
     from collections.abc import Callable as _Callable
@@ -104,23 +104,22 @@ _DUMMY_HASH = "0" * 64
 # token; later requests with a mismatched id are rejected as 403.
 _DASHBOARD_ID_HEADER = "X-Dashboard-ID"
 
-# ``dashboard_id`` is generated via ``secrets.token_urlsafe(24)``
-# in phase 3a, so 32 base64url chars. Cap the accepted length at
-# 64 to defend against a runaway header carrying megabytes; the
-# pattern (base64url chars only) catches probes carrying control
-# bytes / non-printables.
-_DASHBOARD_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
-_DASHBOARD_ID_MAX_CHARS = 64
-
 
 def _validate_dashboard_id(raw: str | None) -> str | None:
-    """Return the trimmed value if the header parses cleanly, else ``None``."""
+    """
+    Return the trimmed value if the header parses cleanly, else ``None``.
+
+    Uses the shared ``DASHBOARD_ID_*`` validation constants from
+    :mod:`helpers.dashboard_identity` so the WS-command path
+    (:func:`controllers.remote_build._validate_dashboard_id`) can't
+    drift from the HTTP-header path here.
+    """
     if not raw:
         return None
     trimmed = raw.strip()
-    if not trimmed or len(trimmed) > _DASHBOARD_ID_MAX_CHARS:
+    if not trimmed or len(trimmed) > DASHBOARD_ID_MAX_CHARS:
         return None
-    if not _DASHBOARD_ID_PATTERN.fullmatch(trimmed):
+    if not DASHBOARD_ID_PATTERN.fullmatch(trimmed):
         return None
     return trimmed
 

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -96,6 +96,45 @@ class EventType(StrEnum):
     # changed.
     REMOTE_BUILD_IDENTITY_ROTATED = "remote_build_identity_rotated"
 
+    # A pair_request Noise frame landed for a previously-unknown
+    # peer while the receiver's pairing window was open (phase 4
+    # auth flow; see issue #106 design choice (b)/(c)). Payload:
+    # ``{dashboard_id, pin_sha256, label, peer_ip}``. The receiver
+    # Settings UI surfaces this in the Pairing requests inbox.
+    # Fires only when the pairing window is open; closed-window
+    # pair_requests are rejected at the listener with
+    # ``intent_response=no_pairing_window`` and don't create a
+    # row. The listener (part 4) is the actual emitter; this
+    # entry is added in part 3 alongside the receiver-UI WS
+    # commands so the model surface lands together.
+    REMOTE_BUILD_PAIR_REQUEST_RECEIVED = "remote_build_pair_request_received"
+
+    # A ``StoredPeer`` row's status changed. Payload:
+    # ``{dashboard_id, status: "approved" | "removed"}``. Fired
+    # by ``remote_build/approve_peer`` (status="approved") and by
+    # ``remote_build/remove_peer`` for previously-APPROVED rows
+    # (status="removed"). Removing a still-PENDING row is just
+    # rejection-as-cleanup and fires nothing; the row never
+    # represented an established trust relationship. Receiver
+    # Settings UI updates the inbox + approved-peers list on
+    # this event; in phase 4b-3 the offloader's polling loop
+    # observes the same flip via the offloader-side ``list_pool``
+    # WS command.
+    REMOTE_BUILD_PAIR_STATUS_CHANGED = "remote_build_pair_status_changed"
+
+    # Pairing window opened, extended, or closed. Payload:
+    # ``{open: bool, expires_in_seconds: float | None}``. Fires
+    # on every state transition: window open (open=true,
+    # expires_in_seconds=300), activity-driven extension
+    # (open=true, expires_in_seconds=300 again, deadline
+    # bumped), explicit close from the frontend (open=false,
+    # expires_in_seconds=null), or auto-close on deadline reach
+    # (open=false). The receiver frontend renders a live
+    # countdown from ``expires_in_seconds``; idempotent calls
+    # that don't change state (e.g. close-while-already-closed)
+    # do NOT fire the event.
+    REMOTE_BUILD_PAIRING_WINDOW_CHANGED = "remote_build_pairing_window_changed"
+
 
 class StreamEvent(StrEnum):
     """Per-stream frame names sent via ``WebSocketClient.send_event``.

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -214,6 +214,34 @@ class RemoteBuildSettingsView(DataClassORJSONMixin):
 
 
 @dataclass
+class PairingWindowState(DataClassORJSONMixin):
+    """
+    In-process pairing-window state on the receiver.
+
+    The pairing window narrows when ``intent="pair_request"``
+    Noise frames are even accepted: only while the receiver-side
+    Pairing requests screen is mounted. ``open`` is the boolean
+    state; ``expires_in_seconds`` is the remaining lifetime when
+    the window is open (``None`` when closed). The frontend
+    renders a live countdown from ``expires_in_seconds`` and
+    re-extends by calling ``remote_build/set_pairing_window``
+    with ``open=true`` on each activity-driven extend tick (one
+    call per 30s on the wire).
+
+    Wire shape for the ``set_pairing_window`` response and the
+    ``remote_build_pairing_window_changed`` event payload. Not
+    persisted; the deadline lives in
+    :attr:`RemoteBuildController._pairing_window_open_until`
+    only and resets on every dashboard restart (which is fine —
+    the receiver-side admin re-opens the screen after restart
+    and the window opens fresh).
+    """
+
+    open: bool
+    expires_in_seconds: float | None = None
+
+
+@dataclass
 class RemoteBuildPeer(DataClassORJSONMixin):
     """
     A peer dashboard known to this dashboard.

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -230,11 +230,13 @@ class PairingWindowState(DataClassORJSONMixin):
 
     Wire shape for the ``set_pairing_window`` response and the
     ``remote_build_pairing_window_changed`` event payload. Not
-    persisted; the deadline lives in
-    :attr:`RemoteBuildController._pairing_window_open_until`
-    only and resets on every dashboard restart (which is fine —
-    the receiver-side admin re-opens the screen after restart
-    and the window opens fresh).
+    persisted; the per-client extend timestamps live in
+    :attr:`RemoteBuildController._pairing_window_clients` and the
+    auto-close timer in
+    :attr:`RemoteBuildController._pairing_window_handle`. State
+    resets on every dashboard restart (which is fine; the
+    receiving dashboard's user re-opens the Pairing requests
+    screen after restart and the window opens fresh).
     """
 
     open: bool

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1650,7 +1650,10 @@ async def test_approve_peer_promotes_pending_to_approved(tmp_path: Path) -> None
     view = await controller.approve_peer(dashboard_id="alpha")
 
     assert view.peers[0].status == PeerStatus.APPROVED
-    settings = load_remote_build_settings(tmp_path)
+    # Hop the sync I/O off the loop so blockbuster doesn't flag it
+    # (the production path always goes through run_in_executor too).
+    loop = asyncio.get_running_loop()
+    settings = await loop.run_in_executor(None, load_remote_build_settings, tmp_path)
     assert settings.peers[0].status == PeerStatus.APPROVED
 
 
@@ -1933,17 +1936,51 @@ async def test_pairing_window_auto_closes_when_clients_age_out(
 
 
 @pytest.mark.asyncio
-async def test_stop_cancels_pairing_window_task(tmp_path: Path) -> None:
-    """``controller.stop()`` cleans up the auto-close task without leaking."""
+async def test_stop_cancels_pairing_window_handle(tmp_path: Path) -> None:
+    """``controller.stop()`` cleans up the auto-close TimerHandle."""
     controller = _make_controller(config_dir=tmp_path)
     controller._db.bus = MagicMock()
     await controller.set_pairing_window(open=True, client="tab-1")
-    task = controller._pairing_window_task
-    assert task is not None
-    assert task.done() is False
+    assert controller._pairing_window_handle is not None
 
     await controller.stop()
 
-    assert controller._pairing_window_task is None
-    assert task.done() is True
+    assert controller._pairing_window_handle is None
     assert controller.is_pairing_window_open() is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_close_cancels_handle_no_duplicate_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Explicit ``open=false`` cancels the auto-close handle.
+
+    Regression for a class of bug Copilot flagged on PR #476: an
+    explicit close left the deadline-fire handle running, which
+    would fire a SECOND ``REMOTE_BUILD_PAIRING_WINDOW_CHANGED``
+    close event when the original deadline lapsed (after a real
+    close had already fired one). The TimerHandle redesign makes
+    every set_pairing_window call cancel-and-reschedule, so the
+    explicit-close path leaves no stale handle behind.
+    """
+    monkeypatch.setattr(rb, "_PAIRING_WINDOW_DURATION_SECONDS", 0.1)
+
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    await controller.set_pairing_window(open=True, client="tab-1")
+    await controller.set_pairing_window(open=False, client="tab-1")
+    # Two events: open + close. After this point, the handle should
+    # be None (explicit close cancelled it; no replacement scheduled
+    # because the client map is empty).
+    assert controller._pairing_window_handle is None
+    initial_fire_count = controller._db.bus.fire.call_count
+    assert initial_fire_count == 2  # open + explicit close
+
+    # Wait past the original (now-cancelled) deadline. If the handle
+    # was leaked, it would fire a second close event here.
+    await asyncio.sleep(0.3)
+
+    assert controller._db.bus.fire.call_count == initial_fire_count
+    assert controller._pairing_window_handle is None

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1711,6 +1711,19 @@ async def test_approve_peer_rejects_invalid_dashboard_id(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_approve_peer_rejects_non_string_dashboard_id(tmp_path: Path) -> None:
+    """Non-string ``dashboard_id`` is rejected up front, not silently coerced."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await controller.approve_peer(dashboard_id=12345)  # type: ignore[arg-type]
+
+    assert exc.value.code is ErrorCode.INVALID_ARGS
+    controller._db.bus.fire.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_remove_peer_drops_pending_silently(tmp_path: Path) -> None:
     """Removing a PENDING peer is rejection-as-cleanup; no event fires."""
     controller = _make_controller(config_dir=tmp_path)

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from zeroconf import ServiceStateChange
 
+from esphome_device_builder.controllers import remote_build as rb
 from esphome_device_builder.controllers.config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
@@ -42,9 +43,11 @@ from esphome_device_builder.models import (
     EventType,
     IdentityView,
     ManualHost,
+    PeerStatus,
     RemoteBuildPeer,
     RemoteBuildPeerSource,
     RemoteBuildSettingsView,
+    StoredPeer,
     StoredToken,
     TokenSummary,
 )
@@ -1562,3 +1565,385 @@ async def test_rotate_identity_clears_in_flight_flag_on_failure(tmp_path: Path) 
     # Flag must be back to False; otherwise every subsequent
     # rotate attempt would 409 forever.
     assert controller._rotation_in_flight is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 4a-r1 part 3: peer CRUD + pairing window
+# ---------------------------------------------------------------------------
+
+
+def _stored_peer(
+    *,
+    dashboard_id: str = "alpha",
+    label: str = "alpha",
+    pin_sha256: str | None = None,
+    static_x25519_pub: bytes | None = None,
+    paired_at: float = 1_700_000_000.0,
+    status: PeerStatus = PeerStatus.PENDING,
+) -> StoredPeer:
+    """Construct a ``StoredPeer`` with sensible defaults for tests."""
+    pub = static_x25519_pub if static_x25519_pub is not None else _secrets.token_bytes(32)
+    pin = pin_sha256 if pin_sha256 is not None else hashlib.sha256(pub).hexdigest()
+    return StoredPeer(
+        dashboard_id=dashboard_id,
+        pin_sha256=pin,
+        static_x25519_pub=pub,
+        label=label,
+        paired_at=paired_at,
+        status=status,
+    )
+
+
+async def _seed_peer(config_dir: Path, peer: StoredPeer) -> None:
+    """Persist a single ``StoredPeer`` row under ``_remote_build.peers``."""
+    loop = asyncio.get_running_loop()
+
+    def _write() -> None:
+        with remote_build_settings_transaction(config_dir) as settings:
+            settings.peers.append(peer)
+
+    await loop.run_in_executor(None, _write)
+
+
+@pytest.mark.asyncio
+async def test_list_peers_returns_empty_when_none_stored(tmp_path: Path) -> None:
+    """List on a fresh dashboard returns an empty list, not an error."""
+    controller = _make_controller(config_dir=tmp_path)
+    assert await controller.list_peers() == []
+
+
+@pytest.mark.asyncio
+async def test_list_peers_returns_summary_for_each_row(tmp_path: Path) -> None:
+    """``list_peers`` projects every stored peer to ``PeerSummary``."""
+    controller = _make_controller(config_dir=tmp_path)
+    pending = _stored_peer(dashboard_id="pending", status=PeerStatus.PENDING)
+    approved = _stored_peer(dashboard_id="approved", status=PeerStatus.APPROVED)
+    await _seed_peer(tmp_path, pending)
+    await _seed_peer(tmp_path, approved)
+
+    rows = await controller.list_peers()
+
+    assert {row.dashboard_id for row in rows} == {"pending", "approved"}
+    statuses = {row.dashboard_id: row.status for row in rows}
+    assert statuses == {"pending": PeerStatus.PENDING, "approved": PeerStatus.APPROVED}
+
+
+@pytest.mark.asyncio
+async def test_list_peers_drops_static_x25519_pub_from_wire(tmp_path: Path) -> None:
+    """The wire summary must not expose raw ``static_x25519_pub`` bytes."""
+    controller = _make_controller(config_dir=tmp_path)
+    await _seed_peer(tmp_path, _stored_peer(static_x25519_pub=b"\xaa" * 32))
+
+    [row] = await controller.list_peers()
+
+    serialised = row.to_dict()
+    assert "static_x25519_pub" not in serialised
+    assert serialised["pin_sha256"]  # the wire-friendly form is present
+
+
+@pytest.mark.asyncio
+async def test_approve_peer_promotes_pending_to_approved(tmp_path: Path) -> None:
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await _seed_peer(tmp_path, _stored_peer(dashboard_id="alpha", status=PeerStatus.PENDING))
+
+    view = await controller.approve_peer(dashboard_id="alpha")
+
+    assert view.peers[0].status == PeerStatus.APPROVED
+    settings = load_remote_build_settings(tmp_path)
+    assert settings.peers[0].status == PeerStatus.APPROVED
+
+
+@pytest.mark.asyncio
+async def test_approve_peer_fires_pair_status_changed(tmp_path: Path) -> None:
+    """Approval fires ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` with status=approved."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await _seed_peer(tmp_path, _stored_peer(dashboard_id="alpha"))
+
+    await controller.approve_peer(dashboard_id="alpha")
+
+    fire = controller._db.bus.fire
+    fire.assert_called_once()
+    event_type, payload = fire.call_args.args
+    assert event_type is EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED
+    assert payload == {"dashboard_id": "alpha", "status": "approved"}
+
+
+@pytest.mark.asyncio
+async def test_approve_peer_unknown_returns_not_found(tmp_path: Path) -> None:
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await controller.approve_peer(dashboard_id="ghost")
+
+    assert exc.value.code is ErrorCode.NOT_FOUND
+    controller._db.bus.fire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_approve_peer_already_approved_returns_invalid_args(tmp_path: Path) -> None:
+    """Re-approving an already-APPROVED peer is rejected, not silently re-fired."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await _seed_peer(tmp_path, _stored_peer(dashboard_id="alpha", status=PeerStatus.APPROVED))
+
+    with pytest.raises(CommandError) as exc:
+        await controller.approve_peer(dashboard_id="alpha")
+
+    assert exc.value.code is ErrorCode.INVALID_ARGS
+    controller._db.bus.fire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_approve_peer_rejects_invalid_dashboard_id(tmp_path: Path) -> None:
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await controller.approve_peer(dashboard_id="has spaces!")
+
+    assert exc.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_remove_peer_drops_pending_silently(tmp_path: Path) -> None:
+    """Removing a PENDING peer is rejection-as-cleanup; no event fires."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await _seed_peer(tmp_path, _stored_peer(dashboard_id="alpha", status=PeerStatus.PENDING))
+
+    view = await controller.remove_peer(dashboard_id="alpha")
+
+    assert view.peers == []
+    controller._db.bus.fire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remove_peer_drops_approved_and_fires_event(tmp_path: Path) -> None:
+    """Removing an APPROVED peer is revocation; fires the removed event."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await _seed_peer(tmp_path, _stored_peer(dashboard_id="alpha", status=PeerStatus.APPROVED))
+
+    view = await controller.remove_peer(dashboard_id="alpha")
+
+    assert view.peers == []
+    fire = controller._db.bus.fire
+    fire.assert_called_once()
+    event_type, payload = fire.call_args.args
+    assert event_type is EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED
+    assert payload == {"dashboard_id": "alpha", "status": "removed"}
+
+
+@pytest.mark.asyncio
+async def test_remove_peer_keeps_other_rows(tmp_path: Path) -> None:
+    """``remove_peer`` only touches the matching dashboard_id."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await _seed_peer(tmp_path, _stored_peer(dashboard_id="keep"))
+    await _seed_peer(tmp_path, _stored_peer(dashboard_id="drop"))
+
+    view = await controller.remove_peer(dashboard_id="drop")
+
+    assert {peer.dashboard_id for peer in view.peers} == {"keep"}
+
+
+@pytest.mark.asyncio
+async def test_remove_peer_unknown_returns_not_found(tmp_path: Path) -> None:
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await controller.remove_peer(dashboard_id="ghost")
+
+    assert exc.value.code is ErrorCode.NOT_FOUND
+    controller._db.bus.fire.assert_not_called()
+
+
+# --- pairing window ---
+
+
+@pytest.mark.asyncio
+async def test_pairing_window_starts_closed(tmp_path: Path) -> None:
+    controller = _make_controller(config_dir=tmp_path)
+    assert controller.is_pairing_window_open() is False
+
+
+@pytest.mark.asyncio
+async def test_set_pairing_window_open_opens_and_fires(tmp_path: Path) -> None:
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    state = await controller.set_pairing_window(open=True, client="tab-1")
+
+    assert state.open is True
+    assert state.expires_in_seconds is not None
+    assert 0 < state.expires_in_seconds <= 300.0
+    assert controller.is_pairing_window_open() is True
+    fire = controller._db.bus.fire
+    fire.assert_called_once()
+    event_type, payload = fire.call_args.args
+    assert event_type is EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED
+    assert payload["open"] is True
+    assert payload["expires_in_seconds"] is not None
+
+    # cleanup the auto-close task so the test loop can exit
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_set_pairing_window_close_closes_and_fires(tmp_path: Path) -> None:
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await controller.set_pairing_window(open=True, client="tab-1")
+    controller._db.bus.fire.reset_mock()
+
+    state = await controller.set_pairing_window(open=False, client="tab-1")
+
+    assert state.open is False
+    assert state.expires_in_seconds is None
+    assert controller.is_pairing_window_open() is False
+    fire = controller._db.bus.fire
+    fire.assert_called_once()
+    event_type, payload = fire.call_args.args
+    assert event_type is EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED
+    assert payload == {"open": False, "expires_in_seconds": None}
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_set_pairing_window_close_while_already_closed_is_silent(tmp_path: Path) -> None:
+    """A close from a client that wasn't extending must not fire."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    state = await controller.set_pairing_window(open=False, client="tab-1")
+
+    assert state.open is False
+    controller._db.bus.fire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_pairing_window_extend_refreshes_deadline_and_fires(tmp_path: Path) -> None:
+    """Repeat ``open=true`` extends the deadline AND fires the event."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    first = await controller.set_pairing_window(open=True, client="tab-1")
+    # tiny sleep so the second extend's deadline is strictly later than the first's
+    await asyncio.sleep(0.01)
+    second = await controller.set_pairing_window(open=True, client="tab-1")
+
+    assert first.expires_in_seconds is not None
+    assert second.expires_in_seconds is not None
+    # Both fires landed (open + extend); both events have open=True.
+    assert controller._db.bus.fire.call_count == 2
+    for call in controller._db.bus.fire.call_args_list:
+        _, payload = call.args
+        assert payload["open"] is True
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_pairing_window_two_clients_refcount(tmp_path: Path) -> None:
+    """Two tabs / two users: window stays open until the LAST client closes."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    await controller.set_pairing_window(open=True, client="tab-A")
+    await controller.set_pairing_window(open=True, client="tab-B")
+    assert controller.is_pairing_window_open() is True
+
+    # Tab A graceful close: tab B is still extending → window must stay open.
+    await controller.set_pairing_window(open=False, client="tab-A")
+    assert controller.is_pairing_window_open() is True
+
+    # Tab B graceful close: now no clients are extending → window closes.
+    await controller.set_pairing_window(open=False, client="tab-B")
+    assert controller.is_pairing_window_open() is False
+
+    # Three events: open (tab A), extend (tab B opens, fires too), close (tab B unsets).
+    # Tab A's close was non-state-changing (tab B still extending) → no fire.
+    fire_calls = controller._db.bus.fire.call_args_list
+    open_states = [call.args[1]["open"] for call in fire_calls]
+    assert open_states == [True, True, False]
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_pairing_window_close_from_non_extender_does_not_fire(tmp_path: Path) -> None:
+    """A spurious open=False from a client that wasn't extending is a no-op."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await controller.set_pairing_window(open=True, client="tab-A")
+    controller._db.bus.fire.reset_mock()
+
+    # tab-B never called open=true; its close call is a no-op.
+    await controller.set_pairing_window(open=False, client="tab-B")
+
+    assert controller.is_pairing_window_open() is True
+    controller._db.bus.fire.assert_not_called()
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_set_pairing_window_rejects_non_bool(tmp_path: Path) -> None:
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await controller.set_pairing_window(open="yes", client="tab-1")  # type: ignore[arg-type]
+
+    assert exc.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_pairing_window_auto_closes_when_clients_age_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The window auto-closes when every client's last-extend ages past the duration."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    # Patch the duration to ~0 so the auto-close fires almost immediately.
+    monkeypatch.setattr(rb, "_PAIRING_WINDOW_DURATION_SECONDS", 0.05)
+
+    await controller.set_pairing_window(open=True, client="tab-1")
+    assert controller.is_pairing_window_open() is True
+    controller._db.bus.fire.reset_mock()
+
+    # Wait for the deadline to lapse + a hair for the task to settle.
+    await asyncio.sleep(0.2)
+
+    assert controller.is_pairing_window_open() is False
+    # An auto-close event fired (open=False).
+    fire = controller._db.bus.fire
+    assert fire.call_count >= 1
+    last_event_type, last_payload = fire.call_args.args
+    assert last_event_type is EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED
+    assert last_payload["open"] is False
+
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_pairing_window_task(tmp_path: Path) -> None:
+    """``controller.stop()`` cleans up the auto-close task without leaking."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    await controller.set_pairing_window(open=True, client="tab-1")
+    task = controller._pairing_window_task
+    assert task is not None
+    assert task.done() is False
+
+    await controller.stop()
+
+    assert controller._pairing_window_task is None
+    assert task.done() is True
+    assert controller.is_pairing_window_open() is False

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1844,17 +1844,42 @@ async def test_set_pairing_window_close_while_already_closed_is_silent(tmp_path:
 
 @pytest.mark.asyncio
 async def test_set_pairing_window_extend_refreshes_deadline_and_fires(tmp_path: Path) -> None:
-    """Repeat ``open=true`` extends the deadline AND fires the event."""
+    """
+    Repeat ``open=true`` advances the client's timestamp and fires the event.
+
+    The load-bearing invariant the whole multi-tab UX rests on:
+    extending must move the per-client timestamp forward, not
+    just observe it. A regression where extend is silently
+    skipped for already-extending clients (e.g. an
+    "if client not in clients: clients[client] = now" guard
+    instead of "clients[client] = now") would still leave the
+    window technically "open" with the old deadline; the
+    TimerHandle would auto-close 5 minutes after the first
+    extend instead of 5 after the latest user activity. Pin
+    the actual timestamp advance so a guard like that fails
+    here, not in production.
+    """
     controller = _make_controller(config_dir=tmp_path)
     controller._db.bus = MagicMock()
 
     first = await controller.set_pairing_window(open=True, client="tab-1")
-    # tiny sleep so the second extend's deadline is strictly later than the first's
+    first_extend_ts = controller._pairing_window_clients["tab-1"]
+    # tiny sleep so the second extend's monotonic timestamp is
+    # strictly later than the first's (microsecond resolution
+    # makes 10ms reliably non-flaky)
     await asyncio.sleep(0.01)
     second = await controller.set_pairing_window(open=True, client="tab-1")
+    second_extend_ts = controller._pairing_window_clients["tab-1"]
 
     assert first.expires_in_seconds is not None
     assert second.expires_in_seconds is not None
+    # The actual extend invariant: the second call advanced the
+    # client's last-extend timestamp. Without this assertion,
+    # a silent extend-is-a-no-op regression would still pass
+    # the rest of the test (window is "open", events fired,
+    # both payloads carry open=True) while breaking the
+    # multi-tab UX.
+    assert second_extend_ts > first_extend_ts
     # Both fires landed (open + extend); both events have open=True.
     assert controller._db.bus.fire.call_count == 2
     for call in controller._db.bus.fire.call_args_list:


### PR DESCRIPTION
# What does this implement/fix?

Third slice of phase 4a-r1 from #106's auth-model pivot. Adds the receiver-side admin's WS surface for the post-pivot pairing flow: peer CRUD (`list_peers` / `approve_peer` / `remove_peer`) plus the in-process pairing window (`set_pairing_window`) from issue #106 design choice (c). The peer-link listener that creates PENDING `StoredPeer` rows lands in part 4; this slice ships the controller methods + event types so the frontend (4b-2) can build against a stable API.

## What's in this PR

**WS commands** (all decorated with `@api_command`, auto-routed via the existing `collect_api_commands` dispatcher):

- `remote_build/list_peers` — projects every `StoredPeer` to `PeerSummary`, dropping the raw `static_x25519_pub` bytes. Wire view contains `dashboard_id` / `pin_sha256` / `label` / `paired_at` / `status`.
- `remote_build/approve_peer({dashboard_id})` — flips `PENDING` → `APPROVED`, fires `REMOTE_BUILD_PAIR_STATUS_CHANGED` with `status="approved"`. `NOT_FOUND` when no peer matches; `INVALID_ARGS` when the peer is already `APPROVED` (a re-Accept click is almost always a UI race and silently re-firing would mislead the offloader's polling loop).
- `remote_build/remove_peer({dashboard_id})` — deletes the row. Removing `PENDING` is rejection-as-cleanup (no event; the row never represented established trust). Removing `APPROVED` is revocation; fires `REMOTE_BUILD_PAIR_STATUS_CHANGED` with `status="removed"` so the offloader's polling loop can surface a `peer_revoked` alert in 4b-3.
- `remote_build/set_pairing_window({open: bool})` — see below.

**Pairing window** (refcounted, multi-client-safe):

- Each `open=true` adds (or refreshes) the calling WS client's entry in an in-process map; `open=false` removes it. The window is open iff any client has a non-stale entry; deadline is `latest-extend + 300s` (5min default).
- **Multi-tab / multi-user safe.** Window stays open as long as anyone is extending. The user's question while reviewing: "what if there are two people with the dashboard UI open at the same time?" The naive single-client implementation would have closed the window when the first user navigated away even though the second was still on the screen. Refcount fixes this. Crashed tabs (no graceful `open=false`) age out via the same 300s timeout, so no per-client disconnect hook is needed.
- **Extend semantics.** The frontend calls `open=true` on screen-mount, on each activity-driven extend tick (debounced to once per 30s on the wire), and on an explicit "extend" / "still pairing?" button click. All three paths are the same wire call; no separate "extend" command.
- **Event firing.** `REMOTE_BUILD_PAIRING_WINDOW_CHANGED` fires on every state transition AND on every successful extend (the frontend's live countdown needs the bumped deadline). Idempotent calls that don't change state (`open=false`-while-closed, `open=false` from a non-extending client while another client still extends) do NOT fire.
- **Auto-close.** `_run_pairing_window_task` wakes at the latest deadline; on wake it prunes stale entries and either re-sleeps (someone extended) or fires the close event. One task handles arbitrary numbers of extensions across all clients.

**`is_pairing_window_open()`** is the public utility part 4's peer-link listener calls before accepting an `intent="pair_request"` Noise frame. A closed window rejects with `intent_response=no_pairing_window` and closes the WS without creating a row.

**EventType entries** (in `models/common.py`): two of these fire from this slice; the third is added now so the model surface lands together.

- `REMOTE_BUILD_PAIR_STATUS_CHANGED` — fired by `approve_peer` (status=approved) and `remove_peer` of `APPROVED` rows (status=removed).
- `REMOTE_BUILD_PAIRING_WINDOW_CHANGED` — fired by `set_pairing_window` and the auto-close task.
- `REMOTE_BUILD_PAIR_REQUEST_RECEIVED` — emitter is part 4's listener; entry added in this PR so the model surface is complete.

**`PairingWindowState` model** (in `models/remote_build.py`): wire shape for the `set_pairing_window` response and the `pairing_window_changed` event payload. `{open: bool, expires_in_seconds: float | None}`.

**Drive-by fix:** `_to_view` now projects the `peers` list to `PeerSummary`. The view's `peers` field already existed (added in #472) but no caller was routing the projection through here yet.

## Tests

22 new tests in `tests/test_remote_build_controller.py` (126 total, all green):

- `list_peers`: empty / projection / summary-doesn't-leak-pubkey-bytes
- `approve_peer`: happy-path / event-fires / NOT_FOUND / INVALID_ARGS-when-already-approved / INVALID_ARGS-on-bad-id
- `remove_peer`: pending-no-event / approved-fires-removed-event / multi-row / NOT_FOUND
- `pairing_window`: starts-closed / open-fires / close-fires / close-while-closed-silent / extend-refreshes-and-fires / **two-clients-refcount** / non-extender-close-silent / non-bool-rejected / auto-close-on-deadline / stop-cancels-task

The two-clients refcount test is the load-bearing one for the multi-tab case: it pins the contract that user A's `open=false` doesn't close the window when user B is still extending, AND that user B's eventual `open=false` does.

## Types of changes

- [ ] Bugfix
- [x] New feature — `new-feature`
- [ ] Enhancement
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation only
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump

## Frontend coordination

- [x] No frontend change needed in this PR; the WS surface is intended for 4b-2 (receiver UI inbox) which is separately tracked.

## Checklist

- [x] Code change tested and works locally.
- [x] Pre-commit hooks pass.
- [x] Tests added: 22 new in `tests/test_remote_build_controller.py`.
- [x] `components.json` has not been hand-edited.

## Notes for reviewers

- **No persistent state** for the pairing window. Lives in-memory only; resets on dashboard restart. That's correct: the receiver-side admin re-opens the screen after restart and the window opens fresh, which is the desired user-visible outcome anyway. Persisting it would just be a footgun.
- **No new disconnect hook.** The pairing window doesn't need to know when a WS client disconnects: the 300s idle timeout aged-out a crashed tab without any plumbing. A per-client disconnect hook would tighten the auto-close window (5min → 0s on disconnect) but adds a hook surface the rest of the controller doesn't need.
- **The dispatcher injects `client=self`** as a kwarg on every command call. The pairing window methods consume it via `kwargs.get("client")` and use it as the dict key. Tests pass arbitrary `client="tab-A"` strings to simulate multiple clients.
- **`open` shadows the Python builtin** in the `set_pairing_window` signature; suppressed with `# noqa: A002` because the wire format names the field `open` and renaming the kwarg to `is_open` would break the dispatcher's `**args` unpacking. The shadowing is safe within the method's scope (the function never calls `open()`).

## Related

- Tracking issue: esphome/device-builder#106 (phase 4a-r1 part 3)
- Depends on: esphome/device-builder#472 (Noise framing helper + StoredPeer model, merged)
- Depends on: esphome/device-builder#473 (X25519 identity helper, merged)
- Unblocks: phase 4a-r1 part 4 (peer-link listener + Noise dispatch on `intent`); phase 4b-2 (receiver UI pairing-requests inbox).
