### PR TITLE
event-bus: type IMPORTABLE_DEVICE_* + LABEL_* payloads

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -62,6 +62,8 @@ from ...models import (
     DeviceStateChangedData,
     ErrorCode,
     EventType,
+    ImportableDeviceAddedData,
+    ImportableDeviceRemovedData,
     JobLifecycleData,
     JobStatus,
     JobType,
@@ -2080,7 +2082,9 @@ class DevicesController:
         if existing is not None and existing.ignored != ignore:
             updated = replace(existing, ignored=ignore)
             self.import_result[name] = updated
-            self._db.bus.fire(EventType.IMPORTABLE_DEVICE_ADDED, {"device": updated})
+            self._db.bus.fire(
+                EventType.IMPORTABLE_DEVICE_ADDED, ImportableDeviceAddedData(device=updated)
+            )
 
     # ------------------------------------------------------------------
     # API commands — per-connection streams (validate, logs)
@@ -2793,13 +2797,17 @@ class DevicesController:
         # configured devices and ``devices/ignore`` can flip the flag
         # by name without juggling the full mdns service-instance.
         self.import_result[device.name] = device
-        self._db.bus.fire(EventType.IMPORTABLE_DEVICE_ADDED, {"device": device})
+        self._db.bus.fire(
+            EventType.IMPORTABLE_DEVICE_ADDED, ImportableDeviceAddedData(device=device)
+        )
 
     def _on_importable_removed(self, name: str) -> None:
         """Forget an importable device that disappeared from mDNS."""
         if self.import_result.pop(name, None) is None:
             return
-        self._db.bus.fire(EventType.IMPORTABLE_DEVICE_REMOVED, {"name": name})
+        self._db.bus.fire(
+            EventType.IMPORTABLE_DEVICE_REMOVED, ImportableDeviceRemovedData(name=name)
+        )
 
     def get_importable_devices(self) -> list[AdoptableDevice]:
         """

--- a/esphome_device_builder/controllers/labels.py
+++ b/esphome_device_builder/controllers/labels.py
@@ -9,7 +9,7 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from ..helpers.api import CommandError, api_command
-from ..models import ErrorCode, EventType, Label
+from ..models import ErrorCode, EventType, Label, LabelDeletedData, LabelEventData
 from .config import (
     delete_label_cascade,
     labels_transaction,
@@ -135,7 +135,7 @@ class LabelsController:
                 return created
 
         label = await asyncio.to_thread(_persist)
-        self._db.bus.fire(EventType.LABEL_CREATED, {"label": label})
+        self._db.bus.fire(EventType.LABEL_CREATED, LabelEventData(label=label))
         return label
 
     @api_command("labels/update")
@@ -177,7 +177,7 @@ class LabelsController:
                 return updated
 
         label = await asyncio.to_thread(_persist)
-        self._db.bus.fire(EventType.LABEL_UPDATED, {"label": label})
+        self._db.bus.fire(EventType.LABEL_UPDATED, LabelEventData(label=label))
         return label
 
     @api_command("labels/delete")
@@ -215,5 +215,5 @@ class LabelsController:
                 except Exception:
                     _LOGGER.warning("Failed to reload device %s after label cascade", filename)
 
-        self._db.bus.fire(EventType.LABEL_DELETED, {"label_id": label_id})
+        self._db.bus.fire(EventType.LABEL_DELETED, LabelDeletedData(label_id=label_id))
         return {"deleted": True}

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -323,3 +323,31 @@ class DeviceReachabilityData(TypedDict):
     ping_last_seen_seconds_ago: float | None
     mqtt_last_seen_seconds_ago: float | None
     ping_rtt_ms: float | None
+
+
+class ImportableDeviceAddedData(TypedDict):
+    """
+    Payload for ``EventType.IMPORTABLE_DEVICE_ADDED``.
+
+    Carries the full ``AdoptableDevice`` so the frontend's
+    discoverable-device list has every field it needs (mDNS host,
+    port, version) without an additional fetch. Distinct from
+    ``IMPORTABLE_DEVICE_REMOVED`` (which only ships the name)
+    because the ADD event has to land a complete row whereas
+    REMOVE only needs the id key to delete the row.
+    """
+
+    device: AdoptableDevice
+
+
+class ImportableDeviceRemovedData(TypedDict):
+    """
+    Payload for ``EventType.IMPORTABLE_DEVICE_REMOVED``.
+
+    Carries only the removed device's mDNS name — the catalog row
+    is already gone, and clients track importable devices by name
+    (not by full payload) so the id key is all that's needed to
+    drop the row.
+    """
+
+    name: str

--- a/esphome_device_builder/models/labels.py
+++ b/esphome_device_builder/models/labels.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypedDict
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
@@ -27,3 +28,38 @@ class Label(DataClassORJSONMixin):
     # ``#rrggbb`` (lowercase). ``None`` lets the frontend pick a
     # theme-default chip color.
     color: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Event payload shapes (TypedDict so the bus.fire data dict is
+# type-checked at the call site without changing the wire shape).
+# See ``mypy_plan.md`` for the migration scope.
+# ---------------------------------------------------------------------------
+
+
+class LabelEventData(TypedDict):
+    """
+    Payload for ``EventType.LABEL_CREATED`` / ``LABEL_UPDATED``.
+
+    Both creation and update events carry the full ``Label`` so
+    the frontend's catalog renderer has the canonical form
+    (server-trimmed name, lowercased ``#rrggbb`` color, opaque
+    id) without an additional fetch. Subscribers differentiate by
+    the ``EventType`` carried alongside.
+    """
+
+    label: Label
+
+
+class LabelDeletedData(TypedDict):
+    """
+    Payload for ``EventType.LABEL_DELETED``.
+
+    Carries only the deleted label's id — the catalog row is
+    already gone by the time the event fires, and clients track
+    labels by id. Per-device label assignment cascades fire
+    ``DEVICE_UPDATED`` events for each affected device alongside
+    this one.
+    """
+
+    label_id: str


### PR DESCRIPTION
# What does this implement/fix?

PR 5 of the event-bus typing migration tracked in
`mypy_plan.md` (#496 / #497 / #498 / #499). Lays TypedDicts over
the 5 importable-device + label events.

## TypedDicts

```python
# models/devices.py
class ImportableDeviceAddedData(TypedDict):
    """Payload for EventType.IMPORTABLE_DEVICE_ADDED."""
    device: AdoptableDevice


class ImportableDeviceRemovedData(TypedDict):
    """Payload for EventType.IMPORTABLE_DEVICE_REMOVED."""
    name: str


# models/labels.py
class LabelEventData(TypedDict):
    """Payload for EventType.LABEL_CREATED / LABEL_UPDATED."""
    label: Label


class LabelDeletedData(TypedDict):
    """Payload for EventType.LABEL_DELETED."""
    label_id: str
```

## Asymmetric add/remove shapes

`IMPORTABLE_DEVICE_ADDED` ships the full `AdoptableDevice` so the
frontend's discoverable list has every field (mDNS host / port /
version) without a follow-up fetch. `IMPORTABLE_DEVICE_REMOVED`
ships only `name` because the catalog row is already gone by the
time the event lands; the id key is all the client needs to drop
the row. Same shape asymmetry on labels — `LabelEventData` for
CREATE/UPDATE (full `Label`) vs `LabelDeletedData` for DELETE
(just the id). The TypedDicts pin the wire contract on both
sides so a future caller can't accidentally fall back to "send
the whole row" on REMOVE.

## Retypes

- `controllers/labels.py` — 3 fire sites switched to TypedDict-
  call syntax (`LabelEventData(label=label)` /
  `LabelDeletedData(label_id=label_id)`).
- `controllers/devices/controller.py` — 3 importable fire sites
  retyped (`ImportableDeviceAddedData(device=...)` ×2 +
  `ImportableDeviceRemovedData(name=name)`).

## Verification

- `mypy esphome_device_builder` clean (70 source files).
- 2392 backend tests pass locally.

**Related issue or feature (if applicable):**

- Final family PR in the `mypy_plan.md` migration. PR 6 is the
  editorial audit pinning the end-state contract.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
