### PR TITLE
ci: lint bus.fire(EventType.X, ...) sites for typed payloads

### DIFF
--- a/tests/test_event_bus_fire_lint.py
+++ b/tests/test_event_bus_fire_lint.py
@@ -1,0 +1,138 @@
+"""
+Lint: every ``bus.fire(EventType.X, payload)`` site uses a typed payload.
+
+The TypedDict-per-event convention (CLAUDE.md "Event payloads use
+TypedDict, not dataclass") is enforced at the construction site
+by mypy:
+
+- ``DataT(field=value)`` — TypedDict-call syntax; mypy validates
+  the kwargs against the declared fields.
+- ``payload: SomeData = {...}; bus.fire(...)`` — annotated local
+  binding; mypy validates the literal against the annotation.
+
+The hole mypy *can't* close: ``bus.fire`` is generic on
+``DataT`` with no upper bound, so a bare dict literal at the
+fire site (``bus.fire(EventType.X, {"k": "v"})``) types as
+``dict[str, str]`` and silently bypasses the convention. A new
+``EventType`` member could land without any TypedDict and mypy
+would never object.
+
+This file walks every Python source file under
+``esphome_device_builder/`` with :mod:`ast` and asserts no
+``bus.fire(EventType.X, {...})`` site exists. Migrating a fire
+site away from a typed payload would have to land here too,
+making the regression visible at review time and in CI.
+
+Listener sites are intentionally not linted — there's a single
+``bus.add_listener(EventType.X, _handler)`` call site outside
+the bus itself today (``DevicesController._on_firmware_job_completed``)
+and its handler is typed ``Event[JobLifecycleData]``. A
+multi-listener-site lint can land alongside the next
+``add_listener`` call that needs guarding.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_PACKAGE_ROOT = Path(__file__).parent.parent / "esphome_device_builder"
+
+
+def _is_event_type_attr(node: ast.expr) -> bool:
+    """Return True when *node* is an ``EventType.<NAME>`` attribute access."""
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "EventType"
+    )
+
+
+def _resolve_fire_args(node: ast.Call) -> tuple[ast.expr, ast.expr] | None:
+    """Resolve ``(event_type, data)`` from a ``.fire(...)`` call.
+
+    Handles both positional (``fire(EventType.X, payload)``) and
+    keyword (``fire(event_type=EventType.X, data=payload)``)
+    forms, plus mixed (``fire(EventType.X, data=payload)``).
+    Returns ``None`` when either argument is missing — the lint
+    skips those calls entirely; mypy already rejects an ``.fire``
+    call with the wrong arity.
+    """
+    event_type: ast.expr | None = None
+    data: ast.expr | None = None
+
+    if len(node.args) >= 1:
+        event_type = node.args[0]
+    if len(node.args) >= 2:
+        data = node.args[1]
+
+    for kw in node.keywords:
+        if kw.arg == "event_type":
+            event_type = kw.value
+        elif kw.arg == "data":
+            data = kw.value
+
+    if event_type is None or data is None:
+        return None
+    return event_type, data
+
+
+def _find_raw_dict_fire_sites(src: str, path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, EventType.X)`` for every raw-dict-literal fire site.
+
+    Matches ``<expr>.fire(EventType.X, {<dict literal>}, ...)``
+    anywhere in *src* — covers ``bus.fire``, ``self._db.bus.fire``,
+    and any other attribute chain ending in ``.fire``. Resolves
+    both positional and keyword forms (``fire(EventType.X, {})``
+    and ``fire(event_type=EventType.X, data={})`` are both
+    flagged). The event_type argument has to be a direct
+    ``EventType.X`` reference; aliased / dynamic event values
+    (``event = EventType.JOB_COMPLETED if success else
+    EventType.JOB_FAILED``) bypass this lint by design — those
+    sites already pass typed local payloads, and the call-graph
+    analysis to chase a ``Name`` back to its EventType assignment
+    is more brittle than it's worth.
+    """
+    tree = ast.parse(src, filename=str(path))
+    bad: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "fire":
+            continue
+        resolved = _resolve_fire_args(node)
+        if resolved is None:
+            continue
+        event_type, data = resolved
+        if not _is_event_type_attr(event_type):
+            continue
+        if isinstance(data, ast.Dict):
+            assert isinstance(event_type, ast.Attribute)  # type narrowing for mypy
+            bad.append((node.lineno, f"EventType.{event_type.attr}"))
+    return bad
+
+
+def test_no_raw_dict_payloads_at_bus_fire_sites() -> None:
+    """Every ``bus.fire(EventType.X, payload)`` site uses a typed payload.
+
+    See module docstring for why mypy can't close this gap on
+    its own. Failing this test means a fire site landed with a
+    bare ``{...}`` dict literal — convert it to TypedDict-call
+    syntax (``SomeData(field=value)``) or an annotated local
+    (``payload: SomeData = {...}; bus.fire(..., payload)``).
+    """
+    offenders: list[str] = []
+    for path in _PACKAGE_ROOT.rglob("*.py"):
+        # Force UTF-8 — Windows CI's default ``cp1252`` locale chokes
+        # on the em-dashes / smart quotes used throughout the
+        # codebase's docstrings and comments.
+        src = path.read_text(encoding="utf-8")
+        for lineno, event_name in _find_raw_dict_fire_sites(src, path):
+            rel = path.relative_to(_PACKAGE_ROOT.parent)
+            offenders.append(f"{rel}:{lineno}  bus.fire({event_name}, {{...}})")
+
+    assert not offenders, (
+        "Bare dict literal at bus.fire site bypasses the per-event TypedDict "
+        "convention. Convert each to ``SomeData(...)`` or a typed local:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
# What does this implement/fix?

Catches the convention regression that #503 fixed: a new
`EventType` member firing with a bare dict literal silently
bypasses the per-event TypedDict typing.

```python
# This is what we want:
bus.fire(EventType.X, SomeData(field=value))                    # mypy validates kwargs
bus.fire(EventType.X, payload)  # where payload: SomeData = {}  # mypy validates literal vs annotation

# This is what slipped through pre-#503:
bus.fire(EventType.X, {"field": value})                         # mypy: dict[str, T], no error
```

`EventBus.fire` is generic on `DataT` with no upper bound, so a
bare dict literal types as `dict[str, T]` and silently bypasses
the per-event TypedDict convention. There's no way to bound
`DataT` to "must be a TypedDict subtype" in Python typing — so a
new `EventType` member could land without any TypedDict and mypy
would never object.

## How

`tests/test_event_bus_fire_lint.py` walks every Python source
file under `esphome_device_builder/` with `ast` and asserts no
`<expr>.fire(EventType.X, {...})` site exists. The traversal
matches any attribute chain ending in `.fire` (covers `bus.fire`,
`self._db.bus.fire`, etc.), and the first arg has to be a direct
`EventType.X` reference — aliased / dynamic event values
(`event = EventType.JOB_COMPLETED if success else
EventType.JOB_FAILED`) bypass the lint by design, since those
sites already pass typed local payloads and call-graph analysis
to chase a `Name` back to its `EventType` assignment is more
brittle than it's worth.

## What this does *not* lint

Listener sites — there's a single `bus.add_listener(EventType.X,
_handler)` call site outside the bus itself today
(`DevicesController._on_firmware_job_completed` →
`Event[JobLifecycleData]`). A multi-listener-site lint can land
alongside the next `add_listener` that needs guarding. The four
`_handle_event(event: Event, controls: StreamControls)`
callbacks inside `stream_events` consumers are multi-event
multiplexers (legacy WS, follow_job, follow_jobs, broadcast
subscribe) where `Event[Any]` is the right shape — narrowing
happens inside via the `event_type` check.

## Stacking

Stacked on #503 — without that PR, this lint would fail on the
`REMOTE_BUILD_IDENTITY_ROTATED` raw-dict fire site. Once #503
lands, this PR rebases trivially onto main.

## Verification

- `mypy esphome_device_builder` clean (71 source files).
- 2408 backend tests pass locally (existing 2407 + the new lint).

**Related issue or feature (if applicable):**

- Closes the typed-payload migration tracked across #496 / #497
  / #498 / #499 / #500 / #502 / #503 by gating the regression
  shape that slipped past mypy.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

There's no clean fit in the labels — the change is a test that
gates a convention. Closest is `ci` since it's CI-side
enforcement of a code-style invariant.

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
