### PR TITLE
Cap pytest CI step at 5 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,6 +156,11 @@ jobs:
         # The ``benchmarks/`` subtree is excluded — it's CodSpeed-driven,
         # runs in a separate job, and its assertions only check chunk
         # counts (not behaviour).
+        # ``timeout-minutes: 5`` caps the suite — healthy runs land at
+        # ~1-2 minutes, so anything past 5 is a hang (a bad fixture, a
+        # deadlocked async wait, an upstream regression). Without the
+        # cap a single hung test burns the runner's full 6h budget.
+        timeout-minutes: 5
         run: pytest -q -n auto --maxfail=5 --durations=10 --ignore=tests/benchmarks --cov=esphome_device_builder --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
@@ -234,7 +239,10 @@ jobs:
         # the OS-axis matrix gets. No ``--cov`` here — the merged
         # coverage report comes from the OS-axis ``test`` job; this
         # run is purely a "does the suite still pass against
-        # upstream X" probe.
+        # upstream X" probe. ``timeout-minutes: 5`` matches the
+        # OS-axis cap — hangs against upstream beta/dev are exactly
+        # the case this protects against.
+        timeout-minutes: 5
         run: pytest -q -n auto --maxfail=5 --durations=10 --ignore=tests/benchmarks
 
   benchmarks:


### PR DESCRIPTION
# What does this implement/fix?

Caps the `Run pytest` step at `timeout-minutes: 5` in both CI test jobs (the OS-axis `test` matrix and `test-esphome-channels`). Without a step-level cap, a single hung worker can burn the runner's full 6h budget.

Triggered by [run 25612583057 on PR #507](https://github.com/esphome/device-builder/actions/runs/25612583057/job/75185169962?pr=507): the beta-channel pytest job hung for 1h5m49s while every other matrix entry finished in 1-2 minutes. Healthy runs are well under 5 minutes, so the cap doesn't squeeze normal CI; anything past it is a hang signal (deadlocked async wait, bad fixture, upstream regression) we want to fail loudly and quickly.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
