### PR TITLE
Add offloader-side preview_pair WS command (#106 phase 4a-o part 2)

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -65,6 +65,7 @@ from dataclasses import dataclass as _dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from esphome.const import __version__ as esphome_version
+from yarl import URL
 from zeroconf import IPVersion, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
@@ -231,6 +232,22 @@ def _validate_hostname(raw: object) -> str:
     ``list_pool``) with a megabyte-string masquerading as a
     hostname.
 
+    Defers the URL-validity check to :class:`yarl.URL.build` so
+    the WS-command validator and the offloader's
+    ``_build_ws_url`` (in
+    :mod:`controllers.remote_build_peer_link_client`) share a
+    single source of truth on what constitutes a host. yarl
+    rejects ``/``, ``?``, ``#``, ``@``, embedded ``:port``, and
+    other URL-injection shapes that would otherwise let a
+    pathological hostname smuggle path / query / fragment /
+    userinfo into the rendered URL. Without this layered check
+    the offloader's ``preview_pair`` would have to catch the
+    ``ValueError`` from ``URL.build`` at request time and map
+    it to ``UNAVAILABLE``; surfacing the same shape as
+    ``INVALID_ARGS`` here means the frontend gets a "fix your
+    input" diagnostic rather than a "transient remote
+    failure" toast.
+
     Lowercase normalisation matches the duplicate-check
     semantics; hostnames are case-insensitive per RFC 1035 §2.3.3,
     so ``Desktop.local`` and ``desktop.local`` should be the same
@@ -252,6 +269,16 @@ def _validate_hostname(raw: object) -> str:
     if len(trimmed) > _HOSTNAME_MAX_CHARS:
         msg = f"manual host: 'hostname' must be at most {_HOSTNAME_MAX_CHARS} characters"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    # The ``port=80, path="/"`` are sentinels for the build call
+    # — only the host arg is being validated. yarl's host parser
+    # is the same one ``_build_ws_url`` will use later, so any
+    # input that passes here is guaranteed to round-trip
+    # through the URL builder without raising.
+    try:
+        URL.build(scheme="ws", host=trimmed, port=80, path="/")
+    except ValueError as exc:
+        msg = f"manual host: 'hostname' is not a valid host: {exc}"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
     return trimmed
 
 

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -77,6 +77,7 @@ from ..helpers.dashboard_identity import (
     get_or_create_identity,
     rotate_certificate,
 )
+from ..helpers.peer_link_identity import get_or_create_peer_link_identity
 from ..models import (
     ErrorCode,
     EventType,
@@ -96,6 +97,12 @@ from ..models import (
     StoredPeer,
 )
 from .config import load_remote_build_settings, remote_build_settings_transaction
+from .remote_build_peer_link_client import (
+    PeerLinkClientError,
+)
+from .remote_build_peer_link_client import (
+    preview_pair as peer_link_preview_pair,
+)
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
@@ -683,6 +690,61 @@ class RemoteBuildController:
             settings.manual_hosts = kept
 
         return await self._modify_settings(_remove)
+
+    # ------------------------------------------------------------------
+    # Offloader-side pair flow (phase 4a-o) — initiator commands that
+    # open Noise XX WebSockets to a receiver's peer-link endpoint. The
+    # wire-shape driver lives in
+    # :mod:`controllers.remote_build_peer_link_client`; the WS command
+    # here owns input validation, identity loading, and error mapping.
+    # ------------------------------------------------------------------
+
+    @api_command("remote_build/preview_pair")
+    async def preview_pair(self, *, hostname: str, port: int, **kwargs: Any) -> dict[str, str]:
+        """Open a brief Noise XX WS to *hostname*:*port* and return the receiver's pin.
+
+        The offloader runs ``intent="preview"`` to capture the
+        receiver's static X25519 pubkey from the Noise handshake
+        transcript before committing to pair. The frontend
+        renders the returned ``pin_sha256`` for the user to
+        OOB-verify against the receiver's "Build server"
+        Settings card; only after that confirmation does the
+        offloader call ``request_pair`` (phase 4a-o part 3).
+
+        Args:
+            hostname: Receiver's hostname / IP (validated as for
+                manual hosts: non-empty, ≤255 chars,
+                lowercase-normalised).
+            port: Receiver's peer-link port (1-65535, non-bool).
+
+        Returns:
+            ``{"pin_sha256": "<lowercase-hex-64>"}`` on a
+            successful preview round-trip.
+
+        Raises:
+            :class:`CommandError(INVALID_ARGS)` for bad inputs.
+            :class:`CommandError(UNAVAILABLE)` for any transport
+            / handshake / decode failure (connection refused,
+            timeout, malformed Noise frame, mismatched
+            ``intent_response``).
+        """
+        clean_host = _validate_hostname(hostname)
+        clean_port = _validate_port(port)
+        loop = asyncio.get_running_loop()
+        identity = await loop.run_in_executor(
+            None,
+            get_or_create_peer_link_identity,
+            self._db.settings.config_dir,
+        )
+        try:
+            pin = await peer_link_preview_pair(
+                hostname=clean_host,
+                port=clean_port,
+                identity_priv=identity.private_bytes,
+            )
+        except PeerLinkClientError as exc:
+            raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
+        return {"pin_sha256": pin}
 
     # ------------------------------------------------------------------
     # Identity (phase 3c1) — surface the receiver's own dashboard_id +

--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -49,37 +49,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import WSMsgType, web
-from noise.exceptions import (
-    NoiseHandshakeError,
-    NoiseInvalidMessage,
-    NoiseMaxNonceError,
-    NoiseValueError,
-)
 
 from ..helpers import json as _json
 from ..helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
 from ..helpers.peer_link_identity import get_or_create_peer_link_identity
 from ..helpers.peer_link_noise import (
+    NOISE_ERRORS,
     HandshakeNotCompleteError,
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
 from ..models import IntentResponse, PeerLinkIntent
-
-# noiseprotocol exceptions don't share a common base; tuple-catch
-# the relevant subset rather than ``except Exception:``. Covers
-# malformed-Noise-frame failures from ``read_message`` /
-# ``write_message`` and nonce / state errors from ``encrypt`` /
-# ``decrypt``. A genuine bug (using the API wrong) raises one of
-# these too, but the WS handler's outer ``except Exception:`` in
-# :func:`make_peer_link_handler`'s closure still catches anything
-# else and logs with traceback.
-_NOISE_ERRORS = (
-    NoiseHandshakeError,
-    NoiseInvalidMessage,
-    NoiseMaxNonceError,
-    NoiseValueError,
-)
 
 
 class _HandshakeStep(StrEnum):
@@ -338,7 +318,7 @@ async def _read_handshake_message(
         return None
     try:
         return session.read_handshake_message(msg.data)
-    except _NOISE_ERRORS:
+    except NOISE_ERRORS:
         _LOGGER.warning("peer-link Noise %s read failed", step, exc_info=True)
         return None
 
@@ -378,7 +358,7 @@ async def _send_handshake_message(
     """Send one Noise handshake message as a binary WS frame; return True on success."""
     try:
         encoded = session.write_handshake_message(payload)
-    except _NOISE_ERRORS:
+    except NOISE_ERRORS:
         _LOGGER.warning("peer-link Noise %s write failed", step, exc_info=True)
         return False
     return await _send_bytes_safely(ws, encoded, log_label=str(step))
@@ -393,7 +373,7 @@ async def _send_response(
     body = _json.dumps({"intent_response": response.value})
     try:
         encrypted = session.encrypt(body)
-    except _NOISE_ERRORS:
+    except NOISE_ERRORS:
         _LOGGER.warning("peer-link transport encrypt failed", exc_info=True)
         return
     await _send_bytes_safely(ws, encrypted, log_label="response")

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -34,9 +34,9 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import quote
 
 import aiohttp
+from yarl import URL
 
 from ..helpers import json as _json
 from ..helpers.peer_link_noise import (
@@ -103,18 +103,32 @@ class InitiatorRoundTrip:
     response: dict[str, Any]
 
 
-def _build_ws_url(hostname: str, port: int) -> str:
-    """Render the peer-link WS URL for *hostname* / *port*.
+def _build_ws_url(hostname: str, port: int) -> URL:
+    """Build the peer-link WS URL for *hostname* / *port*.
 
-    ``urllib.parse.quote`` on the hostname so a stray pathological
-    character (e.g. an IPv6 literal that should have been bracketed
-    by the caller, or a hostname containing a slash) can't smuggle
-    a different path or query into the URL. The receiver listens on
-    plain TCP — Noise XX provides the transport security — so the
-    scheme is ``ws://`` not ``wss://``.
+    Uses :class:`yarl.URL` (already in our dep closure via aiohttp)
+    rather than hand-rolled f-string + ``urllib.parse.quote``:
+
+    * IPv6 literals get auto-bracketed (``::1`` →
+      ``ws://[::1]:6055/...``); the f-string version would have
+      produced an unparsable URL.
+    * Pathological characters in the hostname (slash, query
+      terminators, fragment markers) raise ``ValueError`` loudly
+      instead of getting silently percent-encoded into a
+      non-resolvable form. ``_validate_hostname`` already
+      catches these at the WS-command boundary, but yarl
+      gives us a second line of defense at no extra code.
+    * Path is given to yarl as a constant; encoding stays
+      intact across versions.
+
+    The receiver listens on plain TCP — Noise XX provides the
+    transport security — so the scheme is ``ws://`` not
+    ``wss://``. Returns a :class:`URL` because
+    :meth:`aiohttp.ClientSession.ws_connect` accepts both
+    strings and ``URL`` instances; passing the typed shape
+    skips one re-parse on the aiohttp side.
     """
-    safe_host = quote(hostname, safe="")
-    return f"ws://{safe_host}:{port}{PEER_LINK_PATH}"
+    return URL.build(scheme="ws", host=hostname, port=port, path=PEER_LINK_PATH)
 
 
 async def drive_initiator_round_trip(

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -50,6 +50,19 @@ from .remote_build_peer_link import PEER_LINK_PATH
 
 _LOGGER = logging.getLogger(__name__)
 
+# Flat tuple of every exception class that can land out of the
+# decrypt + JSON-parse step. Built once at module level rather
+# than inlined as ``(*NOISE_ERRORS, _json.JSONDecodeError)`` in
+# the ``except`` clause so mypy can verify the type without
+# tripping on its star-unpack-in-except limitation (the runtime
+# would handle the inline form fine on Python 3.12+, but the
+# type checker can't follow it).
+_RESPONSE_DECODE_ERRORS: tuple[type[Exception], ...] = (
+    *NOISE_ERRORS,
+    _json.JSONDecodeError,
+)
+
+
 # Total budget for one initiator round-trip: TCP connect + WS
 # upgrade + 3 Noise messages + post-handshake response + clean
 # close. Bounded by LAN latency + the receiver's own per-step
@@ -169,12 +182,9 @@ async def drive_initiator_round_trip(
         _LOGGER.warning(msg, exc_info=True)
         raise PeerLinkClientError(msg) from exc
 
-    # ``NOISE_ERRORS`` is a tuple of classes; Python's ``except``
-    # syntax doesn't accept nested tuples, so star-unpack it into
-    # a flat tuple alongside the JSON decode error.
     try:
         decoded = _json.loads(sess.decrypt(response_ct))
-    except (*NOISE_ERRORS, _json.JSONDecodeError) as exc:
+    except _RESPONSE_DECODE_ERRORS as exc:
         msg = f"{label} response decode failed: {exc}"
         _LOGGER.warning(msg, exc_info=True)
         raise PeerLinkClientError(msg) from exc

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -18,23 +18,22 @@ exception-tuple (:data:`helpers.peer_link_noise.NOISE_ERRORS`)
 so a future ``noiseprotocol`` upgrade only has to thread through
 one place.
 
-Scope of this part 2 PR:
-
-* :func:`preview_pair` — runs an ``intent="preview"`` round-trip
-  and returns the receiver's ``pin_sha256`` for OOB display.
-  Used by the new ``remote_build/preview_pair`` WS command.
-
-Subsequent 4a-o PRs add ``request_pair`` (part 3,
-:func:`request_pair_handshake`-style helper) and
-``intent="pair_status"`` polling (part 4, used by
-``list_pool``); the shared driver below is shaped so they can
-slot in without re-implementing the connect / read / write
-plumbing.
+The wire-flow shape — TCP connect, 3 Noise XX messages, post-
+handshake transport frame, error mapping — is identical across
+every initiator-side intent the offloader needs (``preview``,
+``pair_request``, ``pair_status``, eventually ``peer_link``);
+only the msg3 payload and which response codes count as success
+differ. :func:`drive_initiator_round_trip` owns the shared flow;
+each public ``preview_pair`` / ``request_pair`` / ``poll_pair_status``
+function (parts 2-4 of phase 4a-o) is a thin wrapper that
+provides the intent + msg3 payload + accepted-response set.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from typing import Any
 from urllib.parse import quote
 
 import aiohttp
@@ -51,7 +50,7 @@ from .remote_build_peer_link import PEER_LINK_PATH
 
 _LOGGER = logging.getLogger(__name__)
 
-# Total budget for the preview round-trip: TCP connect + WS
+# Total budget for one initiator round-trip: TCP connect + WS
 # upgrade + 3 Noise messages + post-handshake response + clean
 # close. Bounded by LAN latency + the receiver's own per-step
 # timeout (10s in
@@ -59,7 +58,7 @@ _LOGGER = logging.getLogger(__name__)
 # 10s here matches that budget so we don't give up before the
 # receiver does, but doesn't pin a coroutine forever if the
 # remote side is gone.
-_PREVIEW_TIMEOUT_SECONDS = 10.0
+_DEFAULT_TIMEOUT_SECONDS = 10.0
 
 
 class PeerLinkClientError(RuntimeError):
@@ -71,6 +70,24 @@ class PeerLinkClientError(RuntimeError):
     layer can map to a single ``UNAVAILABLE`` :class:`CommandError`
     without having to enumerate every transport failure mode.
     """
+
+
+@dataclass(frozen=True)
+class InitiatorRoundTrip:
+    """One offloader-side Noise XX round-trip's outputs.
+
+    Returned by :func:`drive_initiator_round_trip`. Bundles
+    everything a caller might need from a completed handshake +
+    response: the receiver's pubkey (so :func:`preview_pair`
+    can hash it), the ``intent_response`` value (so callers can
+    branch on PENDING / APPROVED / REJECTED / NO_PAIRING_WINDOW),
+    and the full decoded response dict for any future fields a
+    caller wants beyond the discriminator.
+    """
+
+    intent_response: str
+    remote_static_pub: bytes
+    response: dict[str, Any]
 
 
 def _build_ws_url(hostname: str, port: int) -> str:
@@ -87,6 +104,102 @@ def _build_ws_url(hostname: str, port: int) -> str:
     return f"ws://{safe_host}:{port}{PEER_LINK_PATH}"
 
 
+async def drive_initiator_round_trip(
+    *,
+    hostname: str,
+    port: int,
+    identity_priv: bytes,
+    intent: PeerLinkIntent,
+    msg3_payload: bytes = b"",
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> InitiatorRoundTrip:
+    """Run one Noise XX round-trip from the initiator side.
+
+    The flow is identical for every offloader-side intent
+    (``preview`` / ``pair_request`` / ``pair_status`` /
+    ``peer_link``); callers vary only the *intent* discriminator
+    (cleartext on msg1) and the encrypted *msg3_payload* (carries
+    ``label`` + ``dashboard_id`` for ``pair_request`` and
+    similar). The shared driver here keeps the connect / send /
+    receive / decode / error-map plumbing in one place so future
+    intents don't reinvent it.
+
+    Wire shape, mirroring the receiver-side responder in
+    :func:`controllers.remote_build_peer_link._drive_peer_link_session`:
+
+    * msg1 — send ``{"intent": "..."}`` cleartext-but-noise-framed
+      (msg1's payload is plaintext on the wire per Noise XX;
+      coarse intent only, no sensitive fields).
+    * msg2 — receive the responder's ephemeral + static; the
+      library's read-message places ``static_x25519_pub`` into
+      our handshake state.
+    * msg3 — send our static + the *msg3_payload* (encrypted
+      under the now-mixed cipher).
+    * Post-handshake — receive one transport frame carrying
+      ``{"intent_response": "..."}``; decrypt + JSON-parse.
+
+    Raises :class:`PeerLinkClientError` on any transport,
+    handshake, or decode failure with the underlying exception
+    attached as ``__cause__`` for log inspection. The caller is
+    responsible for branching on
+    :attr:`InitiatorRoundTrip.intent_response` (each intent has
+    its own accept-set).
+    """
+    sess = PeerLinkNoiseSession.initiator(identity_priv)
+    url = _build_ws_url(hostname, port)
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+    label = f"peer-link {intent.value} to {hostname}:{port}"
+
+    try:
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as http,
+            http.ws_connect(url) as ws,
+        ):
+            msg1 = _json.dumps({"intent": intent.value})
+            await ws.send_bytes(sess.write_handshake_message(msg1))
+            sess.read_handshake_message(await ws.receive_bytes())
+            await ws.send_bytes(sess.write_handshake_message(msg3_payload))
+            response_ct = await ws.receive_bytes()
+    except (TimeoutError, aiohttp.ClientError, OSError) as exc:
+        msg = f"{label} failed: {exc}"
+        _LOGGER.debug(msg, exc_info=True)
+        raise PeerLinkClientError(msg) from exc
+    except NOISE_ERRORS as exc:
+        msg = f"{label} Noise handshake failed: {exc}"
+        _LOGGER.warning(msg, exc_info=True)
+        raise PeerLinkClientError(msg) from exc
+
+    # ``NOISE_ERRORS`` is a tuple of classes; Python's ``except``
+    # syntax doesn't accept nested tuples, so star-unpack it into
+    # a flat tuple alongside the JSON decode error.
+    try:
+        decoded = _json.loads(sess.decrypt(response_ct))
+    except (*NOISE_ERRORS, _json.JSONDecodeError) as exc:
+        msg = f"{label} response decode failed: {exc}"
+        _LOGGER.warning(msg, exc_info=True)
+        raise PeerLinkClientError(msg) from exc
+
+    if not isinstance(decoded, dict):
+        msg = f"{label} response was not a JSON object: {decoded!r}"
+        raise PeerLinkClientError(msg)
+    intent_response = decoded.get("intent_response")
+    if not isinstance(intent_response, str):
+        msg = f"{label} response missing 'intent_response' string: {decoded!r}"
+        raise PeerLinkClientError(msg)
+
+    try:
+        remote_static = sess.remote_static_pub
+    except HandshakeNotCompleteError as exc:
+        msg = f"{label} handshake completed without capturing remote static pubkey"
+        raise PeerLinkClientError(msg) from exc
+
+    return InitiatorRoundTrip(
+        intent_response=intent_response,
+        remote_static_pub=remote_static,
+        response=decoded,
+    )
+
+
 async def preview_pair(
     *,
     hostname: str,
@@ -95,78 +208,24 @@ async def preview_pair(
 ) -> str:
     """Run an ``intent="preview"`` round-trip; return the receiver's pin_sha256.
 
-    Drives the three Noise XX messages from the initiator side:
+    Thin wrapper around :func:`drive_initiator_round_trip`:
+    preview's accept-set is just ``IntentResponse.OK`` (anything
+    else is a receiver-side bug or a misconfigured deployment);
+    its msg3 payload is empty (the receiver already has what it
+    needs from msg2 from the offloader's perspective).
 
-    1. msg1 — send ``{"intent": "preview"}`` cleartext-but-noise-
-       framed (msg1's payload is plaintext on the wire per the
-       Noise XX wire spec; coarse intent only, no sensitive
-       fields).
-    2. msg2 — receive the responder's ephemeral + static; the
-       library's read-message is what actually places
-       ``static_x25519_pub`` into our handshake state.
-    3. msg3 — send our static (empty payload; the receiver
-       already knows what it needs after msg2 from the
-       offloader-side perspective).
-
-    Then drains the post-handshake transport frame the receiver
-    sends (``{"intent_response": "ok"}``) so the WS close is
-    clean; the value is asserted (``OK`` is the only non-error
-    response on a successful preview) but not surfaced to the
-    caller — preview's only output is the captured pin.
-
-    Raises :class:`PeerLinkClientError` on any transport,
-    handshake, or decode failure with the underlying exception
-    attached as ``__cause__`` for log inspection.
+    The frontend renders the returned ``pin_sha256`` for the
+    user to OOB-verify against the receiver's "Build server"
+    Settings card; only after that confirmation does the
+    offloader call ``request_pair`` (phase 4a-o part 3).
     """
-    sess = PeerLinkNoiseSession.initiator(identity_priv)
-    url = _build_ws_url(hostname, port)
-    timeout = aiohttp.ClientTimeout(total=_PREVIEW_TIMEOUT_SECONDS)
-
-    try:
-        async with (
-            aiohttp.ClientSession(timeout=timeout) as http,
-            http.ws_connect(url) as ws,
-        ):
-            # msg1: plaintext intent
-            msg1_payload = _json.dumps({"intent": PeerLinkIntent.PREVIEW.value})
-            await ws.send_bytes(sess.write_handshake_message(msg1_payload))
-            # msg2: receiver's ephemeral + static. ``receive_bytes``
-            # raises if the frame is wrong type; that surfaces as
-            # ``aiohttp.ClientError``.
-            sess.read_handshake_message(await ws.receive_bytes())
-            # msg3: our static; preview carries no msg3 payload.
-            await ws.send_bytes(sess.write_handshake_message(b""))
-            # Post-handshake transport frame. Drain for clean
-            # close; assert OK so a future receiver bug that
-            # rejects preview gets surfaced rather than masked.
-            response_ct = await ws.receive_bytes()
-    except (TimeoutError, aiohttp.ClientError, OSError) as exc:
-        msg = f"peer-link preview to {hostname}:{port} failed: {exc}"
-        _LOGGER.debug(msg, exc_info=True)
-        raise PeerLinkClientError(msg) from exc
-    except NOISE_ERRORS as exc:
-        msg = f"peer-link preview Noise handshake failed: {exc}"
-        _LOGGER.warning(msg, exc_info=True)
-        raise PeerLinkClientError(msg) from exc
-
-    # ``NOISE_ERRORS`` is a tuple of classes; Python's ``except``
-    # syntax doesn't accept nested tuples, so star-unpack it into
-    # a flat tuple alongside the JSON decode error.
-    try:
-        response = _json.loads(sess.decrypt(response_ct))
-    except (*NOISE_ERRORS, _json.JSONDecodeError) as exc:
-        msg = f"peer-link preview response decode failed: {exc}"
-        _LOGGER.warning(msg, exc_info=True)
-        raise PeerLinkClientError(msg) from exc
-
-    intent_response = response.get("intent_response") if isinstance(response, dict) else None
-    if intent_response != IntentResponse.OK.value:
-        msg = f"peer-link preview rejected with intent_response={intent_response!r}"
+    rt = await drive_initiator_round_trip(
+        hostname=hostname,
+        port=port,
+        identity_priv=identity_priv,
+        intent=PeerLinkIntent.PREVIEW,
+    )
+    if rt.intent_response != IntentResponse.OK.value:
+        msg = f"peer-link preview rejected with intent_response={rt.intent_response!r}"
         raise PeerLinkClientError(msg)
-
-    try:
-        remote_static = sess.remote_static_pub
-    except HandshakeNotCompleteError as exc:
-        msg = "peer-link preview handshake completed without capturing remote static pubkey"
-        raise PeerLinkClientError(msg) from exc
-    return pin_sha256_for_pubkey(remote_static)
+    return pin_sha256_for_pubkey(rt.remote_static_pub)

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -113,11 +113,18 @@ def _build_ws_url(hostname: str, port: int) -> URL:
       ``ws://[::1]:6055/...``); the f-string version would have
       produced an unparsable URL.
     * Pathological characters in the hostname (slash, query
-      terminators, fragment markers) raise ``ValueError`` loudly
-      instead of getting silently percent-encoded into a
-      non-resolvable form. ``_validate_hostname`` already
-      catches these at the WS-command boundary, but yarl
-      gives us a second line of defense at no extra code.
+      terminators, fragment markers, embedded ``:port``) raise
+      ``ValueError`` loudly instead of getting silently
+      percent-encoded into a non-resolvable form. yarl is the
+      *primary* defense for these characters today —
+      ``_validate_hostname`` checks length and strips
+      whitespace but doesn't reject URL-special characters yet.
+      A follow-up tightens the WS-command validator to fail
+      INVALID_ARGS up front; until then,
+      :func:`drive_initiator_round_trip` catches the
+      ``ValueError`` here and maps it to
+      :class:`PeerLinkClientError` (→ UNAVAILABLE) so the
+      surface contract holds.
     * Path is given to yarl as a constant; encoding stays
       intact across versions.
 
@@ -173,11 +180,24 @@ async def drive_initiator_round_trip(
     its own accept-set).
     """
     sess = PeerLinkNoiseSession.initiator(identity_priv)
-    url = _build_ws_url(hostname, port)
     timeout = aiohttp.ClientTimeout(total=timeout_seconds)
     label = f"peer-link {intent.value} to {hostname}:{port}"
 
+    # ``_build_ws_url`` is inside the try block (rather than a
+    # bare call before it) because :meth:`yarl.URL.build` raises
+    # ``ValueError`` for path-injection-shaped hosts (slash, ``?``,
+    # ``#``, embedded ``:port``). ``_validate_hostname`` doesn't
+    # reject those today — the WS-command boundary's input check
+    # is too permissive — so a frontend that forwards
+    # ``host:8080`` to ``hostname`` would otherwise see the
+    # ``ValueError`` escape this function and surface as
+    # ``INTERNAL_ERROR`` instead of the documented ``UNAVAILABLE``
+    # mapping. Wrap as a transport-style failure so the contract
+    # holds regardless of whether the upstream validator
+    # tightens. Tightening ``_validate_hostname`` to reject these
+    # characters is queued as a follow-up.
     try:
+        url = _build_ws_url(hostname, port)
         async with (
             aiohttp.ClientSession(timeout=timeout) as http,
             http.ws_connect(url) as ws,
@@ -187,7 +207,7 @@ async def drive_initiator_round_trip(
             sess.read_handshake_message(await ws.receive_bytes())
             await ws.send_bytes(sess.write_handshake_message(msg3_payload))
             response_ct = await ws.receive_bytes()
-    except (TimeoutError, aiohttp.ClientError, OSError) as exc:
+    except (TimeoutError, aiohttp.ClientError, OSError, ValueError) as exc:
         msg = f"{label} failed: {exc}"
         _LOGGER.debug(msg, exc_info=True)
         raise PeerLinkClientError(msg) from exc

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -1,0 +1,172 @@
+"""
+Offloader-side peer-link Noise WS client (issue #106 phase 4a-o part 2).
+
+Initiator counterpart of
+:mod:`controllers.remote_build_peer_link`'s responder. Opens a
+``ws://<receiver>:<peer_link_port>/remote-build/peer-link``
+WebSocket, drives the three Noise XX handshake messages from the
+offloader side, optionally exchanges application-level
+``intent`` / ``intent_response`` framing, and surfaces the
+captured receiver static pubkey hash to the caller.
+
+This module is the wire-shape twin of
+``remote_build_peer_link.py``: same handshake, opposite role.
+The two share the cipher suite + frame layout via
+:mod:`helpers.peer_link_noise` (single :class:`PeerLinkNoiseSession`
+class, ``initiator`` / ``responder`` factories) and the same
+exception-tuple (:data:`helpers.peer_link_noise.NOISE_ERRORS`)
+so a future ``noiseprotocol`` upgrade only has to thread through
+one place.
+
+Scope of this part 2 PR:
+
+* :func:`preview_pair` — runs an ``intent="preview"`` round-trip
+  and returns the receiver's ``pin_sha256`` for OOB display.
+  Used by the new ``remote_build/preview_pair`` WS command.
+
+Subsequent 4a-o PRs add ``request_pair`` (part 3,
+:func:`request_pair_handshake`-style helper) and
+``intent="pair_status"`` polling (part 4, used by
+``list_pool``); the shared driver below is shaped so they can
+slot in without re-implementing the connect / read / write
+plumbing.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import quote
+
+import aiohttp
+
+from ..helpers import json as _json
+from ..helpers.peer_link_noise import (
+    NOISE_ERRORS,
+    HandshakeNotCompleteError,
+    PeerLinkNoiseSession,
+    pin_sha256_for_pubkey,
+)
+from ..models import IntentResponse, PeerLinkIntent
+from .remote_build_peer_link import PEER_LINK_PATH
+
+_LOGGER = logging.getLogger(__name__)
+
+# Total budget for the preview round-trip: TCP connect + WS
+# upgrade + 3 Noise messages + post-handshake response + clean
+# close. Bounded by LAN latency + the receiver's own per-step
+# timeout (10s in
+# ``remote_build_peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS``);
+# 10s here matches that budget so we don't give up before the
+# receiver does, but doesn't pin a coroutine forever if the
+# remote side is gone.
+_PREVIEW_TIMEOUT_SECONDS = 10.0
+
+
+class PeerLinkClientError(RuntimeError):
+    """Raised on transport / handshake / decrypt failure on the offloader side.
+
+    Wraps the underlying ``aiohttp.ClientError`` /
+    :class:`OSError` / :class:`asyncio.TimeoutError` /
+    :data:`NOISE_ERRORS` chain into one type the WS-command
+    layer can map to a single ``UNAVAILABLE`` :class:`CommandError`
+    without having to enumerate every transport failure mode.
+    """
+
+
+def _build_ws_url(hostname: str, port: int) -> str:
+    """Render the peer-link WS URL for *hostname* / *port*.
+
+    ``urllib.parse.quote`` on the hostname so a stray pathological
+    character (e.g. an IPv6 literal that should have been bracketed
+    by the caller, or a hostname containing a slash) can't smuggle
+    a different path or query into the URL. The receiver listens on
+    plain TCP — Noise XX provides the transport security — so the
+    scheme is ``ws://`` not ``wss://``.
+    """
+    safe_host = quote(hostname, safe="")
+    return f"ws://{safe_host}:{port}{PEER_LINK_PATH}"
+
+
+async def preview_pair(
+    *,
+    hostname: str,
+    port: int,
+    identity_priv: bytes,
+) -> str:
+    """Run an ``intent="preview"`` round-trip; return the receiver's pin_sha256.
+
+    Drives the three Noise XX messages from the initiator side:
+
+    1. msg1 — send ``{"intent": "preview"}`` cleartext-but-noise-
+       framed (msg1's payload is plaintext on the wire per the
+       Noise XX wire spec; coarse intent only, no sensitive
+       fields).
+    2. msg2 — receive the responder's ephemeral + static; the
+       library's read-message is what actually places
+       ``static_x25519_pub`` into our handshake state.
+    3. msg3 — send our static (empty payload; the receiver
+       already knows what it needs after msg2 from the
+       offloader-side perspective).
+
+    Then drains the post-handshake transport frame the receiver
+    sends (``{"intent_response": "ok"}``) so the WS close is
+    clean; the value is asserted (``OK`` is the only non-error
+    response on a successful preview) but not surfaced to the
+    caller — preview's only output is the captured pin.
+
+    Raises :class:`PeerLinkClientError` on any transport,
+    handshake, or decode failure with the underlying exception
+    attached as ``__cause__`` for log inspection.
+    """
+    sess = PeerLinkNoiseSession.initiator(identity_priv)
+    url = _build_ws_url(hostname, port)
+    timeout = aiohttp.ClientTimeout(total=_PREVIEW_TIMEOUT_SECONDS)
+
+    try:
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as http,
+            http.ws_connect(url) as ws,
+        ):
+            # msg1: plaintext intent
+            msg1_payload = _json.dumps({"intent": PeerLinkIntent.PREVIEW.value})
+            await ws.send_bytes(sess.write_handshake_message(msg1_payload))
+            # msg2: receiver's ephemeral + static. ``receive_bytes``
+            # raises if the frame is wrong type; that surfaces as
+            # ``aiohttp.ClientError``.
+            sess.read_handshake_message(await ws.receive_bytes())
+            # msg3: our static; preview carries no msg3 payload.
+            await ws.send_bytes(sess.write_handshake_message(b""))
+            # Post-handshake transport frame. Drain for clean
+            # close; assert OK so a future receiver bug that
+            # rejects preview gets surfaced rather than masked.
+            response_ct = await ws.receive_bytes()
+    except (TimeoutError, aiohttp.ClientError, OSError) as exc:
+        msg = f"peer-link preview to {hostname}:{port} failed: {exc}"
+        _LOGGER.debug(msg, exc_info=True)
+        raise PeerLinkClientError(msg) from exc
+    except NOISE_ERRORS as exc:
+        msg = f"peer-link preview Noise handshake failed: {exc}"
+        _LOGGER.warning(msg, exc_info=True)
+        raise PeerLinkClientError(msg) from exc
+
+    # ``NOISE_ERRORS`` is a tuple of classes; Python's ``except``
+    # syntax doesn't accept nested tuples, so star-unpack it into
+    # a flat tuple alongside the JSON decode error.
+    try:
+        response = _json.loads(sess.decrypt(response_ct))
+    except (*NOISE_ERRORS, _json.JSONDecodeError) as exc:
+        msg = f"peer-link preview response decode failed: {exc}"
+        _LOGGER.warning(msg, exc_info=True)
+        raise PeerLinkClientError(msg) from exc
+
+    intent_response = response.get("intent_response") if isinstance(response, dict) else None
+    if intent_response != IntentResponse.OK.value:
+        msg = f"peer-link preview rejected with intent_response={intent_response!r}"
+        raise PeerLinkClientError(msg)
+
+    try:
+        remote_static = sess.remote_static_pub
+    except HandshakeNotCompleteError as exc:
+        msg = "peer-link preview handshake completed without capturing remote static pubkey"
+        raise PeerLinkClientError(msg) from exc
+    return pin_sha256_for_pubkey(remote_static)

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -115,16 +115,17 @@ def _build_ws_url(hostname: str, port: int) -> URL:
     * Pathological characters in the hostname (slash, query
       terminators, fragment markers, embedded ``:port``) raise
       ``ValueError`` loudly instead of getting silently
-      percent-encoded into a non-resolvable form. yarl is the
-      *primary* defense for these characters today —
-      ``_validate_hostname`` checks length and strips
-      whitespace but doesn't reject URL-special characters yet.
-      A follow-up tightens the WS-command validator to fail
-      INVALID_ARGS up front; until then,
-      :func:`drive_initiator_round_trip` catches the
-      ``ValueError`` here and maps it to
+      percent-encoded into a non-resolvable form. The
+      WS-command boundary's ``_validate_hostname`` already
+      defers to :class:`yarl.URL.build` for the URL-correctness
+      check and rejects these shapes as ``INVALID_ARGS``, so
+      the validator and ``_build_ws_url`` share a single source
+      of truth on what a host is. A future caller that bypasses
+      ``_validate_hostname`` would still get the ``ValueError``
+      here; :func:`drive_initiator_round_trip` keeps a
+      defense-in-depth catch that maps it to
       :class:`PeerLinkClientError` (→ UNAVAILABLE) so the
-      surface contract holds.
+      surface contract holds even on the bypass path.
     * Path is given to yarl as a constant; encoding stays
       intact across versions.
 
@@ -183,19 +184,21 @@ async def drive_initiator_round_trip(
     timeout = aiohttp.ClientTimeout(total=timeout_seconds)
     label = f"peer-link {intent.value} to {hostname}:{port}"
 
-    # ``_build_ws_url`` is inside the try block (rather than a
-    # bare call before it) because :meth:`yarl.URL.build` raises
-    # ``ValueError`` for path-injection-shaped hosts (slash, ``?``,
-    # ``#``, embedded ``:port``). ``_validate_hostname`` doesn't
-    # reject those today — the WS-command boundary's input check
-    # is too permissive — so a frontend that forwards
-    # ``host:8080`` to ``hostname`` would otherwise see the
+    # ``_build_ws_url`` is inside the try block as defense-in-depth.
+    # The WS-command boundary's ``_validate_hostname`` defers to
+    # :class:`yarl.URL.build` and already rejects
+    # path-injection-shaped hosts (slash, ``?``, ``#``, ``@``,
+    # embedded ``:port``) as ``INVALID_ARGS``, so on the
+    # validator-gated path :meth:`URL.build` here will never
+    # raise. But a future caller that calls this driver
+    # directly without going through the validator (e.g. a
+    # 4a-o part 3/4 helper that takes a stored ``hostname``
+    # off disk and assumes it's clean) would otherwise see the
     # ``ValueError`` escape this function and surface as
-    # ``INTERNAL_ERROR`` instead of the documented ``UNAVAILABLE``
-    # mapping. Wrap as a transport-style failure so the contract
-    # holds regardless of whether the upstream validator
-    # tightens. Tightening ``_validate_hostname`` to reject these
-    # characters is queued as a follow-up.
+    # ``INTERNAL_ERROR`` instead of the documented
+    # ``UNAVAILABLE`` mapping. Wrapping the build inside the
+    # try keeps the contract holding regardless of which entry
+    # point the caller used.
     try:
         url = _build_ws_url(hostname, port)
         async with (

--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -60,12 +60,34 @@ import hashlib
 from typing import cast
 
 from noise.connection import Keypair, NoiseConnection
+from noise.exceptions import (
+    NoiseHandshakeError,
+    NoiseInvalidMessage,
+    NoiseMaxNonceError,
+    NoiseValueError,
+)
 
 # Standard Noise pattern name. Same cipher suite the ESPHome device
 # API uses (``Noise_NNpsk0_25519_ChaChaPoly_SHA256``); only the
 # pattern differs — XX vs NNpsk0 — because we want mutual identity
 # exchange, not a pre-shared key.
 NOISE_PATTERN = b"Noise_XX_25519_ChaChaPoly_SHA256"
+
+# Tuple-catchable subset of ``noise.exceptions`` for callers that
+# want to wrap protocol errors without the verbosity of a 4-element
+# ``except`` clause. The library's exceptions don't share a common
+# base, so the tuple is the recommended shape per its docs. Used
+# by both the responder (``controllers/remote_build_peer_link``) and
+# the initiator (``controllers/remote_build_peer_link_client``);
+# kept here so a future ``noiseprotocol`` upgrade adding a new
+# exception class only has to be threaded through this single
+# constant.
+NOISE_ERRORS: tuple[type[Exception], ...] = (
+    NoiseHandshakeError,
+    NoiseInvalidMessage,
+    NoiseMaxNonceError,
+    NoiseValueError,
+)
 
 
 class HandshakeNotCompleteError(RuntimeError):

--- a/esphome_device_builder/models/api.py
+++ b/esphome_device_builder/models/api.py
@@ -20,6 +20,16 @@ class ErrorCode(StrEnum):
     INTERNAL_ERROR = "internal_error"
     NOT_AUTHENTICATED = "not_authenticated"
     RATE_LIMITED = "rate_limited"
+    # Transient external dependency failed — distinct from
+    # ``INTERNAL_ERROR`` (backend bug) and ``INVALID_ARGS`` (user
+    # typo). The frontend renders this as a "couldn't reach the
+    # receiver / try again" toast rather than a stack-trace
+    # diagnostic. Used by the offloader-side peer-link commands
+    # (``preview_pair`` / ``request_pair`` / ``list_pool``) when
+    # the remote dashboard isn't reachable, the Noise handshake
+    # fails to authenticate, or the post-handshake frame
+    # doesn't decrypt.
+    UNAVAILABLE = "unavailable"
 
 
 @dataclass

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -535,6 +535,48 @@ def test_validate_hostname_rejects_oversize() -> None:
     assert "255 characters" in str(exc.value)
 
 
+@pytest.mark.parametrize(
+    "bad_host",
+    [
+        "evil/path",  # path injection
+        "host?q=1",  # query injection
+        "host#frag",  # fragment injection
+        "user@host",  # userinfo injection
+        "host:8080",  # embedded port (frontend mistake — port goes in its own field)
+    ],
+)
+def test_validate_hostname_rejects_url_injection_shapes(bad_host: str) -> None:
+    """Pathological characters can't smuggle path / query / userinfo into the URL.
+
+    Defers to ``yarl.URL.build`` for the URL-correctness check
+    so the validator and the offloader's ``_build_ws_url``
+    share one source of truth on what a host is. Without this
+    gate, a frontend that forwarded ``host:8080`` to the
+    hostname field would have surfaced as ``UNAVAILABLE`` from
+    ``preview_pair`` (or worse, ``INTERNAL_ERROR`` if the
+    ``ValueError`` escaped error mapping); now it surfaces as
+    ``INVALID_ARGS`` at write time so the user gets a "fix
+    your input" diagnostic.
+    """
+    with pytest.raises(CommandError) as exc:
+        _validate_hostname(bad_host)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_validate_hostname_accepts_ipv6_literal() -> None:
+    """Bare IPv6 literals (no brackets) round-trip through the validator.
+
+    yarl accepts ``::1`` / ``fe80::1`` as host values and
+    auto-brackets them at render time, so the validator doesn't
+    need to reject the colon-laden form even though a hostname
+    with a stray colon (``host:8080``) is rejected: yarl knows
+    the difference because ``::1`` parses as a valid IPv6 and
+    ``host:8080`` doesn't.
+    """
+    assert _validate_hostname("::1") == "::1"
+    assert _validate_hostname("fe80::1") == "fe80::1"
+
+
 def test_validate_port_accepts_typical() -> None:
     assert _validate_port(6052) == 6052
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -240,13 +240,38 @@ def test_build_ws_url_brackets_ipv6_literal() -> None:
 
 
 def test_build_ws_url_rejects_pathological_host() -> None:
-    """Yarl raises on path-injection attempts in the host position.
+    """Yarl raises ``ValueError`` on path-injection attempts in the host position.
 
-    ``_validate_hostname`` is the primary gate at the WS-command
-    boundary; yarl gives us a second line of defense at no extra
-    cost — a slash in the host raises ``ValueError`` rather than
-    silently producing a URL whose path no longer points at
-    ``/remote-build/peer-link``.
+    The error message text is yarl's own and not part of our
+    contract (could change between yarl versions); just assert
+    the type. ``drive_initiator_round_trip`` catches this
+    ``ValueError`` and maps it to ``PeerLinkClientError`` →
+    ``UNAVAILABLE`` so a frontend that forwarded an unvalidated
+    host gets a "couldn't reach receiver" toast rather than an
+    internal-error stack trace; that path is covered by
+    ``test_drive_initiator_round_trip_maps_pathological_host_to_client_error``.
     """
-    with pytest.raises(ValueError, match="cannot contain"):
+    with pytest.raises(ValueError):
         _build_ws_url("evil/path", 6055)
+
+
+@pytest.mark.asyncio
+async def test_drive_initiator_round_trip_maps_pathological_host_to_client_error() -> None:
+    """A pathological host typed in the hostname field maps to PeerLinkClientError.
+
+    yarl raises ``ValueError`` from ``_build_ws_url`` before
+    any TCP connect; the driver catches it alongside the
+    transport-failure tuple so the WS-command layer maps to
+    ``UNAVAILABLE`` (transient, retry) instead of letting the
+    raw ``ValueError`` escape as ``INTERNAL_ERROR``. Pin the
+    contract: a frontend bug that forwards ``host:8080`` to
+    ``hostname`` shouldn't crash the server.
+    """
+    initiator_priv = secrets.token_bytes(32)
+    with pytest.raises(PeerLinkClientError, match="failed"):
+        await drive_initiator_round_trip(
+            hostname="host:8080",  # embedded port — yarl rejects
+            port=6055,
+            identity_priv=initiator_priv,
+            intent=PeerLinkIntent.PREVIEW,
+        )

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -231,13 +231,22 @@ async def test_preview_pair_rejects_garbage_post_handshake_frame(
 
 def test_build_ws_url_uses_plain_ws_scheme() -> None:
     """Peer-link runs over plain TCP; Noise XX provides transport security."""
-    assert _build_ws_url("desk.local", 6055) == "ws://desk.local:6055/remote-build/peer-link"
+    assert str(_build_ws_url("desk.local", 6055)) == "ws://desk.local:6055/remote-build/peer-link"
 
 
-def test_build_ws_url_quotes_hostname() -> None:
-    """Pathological characters in the hostname can't smuggle a different path."""
-    # ``/`` in a hostname is impossible per DNS but we defend anyway:
-    # quoting ensures the url stays bound to ``PEER_LINK_PATH``.
-    url = _build_ws_url("evil/path", 6055)
-    assert "evil%2Fpath" in url
-    assert url.endswith("/remote-build/peer-link")
+def test_build_ws_url_brackets_ipv6_literal() -> None:
+    """Yarl auto-brackets IPv6 hostnames; an f-string approach would have garbled them."""
+    assert str(_build_ws_url("::1", 6055)) == "ws://[::1]:6055/remote-build/peer-link"
+
+
+def test_build_ws_url_rejects_pathological_host() -> None:
+    """Yarl raises on path-injection attempts in the host position.
+
+    ``_validate_hostname`` is the primary gate at the WS-command
+    boundary; yarl gives us a second line of defense at no extra
+    cost — a slash in the host raises ``ValueError`` rather than
+    silently producing a URL whose path no longer points at
+    ``/remote-build/peer-link``.
+    """
+    with pytest.raises(ValueError, match="cannot contain"):
+        _build_ws_url("evil/path", 6055)

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -1,0 +1,239 @@
+"""
+Tests for the offloader-side peer-link Noise WS client (phase 4a-o part 2).
+
+Two layers:
+
+* End-to-end: stand up the receiver-side handler in-process via
+  :func:`make_peer_link_handler` against an
+  :class:`aiohttp.test_utils.TestServer`, then drive
+  :func:`preview_pair` from the offloader side and assert the
+  captured ``pin_sha256`` matches the receiver's actual identity.
+* Error mapping: the various transport / handshake / decode
+  failure modes all surface as :class:`PeerLinkClientError` so
+  the WS-command layer can map them to a single
+  ``UNAVAILABLE`` :class:`CommandError` without enumerating
+  every cause.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from esphome_device_builder.controllers.remote_build import RemoteBuildController
+from esphome_device_builder.controllers.remote_build_peer_link import (
+    PEER_LINK_PATH,
+    make_peer_link_handler,
+)
+from esphome_device_builder.controllers.remote_build_peer_link_client import (
+    PeerLinkClientError,
+    _build_ws_url,
+    preview_pair,
+)
+from esphome_device_builder.helpers.peer_link_identity import (
+    get_or_create_peer_link_identity,
+)
+from esphome_device_builder.helpers.peer_link_noise import (
+    PeerLinkNoiseSession,
+    pin_sha256_for_pubkey,
+)
+
+
+def _make_controller(*, config_dir: Path) -> RemoteBuildController:
+    db = MagicMock()
+    db.devices = MagicMock()
+    db.devices.zeroconf = None
+    db._dashboard_advertiser = None
+    db.settings = MagicMock()
+    db.settings.config_dir = config_dir
+    return RemoteBuildController(db)
+
+
+@pytest.fixture
+async def receiver_server(
+    tmp_path: Path,
+) -> AsyncGenerator[tuple[TestServer, RemoteBuildController, str], None]:
+    """Spin up an in-process receiver. Yields (server, controller, expected_pin)."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    loop = asyncio.get_running_loop()
+    identity = await loop.run_in_executor(None, get_or_create_peer_link_identity, tmp_path)
+
+    app = web.Application()
+    handler = await make_peer_link_handler(controller, tmp_path)
+    app.router.add_get(PEER_LINK_PATH, handler)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        yield server, controller, pin_sha256_for_pubkey(identity.public_bytes)
+    finally:
+        await server.close()
+        await controller.stop()
+
+
+# ---------------------------------------------------------------------------
+# preview_pair — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_pair_returns_receivers_pin(
+    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    tmp_path: Path,
+) -> None:
+    """The captured pin from the handshake matches the receiver's actual identity."""
+    server, _, expected_pin = receiver_server
+    initiator_priv = secrets.token_bytes(32)
+
+    pin = await preview_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+        identity_priv=initiator_priv,
+    )
+
+    assert pin == expected_pin
+
+
+@pytest.mark.asyncio
+async def test_preview_pair_does_not_persist_state_on_receiver(
+    receiver_server: tuple[TestServer, RemoteBuildController, str],
+) -> None:
+    """``intent="preview"`` returns ``OK`` without creating a peer row.
+
+    Pin the contract that preview is read-only against the
+    receiver's pairing state — the offloader runs preview before
+    the user has decided whether to trust the receiver, so
+    receiver-side bookkeeping must not happen yet.
+    """
+    server, controller, _ = receiver_server
+    initiator_priv = secrets.token_bytes(32)
+
+    await preview_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+        identity_priv=initiator_priv,
+    )
+    # No pair_request_received event fired (preview doesn't create rows).
+    controller._db.bus.fire.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# preview_pair — error mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_pair_connection_refused_raises_client_error(
+    tmp_path: Path,
+    unused_tcp_port: int,
+) -> None:
+    """Connecting to a closed port raises :class:`PeerLinkClientError`."""
+    initiator_priv = secrets.token_bytes(32)
+    with pytest.raises(PeerLinkClientError, match="failed"):
+        await preview_pair(
+            hostname="127.0.0.1",
+            port=unused_tcp_port,
+            identity_priv=initiator_priv,
+        )
+
+
+@pytest.mark.asyncio
+async def test_preview_pair_timeout_raises_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hung TCP socket trips the WS handshake timeout, surfaced as PeerLinkClientError."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build_peer_link_client._PREVIEW_TIMEOUT_SECONDS",
+        0.1,
+    )
+
+    # Bind a TCP socket that accepts connections but never speaks.
+    loop = asyncio.get_running_loop()
+    server = await loop.create_server(asyncio.Protocol, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    initiator_priv = secrets.token_bytes(32)
+    try:
+        with pytest.raises(PeerLinkClientError):
+            await preview_pair(
+                hostname="127.0.0.1",
+                port=port,
+                identity_priv=initiator_priv,
+            )
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# URL builder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_pair_rejects_garbage_post_handshake_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Receiver sends a frame that decrypts to non-JSON → PeerLinkClientError.
+
+    Stand up a custom WS handler that runs a real Noise XX
+    responder for the 3 handshake messages but then writes a
+    *plaintext* frame instead of a properly encrypted
+    intent_response. The offloader's ``decrypt`` (or the JSON
+    parse) on that frame should fail and surface as
+    :class:`PeerLinkClientError` rather than escape uncaught.
+    """
+    receiver_priv = secrets.token_bytes(32)
+
+    async def _faulty_handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        sess = PeerLinkNoiseSession.responder(receiver_priv)
+        # msg1
+        msg1 = await ws.receive_bytes()
+        sess.read_handshake_message(msg1)
+        # msg2
+        await ws.send_bytes(sess.write_handshake_message(b""))
+        # msg3
+        msg3 = await ws.receive_bytes()
+        sess.read_handshake_message(msg3)
+        # Send a plaintext (non-Noise) frame so decrypt fails.
+        await ws.send_bytes(b"this is not an encrypted frame")
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_get(PEER_LINK_PATH, _faulty_handler)
+    server = TestServer(app)
+    await server.start_server()
+    initiator_priv = secrets.token_bytes(32)
+    try:
+        with pytest.raises(PeerLinkClientError, match="decode failed"):
+            await preview_pair(
+                hostname="127.0.0.1",
+                port=server.port,
+                identity_priv=initiator_priv,
+            )
+    finally:
+        await server.close()
+
+
+def test_build_ws_url_uses_plain_ws_scheme() -> None:
+    """Peer-link runs over plain TCP; Noise XX provides transport security."""
+    assert _build_ws_url("desk.local", 6055) == "ws://desk.local:6055/remote-build/peer-link"
+
+
+def test_build_ws_url_quotes_hostname() -> None:
+    """Pathological characters in the hostname can't smuggle a different path."""
+    # ``/`` in a hostname is impossible per DNS but we defend anyway:
+    # quoting ensures the url stays bound to ``PEER_LINK_PATH``.
+    url = _build_ws_url("evil/path", 6055)
+    assert "evil%2Fpath" in url
+    assert url.endswith("/remote-build/peer-link")

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -35,6 +35,7 @@ from esphome_device_builder.controllers.remote_build_peer_link import (
 from esphome_device_builder.controllers.remote_build_peer_link_client import (
     PeerLinkClientError,
     _build_ws_url,
+    drive_initiator_round_trip,
     preview_pair,
 )
 from esphome_device_builder.helpers.peer_link_identity import (
@@ -44,6 +45,7 @@ from esphome_device_builder.helpers.peer_link_noise import (
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
+from esphome_device_builder.models import PeerLinkIntent
 
 
 def _make_controller(*, config_dir: Path) -> RemoteBuildController:
@@ -146,26 +148,28 @@ async def test_preview_pair_connection_refused_raises_client_error(
 
 
 @pytest.mark.asyncio
-async def test_preview_pair_timeout_raises_client_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A hung TCP socket trips the WS handshake timeout, surfaced as PeerLinkClientError."""
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_peer_link_client._PREVIEW_TIMEOUT_SECONDS",
-        0.1,
-    )
+async def test_drive_initiator_round_trip_timeout_raises_client_error() -> None:
+    """A hung TCP socket trips the WS handshake timeout, surfaced as PeerLinkClientError.
 
-    # Bind a TCP socket that accepts connections but never speaks.
+    Tests the shared driver directly via the ``timeout_seconds``
+    kwarg rather than monkeypatching a module-level constant —
+    the wrapper functions (preview_pair, future request_pair /
+    poll_pair_status) all funnel through the driver, so the
+    timeout contract stays under one test.
+    """
     loop = asyncio.get_running_loop()
+    # Bind a TCP socket that accepts connections but never speaks.
     server = await loop.create_server(asyncio.Protocol, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
     initiator_priv = secrets.token_bytes(32)
     try:
         with pytest.raises(PeerLinkClientError):
-            await preview_pair(
+            await drive_initiator_round_trip(
                 hostname="127.0.0.1",
                 port=port,
                 identity_priv=initiator_priv,
+                intent=PeerLinkIntent.PREVIEW,
+                timeout_seconds=0.1,
             )
     finally:
         server.close()


### PR DESCRIPTION
# What does this implement/fix?

Second sub-PR of phase 4a-o. Adds the initiator-side Noise WS
client and the first WS command (`remote_build/preview_pair`)
that uses it.

Subsequent 4a-o sub-PRs:
- Part 3: `remote_build/request_pair` — re-handshakes, asserts
  pin matches preview, sends `intent="pair_request"`, persists
  local `StoredPairing` row.
- Part 4: `remote_build/unpair` + `remote_build/list_pool` —
  pool refresh via `intent="pair_status"` polling with 2s
  server-side debounce cache.

**New module `controllers/remote_build_peer_link_client.py`** —
initiator-side wire-shape twin of the receiver-side
`remote_build_peer_link.py`:

- `PeerLinkClientError` wraps every transport / handshake /
  decode failure mode so the WS-command layer can map to a
  single `UNAVAILABLE` `CommandError`.
- `preview_pair(hostname, port, identity_priv)` opens a brief
  `ws://` WebSocket, runs the 3 Noise XX messages with
  `intent="preview"`, asserts `IntentResponse.OK`, and returns
  the receiver's `pin_sha256` (lowercase hex).
- `_build_ws_url` quotes the hostname so a pathological
  character can't smuggle a different path / query.

**New `RemoteBuildController.preview_pair` WS command:**
validates hostname (reuses `_validate_hostname` from part 1's
255-char cap) + port, loads X25519 peer-link identity via
`run_in_executor`, returns `{pin_sha256}`, maps
`PeerLinkClientError` → `CommandError(UNAVAILABLE)`.

**Refactor:** `NOISE_ERRORS` lifted from
`controllers/remote_build_peer_link` into
`helpers/peer_link_noise` so both responder + initiator import
the same tuple. A future `noiseprotocol` upgrade with a new
exception class threads through one place.

**Tests:** 7 in `tests/test_remote_build_peer_link_client.py`:
end-to-end happy path against an in-process
`make_peer_link_handler` (TestServer-hosted) — captured pin
matches receiver's actual identity, no peer row created
(preview is read-only); error mapping for connection refused,
hung-socket timeout (monkeypatched 0.1s budget),
non-Noise post-handshake frame (`decrypt` / JSON parse
failures); URL-shape contract.

Coverage: 82% on the new module (15 lines uncovered cover
extreme edge cases — Noise write/read mid-handshake failure,
`HandshakeNotCompleteError` after a successful handshake —
that parts 3 and 4 will exercise naturally when their
`request_pair` / `pair_status` flows share the helpers). Full
suite: 2374 pass.

**Related issue or feature (if applicable):**

- part 2 of #106 phase 4a-o; builds on phase 4a-o part 1 (#494)

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Frontend coordination

- [x] No frontend change needed — the WS command is wired up here
  but the offloader UI is a 4b-3 concern. The frontend team can
  start typing the command shape (`{hostname, port}` →
  `{pin_sha256}`) once this lands.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (Doc updates land with parts 3-4 once the full offloader WS surface is in.)
