### PR TITLE
docs: document event-bus typing convention in ARCHITECTURE.md + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,23 +123,49 @@ in case anything has resurfaced.
   `subscribe_events` once and get pushes. REST is only kept for HA
   backward compat in `api/legacy.py`.
 - **Event payloads use TypedDict, not dataclass.** Mirrors
-  Home Assistant core's `EventStateChangedData` /
-  `EventStateReportedData` pattern. Each event-specific shape
-  gets a `TypedDict` declaration next to the controller that
-  fires it (e.g. `RemoteBuildPairRequestReceivedData` in
-  `models/remote_build.py`). Call sites build
-  `payload: SomeEventData = {...}` then
-  `bus.fire(EventType.X, payload)` — type checkers validate the
-  keys at construction. `EventBus.fire` and `Event.data` use
-  `Mapping[str, Any]` (not `dict[str, Any]`) so TypedDicts pass
-  through without `cast()`; subscribers consume via
-  `event.data.get(...)` since none of them needs the full
-  TypedDict view today. See `docs/ARCHITECTURE.md` "Event bus →
-  Typing event payloads" for the full rationale (why TypedDict
-  vs dataclass; why we use `Mapping` rather than HA's fully
-  generic `Event[_DataT]`). Older payloads fired with raw dicts
-  predate this convention; new events should ship with a
-  TypedDict from day one.
+  Home Assistant core's `Event[_DataT]` /
+  `EventStateChangedData` / `EventStateReportedData` pattern.
+  Each event-specific shape gets a `TypedDict` declaration next
+  to the controller that fires it (e.g.
+  `RemoteBuildPairRequestReceivedData` in `models/remote_build.py`,
+  `JobLifecycleData` / `JobOutputData` / `JobProgressData` in
+  `models/firmware.py`, `DeviceEventData` /
+  `DeviceStateChangedData` / `DeviceReachabilityData` in
+  `models/devices.py`). Fire sites use the TypedDict-call syntax
+  so mypy validates the construction:
+
+  ```python
+  bus.fire(EventType.X, SomeEventData(field=value))
+  ```
+
+  `Event` and `EventBus.fire` are generic on `DataT` so a typed
+  payload flows through without a `cast()` and without a
+  `Mapping[str, Any]` widening. Subscribers narrow at the
+  callback signature:
+
+  ```python
+  def _on_x(event: Event[SomeEventData]) -> None:
+      value = event.data["field"]  # typed
+  bus.add_listener(EventType.X, _on_x)
+  ```
+
+  `add_listener` is intentionally non-generic — listeners share
+  a type-erased `Callable[[Event[Any]], None]` bucket and
+  ``Any`` bridges the variance gap. The trade vs ~42
+  `Literal[EventType.X]`-keyed overloads at end-state: the type
+  system enforces the *correct* pairing (subscriber typed for
+  the matching event) but doesn't reject the *wrong* pairing
+  (subscriber typed for a different event). Mismatches live in
+  code review.
+
+  `tests/test_event_payload_contracts.py` pins each TypedDict
+  against its emitter at runtime + walks `models.*` to assert
+  every `*Data(TypedDict)` is covered, so a new TypedDict can't
+  silently skip the wire-shape contract check.
+
+  See `docs/ARCHITECTURE.md` "Event bus → Typing event payloads"
+  for the full rationale. New events ship with a TypedDict from
+  day one and a row in `_PAYLOAD_FACTORIES`.
 - **Persistent firmware queue.** One job runs at a time; queue +
   output buffers survive restarts. See `controllers/firmware.py`.
 - **Component catalog is generated**, not hand-edited. Source is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,13 +73,29 @@ esphome_device_builder/
 
 ## Event bus
 
-In-process pub/sub, owned by `DeviceBuilder.bus` (an `EventBus` from `helpers/event_bus`). Controllers fire events on state transitions; WS commands subscribe via `subscribe_events` and stream them to connected clients. Event types are declared in `models/common.py` as `EventType(StrEnum)` members; the bus signature is `fire(event_type, data: Mapping[str, Any] | None)`.
+In-process pub/sub, owned by `DeviceBuilder.bus` (an `EventBus` from `helpers/event_bus`). Controllers fire events on state transitions; WS commands subscribe via `subscribe_events` and stream them to connected clients. Event types are declared in `models/common.py` as `EventType(StrEnum)` members.
 
 ### Typing event payloads
 
-Mirrors Home Assistant core's `EventStateChangedData` / `EventStateReportedData` pattern: the wire shape stays a `dict`, but each event-specific shape is declared as a `TypedDict` next to the controller that fires it so type checkers validate the keys at the construction site.
+`Event` and `EventBus.fire` are generic on the data shape so each event flows through with its TypedDict intact:
 
-Concretely, in `models/remote_build.py`:
+```python
+@dataclass
+class Event[DataT]:
+    event_type: EventType
+    data: DataT
+
+
+class EventBus:
+    def fire[DataT](self, event_type: EventType, data: DataT) -> None: ...
+    def add_listener(
+        self,
+        event_type: EventType,
+        listener: Callable[[Event[Any]], None],
+    ) -> Callable[[], None]: ...
+```
+
+Each event-specific shape is declared as a `TypedDict` next to the controller that fires it. In `models/remote_build.py`:
 
 ```python
 class RemoteBuildPairRequestReceivedData(TypedDict):
@@ -89,19 +105,32 @@ class RemoteBuildPairRequestReceivedData(TypedDict):
     peer_ip: str
 ```
 
-The call site builds the typed dict before firing:
+The fire site uses the TypedDict-call syntax so mypy validates the construction:
 
 ```python
-payload: RemoteBuildPairRequestReceivedData = {
-    "dashboard_id": dashboard_id,
-    "pin_sha256": pin_sha256,
-    "label": label,
-    "peer_ip": peer_ip,
-}
-self._db.bus.fire(EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED, payload)
+self._db.bus.fire(
+    EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED,
+    RemoteBuildPairRequestReceivedData(
+        dashboard_id=dashboard_id,
+        pin_sha256=pin_sha256,
+        label=label,
+        peer_ip=peer_ip,
+    ),
+)
 ```
 
-`EventBus.fire` (and `Event.data`) takes `Mapping[str, Any]` rather than `dict[str, Any]` so a `TypedDict` flows through without a `cast()` — `TypedDict` is structurally compatible with a read-only `Mapping`, and every consumer in the codebase reads via `event.data.get(...)` / `event.data["k"]` rather than mutating. Home Assistant goes one step further with a fully generic `Event[_DataT]` / `EventType[_DataT]` so subscribers also get a typed `event.data`; we don't need that depth, since no subscriber annotates `event.data` as a `TypedDict` today — they all just `.get()` the key they care about.
+The subscriber narrows by typing its callback's `event` parameter:
+
+```python
+def _on_pair_status(event: Event[RemoteBuildPairStatusChangedData]) -> None:
+    status = event.data["status"]  # mypy: Literal['approved'] | Literal['removed']
+
+bus.add_listener(EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED, _on_pair_status)
+```
+
+`add_listener` is *not* generic on `_DataT` — listeners share a bucket type-erased as `Callable[[Event[Any]], None]` and `Any`'s bidirectional compatibility lets a `Callable[[Event[XData]], None]` register cleanly. The alternative — per-event-type overloads keyed on `Literal[EventType.X]` — was rejected: at end-state it would mean ~42 overloads (21 events × `fire`+`add_listener`), past mypy's practical resolution-perf limits. The trade: the type system enforces the *correct* pairing (subscriber typed for the matching event) but doesn't reject the *wrong* pairing (subscriber typed for a different event). Mismatches live in code review.
+
+Mirrors HA core's `Event[_DataT]` / `EventType[_DataT]` pattern. Deliberate divergence: HA bounds `_DataT` to `Mapping[str, Any]` with that as the default so untyped events fall through; we drop the bound entirely. Untyped fire sites pass plain `dict[str, Any]` and mypy infers `DataT` from the call.
 
 `TypedDict` rather than `@dataclass` because:
 
@@ -109,7 +138,9 @@ self._db.bus.fire(EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED, payload)
 - Subscribers that ride the existing `subscribe_events` WS plumbing serialise the payload through `helpers.json.dumps` (orjson), which handles `dict` natively.
 - It mirrors HA's convention so contributors moving between this codebase and HA find the same pattern.
 
-Older event payloads fired with raw dicts predate this convention and get the typed treatment as they're touched. New events should ship with a TypedDict from day one.
+`tests/test_event_payload_contracts.py` pins each TypedDict against its emitter at runtime — for every payload class, a factory invokes the production code path (TypedDict-call constructor or a helper that returns the dict literal as a TypedDict alias) and asserts the resulting dict's keys equal the TypedDict's `__annotations__`. A second test walks `models.*` and asserts every `*Data(TypedDict)` discoverable in the namespace is listed in the factory table — so a future PR adding a TypedDict can't silently skip the contract check.
+
+New events should ship with a TypedDict from day one.
 
 ## Firmware Job Queue
 

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -258,7 +258,8 @@ class UpdateDeviceResponse(DataClassORJSONMixin):
 # ---------------------------------------------------------------------------
 # Event payload shapes (TypedDict so the bus.fire data dict is
 # type-checked at the call site without changing the wire shape).
-# See ``mypy_plan.md`` for the migration scope.
+# See ``docs/ARCHITECTURE.md`` "Event bus → Typing event payloads"
+# for the subscriber-side narrowing pattern.
 # ---------------------------------------------------------------------------
 
 

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -134,8 +134,8 @@ _RECOVERY_NOTICE = (
 # Event payload shapes (TypedDict so the bus.fire data dict is
 # type-checked at the call site without changing the wire shape;
 # mirrors HA's ``EventStateChangedData`` / ``EventStateReportedData``
-# pattern). See ``mypy_plan.md`` for the migration scope and
-# ``Event[DataT]`` for the subscriber-side narrowing pattern.
+# pattern). See ``docs/ARCHITECTURE.md`` "Event bus → Typing event
+# payloads" for the subscriber-side narrowing pattern.
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
# What does this implement/fix?

Documents the event-bus typing convention introduced across
#496 (foundation) / #497 (jobs) / #498 (device CRUD) and
extended in PR #499 (state + reachability) / PR #500
(importable + label).

The pattern landed in commit messages and a local working doc
but never made it into the canonical orientation files. This PR
moves it into:

- **`docs/ARCHITECTURE.md` "Event bus → Typing event payloads"** —
  full rationale: the `Event[DataT]` generic, the
  `fire[DataT]` / `add_listener` shapes, why no overloads (~42
  at end-state ruled out), the trade-off (correct pairing
  enforced; wrong pairing not rejected), the test-contract
  pattern.
- **`CLAUDE.md` "Architecture conventions worth knowing"** —
  short orientation summary + a worked subscriber-side
  narrowing example. Replaces the older `Mapping[str, Any]`
  description that's no longer accurate.

Also fixes the broken `See ``mypy_plan.md``` references in the
TypedDict block headers in `models/devices.py` and
`models/firmware.py` (the working doc isn't in the repo) — they
now point at the new ARCHITECTURE.md section.

## Verification

- `mypy esphome_device_builder` clean.
- `pytest -q` green.
- Sphinx-style doc anchors verified by hand (the
  `"Event bus → Typing event payloads"` heading exists).

**Related issue or feature (if applicable):**

- Documents the design that landed in #496 / #497 / #498
  and the in-flight #499 / #500.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
