### PR TITLE
mypy: narrow value before int() coercion in coerce_sidecar_int

### DIFF
--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -298,7 +298,11 @@ def coerce_sidecar_int(value: object) -> int:
     ``0`` matches the "never walked" sentinel and lets the next
     refresh repopulate from the build dir.
     """
-    if value is None:
+    # Narrow before ``int(...)`` so mypy can resolve the overload —
+    # JSON-decoded sidecars realistically carry only these scalar
+    # shapes; lists / dicts / arbitrary objects fall straight to
+    # the ``0`` sentinel without an exception round-trip.
+    if not isinstance(value, (int, float, str, bytes)):
         return 0
     try:
         return int(value)


### PR DESCRIPTION
# What does this implement/fix?

PR 8 of the mypy-baseline cleanup tracked in `mypy_plan.md`.

`coerce_sidecar_int(value: object)` accepts the most permissive
input type because the sidecar JSON could realistically carry any
shape (str / int / float / list / dict / null / bool). The body
fell straight through to `int(value)` and let the `try/except`
handle anything `int()` rejected:

```python
if value is None:
    return 0
try:
    return int(value)
except (TypeError, ValueError):
    return 0
```

mypy correctly flagged this as two errors:

```text
helpers/build_size.py:304: error: No overload variant of "int" matches argument type "object"  [call-overload]
helpers/build_size.py:304: error: Returning Any from function declared to return "int"  [no-any-return]
```

`int(...)`'s overloads are typed against `ConvertibleToInt =
Union[str, ReadableBuffer, SupportsInt, SupportsIndex, SupportsTrunc]`
— a bare `object` doesn't match, so mypy falls back to the `Any`
return that triggers `[no-any-return]`.

## Fix

Narrow before the call:

```python
if not isinstance(value, (int, float, str, bytes)):
    return 0
try:
    return int(value)
except (TypeError, ValueError):
    return 0
```

`int | float | str | bytes` covers every shape `int()` actually
accepts in practice — `bool` is a subclass of `int`, dict/list/None
land on the early `0` return without an exception round-trip. The
None-check stops being a separate branch because `None` is not in
the isinstance tuple.

The existing `tests/test_build_size.py::test_coerce_sidecar_int`
parametrize already covers every shape (`int`, str, decimal-string,
None, empty-string, non-numeric, dict, list, float) — same
observable behaviour, just with mypy able to follow the overload
resolution.

## Baseline

11 → 9. 32 `tests/test_build_size.py` tests still pass.

**Related issue or feature (if applicable):**

- Part of the mypy-baseline cleanup tracked in `mypy_plan.md`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
