### PR TITLE
mypy: type aiohttp middleware Handler instead of Any

### DIFF
--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -10,9 +10,9 @@ import os
 import secrets
 import time
 from collections import deque
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
 
 from aiohttp import web
 
@@ -315,7 +315,10 @@ _PUBLIC_PREFIXES = ("/assets/", "/boards/images/")
 
 
 @web.middleware
-async def auth_middleware(request: web.Request, handler: Any) -> web.StreamResponse:  # noqa: PLR0911
+async def auth_middleware(  # noqa: PLR0911
+    request: web.Request,
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+) -> web.StreamResponse:
     """
     Gate REST endpoints by ``Authorization`` header.
 


### PR DESCRIPTION
# What does this implement/fix?

PR 2 of the mypy-baseline cleanup tracked in `mypy_plan.md`
(post-#481, post-#482).

`auth_middleware`'s `handler` parameter was annotated `Any`,
which forced every `return await handler(request)` to land as
`[no-any-return]` under our strict config — 5 errors at lines
329 / 332 / 336 / 343 / 352, all the same shape:

```text
helpers/auth.py:329: error: Returning Any from function declared
to return "StreamResponse"  [no-any-return]
```

## Fix

Type the parameter explicitly as
`Callable[[Request], Awaitable[StreamResponse]]` — the same
shape Home Assistant uses for its own `@middleware`-decorated
functions:

```python
# homeassistant/components/http/auth.py:227-229
@middleware
async def auth_middleware(
    request: Request, handler: Callable[[Request], Awaitable[StreamResponse]]
) -> StreamResponse:
```

Behaviour unchanged. Pre-existing `# noqa: PLR0911` carried
forward (the function genuinely has 7 return statements and
the structure isn't worth a refactor in a typing-only PR).

## Baseline

23 → 19. 2433 backend tests pass; ruff clean.

**Related issue or feature (if applicable):**

- Part of the mypy-baseline cleanup tracked in `mypy_plan.md`
  (#481 enabled the advisory step; this PR walks it down).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
