### PR TITLE
event-bus: type DEVICE_STATE_CHANGED + DEVICE_REACHABILITY payloads

### DIFF
--- a/esphome_device_builder/controllers/_reachability_tracker.py
+++ b/esphome_device_builder/controllers/_reachability_tracker.py
@@ -48,13 +48,14 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-from ..models import DeviceState
+from ..models import DeviceReachabilityData, DeviceState
 
 # Wire-format dict the drawer's ``devices/subscribe_reachability`` event
-# carries. Defined as a TypedDict-style note rather than a runtime type
-# so we don't pay for an extra dataclass — the dict is JSON-serialized
-# by the WS layer either way.
-ReachabilitySnapshot = dict[str, object]
+# carries — see :class:`DeviceReachabilityData` for the field-by-field
+# shape. The alias is kept as the local name for the snapshot
+# constructions in this module; ``DeviceReachabilityData`` is the
+# canonical name used at fire / listener sites.
+ReachabilitySnapshot = DeviceReachabilityData
 
 # Callback fired every time we observe a freshness signal for a device,
 # so the per-device subscription stream can push a refreshed snapshot.

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -56,8 +56,10 @@ from ...models import (
     AdoptableDevice,
     Device,
     DeviceEventData,
+    DeviceReachabilityData,
     DevicesResponse,
     DeviceState,
+    DeviceStateChangedData,
     ErrorCode,
     EventType,
     JobLifecycleData,
@@ -2517,7 +2519,7 @@ class DevicesController:
         """
         return self._scanner.get_by_name(name)
 
-    def _build_reachability_snapshot(self, name: str) -> dict[str, object] | None:
+    def _build_reachability_snapshot(self, name: str) -> DeviceReachabilityData | None:
         """
         Stitch state + tracker fields into the reachability wire shape.
 
@@ -2557,7 +2559,7 @@ class DevicesController:
             return
         self._db.bus.fire(EventType.DEVICE_REACHABILITY, snapshot)
 
-    def get_reachability_snapshot(self, name: str) -> dict[str, object] | None:
+    def get_reachability_snapshot(self, name: str) -> DeviceReachabilityData | None:
         """Return the current reachability snapshot for *name*, or ``None``.
 
         Public so the WS ``devices/subscribe_reachability`` handler can
@@ -2591,7 +2593,10 @@ class DevicesController:
             # exactly so the row's state cell flips on the next event.
             self._db.bus.fire(
                 EventType.DEVICE_STATE_CHANGED,
-                {"configuration": device.configuration, "state": state.value},
+                DeviceStateChangedData(
+                    configuration=device.configuration,
+                    state=state.value,
+                ),
             )
 
     def _on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -276,3 +276,49 @@ class DeviceEventData(TypedDict):
     """
 
     device: Device
+
+
+class DeviceStateChangedData(TypedDict):
+    """
+    Payload for ``EventType.DEVICE_STATE_CHANGED``.
+
+    Flat ``{configuration, state}`` shape — deliberately *not* the
+    full ``Device`` object. The frontend's
+    ``DeviceStateChangedEventData`` destructures these two fields
+    by name; sending the full device object made both resolve to
+    ``undefined`` and the table never updated when ping (or any
+    other source) flipped a device online. ``state`` ships as the
+    serialised ``DeviceState.value`` string for the same reason —
+    the JSON encoder for ``DeviceState`` produces the same form
+    but firing the enum object directly leaks an enum into the
+    listener's ``data["state"]``.
+    """
+
+    configuration: str
+    state: str
+
+
+class DeviceReachabilityData(TypedDict):
+    """
+    Payload for ``EventType.DEVICE_REACHABILITY``.
+
+    Per-device freshness snapshot fired every time a reachability
+    signal (mDNS announce / ICMP success / MQTT discover) lands
+    for a configured device. Wire shape mirrored on the frontend
+    by ``DeviceReachabilityEventData``; the device drawer's per-
+    device subscription keys on ``device`` and pushes the
+    snapshot to the client. Optional fields are ``None`` when the
+    corresponding signal hasn't been observed yet — the drawer
+    hides the row entirely in that case.
+    """
+
+    device: str
+    state: str
+    active_source: str
+    ip: str
+    mdns_last_seen_seconds_ago: float | None
+    mdns_ttl_remaining_seconds: float | None
+    mdns_txt_records: dict[str, str] | None
+    ping_last_seen_seconds_ago: float | None
+    mqtt_last_seen_seconds_ago: float | None
+    ping_rtt_ms: float | None

--- a/tests/test_event_payload_contracts.py
+++ b/tests/test_event_payload_contracts.py
@@ -1,211 +1,171 @@
 """
-Wire-shape contract tests for every event-payload :class:`TypedDict`.
+Belt-and-suspenders for the alias that pins TypedDict ↔ dict-literal builders.
 
-Each ``EventType.*`` member's wire shape is declared as a
-``TypedDict`` next to the controller that fires it. mypy validates
-that fire sites construct payloads matching the declared shape,
-but mypy can't see runtime drift inside helpers that build a dict
-literal and return it as a TypedDict alias (e.g.
-``ReachabilityTracker.snapshot``, where the dict literal is the
-source of truth and a missing / extra key would be silently wrong
-on the wire).
+mypy is the primary gate: when a function's return annotation is
+a TypedDict (directly or via an alias like ``ReachabilitySnapshot
+= DeviceReachabilityData``), mypy emits
+``[typeddict-unknown-key]`` / ``[typeddict-item]`` if the
+``return {...}`` literal in the body drifts from the declared
+fields. The hard mypy gate from #493 blocks any PR that drifts.
 
-This file pins the contract at runtime: for every TypedDict, a
-sample-payload factory exercises the *actual* code path that
-emits the dict (or constructs it via the TypedDict-call syntax)
-and asserts the dict's keys equal the TypedDict's declared
-``__annotations__``. Adding a field to the model without updating
-the emitter — or vice versa — fails this test.
+The narrow gap mypy *can't* close on its own: the alias annotation
+is load-bearing. If a future contributor regresses the return
+type — e.g. swaps ``-> ReachabilitySnapshot`` back to
+``-> dict[str, object]`` for any reason — mypy stops checking
+and the wire shape can silently drift from the TypedDict.
+Subscribers that type ``event.data["new_field"]`` would
+mypy-pass and ``KeyError`` at runtime.
 
-Each TypedDict appears once in :data:`_PAYLOAD_FACTORIES` with a
-factory that produces a *real* payload via the production code
-path, not a hand-rolled dict. Future event-payload TypedDicts
-land their factory here at the same time as the model edit;
-:func:`test_event_payload_factories_cover_every_event_data_typeddict`
-walks ``models.*`` and asserts every ``*Data(TypedDict)`` is
-covered, so a new TypedDict can't silently skip the contract.
+This file walks the builder function's source via :mod:`ast` and
+asserts the dict literal's keys equal the TypedDict's
+``__annotations__`` *regardless of the return annotation*. So the
+test fails the moment the alias regresses, even though mypy
+would still be green.
+
+Today there's one entry: ``ReachabilityTracker.snapshot`` ↔
+``DeviceReachabilityData``. New entries land here as new
+dict-literal builders are introduced — the (alternative) shape
+where subscribers' typed access depends on a function's return
+annotation matching a TypedDict declared elsewhere.
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
+from collections.abc import Callable
 from typing import Any, get_type_hints
 
 import pytest
 
-import esphome_device_builder.models as models_pkg
 from esphome_device_builder.controllers._reachability_tracker import (
-    MdnsCacheInfo,
     ReachabilityTracker,
 )
-from esphome_device_builder.models import (
-    DeviceEventData,
-    DeviceReachabilityData,
-    DeviceState,
-    DeviceStateChangedData,
-    FirmwareJob,
-    JobLifecycleData,
-    JobOutputData,
-    JobProgressData,
-    JobStatus,
-    JobType,
-    RemoteBuildPairingWindowChangedData,
-    RemoteBuildPairRequestReceivedData,
-    RemoteBuildPairStatusChangedData,
-)
-from esphome_device_builder.models.devices import Device
+from esphome_device_builder.models import DeviceReachabilityData
 
 
-def _make_device() -> Device:
-    return Device(
-        name="kitchen",
-        friendly_name="Kitchen",
-        configuration="kitchen.yaml",
-    )
-
-
-def _make_job() -> FirmwareJob:
-    return FirmwareJob(
-        job_id="abc123",
-        configuration="kitchen.yaml",
-        job_type=JobType.COMPILE,
-        status=JobStatus.QUEUED,
-    )
-
-
-def _reachability_snapshot() -> DeviceReachabilityData:
-    """Real ``ReachabilityTracker.snapshot`` output — the highest-drift target.
-
-    The tracker builds the dict literal as the source of truth
-    for the wire shape; the TypedDict declaration mirrors it.
-    Adding a freshness field on one side without the other would
-    silently desync subscribers, so this factory exercises the
-    actual snapshot path with a populated mDNS cache reader.
+class _OutermostReturnDictFinder(ast.NodeVisitor):
     """
-    info = MdnsCacheInfo(
-        age_seconds=12.4,
-        ttl_remaining_seconds=107.6,
-        txt_records={"version": "2025.5.0"},
-    )
-    tracker = ReachabilityTracker(mdns_cache_reader={"kitchen": info}.get)
-    return tracker.snapshot(
-        "kitchen",
-        state=DeviceState.ONLINE,
-        active_source="mdns",
-        ip="10.0.0.42",
-    )
+    Collect every ``return {...}`` whose ``Dict`` is at the function's outer scope.
+
+    Skips into nested ``def`` / ``async def`` / ``lambda`` /
+    ``class`` bodies so a helper closure inside the function
+    (e.g. ``snapshot``'s ``_ago``) can't accidentally shadow the
+    outer ``return {...}`` we actually care about. Walks
+    everything else (``if`` / ``try`` / ``with`` branches, etc.)
+    so a return nested in control flow still counts.
+
+    Visit results land in :attr:`dict_returns` in source order;
+    callers typically assert exactly one entry.
+    """
+
+    def __init__(self) -> None:
+        self.dict_returns: list[ast.Dict] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # Don't recurse — nested function bodies aren't the outer return.
+        return
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        return
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        return
+
+    def visit_Return(self, node: ast.Return) -> None:
+        if isinstance(node.value, ast.Dict):
+            self.dict_returns.append(node.value)
+        self.generic_visit(node)
 
 
-# Each entry: (TypedDict, sample-payload factory). The factory must
-# exercise the actual wire-shape construction site (TypedDict-call
-# syntax, dict literal returned as a TypedDict, snapshot helper)
-# rather than hand-rolling a dict — the whole point is to catch
-# drift between the emitter and the model.
-_PAYLOAD_FACTORIES: list[tuple[type, Any]] = [
-    (
-        DeviceEventData,
-        lambda: DeviceEventData(device=_make_device()),
-    ),
-    (
-        DeviceStateChangedData,
-        lambda: DeviceStateChangedData(
-            configuration="kitchen.yaml",
-            state=DeviceState.ONLINE.value,
-        ),
-    ),
-    (DeviceReachabilityData, _reachability_snapshot),
-    (
-        JobLifecycleData,
-        lambda: JobLifecycleData(job=_make_job()),
-    ),
-    (
-        JobOutputData,
-        lambda: JobOutputData(job_id="abc123", line="hello\n"),
-    ),
-    (
-        JobProgressData,
-        lambda: JobProgressData(job_id="abc123", progress=42),
-    ),
-    (
-        RemoteBuildPairRequestReceivedData,
-        lambda: RemoteBuildPairRequestReceivedData(
-            dashboard_id="peer-1",
-            pin_sha256="0" * 64,
-            label="laptop",
-            peer_ip="10.0.0.99",
-        ),
-    ),
-    (
-        RemoteBuildPairStatusChangedData,
-        lambda: RemoteBuildPairStatusChangedData(
-            dashboard_id="peer-1",
-            status="approved",
-        ),
-    ),
-    (
-        RemoteBuildPairingWindowChangedData,
-        lambda: RemoteBuildPairingWindowChangedData(
-            open=True,
-            expires_in_seconds=300.0,
-        ),
-    ),
+def _outermost_return_dict_keys(func: Callable[..., Any]) -> set[str]:
+    """Return the keys of *func*'s outermost ``return {...}`` literal.
+
+    Skips into nested function / class / lambda bodies so a
+    helper closure that happens to return a dict can't shadow the
+    outer wire-shape return. Asserts exactly one outer-scope
+    dict-literal return — a builder with multiple wire-shape
+    returns needs a per-branch test, not this one.
+    """
+    src = inspect.cleandoc("\n" + inspect.getsource(func))
+    tree = ast.parse(src)
+    if len(tree.body) != 1 or not isinstance(tree.body[0], ast.FunctionDef | ast.AsyncFunctionDef):
+        msg = f"Expected a single function definition in source of {func!r}"
+        raise AssertionError(msg)
+    func_def = tree.body[0]
+
+    finder = _OutermostReturnDictFinder()
+    # Visit the body's children (not the function def itself, which
+    # would re-enter ``visit_FunctionDef`` and stop).
+    for stmt in func_def.body:
+        finder.visit(stmt)
+
+    if len(finder.dict_returns) != 1:
+        msg = (
+            f"Expected exactly one outer-scope ``return {{...}}`` literal "
+            f"in {func!r}, found {len(finder.dict_returns)}."
+        )
+        raise AssertionError(msg)
+
+    keys: set[str] = set()
+    for key_node in finder.dict_returns[0].keys:
+        if not isinstance(key_node, ast.Constant) or not isinstance(key_node.value, str):
+            msg = (
+                f"Non-string-literal key in {func!r} dict literal — the "
+                "drift check assumes a flat ``{'k': v, ...}`` dict."
+            )
+            raise AssertionError(msg)
+        keys.add(key_node.value)
+    return keys
+
+
+# Each entry: (TypedDict class, builder function whose body
+# returns a dict literal aliased to the TypedDict). The contract
+# test walks *builder*'s source via :mod:`ast` and asserts the
+# literal's keys equal the TypedDict's declared
+# ``__annotations__``.
+#
+# Add an entry here when a new builder lands in the same shape —
+# i.e. a function with a TypedDict-aliased return annotation
+# whose body builds the wire shape via a single
+# ``return {...}`` literal. Fire-site constructions
+# (``payload: T = {...}`` / ``T(field=...)``) don't belong here;
+# mypy enforces those at the call site.
+_DICT_LITERAL_BUILDERS: list[tuple[type, Callable[..., Any]]] = [
+    (DeviceReachabilityData, ReachabilityTracker.snapshot),
 ]
 
 
 @pytest.mark.parametrize(
-    ("typed_dict", "factory"),
-    _PAYLOAD_FACTORIES,
-    ids=[td.__name__ for td, _ in _PAYLOAD_FACTORIES],
+    ("typed_dict", "builder"),
+    _DICT_LITERAL_BUILDERS,
+    ids=[td.__name__ for td, _ in _DICT_LITERAL_BUILDERS],
 )
-def test_event_payload_keys_match_typeddict(
+def test_dict_literal_builder_keys_match_typeddict(
     typed_dict: type,
-    factory: Any,
+    builder: Callable[..., Any],
 ) -> None:
-    """Every emitted payload's keys equal the TypedDict's declared fields.
+    """The builder's literal keys equal the TypedDict's declared fields.
 
-    Pins the wire-shape contract at runtime. mypy already checks
-    the TypedDict-call syntax at fire sites, but the
-    ``ReachabilityTracker.snapshot`` path returns a dict-literal
-    typed via the ``ReachabilitySnapshot = DeviceReachabilityData``
-    alias — drift there would only surface as a runtime mismatch.
-    Failing this test means a TypedDict field was added without
-    updating the emitter (or the other way around).
+    See the module docstring for the alias-regression scenario
+    this guards against. mypy already enforces drift in either
+    direction *while the alias is in place*; this test fails
+    even if the alias is dropped or loosened to ``dict[str,
+    object]``, because the ``ast`` walk doesn't depend on the
+    return annotation.
     """
-    payload = factory()
-    declared = set(get_type_hints(typed_dict).keys())
-    actual = set(payload.keys())
+    literal_keys = _outermost_return_dict_keys(builder)
+    declared_keys = set(get_type_hints(typed_dict).keys())
 
-    extra = actual - declared
-    missing = declared - actual
-    assert not extra, f"{typed_dict.__name__} payload has unexpected keys: {extra}"
-    assert not missing, f"{typed_dict.__name__} payload missing declared keys: {missing}"
-
-
-def test_event_payload_factories_cover_every_event_data_typeddict() -> None:
-    """Pin every ``*Data`` TypedDict to a row in ``_PAYLOAD_FACTORIES``.
-
-    Without this gate, a future PR could land a new TypedDict and
-    forget to add a factory — the param test would silently skip
-    coverage for the new type. Walks every model module's
-    namespace, finds anything matching the convention
-    ``class XxxData(TypedDict)``, and verifies it's listed above.
-    """
-    discovered: set[str] = set()
-    for name in dir(models_pkg):
-        obj = getattr(models_pkg, name)
-        # ``TypedDict`` declares a ``__total__`` attribute on its
-        # subclasses (the runtime hook ``typing.TypedDict`` plants
-        # for ``total=`` introspection); plain classes don't.
-        if (
-            isinstance(obj, type)
-            and getattr(obj, "__total__", None) is not None
-            and name.endswith("Data")
-        ):
-            discovered.add(name)
-
-    covered = {td.__name__ for td, _ in _PAYLOAD_FACTORIES}
-    uncovered = discovered - covered
-    assert not uncovered, (
-        f"TypedDicts without a payload factory: {sorted(uncovered)}. "
-        "Add a factory to ``_PAYLOAD_FACTORIES`` so the contract "
-        "test exercises the new shape."
+    extra = literal_keys - declared_keys
+    missing = declared_keys - literal_keys
+    assert not extra, (
+        f"{builder.__qualname__} dict literal has keys not declared in "
+        f"{typed_dict.__name__}: {extra}"
+    )
+    assert not missing, (
+        f"{typed_dict.__name__} declares keys missing from {builder.__qualname__}: {missing}"
     )

--- a/tests/test_event_payload_contracts.py
+++ b/tests/test_event_payload_contracts.py
@@ -1,0 +1,211 @@
+"""
+Wire-shape contract tests for every event-payload :class:`TypedDict`.
+
+Each ``EventType.*`` member's wire shape is declared as a
+``TypedDict`` next to the controller that fires it. mypy validates
+that fire sites construct payloads matching the declared shape,
+but mypy can't see runtime drift inside helpers that build a dict
+literal and return it as a TypedDict alias (e.g.
+``ReachabilityTracker.snapshot``, where the dict literal is the
+source of truth and a missing / extra key would be silently wrong
+on the wire).
+
+This file pins the contract at runtime: for every TypedDict, a
+sample-payload factory exercises the *actual* code path that
+emits the dict (or constructs it via the TypedDict-call syntax)
+and asserts the dict's keys equal the TypedDict's declared
+``__annotations__``. Adding a field to the model without updating
+the emitter — or vice versa — fails this test.
+
+Each TypedDict appears once in :data:`_PAYLOAD_FACTORIES` with a
+factory that produces a *real* payload via the production code
+path, not a hand-rolled dict. Future event-payload TypedDicts
+land their factory here at the same time as the model edit;
+:func:`test_event_payload_factories_cover_every_event_data_typeddict`
+walks ``models.*`` and asserts every ``*Data(TypedDict)`` is
+covered, so a new TypedDict can't silently skip the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, get_type_hints
+
+import pytest
+
+import esphome_device_builder.models as models_pkg
+from esphome_device_builder.controllers._reachability_tracker import (
+    MdnsCacheInfo,
+    ReachabilityTracker,
+)
+from esphome_device_builder.models import (
+    DeviceEventData,
+    DeviceReachabilityData,
+    DeviceState,
+    DeviceStateChangedData,
+    FirmwareJob,
+    JobLifecycleData,
+    JobOutputData,
+    JobProgressData,
+    JobStatus,
+    JobType,
+    RemoteBuildPairingWindowChangedData,
+    RemoteBuildPairRequestReceivedData,
+    RemoteBuildPairStatusChangedData,
+)
+from esphome_device_builder.models.devices import Device
+
+
+def _make_device() -> Device:
+    return Device(
+        name="kitchen",
+        friendly_name="Kitchen",
+        configuration="kitchen.yaml",
+    )
+
+
+def _make_job() -> FirmwareJob:
+    return FirmwareJob(
+        job_id="abc123",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.QUEUED,
+    )
+
+
+def _reachability_snapshot() -> DeviceReachabilityData:
+    """Real ``ReachabilityTracker.snapshot`` output — the highest-drift target.
+
+    The tracker builds the dict literal as the source of truth
+    for the wire shape; the TypedDict declaration mirrors it.
+    Adding a freshness field on one side without the other would
+    silently desync subscribers, so this factory exercises the
+    actual snapshot path with a populated mDNS cache reader.
+    """
+    info = MdnsCacheInfo(
+        age_seconds=12.4,
+        ttl_remaining_seconds=107.6,
+        txt_records={"version": "2025.5.0"},
+    )
+    tracker = ReachabilityTracker(mdns_cache_reader={"kitchen": info}.get)
+    return tracker.snapshot(
+        "kitchen",
+        state=DeviceState.ONLINE,
+        active_source="mdns",
+        ip="10.0.0.42",
+    )
+
+
+# Each entry: (TypedDict, sample-payload factory). The factory must
+# exercise the actual wire-shape construction site (TypedDict-call
+# syntax, dict literal returned as a TypedDict, snapshot helper)
+# rather than hand-rolling a dict — the whole point is to catch
+# drift between the emitter and the model.
+_PAYLOAD_FACTORIES: list[tuple[type, Any]] = [
+    (
+        DeviceEventData,
+        lambda: DeviceEventData(device=_make_device()),
+    ),
+    (
+        DeviceStateChangedData,
+        lambda: DeviceStateChangedData(
+            configuration="kitchen.yaml",
+            state=DeviceState.ONLINE.value,
+        ),
+    ),
+    (DeviceReachabilityData, _reachability_snapshot),
+    (
+        JobLifecycleData,
+        lambda: JobLifecycleData(job=_make_job()),
+    ),
+    (
+        JobOutputData,
+        lambda: JobOutputData(job_id="abc123", line="hello\n"),
+    ),
+    (
+        JobProgressData,
+        lambda: JobProgressData(job_id="abc123", progress=42),
+    ),
+    (
+        RemoteBuildPairRequestReceivedData,
+        lambda: RemoteBuildPairRequestReceivedData(
+            dashboard_id="peer-1",
+            pin_sha256="0" * 64,
+            label="laptop",
+            peer_ip="10.0.0.99",
+        ),
+    ),
+    (
+        RemoteBuildPairStatusChangedData,
+        lambda: RemoteBuildPairStatusChangedData(
+            dashboard_id="peer-1",
+            status="approved",
+        ),
+    ),
+    (
+        RemoteBuildPairingWindowChangedData,
+        lambda: RemoteBuildPairingWindowChangedData(
+            open=True,
+            expires_in_seconds=300.0,
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("typed_dict", "factory"),
+    _PAYLOAD_FACTORIES,
+    ids=[td.__name__ for td, _ in _PAYLOAD_FACTORIES],
+)
+def test_event_payload_keys_match_typeddict(
+    typed_dict: type,
+    factory: Any,
+) -> None:
+    """Every emitted payload's keys equal the TypedDict's declared fields.
+
+    Pins the wire-shape contract at runtime. mypy already checks
+    the TypedDict-call syntax at fire sites, but the
+    ``ReachabilityTracker.snapshot`` path returns a dict-literal
+    typed via the ``ReachabilitySnapshot = DeviceReachabilityData``
+    alias — drift there would only surface as a runtime mismatch.
+    Failing this test means a TypedDict field was added without
+    updating the emitter (or the other way around).
+    """
+    payload = factory()
+    declared = set(get_type_hints(typed_dict).keys())
+    actual = set(payload.keys())
+
+    extra = actual - declared
+    missing = declared - actual
+    assert not extra, f"{typed_dict.__name__} payload has unexpected keys: {extra}"
+    assert not missing, f"{typed_dict.__name__} payload missing declared keys: {missing}"
+
+
+def test_event_payload_factories_cover_every_event_data_typeddict() -> None:
+    """Pin every ``*Data`` TypedDict to a row in ``_PAYLOAD_FACTORIES``.
+
+    Without this gate, a future PR could land a new TypedDict and
+    forget to add a factory — the param test would silently skip
+    coverage for the new type. Walks every model module's
+    namespace, finds anything matching the convention
+    ``class XxxData(TypedDict)``, and verifies it's listed above.
+    """
+    discovered: set[str] = set()
+    for name in dir(models_pkg):
+        obj = getattr(models_pkg, name)
+        # ``TypedDict`` declares a ``__total__`` attribute on its
+        # subclasses (the runtime hook ``typing.TypedDict`` plants
+        # for ``total=`` introspection); plain classes don't.
+        if (
+            isinstance(obj, type)
+            and getattr(obj, "__total__", None) is not None
+            and name.endswith("Data")
+        ):
+            discovered.add(name)
+
+    covered = {td.__name__ for td, _ in _PAYLOAD_FACTORIES}
+    uncovered = discovered - covered
+    assert not uncovered, (
+        f"TypedDicts without a payload factory: {sorted(uncovered)}. "
+        "Add a factory to ``_PAYLOAD_FACTORIES`` so the contract "
+        "test exercises the new shape."
+    )


### PR DESCRIPTION
# What does this implement/fix?

PR 4 of the event-bus typing migration. Lays TypedDicts over the
two device-state events.

## TypedDicts (`models/devices.py`)

```python
class DeviceStateChangedData(TypedDict):
    """Payload for EventType.DEVICE_STATE_CHANGED."""
    configuration: str
    state: str


class DeviceReachabilityData(TypedDict):
    """Payload for EventType.DEVICE_REACHABILITY."""
    device: str
    state: str
    active_source: str
    ip: str
    mdns_last_seen_seconds_ago: float | None
    mdns_ttl_remaining_seconds: float | None
    mdns_txt_records: dict[str, str] | None
    ping_last_seen_seconds_ago: float | None
    mqtt_last_seen_seconds_ago: float | None
    ping_rtt_ms: float | None
```

`DeviceStateChangedData` pins the *flat* `{configuration, state}` shape — deliberately not the full `Device` object. The frontend's `DeviceStateChangedEventData` destructures these two fields by name; sending the full device object made both resolve to `undefined` and the table never updated when ping (or any other source) flipped a device online (the bug fix that originally shipped this shape, pinned by `tests/test_device_state_event.py`).

`DeviceReachabilityData` pins the per-device freshness snapshot fired every time a reachability signal lands. Optional fields are `None` when the corresponding signal hasn't been observed.

## Retypes

- `_reachability_tracker.py`: `ReachabilitySnapshot` alias is now `DeviceReachabilityData` (was `dict[str, object]`). The `snapshot()` constructor's return-type narrowing comes through the alias — and mypy enforces the dict literal it returns matches the TypedDict's declared fields (catches drift on either side at the return site).
- `controllers/devices/controller.py`:
  - `_build_reachability_snapshot` / `get_reachability_snapshot` return `DeviceReachabilityData | None`.
  - `_on_state_change` fires `DeviceStateChangedData(configuration=..., state=...)` so mypy validates the construction.

## Alias-regression guard test

`tests/test_event_payload_contracts.py` is a single parametrized test that walks each builder function's source via `ast` and asserts the `return {...}` literal's keys equal the TypedDict's `__annotations__`. Today there's one entry: `(DeviceReachabilityData, ReachabilityTracker.snapshot)`.

mypy is the primary gate — the `ReachabilitySnapshot = DeviceReachabilityData` alias on `snapshot()`'s return type makes mypy emit `[typeddict-unknown-key]` / `[typeddict-item]` on drift in either direction. The narrow gap mypy can't close: if the alias annotation is ever regressed (loosened to `dict[str, object]`, dropped, etc.), mypy stops checking but the wire shape can silently drift. This test fails regardless of the return annotation because the AST walk doesn't depend on it.

The AST traversal uses a custom `NodeVisitor` that skips into nested `def` / `class` / `lambda` bodies so an inner closure (e.g. `snapshot`'s `_ago` helper) can't shadow the outer wire-shape return — `ast.walk`'s default unordered descent would have made the picked return non-deterministic.

## Verification

- `mypy esphome_device_builder` clean (71 source files).
- 2407 backend tests pass locally.
- `tests/test_device_state_event.py` (3 tests pinning the flat-shape contract) still green.

**Related issue or feature (if applicable):**

- Continuation of #496 / #497 / #498. ARCHITECTURE.md + CLAUDE.md updates split into #502 (merged).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.