### PR TITLE
event-bus: type REMOTE_BUILD_IDENTITY_ROTATED payload via TypedDict

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -92,6 +92,7 @@ from ..models import (
     PairingWindowState,
     PeerStatus,
     PeerSummary,
+    RemoteBuildIdentityRotatedData,
     RemoteBuildPairingWindowChangedData,
     RemoteBuildPairRequestReceivedData,
     RemoteBuildPairStatusChangedData,
@@ -1275,10 +1276,10 @@ class RemoteBuildController:
             )
             self._db.bus.fire(
                 EventType.REMOTE_BUILD_IDENTITY_ROTATED,
-                {
-                    "dashboard_id": identity.dashboard_id,
-                    "pin_sha256": identity.pin_sha256,
-                },
+                RemoteBuildIdentityRotatedData(
+                    dashboard_id=identity.dashboard_id,
+                    pin_sha256=identity.pin_sha256,
+                ),
             )
             return _identity_view(identity, listener_bound=listener_bound)
         finally:

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -149,6 +149,24 @@ class IntentResponse(StrEnum):
 # ---------------------------------------------------------------------------
 
 
+class RemoteBuildIdentityRotatedData(TypedDict):
+    """
+    Payload for ``EventType.REMOTE_BUILD_IDENTITY_ROTATED``.
+
+    Fired after ``rotate_certificate`` succeeds and the new
+    ``pin_sha256`` is reloaded into the listener. Subscribers
+    (the offloader-side peer-link in phase 4+, the receiver
+    Settings UI in 3c2) refresh their cached pin without polling
+    ``get_identity``. The event reflects only that the cert + key
+    on disk changed; the listener rebuild may still fail-soft, in
+    which case the rotater's ``IdentityView`` response carries
+    ``listener_bound=False``.
+    """
+
+    dashboard_id: str
+    pin_sha256: str
+
+
 class RemoteBuildPairRequestReceivedData(TypedDict):
     """
     Payload for ``EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED``.


### PR DESCRIPTION
# What does this implement/fix?

Catches a gap in the typed-payload migration: the
`REMOTE_BUILD_IDENTITY_ROTATED` fire site in
`controllers/remote_build.py` was still passing a raw dict
literal even though the surrounding three remote-build events
have shipped TypedDicts since the foundation (#496) landed.

```python
# Before
self._db.bus.fire(
    EventType.REMOTE_BUILD_IDENTITY_ROTATED,
    {
        "dashboard_id": identity.dashboard_id,
        "pin_sha256": identity.pin_sha256,
    },
)

# After
self._db.bus.fire(
    EventType.REMOTE_BUILD_IDENTITY_ROTATED,
    RemoteBuildIdentityRotatedData(
        dashboard_id=identity.dashboard_id,
        pin_sha256=identity.pin_sha256,
    ),
)
```

`EventBus.fire` is generic on `DataT` with no upper bound, so a
bare dict literal types as `dict[str, str]` and silently bypasses
the per-event TypedDict convention. mypy doesn't object — there's
no way to bound `DataT` to "must be a TypedDict subtype" in
Python typing.

A follow-up PR adds an AST lint that catches this regression
shape (raw `bus.fire(EventType.X, {...})` literals) so a future
event member can't ship without a TypedDict.

## Verification

- `mypy esphome_device_builder` clean (71 source files).
- 2407 backend tests pass locally.
- `RemoteBuildIdentityRotatedData` placed alphabetically in
  `models/remote_build.py` next to the other three remote-build
  payload TypedDicts.

**Related issue or feature (if applicable):**

- Fills a gap in the migration tracked across #496 / #497 /
  #498 / #499 / #500 / #502.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
