### PR TITLE
event-bus: narrow per-device reachability listener

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -2233,9 +2233,9 @@ class DevicesController:
                 await client.send_event(message_id, "reachability_state", snapshot)
             await client.send_result(message_id, {"subscribed": True})
 
-        def _handle_event(event: Event, controls: StreamControls) -> None:
+        def _handle_event(event: Event[DeviceReachabilityData], controls: StreamControls) -> None:
             data = event.data
-            if data.get("device") != device_name:
+            if data["device"] != device_name:
                 # The bus event is broadcast (one listener for every
                 # subscriber); filter inside the closure so each
                 # subscriber only forwards the events for its device.


### PR DESCRIPTION
# What does this implement/fix?

Narrows the per-device reachability subscription handler from
bare `Event` to `Event[DeviceReachabilityData]`, giving the
closure typed access to the wire shape:

```python
# Before
def _handle_event(event: Event, controls: StreamControls) -> None:
    data = event.data            # data: Any
    if data.get("device") != device_name:
        return
    controls.push("reachability_state", data)

# After
def _handle_event(
    event: Event[DeviceReachabilityData], controls: StreamControls
) -> None:
    data = event.data            # data: DeviceReachabilityData
    if data["device"] != device_name:
        return
    controls.push("reachability_state", data)
```

The handler only ever subscribes to a single event type
(`EventType.DEVICE_REACHABILITY`), so the per-callback narrowing
pattern documented in `docs/ARCHITECTURE.md` "Event bus → Typing
event payloads" applies. Drops the defensive `.get("device")` in
favour of direct keyed access — `DeviceReachabilityData`
guarantees the key, and the broadcast path never fires the event
without the field. Same pattern as the
`_on_firmware_job_completed` listener that already uses
`Event[JobLifecycleData]`.

## What this does *not* change

The four `_handle_event` callbacks elsewhere in the codebase
stay bare `Event`:

- `device_builder.py:557` — broadcast subscribe (~20 events,
  mixed shapes)
- `legacy.py:160` — legacy WS `/compile` `/upload` (4 events)
- `firmware/controller.py:495` — `follow_job` (4 events)
- `firmware/controller.py:582` — `follow_jobs` (7 events)

Those multiplex multiple event types whose payload shapes
differ, so `Event[Any]` is the right level there. Narrowing
inside the handler happens via the `event_type` check.

## Verification

- `mypy esphome_device_builder` clean (71 source files).
- 2444 backend tests pass locally.
- `tests/controllers/devices/test_subscribe_reachability.py`
  still green — wire shape unchanged.

**Related issue or feature (if applicable):**

- Closes the receiver-typing gap noted in #504's audit; the
  fire-site lint already shipped the fire-side enforcement.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
