### PR TITLE
Vendor MetadataKeyStore: debounced single-key sidecar writer

### DIFF
--- a/esphome_device_builder/helpers/metadata_store.py
+++ b/esphome_device_builder/helpers/metadata_store.py
@@ -80,6 +80,9 @@ loader::
             # time. ``.append`` matches the
             # ``Callable[[ShutdownCallback], None]`` shape exactly.
             shutdown_register=self._db.shutdown_callbacks.append,
+            # Surfaces in error logs + the asyncio task name so a
+            # production failure trace identifies which sub-key broke.
+            name="_offloader_remote_build",
         )
     )
 
@@ -128,7 +131,7 @@ class MetadataKeyStore[T]:
     instances pointing at the same key is supported (each runs its
     own debounce) but redundant; production has one per controller.
 
-    *_T* is the type the caller's *data_func* returns and the type
+    *T* is the type the caller's *data_func* returns and the type
     *load_sync* yields back from disk; the store is agnostic to its
     shape (typically a mashumaro dataclass like
     :class:`OffloaderRemoteBuildSettings`).
@@ -141,6 +144,7 @@ class MetadataKeyStore[T]:
         load_sync: Callable[[Path], T],
         write_sync: Callable[[Path, T], None],
         shutdown_register: ShutdownRegister,
+        name: str | None = None,
     ) -> None:
         """Bind the store to ``config_dir`` + caller-supplied I/O hooks.
 
@@ -160,6 +164,14 @@ class MetadataKeyStore[T]:
         None`` to opt out, but production paths should always wire
         a real registry.
 
+        *name* is a free-form diagnostic label (typically the
+        sidecar sub-key, e.g. ``"_offloader_remote_build"``)
+        attached to the write task and to error log lines so
+        production failure traces identify *which* sidecar key
+        failed without the caller having to ship its own context
+        through. Optional; defaults to a stand-in derived from
+        ``config_dir`` when omitted.
+
         Injection avoids importing ``controllers.config`` from a
         helper module — the ``controllers.config`` layer already
         owns the metadata sidecar (lock + atomic write); this store
@@ -168,6 +180,7 @@ class MetadataKeyStore[T]:
         self._config_dir = config_dir
         self._load_sync_cb = load_sync
         self._write_sync_cb = write_sync
+        self._name = name or f"<unnamed:{config_dir}>"
         # Captured at every ``async_delay_save`` call; the actual
         # invocation happens at flush time inside the write lock so
         # the value reflects the latest in-RAM state.
@@ -241,7 +254,7 @@ class MetadataKeyStore[T]:
             return
         self._delay_handle = None
         self._inflight_write = asyncio.create_task(
-            self._async_handle_write(), name="metadata-store-write"
+            self._async_handle_write(), name=f"metadata-store-write:{self._name}"
         )
 
     async def _async_handle_write(self) -> None:
@@ -264,8 +277,14 @@ class MetadataKeyStore[T]:
                 # save) and a crash here would unwind through the
                 # asyncio task machinery noisily. Mirrors HA's
                 # swallow of WriteError / SerializationError in
-                # ``_async_handle_write_data``.
-                _LOGGER.exception("Error writing metadata key")
+                # ``_async_handle_write_data``. Include the store's
+                # *name* + ``config_dir`` so production traces can
+                # point at the failing sub-key.
+                _LOGGER.exception(
+                    "Error writing metadata key %s under %s",
+                    self._name,
+                    self._config_dir,
+                )
 
     async def async_save_now(self) -> None:
         """Cancel any pending delay + flush whatever's queued.

--- a/esphome_device_builder/helpers/metadata_store.py
+++ b/esphome_device_builder/helpers/metadata_store.py
@@ -1,0 +1,239 @@
+"""
+Debounced single-key writer for the shared metadata sidecar.
+
+Vendored down from Home Assistant's ``homeassistant.helpers.storage.Store``
+(see ``~/home-assistant/homeassistant/helpers/storage.py``) and adapted
+for our case: HA's :class:`Store` owns its own JSON file, but our
+``device-builder.json`` is a single sidecar shared across many keys
+(``_remote_build``, ``_offloader_remote_build``, ``_devices``,
+``_labels``, …) under one process-wide
+:func:`~controllers.config.metadata_transaction` lock. So instead of
+managing a file path, this store manages **one sub-key** of the shared
+sidecar; the actual disk write hops through caller-supplied ``load_sync``
+/ ``write_sync`` callbacks so it stays serialised against every other
+writer of the same file (the callbacks own the
+``metadata_transaction``).
+
+Drops every HA dependency we don't need: no ``hass.bus`` / no
+``EVENT_HOMEASSISTANT_FINAL_WRITE`` (we use an explicit
+:meth:`async_save_now` from controller ``stop()``), no ``_StoreManager``
+preload cache (the sidecar is one read), no version migration (the
+storage shape is owned by mashumaro on the controller side), no
+``_load_future`` reentrancy guard (we load once at controller start).
+
+Keeps the parts that earn their complexity:
+
+* **Debounce + extend semantics matching HA.** Calls during an open
+  delay window update the *latest* deadline rather than firing
+  immediately; the timer reschedules itself to the latest requested
+  write time when it fires too early. Mirrors HA's
+  ``Store.async_delay_save`` behaviour bit-for-bit so a future reader
+  with HA muscle memory isn't surprised.
+* **Lock-protected write hop.** The disk write hands off to the
+  default executor via ``run_in_executor``; an ``asyncio.Lock``
+  serialises overlapping flushes against the same key. Without it a
+  ``stop()`` flush could race with a still-pending delayed write.
+* **Captured data_func at write time.** The caller hands us a
+  zero-arg callable that produces the current dict to persist; we
+  call it inside the write critical section, so a mutation that
+  lands between ``async_delay_save`` and the eventual flush picks up
+  the latest in-RAM state.
+
+Typical use, paired with
+:func:`~controllers.config.metadata_transaction` and a per-key
+loader::
+
+    from ..controllers.config import (
+        load_offloader_remote_build_settings,
+        save_offloader_remote_build_settings,
+    )
+
+    def _load(config_dir: Path) -> OffloaderRemoteBuildSettings:
+        return load_offloader_remote_build_settings(config_dir)
+
+    def _save(config_dir: Path, value: OffloaderRemoteBuildSettings) -> None:
+        save_offloader_remote_build_settings(config_dir, value)
+
+    self._store: MetadataKeyStore[OffloaderRemoteBuildSettings] = (
+        MetadataKeyStore(
+            config_dir=self._db.settings.config_dir,
+            load_sync=_load,
+            write_sync=_save,
+        )
+    )
+
+    # On every mutation:
+    self._pairings[key] = pairing
+    self._store.async_delay_save(self._serialize_pairings, delay=1.0)
+
+    # On controller stop:
+    await self._store.async_save_now()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from contextlib import suppress
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MetadataKeyStore[T]:
+    """Debounced writer for a single key of the shared metadata sidecar.
+
+    Owns no in-RAM state of its own — the controller holds the live
+    dict (``_pairings`` etc.) and hands us a *data_func* that
+    serialises it on demand. We track only the pending write
+    deadline + timer so the disk write can be debounced.
+
+    Per-instance, single key, single ``config_dir``. Spinning up two
+    instances pointing at the same key is supported (each runs its
+    own debounce) but redundant; production has one per controller.
+
+    *_T* is the type the caller's *data_func* returns and the type
+    *load_sync* yields back from disk; the store is agnostic to its
+    shape (typically a mashumaro dataclass like
+    :class:`OffloaderRemoteBuildSettings`).
+    """
+
+    def __init__(
+        self,
+        config_dir: Path,
+        *,
+        load_sync: Callable[[Path], T],
+        write_sync: Callable[[Path, T], None],
+    ) -> None:
+        """Bind the store to ``config_dir`` + caller-supplied I/O hooks.
+
+        *load_sync* takes ``config_dir`` and returns the decoded
+        value (or whatever default the caller chooses for missing
+        keys). *write_sync* takes ``(config_dir, value)`` and
+        atomically persists it. Both are sync (executor-bound).
+
+        Injection avoids importing ``controllers.config`` from a
+        helper module — the ``controllers.config`` layer already
+        owns the metadata sidecar (lock + atomic write); this store
+        is just a debounced wrapper around it.
+        """
+        self._config_dir = config_dir
+        self._load_sync_cb = load_sync
+        self._write_sync_cb = write_sync
+        # Captured at every ``async_delay_save`` call; the actual
+        # invocation happens at flush time inside the write lock so
+        # the value reflects the latest in-RAM state.
+        self._data_func: Callable[[], T] | None = None
+        self._delay_handle: asyncio.TimerHandle | None = None
+        self._next_write_time = 0.0
+        # Single-flight writes against this key. Without it, a
+        # ``stop()``-triggered ``async_save_now`` could land while a
+        # delayed-handler-triggered write is mid-executor; the second
+        # would observe ``_data_func is None`` and return early,
+        # losing the user's latest mutation.
+        self._write_lock = asyncio.Lock()
+        # Latest in-flight write task, if any. ``async_save_now``
+        # awaits this before issuing its own final write so the two
+        # don't interleave.
+        self._inflight_write: asyncio.Task[None] | None = None
+
+    async def async_load(self) -> T:
+        """Load the current value at this key from disk.
+
+        Single-shot read intended for controller start; the in-RAM
+        state is the source of truth from then on. Hops to the
+        default executor so the load doesn't block the event loop.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._load_sync_cb, self._config_dir)
+
+    def async_delay_save(self, data_func: Callable[[], T], delay: float = 0.0) -> None:
+        """Schedule a write of *data_func()*'s output after *delay* seconds.
+
+        Calls during an open delay window extend the deadline to the
+        latest requested write time (matches HA's
+        ``Store.async_delay_save``). The data_func is captured each
+        call but only invoked at flush time, so the persisted
+        snapshot reflects the controller's in-RAM state at flush
+        rather than at scheduling — multiple mutations within a
+        single debounce window all collapse into one write of the
+        final state.
+        """
+        self._data_func = data_func
+        loop = asyncio.get_running_loop()
+        next_when = loop.time() + delay
+        if self._delay_handle is not None and self._delay_handle.when() < next_when:
+            # Existing handle fires earlier than the new request;
+            # remember the later deadline and let the handle
+            # reschedule itself when it wakes (see
+            # ``_on_delay_handle_fire``).
+            self._next_write_time = next_when
+            return
+        if self._delay_handle is not None:
+            self._delay_handle.cancel()
+        self._next_write_time = next_when
+        self._delay_handle = loop.call_at(next_when, self._on_delay_handle_fire)
+
+    def _on_delay_handle_fire(self) -> None:
+        """Sync timer callback; reschedule or kick off the actual write."""
+        loop = asyncio.get_running_loop()
+        if loop.time() < self._next_write_time:
+            # A later ``async_delay_save`` extended the deadline while
+            # this handle was sitting in the loop; reschedule to the
+            # new target instead of firing now. Mirrors HA's
+            # ``_async_schedule_callback_delayed_write``.
+            self._delay_handle = loop.call_at(self._next_write_time, self._on_delay_handle_fire)
+            return
+        self._delay_handle = None
+        self._inflight_write = asyncio.create_task(
+            self._async_handle_write(), name="metadata-store-write"
+        )
+
+    async def _async_handle_write(self) -> None:
+        """Run one write under the lock; clear the captured data_func."""
+        async with self._write_lock:
+            data_func = self._data_func
+            self._data_func = None
+            if data_func is None:
+                # A concurrent ``async_save_now`` already drained
+                # the captured func; nothing to write.
+                return
+            loop = asyncio.get_running_loop()
+            try:
+                value = data_func()
+                await loop.run_in_executor(None, self._write_sync_cb, self._config_dir, value)
+            except Exception:
+                # Disk-write failures shouldn't propagate out of a
+                # background task — the controller's mutation is
+                # still in RAM (next mutation will reschedule a
+                # save) and a crash here would unwind through the
+                # asyncio task machinery noisily. Mirrors HA's
+                # swallow of WriteError / SerializationError in
+                # ``_async_handle_write_data``.
+                _LOGGER.exception("Error writing metadata key")
+
+    async def async_save_now(self) -> None:
+        """Cancel any pending delay + flush whatever's queued.
+
+        Used from the controller's ``stop()`` so a debounced save
+        scheduled microseconds before shutdown still lands on disk.
+        Awaits any in-flight executor write before issuing its own,
+        so back-to-back stop / shutdown paths don't interleave.
+        Idempotent — calling on an empty store is a no-op.
+        """
+        if self._delay_handle is not None:
+            self._delay_handle.cancel()
+            self._delay_handle = None
+        if self._inflight_write is not None and not self._inflight_write.done():
+            # An earlier delayed handler already kicked off a write;
+            # let it complete so the executor isn't running two
+            # writer callbacks back-to-back. The second write below
+            # picks up any data_func captured *after* the in-flight
+            # write started. Errors were already logged inside
+            # ``_async_handle_write``; suppress so the post-snapshot
+            # flush still runs.
+            with suppress(Exception):
+                await self._inflight_write
+        if self._data_func is not None:
+            await self._async_handle_write()

--- a/esphome_device_builder/helpers/metadata_store.py
+++ b/esphome_device_builder/helpers/metadata_store.py
@@ -15,11 +15,12 @@ writer of the same file (the callbacks own the
 ``metadata_transaction``).
 
 Drops every HA dependency we don't need: no ``hass.bus`` / no
-``EVENT_HOMEASSISTANT_FINAL_WRITE`` (we use an explicit
-:meth:`async_save_now` from controller ``stop()``), no ``_StoreManager``
-preload cache (the sidecar is one read), no version migration (the
-storage shape is owned by mashumaro on the controller side), no
-``_load_future`` reentrancy guard (we load once at controller start).
+``EVENT_HOMEASSISTANT_FINAL_WRITE`` (we replace it with a mandatory
+*shutdown_register* callback the caller supplies — see below), no
+``_StoreManager`` preload cache (the sidecar is one read), no
+version migration (the storage shape is owned by mashumaro on the
+controller side), no ``_load_future`` reentrancy guard (we load
+once at controller start).
 
 Keeps the parts that earn their complexity:
 
@@ -38,6 +39,22 @@ Keeps the parts that earn their complexity:
   call it inside the write critical section, so a mutation that
   lands between ``async_delay_save`` and the eventual flush picks up
   the latest in-RAM state.
+* **Mandatory shutdown registration.** The constructor takes a
+  *shutdown_register* callback that's invoked *exactly once* with
+  ``self.async_save_now`` at construction. The caller's lifecycle
+  layer (typically :class:`DeviceBuilder.shutdown_callbacks`) holds
+  the resulting list and ``await``s every callback during graceful
+  stop, so a debounced save scheduled microseconds before shutdown
+  always lands. Making registration a constructor parameter rather
+  than a "remember to call ``stop()``" convention closes the
+  forgot-to-wire-it footgun structurally — a store can't be
+  instantiated without telling the lifecycle who's responsible for
+  flushing it. Caveats: ``SIGKILL`` / process crash skip the
+  registry the same way HA's ``EVENT_HOMEASSISTANT_FINAL_WRITE``
+  skips on hard kills; in-RAM mutations not yet flushed are lost.
+  Persistence under crashes would require an after-every-mutation
+  write, defeating the debounce; for our use case (paired-receivers
+  list, similar low-frequency state) the trade is accepted.
 
 Typical use, paired with
 :func:`~controllers.config.metadata_transaction` and a per-key
@@ -59,6 +76,10 @@ loader::
             config_dir=self._db.settings.config_dir,
             load_sync=_load,
             write_sync=_save,
+            # Caller-owned: a list the lifecycle layer walks at stop
+            # time. ``.append`` matches the
+            # ``Callable[[ShutdownCallback], None]`` shape exactly.
+            shutdown_register=self._db.shutdown_callbacks.append,
         )
     )
 
@@ -66,19 +87,33 @@ loader::
     self._pairings[key] = pairing
     self._store.async_delay_save(self._serialize_pairings, delay=1.0)
 
-    # On controller stop:
-    await self._store.async_save_now()
+    # ``async_save_now`` is also still available for callers that
+    # want a synchronous flush outside the shutdown path (e.g. on a
+    # configuration import that wants the new state on disk before
+    # the response goes back).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
+
+# Type aliases for the shutdown-registry contract. ``ShutdownCallback``
+# is what we hand the registry; ``ShutdownRegister`` is the registry's
+# own shape (a function that accepts one). Splitting them out means
+# call sites don't have to spell ``Callable[[Callable[[], Awaitable[None]]], None]``
+# inline, and a future audit that switches the registry to a more
+# structured type (e.g. an ``asyncio.TaskGroup`` exit hook) only
+# touches the alias. PEP 695 ``type`` syntax (Python 3.12+) so the
+# aliases live in their own namespace and don't need
+# ``from __future__ import annotations`` evaluation tricks.
+type ShutdownCallback = Callable[[], Awaitable[None]]
+type ShutdownRegister = Callable[[ShutdownCallback], None]
 
 
 class MetadataKeyStore[T]:
@@ -105,6 +140,7 @@ class MetadataKeyStore[T]:
         *,
         load_sync: Callable[[Path], T],
         write_sync: Callable[[Path, T], None],
+        shutdown_register: ShutdownRegister,
     ) -> None:
         """Bind the store to ``config_dir`` + caller-supplied I/O hooks.
 
@@ -112,6 +148,17 @@ class MetadataKeyStore[T]:
         value (or whatever default the caller chooses for missing
         keys). *write_sync* takes ``(config_dir, value)`` and
         atomically persists it. Both are sync (executor-bound).
+
+        *shutdown_register* is invoked exactly once during
+        construction with :meth:`async_save_now`; the caller's
+        lifecycle layer is then responsible for awaiting that
+        callback at graceful shutdown. The simplest valid value is
+        ``some_list.append`` — the lifecycle iterates the list and
+        ``await``s each entry. Required (not optional) so a store
+        can't be instantiated without telling someone who will
+        flush it; tests that don't care can pass ``lambda _cb:
+        None`` to opt out, but production paths should always wire
+        a real registry.
 
         Injection avoids importing ``controllers.config`` from a
         helper module — the ``controllers.config`` layer already
@@ -137,6 +184,13 @@ class MetadataKeyStore[T]:
         # awaits this before issuing its own final write so the two
         # don't interleave.
         self._inflight_write: asyncio.Task[None] | None = None
+        # Self-registration with the caller's lifecycle layer.
+        # Done last so a misbehaving registry that synchronously
+        # calls the callback (which would race a half-initialised
+        # ``self``) at least sees a fully-built object — it's
+        # legal but odd; production registries are list ``.append``
+        # which never invokes the callback at registration time.
+        shutdown_register(self.async_save_now)
 
     async def async_load(self) -> T:
         """Load the current value at this key from disk.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ select = [
 
 [tool.codespell]
 skip = "*.json,*/definitions/*"
-ignore-words-list = "commitish"
+ignore-words-list = "commitish,hass"
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/tests/test_helpers_metadata_store.py
+++ b/tests/test_helpers_metadata_store.py
@@ -233,7 +233,12 @@ async def test_async_save_now_awaits_inflight_write(tmp_path: Path) -> None:
 async def test_write_failure_logged_and_swallowed(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A write that raises is logged but doesn't crash the loop."""
+    """A write that raises is logged but doesn't crash the loop.
+
+    Also pins the diagnostic shape: the log line includes both
+    *name* and *config_dir* so production traces identify which
+    sub-key failed without the caller plumbing its own context.
+    """
 
     def _raising_write(_config_dir: Path, _value: object) -> None:
         msg = "boom"
@@ -248,6 +253,7 @@ async def test_write_failure_logged_and_swallowed(
         load_sync=_load,
         write_sync=_raising_write,
         shutdown_register=lambda _cb: None,
+        name="_pairings_test_key",
     )
 
     with caplog.at_level("ERROR"):
@@ -256,6 +262,38 @@ async def test_write_failure_logged_and_swallowed(
             lambda: any("Error writing metadata key" in r.message for r in caplog.records),
             timeout=1.0,
         )
+
+    matching = [r for r in caplog.records if "Error writing metadata key" in r.message]
+    assert matching, "expected error log line"
+    assert "_pairings_test_key" in matching[0].getMessage()
+    assert str(tmp_path) in matching[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_default_name_falls_back_to_config_dir(tmp_path: Path) -> None:
+    """Omitting *name* derives a stand-in from ``config_dir``.
+
+    Belt-and-braces so a caller that forgets to pass *name* still
+    gets *some* identifying string in error logs / asyncio task
+    names rather than a bare ``"metadata-store-write:None"``.
+    """
+
+    def _no_load(_config_dir: Path) -> object:  # pragma: no cover
+        msg = "load not used in this test"
+        raise AssertionError(msg)
+
+    def _noop_write(_config_dir: Path, _value: object) -> None:  # pragma: no cover
+        pass
+
+    store = MetadataKeyStore[object](
+        tmp_path,
+        load_sync=_no_load,
+        write_sync=_noop_write,
+        shutdown_register=lambda _cb: None,
+    )
+    # Internal but stable: the derived name embeds config_dir so a
+    # forgotten *name* still gives an operator a starting point.
+    assert str(tmp_path) in store._name
 
 
 @pytest.mark.asyncio

--- a/tests/test_helpers_metadata_store.py
+++ b/tests/test_helpers_metadata_store.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import asyncio
 import threading
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 
-from esphome_device_builder.helpers.metadata_store import MetadataKeyStore
+from esphome_device_builder.helpers.metadata_store import (
+    MetadataKeyStore,
+    ShutdownCallback,
+)
 
 
 @dataclass
@@ -19,10 +22,14 @@ class _FakeBackend:
 
     Records how many times the writer ran + the latest payload, so
     tests can assert debounce collapsing without touching disk.
+    Bundles the shutdown callback list so a test can both inspect
+    *that the store registered* and run the registered callbacks
+    to simulate the lifecycle layer's ``stop()`` behaviour.
     """
 
     config_dir: Path
     writes: list[object]
+    shutdown_callbacks: list[ShutdownCallback] = field(default_factory=list)
     initial_value: object | None = None
 
     def load(self, config_dir: Path) -> object:
@@ -33,6 +40,11 @@ class _FakeBackend:
         assert config_dir == self.config_dir
         self.writes.append(value)
 
+    async def run_shutdown_callbacks(self) -> None:
+        """Mimic the lifecycle layer awaiting every registered store."""
+        for cb in self.shutdown_callbacks:
+            await cb()
+
 
 @pytest.fixture
 def backend(tmp_path: Path) -> _FakeBackend:
@@ -42,7 +54,10 @@ def backend(tmp_path: Path) -> _FakeBackend:
 @pytest.fixture
 def store(backend: _FakeBackend) -> MetadataKeyStore[object]:
     return MetadataKeyStore[object](
-        backend.config_dir, load_sync=backend.load, write_sync=backend.write
+        backend.config_dir,
+        load_sync=backend.load,
+        write_sync=backend.write,
+        shutdown_register=backend.shutdown_callbacks.append,
     )
 
 
@@ -193,7 +208,12 @@ async def test_async_save_now_awaits_inflight_write(tmp_path: Path) -> None:
         msg = "load not used in this test"
         raise AssertionError(msg)
 
-    store = MetadataKeyStore[object](tmp_path, load_sync=_load, write_sync=_slow_write)
+    store = MetadataKeyStore[object](
+        tmp_path,
+        load_sync=_load,
+        write_sync=_slow_write,
+        shutdown_register=lambda _cb: None,
+    )
 
     store.async_delay_save(lambda: "first", delay=0.0)
     # Wait for the executor thread to enter the write.
@@ -223,7 +243,12 @@ async def test_write_failure_logged_and_swallowed(
         msg = "load not used in this test"
         raise AssertionError(msg)
 
-    store = MetadataKeyStore[object](tmp_path, load_sync=_load, write_sync=_raising_write)
+    store = MetadataKeyStore[object](
+        tmp_path,
+        load_sync=_load,
+        write_sync=_raising_write,
+        shutdown_register=lambda _cb: None,
+    )
 
     with caplog.at_level("ERROR"):
         store.async_delay_save(lambda: "x", delay=0.0)
@@ -267,7 +292,12 @@ async def test_load_sync_runs_in_executor(
         msg = "should not be called"
         raise AssertionError(msg)
 
-    store = MetadataKeyStore[str](tmp_path, load_sync=_slow_load, write_sync=_write)
+    store = MetadataKeyStore[str](
+        tmp_path,
+        load_sync=_slow_load,
+        write_sync=_write,
+        shutdown_register=lambda _cb: None,
+    )
     assert await store.async_load() == "loaded"
 
 
@@ -293,6 +323,79 @@ async def test_save_now_skips_when_no_pending_data_after_drain(
     await store.async_save_now()
     # Still only one write — the second flush had nothing to do.
     assert backend.writes == ["v"]
+
+
+@pytest.mark.asyncio
+async def test_constructor_registers_shutdown_callback(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """``shutdown_register`` is invoked exactly once at construction.
+
+    The registered callback is :meth:`async_save_now` itself —
+    awaiting it from the registry's flush loop drains any pending
+    debounced save without the caller having to thread a reference
+    to the store instance through the lifecycle layer.
+    """
+    assert len(backend.shutdown_callbacks) == 1
+    # The registered callback IS ``async_save_now``; awaiting it
+    # should drain a queued save just like a direct call.
+    store.async_delay_save(lambda: "via-shutdown", delay=10.0)
+    await backend.shutdown_callbacks[0]()
+    assert backend.writes == ["via-shutdown"]
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_walk_flushes_pending_saves_across_stores(
+    tmp_path: Path,
+) -> None:
+    """Multiple stores share one shutdown registry; the walker drains all of them.
+
+    Mirrors the production wiring where ``DeviceBuilder.stop()``
+    iterates a single registry list that every controller's stores
+    appended themselves to. A pending delayed save in any of them
+    must land before the lifecycle-layer's ``stop()`` returns.
+    """
+    callbacks: list[ShutdownCallback] = []
+
+    pairings_writes: list[object] = []
+    peers_writes: list[object] = []
+
+    def _no_load(_config_dir: Path) -> object:  # pragma: no cover
+        msg = "load not used in this test"
+        raise AssertionError(msg)
+
+    def _pairings_write(_config_dir: Path, value: object) -> None:
+        pairings_writes.append(value)
+
+    def _peers_write(_config_dir: Path, value: object) -> None:
+        peers_writes.append(value)
+
+    pairings = MetadataKeyStore[object](
+        tmp_path,
+        load_sync=_no_load,
+        write_sync=_pairings_write,
+        shutdown_register=callbacks.append,
+    )
+    peers = MetadataKeyStore[object](
+        tmp_path,
+        load_sync=_no_load,
+        write_sync=_peers_write,
+        shutdown_register=callbacks.append,
+    )
+
+    # Both stores have unflushed delayed saves with long deadlines.
+    pairings.async_delay_save(lambda: "pairings-final", delay=10.0)
+    peers.async_delay_save(lambda: "peers-final", delay=10.0)
+
+    assert pairings_writes == []
+    assert peers_writes == []
+
+    # Lifecycle-layer drain.
+    for cb in callbacks:
+        await cb()
+
+    assert pairings_writes == ["pairings-final"]
+    assert peers_writes == ["peers-final"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_helpers_metadata_store.py
+++ b/tests/test_helpers_metadata_store.py
@@ -1,0 +1,314 @@
+"""Tests for the debounced :mod:`helpers.metadata_store` writer."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.metadata_store import MetadataKeyStore
+
+
+@dataclass
+class _FakeBackend:
+    """In-memory stand-in for the metadata sidecar.
+
+    Records how many times the writer ran + the latest payload, so
+    tests can assert debounce collapsing without touching disk.
+    """
+
+    config_dir: Path
+    writes: list[object]
+    initial_value: object | None = None
+
+    def load(self, config_dir: Path) -> object:
+        assert config_dir == self.config_dir
+        return self.initial_value
+
+    def write(self, config_dir: Path, value: object) -> None:
+        assert config_dir == self.config_dir
+        self.writes.append(value)
+
+
+@pytest.fixture
+def backend(tmp_path: Path) -> _FakeBackend:
+    return _FakeBackend(config_dir=tmp_path, writes=[])
+
+
+@pytest.fixture
+def store(backend: _FakeBackend) -> MetadataKeyStore[object]:
+    return MetadataKeyStore[object](
+        backend.config_dir, load_sync=backend.load, write_sync=backend.write
+    )
+
+
+async def _drain_loop_until(predicate: Callable[[], bool], timeout: float = 1.0) -> None:
+    """Yield to the loop until *predicate()* is true or *timeout* elapses."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    msg = f"timed out waiting for predicate after {timeout}s"
+    raise AssertionError(msg)
+
+
+@pytest.mark.asyncio
+async def test_async_load_returns_initial_value(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """``async_load`` hops to the executor + returns the loader's output."""
+    backend.initial_value = {"pairings": [1, 2, 3]}
+    result = await store.async_load()
+    assert result == {"pairings": [1, 2, 3]}
+
+
+@pytest.mark.asyncio
+async def test_async_delay_save_writes_after_delay(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """A scheduled save lands after the delay elapses."""
+    store.async_delay_save(lambda: {"v": 1}, delay=0.05)
+    await _drain_loop_until(lambda: bool(backend.writes))
+    assert backend.writes == [{"v": 1}]
+
+
+@pytest.mark.asyncio
+async def test_async_delay_save_collapses_within_window(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """Multiple calls within the debounce window emit one write of the latest state.
+
+    ``data_func`` is called at flush time, not at scheduling time —
+    so the persisted value reflects the controller's in-RAM state at
+    flush, not whatever existed when the first call queued the
+    handle. This is the property that lets a controller call
+    ``async_delay_save`` cheaply on every mutation without worrying
+    about coalescing.
+    """
+    state = {"v": 0}
+
+    def _capture() -> dict[str, int]:
+        return dict(state)
+
+    store.async_delay_save(_capture, delay=0.1)
+    state["v"] = 1
+    store.async_delay_save(_capture, delay=0.1)
+    state["v"] = 2
+    store.async_delay_save(_capture, delay=0.1)
+
+    await _drain_loop_until(lambda: bool(backend.writes), timeout=2.0)
+    # Only one write, with the LATEST state.
+    assert backend.writes == [{"v": 2}]
+
+
+@pytest.mark.asyncio
+async def test_async_delay_save_extends_deadline_on_later_call(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """A later ``async_delay_save`` extends the deadline rather than firing earlier.
+
+    Mirrors HA's extend semantics: if a call requests a write
+    further in the future than the existing handle, the existing
+    handle still fires first but reschedules itself to the later
+    deadline. Net effect — the latest requested write time wins.
+    """
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+
+    store.async_delay_save(lambda: "early", delay=0.05)
+    # Same scheduling thread; second call extends.
+    store.async_delay_save(lambda: "late", delay=0.20)
+
+    await _drain_loop_until(lambda: bool(backend.writes), timeout=2.0)
+    elapsed = loop.time() - started
+    # We should NOT have written before the *later* deadline.
+    assert elapsed >= 0.18, f"wrote too early: {elapsed:.3f}s"
+    assert backend.writes == ["late"]
+
+
+@pytest.mark.asyncio
+async def test_async_delay_save_earlier_call_replaces_handle(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """A call requesting an earlier deadline cancels the existing handle."""
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    store.async_delay_save(lambda: "later", delay=0.50)
+    store.async_delay_save(lambda: "earlier", delay=0.05)
+
+    await _drain_loop_until(lambda: bool(backend.writes), timeout=1.0)
+    elapsed = loop.time() - started
+    assert elapsed < 0.45
+    assert backend.writes == ["earlier"]
+
+
+@pytest.mark.asyncio
+async def test_async_save_now_flushes_pending_save(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """``async_save_now`` cancels the timer + writes immediately."""
+    store.async_delay_save(lambda: "pending", delay=10.0)
+    assert backend.writes == []
+    await store.async_save_now()
+    assert backend.writes == ["pending"]
+
+
+@pytest.mark.asyncio
+async def test_async_save_now_is_noop_when_empty(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """Calling on an empty store is idempotent."""
+    await store.async_save_now()
+    await store.async_save_now()
+    assert backend.writes == []
+
+
+@pytest.mark.asyncio
+async def test_async_save_now_awaits_inflight_write(tmp_path: Path) -> None:
+    """Concurrent in-flight write completes before the final flush issues.
+
+    Race: the delayed-handler-driven write is mid-executor when
+    ``async_save_now`` runs. Without the await, both writes would
+    race on the lock and the final flush could observe ``data_func
+    is None`` and silently no-op, dropping a mutation queued AFTER
+    the in-flight write. ``threading.Event`` (not ``asyncio.Event``)
+    because the writer runs in a real executor thread.
+    """
+    seen: list[str] = []
+    write_started = threading.Event()
+    release_write = threading.Event()
+
+    def _slow_write(_config_dir: Path, value: object) -> None:
+        seen.append(str(value))
+        write_started.set()
+        release_write.wait(timeout=2.0)
+
+    def _load(_config_dir: Path) -> object:  # pragma: no cover
+        msg = "load not used in this test"
+        raise AssertionError(msg)
+
+    store = MetadataKeyStore[object](tmp_path, load_sync=_load, write_sync=_slow_write)
+
+    store.async_delay_save(lambda: "first", delay=0.0)
+    # Wait for the executor thread to enter the write.
+    await asyncio.get_running_loop().run_in_executor(None, write_started.wait, 2.0)
+    # Queue a follow-up that should land AFTER the in-flight write.
+    store.async_delay_save(lambda: "second", delay=10.0)
+    flush_task = asyncio.create_task(store.async_save_now())
+    # Give the flush task a chance to await the in-flight write.
+    await asyncio.sleep(0.05)
+    release_write.set()
+    await flush_task
+
+    assert seen == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_write_failure_logged_and_swallowed(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A write that raises is logged but doesn't crash the loop."""
+
+    def _raising_write(_config_dir: Path, _value: object) -> None:
+        msg = "boom"
+        raise OSError(msg)
+
+    def _load(_config_dir: Path) -> object:  # pragma: no cover
+        msg = "load not used in this test"
+        raise AssertionError(msg)
+
+    store = MetadataKeyStore[object](tmp_path, load_sync=_load, write_sync=_raising_write)
+
+    with caplog.at_level("ERROR"):
+        store.async_delay_save(lambda: "x", delay=0.0)
+        await _drain_loop_until(
+            lambda: any("Error writing metadata key" in r.message for r in caplog.records),
+            timeout=1.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_data_func_called_at_flush_not_scheduling(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """``data_func`` is invoked at flush, capturing post-schedule mutations."""
+    state = {"counter": 0}
+
+    def _read() -> dict[str, int]:
+        # Reads at flush time. If we read at scheduling time the
+        # write would land with counter=0.
+        return dict(state)
+
+    store.async_delay_save(_read, delay=0.05)
+    state["counter"] = 99
+    await _drain_loop_until(lambda: bool(backend.writes), timeout=1.0)
+    assert backend.writes == [{"counter": 99}]
+
+
+@pytest.mark.asyncio
+async def test_load_sync_runs_in_executor(
+    tmp_path: Path,
+) -> None:
+    """``async_load`` doesn't block the event loop on the loader."""
+
+    def _slow_load(config_dir: Path) -> str:
+        # Sentinel for "ran on a thread" — pure-sync function;
+        # ``run_in_executor`` is what makes this safe.
+        assert config_dir == tmp_path
+        return "loaded"
+
+    def _write(_config_dir: Path, _value: object) -> None:  # pragma: no cover
+        msg = "should not be called"
+        raise AssertionError(msg)
+
+    store = MetadataKeyStore[str](tmp_path, load_sync=_slow_load, write_sync=_write)
+    assert await store.async_load() == "loaded"
+
+
+@pytest.mark.asyncio
+async def test_extend_then_save_now_picks_up_latest(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """A flush after multiple extending calls writes the latest state once."""
+    store.async_delay_save(lambda: "a", delay=10.0)
+    store.async_delay_save(lambda: "b", delay=10.0)
+    store.async_delay_save(lambda: "c", delay=10.0)
+    await store.async_save_now()
+    assert backend.writes == ["c"]
+
+
+@pytest.mark.asyncio
+async def test_save_now_skips_when_no_pending_data_after_drain(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """If a save already drained the data, a follow-up flush is a no-op."""
+    store.async_delay_save(lambda: "v", delay=0.0)
+    await _drain_loop_until(lambda: bool(backend.writes), timeout=1.0)
+    await store.async_save_now()
+    # Still only one write — the second flush had nothing to do.
+    assert backend.writes == ["v"]
+
+
+@pytest.mark.asyncio
+async def test_handle_write_returns_early_when_data_func_already_drained(
+    backend: _FakeBackend, store: MetadataKeyStore[object]
+) -> None:
+    """Direct ``_async_handle_write`` call with no captured data is a no-op.
+
+    The early-return is defense-in-depth against a concurrent
+    flush draining the data_func between handle-schedule and the
+    write task entering its critical section. Production paths
+    don't hit it under normal scheduling, but the branch matters
+    if a future caller composes the helper differently (a manual
+    ``_async_handle_write`` after a successful ``async_save_now``).
+    """
+    # Pre-condition: nothing scheduled, no captured func.
+    assert store._data_func is None
+    await store._async_handle_write()
+    assert backend.writes == []


### PR DESCRIPTION
# What does this implement/fix?

Vendors a small `helpers/metadata_store.MetadataKeyStore` modelled on
Home Assistant's `homeassistant.helpers.storage.Store` for the
"all state in RAM, write debounced to disk" pattern. The intent is
to land the helper first so the upcoming receiver / offloader
pairings RAM-only refactors can build on a reviewed primitive (and
so a future audit can flip `_devices`, `_labels`, `_prefs`, etc. onto
it incrementally). No consumers wired up in this PR; `MetadataKeyStore`
imports cleanly and ships at 100% coverage.

The store doesn't reach into our shared metadata sidecar directly —
callers inject `load_sync` / `write_sync` so the heavy lifting
stays in `controllers.config` (which already owns the lock + atomic
write).

Drops every HA dep we don't need: bus events
(`EVENT_HOMEASSISTANT_FINAL_WRITE`), `_StoreManager` preload cache,
version migration, `_load_future` reentrancy guard. Keeps the parts
that earn complexity:

* **Debounce + extend semantics matching HA bit-for-bit** — calls
  during an open delay window update the latest deadline; the timer
  reschedules itself when it wakes early.
* **Lock-protected single-flight writes** so a `stop()`-triggered
  final flush can't race a delayed-handler-driven write.
* **`data_func` captured at every schedule, invoked at flush time**,
  so the persisted snapshot reflects the controller's latest
  in-RAM state instead of stale data from when the first call
  queued the handle.

Adds `hass` to the codespell ignore list (the docstring references
HA's storage module by path).

**Related issue or feature (if applicable):**

- Prep for the offloader-side pairings RAM-only refactor; consumer
  PR follows once this lands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
