### PR TITLE
mypy: narrow subscript-expression type via local rebind

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -261,16 +261,16 @@ def _decode_txt_bytes_to_sorted_pairs(txt_bytes: bytes) -> tuple[tuple[str, str]
     info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"_decode.{_ESPHOME_SERVICE_TYPE}")
     info.text = txt_bytes
     decoded = info.decoded_properties
-    # Bind ``value`` to a local so mypy can narrow with
-    # ``isinstance(value, str)`` — narrowing on a subscript
-    # expression (``decoded[key]``) doesn't carry across the two
-    # references in the conditional, so the comprehension form
-    # was inferred as ``tuple[str, str | None]`` and tripped
-    # ``[misc]`` at the call site.
+    # Filter to string keys *before* sorting — ``decoded`` can
+    # contain ``bytes`` keys when a TXT entry fails UTF-8 decode,
+    # and ``sorted()`` of a mixed ``str | bytes`` set raises
+    # ``TypeError`` in Python 3. Binding ``value`` to a local also
+    # lets mypy narrow with ``isinstance(value, str)`` — narrowing
+    # on a subscript expression (``decoded[key]``) doesn't carry
+    # across the two references in the inline conditional.
+    str_keys = sorted(key for key in decoded if isinstance(key, str))
     pairs: list[tuple[str, str]] = []
-    for key in sorted(decoded):
-        if not isinstance(key, str):
-            continue
+    for key in str_keys:
         value = decoded[key]
         pairs.append((key, value if isinstance(value, str) else ""))
     return tuple(pairs)

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -261,11 +261,19 @@ def _decode_txt_bytes_to_sorted_pairs(txt_bytes: bytes) -> tuple[tuple[str, str]
     info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"_decode.{_ESPHOME_SERVICE_TYPE}")
     info.text = txt_bytes
     decoded = info.decoded_properties
-    return tuple(
-        (key, decoded[key] if isinstance(decoded[key], str) else "")
-        for key in sorted(decoded)
-        if isinstance(key, str)
-    )
+    # Bind ``value`` to a local so mypy can narrow with
+    # ``isinstance(value, str)`` — narrowing on a subscript
+    # expression (``decoded[key]``) doesn't carry across the two
+    # references in the conditional, so the comprehension form
+    # was inferred as ``tuple[str, str | None]`` and tripped
+    # ``[misc]`` at the call site.
+    pairs: list[tuple[str, str]] = []
+    for key in sorted(decoded):
+        if not isinstance(key, str):
+            continue
+        value = decoded[key]
+        pairs.append((key, value if isinstance(value, str) else ""))
+    return tuple(pairs)
 
 
 def _decode_mdns_txt_records(txt_dns_records: list[Any]) -> dict[str, str]:

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -710,6 +710,30 @@ def test_decode_txt_bytes_to_sorted_pairs_caches_by_bytes() -> None:
     assert third is first  # value-equal bytes hit the same cache slot
 
 
+def test_decode_txt_bytes_to_sorted_pairs_collapses_none_values_to_empty_string() -> None:
+    """A TXT entry with no ``=`` separator decodes as ``None`` → ``""``.
+
+    zeroconf's ``decoded_properties`` returns ``dict[str, str | None]``:
+    a TXT entry written as ``key`` (no ``=``) or ``key=`` (empty
+    payload) both surface as ``{"key": None}``. The reachability
+    snapshot then materialises a ``dict[str, str]`` for the wire,
+    so ``None`` has to collapse to ``""`` here — otherwise a
+    downstream consumer that expects "always a string" trips on
+    a ``None`` it never asked for. Pin both the decode shape and
+    the collapse so a future zeroconf API change can't silently
+    leak ``None`` values into the snapshot.
+    """
+    _decode_txt_bytes_to_sorted_pairs.cache_clear()
+    # Mix the no-``=`` form with a normal ``key=value`` entry to
+    # confirm both branches of the value ternary are exercised in
+    # the same call.
+    txt = b"".join(bytes([len(e)]) + e for e in (b"empty", b"version=1"))
+    assert _decode_txt_bytes_to_sorted_pairs(txt) == (
+        ("empty", ""),
+        ("version", "1"),
+    )
+
+
 def test_get_mdns_cache_info_no_txt_records_returns_empty_mapping() -> None:
     """
     Address records present but no TXT → ``txt_records == {}``.


### PR DESCRIPTION
# What does this implement/fix?

PR 6 of the mypy-baseline cleanup tracked in `mypy_plan.md`.

`_decode_txt_bytes_to_sorted_pairs` was building tuples via a
generator with the inline conditional
`decoded[key] if isinstance(decoded[key], str) else ""`. mypy
doesn't carry `isinstance` narrowing across two references to
a subscript expression — each `decoded[key]` is treated
independently — so the comprehension's element type was
inferred as `tuple[str, str | None]` while the function
signature is `tuple[tuple[str, str], ...]`. That tripped:

```text
controllers/_device_state_monitor.py:265: error: Generator has
incompatible item type "tuple[str, str | None]"; expected
"tuple[str, str]"  [misc]
```

## Fix

Replace the comprehension with an explicit `for` loop that
binds `value = decoded[key]` to a local and narrows that local
via `isinstance(value, str)`. Same logic; mypy can now follow
the narrowing through the conditional.

```python
pairs: list[tuple[str, str]] = []
for key in sorted(decoded):
    if not isinstance(key, str):
        continue
    value = decoded[key]
    pairs.append((key, value if isinstance(value, str) else ""))
return tuple(pairs)
```

No behaviour change.

## Baseline

9 → 8. 2433 backend tests pass.

**Related issue or feature (if applicable):**

- Part of the mypy-baseline cleanup tracked in `mypy_plan.md`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
