### PR TITLE
Add offloader-side request_pair WS command (#106 phase 4a-o part 3)

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -85,6 +85,8 @@ from ..models import (
     IdentityView,
     IntentResponse,
     ManualHost,
+    OffloaderRemoteBuildSettings,
+    PairingSummary,
     PairingWindowState,
     PeerStatus,
     PeerSummary,
@@ -95,14 +97,22 @@ from ..models import (
     RemoteBuildPeerSource,
     RemoteBuildSettings,
     RemoteBuildSettingsView,
+    StoredPairing,
     StoredPeer,
 )
-from .config import load_remote_build_settings, remote_build_settings_transaction
+from .config import (
+    load_remote_build_settings,
+    offloader_remote_build_settings_transaction,
+    remote_build_settings_transaction,
+)
 from .remote_build_peer_link_client import (
     PeerLinkClientError,
 )
 from .remote_build_peer_link_client import (
     preview_pair as peer_link_preview_pair,
+)
+from .remote_build_peer_link_client import (
+    request_pair as peer_link_request_pair,
 )
 
 if TYPE_CHECKING:
@@ -314,6 +324,23 @@ def _peer_summary(peer: StoredPeer) -> PeerSummary:
     )
 
 
+def _pairing_summary(pairing: StoredPairing) -> PairingSummary:
+    """Project a :class:`StoredPairing` to wire :class:`PairingSummary`.
+
+    Mirror of :func:`_peer_summary` for the offloader side.
+    Drops the raw ``static_x25519_pub`` bytes; the rest is
+    safe to send to the frontend.
+    """
+    return PairingSummary(
+        receiver_hostname=pairing.receiver_hostname,
+        receiver_port=pairing.receiver_port,
+        pin_sha256=pairing.pin_sha256,
+        label=pairing.label,
+        paired_at=pairing.paired_at,
+        status=pairing.status,
+    )
+
+
 def _find_peer_by_dashboard_id(
     settings: RemoteBuildSettings, dashboard_id: str
 ) -> StoredPeer | None:
@@ -329,6 +356,129 @@ def _find_peer_by_dashboard_id(
     for any production-realistic peer count.
     """
     return next((peer for peer in settings.peers if peer.dashboard_id == dashboard_id), None)
+
+
+_PIN_SHA256_LEN = 64  # 32-byte SHA-256 → 64 lowercase-hex chars
+_PAIR_LABEL_MAX_CHARS = 128  # mirrors :data:`_PEER_LABEL_MAX_CHARS` on the receiver
+
+
+def _validate_pin_sha256(raw: object) -> str:
+    """Validate a wire ``pin_sha256`` value as 64 lowercase-hex chars.
+
+    Same alphabet and length the storage seam enforces in
+    :class:`StoredPairing` (and the receiver's :class:`StoredPeer`),
+    just at the WS-command boundary so a bad pin gets rejected as
+    ``INVALID_ARGS`` before the offloader opens a Noise WS only to
+    fail the TOCTOU check post-handshake.
+    """
+    if not isinstance(raw, str):
+        msg = "pin_sha256 must be a string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    cleaned = raw.strip()
+    if (
+        len(cleaned) != _PIN_SHA256_LEN
+        or not cleaned.isascii()
+        or any(c not in "0123456789abcdef" for c in cleaned)
+    ):
+        msg = f"pin_sha256 must be {_PIN_SHA256_LEN} lowercase-hex characters"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return cleaned
+
+
+def _validate_pair_label(raw: object) -> str:
+    """Validate the user-supplied ``label`` for a new pairing.
+
+    Capped at 128 chars to match
+    :data:`controllers.remote_build_peer_link._PEER_LABEL_MAX_CHARS`
+    (the receiver's truncation cap on the same field), so a
+    label that round-trips through pair_request lands in both
+    sides' tables with identical content. Empty labels are
+    allowed — the user may legitimately not name the receiver
+    yet; the frontend can render a placeholder.
+    """
+    if not isinstance(raw, str):
+        msg = "label must be a string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    cleaned = raw.strip()
+    if len(cleaned) > _PAIR_LABEL_MAX_CHARS:
+        msg = f"label must be at most {_PAIR_LABEL_MAX_CHARS} characters"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return cleaned
+
+
+# Maps non-success ``IntentResponse`` values from a peer-link
+# round-trip to the typed :class:`CommandError` the frontend
+# branches on. Used by ``request_pair`` (part 3) and
+# ``list_pool``'s pair_status polling (part 4); shared so both
+# WS commands surface receiver decisions through the same wire
+# error codes.
+_INTENT_RESPONSE_ERRORS: dict[IntentResponse, tuple[ErrorCode, str]] = {
+    IntentResponse.NO_PAIRING_WINDOW: (
+        ErrorCode.NO_PAIRING_WINDOW,
+        "receiver pairing window closed; ask the receiver-side admin to "
+        "open Settings → Build server → Pairing requests, then retry",
+    ),
+    IntentResponse.REJECTED: (
+        ErrorCode.PRECONDITION_FAILED,
+        "receiver declined the pair request",
+    ),
+}
+
+
+def _intent_response_to_command_error(status: IntentResponse) -> CommandError | None:
+    """Translate a non-success ``IntentResponse`` to a typed ``CommandError``.
+
+    Returns ``None`` for the success values
+    (``OK``, ``PENDING``, ``APPROVED``); the caller branches on
+    those for persistence. Returns a fresh ``CommandError`` (not
+    yet raised) for ``REJECTED`` / ``NO_PAIRING_WINDOW`` so the
+    caller can decide whether to attach extra context before
+    raising.
+    """
+    pair = _INTENT_RESPONSE_ERRORS.get(status)
+    if pair is None:
+        return None
+    code, msg = pair
+    return CommandError(code, msg)
+
+
+def _enforce_pin_match(*, expected: str, observed: str) -> None:
+    """Raise ``CommandError(PRECONDITION_FAILED)`` on a TOCTOU pin drift.
+
+    The offloader's ``request_pair`` (and any future
+    pin-pinned re-handshake) compares the pin the user
+    OOB-confirmed during ``preview_pair`` against the actual
+    pubkey from the live handshake. A mismatch means the
+    receiver rotated identity (or a MITM intervened) between
+    preview and request; the offloader bails before persisting
+    the row so a fresh preview round-trip is required.
+    """
+    if expected == observed:
+        return
+    msg = f"receiver pin changed since preview; expected {expected[:16]}..., got {observed[:16]}..."
+    raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
+
+
+def _upsert_pairing(settings: OffloaderRemoteBuildSettings, pairing: StoredPairing) -> None:
+    """Replace any existing row for ``(receiver_hostname, receiver_port)``.
+
+    Re-pair from the same offloader to the same receiver should
+    overwrite, not duplicate — the user's intent is "pair me
+    with this receiver again" not "give me two rows pointing
+    at the same place." Used by ``request_pair`` (part 3); a
+    future ``list_pool`` (part 4) status refresh can reuse the
+    same shape when the receiver's response flips a row's
+    status.
+    """
+    settings.pairings = [
+        p
+        for p in settings.pairings
+        if not (
+            p.receiver_hostname == pairing.receiver_hostname
+            and p.receiver_port == pairing.receiver_port
+        )
+    ]
+    settings.pairings.append(pairing)
 
 
 def _validate_dashboard_id(raw: object) -> str:
@@ -772,6 +922,130 @@ class RemoteBuildController:
         except PeerLinkClientError as exc:
             raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
         return {"pin_sha256": pin}
+
+    @api_command("remote_build/request_pair")
+    async def request_pair(
+        self,
+        *,
+        hostname: str,
+        port: int,
+        pin_sha256: str,
+        label: str,
+        **kwargs: Any,
+    ) -> PairingSummary:
+        """Open a Noise XX WS, send ``intent="pair_request"``, persist a local row.
+
+        The offloader's second handshake with a receiver, after
+        the user has OOB-confirmed the receiver's pin via
+        :meth:`preview_pair`. Sends ``{"label": label,
+        "dashboard_id": <ours>}`` in the encrypted msg3
+        payload; the receiver's response decides what state the
+        local :class:`StoredPairing` row lands in.
+
+        TOCTOU defense: the *pin_sha256* arg is the value the
+        user OOB-confirmed in preview; the live handshake
+        captures the receiver's actual pubkey. If the two don't
+        match — receiver rotated identity between preview and
+        request, or an active MITM intervened — the call
+        rejects with ``PRECONDITION_FAILED`` and persists
+        nothing. The offloader's frontend should re-run
+        preview before retrying.
+
+        Args:
+            hostname: Receiver's hostname (validated /
+                normalised by :func:`_validate_hostname`;
+                yarl-correct).
+            port: Receiver's peer-link port (1-65535).
+            pin_sha256: Lowercase-hex SHA-256 of the receiver's
+                X25519 pubkey, captured + OOB-verified during
+                ``preview_pair``.
+            label: Human-readable name the offloader's user
+                gives this receiver (the value lands in the
+                local ``StoredPairing`` row's ``label``;
+                separately, the receiver's
+                :class:`StoredPeer.label` comes from a
+                receiver-side rendering of *our* label, not
+                this one).
+
+        Returns:
+            :class:`PairingSummary` for the newly-created or
+            refreshed :class:`StoredPairing` row, with
+            ``status`` = ``PENDING`` (typical) or ``APPROVED``
+            (re-pair against a row the receiver already
+            approved).
+
+        Raises:
+            :class:`CommandError(INVALID_ARGS)` for bad inputs
+                (host / port / pin / label shape).
+            :class:`CommandError(UNAVAILABLE)` for transport,
+                handshake, or decode failures.
+            :class:`CommandError(PRECONDITION_FAILED)` for
+                pin mismatch (TOCTOU) or receiver-side
+                ``REJECTED`` (admin declined).
+            :class:`CommandError(NO_PAIRING_WINDOW)` when the
+                receiver returns ``no_pairing_window`` —
+                frontend prompts the user to ask the
+                receiver-side admin to open the Pairing
+                requests screen.
+        """
+        clean_host = _validate_hostname(hostname)
+        clean_port = _validate_port(port)
+        clean_pin = _validate_pin_sha256(pin_sha256)
+        clean_label = _validate_pair_label(label)
+        loop = asyncio.get_running_loop()
+        # X25519 peer-link key drives the Noise handshake; the
+        # dashboard_id is what we send in msg3 so the receiver's
+        # ``StoredPeer`` row keys on it.
+        peer_link_identity = await loop.run_in_executor(
+            None, get_or_create_peer_link_identity, self._db.settings.config_dir
+        )
+        dashboard_identity = await loop.run_in_executor(
+            None, get_or_create_identity, self._db.settings.config_dir
+        )
+
+        try:
+            result = await peer_link_request_pair(
+                hostname=clean_host,
+                port=clean_port,
+                identity_priv=peer_link_identity.private_bytes,
+                label=clean_label,
+                dashboard_id=dashboard_identity.dashboard_id,
+            )
+        except PeerLinkClientError as exc:
+            raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
+
+        _enforce_pin_match(expected=clean_pin, observed=result.pin_sha256)
+        if (err := _intent_response_to_command_error(result.status)) is not None:
+            raise err
+        if result.status not in (IntentResponse.PENDING, IntentResponse.APPROVED):
+            msg = f"unexpected receiver intent_response={result.status.value!r}"
+            raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
+
+        # APPROVED happens when this offloader paired with the same
+        # receiver previously and the receiver-side row is still
+        # APPROVED — the receiver short-circuits the inbox dance.
+        pairing = StoredPairing(
+            receiver_hostname=clean_host,
+            receiver_port=clean_port,
+            pin_sha256=result.pin_sha256,
+            static_x25519_pub=result.remote_static_pub,
+            label=clean_label,
+            paired_at=time.time(),
+            status=(
+                PeerStatus.APPROVED
+                if result.status is IntentResponse.APPROVED
+                else PeerStatus.PENDING
+            ),
+        )
+
+        def _persist() -> None:
+            with offloader_remote_build_settings_transaction(
+                self._db.settings.config_dir
+            ) as settings:
+                _upsert_pairing(settings, pairing)
+
+        await loop.run_in_executor(None, _persist)
+        return _pairing_summary(pairing)
 
     # ------------------------------------------------------------------
     # Identity (phase 3c1) — surface the receiver's own dashboard_id +

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -462,6 +462,19 @@ def _validate_pair_label(raw: object, *, field: _PairLabelField) -> str:
     allowed; the user may legitimately not name the receiver
     yet, and the frontend can render a placeholder.
 
+    Rejects strings containing C0 / C1 control chars (incl. null
+    bytes, ANSI escapes, newlines, DEL) via :meth:`str.isprintable`.
+    The ``offloader_label`` transits to the receiver-side admin
+    UI's pairing-requests inbox; refusing control chars here is
+    defense-in-depth against ANSI / bidi-override / null-byte
+    injection attacks against an admin terminal or log reader
+    (the load-bearing fix is on the receiver side, but symmetric
+    rejection here catches honest typos and a future
+    direct-driver caller that bypasses the receiver's normaliser).
+    Non-ASCII printables (CJK, accented Latin, emoji) pass —
+    :meth:`str.isprintable` only excludes the C0/C1 control sets
+    plus surrogates, which is the right cut for a name field.
+
     *field* names the failing arg in the diagnostic via
     :class:`_PairLabelField` so the frontend can pin the inline
     error to the right input.
@@ -472,6 +485,9 @@ def _validate_pair_label(raw: object, *, field: _PairLabelField) -> str:
     cleaned = raw.strip()
     if len(cleaned) > _PAIR_LABEL_MAX_CHARS:
         msg = f"{field} must be at most {_PAIR_LABEL_MAX_CHARS} characters"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if not cleaned.isprintable():
+        msg = f"{field} must contain only printable characters"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return cleaned
 
@@ -533,6 +549,10 @@ def _enforce_pin_match(*, expected: str, observed: str) -> None:
     quick visual scan; the human OOB check is the
     load-bearing security property, so full digest wins.
     """
+    # Plain ``==`` is fine here: the pin is a SHA-256 of a public
+    # key, broadcast in mDNS and rendered in the receiver's UI.
+    # There's no secret to leak via timing; constant-time
+    # comparison would be defending nothing.
     if expected == observed:
         return
     msg = f"receiver pin changed since preview; expected {expected}, got {observed}"
@@ -543,12 +563,24 @@ def _upsert_pairing(settings: OffloaderRemoteBuildSettings, pairing: StoredPairi
     """Replace any existing row for ``(receiver_hostname, receiver_port)``.
 
     Re-pair from the same offloader to the same receiver should
-    overwrite, not duplicate — the user's intent is "pair me
+    overwrite, not duplicate; the user's intent is "pair me
     with this receiver again" not "give me two rows pointing
     at the same place." Used by ``request_pair`` (part 3); a
     future ``list_pool`` (part 4) status refresh can reuse the
     same shape when the receiver's response flips a row's
     status.
+
+    Security note: an upsert against an existing ``(host, port)``
+    silently replaces the stored ``pin_sha256`` and
+    ``static_x25519_pub`` even when they differ from the prior
+    row. The OOB pin check the user performs during
+    ``preview_pair`` is the load-bearing defense against an
+    attacker spoofing the receiver's address; if the user is
+    socially engineered into approving a different pin, the
+    legitimate row is overwritten without an audit trail. A
+    future hardening could require an explicit ``unpair`` step
+    before re-pairing to a different identity at the same
+    address; out of scope here.
     """
     settings.pairings = [
         p

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -62,6 +62,7 @@ import logging
 import time
 from collections.abc import Callable, Hashable
 from dataclasses import dataclass as _dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -252,7 +253,48 @@ def _peer_from_manual_host(entry: ManualHost) -> RemoteBuildPeer:
 _HOSTNAME_MAX_CHARS = 255  # RFC 1035 §2.3.4 caps a FQDN at 253; round up to 255.
 
 
-def _validate_hostname(raw: object) -> str:
+class _HostFieldContext(StrEnum):
+    """Error-message prefix for the shared host / port validators.
+
+    The same ``_validate_hostname`` / ``_validate_port`` pair gates
+    both the receiver-side ``add_manual_host`` surface and the
+    offloader-side ``preview_pair`` / ``request_pair`` flow.
+    Hardcoding ``"manual host:"`` in the error messages would leak
+    misleading diagnostics into the WS layer when a frontend bug
+    sends a bad ``hostname`` to ``request_pair`` ("manual host:
+    'hostname' must not be empty" — but the user wasn't editing
+    a manual host). Pick the right prefix at the call site
+    instead.
+
+    StrEnum values are the message prefix verbatim; new call sites
+    that want a distinct user-facing string add a new enum member
+    rather than passing a free-form string (so the prefixes are
+    grep-able and don't drift).
+    """
+
+    MANUAL_HOST = "manual host"
+    RECEIVER = "receiver"
+
+
+class _PairLabelField(StrEnum):
+    """Wire arg name for ``_validate_pair_label`` error messages.
+
+    ``request_pair`` takes two distinct labels — ``receiver_label``
+    for local storage and ``offloader_label`` sent to the receiver
+    in msg3 — and a validation failure must name the failing arg so
+    the frontend can pin the inline error to the right input. StrEnum
+    values are the wire arg name verbatim; new call sites add a new
+    enum member rather than passing a free-form string (mirrors
+    :class:`_HostFieldContext`).
+    """
+
+    RECEIVER_LABEL = "receiver_label"
+    OFFLOADER_LABEL = "offloader_label"
+
+
+def _validate_hostname(
+    raw: object, *, context: _HostFieldContext = _HostFieldContext.MANUAL_HOST
+) -> str:
     """
     Normalise a user-entered hostname to its canonical lowercase form.
 
@@ -294,14 +336,14 @@ def _validate_hostname(raw: object) -> str:
     for later.
     """
     if not isinstance(raw, str):
-        msg = "manual host: 'hostname' must be a string"
+        msg = f"{context}: 'hostname' must be a string"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     trimmed = raw.strip().lower()
     if not trimmed:
-        msg = "manual host: 'hostname' must not be empty"
+        msg = f"{context}: 'hostname' must not be empty"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     if len(trimmed) > _HOSTNAME_MAX_CHARS:
-        msg = f"manual host: 'hostname' must be at most {_HOSTNAME_MAX_CHARS} characters"
+        msg = f"{context}: 'hostname' must be at most {_HOSTNAME_MAX_CHARS} characters"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     # The ``port=80, path="/"`` are sentinels for the build call
     # — only the host arg is being validated. yarl's host parser
@@ -311,7 +353,7 @@ def _validate_hostname(raw: object) -> str:
     try:
         URL.build(scheme="ws", host=trimmed, port=80, path="/")
     except ValueError as exc:
-        msg = f"manual host: 'hostname' is not a valid host: {exc}"
+        msg = f"{context}: 'hostname' is not a valid host: {exc}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
     return trimmed
 
@@ -409,23 +451,27 @@ def _validate_pin_sha256(raw: object) -> str:
     return cleaned
 
 
-def _validate_pair_label(raw: object) -> str:
-    """Validate the user-supplied ``label`` for a new pairing.
+def _validate_pair_label(raw: object, *, field: _PairLabelField) -> str:
+    """Validate a user-supplied pair-flow label.
 
     Capped at 128 chars to match
     :data:`controllers.remote_build_peer_link._PEER_LABEL_MAX_CHARS`
     (the receiver's truncation cap on the same field), so a
     label that round-trips through pair_request lands in both
     sides' tables with identical content. Empty labels are
-    allowed — the user may legitimately not name the receiver
-    yet; the frontend can render a placeholder.
+    allowed; the user may legitimately not name the receiver
+    yet, and the frontend can render a placeholder.
+
+    *field* names the failing arg in the diagnostic via
+    :class:`_PairLabelField` so the frontend can pin the inline
+    error to the right input.
     """
     if not isinstance(raw, str):
-        msg = "label must be a string"
+        msg = f"{field} must be a string"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     cleaned = raw.strip()
     if len(cleaned) > _PAIR_LABEL_MAX_CHARS:
-        msg = f"label must be at most {_PAIR_LABEL_MAX_CHARS} characters"
+        msg = f"{field} must be at most {_PAIR_LABEL_MAX_CHARS} characters"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return cleaned
 
@@ -544,7 +590,9 @@ def _validate_dashboard_id(raw: object) -> str:
     return cleaned
 
 
-def _validate_port(raw: object) -> int:
+def _validate_port(
+    raw: object, *, context: _HostFieldContext = _HostFieldContext.MANUAL_HOST
+) -> int:
     """
     Validate a user-entered port number.
 
@@ -553,12 +601,16 @@ def _validate_port(raw: object) -> int:
     (silently coerces to 1, which IANA reserves for tcpmux).
     Range is the IANA-registered ephemeral plus
     well-known: 1-65535.
+
+    *context* prefixes every error message; see
+    :class:`_HostFieldContext` for the rationale and the
+    list of valid prefixes.
     """
     if isinstance(raw, bool) or not isinstance(raw, int):
-        msg = "manual host: 'port' must be an integer"
+        msg = f"{context}: 'port' must be an integer"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     if not 1 <= raw <= 65535:
-        msg = "manual host: 'port' must be between 1 and 65535"
+        msg = f"{context}: 'port' must be between 1 and 65535"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return raw
 
@@ -939,8 +991,8 @@ class RemoteBuildController:
             timeout, malformed Noise frame, mismatched
             ``intent_response``).
         """
-        clean_host = _validate_hostname(hostname)
-        clean_port = _validate_port(port)
+        clean_host = _validate_hostname(hostname, context=_HostFieldContext.RECEIVER)
+        clean_port = _validate_port(port, context=_HostFieldContext.RECEIVER)
         loop = asyncio.get_running_loop()
         identity = await loop.run_in_executor(
             None,
@@ -964,17 +1016,35 @@ class RemoteBuildController:
         hostname: str,
         port: int,
         pin_sha256: str,
-        label: str,
+        receiver_label: str,
+        offloader_label: str,
         **kwargs: Any,
     ) -> PairingSummary:
         """Open a Noise XX WS, send ``intent="pair_request"``, persist a local row.
 
         The offloader's second handshake with a receiver, after
         the user has OOB-confirmed the receiver's pin via
-        :meth:`preview_pair`. Sends ``{"label": label,
-        "dashboard_id": <ours>}`` in the encrypted msg3
-        payload; the receiver's response decides what state the
-        local :class:`StoredPairing` row lands in.
+        :meth:`preview_pair`. Sends ``{"label":
+        offloader_label, "dashboard_id": <ours>}`` in the
+        encrypted msg3 payload; the receiver's response decides
+        what state the local :class:`StoredPairing` row lands
+        in.
+
+        Two distinct labels because the offloader-side and
+        receiver-side rows mean different things:
+
+        * *receiver_label* — what the offloader's user calls the
+          receiver in their own settings UI (e.g. "desktop").
+          Persisted to ``StoredPairing.label``; never sent to
+          the receiver.
+        * *offloader_label* — what the offloader-side user
+          identifies *itself* as so the receiver-side admin's
+          Pairing requests inbox shows a friendly name (e.g.
+          "green-laptop"). Sent to the receiver in the
+          encrypted msg3 payload; the receiver's
+          ``record_pair_request`` lands it in
+          ``StoredPeer.label``. Never persisted on the
+          offloader side.
 
         TOCTOU defense: the *pin_sha256* arg is the value the
         user OOB-confirmed in preview; the live handshake
@@ -993,13 +1063,11 @@ class RemoteBuildController:
             pin_sha256: Lowercase-hex SHA-256 of the receiver's
                 X25519 pubkey, captured + OOB-verified during
                 ``preview_pair``.
-            label: Human-readable name the offloader's user
-                gives this receiver (the value lands in the
-                local ``StoredPairing`` row's ``label``;
-                separately, the receiver's
-                :class:`StoredPeer.label` comes from a
-                receiver-side rendering of *our* label, not
-                this one).
+            receiver_label: Offloader-side display name for the
+                receiver (stored locally only).
+            offloader_label: Offloader-side self-identification
+                label (sent to the receiver, stored receiver-
+                side).
 
         Returns:
             :class:`PairingSummary` for the newly-created or
@@ -1022,10 +1090,15 @@ class RemoteBuildController:
                 receiver-side admin to open the Pairing
                 requests screen.
         """
-        clean_host = _validate_hostname(hostname)
-        clean_port = _validate_port(port)
+        clean_host = _validate_hostname(hostname, context=_HostFieldContext.RECEIVER)
+        clean_port = _validate_port(port, context=_HostFieldContext.RECEIVER)
         clean_pin = _validate_pin_sha256(pin_sha256)
-        clean_label = _validate_pair_label(label)
+        clean_receiver_label = _validate_pair_label(
+            receiver_label, field=_PairLabelField.RECEIVER_LABEL
+        )
+        clean_offloader_label = _validate_pair_label(
+            offloader_label, field=_PairLabelField.OFFLOADER_LABEL
+        )
         loop = asyncio.get_running_loop()
         peer_link_identity, dashboard_identity = await loop.run_in_executor(
             None, _load_offloader_identities, self._db.settings.config_dir
@@ -1036,7 +1109,7 @@ class RemoteBuildController:
                 hostname=clean_host,
                 port=clean_port,
                 identity_priv=peer_link_identity.private_bytes,
-                label=clean_label,
+                label=clean_offloader_label,
                 dashboard_id=dashboard_identity.dashboard_id,
             )
         except PeerLinkClientError as exc:
@@ -1063,7 +1136,7 @@ class RemoteBuildController:
             receiver_port=clean_port,
             pin_sha256=result.pin_sha256,
             static_x25519_pub=result.remote_static_pub,
-            label=clean_label,
+            label=clean_receiver_label,
             paired_at=time.time(),
             status=(
                 PeerStatus.APPROVED

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -62,6 +62,7 @@ import logging
 import time
 from collections.abc import Callable, Hashable
 from dataclasses import dataclass as _dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from esphome.const import __version__ as esphome_version
@@ -118,8 +119,31 @@ from .remote_build_peer_link_client import (
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
     from ..helpers.dashboard_identity import DashboardIdentity
+    from ..helpers.peer_link_identity import PeerLinkIdentity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _load_offloader_identities(
+    config_dir: Path,
+) -> tuple[PeerLinkIdentity, DashboardIdentity]:
+    """Load both offloader-side identities in one executor hop.
+
+    The peer-link X25519 keypair drives the Noise XX handshake;
+    the dashboard cert (phase 3a) carries the stable
+    ``dashboard_id`` we send in msg3 so the receiver's
+    ``StoredPeer`` row keys on it. The two are both lazy-create
+    on first read, both protected by per-process locks
+    in their respective helpers, and both involve disk I/O
+    (each is one file read + occasional first-call generation).
+    Bundling into a single sync helper means one
+    ``run_in_executor`` round-trip rather than two — matters
+    less for the threadpool overhead than for the
+    "two awaits where one would do" code shape; keeps the
+    caller's body tight.
+    """
+    return get_or_create_peer_link_identity(config_dir), get_or_create_identity(config_dir)
+
 
 # Timeout for the cache-miss resolve path. Longer than
 # ``DeviceStateMonitor._MDNS_RESOLVE_TIMEOUT_MS`` (2s) because peer
@@ -452,10 +476,20 @@ def _enforce_pin_match(*, expected: str, observed: str) -> None:
     receiver rotated identity (or a MITM intervened) between
     preview and request; the offloader bails before persisting
     the row so a fresh preview round-trip is required.
+
+    The error message carries both pins in full (no
+    truncation) so the user can do a side-by-side OOB
+    comparison against the receiver's "Build server"
+    Settings card and tell which end's pin changed.
+    Truncating the displayed pin would shrink the log volume
+    but at the cost of letting an attacker who deliberately
+    collides a 16-char prefix slip the mismatch past a
+    quick visual scan; the human OOB check is the
+    load-bearing security property, so full digest wins.
     """
     if expected == observed:
         return
-    msg = f"receiver pin changed since preview; expected {expected[:16]}..., got {observed[:16]}..."
+    msg = f"receiver pin changed since preview; expected {expected}, got {observed}"
     raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
 
 
@@ -993,14 +1027,8 @@ class RemoteBuildController:
         clean_pin = _validate_pin_sha256(pin_sha256)
         clean_label = _validate_pair_label(label)
         loop = asyncio.get_running_loop()
-        # X25519 peer-link key drives the Noise handshake; the
-        # dashboard_id is what we send in msg3 so the receiver's
-        # ``StoredPeer`` row keys on it.
-        peer_link_identity = await loop.run_in_executor(
-            None, get_or_create_peer_link_identity, self._db.settings.config_dir
-        )
-        dashboard_identity = await loop.run_in_executor(
-            None, get_or_create_identity, self._db.settings.config_dir
+        peer_link_identity, dashboard_identity = await loop.run_in_executor(
+            None, _load_offloader_identities, self._db.settings.config_dir
         )
 
         try:
@@ -1024,6 +1052,12 @@ class RemoteBuildController:
         # APPROVED happens when this offloader paired with the same
         # receiver previously and the receiver-side row is still
         # APPROVED — the receiver short-circuits the inbox dance.
+        # ``paired_at`` reflects this re-pair attempt (last-touch
+        # semantic), not the original first-pair time. ``_upsert_pairing``
+        # below replaces the row wholesale, so any earlier ``paired_at``
+        # is overwritten. That's right for the inbox-sort use case
+        # (most recent on top) but a future "first paired on" UI would
+        # need a separate ``first_paired_at`` field.
         pairing = StoredPairing(
             receiver_hostname=clean_host,
             receiver_port=clean_port,

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -276,3 +276,89 @@ async def preview_pair(
         msg = f"peer-link preview rejected with intent_response={rt.intent_response!r}"
         raise PeerLinkClientError(msg)
     return pin_sha256_for_pubkey(rt.remote_static_pub)
+
+
+@dataclass(frozen=True)
+class RequestPairResult:
+    """Outcome of an ``intent="pair_request"`` round-trip from the offloader.
+
+    Returned by :func:`request_pair` after the Noise XX
+    handshake completes and the receiver's
+    ``intent_response`` has been received.
+
+    * :attr:`status` carries the receiver's response verbatim
+      (``IntentResponse.PENDING`` for a freshly-created /
+      refreshed pending row, ``IntentResponse.APPROVED`` for a
+      re-pair against a pre-existing approved row,
+      ``IntentResponse.REJECTED`` for receiver-side decline /
+      pin mismatch, ``IntentResponse.NO_PAIRING_WINDOW`` for
+      a closed window).
+    * :attr:`pin_sha256` is the lowercase-hex hash of the
+      receiver's static X25519 pubkey actually observed on the
+      live handshake. The caller compares this against the
+      pin the user OOB-confirmed in ``preview_pair``; a
+      mismatch indicates the receiver rotated identity (or an
+      active MITM intervened) between preview and request.
+    * :attr:`remote_static_pub` is the raw 32-byte pubkey
+      itself, for storage in :class:`StoredPairing`.
+    """
+
+    status: IntentResponse
+    pin_sha256: str
+    remote_static_pub: bytes
+
+
+async def request_pair(
+    *,
+    hostname: str,
+    port: int,
+    identity_priv: bytes,
+    label: str,
+    dashboard_id: str,
+) -> RequestPairResult:
+    """Run an ``intent="pair_request"`` round-trip; return the receiver's response.
+
+    Thin wrapper around :func:`drive_initiator_round_trip`:
+    sends ``{"label": ..., "dashboard_id": ...}`` in the
+    encrypted msg3 payload (per the Noise XX wire spec, msg3 is
+    encrypted under the now-finalized cipher — safe for the
+    offloader-side identity metadata) and returns the
+    receiver's ``intent_response`` alongside the receiver's
+    captured pubkey.
+
+    The caller is responsible for the TOCTOU pin check:
+    compare the returned :attr:`RequestPairResult.pin_sha256`
+    against the value the user OOB-confirmed in
+    ``preview_pair`` *before* persisting any state. The driver
+    here completes the handshake regardless because the
+    receiver doesn't expose its pubkey otherwise — the check
+    has to happen post-handshake on the offloader side. A
+    mismatch + bail-after-handshake leaks no information to
+    the receiver beyond the fact that the offloader requested
+    pairing (which is also true on the no-mismatch path).
+
+    Maps ``IntentResponse`` strings the receiver may return —
+    ``REJECTED`` / ``NO_PAIRING_WINDOW`` / ``PENDING`` /
+    ``APPROVED`` — back to the typed enum. An unknown wire
+    value (e.g. a future receiver protocol bump) raises
+    :class:`PeerLinkClientError`; the WS-command layer above
+    should treat that as ``UNAVAILABLE``.
+    """
+    msg3_payload = _json.dumps({"label": label, "dashboard_id": dashboard_id})
+    rt = await drive_initiator_round_trip(
+        hostname=hostname,
+        port=port,
+        identity_priv=identity_priv,
+        intent=PeerLinkIntent.PAIR_REQUEST,
+        msg3_payload=msg3_payload,
+    )
+    try:
+        status = IntentResponse(rt.intent_response)
+    except ValueError as exc:
+        msg = f"peer-link pair_request: unknown intent_response={rt.intent_response!r}"
+        raise PeerLinkClientError(msg) from exc
+    return RequestPairResult(
+        status=status,
+        pin_sha256=pin_sha256_for_pubkey(rt.remote_static_pub),
+        remote_static_pub=rt.remote_static_pub,
+    )

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -74,17 +74,28 @@ _RESPONSE_DECODE_ERRORS: tuple[type[Exception], ...] = (
 _DEFAULT_TIMEOUT_SECONDS = 10.0
 
 
-# Hard cap on a single inbound WS frame the offloader will read
-# from a peer-link receiver. Each receiver response is a Noise-
-# encrypted JSON object with a small fixed shape (status code,
-# pubkey hash, optional label) — well under 1 KiB in practice.
-# aiohttp's default ``max_msg_size`` is 4 MiB, which is wildly
-# generous here: a malicious or buggy receiver could otherwise
-# spend ~4 MiB of offloader memory + Noise-decrypt + JSON-parse
-# CPU per round-trip. 64 KiB is two orders of magnitude above
-# the realistic max while still giving aiohttp a reasonable
-# header-and-frame slack.
-_RECEIVER_RESPONSE_MAX_BYTES = 64 * 1024
+# Hard cap on a single inbound WS frame for the *control-plane*
+# round-trip driven by :func:`drive_initiator_round_trip`. Each
+# receiver response on this path is a Noise-encrypted JSON object
+# with a small fixed shape (status code, pubkey hash, optional
+# label); well under 1 KiB in practice. aiohttp's default
+# ``max_msg_size`` is 4 MiB, which is wildly generous here: a
+# malicious or buggy receiver could otherwise spend ~4 MiB of
+# offloader memory + Noise-decrypt + JSON-parse CPU per round-
+# trip. 64 KiB is two orders of magnitude above the realistic
+# max while still giving aiohttp a reasonable header-and-frame
+# slack.
+#
+# This cap explicitly does NOT apply to the future firmware-bytes
+# ``peer_link`` intent (issue #106 phase 4c onward). That payload
+# is megabytes of compiled firmware and will use a separate
+# streaming driver — Noise has a hard 65535-byte ciphertext frame
+# limit, so the firmware path will read many small frames and
+# stream them to disk, not a single ``receive_bytes()`` call.
+# When that driver lands, it gets its own ``max_msg_size``
+# tuned to one Noise frame (~64 KiB + slack); this constant
+# stays scoped to the JSON status responses.
+_CONTROL_RESPONSE_MAX_BYTES = 64 * 1024
 
 
 class PeerLinkClientError(RuntimeError):
@@ -216,7 +227,7 @@ async def drive_initiator_round_trip(
         url = _build_ws_url(hostname, port)
         async with (
             aiohttp.ClientSession(timeout=timeout) as http,
-            http.ws_connect(url, max_msg_size=_RECEIVER_RESPONSE_MAX_BYTES) as ws,
+            http.ws_connect(url, max_msg_size=_CONTROL_RESPONSE_MAX_BYTES) as ws,
         ):
             msg1 = _json.dumps({"intent": intent.value})
             await ws.send_bytes(sess.write_handshake_message(msg1))

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -74,6 +74,19 @@ _RESPONSE_DECODE_ERRORS: tuple[type[Exception], ...] = (
 _DEFAULT_TIMEOUT_SECONDS = 10.0
 
 
+# Hard cap on a single inbound WS frame the offloader will read
+# from a peer-link receiver. Each receiver response is a Noise-
+# encrypted JSON object with a small fixed shape (status code,
+# pubkey hash, optional label) — well under 1 KiB in practice.
+# aiohttp's default ``max_msg_size`` is 4 MiB, which is wildly
+# generous here: a malicious or buggy receiver could otherwise
+# spend ~4 MiB of offloader memory + Noise-decrypt + JSON-parse
+# CPU per round-trip. 64 KiB is two orders of magnitude above
+# the realistic max while still giving aiohttp a reasonable
+# header-and-frame slack.
+_RECEIVER_RESPONSE_MAX_BYTES = 64 * 1024
+
+
 class PeerLinkClientError(RuntimeError):
     """Raised on transport / handshake / decrypt failure on the offloader side.
 
@@ -203,7 +216,7 @@ async def drive_initiator_round_trip(
         url = _build_ws_url(hostname, port)
         async with (
             aiohttp.ClientSession(timeout=timeout) as http,
-            http.ws_connect(url) as ws,
+            http.ws_connect(url, max_msg_size=_RECEIVER_RESPONSE_MAX_BYTES) as ws,
         ):
             msg1 = _json.dumps({"intent": intent.value})
             await ws.send_bytes(sess.write_handshake_message(msg1))

--- a/esphome_device_builder/models/api.py
+++ b/esphome_device_builder/models/api.py
@@ -30,6 +30,30 @@ class ErrorCode(StrEnum):
     # fails to authenticate, or the post-handshake frame
     # doesn't decrypt.
     UNAVAILABLE = "unavailable"
+    # State precondition not met — the operation is well-formed
+    # and the remote is reachable, but the current state of one
+    # side disqualifies the request. Used by the offloader's
+    # ``request_pair`` for: (a) pin mismatch between the value
+    # the user OOB-confirmed in ``preview_pair`` and the actual
+    # pubkey from the live handshake (TOCTOU defense — the
+    # receiver may have rotated identity, or there's an active
+    # MITM), and (b) the receiver returning ``rejected`` (admin
+    # explicitly declined or there's a stale "rejected" memo
+    # within the soft-block window). The frontend rendering
+    # distinguishes these via the ``details`` field; both share
+    # the same "you can't proceed past this without out-of-band
+    # action" semantic.
+    PRECONDITION_FAILED = "precondition_failed"
+    # Pairing window on the receiver is closed — the offloader's
+    # ``intent="pair_request"`` arrived outside the receiver's
+    # admin-supervised acceptance window. The frontend prompts
+    # the user to ask the receiver-side admin to open the
+    # Pairing requests screen, then retry. Distinct from
+    # ``UNAVAILABLE`` (transport failure: receiver unreachable)
+    # and ``PRECONDITION_FAILED`` (receiver reachable + made a
+    # decision); this is "receiver reachable but not currently
+    # listening."
+    NO_PAIRING_WINDOW = "no_pairing_window"
 
 
 @dataclass

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1896,13 +1896,19 @@ def test_enforce_pin_match_passes_on_match() -> None:
 
 
 def test_enforce_pin_match_raises_precondition_failed_on_drift() -> None:
-    """A pubkey-hash drift between preview and request → PRECONDITION_FAILED."""
+    """A pubkey-hash drift between preview and request → PRECONDITION_FAILED.
+
+    The error message carries both pins in full (no
+    truncation) so the user can do a full side-by-side OOB
+    comparison; an attacker who collides a 16-char prefix
+    can't slip the mismatch past a quick visual scan.
+    """
     with pytest.raises(CommandError) as exc:
         _enforce_pin_match(expected="a" * 64, observed="b" * 64)
     assert exc.value.code == ErrorCode.PRECONDITION_FAILED
-    # The error message includes a prefix of each pin so log-readers
-    # can spot the rotation, but truncates to avoid full hash dumps.
-    assert "expected " + "a" * 16 in str(exc.value)
+    # Full digest is shown for both expected and observed.
+    assert "expected " + "a" * 64 in str(exc.value)
+    assert "got " + "b" * 64 in str(exc.value)
 
 
 # --- _upsert_pairing ---

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -33,6 +33,7 @@ from esphome_device_builder.controllers.remote_build import (
     _enforce_pin_match,
     _intent_response_to_command_error,
     _pairing_summary,
+    _PairLabelField,
     _peer_from_manual_host,
     _peer_from_service_info,
     _upsert_pairing,
@@ -1845,24 +1846,26 @@ def test_validate_pin_sha256_rejects_non_string() -> None:
 
 
 def test_validate_pair_label_strips_and_returns() -> None:
-    assert _validate_pair_label("  Kitchen  ") == "Kitchen"
+    assert _validate_pair_label("  Kitchen  ", field=_PairLabelField.RECEIVER_LABEL) == "Kitchen"
 
 
 def test_validate_pair_label_accepts_empty() -> None:
-    """Empty label is fine — user may not have named the receiver."""
-    assert _validate_pair_label("") == ""
+    """Empty label is fine; user may not have named the receiver."""
+    assert _validate_pair_label("", field=_PairLabelField.RECEIVER_LABEL) == ""
 
 
 def test_validate_pair_label_rejects_oversize() -> None:
     with pytest.raises(CommandError) as exc:
-        _validate_pair_label("x" * 129)
+        _validate_pair_label("x" * 129, field=_PairLabelField.OFFLOADER_LABEL)
     assert exc.value.code == ErrorCode.INVALID_ARGS
+    assert "offloader_label" in str(exc.value)
 
 
 def test_validate_pair_label_rejects_non_string() -> None:
     with pytest.raises(CommandError) as exc:
-        _validate_pair_label(42)  # type: ignore[arg-type]
+        _validate_pair_label(42, field=_PairLabelField.RECEIVER_LABEL)  # type: ignore[arg-type]
     assert exc.value.code == ErrorCode.INVALID_ARGS
+    assert "receiver_label" in str(exc.value)
 
 
 # --- _intent_response_to_command_error ---

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -30,9 +30,15 @@ from esphome_device_builder.controllers.config import (
 from esphome_device_builder.controllers.remote_build import (
     RemoteBuildController,
     _decode_txt_value,
+    _enforce_pin_match,
+    _intent_response_to_command_error,
+    _pairing_summary,
     _peer_from_manual_host,
     _peer_from_service_info,
+    _upsert_pairing,
     _validate_hostname,
+    _validate_pair_label,
+    _validate_pin_sha256,
     _validate_port,
 )
 from esphome_device_builder.helpers.api import CommandError
@@ -41,11 +47,15 @@ from esphome_device_builder.models import (
     ErrorCode,
     EventType,
     IdentityView,
+    IntentResponse,
     ManualHost,
+    OffloaderRemoteBuildSettings,
+    PairingSummary,
     PeerStatus,
     RemoteBuildPeer,
     RemoteBuildPeerSource,
     RemoteBuildSettingsView,
+    StoredPairing,
     StoredPeer,
 )
 
@@ -1771,3 +1781,175 @@ async def test_lookup_peer_for_status_unknown_returns_rejected(tmp_path: Path) -
     response = await controller.lookup_peer_for_status(dashboard_id="ghost", pin_sha256="pin")
 
     assert response == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Offloader-side pair-flow helpers (phase 4a-o part 3)
+# ---------------------------------------------------------------------------
+
+
+def _valid_stored_pairing(
+    *,
+    receiver_hostname: str = "build.local",
+    receiver_port: int = 6055,
+    label: str = "desktop",
+    paired_at: float = 1.0,
+    status: PeerStatus = PeerStatus.PENDING,
+) -> StoredPairing:
+    """Build a passing :class:`StoredPairing` so tests don't repeat the boilerplate."""
+    return StoredPairing(
+        receiver_hostname=receiver_hostname,
+        receiver_port=receiver_port,
+        pin_sha256="a" * 64,
+        static_x25519_pub=b"\x01" * 32,
+        label=label,
+        paired_at=paired_at,
+        status=status,
+    )
+
+
+# --- _validate_pin_sha256 ---
+
+
+def test_validate_pin_sha256_accepts_canonical() -> None:
+    assert _validate_pin_sha256("a" * 64) == "a" * 64
+    assert _validate_pin_sha256("0123456789abcdef" * 4) == "0123456789abcdef" * 4
+
+
+def test_validate_pin_sha256_strips_whitespace() -> None:
+    assert _validate_pin_sha256("  " + "a" * 64 + "  ") == "a" * 64
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "a" * 63,  # too short
+        "a" * 65,  # too long
+        "A" * 64,  # uppercase
+        "z" * 64,  # outside hex alphabet
+    ],
+)
+def test_validate_pin_sha256_rejects_invalid_shapes(bad: str) -> None:
+    with pytest.raises(CommandError) as exc:
+        _validate_pin_sha256(bad)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_validate_pin_sha256_rejects_non_string() -> None:
+    with pytest.raises(CommandError) as exc:
+        _validate_pin_sha256(123)  # type: ignore[arg-type]
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+# --- _validate_pair_label ---
+
+
+def test_validate_pair_label_strips_and_returns() -> None:
+    assert _validate_pair_label("  Kitchen  ") == "Kitchen"
+
+
+def test_validate_pair_label_accepts_empty() -> None:
+    """Empty label is fine — user may not have named the receiver."""
+    assert _validate_pair_label("") == ""
+
+
+def test_validate_pair_label_rejects_oversize() -> None:
+    with pytest.raises(CommandError) as exc:
+        _validate_pair_label("x" * 129)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_validate_pair_label_rejects_non_string() -> None:
+    with pytest.raises(CommandError) as exc:
+        _validate_pair_label(42)  # type: ignore[arg-type]
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+# --- _intent_response_to_command_error ---
+
+
+def test_intent_response_to_command_error_pending_returns_none() -> None:
+    """Success values aren't translated; the caller branches on them for persistence."""
+    assert _intent_response_to_command_error(IntentResponse.PENDING) is None
+    assert _intent_response_to_command_error(IntentResponse.APPROVED) is None
+    assert _intent_response_to_command_error(IntentResponse.OK) is None
+
+
+def test_intent_response_to_command_error_no_pairing_window() -> None:
+    err = _intent_response_to_command_error(IntentResponse.NO_PAIRING_WINDOW)
+    assert err is not None
+    assert err.code == ErrorCode.NO_PAIRING_WINDOW
+
+
+def test_intent_response_to_command_error_rejected() -> None:
+    err = _intent_response_to_command_error(IntentResponse.REJECTED)
+    assert err is not None
+    assert err.code == ErrorCode.PRECONDITION_FAILED
+
+
+# --- _enforce_pin_match ---
+
+
+def test_enforce_pin_match_passes_on_match() -> None:
+    """No exception raised when expected and observed pins agree."""
+    _enforce_pin_match(expected="a" * 64, observed="a" * 64)
+
+
+def test_enforce_pin_match_raises_precondition_failed_on_drift() -> None:
+    """A pubkey-hash drift between preview and request → PRECONDITION_FAILED."""
+    with pytest.raises(CommandError) as exc:
+        _enforce_pin_match(expected="a" * 64, observed="b" * 64)
+    assert exc.value.code == ErrorCode.PRECONDITION_FAILED
+    # The error message includes a prefix of each pin so log-readers
+    # can spot the rotation, but truncates to avoid full hash dumps.
+    assert "expected " + "a" * 16 in str(exc.value)
+
+
+# --- _upsert_pairing ---
+
+
+def test_upsert_pairing_appends_when_no_existing_row() -> None:
+    settings = OffloaderRemoteBuildSettings()
+    pairing = _valid_stored_pairing()
+    _upsert_pairing(settings, pairing)
+    assert settings.pairings == [pairing]
+
+
+def test_upsert_pairing_replaces_existing_row_for_same_host_port() -> None:
+    """Re-pair from the same offloader to the same receiver overwrites, doesn't duplicate."""
+    old = _valid_stored_pairing(label="old", paired_at=1.0)
+    new = _valid_stored_pairing(label="new", paired_at=2.0, status=PeerStatus.APPROVED)
+    settings = OffloaderRemoteBuildSettings(pairings=[old])
+    _upsert_pairing(settings, new)
+    assert len(settings.pairings) == 1
+    assert settings.pairings[0].label == "new"
+    assert settings.pairings[0].status is PeerStatus.APPROVED
+
+
+def test_upsert_pairing_keeps_other_rows_intact() -> None:
+    """Replacement is keyed on (hostname, port) — different receivers are independent."""
+    other = _valid_stored_pairing(receiver_hostname="other.local")
+    target_old = _valid_stored_pairing(receiver_hostname="target.local", label="old")
+    target_new = _valid_stored_pairing(receiver_hostname="target.local", label="new")
+    settings = OffloaderRemoteBuildSettings(pairings=[other, target_old])
+    _upsert_pairing(settings, target_new)
+    assert {(p.receiver_hostname, p.label) for p in settings.pairings} == {
+        ("other.local", "desktop"),
+        ("target.local", "new"),
+    }
+
+
+# --- _pairing_summary ---
+
+
+def test_pairing_summary_drops_static_pubkey() -> None:
+    """Wire view drops ``static_x25519_pub`` so the raw pubkey stays server-side."""
+    pairing = _valid_stored_pairing()
+    summary = _pairing_summary(pairing)
+    assert isinstance(summary, PairingSummary)
+    assert summary.receiver_hostname == "build.local"
+    assert summary.pin_sha256 == "a" * 64
+    assert summary.label == "desktop"
+    assert summary.status is PeerStatus.PENDING
+    # PairingSummary doesn't carry the raw bytes.
+    assert not hasattr(summary, "static_x25519_pub")

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1868,6 +1868,38 @@ def test_validate_pair_label_rejects_non_string() -> None:
     assert "receiver_label" in str(exc.value)
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param("evil\x1b[31mboo", id="ansi_escape"),
+        pytest.param("two\nlines", id="newline"),
+        pytest.param("car\rriage", id="carriage_return"),
+        pytest.param("null\x00byte", id="null_byte"),
+        pytest.param("zero\u200bwidth", id="zero_width"),
+        pytest.param("bidi\u202eflip", id="bidi_override"),
+    ],
+)
+def test_validate_pair_label_rejects_control_characters(payload: str) -> None:
+    """Control / bidi / zero-width chars are rejected (defense-in-depth).
+
+    The ``offloader_label`` transits to the receiver-side admin
+    inbox; a malicious offloader must not be able to inject ANSI
+    escapes, newlines, null bytes, or bidi-override Unicode that
+    could fake a label's identity in a terminal-rendered admin
+    tool.
+    """
+    with pytest.raises(CommandError) as exc:
+        _validate_pair_label(payload, field=_PairLabelField.OFFLOADER_LABEL)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+    assert "printable" in str(exc.value)
+
+
+def test_validate_pair_label_accepts_non_ascii_printables() -> None:
+    """Non-ASCII printables (CJK, accented Latin, emoji) round-trip cleanly."""
+    assert _validate_pair_label("キッチン", field=_PairLabelField.RECEIVER_LABEL) == "キッチン"
+    assert _validate_pair_label("café 🚀", field=_PairLabelField.RECEIVER_LABEL) == "café 🚀"
+
+
 # --- _intent_response_to_command_error ---
 
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -297,6 +297,10 @@ async def test_request_pair_open_window_returns_pending(
     await controller.set_pairing_window(open=True, client="test-tab")
     initiator_priv = secrets.token_bytes(32)
 
+    # ``dashboard_id`` is deliberately a 16-char base64url shape
+    # rather than the 32-char production form. Either passes the
+    # receiver's validator (``DASHBOARD_ID_PATTERN`` allows 1-64
+    # base64url chars); shorter keeps the test readable.
     result = await request_pair(
         hostname="127.0.0.1",
         port=server.port,

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -424,7 +424,8 @@ async def test_controller_request_pair_persists_pending_row(
         hostname="127.0.0.1",
         port=server.port,
         pin_sha256=expected_pin,
-        label="my-receiver",
+        receiver_label="my-receiver",
+        offloader_label="my-builder",
     )
 
     assert summary.receiver_hostname == "127.0.0.1"
@@ -461,7 +462,8 @@ async def test_controller_request_pair_pin_mismatch_raises_precondition_failed(
             hostname="127.0.0.1",
             port=server.port,
             pin_sha256="b" * 64,  # not the receiver's actual pin
-            label="my-receiver",
+            receiver_label="my-receiver",
+            offloader_label="my-builder",
         )
     assert exc.value.code == ErrorCode.PRECONDITION_FAILED
     # Pin-mismatch bails before persisting; offloader sidecar stays empty.
@@ -488,7 +490,8 @@ async def test_controller_request_pair_closed_window_raises_no_pairing_window(
             hostname="127.0.0.1",
             port=server.port,
             pin_sha256=expected_pin,
-            label="my-receiver",
+            receiver_label="my-receiver",
+            offloader_label="my-builder",
         )
     assert exc.value.code == ErrorCode.NO_PAIRING_WINDOW
 
@@ -507,7 +510,8 @@ async def test_controller_request_pair_unavailable_on_unreachable_receiver(
             hostname="127.0.0.1",
             port=unused_tcp_port,
             pin_sha256="a" * 64,
-            label="my-receiver",
+            receiver_label="my-receiver",
+            offloader_label="my-builder",
         )
     assert exc.value.code == ErrorCode.UNAVAILABLE
 
@@ -551,6 +555,7 @@ async def test_controller_request_pair_unexpected_status_raises_internal_error(
             hostname="127.0.0.1",
             port=6055,
             pin_sha256=fake_pin,
-            label="my-receiver",
+            receiver_label="my-receiver",
+            offloader_label="my-builder",
         )
     assert exc.value.code == ErrorCode.INTERNAL_ERROR

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -409,6 +409,48 @@ def _make_offloader_controller(*, config_dir: Path) -> RemoteBuildController:
 
 
 @pytest.mark.asyncio
+async def test_controller_preview_pair_returns_receiver_pin(
+    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    offloader_controller_dir: Path,
+) -> None:
+    """End-to-end: ``RemoteBuildController.preview_pair`` returns the receiver's pin."""
+    server, _, expected_pin = receiver_server
+
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+
+    result = await offloader.preview_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+    )
+
+    assert result == {"pin_sha256": expected_pin}
+    # Preview is read-only on the offloader side too: no StoredPairing
+    # row written until the user OOB-confirms and calls request_pair.
+    saved = await asyncio.get_running_loop().run_in_executor(
+        None, load_offloader_remote_build_settings, offloader_controller_dir
+    )
+    assert saved.pairings == []
+
+
+@pytest.mark.asyncio
+async def test_controller_preview_pair_unavailable_on_unreachable_receiver(
+    offloader_controller_dir: Path,
+    unused_tcp_port: int,
+) -> None:
+    """Receiver unreachable → CommandError(UNAVAILABLE)."""
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await offloader.preview_pair(
+            hostname="127.0.0.1",
+            port=unused_tcp_port,
+        )
+    assert exc.value.code == ErrorCode.UNAVAILABLE
+
+
+@pytest.mark.asyncio
 async def test_controller_request_pair_persists_pending_row(
     receiver_server: tuple[TestServer, RemoteBuildController, str],
     offloader_controller_dir: Path,

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -27,6 +27,9 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
 
+from esphome_device_builder.controllers.config import (
+    load_offloader_remote_build_settings,
+)
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.controllers.remote_build_peer_link import (
     PEER_LINK_PATH,
@@ -37,7 +40,9 @@ from esphome_device_builder.controllers.remote_build_peer_link_client import (
     _build_ws_url,
     drive_initiator_round_trip,
     preview_pair,
+    request_pair,
 )
+from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.peer_link_identity import (
     get_or_create_peer_link_identity,
 )
@@ -45,7 +50,7 @@ from esphome_device_builder.helpers.peer_link_noise import (
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
-from esphome_device_builder.models import PeerLinkIntent
+from esphome_device_builder.models import ErrorCode, IntentResponse, PeerLinkIntent, PeerStatus
 
 
 def _make_controller(*, config_dir: Path) -> RemoteBuildController:
@@ -275,3 +280,187 @@ async def test_drive_initiator_round_trip_maps_pathological_host_to_client_error
             identity_priv=initiator_priv,
             intent=PeerLinkIntent.PREVIEW,
         )
+
+
+# ---------------------------------------------------------------------------
+# request_pair — happy path + receiver-side response shapes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_pair_open_window_returns_pending(
+    receiver_server: tuple[TestServer, RemoteBuildController, str],
+) -> None:
+    """Request_pair against an open pairing window returns PENDING + lands a peer row."""
+    server, controller, expected_pin = receiver_server
+    await controller.set_pairing_window(open=True, client="test-tab")
+    initiator_priv = secrets.token_bytes(32)
+
+    result = await request_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+        identity_priv=initiator_priv,
+        label="green",
+        dashboard_id="abcdef0123456789",
+    )
+
+    assert result.status is IntentResponse.PENDING
+    assert result.pin_sha256 == expected_pin
+    assert len(result.remote_static_pub) == 32
+    # Receiver's StoredPeer table got a new PENDING row keyed on
+    # the offloader's dashboard_id.
+    peers = await controller.list_peers()
+    assert len(peers) == 1
+    assert peers[0].dashboard_id == "abcdef0123456789"
+    assert peers[0].status is PeerStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_request_pair_closed_window_returns_no_pairing_window(
+    receiver_server: tuple[TestServer, RemoteBuildController, str],
+) -> None:
+    """Request_pair when the receiver window is closed returns NO_PAIRING_WINDOW."""
+    server, _, _ = receiver_server
+    initiator_priv = secrets.token_bytes(32)
+
+    result = await request_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+        identity_priv=initiator_priv,
+        label="green",
+        dashboard_id="abcdef0123456789",
+    )
+
+    assert result.status is IntentResponse.NO_PAIRING_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# RemoteBuildController.request_pair — end-to-end through the WS-command shell
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def offloader_controller_dir(tmp_path: Path) -> Path:
+    """Sibling directory to the receiver fixture's ``tmp_path``.
+
+    Each side has its own peer-link key + dashboard cert, so the
+    offloader's identities don't collide with the receiver's
+    when both run in the same test process.
+    """
+    offloader_dir = tmp_path / "offloader"
+    offloader_dir.mkdir()
+    return offloader_dir
+
+
+def _make_offloader_controller(*, config_dir: Path) -> RemoteBuildController:
+    db = MagicMock()
+    db.devices = MagicMock()
+    db.devices.zeroconf = None
+    db._dashboard_advertiser = None
+    db.settings = MagicMock()
+    db.settings.config_dir = config_dir
+    return RemoteBuildController(db)
+
+
+@pytest.mark.asyncio
+async def test_controller_request_pair_persists_pending_row(
+    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    offloader_controller_dir: Path,
+) -> None:
+    """End-to-end: ``RemoteBuildController.request_pair`` persists a PENDING StoredPairing."""
+    server, receiver_controller, expected_pin = receiver_server
+    await receiver_controller.set_pairing_window(open=True, client="test-tab")
+
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+
+    summary = await offloader.request_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+        pin_sha256=expected_pin,
+        label="my-receiver",
+    )
+
+    assert summary.receiver_hostname == "127.0.0.1"
+    assert summary.receiver_port == server.port
+    assert summary.pin_sha256 == expected_pin
+    assert summary.label == "my-receiver"
+    assert summary.status is PeerStatus.PENDING
+    # Persisted to disk under the offloader's _offloader_remote_build key.
+    saved = await asyncio.get_running_loop().run_in_executor(
+        None, load_offloader_remote_build_settings, offloader_controller_dir
+    )
+    assert len(saved.pairings) == 1
+    assert saved.pairings[0].pin_sha256 == expected_pin
+
+
+@pytest.mark.asyncio
+async def test_controller_request_pair_pin_mismatch_raises_precondition_failed(
+    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    offloader_controller_dir: Path,
+) -> None:
+    """User-supplied pin doesn't match the handshake → PRECONDITION_FAILED.
+
+    A receiver-side identity rotation between preview and request would land here
+    in production; the test forces the same shape by passing a wrong pin.
+    """
+    server, receiver_controller, _ = receiver_server
+    await receiver_controller.set_pairing_window(open=True, client="test-tab")
+
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await offloader.request_pair(
+            hostname="127.0.0.1",
+            port=server.port,
+            pin_sha256="b" * 64,  # not the receiver's actual pin
+            label="my-receiver",
+        )
+    assert exc.value.code == ErrorCode.PRECONDITION_FAILED
+    # Pin-mismatch bails before persisting; offloader sidecar stays empty.
+    saved = await asyncio.get_running_loop().run_in_executor(
+        None, load_offloader_remote_build_settings, offloader_controller_dir
+    )
+    assert saved.pairings == []
+
+
+@pytest.mark.asyncio
+async def test_controller_request_pair_closed_window_raises_no_pairing_window(
+    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    offloader_controller_dir: Path,
+) -> None:
+    """Receiver window closed → CommandError(NO_PAIRING_WINDOW)."""
+    server, _, expected_pin = receiver_server
+    # Don't open the pairing window; receiver replies no_pairing_window.
+
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await offloader.request_pair(
+            hostname="127.0.0.1",
+            port=server.port,
+            pin_sha256=expected_pin,
+            label="my-receiver",
+        )
+    assert exc.value.code == ErrorCode.NO_PAIRING_WINDOW
+
+
+@pytest.mark.asyncio
+async def test_controller_request_pair_unavailable_on_unreachable_receiver(
+    offloader_controller_dir: Path,
+    unused_tcp_port: int,
+) -> None:
+    """Receiver unreachable → CommandError(UNAVAILABLE)."""
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await offloader.request_pair(
+            hostname="127.0.0.1",
+            port=unused_tcp_port,
+            pin_sha256="a" * 64,
+            label="my-receiver",
+        )
+    assert exc.value.code == ErrorCode.UNAVAILABLE

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -37,6 +37,7 @@ from esphome_device_builder.controllers.remote_build_peer_link import (
 )
 from esphome_device_builder.controllers.remote_build_peer_link_client import (
     PeerLinkClientError,
+    RequestPairResult,
     _build_ws_url,
     drive_initiator_round_trip,
     preview_pair,
@@ -334,6 +335,47 @@ async def test_request_pair_closed_window_returns_no_pairing_window(
     assert result.status is IntentResponse.NO_PAIRING_WINDOW
 
 
+@pytest.mark.asyncio
+async def test_request_pair_unknown_intent_response_raises_client_error() -> None:
+    """A wire ``intent_response`` outside the known enum surfaces as PeerLinkClientError.
+
+    Defends against a future receiver protocol bump that adds a
+    new response code the offloader's enum doesn't know about.
+    Custom WS handler completes the Noise XX handshake then
+    sends ``{"intent_response": "weather"}`` — parses as JSON,
+    isn't a valid :class:`IntentResponse` member.
+    """
+    receiver_priv = secrets.token_bytes(32)
+
+    async def _handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        sess = PeerLinkNoiseSession.responder(receiver_priv)
+        sess.read_handshake_message(await ws.receive_bytes())
+        await ws.send_bytes(sess.write_handshake_message(b""))
+        sess.read_handshake_message(await ws.receive_bytes())
+        await ws.send_bytes(sess.encrypt(b'{"intent_response": "weather"}'))
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_get(PEER_LINK_PATH, _handler)
+    server = TestServer(app)
+    await server.start_server()
+    initiator_priv = secrets.token_bytes(32)
+    try:
+        with pytest.raises(PeerLinkClientError, match="unknown intent_response"):
+            await request_pair(
+                hostname="127.0.0.1",
+                port=server.port,
+                identity_priv=initiator_priv,
+                label="green",
+                dashboard_id="abcdef0123456789",
+            )
+    finally:
+        await server.close()
+
+
 # ---------------------------------------------------------------------------
 # RemoteBuildController.request_pair — end-to-end through the WS-command shell
 # ---------------------------------------------------------------------------
@@ -464,3 +506,47 @@ async def test_controller_request_pair_unavailable_on_unreachable_receiver(
             label="my-receiver",
         )
     assert exc.value.code == ErrorCode.UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_controller_request_pair_unexpected_status_raises_internal_error(
+    offloader_controller_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Helper returns a known IntentResponse the controller doesn't expect → INTERNAL_ERROR.
+
+    ``IntentResponse.OK`` is valid wire but only used by
+    ``intent="preview"``; if a future receiver bug routed it
+    back as a pair_request response it would slip past
+    ``_intent_response_to_command_error`` (which only handles
+    ``REJECTED`` / ``NO_PAIRING_WINDOW``) and hit the
+    catch-all branch. Pin that branch with a mock so the
+    contract holds: unexpected-but-valid wire values map to
+    ``INTERNAL_ERROR``, not silently land as a corrupt local
+    StoredPairing row.
+    """
+    fake_pin = "a" * 64
+
+    async def _fake_request_pair(**_: object) -> RequestPairResult:
+        return RequestPairResult(
+            status=IntentResponse.OK,  # not in PENDING/APPROVED accept-set
+            pin_sha256=fake_pin,
+            remote_static_pub=b"\x00" * 32,
+        )
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.peer_link_request_pair",
+        _fake_request_pair,
+    )
+
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+
+    with pytest.raises(CommandError) as exc:
+        await offloader.request_pair(
+            hostname="127.0.0.1",
+            port=6055,
+            pin_sha256=fake_pin,
+            label="my-receiver",
+        )
+    assert exc.value.code == ErrorCode.INTERNAL_ERROR


### PR DESCRIPTION
# What does this implement/fix?

Third sub-PR of phase 4a-o. Adds the WS command that runs after
`preview_pair` once the user has OOB-confirmed the receiver's pin:
opens a fresh Noise XX WS with `intent="pair_request"`, asserts the
live handshake's pubkey-hash matches the user-supplied `pin_sha256`
(TOCTOU defense — receiver may have rotated identity / MITM
intervened between preview and request), and persists a local
`StoredPairing` row.

Subsequent 4a-o sub-PR:
- Part 4: `remote_build/unpair` + `remote_build/list_pool` (with 2s
  debounce cache). The shared `drive_initiator_round_trip` driver +
  the `_intent_response_to_command_error` / `_upsert_pairing` helpers
  this PR pulled out are sized so part 4's wire commands land as thin
  wrappers.

**New WS command** `remote_build/request_pair` (controller method):
- Validates `hostname` (yarl-correct via `_validate_hostname`),
  `port` (1-65535 non-bool), `pin_sha256` (64 lowercase-hex), `label`
  (≤128 chars).
- Loads peer-link X25519 identity + dashboard cert in a single
  executor hop via `_load_offloader_identities` (sync helper that
  reads both files in one threadpool round-trip — both are I/O-bound
  with per-process locks; bundling into one helper is cleaner than
  two awaits or `asyncio.gather`).
- Sends `{"label": ..., "dashboard_id": ours}` in encrypted msg3.
- Returns `PairingSummary` (drops `static_x25519_pub`) on success,
  typed `CommandError` on failures.

**New `ErrorCode` values** in `models/api.py`:
- `PRECONDITION_FAILED` — pin mismatch (TOCTOU) or receiver
  `REJECTED`; details field distinguishes. Pin-mismatch error
  message carries both pins in full (no truncation) so the human
  OOB comparison is reliable against attackers who collide a
  16-char prefix.
- `NO_PAIRING_WINDOW` — receiver reachable but window closed;
  frontend prompts the user to ask the receiver-side admin to open
  Pairing requests.

**DRY helpers** (each will be reused by part 4):
- `_load_offloader_identities` — single-executor-hop helper.
- `_intent_response_to_command_error` — single-source mapping from
  non-success `IntentResponse` values to typed `CommandError`s.
- `_enforce_pin_match` — TOCTOU pin check.
- `_upsert_pairing` — replace-or-append on `(hostname, port)`.
- `_pairing_summary` — wire projection mirror of `_peer_summary`.

**`paired_at` semantic.** A re-pair against a receiver that's still
APPROVED on the receiver side (offloader had previously paired)
overwrites `paired_at` to the re-pair time (last-touch). That's
right for the inbox-sort use case but a future "first paired on"
UI would need a separate `first_paired_at` field; flagged inline.

**Tests:** 4 e2e through `RemoteBuildController.request_pair` against
an in-process receiver (PENDING happy path, pin-mismatch
PRECONDITION_FAILED + no row written, closed-window
NO_PAIRING_WINDOW, unreachable host UNAVAILABLE) + 4 wire-helper
tests (open-window PENDING, closed-window NO_PAIRING_WINDOW,
unknown wire `intent_response` → PeerLinkClientError, unexpected
valid `IntentResponse` → INTERNAL_ERROR) + ~17 unit tests for the
new validators / helpers. Full suite: 2408 pass.

**Related issue or feature (if applicable):**

- part 3 of #106 phase 4a-o; builds on part 2 (#495)

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Frontend coordination

- [x] No frontend change needed yet — the offloader UI lands in 4b-3.
  The frontend team can start typing the command shape (`{hostname,
  port, pin_sha256, label}` → `PairingSummary`) once this lands.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass.
- [x] Tests added for new code.
- [x] `components.json` not hand-edited.
- [ ] Architecture / API docs updated. (Doc updates land with part 4 once the offloader WS surface is complete.)

## Self-review notes (resolved in 8215860f)

- The two `run_in_executor` calls were sequential, not parallel as
  the original description claimed; combined into the single
  `_load_offloader_identities` helper.
- `_enforce_pin_match` truncated displayed pins to 16 chars; now
  shows full digests so the human OOB comparison can't be defeated
  by a prefix collision.
- `paired_at` overwrites on re-pair (last-touch semantic) clarified
  in inline comment.