### PR TITLE
Add pytest-timeout=2m as the inner CI hang signal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,12 +156,17 @@ jobs:
         # The ``benchmarks/`` subtree is excluded — it's CodSpeed-driven,
         # runs in a separate job, and its assertions only check chunk
         # counts (not behaviour).
-        # ``timeout-minutes: 5`` caps the suite — healthy runs land at
-        # ~1-2 minutes, so anything past 5 is a hang (a bad fixture, a
-        # deadlocked async wait, an upstream regression). Without the
-        # cap a single hung test burns the runner's full 6h budget.
+        # Two-layer hang protection:
+        # * ``--timeout=120`` (pytest-timeout plugin) faults any
+        #   individual test that wedges for more than 2 minutes,
+        #   surfacing the offending test name + traceback in the log.
+        # * ``timeout-minutes: 5`` is the outer hard cap — if the
+        #   plugin can't recover (deadlocked event loop, stuck
+        #   subprocess), the runner kills the step. Healthy runs land
+        #   at ~1-2 minutes; without the cap a single hung worker
+        #   burns the runner's full 6h budget.
         timeout-minutes: 5
-        run: pytest -q -n auto --maxfail=5 --durations=10 --ignore=tests/benchmarks --cov=esphome_device_builder --cov-report=xml --cov-report=term
+        run: pytest -q -n auto --maxfail=5 --durations=10 --timeout=120 --ignore=tests/benchmarks --cov=esphome_device_builder --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
@@ -239,11 +244,12 @@ jobs:
         # the OS-axis matrix gets. No ``--cov`` here — the merged
         # coverage report comes from the OS-axis ``test`` job; this
         # run is purely a "does the suite still pass against
-        # upstream X" probe. ``timeout-minutes: 5`` matches the
-        # OS-axis cap — hangs against upstream beta/dev are exactly
-        # the case this protects against.
+        # upstream X" probe. ``--timeout=120`` (per-test) +
+        # ``timeout-minutes: 5`` (outer hard cap) match the OS-axis
+        # job — hangs against upstream beta/dev are exactly the case
+        # this protects against.
         timeout-minutes: 5
-        run: pytest -q -n auto --maxfail=5 --durations=10 --ignore=tests/benchmarks
+        run: pytest -q -n auto --maxfail=5 --durations=10 --timeout=120 --ignore=tests/benchmarks
 
   benchmarks:
     name: Run benchmarks (CodSpeed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test = [
   "pytest-aiohttp==1.1.0",
   "pytest-codspeed==4.5.0",
   "pytest-cov==7.1.0",
+  "pytest-timeout==2.4.0",
   "pytest-xdist==3.8.0",
   "ruff==0.15.12",
   "types-PyYAML",


### PR DESCRIPTION
# What does this implement/fix?

Layers a per-test timeout under the existing `timeout-minutes: 5` step cap that landed in #510. Two-layer hang protection:

* **Inner — `pytest-timeout` plugin, `--timeout=120`.** Faults any individual test that wedges for more than 2 minutes and prints its name + traceback to the log. Lets a hang surface as "this specific test hung" instead of "pytest exited with no output".
* **Outer — `timeout-minutes: 5` (unchanged from #510).** Hard cap if the plugin can't recover (deadlocked event loop, stuck subprocess that swallows the signal).

120s is well above the slowest individual test in the suite (a few seconds) and well under the 5m outer cap, so it has room to fault and print before the runner kills the step.

`pytest-timeout==2.4.0` added to the `[test]` extra; `--timeout=120` wired into both pytest invocations (OS-axis `test` job + `test-esphome-channels`).

**Related issue or feature (if applicable):**

- Follow-up to #510.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
