### PR TITLE
Document the TypedDict event-payload pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,23 @@ in case anything has resurfaced.
 - **WS-first API.** Real-time updates are the default — clients
   `subscribe_events` once and get pushes. REST is only kept for HA
   backward compat in `api/legacy.py`.
+- **Event payloads use TypedDict, not dataclass.** Mirrors
+  Home Assistant core's `EventStateChangedData` /
+  `EventStateReportedData` pattern. The wire shape stays
+  `dict[str, Any]` because `EventBus.fire`'s signature is
+  generic; each event-specific shape gets a `TypedDict`
+  declaration next to the controller that fires it (e.g.
+  `RemoteBuildPairRequestReceivedData` in
+  `models/remote_build.py`). Call sites build
+  `payload: SomeEventData = {...}` before
+  `bus.fire(EventType.X, payload)` so type checkers validate the
+  keys without changing the wire serialisation. Subscribers that
+  want the same view annotate `data: SomeEventData = event.data`
+  on the receive side. See `docs/ARCHITECTURE.md` "Event bus →
+  Typing event payloads" for the full rationale (why TypedDict
+  vs dataclass; how it interacts with `helpers.json.dumps`).
+  Older payloads fired with raw dicts predate this convention;
+  new events should ship with a TypedDict from day one.
 - **Persistent firmware queue.** One job runs at a time; queue +
   output buffers survive restarts. See `controllers/firmware.py`.
 - **Component catalog is generated**, not hand-edited. Source is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,52 @@ esphome_device_builder/
 | RemoteBuild | mDNS browse + manual host entry + token store + first-use binding for the remote-build offload feature (issue #106) |
 | Built-in | ping, subscribe_events |
 
+## Event bus
+
+In-process pub/sub, owned by `DeviceBuilder.bus` (an `EventBus` from `helpers/event_bus`). Controllers fire events on state transitions; WS commands subscribe via `subscribe_events` and stream them to connected clients. Event types are declared in `models/common.py` as `EventType(StrEnum)` members; the bus accepts `(event_type, data: dict[str, Any])`.
+
+### Typing event payloads
+
+Mirrors Home Assistant core's `EventStateChangedData` / `EventStateReportedData` pattern: the wire shape stays a `dict[str, Any]` (so `EventBus.fire`'s signature stays generic, JSON serialisation is direct, and the bus doesn't need to know about every event's fields), but each event-specific dict shape is declared as a `TypedDict` next to the controller that fires it.
+
+Concretely, in `models/remote_build.py`:
+
+```python
+class RemoteBuildPairRequestReceivedData(TypedDict):
+    dashboard_id: str
+    pin_sha256: str
+    label: str
+    peer_ip: str
+```
+
+And the call site builds the typed dict before firing:
+
+```python
+payload: RemoteBuildPairRequestReceivedData = {
+    "dashboard_id": dashboard_id,
+    "pin_sha256": pin_sha256,
+    "label": label,
+    "peer_ip": peer_ip,
+}
+self._db.bus.fire(EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED, payload)
+```
+
+Type checkers see the dict's keys + value types; subscribers that want the same view annotate the receive side:
+
+```python
+def _on_pair_request(event: Event) -> None:
+    data: RemoteBuildPairRequestReceivedData = event.data
+    ...
+```
+
+`TypedDict` rather than `@dataclass` because:
+
+- The wire shape is a `dict`, not a class instance. `TypedDict` matches the runtime shape; `@dataclass` would need an `asdict()` step on every fire.
+- Subscribers that ride the existing `subscribe_events` WS plumbing serialise the payload through `helpers.json.dumps` (orjson), which handles `dict` natively.
+- It mirrors HA's convention so contributors moving between this codebase and HA find the same pattern.
+
+Older event payloads (e.g. `REMOTE_BUILD_BINDING_MISMATCH`'s, fired with `asdict(BindingMismatch)`) predate this convention and get the typed treatment as they're touched. New events should ship with a TypedDict from day one.
+
 ## Firmware Job Queue
 
 Jobs are persistent, event-driven, and decoupled from WebSocket connections:


### PR DESCRIPTION
# What does this implement/fix?

Adds documentation for the typed-event-payload convention introduced in PR #479's type-discipline pass. New events should ship with a `TypedDict` declaration next to their controller (mirroring Home Assistant core's `EventStateChangedData` / `EventStateReportedData` pattern); call sites build `payload: SomeEventData = {...}` before `bus.fire(EventType.X, payload)` so type checkers validate the dict keys without changing the wire shape.

## What changed

* **`docs/ARCHITECTURE.md`** gains a new top-level "Event bus" section between Controllers and Firmware Job Queue. Covers the in-process pub/sub shape (`EventBus` ownership, controller-fires + WS-subscribes pattern) and a "Typing event payloads" subsection with the TypedDict pattern, a worked example using `RemoteBuildPairRequestReceivedData`, and the rationale for TypedDict over dataclass:
  - The wire shape is a `dict`, not a class instance — TypedDict matches the runtime shape; dataclass would need an `asdict()` step on every fire.
  - Subscribers ride `helpers.json.dumps` (orjson), which serialises dicts natively.
  - Mirrors HA's convention so contributors moving between this codebase and HA see the same pattern.
* **`CLAUDE.md`** gains a sibling bullet under "Architecture conventions worth knowing" so the rule's at the top of any future event-firing change. Points at the ARCHITECTURE section for the full rationale.
* No code change. Doesn't backfill the older payloads (`REMOTE_BUILD_BINDING_MISMATCH` fires `asdict(BindingMismatch)`; `REMOTE_BUILD_IDENTITY_ROTATED` fires a raw dict). The convention documented here is "new events ship with a TypedDict from day one"; older ones get the treatment as they're touched.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation only — `docs`
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump

## Frontend coordination

- [x] No frontend change needed.

## Related

- Pattern introduced in: esphome/device-builder#479 (phase 4a-r1 part 4 type-discipline pass).
- Models touched in #479: `RemoteBuildPairRequestReceivedData`, `RemoteBuildPairStatusChangedData`, `RemoteBuildPairingWindowChangedData`.
