### PR TITLE
Address late Copilot review on PR #480

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,21 +124,22 @@ in case anything has resurfaced.
   backward compat in `api/legacy.py`.
 - **Event payloads use TypedDict, not dataclass.** Mirrors
   Home Assistant core's `EventStateChangedData` /
-  `EventStateReportedData` pattern. The wire shape stays
-  `dict[str, Any]` because `EventBus.fire`'s signature is
-  generic; each event-specific shape gets a `TypedDict`
-  declaration next to the controller that fires it (e.g.
-  `RemoteBuildPairRequestReceivedData` in
+  `EventStateReportedData` pattern. Each event-specific shape
+  gets a `TypedDict` declaration next to the controller that
+  fires it (e.g. `RemoteBuildPairRequestReceivedData` in
   `models/remote_build.py`). Call sites build
-  `payload: SomeEventData = {...}` before
-  `bus.fire(EventType.X, payload)` so type checkers validate the
-  keys without changing the wire serialisation. Subscribers that
-  want the same view annotate `data: SomeEventData = event.data`
-  on the receive side. See `docs/ARCHITECTURE.md` "Event bus →
+  `payload: SomeEventData = {...}` then
+  `bus.fire(EventType.X, payload)` — type checkers validate the
+  keys at construction. `EventBus.fire` and `Event.data` use
+  `Mapping[str, Any]` (not `dict[str, Any]`) so TypedDicts pass
+  through without `cast()`; subscribers consume via
+  `event.data.get(...)` since none of them needs the full
+  TypedDict view today. See `docs/ARCHITECTURE.md` "Event bus →
   Typing event payloads" for the full rationale (why TypedDict
-  vs dataclass; how it interacts with `helpers.json.dumps`).
-  Older payloads fired with raw dicts predate this convention;
-  new events should ship with a TypedDict from day one.
+  vs dataclass; why we use `Mapping` rather than HA's fully
+  generic `Event[_DataT]`). Older payloads fired with raw dicts
+  predate this convention; new events should ship with a
+  TypedDict from day one.
 - **Persistent firmware queue.** One job runs at a time; queue +
   output buffers survive restarts. See `controllers/firmware.py`.
 - **Component catalog is generated**, not hand-edited. Source is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,11 +73,11 @@ esphome_device_builder/
 
 ## Event bus
 
-In-process pub/sub, owned by `DeviceBuilder.bus` (an `EventBus` from `helpers/event_bus`). Controllers fire events on state transitions; WS commands subscribe via `subscribe_events` and stream them to connected clients. Event types are declared in `models/common.py` as `EventType(StrEnum)` members; the bus accepts `(event_type, data: dict[str, Any])`.
+In-process pub/sub, owned by `DeviceBuilder.bus` (an `EventBus` from `helpers/event_bus`). Controllers fire events on state transitions; WS commands subscribe via `subscribe_events` and stream them to connected clients. Event types are declared in `models/common.py` as `EventType(StrEnum)` members; the bus signature is `fire(event_type, data: Mapping[str, Any] | None)`.
 
 ### Typing event payloads
 
-Mirrors Home Assistant core's `EventStateChangedData` / `EventStateReportedData` pattern: the wire shape stays a `dict[str, Any]` (so `EventBus.fire`'s signature stays generic, JSON serialisation is direct, and the bus doesn't need to know about every event's fields), but each event-specific dict shape is declared as a `TypedDict` next to the controller that fires it.
+Mirrors Home Assistant core's `EventStateChangedData` / `EventStateReportedData` pattern: the wire shape stays a `dict`, but each event-specific shape is declared as a `TypedDict` next to the controller that fires it so type checkers validate the keys at the construction site.
 
 Concretely, in `models/remote_build.py`:
 
@@ -89,7 +89,7 @@ class RemoteBuildPairRequestReceivedData(TypedDict):
     peer_ip: str
 ```
 
-And the call site builds the typed dict before firing:
+The call site builds the typed dict before firing:
 
 ```python
 payload: RemoteBuildPairRequestReceivedData = {
@@ -101,13 +101,7 @@ payload: RemoteBuildPairRequestReceivedData = {
 self._db.bus.fire(EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED, payload)
 ```
 
-Type checkers see the dict's keys + value types; subscribers that want the same view annotate the receive side:
-
-```python
-def _on_pair_request(event: Event) -> None:
-    data: RemoteBuildPairRequestReceivedData = event.data
-    ...
-```
+`EventBus.fire` (and `Event.data`) takes `Mapping[str, Any]` rather than `dict[str, Any]` so a `TypedDict` flows through without a `cast()` — `TypedDict` is structurally compatible with a read-only `Mapping`, and every consumer in the codebase reads via `event.data.get(...)` / `event.data["k"]` rather than mutating. Home Assistant goes one step further with a fully generic `Event[_DataT]` / `EventType[_DataT]` so subscribers also get a typed `event.data`; we don't need that depth, since no subscriber annotates `event.data` as a `TypedDict` today — they all just `.get()` the key they care about.
 
 `TypedDict` rather than `@dataclass` because:
 

--- a/esphome_device_builder/helpers/event_bus.py
+++ b/esphome_device_builder/helpers/event_bus.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Iterable, Iterator
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from functools import partial
@@ -25,10 +25,22 @@ _DEFAULT_STREAM_QUEUE_MAX = 4000
 
 @dataclass
 class Event:
-    """A device builder event."""
+    """
+    A device builder event.
+
+    ``data`` is typed as a read-only :class:`Mapping` so per-event
+    :class:`TypedDict` payloads are accepted at the fire site
+    without a ``cast()``. ``TypedDict`` is structurally compatible
+    with ``Mapping[str, Any]`` (read-only access), which is all
+    subscribers ever do — every ``event.data`` reference in the
+    codebase is a ``.get(...)`` or ``[key]`` lookup, never a
+    mutation. Mirrors HA's ``Event[_DataT]`` pattern's *result*
+    (typed access without casts) without paying for the full
+    generic infrastructure HA needs in core.
+    """
 
     event_type: EventType
-    data: dict[str, Any]
+    data: Mapping[str, Any]
 
 
 class EventBus:
@@ -47,8 +59,16 @@ class EventBus:
     def _remove_listener(self, event_type: EventType, listener: Callable[[Event], None]) -> None:
         self._listeners.get(event_type, set()).discard(listener)
 
-    def fire(self, event_type: EventType, data: dict[str, Any] | None = None) -> None:
-        """Fire an event to all listeners."""
+    def fire(self, event_type: EventType, data: Mapping[str, Any] | None = None) -> None:
+        """
+        Fire an event to all listeners.
+
+        ``data`` is :class:`Mapping[str, Any]` so per-event
+        :class:`TypedDict` payloads pass through without a cast —
+        ``payload: SomeEventData = {...}; bus.fire(EventType.X,
+        payload)`` type-checks. See :class:`Event` for the rest
+        of the rationale.
+        """
         event = Event(event_type, data or {})
         for listener in list(self._listeners.get(event_type, set())):
             try:

--- a/tests/test_remote_build_listener.py
+++ b/tests/test_remote_build_listener.py
@@ -1,22 +1,31 @@
 """
-End-to-end TLS verification of the phase-3b2 remote-build HTTPS site.
+Listener lifecycle + dormant bearer-auth tests for the remote-build feature.
 
-Covers the auth + listener wiring for the receiver site:
+Two layers of coverage:
 
-* A strict-TLS aiohttp client gets 401 without a valid bearer
-  and 200 with one (real handshake against the cert + key from
-  phase 3a, real auth middleware from phase 3b2 against the
-  token store from phase 3b1).
-* The lifecycle hook ``_maybe_start_remote_build_site``
-  default-skips when ``enabled=False``, binds when
-  ``enabled=True``, fails-soft on bind error, advertises the
-  OS-assigned port for ephemeral binds, and warns on
-  HA-addon mode.
-* The strip-Server-header middleware removes aiohttp's default
-  banner from on-the-wire responses.
+* **Listener lifecycle (live)** — exercises the real
+  :func:`DeviceBuilder._maybe_start_remote_build_site` and
+  :func:`DeviceBuilder.reload_remote_build_identity` hooks.
+  Default-skip when ``enabled=False``; bind when
+  ``enabled=True``; fail-soft on bind error; advertise the
+  OS-assigned port for ephemeral binds; warn on HA-addon mode;
+  rebuild the listener (now serving the peer-link Noise WS at
+  ``/remote-build/peer-link``) on identity rotation. These
+  tests stay relevant post-pivot because the lifecycle hook
+  now binds the Noise WS rather than the old HTTPS site.
+* **Dormant HTTPS+bearer auth (phase 4a-r2 tear-out)** —
+  stands up an inline aiohttp HTTPS app that mirrors the
+  pre-pivot ``/remote-build/v1/health`` route + bearer
+  middleware so the auth-middleware unit + binding-mismatch
+  event-fire surface stay covered until issue #106 phase
+  4a-r2 deletes the bearer machinery wholesale. The tests'
+  inline setup decouples them from production wiring; this
+  file flagging itself as the home for "dormant pre-pivot
+  bearer code" makes the 4a-r2 deletion easier to land.
 
-Pin-vs-observed-cert verification is the pairing flow's job
-(phase 4) and isn't exercised here.
+Pin-vs-handshake verification is the pairing flow's job
+(``test_remote_build_peer_link.py``); the dormant tests here
+don't exercise the post-pivot Noise WS at all.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
# What does this implement/fix?

Two real issues Copilot raised on the merged docs PR (#480):

1. **The TypedDict event-payload pattern didn't actually type-check.**
   `EventBus.fire(data: dict[str, Any])` rejects TypedDict
   arguments under mypy; the worked example in the docs would
   produce errors if anyone ran the type checker.
2. **Receive-side annotation needed a `cast()`** — silently broken
   guidance.

Fix the API rather than the docs: widen `EventBus.fire`'s `data`
parameter and `Event.data` from `dict[str, Any]` to
`Mapping[str, Any]`. TypedDict is structurally compatible with
read-only `Mapping`, so `payload: SomeEventData = {...};
bus.fire(EventType.X, payload)` now type-checks without a
`cast()`. Mypy on `controllers/remote_build.py` (which has the
three TypedDict fire sites) now passes clean (was 3 errors
pre-fix).

Casts aren't free — they add visual noise at every call site and
need updating when types change. The Mapping widening costs
nothing at runtime, no call sites change, and consumers already
treat `event.data` as read-only (every reference is
`.get(...)` / `[key]`, never mutation).

Home Assistant goes one step further with a fully generic
`Event[_DataT]` / `EventType[_DataT]` so subscribers also get a
typed `event.data`. We don't need that depth — no subscriber
annotates `event.data` as a TypedDict today; ARCHITECTURE.md
now mentions the HA-style generic upgrade as a future option.

Also renames `tests/test_remote_build_https_site.py` →
`tests/test_remote_build_listener.py`. The file's listener-
lifecycle tests now exercise the peer-link Noise WS bind
(post-#479 pivot); the dormant HTTPS+bearer-auth tests inside
it are flagged for the phase 4a-r2 cleanup. The "https" in the
old name was misleading after the pivot.

**Related issue or feature (if applicable):**

- follow-up to #480
- builds on #479

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable. (No new tests; existing 2408 still pass + mypy clean on the touched module.)
- [x] `components.json` has **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
