### PR TITLE
mypy: cast at remaining lib boundaries + preserve types through @api_command

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -9,7 +9,7 @@ import sys
 import threading
 from contextlib import suppress
 from logging.handlers import RotatingFileHandler
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from colorlog import ColoredFormatter
 
@@ -261,7 +261,10 @@ def _esphome_version() -> str | None:
         from esphome.const import __version__ as version  # noqa: PLC0415
     except ImportError:
         return None
-    return version
+    # ``esphome`` ships no type stubs, so ``__version__`` arrives as
+    # ``Any`` and the raw return trips ``no-any-return``. Cast at the
+    # boundary — runtime contract is the documented version string.
+    return cast("str | None", version)
 
 
 def _format_version() -> str:

--- a/esphome_device_builder/helpers/api.py
+++ b/esphome_device_builder/helpers/api.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, TypeVar
 
 from ..models import ErrorCode
 
-# Type alias for command handler functions
+# Type alias for command handler functions. ``CommandHandler`` is the
+# erased shape used by the registry side (``collect_api_commands``);
+# the decorator preserves the actual handler's signature via the
+# ``_F`` TypeVar so call-sites keep their precise return types
+# instead of widening to ``Any``.
 CommandHandler = Callable[..., Coroutine[Any, Any, Any]]
+_F = TypeVar("_F", bound=CommandHandler)
 
 
 class CommandError(Exception):
@@ -27,7 +32,7 @@ class CommandError(Exception):
         self.message = message
 
 
-def api_command(command: str) -> Callable[[CommandHandler], CommandHandler]:
+def api_command(command: str) -> Callable[[_F], _F]:
     """Decorate a controller method to register it as a WebSocket API command.
 
     Usage:
@@ -37,9 +42,18 @@ def api_command(command: str) -> Callable[[CommandHandler], CommandHandler]:
 
     The decorated method is discoverable via `_api_command` attribute.
     DeviceBuilder scans controllers for these and builds its command registry.
+
+    Returns the function unchanged at runtime — only the
+    ``_api_command`` attribute is set. The ``_F`` ``TypeVar``
+    bound to ``CommandHandler`` carries the precise function
+    signature through the decorator so call-sites keep their
+    actual return type (e.g. ``OnboardingState``,
+    ``PagedBoardsResponse``) instead of widening to
+    ``Coroutine[Any, Any, Any]`` like a plain
+    ``Callable[[CommandHandler], CommandHandler]`` shape would.
     """
 
-    def decorator(func: CommandHandler) -> CommandHandler:
+    def decorator(func: _F) -> _F:
         func._api_command = command  # type: ignore[attr-defined]
         return func
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -14,7 +14,7 @@ import logging
 import re
 import secrets
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from esphome import const, yaml_util
 from esphome.const import CONF_PACKAGES
@@ -475,7 +475,12 @@ def detect_platform_from_yaml(path: Path) -> str:
     config = load_device_yaml(path)
     if isinstance(config, dict):
         for key in config:
-            if key in _PLATFORM_KEYS:
+            # ``key`` is ``Any`` (dict came from ``yaml_util.load_yaml``
+            # which is untyped); the runtime contract is "platform keys
+            # are always strings", so narrow with ``isinstance`` before
+            # returning rather than blind-returning ``Any`` and tripping
+            # ``no-any-return``.
+            if isinstance(key, str) and key in _PLATFORM_KEYS:
                 return key
     return ""
 
@@ -1115,7 +1120,13 @@ def load_device_yaml(path: Path) -> dict | None:
                 path,
                 exc_info=True,
             )
-    return config
+    # ``config`` came from ``yaml_util.load_yaml`` (esphome,
+    # untyped) and was further passed through the package-merge
+    # helpers (also untyped), so it stays ``Any`` despite the
+    # ``isinstance(config, dict)`` narrowing earlier. Cast at the
+    # return so the public ``dict | None`` signature is honest
+    # without forcing every caller to re-narrow on receive.
+    return cast("dict[Any, Any] | None", config)
 
 
 def get_api_encryption_block(config: dict | None) -> dict | None:

--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -57,6 +57,7 @@ through it. The held-ref pattern is verified by the unit tests.
 from __future__ import annotations
 
 import hashlib
+from typing import cast
 
 from noise.connection import Keypair, NoiseConnection
 
@@ -182,7 +183,11 @@ class PeerLinkNoiseSession:
     @property
     def handshake_finished(self) -> bool:
         """``True`` once the 3rd handshake message has been processed."""
-        return self._nc.handshake_finished
+        # ``noiseprotocol`` ships no type stubs, so
+        # ``NoiseConnection.handshake_finished`` arrives as ``Any`` and
+        # the raw return trips ``no-any-return``. The runtime contract
+        # is documented as ``bool``; cast to pin the signature.
+        return cast(bool, self._nc.handshake_finished)
 
     @property
     def remote_static_pub(self) -> bytes:


### PR DESCRIPTION
# What does this implement/fix?

PR 3 of the mypy-baseline cleanup tracked in `mypy_plan.md`.

Five errors across four files cleared via three patterns —
all type-only, no behaviour changes.

## 1. Cast at the lib boundary

For libraries without type stubs whose return values mypy
widens to `Any`:

- `peer_link_noise.py:185` — `self._nc.handshake_finished`
  from `noise.connection`. `cast(bool, ...)`.
- `__main__.py:264` — `esphome.const.__version__`.
  `cast("str | None", ...)`.
- `device_yaml.py:1118` — config dict from `yaml_util.load_yaml`
  (esphome, untyped) round-tripped through the also-untyped
  package-merge helpers. `cast("dict[Any, Any] | None", config)`
  at the return.

Runtime contracts were already documented; the cast pins
them in the type system. Mirrors
`homeassistant/components/homekit/__init__.py:473` and
`homeassistant/components/kostal_plenticore/coordinator.py:327`.

## 2. Narrow with `isinstance` before returning

`device_yaml.py:479` — the dict came from `yaml_util.load_yaml`
so iterating with `for key in config` typed `key: Any`.
Runtime contract is "platform keys are always strings"; an
`isinstance(key, str)` check before returning makes that
explicit and clears the `no-any-return`.

## 3. TypeVar through `@api_command`

`onboarding.py:152` and `onboarding.py:178` were both
`return await self.get_state()` calls. `get_state` is
properly typed as `-> OnboardingState`, but the
`@api_command` decorator's previous signature
`Callable[[CommandHandler], CommandHandler]` widened every
decorated method's return to `Coroutine[Any, Any, Any]`
because `CommandHandler` is the erased shape used by the
registry side.

Replacing it with a `TypeVar("_F", bound=CommandHandler)`
preserves the actual function shape through the decorator —
call-sites keep their precise return type instead of widening
to `Any`. Cleared both onboarding errors without touching
their bodies.

```python
_F = TypeVar("_F", bound=CommandHandler)

def api_command(command: str) -> Callable[[_F], _F]:
    def decorator(func: _F) -> _F:
        func._api_command = command  # type: ignore[attr-defined]
        return func
    return decorator
```

The `# type: ignore[attr-defined]` on `func._api_command`
stays — that's the legitimate dynamic-attr pattern the
registry-discovery side relies on.

## Baseline

Branch starts off `main`, so `auth.py:329-352` from PR #484
still show locally (5 errors). Net effect of this PR alone is
**6 errors cleared** (4 in this PR's diff + the 2 onboarding
ones via the decorator change). Combined with #484 the
baseline drops from 23 to 12 once both land.

2433 backend tests pass. ruff clean.

**Related issue or feature (if applicable):**

- Part of the mypy-baseline cleanup tracked in `mypy_plan.md`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
