### PR TITLE
Offloader-side StoredPairing storage layer (#106 phase 4a-o part 1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,11 @@ repos:
         name: regenerate boards.json from manifests
         entry: python script/sync_boards.py
         language: python
-        additional_dependencies: [pyyaml, orjson, mashumaro]
+        # ``voluptuous`` is needed because importing
+        # ``esphome_device_builder.models.remote_build`` (transitively
+        # imported via the script's models import chain) runs the
+        # ``StoredPairing`` schema validator at module-load time.
+        additional_dependencies: [pyyaml, orjson, mashumaro, voluptuous]
         pass_filenames: false
         files: ^esphome_device_builder/definitions/boards/.*\.yaml$
         types: [yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,11 @@ repos:
         language: python
         # ``voluptuous`` is needed because importing
         # ``esphome_device_builder.models.remote_build`` (transitively
-        # imported via the script's models import chain) runs the
-        # ``StoredPairing`` schema validator at module-load time.
+        # imported via the script's models import chain) builds the
+        # ``StoredPairing`` ``vol.Schema`` at module-load time. The
+        # schema only *runs* later, in ``__post_init__``, but the
+        # ``import voluptuous as vol`` at the top of the module
+        # fails without the dep installed in the hook's slim env.
         additional_dependencies: [pyyaml, orjson, mashumaro, voluptuous]
         pass_filenames: false
         files: ^esphome_device_builder/definitions/boards/.*\.yaml$

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -34,6 +34,7 @@ from ..helpers.secrets_state import (
 from ..models import (
     ErrorCode,
     Label,
+    OffloaderRemoteBuildSettings,
     RemoteBuildSettings,
     UserPreferences,
 )
@@ -48,6 +49,7 @@ _METADATA_FILE = ".device-builder.json"
 _PREFS_KEY = "_preferences"
 _LABELS_KEY = "_labels"
 _REMOTE_BUILD_KEY = "_remote_build"
+_OFFLOADER_REMOTE_BUILD_KEY = "_offloader_remote_build"
 
 
 # ---------------------------------------------------------------------------
@@ -640,6 +642,77 @@ def remote_build_settings_transaction(
         settings = _settings_from_raw(data.get(_REMOTE_BUILD_KEY, {}))
         yield settings
         data[_REMOTE_BUILD_KEY] = settings.to_dict()
+
+
+def _offloader_settings_from_raw(raw: Any) -> OffloaderRemoteBuildSettings:
+    """
+    Decode an ``_offloader_remote_build`` blob, defaults on shape mismatch.
+
+    Mirrors :func:`_settings_from_raw` for the offloader-side
+    storage shape: a wholly malformed blob resets to defaults
+    rather than crashing dashboard startup, and unknown keys
+    on older sidecars are ignored by mashumaro's
+    ``DataClassORJSONMixin``.
+    """
+    if not isinstance(raw, dict):
+        return OffloaderRemoteBuildSettings()
+    try:
+        return OffloaderRemoteBuildSettings.from_dict(raw)
+    except Exception:
+        return OffloaderRemoteBuildSettings()
+
+
+def load_offloader_remote_build_settings(
+    config_dir: Path,
+) -> OffloaderRemoteBuildSettings:
+    """
+    Load the offloader-side remote-build settings.
+
+    Returns defaults (empty ``pairings``) when the metadata file
+    is missing or the ``_offloader_remote_build`` key isn't
+    present. A wholly malformed blob falls back to defaults
+    rather than crashing dashboard startup.
+    """
+    return _offloader_settings_from_raw(
+        _load_metadata(config_dir).get(_OFFLOADER_REMOTE_BUILD_KEY, {})
+    )
+
+
+def save_offloader_remote_build_settings(
+    config_dir: Path, settings: OffloaderRemoteBuildSettings
+) -> None:
+    """Persist the offloader-side remote-build settings."""
+    with metadata_transaction(config_dir) as data:
+        data[_OFFLOADER_REMOTE_BUILD_KEY] = settings.to_dict()
+
+
+@contextmanager
+def offloader_remote_build_settings_transaction(
+    config_dir: Path,
+) -> Iterator[OffloaderRemoteBuildSettings]:
+    """
+    Atomic read-modify-write context for the offloader-side settings.
+
+    Yields the current
+    :class:`OffloaderRemoteBuildSettings` (defaults if missing
+    or corrupt). Mutate it in place; on a clean exit the
+    changes are persisted under the same
+    :func:`metadata_transaction` lock so the whole RMW is
+    atomic against concurrent transactions on either the
+    offloader or the receiver-side ``_remote_build`` key.
+    Exceptions raised inside the block discard the pending
+    mutation.
+
+    Used whenever the offloader's pair / unpair flow needs to
+    add, remove, or refresh a :class:`StoredPairing` row. A
+    bare ``load + save`` pair would race two concurrent pair
+    operations against each other; this context manager
+    serialises them.
+    """
+    with metadata_transaction(config_dir) as data:
+        settings = _offloader_settings_from_raw(data.get(_OFFLOADER_REMOTE_BUILD_KEY, {}))
+        yield settings
+        data[_OFFLOADER_REMOTE_BUILD_KEY] = settings.to_dict()
 
 
 def _decode_labels(raw: Any) -> list[Label]:

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -207,21 +207,33 @@ def _peer_from_manual_host(entry: ManualHost) -> RemoteBuildPeer:
     )
 
 
+_HOSTNAME_MAX_CHARS = 255  # RFC 1035 §2.3.4 caps a FQDN at 253; round up to 255.
+
+
 def _validate_hostname(raw: object) -> str:
     """
     Normalise a user-entered hostname to its canonical lowercase form.
 
     Rejects non-string and empty / whitespace-only input with
-    :class:`CommandError(INVALID_ARGS)`. Lowercase normalisation
-    matches the duplicate-check semantics; hostnames are
-    case-insensitive per RFC 1035 §2.3.3, so ``Desktop.local`` and
-    ``desktop.local`` should be the same entry. The stored form
-    is the trimmed, lowercased string (so two adds with different
-    casing collapse to one entry rather than registering twice).
-    Phase 4 attempts the actual connection (and discovers DNS /
-    TLS validity); phase 2b deliberately doesn't pre-flight an
-    "is this resolvable now?" check, which would fail on offline
-    laptops adding a peer for later.
+    :class:`CommandError(INVALID_ARGS)`. Caps length at
+    :data:`_HOSTNAME_MAX_CHARS` (RFC 1035 §2.3.4 caps a fully-
+    qualified domain name at 253 characters; we accept up to 255
+    to leave room for trailing-dot variations). The cap stops a
+    misbehaving frontend from bloating the on-disk sidecar (and,
+    for the offloader-side pairing pool, the wire payload of
+    ``list_pool``) with a megabyte-string masquerading as a
+    hostname.
+
+    Lowercase normalisation matches the duplicate-check
+    semantics; hostnames are case-insensitive per RFC 1035 §2.3.3,
+    so ``Desktop.local`` and ``desktop.local`` should be the same
+    entry. The stored form is the trimmed, lowercased string (so
+    two adds with different casing collapse to one entry rather
+    than registering twice). Phase 4 attempts the actual
+    connection (and discovers DNS / TLS validity); phase 2b
+    deliberately doesn't pre-flight an "is this resolvable now?"
+    check, which would fail on offline laptops adding a peer
+    for later.
     """
     if not isinstance(raw, str):
         msg = "manual host: 'hostname' must be a string"
@@ -229,6 +241,9 @@ def _validate_hostname(raw: object) -> str:
     trimmed = raw.strip().lower()
     if not trimmed:
         msg = "manual host: 'hostname' must not be empty"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if len(trimmed) > _HOSTNAME_MAX_CHARS:
+        msg = f"manual host: 'hostname' must be at most {_HOSTNAME_MAX_CHARS} characters"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return trimmed
 

--- a/esphome_device_builder/helpers/voluptuous_validators.py
+++ b/esphome_device_builder/helpers/voluptuous_validators.py
@@ -1,0 +1,40 @@
+"""
+Project-local custom :mod:`voluptuous` validators.
+
+Voluptuous lives in our dependency closure (transitive via
+ESPHome's ``config_validation``) and is the natural choice for
+declarative field validation on dataclass schemas in this
+project. Anything we need that the upstream library doesn't
+already ship lands here so each consumer pulls from one place
+rather than reinventing the wrapper.
+
+Each validator is a callable suitable for use inside
+``vol.Schema`` / ``vol.All`` chains: it accepts a value and
+either returns the (possibly normalised) value or raises
+``vol.Invalid``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+
+def not_bool(value: Any) -> Any:
+    """
+    Reject :class:`bool` values, return everything else unchanged.
+
+    Voluptuous's ``int`` check accepts ``bool`` — Python's
+    ``isinstance(True, int)`` is true — so a schema like
+    ``vol.All(int, vol.Range(min=1, max=65535))`` would silently
+    coerce ``True`` to ``1`` and ``False`` to ``0``. Chain
+    :func:`not_bool` *before* the ``int`` check (e.g. for ports,
+    refcounts, anything where a stray boolean would be a
+    user-error rather than the intended type) so the rejection
+    happens at validation time with a legible message rather
+    than landing as a wrong-but-valid integer downstream.
+    """
+    if isinstance(value, bool):
+        raise vol.Invalid("must not be a bool")
+    return value

--- a/esphome_device_builder/helpers/voluptuous_validators.py
+++ b/esphome_device_builder/helpers/voluptuous_validators.py
@@ -38,3 +38,31 @@ def not_bool(value: Any) -> Any:
     if isinstance(value, bool):
         raise vol.Invalid("must not be a bool")
     return value
+
+
+def lowercase_hex(length: int) -> vol.All:
+    """
+    Build a validator for a ``length``-char lowercase-hex string.
+
+    Returns a :class:`vol.All` chain that asserts the value is
+    a string of exactly ``length`` characters drawn from
+    ``[0-9a-f]``. Used for SHA-256 hashes (``length=64``,
+    ``pin_sha256`` on every peer-link row, the deleted
+    bearer-secret hash, etc.) + any other lowercase-hex digest
+    surface.
+
+    The :class:`vol.Length` chain element is redundant with
+    the regex's ``{length}`` quantifier but kept as a defensive
+    belt — a future regex tweak that accidentally widened the
+    alphabet (or dropped the anchors) would still get caught
+    by the explicit length check. The caller pays one extra
+    tiny check at validation time; the readability of "length
+    + alphabet, both pinned" wins.
+
+    Returns ``vol.All`` rather than the bare regex so the
+    chain is callable directly inside a ``vol.Schema``
+    field-position without an extra ``vol.All(...)`` wrap at
+    each call site.
+    """
+    pattern = rf"^[0-9a-f]{{{length}}}$"
+    return vol.All(str, vol.Length(min=length, max=length), vol.Match(pattern))

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from typing import Literal, TypedDict
 
@@ -405,17 +405,7 @@ class StoredPairing(DataClassORJSONMixin):
     def __post_init__(self) -> None:
         """Run :data:`_PAIRING_VALIDATOR`; re-raise as ``ValueError``."""
         try:
-            _PAIRING_VALIDATOR(
-                {
-                    "receiver_hostname": self.receiver_hostname,
-                    "receiver_port": self.receiver_port,
-                    "pin_sha256": self.pin_sha256,
-                    "static_x25519_pub": self.static_x25519_pub,
-                    "label": self.label,
-                    "paired_at": self.paired_at,
-                    "status": self.status,
-                }
-            )
+            _PAIRING_VALIDATOR(asdict(self))
         except vol.Invalid as exc:
             field_name = exc.path[0] if exc.path else "<row>"
             raise ValueError(f"StoredPairing.{field_name}: {exc.msg}") from exc

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -300,6 +300,31 @@ class PeerSummary(DataClassORJSONMixin):
 # field bounds beat hand-rolled if-chains for readability, and
 # (c) the upstream ESPHome codebase uses the same primitive so
 # contributors moving between repos see a familiar shape.
+#
+# **Maintenance note.** The schema below is a second source of
+# truth alongside the dataclass field annotations: each
+# ``vol.Required(...)`` mirrors a field declared on
+# :class:`StoredPairing`, and dropping or renaming a field in
+# one place without the other will silently desync (the schema
+# would either fail-pass — ``vol.Required`` against a missing
+# key raises — or accept-everything if the annotation widens).
+# Keep the two in lockstep when changing the row shape: add /
+# rename / remove the dataclass field AND the corresponding
+# schema entry in the same change.
+#
+# **Asymmetry with :class:`StoredPeer`.** The receiver-side
+# row doesn't run a comparable schema in
+# ``__post_init__``: ``record_pair_request`` is its only
+# constructor in production, and that path runs after a
+# successful Noise XX handshake (the noiseprotocol library
+# guarantees ``static_x25519_pub`` is exactly 32 bytes; the
+# dispatcher validates ``dashboard_id`` against
+# ``DASHBOARD_ID_PATTERN`` and caps ``label`` via
+# ``_normalize_label`` *before* reaching the controller). A
+# follow-up applying the same storage-seam validator to
+# ``StoredPeer`` for symmetry is on the 4a-o follow-up list;
+# for now this PR is documenting the inconsistency rather
+# than masking it.
 _PAIRING_VALIDATOR = vol.Schema(
     {
         # RFC 1035 §2.3.4 caps a fully-qualified domain name at 253

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Literal, TypedDict
 
+import voluptuous as vol
 from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+from ..helpers.voluptuous_validators import not_bool
 
 
 class RemoteBuildPeerSource(StrEnum):
@@ -282,6 +285,138 @@ class PeerSummary(DataClassORJSONMixin):
     status: PeerStatus
 
 
+# Bounds enforced both at the WS-command boundary (the future
+# 4a-o ``request_pair`` validators) and at the storage seam
+# (``StoredPairing.__post_init__``). Defense-in-depth for the
+# storage layer keeps a hand-edited sidecar from smuggling huge
+# values past the WS validators — the on-disk shape is the same
+# trust surface as anything else under ``<config_dir>``, and a
+# malformed row is the kind of thing the loader's
+# ``DataClassORJSONMixin.from_dict`` happily round-trips
+# regardless of size.
+#
+# Schema is voluptuous because (a) it's already a transitive
+# dep through ESPHome's ``config_validation``, (b) declarative
+# field bounds beat hand-rolled if-chains for readability, and
+# (c) the upstream ESPHome codebase uses the same primitive so
+# contributors moving between repos see a familiar shape.
+_PAIRING_VALIDATOR = vol.Schema(
+    {
+        # RFC 1035 §2.3.4 caps a fully-qualified domain name at 253
+        # characters; round up to 255 to leave room for trailing-dot
+        # variations.
+        vol.Required("receiver_hostname"): vol.All(str, vol.Length(min=1, max=255)),
+        # :func:`not_bool` first because voluptuous's ``int`` check
+        # accepts ``bool`` (Python's ``isinstance(True, int)`` is true) —
+        # without the explicit reject, ``receiver_port=True`` would pass
+        # as port 1.
+        vol.Required("receiver_port"): vol.All(not_bool, int, vol.Range(min=1, max=65535)),
+        vol.Required("pin_sha256"): vol.All(str, vol.Length(min=64, max=64)),
+        # ``static_x25519_pub`` is the raw X25519 pubkey — exactly 32
+        # bytes per RFC 7748 §5.
+        vol.Required("static_x25519_pub"): vol.All(bytes, vol.Length(min=32, max=32)),
+        vol.Required("label"): vol.All(str, vol.Length(max=128)),
+        vol.Required("paired_at"): vol.Any(int, float),
+        vol.Required("status"): PeerStatus,
+    }
+)
+
+
+@dataclass
+class StoredPairing(DataClassORJSONMixin):
+    """
+    Offloader-side record of a paired (or pending) receiver.
+
+    Persisted under ``_offloader_remote_build.pairings``. Created
+    by the ``request_pair`` flow over the peer-link WS: the
+    offloader runs a Noise XX handshake with
+    ``intent="pair_request"``, captures the receiver's static
+    X25519 pubkey from the handshake transcript, and stores it
+    here together with the receiver's ``(hostname, port)``
+    coordinates.
+
+    This is the offloader-side counterpart to
+    :class:`StoredPeer` (receiver-side). The two shapes are
+    deliberately *not* the same row passed both ways: the
+    receiver's ``StoredPeer`` keys on the offloader's
+    ``dashboard_id`` (the offloader's stable identity), while
+    the offloader's ``StoredPairing`` keys on
+    ``(receiver_hostname, receiver_port)`` because that's what
+    the user enters in the Pair dialog and what reconnection
+    needs.
+
+    ``static_x25519_pub`` is the canonical identifier the Noise
+    handshake binds to. ``pin_sha256`` is its lowercase-hex
+    SHA-256 (the OOB-verified pin the user confirmed on the
+    receiver's Build server card). Both are stored so a future
+    re-pair can detect a receiver-side identity rotation
+    (handshake's pubkey-hash drifts from the stored
+    ``pin_sha256``) without re-deriving from the raw bytes on
+    every connect.
+
+    ``label`` is the human-readable name the offloader's user
+    typed when pairing (e.g. ``desktop``, ``build server``).
+    Surfaced in the offloader's settings list; not sent to the
+    receiver — the receiver gets its own ``label`` from the
+    offloader's pair_request payload (the offloader-supplied
+    name FOR the offloader, not for the receiver).
+
+    ``__post_init__`` enforces upper bounds on the user-supplied
+    string fields (hostname, label) + shape on the cryptographic
+    fields so a malformed sidecar row (hand-edit, partial-write
+    recovery, schema-skew across ESPHome upgrades) is rejected
+    by the loader's ``from_dict`` rather than landing as a
+    multi-megabyte string in memory + on the wire.
+    """
+
+    receiver_hostname: str
+    receiver_port: int
+    pin_sha256: str
+    static_x25519_pub: bytes
+    label: str
+    paired_at: float
+    status: PeerStatus = PeerStatus.PENDING
+
+    def __post_init__(self) -> None:
+        """Run :data:`_PAIRING_VALIDATOR`; re-raise as ``ValueError``."""
+        try:
+            _PAIRING_VALIDATOR(
+                {
+                    "receiver_hostname": self.receiver_hostname,
+                    "receiver_port": self.receiver_port,
+                    "pin_sha256": self.pin_sha256,
+                    "static_x25519_pub": self.static_x25519_pub,
+                    "label": self.label,
+                    "paired_at": self.paired_at,
+                    "status": self.status,
+                }
+            )
+        except vol.Invalid as exc:
+            field_name = exc.path[0] if exc.path else "<row>"
+            raise ValueError(f"StoredPairing.{field_name}: {exc.msg}") from exc
+
+
+@dataclass
+class PairingSummary(DataClassORJSONMixin):
+    """
+    Public-facing wire view of :class:`StoredPairing`.
+
+    Drops ``static_x25519_pub`` — the raw 32-byte pubkey is
+    on-disk only; ``pin_sha256`` is the wire-friendly form
+    UIs render. Mirrors the :class:`PeerSummary` projection
+    seam on the receiver side so a future "store extra
+    offloader-only fields on the row" change can't leak those
+    by accident.
+    """
+
+    receiver_hostname: str
+    receiver_port: int
+    pin_sha256: str
+    label: str
+    paired_at: float
+    status: PeerStatus
+
+
 @dataclass
 class RemoteBuildSettings(DataClassORJSONMixin):
     """
@@ -319,6 +454,43 @@ class RemoteBuildSettingsView(DataClassORJSONMixin):
     enabled: bool = False
     manual_hosts: list[ManualHost] = field(default_factory=list)
     peers: list[PeerSummary] = field(default_factory=list)
+
+
+@dataclass
+class OffloaderRemoteBuildSettings(DataClassORJSONMixin):
+    """
+    Offloader-side settings for the remote-build feature (storage shape).
+
+    Stored in ``.device-builder.json`` under the
+    ``_offloader_remote_build`` top-level key — distinct from
+    the receiver's ``_remote_build`` key so a dashboard playing
+    both roles persists each side's state independently and a
+    future "split offloader / receiver into separate processes"
+    refactor only has to peel one key out.
+
+    ``pairings`` carries phase-4a-o :class:`StoredPairing`
+    rows: the offloader's pinned receivers. There's no
+    ``enabled`` toggle here because the offloader is always
+    the initiator (it doesn't bind a listener); whether the
+    dashboard exposes the offloader UI is a frontend concern
+    for now.
+    """
+
+    pairings: list[StoredPairing] = field(default_factory=list)
+
+
+@dataclass
+class OffloaderRemoteBuildSettingsView(DataClassORJSONMixin):
+    """
+    Wire view of :class:`OffloaderRemoteBuildSettings`.
+
+    Returned from offloader-side WS commands. ``pairings`` is
+    projected to :class:`PairingSummary` (drops
+    ``static_x25519_pub``); same projection-seam pattern as
+    :class:`RemoteBuildSettingsView`.
+    """
+
+    pairings: list[PairingSummary] = field(default_factory=list)
 
 
 @dataclass

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -329,19 +329,39 @@ _PAIRING_VALIDATOR = vol.Schema(
     {
         # RFC 1035 §2.3.4 caps a fully-qualified domain name at 253
         # characters; round up to 255 to leave room for trailing-dot
-        # variations.
-        vol.Required("receiver_hostname"): vol.All(str, vol.Length(min=1, max=255)),
+        # variations. The ``\S`` requirement rejects whitespace-only
+        # values that would otherwise pass ``Length(min=1)`` —
+        # storing a hostname that can't resolve is worse than
+        # rejecting at write time. Normalisation (strip + lowercase)
+        # is the WS-command validator's job; the storage seam just
+        # rejects malformed rows.
+        vol.Required("receiver_hostname"): vol.All(
+            str, vol.Length(min=1, max=255), vol.Match(r"\S")
+        ),
         # :func:`not_bool` first because voluptuous's ``int`` check
         # accepts ``bool`` (Python's ``isinstance(True, int)`` is true) —
         # without the explicit reject, ``receiver_port=True`` would pass
         # as port 1.
         vol.Required("receiver_port"): vol.All(not_bool, int, vol.Range(min=1, max=65535)),
-        vol.Required("pin_sha256"): vol.All(str, vol.Length(min=64, max=64)),
+        # Lowercase-hex SHA-256: 64 chars from ``[0-9a-f]``. The regex
+        # is anchored so a non-hex char anywhere in the string fails;
+        # the explicit length is redundant with the regex's
+        # ``{64}`` quantifier but kept as a defensive belt — a future
+        # regex tweak that accidentally widens the alphabet still
+        # gets caught by the length check.
+        vol.Required("pin_sha256"): vol.All(
+            str, vol.Length(min=64, max=64), vol.Match(r"^[0-9a-f]{64}$")
+        ),
         # ``static_x25519_pub`` is the raw X25519 pubkey — exactly 32
         # bytes per RFC 7748 §5.
         vol.Required("static_x25519_pub"): vol.All(bytes, vol.Length(min=32, max=32)),
         vol.Required("label"): vol.All(str, vol.Length(max=128)),
-        vol.Required("paired_at"): vol.Any(int, float),
+        # ``vol.All(not_bool, ...)`` rather than ``vol.Any(int, float,
+        # not_bool)`` because ``Any`` short-circuits on the first
+        # accepting branch — ``int`` would accept ``True``
+        # (``isinstance(True, int)`` is true) before ever reaching the
+        # bool reject. Run ``not_bool`` first, then assert int-or-float.
+        vol.Required("paired_at"): vol.All(not_bool, vol.Any(int, float)),
         vol.Required("status"): PeerStatus,
     }
 )

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -9,7 +9,7 @@ from typing import Literal, TypedDict
 import voluptuous as vol
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from ..helpers.voluptuous_validators import not_bool
+from ..helpers.voluptuous_validators import lowercase_hex, not_bool
 
 
 class RemoteBuildPeerSource(StrEnum):
@@ -343,15 +343,12 @@ _PAIRING_VALIDATOR = vol.Schema(
         # without the explicit reject, ``receiver_port=True`` would pass
         # as port 1.
         vol.Required("receiver_port"): vol.All(not_bool, int, vol.Range(min=1, max=65535)),
-        # Lowercase-hex SHA-256: 64 chars from ``[0-9a-f]``. The regex
-        # is anchored so a non-hex char anywhere in the string fails;
-        # the explicit length is redundant with the regex's
-        # ``{64}`` quantifier but kept as a defensive belt — a future
-        # regex tweak that accidentally widens the alphabet still
-        # gets caught by the length check.
-        vol.Required("pin_sha256"): vol.All(
-            str, vol.Length(min=64, max=64), vol.Match(r"^[0-9a-f]{64}$")
-        ),
+        # Lowercase-hex SHA-256: 64 chars from ``[0-9a-f]``. Factory
+        # in ``helpers/voluptuous_validators.py`` so the same shape
+        # can be reused by the future ``StoredPeer`` validator (issue
+        # #106 follow-up) and the 4a-o parts 2-3 WS-command
+        # validators without drifting.
+        vol.Required("pin_sha256"): lowercase_hex(64),
         # ``static_x25519_pub`` is the raw X25519 pubkey — exactly 32
         # bytes per RFC 7748 §5.
         vol.Required("static_x25519_pub"): vol.All(bytes, vol.Length(min=32, max=32)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ dependencies = [
   "mashumaro>=3.13",
   "orjson>=3.9.0",
   "pyyaml>=6.0",
+  # ESPHome already drags voluptuous in transitively, but the
+  # remote-build storage models (``models/remote_build.py``) use it
+  # directly via project-local validators. Pinning it explicitly so
+  # lean envs (the sync-boards pre-commit hook, any future
+  # esphome-less install path) don't drop it.
+  "voluptuous>=0.13.1",
 ]
 description = "ESPHome Device Builder"
 license = "Apache-2.0"

--- a/tests/test_offloader_remote_build_storage.py
+++ b/tests/test_offloader_remote_build_storage.py
@@ -78,6 +78,12 @@ def test_stored_pairing_rejects_oversize_hostname() -> None:
         _valid_pairing(receiver_hostname="x" * 256)
 
 
+def test_stored_pairing_rejects_whitespace_only_hostname() -> None:
+    """``"   "`` passes ``Length(min=1)`` but is unresolvable; reject pre-store."""
+    with pytest.raises(ValueError, match="receiver_hostname"):
+        _valid_pairing(receiver_hostname="   ")
+
+
 def test_stored_pairing_rejects_non_string_hostname() -> None:
     with pytest.raises(ValueError, match="receiver_hostname"):
         _valid_pairing(receiver_hostname=123)
@@ -103,6 +109,18 @@ def test_stored_pairing_rejects_wrong_pin_length() -> None:
         _valid_pairing(pin_sha256="a" * 65)
 
 
+def test_stored_pairing_rejects_uppercase_hex_pin() -> None:
+    """Pin is canonical lowercase-hex; uppercase is the canonicalisation seam."""
+    with pytest.raises(ValueError, match="pin_sha256"):
+        _valid_pairing(pin_sha256="A" * 64)
+
+
+def test_stored_pairing_rejects_non_hex_pin() -> None:
+    """Right length, wrong alphabet — schema's regex catches it."""
+    with pytest.raises(ValueError, match="pin_sha256"):
+        _valid_pairing(pin_sha256="z" * 64)
+
+
 def test_stored_pairing_rejects_wrong_pubkey_length() -> None:
     with pytest.raises(ValueError, match="static_x25519_pub"):
         _valid_pairing(static_x25519_pub=b"\x00" * 31)
@@ -113,6 +131,14 @@ def test_stored_pairing_rejects_wrong_pubkey_length() -> None:
 def test_stored_pairing_rejects_oversize_label() -> None:
     with pytest.raises(ValueError, match="label"):
         _valid_pairing(label="x" * 129)
+
+
+def test_stored_pairing_rejects_bool_paired_at() -> None:
+    """``paired_at=True`` would silently coerce to 1.0 without ``not_bool``."""
+    with pytest.raises(ValueError, match="paired_at"):
+        _valid_pairing(paired_at=True)
+    with pytest.raises(ValueError, match="paired_at"):
+        _valid_pairing(paired_at=False)
 
 
 def test_stored_pairing_accepts_empty_label() -> None:

--- a/tests/test_offloader_remote_build_storage.py
+++ b/tests/test_offloader_remote_build_storage.py
@@ -1,0 +1,307 @@
+"""
+Tests for the offloader-side remote-build storage layer (phase 4a-o part 1).
+
+Three layers:
+
+* ``StoredPairing`` field validation in ``__post_init__`` — the
+  storage-seam defense against a hand-edited / corrupt sidecar
+  smuggling oversize hostnames, malformed pins, or
+  wrong-length pubkeys past the WS-command validators.
+* ``OffloaderRemoteBuildSettings`` JSON round-trip — a freshly
+  saved blob loads back identical, including the raw
+  ``static_x25519_pub`` bytes (mashumaro encodes ``bytes`` as
+  base64).
+* ``offloader_remote_build_settings_transaction`` RMW — atomic
+  read-modify-write under the same metadata-transaction lock
+  that the receiver-side helpers use, so a concurrent
+  offloader pair + receiver token edit don't race.
+
+Tolerance: a wholly malformed ``_offloader_remote_build`` blob
+falls back to defaults (empty ``pairings``); the loader doesn't
+crash dashboard startup on a corrupt sidecar.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.controllers.config import (
+    _METADATA_FILE,
+    _OFFLOADER_REMOTE_BUILD_KEY,
+    load_offloader_remote_build_settings,
+    offloader_remote_build_settings_transaction,
+    save_offloader_remote_build_settings,
+)
+from esphome_device_builder.models import (
+    OffloaderRemoteBuildSettings,
+    PeerStatus,
+    StoredPairing,
+)
+
+
+def _valid_pairing(**overrides: object) -> StoredPairing:
+    """Build a passing :class:`StoredPairing` with the given overrides."""
+    base: dict[str, object] = {
+        "receiver_hostname": "build.local",
+        "receiver_port": 6055,
+        "pin_sha256": "a" * 64,
+        "static_x25519_pub": b"\x01" * 32,
+        "label": "desktop",
+        "paired_at": 1.0,
+        "status": PeerStatus.PENDING,
+    }
+    base.update(overrides)
+    return StoredPairing(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# StoredPairing field validation
+# ---------------------------------------------------------------------------
+
+
+def test_stored_pairing_accepts_minimal_valid_row() -> None:
+    pairing = _valid_pairing()
+    assert pairing.receiver_hostname == "build.local"
+    assert pairing.status is PeerStatus.PENDING
+
+
+def test_stored_pairing_rejects_empty_hostname() -> None:
+    with pytest.raises(ValueError, match="receiver_hostname"):
+        _valid_pairing(receiver_hostname="")
+
+
+def test_stored_pairing_rejects_oversize_hostname() -> None:
+    with pytest.raises(ValueError, match="receiver_hostname"):
+        _valid_pairing(receiver_hostname="x" * 256)
+
+
+def test_stored_pairing_rejects_non_string_hostname() -> None:
+    with pytest.raises(ValueError, match="receiver_hostname"):
+        _valid_pairing(receiver_hostname=123)
+
+
+def test_stored_pairing_rejects_port_out_of_range() -> None:
+    with pytest.raises(ValueError, match="receiver_port"):
+        _valid_pairing(receiver_port=0)
+    with pytest.raises(ValueError, match="receiver_port"):
+        _valid_pairing(receiver_port=70000)
+
+
+def test_stored_pairing_rejects_bool_port() -> None:
+    """``isinstance(True, int)`` is true in Python; explicit bool reject."""
+    with pytest.raises(ValueError, match="receiver_port"):
+        _valid_pairing(receiver_port=True)
+
+
+def test_stored_pairing_rejects_wrong_pin_length() -> None:
+    with pytest.raises(ValueError, match="pin_sha256"):
+        _valid_pairing(pin_sha256="a" * 63)
+    with pytest.raises(ValueError, match="pin_sha256"):
+        _valid_pairing(pin_sha256="a" * 65)
+
+
+def test_stored_pairing_rejects_wrong_pubkey_length() -> None:
+    with pytest.raises(ValueError, match="static_x25519_pub"):
+        _valid_pairing(static_x25519_pub=b"\x00" * 31)
+    with pytest.raises(ValueError, match="static_x25519_pub"):
+        _valid_pairing(static_x25519_pub=b"\x00" * 33)
+
+
+def test_stored_pairing_rejects_oversize_label() -> None:
+    with pytest.raises(ValueError, match="label"):
+        _valid_pairing(label="x" * 129)
+
+
+def test_stored_pairing_accepts_empty_label() -> None:
+    """Empty label is fine — the user may legitimately not name the receiver."""
+    pairing = _valid_pairing(label="")
+    assert pairing.label == ""
+
+
+# ---------------------------------------------------------------------------
+# OffloaderRemoteBuildSettings round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_settings_default_is_empty_pairings() -> None:
+    settings = OffloaderRemoteBuildSettings()
+    assert settings.pairings == []
+
+
+def test_settings_round_trip_preserves_pairing_fields(tmp_path: Path) -> None:
+    """Save then load — every field round-trips identical.
+
+    Includes the raw ``static_x25519_pub`` bytes (mashumaro
+    base64-encodes them on the wire).
+    """
+    pubkey = bytes(range(32))
+    settings = OffloaderRemoteBuildSettings(
+        pairings=[
+            _valid_pairing(
+                receiver_hostname="desk.local",
+                receiver_port=6055,
+                pin_sha256="b" * 64,
+                static_x25519_pub=pubkey,
+                label="desk",
+                paired_at=42.5,
+                status=PeerStatus.APPROVED,
+            )
+        ]
+    )
+
+    save_offloader_remote_build_settings(tmp_path, settings)
+    loaded = load_offloader_remote_build_settings(tmp_path)
+
+    [row] = loaded.pairings
+    assert row.receiver_hostname == "desk.local"
+    assert row.receiver_port == 6055
+    assert row.pin_sha256 == "b" * 64
+    assert row.static_x25519_pub == pubkey
+    assert row.label == "desk"
+    assert row.paired_at == 42.5
+    assert row.status is PeerStatus.APPROVED
+
+
+def test_load_returns_defaults_when_metadata_missing(tmp_path: Path) -> None:
+    """No sidecar at all → empty pairings, no exception."""
+    settings = load_offloader_remote_build_settings(tmp_path)
+    assert settings.pairings == []
+
+
+def test_load_returns_defaults_when_offloader_key_missing(tmp_path: Path) -> None:
+    """Sidecar exists but no offloader key → empty pairings."""
+    (tmp_path / _METADATA_FILE).write_text(json.dumps({"_remote_build": {"enabled": False}}))
+    settings = load_offloader_remote_build_settings(tmp_path)
+    assert settings.pairings == []
+
+
+def test_load_returns_defaults_when_blob_is_not_a_dict(tmp_path: Path) -> None:
+    """A scalar / list under the offloader key falls back to defaults."""
+    (tmp_path / _METADATA_FILE).write_text(json.dumps({_OFFLOADER_REMOTE_BUILD_KEY: ["nonsense"]}))
+    settings = load_offloader_remote_build_settings(tmp_path)
+    assert settings.pairings == []
+
+
+def test_load_returns_defaults_on_malformed_pairing_row(tmp_path: Path) -> None:
+    """A bad row trips ``from_dict``; the whole blob falls back to defaults.
+
+    Hand-edited / partial-write sidecars that violate the
+    schema (e.g. oversize hostname) shouldn't crash dashboard
+    startup. Per-row tolerance (keep the good rows, drop the
+    bad one) would mirror the deleted ``_decode_tokens`` helper
+    from phase 4a-r2; deferred until the offloader pool
+    actually accumulates enough rows for one bad entry to
+    matter.
+    """
+    (tmp_path / _METADATA_FILE).write_text(
+        json.dumps(
+            {
+                _OFFLOADER_REMOTE_BUILD_KEY: {
+                    "pairings": [
+                        {
+                            "receiver_hostname": "x" * 1000,  # oversize
+                            "receiver_port": 6055,
+                            "pin_sha256": "a" * 64,
+                            "static_x25519_pub": "AA==",  # base64 of 1 byte; wrong len
+                            "label": "bad",
+                            "paired_at": 1.0,
+                            "status": "pending",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    settings = load_offloader_remote_build_settings(tmp_path)
+    assert settings.pairings == []
+
+
+def test_load_ignores_unknown_keys_on_legacy_blob(tmp_path: Path) -> None:
+    """Older sidecars with extra keys are tolerated by mashumaro defaults."""
+    (tmp_path / _METADATA_FILE).write_text(
+        json.dumps(
+            {
+                _OFFLOADER_REMOTE_BUILD_KEY: {
+                    "pairings": [],
+                    "future_field": "ignore me",
+                }
+            }
+        )
+    )
+    settings = load_offloader_remote_build_settings(tmp_path)
+    assert settings.pairings == []
+
+
+# ---------------------------------------------------------------------------
+# RMW transaction
+# ---------------------------------------------------------------------------
+
+
+def test_transaction_persists_mutations_on_clean_exit(tmp_path: Path) -> None:
+    with offloader_remote_build_settings_transaction(tmp_path) as settings:
+        settings.pairings.append(_valid_pairing(label="from-txn"))
+
+    loaded = load_offloader_remote_build_settings(tmp_path)
+    [row] = loaded.pairings
+    assert row.label == "from-txn"
+
+
+def test_transaction_discards_mutations_on_exception(tmp_path: Path) -> None:
+    """An exception inside the block aborts the metadata write."""
+    with (
+        pytest.raises(RuntimeError, match="boom"),
+        offloader_remote_build_settings_transaction(tmp_path) as settings,
+    ):
+        settings.pairings.append(_valid_pairing(label="will-be-rolled-back"))
+        raise RuntimeError("boom")
+
+    loaded = load_offloader_remote_build_settings(tmp_path)
+    assert loaded.pairings == []
+
+
+def test_transaction_observes_existing_state(tmp_path: Path) -> None:
+    """RMW reads the current state, not a fresh default."""
+    save_offloader_remote_build_settings(
+        tmp_path,
+        OffloaderRemoteBuildSettings(pairings=[_valid_pairing(label="seeded")]),
+    )
+
+    with offloader_remote_build_settings_transaction(tmp_path) as settings:
+        assert len(settings.pairings) == 1
+        assert settings.pairings[0].label == "seeded"
+        settings.pairings.append(_valid_pairing(label="appended"))
+
+    loaded = load_offloader_remote_build_settings(tmp_path)
+    assert [p.label for p in loaded.pairings] == ["seeded", "appended"]
+
+
+def test_transaction_does_not_disturb_receiver_remote_build_key(
+    tmp_path: Path,
+) -> None:
+    """Offloader writes don't disturb the receiver's ``_remote_build`` key.
+
+    The two roles can coexist on the same dashboard; pin the
+    isolation so a future "share state across keys" refactor
+    has to fail this test on purpose.
+    """
+    (tmp_path / _METADATA_FILE).write_text(
+        json.dumps(
+            {
+                "_remote_build": {
+                    "enabled": True,
+                    "manual_hosts": [{"hostname": "peer.local", "port": 6055}],
+                }
+            }
+        )
+    )
+
+    with offloader_remote_build_settings_transaction(tmp_path) as settings:
+        settings.pairings.append(_valid_pairing(label="offloader-only"))
+
+    raw = json.loads((tmp_path / _METADATA_FILE).read_text())
+    assert raw["_remote_build"]["enabled"] is True
+    assert raw["_remote_build"]["manual_hosts"] == [{"hostname": "peer.local", "port": 6055}]
+    assert raw[_OFFLOADER_REMOTE_BUILD_KEY]["pairings"][0]["label"] == "offloader-only"

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -522,6 +522,19 @@ def test_validate_hostname_rejects_empty() -> None:
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
+def test_validate_hostname_rejects_oversize() -> None:
+    """A megabyte-string masquerading as a hostname is rejected pre-store.
+
+    Caps at 255 chars (RFC 1035 §2.3.4 = 253, plus slack for
+    trailing-dot variations). The error message names the cap so a
+    misbehaving frontend can surface a useful diagnostic to the user.
+    """
+    with pytest.raises(CommandError) as exc:
+        _validate_hostname("a" * 256)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+    assert "255 characters" in str(exc.value)
+
+
 def test_validate_port_accepts_typical() -> None:
     assert _validate_port(6052) == 6052
 

--- a/tests/test_voluptuous_validators.py
+++ b/tests/test_voluptuous_validators.py
@@ -1,0 +1,57 @@
+"""
+Tests for the project-local :mod:`voluptuous` validators.
+
+Pin the contract of each custom validator so a future
+"refactor a chain to use a different upstream primitive"
+doesn't silently change the rejection surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+import voluptuous as vol
+
+from esphome_device_builder.helpers.voluptuous_validators import not_bool
+
+
+def test_not_bool_rejects_true() -> None:
+    with pytest.raises(vol.Invalid, match="must not be a bool"):
+        not_bool(True)
+
+
+def test_not_bool_rejects_false() -> None:
+    with pytest.raises(vol.Invalid, match="must not be a bool"):
+        not_bool(False)
+
+
+def test_not_bool_passes_int() -> None:
+    assert not_bool(0) == 0
+    assert not_bool(1) == 1
+    assert not_bool(-42) == -42
+
+
+def test_not_bool_passes_str() -> None:
+    """Non-bool, non-int values flow through; downstream chain decides."""
+    assert not_bool("hi") == "hi"
+
+
+def test_not_bool_passes_none() -> None:
+    assert not_bool(None) is None
+
+
+def test_not_bool_chains_with_int_range() -> None:
+    """Real usage shape: port validator rejecting ``True`` / ``False`` first.
+
+    Without :func:`not_bool` the chain would silently accept
+    ``True`` as port 1 (Python's ``isinstance(True, int)`` is
+    true, so ``vol.Range`` accepts it).
+    """
+    schema = vol.Schema(vol.All(not_bool, int, vol.Range(min=1, max=65535)))
+
+    with pytest.raises(vol.Invalid, match="must not be a bool"):
+        schema(True)
+    with pytest.raises(vol.Invalid, match="must not be a bool"):
+        schema(False)
+    assert schema(6055) == 6055
+    with pytest.raises(vol.Invalid):
+        schema(70000)

--- a/tests/test_voluptuous_validators.py
+++ b/tests/test_voluptuous_validators.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 import voluptuous as vol
 
-from esphome_device_builder.helpers.voluptuous_validators import not_bool
+from esphome_device_builder.helpers.voluptuous_validators import lowercase_hex, not_bool
 
 
 def test_not_bool_rejects_true() -> None:
@@ -55,3 +55,48 @@ def test_not_bool_chains_with_int_range() -> None:
     assert schema(6055) == 6055
     with pytest.raises(vol.Invalid):
         schema(70000)
+
+
+def test_lowercase_hex_accepts_canonical_hash() -> None:
+    schema = vol.Schema(lowercase_hex(64))
+    assert schema("a" * 64) == "a" * 64
+    assert schema("0123456789abcdef" * 4) == "0123456789abcdef" * 4
+
+
+def test_lowercase_hex_rejects_uppercase() -> None:
+    schema = vol.Schema(lowercase_hex(64))
+    with pytest.raises(vol.Invalid):
+        schema("A" * 64)
+    with pytest.raises(vol.Invalid):
+        schema("0123456789ABCDEF" * 4)
+
+
+def test_lowercase_hex_rejects_non_hex_alphabet() -> None:
+    """Right length, wrong alphabet (``z`` is outside [0-9a-f])."""
+    schema = vol.Schema(lowercase_hex(64))
+    with pytest.raises(vol.Invalid):
+        schema("z" * 64)
+
+
+def test_lowercase_hex_rejects_wrong_length() -> None:
+    schema = vol.Schema(lowercase_hex(64))
+    with pytest.raises(vol.Invalid):
+        schema("a" * 63)
+    with pytest.raises(vol.Invalid):
+        schema("a" * 65)
+
+
+def test_lowercase_hex_rejects_non_string() -> None:
+    schema = vol.Schema(lowercase_hex(64))
+    with pytest.raises(vol.Invalid):
+        schema(b"a" * 64)
+
+
+def test_lowercase_hex_factory_parametric() -> None:
+    """The length is parametric so callers can validate other digest sizes."""
+    schema_8 = vol.Schema(lowercase_hex(8))  # config_hash shape
+    assert schema_8("deadbeef") == "deadbeef"
+    with pytest.raises(vol.Invalid):
+        schema_8("deadbeef0")  # too long
+    with pytest.raises(vol.Invalid):
+        schema_8("DEADBEEF")  # uppercase


### PR DESCRIPTION
# What does this implement/fix?

First sub-PR of phase 4a-o (offloader-side pair-request flow).
Pure data layer: `StoredPairing` model + `OffloaderRemoteBuildSettings`
container + storage helpers under a new `_offloader_remote_build`
key in `.device-builder.json`. No WS commands, no Noise round-trips
in this PR.

Subsequent 4a-o sub-PRs:
- Part 2: initiator Noise client + `remote_build/preview_pair`
- Part 3: `remote_build/request_pair`
- Part 4: `remote_build/unpair` + `remote_build/list_pool` (with 2s debounce cache)

**Field-level validation via voluptuous.** `StoredPairing.__post_init__`
runs a `vol.Schema` enforcing the field bounds (hostname ≤ 255
chars per RFC 1035 §2.3.4 + slack, port 1-65535 non-bool, pin_sha256
exactly 64 lowercase-hex chars, static_x25519_pub exactly 32 bytes,
label ≤ 128 chars). Defense-in-depth at the storage seam so a
hand-edited / partial-write sidecar can't smuggle unbounded values
past the (future) WS-command validators in parts 2-3.

A new `helpers/voluptuous_validators.py` module hosts project-local
custom validators — currently just `not_bool` (since voluptuous's
`int` check accepts `bool` and we don't want `True` slipping through
as port 1). Single home + dedicated tests so future validators land
in one obvious place rather than scattered across modules.

**Asymmetry with `StoredPeer`.** The receiver-side row (#472)
doesn't run a comparable storage-seam schema. Its only constructor
in production is `record_pair_request`, which runs *after* a
successful Noise XX handshake (noiseprotocol guarantees the
32-byte pubkey shape) and *after* the dispatcher's `dashboard_id`
pattern check + `_normalize_label` cap — so the WS surface is
already the validation seam there. Either both rows benefit from
defense-in-depth against hand-edited sidecars or neither does;
flagging this PR's choice as inconsistent rather than masking it.
A follow-up applying the same `vol.Schema`-in-`__post_init__`
pattern to `StoredPeer` is queued for after this lands.

**Schema is a second source of truth alongside the dataclass
annotations.** Each `vol.Required(...)` mirrors a field declared
on `StoredPairing`; renaming / dropping / adding a field in one
place without the other will silently desync. A maintenance note
in the source flags this for future contributors so the two stay
in lockstep.

**Isolation from receiver state.** Offloader pairings live under
`_offloader_remote_build.pairings`; the receiver's
`_remote_build.peers` is untouched. The two roles can coexist on
the same dashboard, and a future "split offloader / receiver into
two processes" refactor only has to peel one key out. Test pins
this isolation.

**Tolerance trade-off.** A single corrupt pairing row currently
trips `_offloader_settings_from_raw`'s outer try/except and the
whole `pairings` list falls back to defaults — same all-or-nothing
shape as `_settings_from_raw` for `_remote_build` post-#489 (which
deleted `_decode_tokens`'s row-by-row tolerance). For a brand-new
feature with no installed base this is the right trade-off; a user
hitting partial-write recovery re-pairs their handful of receivers
rather than living with one mysteriously-missing row. Worth
revisiting if the persisted shape ever grows hundreds of rows
(unlikely — typical install has a single offloader paired with
1-3 receivers).

**Notes on bounds the schema doesn't enforce.** `paired_at` is
informational (sorts the inbox; doesn't gate auth) so the schema
accepts any int/float without a range check. Schema cost is one
`vol.Schema()` call per pairing on every settings load — negligible
at production peer counts, linear if pairings ever balloon.

**Tests:** 21 new in `test_offloader_remote_build_storage.py` (field
validation per failure mode, JSON round-trip including base64-encoded
`static_x25519_pub` bytes, default-on-missing/malformed, RMW atomicity
including rollback-on-exception, isolation from receiver key) +
6 in `test_voluptuous_validators.py` + 1 covering the new
hostname-length-cap branch in `_validate_hostname`. Full suite:
2354 pass; `controllers/remote_build.py` back at 100% line coverage.

**Drive-by:** cap `_validate_hostname` at 255 chars
(`_HOSTNAME_MAX_CHARS`). The receiver's `manual_hosts` surface and
the upcoming offloader pair commands both use it; without the cap a
misbehaving frontend could push a multi-megabyte string into either
side's settings sidecar.

**CI fix:** added `voluptuous` to the `sync-boards` pre-commit
hook's `additional_dependencies` (the slim env doesn't pull in
ESPHome's transitive voluptuous) and to `pyproject.toml`'s explicit
deps so a future esphome-less install path doesn't drop it.

**Related issue or feature (if applicable):**

- part 1 of #106 phase 4a-o; builds on phases 4a-r1 + 4a-r2 (#479, #489)

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Frontend coordination

- [x] No frontend change needed — this is purely backend storage; the WS commands that surface to the frontend come in parts 2-4

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (Doc updates land with parts 2-4 when the offloader WS surface becomes user-visible; this PR is internal storage only.)