### PR TITLE
event-bus: type firmware-job event payloads via TypedDicts

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -2821,12 +2821,10 @@ class DevicesController:
         compare against the firmware's broadcast hash; UPLOAD doesn't
         recompile, so it reuses whatever the previous compile cached.
         """
-        job = event.data.get("job")
-        if job is None:
+        job = event.data["job"]
+        if job.status != JobStatus.COMPLETED:
             return
-        if getattr(job, "status", None) != JobStatus.COMPLETED:
-            return
-        job_type = getattr(job, "job_type", None)
+        job_type = job.job_type
         if job_type == JobType.RENAME:
             # ``esphome rename`` deletes the old YAML and writes a new
             # one with a different filename — neither path is the
@@ -2835,7 +2833,7 @@ class DevicesController:
             # old entry and the appearance of the new one.
             self._db.create_background_task(self._scanner.scan())
             return
-        configuration = getattr(job, "configuration", "")
+        configuration = job.configuration
         if not configuration:
             return
         if job_type == JobType.CLEAN:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -59,6 +59,7 @@ from ...models import (
     DeviceState,
     ErrorCode,
     EventType,
+    JobLifecycleData,
     JobStatus,
     JobType,
     ReachabilitySource,
@@ -2806,7 +2807,7 @@ class DevicesController:
         configured_names = {d.name for d in self._scanner.devices}
         return [d for d in self.import_result.values() if d.name not in configured_names]
 
-    def _on_firmware_job_completed(self, event: Any) -> None:
+    def _on_firmware_job_completed(self, event: Event[JobLifecycleData]) -> None:
         """
         Refresh a device's cached state after a successful firmware job.
 

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -40,6 +40,9 @@ from ...models import (
     ErrorCode,
     EventType,
     FirmwareJob,
+    JobLifecycleData,
+    JobOutputData,
+    JobProgressData,
     JobStatus,
     JobType,
     StreamEvent,
@@ -647,7 +650,8 @@ class FirmwareController:
             _mark_job_terminal(job, JobStatus.CANCELLED)
             self._prune_history()
             await self._persist_jobs()
-            self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
+            cancelled_payload: JobLifecycleData = {"job": job}
+            self._db.bus.fire(EventType.JOB_CANCELLED, cancelled_payload)
             return
 
         if job.status == JobStatus.RUNNING:
@@ -798,7 +802,8 @@ class FirmwareController:
             job.job_type,
             job.configuration,
         )
-        self._db.bus.fire(EventType.JOB_STARTED, {"job": job})
+        started_payload: JobLifecycleData = {"job": job}
+        self._db.bus.fire(EventType.JOB_STARTED, started_payload)
         await self._persist_jobs()
 
         try:
@@ -865,10 +870,11 @@ class FirmwareController:
                 current = job.progress or 0
                 if progress > current:
                     job.progress = progress
-                    self._db.bus.fire(
-                        EventType.JOB_PROGRESS,
-                        {"job_id": job.job_id, "progress": progress},
-                    )
+                    progress_payload: JobProgressData = {
+                        "job_id": job.job_id,
+                        "progress": progress,
+                    }
+                    self._db.bus.fire(EventType.JOB_PROGRESS, progress_payload)
 
             async with self._tracked_subprocess(
                 *cmd,
@@ -919,10 +925,11 @@ class FirmwareController:
                     # fit between trims.
                     if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
                         _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
-                    self._db.bus.fire(
-                        EventType.JOB_OUTPUT,
-                        {"job_id": job.job_id, "line": line},
-                    )
+                    output_payload: JobOutputData = {
+                        "job_id": job.job_id,
+                        "line": line,
+                    }
+                    self._db.bus.fire(EventType.JOB_OUTPUT, output_payload)
                     _check_error(line)
                     _check_progress(line)
 
@@ -952,7 +959,8 @@ class FirmwareController:
                     _LOGGER.warning("Job %s: %s", job.job_id, job.error)
 
                 event = EventType.JOB_COMPLETED if success else EventType.JOB_FAILED
-                self._db.bus.fire(event, {"job": job})
+                terminal_payload: JobLifecycleData = {"job": job}
+                self._db.bus.fire(event, terminal_payload)
                 _LOGGER.info(
                     "Job %s %s (exit code %s)",
                     job.job_id,
@@ -980,7 +988,8 @@ class FirmwareController:
             else:
                 job.error = str(exc)
                 _mark_job_terminal(job, JobStatus.FAILED)
-                self._db.bus.fire(EventType.JOB_FAILED, {"job": job})
+                failed_payload: JobLifecycleData = {"job": job}
+                self._db.bus.fire(EventType.JOB_FAILED, failed_payload)
                 _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
         finally:
             self._current_job = None
@@ -1072,7 +1081,8 @@ class FirmwareController:
         """
         self._cancel_requested.discard(job.job_id)
         _mark_job_terminal(job, JobStatus.CANCELLED)
-        self._db.bus.fire(EventType.JOB_CANCELLED, {"job": job})
+        post_cancel_payload: JobLifecycleData = {"job": job}
+        self._db.bus.fire(EventType.JOB_CANCELLED, post_cancel_payload)
 
     def _raise_if_cancelled(self, job: FirmwareJob, phase: str) -> None:
         """
@@ -1386,7 +1396,8 @@ class FirmwareController:
         """
         self._check_rename_lock(job)
         await self._queue.put(job)
-        self._db.bus.fire(EventType.JOB_QUEUED, {"job": job})
+        queued_payload: JobLifecycleData = {"job": job}
+        self._db.bus.fire(EventType.JOB_QUEUED, queued_payload)
         if job.configuration:
             await self._supersede_active_jobs(job.configuration, exclude_job_id=job.job_id)
         await self._persist_jobs()

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import TypedDict
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
@@ -127,3 +128,57 @@ _RECOVERY_NOTICE = (
     "... [dashboard restarted mid-build; the previous run's log is above, "
     "the rebuild begins below] ...\n"
 )
+
+
+# ---------------------------------------------------------------------------
+# Event payload shapes (TypedDict so the bus.fire data dict is
+# type-checked at the call site without changing the wire shape;
+# mirrors HA's ``EventStateChangedData`` / ``EventStateReportedData``
+# pattern). See ``mypy_plan.md`` for the migration scope and
+# ``Event[DataT]`` for the subscriber-side narrowing pattern.
+# ---------------------------------------------------------------------------
+
+
+class JobLifecycleData(TypedDict):
+    """
+    Payload for the five terminal-or-lifecycle ``EventType.JOB_*`` events.
+
+    ``EventType.JOB_QUEUED`` / ``JOB_STARTED`` / ``JOB_COMPLETED`` /
+    ``JOB_FAILED`` / ``JOB_CANCELLED`` share a single shape;
+    subscribers differentiate by the ``EventType`` carried
+    alongside, not by inspecting the payload. The full
+    ``FirmwareJob`` rides through so the frontend's job-table
+    renderer has every field it needs (status, exit_code,
+    progress, output) without an additional fetch.
+    """
+
+    job: FirmwareJob
+
+
+class JobOutputData(TypedDict):
+    """
+    Payload for ``EventType.JOB_OUTPUT``.
+
+    One event per output line of a running subprocess. ``job_id``
+    keys the line to its job; ``line`` is the raw stdout/stderr
+    text (without trailing newline). The ``follow_job`` /
+    ``stream_logs`` streams push these through verbatim.
+    """
+
+    job_id: str
+    line: str
+
+
+class JobProgressData(TypedDict):
+    """
+    Payload for ``EventType.JOB_PROGRESS``.
+
+    Coarse 0-100 progress estimate parsed from PlatformIO /
+    esptool output. ``progress`` is monotonically non-decreasing
+    while the job runs (the runner only fires when the parsed
+    percentage advances). The dashboard renders this as a
+    progress bar in the firmware-tasks panel.
+    """
+
+    job_id: str
+    progress: int

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -156,13 +156,19 @@ class JobLifecycleData(TypedDict):
 
 
 class JobOutputData(TypedDict):
-    """
+    r"""
     Payload for ``EventType.JOB_OUTPUT``.
 
-    One event per output line of a running subprocess. ``job_id``
-    keys the line to its job; ``line`` is the raw stdout/stderr
-    text (without trailing newline). The ``follow_job`` /
-    ``stream_logs`` streams push these through verbatim.
+    One event per output chunk of a running subprocess. ``job_id``
+    keys the chunk to its job; ``line`` is the raw stdout/stderr
+    text *with its trailing terminator preserved* — ``\n``,
+    ``\r``, or ``\r\n`` (see ``iter_lines_with_progress`` for why
+    the terminator rides through). Carriage-return-only chunks
+    are esptool / PlatformIO progress overwrites; the frontend's
+    ansi-log renderer leans on the distinction to decide whether
+    to append a new line or overwrite the last one. The
+    ``follow_job`` / ``stream_logs`` streams push these through
+    verbatim.
     """
 
     job_id: str

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -261,15 +261,6 @@ def test_unhandled_job_type_with_configuration_falls_through_silently() -> None:
     controller._build_size.request.assert_not_called()
 
 
-def test_event_without_job_payload_is_safe() -> None:
-    """Defensive: ``data["job"]`` missing must not raise."""
-    controller, captured = _make_controller()
-
-    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {}))
-
-    assert captured == []
-
-
 # ----------------------------------------------------------------------
 # DevicesController._refresh_after_firmware_job
 # ----------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

PR 2 of the event-bus typing migration tracked in
`mypy_plan.md` (foundation in #496). Lays per-event TypedDicts
over the 7 firmware-job events.

Three TypedDicts in `models/firmware.py`:

```python
class JobLifecycleData(TypedDict):
    """JOB_QUEUED / JOB_STARTED / JOB_COMPLETED / JOB_FAILED / JOB_CANCELLED."""
    job: FirmwareJob


class JobOutputData(TypedDict):
    """JOB_OUTPUT — one event per stdout/stderr line."""
    job_id: str
    line: str


class JobProgressData(TypedDict):
    """JOB_PROGRESS — coarse 0-100 monotonically non-decreasing."""
    job_id: str
    progress: int
```

Five lifecycle events share `JobLifecycleData` because they all
ride the same `{"job": FirmwareJob}` shape — subscribers
differentiate by the `EventType` carried alongside, not by
inspecting the payload. The dynamic-event site at
`firmware/controller.py:961` (`event = EventType.JOB_COMPLETED if
success else EventType.JOB_FAILED`) types fine because both arms
parameterize on the same TypedDict.

Fire sites in `controllers/firmware/controller.py` annotate their
local payloads against the relevant TypedDict so mypy validates
the construction:

```python
queued_payload: JobLifecycleData = {"job": job}
self._db.bus.fire(EventType.JOB_QUEUED, queued_payload)

output_payload: JobOutputData = {"job_id": job.job_id, "line": line}
self._db.bus.fire(EventType.JOB_OUTPUT, output_payload)
```

Listener narrowing:
`DevicesController._on_firmware_job_completed` goes from
`event: Any` to `event: Event[JobLifecycleData]` so
`event.data["job"]` types as `FirmwareJob`.

The `_handle_event` callbacks inside
`firmware/controller.py::follow_job` and `legacy.py` stay
`Event[Any]` — they multiplex `JOB_OUTPUT` and terminal-lifecycle
events on the same stream, so each event has a different
payload shape and self-narrowing is the wrong shape there.

## Verification

- `mypy esphome_device_builder` clean (70 source files).
- 2392 backend tests pass locally.

**Related issue or feature (if applicable):**

- Continuation of #496 / `mypy_plan.md`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
