### PR TITLE
ci: flip mypy from advisory to hard gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,17 +95,13 @@ jobs:
       - name: Smoke-test component catalog
         run: python script/check_catalog.py
 
-      - name: Type-check (mypy, advisory)
+      - name: Type-check (mypy)
         # Mypy is configured strict in ``pyproject.toml``
         # (``disallow_untyped_defs``, ``disallow_incomplete_defs``,
-        # ``warn_return_any``) but the existing codebase wasn't
-        # mypy-clean at the point this gate landed. Run it as
-        # **advisory** for now (``continue-on-error: true``) so
-        # the report shows up in PR checks without blocking
-        # merges, and contributors get a baseline they can
-        # ratchet down. Flip to a hard gate once the standing
-        # error count hits zero.
-        continue-on-error: true
+        # ``warn_return_any``). Hard gate — a typing regression
+        # blocks the PR. Started life as advisory (#481) while the
+        # 24-error baseline got walked down to zero across PRs
+        # #483-#492; flipped on once the standing count hit zero.
         run: mypy esphome_device_builder
 
   test:


### PR DESCRIPTION
# What does this implement/fix?

Final step of the mypy-baseline cleanup tracked in `mypy_plan.md`.

PR #481 introduced a strict-mypy CI step as **advisory**
(`continue-on-error: true`) so the 24-error baseline existing at
the time wouldn't block merges. Across the eight follow-up PRs
the standing count was walked down to zero:

| PR | Errors fixed | Theme |
|---|---:|---|
| #483 | 1 | icmplib boundary cast |
| #484 | 5 | aiohttp middleware Handler typing |
| #485 | 6 | lib casts + `@api_command` decorator TypeVar |
| #487 | 5 | `None`-narrowing across controllers |
| #488 | 3 | stdlib annotation gaps (`exc_info`, `AbstractServer.sockets`) |
| #490 | 1 | subscript-expression narrowing via local rebind |
| #491 | 1 | `_ESPHOME_RP2040_BOARDS` redef on the fallback import |
| #492 | 2 | `int(object)` overload narrowing in `coerce_sidecar_int` |

`mypy esphome_device_builder` on `main` after #492 lands prints
`Success: no issues found in 69 source files`.

## Fix

Drop `continue-on-error: true` from the workflow step and update
the comment to reflect the new contract — a typing regression now
blocks the PR instead of surfacing as an advisory ✗ a reviewer
might overlook.

```diff
-      - name: Type-check (mypy, advisory)
+      - name: Type-check (mypy)
         # Mypy is configured strict in ``pyproject.toml``
         # (``disallow_untyped_defs``, ``disallow_incomplete_defs``,
-        # ``warn_return_any``) but the existing codebase wasn't
-        # mypy-clean at the point this gate landed. Run it as
-        # **advisory** for now (``continue-on-error: true``) so
-        # the report shows up in PR checks without blocking
-        # merges, and contributors get a baseline they can
-        # ratchet down. Flip to a hard gate once the standing
-        # error count hits zero.
-        continue-on-error: true
+        # ``warn_return_any``). Hard gate — a typing regression
+        # blocks the PR. Started life as advisory (#481) while the
+        # 24-error baseline got walked down to zero across PRs
+        # #483-#492; flipped on once the standing count hit zero.
         run: mypy esphome_device_builder
```

## Follow-up

Now that the baseline is clean, the `EventBus.fire` payload
typing can move from `Mapping[str, Any]` to HA-style
`Event[_DataT]` generics so each subscriber sees the precise
TypedDict shape it consumes. Tracked separately — not part of
this PR.

**Related issue or feature (if applicable):**

- Closes the mypy-baseline cleanup tracked in `mypy_plan.md`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
