### PR TITLE
event-bus: type DEVICE_ADDED/REMOVED/UPDATED via DeviceEventData

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -55,6 +55,7 @@ from ...models import (
     AddComponentResponse,
     AdoptableDevice,
     Device,
+    DeviceEventData,
     DevicesResponse,
     DeviceState,
     ErrorCode,
@@ -2437,7 +2438,7 @@ class DevicesController:
             ScanChange.UPDATED: EventType.DEVICE_UPDATED,
             ScanChange.REMOVED: EventType.DEVICE_REMOVED,
         }[kind]
-        self._db.bus.fire(event, {"device": device})
+        self._db.bus.fire(event, DeviceEventData(device=device))
         # Eagerly probe mDNS for newly-added devices. Catches the
         # YAML-dropped-on-disk case the API entrypoints
         # (``devices/import``, ``devices/create``) can't see — e.g.
@@ -2622,7 +2623,7 @@ class DevicesController:
                 self._db.create_background_task(
                     self._persist_device_ip_async(device.configuration, ip)
                 )
-            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
 
     async def _persist_device_ip_async(self, configuration: str, ip: str) -> None:
         """Save *ip* to the device-builder metadata sidecar."""
@@ -2676,7 +2677,7 @@ class DevicesController:
                 old_version or "?",
                 version,
             )
-            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
 
     def _on_mac_address_change(self, name: str, mac: str) -> None:
         """
@@ -2711,7 +2712,7 @@ class DevicesController:
             self._db.create_background_task(
                 self._persist_device_metadata_async(device.configuration, mac_address=mac)
             )
-            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
 
     def _on_api_encryption_change(self, name: str, encryption: str) -> None:
         r"""
@@ -2747,7 +2748,7 @@ class DevicesController:
             device.api_encryption_active = encryption
             if wire_promotes_encrypted:
                 device.api_encrypted = True
-            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
 
     def _on_config_hash_change(self, name: str, config_hash: str) -> None:
         """
@@ -2778,7 +2779,7 @@ class DevicesController:
                 old_hash or "?",
                 config_hash,
             )
-            self._db.bus.fire(EventType.DEVICE_UPDATED, {"device": device})
+            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
 
     def _on_importable_added(self, device: AdoptableDevice) -> None:
         """Stash a newly-discovered importable device and notify subscribers."""

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import TypedDict
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
@@ -252,3 +253,26 @@ class UpdateDeviceResponse(DataClassORJSONMixin):
     friendly_name: str
     comment: str | None
     board_id: str | None
+
+
+# ---------------------------------------------------------------------------
+# Event payload shapes (TypedDict so the bus.fire data dict is
+# type-checked at the call site without changing the wire shape).
+# See ``mypy_plan.md`` for the migration scope.
+# ---------------------------------------------------------------------------
+
+
+class DeviceEventData(TypedDict):
+    """
+    Payload for ``EventType.DEVICE_ADDED`` / ``DEVICE_REMOVED`` / ``DEVICE_UPDATED``.
+
+    The three CRUD events share a single shape — the disk
+    scanner forwards ``ScanChange`` events through this payload
+    and subscribers differentiate by the ``EventType`` carried
+    alongside, not by inspecting the payload. The full
+    ``Device`` rides through so the frontend's device-table
+    renderer has every field it needs without an additional
+    fetch.
+    """
+
+    device: Device


### PR DESCRIPTION
# What does this implement/fix?

PR 3 of the event-bus typing migration tracked in
`mypy_plan.md` (foundation #496, jobs #497). Lays the
`DeviceEventData` TypedDict over the 3 device-CRUD events.

```python
# models/devices.py
class DeviceEventData(TypedDict):
    """Payload for EventType.DEVICE_ADDED / DEVICE_REMOVED / DEVICE_UPDATED."""
    device: Device
```

Three CRUD events share a single shape — the disk scanner
forwards `ScanChange` events through this payload and
subscribers differentiate by the `EventType` carried alongside,
not by inspecting the payload. This shape covers the dynamic
fire site at `_on_scan_change` (where `event` is one of three
EventType values) the same way `JobLifecycleData` covered the
JOB_COMPLETED / JOB_FAILED dynamic in #497.

Fire sites switched to TypedDict-call syntax for readability —
`DeviceEventData(device=device)` is shorter than the
`payload: DeviceEventData = {"device": device}; bus.fire(...,
payload)` two-line form and reads as one expression at the call
site:

```python
self._db.bus.fire(event, DeviceEventData(device=device))
self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
```

mypy validates the construction at the call. Six fire sites in
`controllers/devices/controller.py` (one dynamic + five explicit
`DEVICE_UPDATED` triggers from `_on_*_change` callbacks) all
flow through the same TypedDict.

No listener narrowing in this PR — the device-CRUD events feed
into the broadcast `subscribe_events` stream, which serialises
the data dict via `to_dict()` for every key (no per-key field
access on the listener side). PR 4 / PR 5 will narrow listeners
where they consume specific keys.

## Verification

- `mypy esphome_device_builder` clean (70 source files).
- 2392 backend tests pass locally.

**Related issue or feature (if applicable):**

- Continuation of #496 / #497 / `mypy_plan.md`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
