### PR TITLE
mypy: cast async_resolve at the icmplib boundary

### DIFF
--- a/esphome_device_builder/controllers/_dns_cache.py
+++ b/esphome_device_builder/controllers/_dns_cache.py
@@ -22,6 +22,7 @@ import logging
 import time
 from contextlib import suppress
 from ipaddress import ip_address
+from typing import cast
 
 try:
     from icmplib import NameLookupError, async_resolve
@@ -148,6 +149,12 @@ class DNSCache:
     async def _try_resolve(hostname: str) -> list[str] | None:
         try:
             async with asyncio.timeout(_RESOLVE_TIMEOUT_SECONDS):
-                return await async_resolve(hostname)
+                # ``icmplib`` ships no type stubs, so ``async_resolve``
+                # arrives untyped and mypy widens its return to ``Any``.
+                # Cast at the boundary to keep the public signature
+                # honest — the runtime shape is documented as
+                # ``list[str]``, and ``except _RESOLVE_EXCEPTIONS`` is
+                # the only path that produces ``None``.
+                return cast("list[str] | None", await async_resolve(hostname))
         except _RESOLVE_EXCEPTIONS:
             return None


### PR DESCRIPTION
# What does this implement/fix?

First in a series of focused PRs to clear the 24-error mypy
baseline that landed advisory in #481.

`icmplib` ships no type stubs, so `async_resolve` arrives
untyped and mypy widens its return to `Any`. The raw return of
an `Any`-typed call then triggers `[no-any-return]` under our
strict config because the public signature
(`list[str] | None`) loses precision:

```text
controllers/_dns_cache.py:151: error: Returning Any from
function declared to return "list[str] | None"  [no-any-return]
```

## Fix

Cast at the boundary:

```python
return cast("list[str] | None", await async_resolve(hostname))
```

Mirrors the `cast(<type>, untyped_call())` pattern Home
Assistant uses for external-library boundaries (e.g.
`homeassistant/components/homekit/__init__.py:473`,
`homeassistant/components/kostal_plenticore/coordinator.py:327`).

Behaviour unchanged. The runtime contract was already documented
as "`list[str]` on success, `None` only via the
`except _RESOLVE_EXCEPTIONS` arm" — the cast pins that in the
type system.

## Baseline

24 → 23. 2433 backend tests pass.

**Related issue or feature (if applicable):**

- Part of the mypy-baseline cleanup tracked from #481.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
