### PR TITLE
ci: cache pre-commit envs to skip the per-run env install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,17 @@ jobs:
         run: uv pip install --system -e '.[esphome,test]'
 
       - name: Run pre-commit (ruff lint + format, codespell, yaml/json checks)
-        # ``no-commit-to-branch`` is a local-only guard; CI runs on
-        # branches by definition, so skip it the same way matter-server does.
-        run: SKIP=no-commit-to-branch pre-commit run --all-files
+        # ``pre-commit/action`` caches ``~/.cache/pre-commit`` keyed
+        # on the config file hash, so the per-hook envs (ruff,
+        # codespell, …) only get installed when the config changes
+        # — the per-run pre-commit init that recreates every env
+        # from scratch (~30s) drops to a near-instant cache hit.
+        # ``SKIP=no-commit-to-branch`` is a local-only guard; CI
+        # runs on branches by definition, so skip it the same way
+        # matter-server does.
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+        env:
+          SKIP: no-commit-to-branch
 
       - name: Validate board / component manifests
         run: python script/validate_definitions.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,18 +61,25 @@ jobs:
         # without a ``uv run`` prefix.
         run: uv pip install --system -e '.[esphome,test]'
 
+      - name: Cache pre-commit hook envs
+        # Keyed on the python version + ``.pre-commit-config.yaml``
+        # hash so any hook bump invalidates automatically. Mirrors
+        # what ``pre-commit/action`` does internally — inlined here
+        # because that action's transitive ``actions/cache@v4``
+        # reference isn't SHA-pinned, which the org policy blocks
+        # ("all actions must be pinned to a full-length commit SHA").
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: Run pre-commit (ruff lint + format, codespell, yaml/json checks)
-        # ``pre-commit/action`` caches ``~/.cache/pre-commit`` keyed
-        # on the config file hash, so the per-hook envs (ruff,
-        # codespell, …) only get installed when the config changes
-        # — the per-run pre-commit init that recreates every env
-        # from scratch (~30s) drops to a near-instant cache hit.
-        # ``SKIP=no-commit-to-branch`` is a local-only guard; CI
-        # runs on branches by definition, so skip it the same way
-        # matter-server does.
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
-        env:
-          SKIP: no-commit-to-branch
+        # On a cache hit the per-hook envs (ruff, codespell, …) are
+        # already on disk, so the previously-30s init phase drops
+        # to a near-instant restore. ``no-commit-to-branch`` is a
+        # local-only guard; CI runs on branches by definition, so
+        # skip it the same way matter-server does.
+        run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure --color=always
 
       - name: Validate board / component manifests
         run: python script/validate_definitions.py


### PR DESCRIPTION
# What does this implement/fix?

CI's `Lint + smoke checks` job currently re-installs every pre-commit hook env from scratch on every run. The init phase logs (visible at the top of any failed run) show ~30s spent on `Installing environment for ...` lines for ruff, codespell, the local PyYAML/jsonschema/orjson/mashumaro hooks, and the pre-commit-hooks repo — once for the first hook in each isolated env.

Add a SHA-pinned `actions/cache@v5.0.5` step that caches `~/.cache/pre-commit` keyed on `hashFiles(.pre-commit-config.yaml)` plus the python version. The existing `pre-commit run --all-files` step is unchanged; on a cache hit the per-hook envs are already on disk so the previously-30s init drops to a near-instant restore. (First attempt used `pre-commit/action@v3.0.1` directly, but its transitive `actions/cache@v4` reference isn't SHA-pinned and the org policy blocks it; inlining gives us the same caching with full-SHA pinning.)



Pinned by SHA with the version comment, matching the org policy for every other action in the workflow.

**Related issue or feature (if applicable):**

- N/A — observed during a recent CI run

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
