### PR TITLE
ci: enable mypy as an advisory CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,19 @@ jobs:
       - name: Smoke-test component catalog
         run: python script/check_catalog.py
 
+      - name: Type-check (mypy, advisory)
+        # Mypy is configured strict in ``pyproject.toml``
+        # (``disallow_untyped_defs``, ``disallow_incomplete_defs``,
+        # ``warn_return_any``) but the existing codebase wasn't
+        # mypy-clean at the point this gate landed. Run it as
+        # **advisory** for now (``continue-on-error: true``) so
+        # the report shows up in PR checks without blocking
+        # merges, and contributors get a baseline they can
+        # ratchet down. Flip to a hard gate once the standing
+        # error count hits zero.
+        continue-on-error: true
+        run: mypy esphome_device_builder
+
   test:
     name: Pytest (${{ matrix.os }} / Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
   "pytest-cov==7.1.0",
   "pytest-xdist==3.8.0",
   "ruff==0.15.12",
+  "types-PyYAML",
 ]
 
 [project.urls]


### PR DESCRIPTION
# What does this implement/fix?

Mypy is already configured strict in `pyproject.toml`
(`disallow_untyped_defs`, `disallow_incomplete_defs`,
`warn_return_any`, etc.) but no CI step ran it — a PR with
type errors merged cleanly. This PR turns the report on as
an **advisory** step so the existing baseline becomes
visible.

## What's wired up

- **New `mypy esphome_device_builder` step** in the `Lint +
  smoke checks` job, sitting after the existing
  pre-commit / definition-validator / catalog-smoke steps.
- **`types-PyYAML` added to the `test` extras** so the
  baseline run isn't itself producing legitimate
  stub-resolution errors.

## Advisory-only ("see what breaks") — for now

`continue-on-error: true` on the new step. Reasons:

- The existing codebase has **27 pre-existing errors across 12
  files** at the moment this lands. Hard-gating now would
  block the PR on a cleanup unrelated to anything CI was
  previously checking.
- Advisory surfaces the report in PR checks so contributors
  see what they're introducing without blocking the rest of
  the pipeline. The standing error count becomes a ratchet.
- Flip to a hard gate (drop `continue-on-error`) once the
  count hits zero — either by fixing each error or by adding
  `# type: ignore[code]` markers with a one-line reason.

## Categories the 27 baseline errors split into

For follow-up planning:

| Category | Approx count | Notes |
|---|---:|---|
| Real type holes (None-narrowing, `int(object)`, generator type mismatch) | ~6 | Worth fixing in code. |
| `EventBus.fire` typed-payload mismatch | 3 | Widening the bus signature is one focused change. |
| Library-induced `Any` returns (aiohttp, esphome, yaml.safe_load) | ~12 | `cast(...)` or `assert isinstance` at the boundary. |
| Stdlib annotation gaps (`sys.exc_info()` for `logger.exception(exc_info=...)`, `AbstractServer.sockets`) | 3 | `# type: ignore[arg-type]` / `# type: ignore[attr-defined]` with a comment. |
| Module-load redef (`_ESPHOME_RP2040_BOARDS` in try/except ImportError block) | 1 | Annotation tweak. |
| `_resolve_packages` Any-typed call | 2 | `cast(...)` at the call site. |

The first follow-up PR can tackle whichever category is
highest-leverage. The bus-payload one is probably the most
useful — it pins the typed `RemoteBuildPair*Data` shapes the
remote-build phase 4 work depends on.

## Not changed

- Mypy's config (already strict — no need to touch
  `[tool.mypy]`).
- The existing pre-commit hooks (mypy stays a CI-only step
  for now; adding it pre-commit would slow every local
  `git commit` by ~1s and is questionable value while
  advisory).

**Related issue or feature (if applicable):**

- N/A — infra hardening.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
