### PR TITLE
remote-build: stop listener finally from orphaning replacement

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1549,9 +1549,16 @@ class RemoteBuildController:
                 # spam logs in a tight reconnect loop.
                 await asyncio.sleep(_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS)
         finally:
-            self._pair_status_listeners.pop(
-                (pairing.receiver_hostname, pairing.receiver_port), None
-            )
+            # Only clear the slot if it still points at this task.
+            # On a re-pair, ``_cancel_pair_status_listener`` has
+            # already popped this task and ``_spawn_pair_status_listener``
+            # has put the replacement in the slot — blindly
+            # ``pop()``-ing here would evict the replacement and
+            # orphan it (no entry left for ``unpair`` to cancel,
+            # the new listener parks forever).
+            key = (pairing.receiver_hostname, pairing.receiver_port)
+            if self._pair_status_listeners.get(key) is asyncio.current_task():
+                del self._pair_status_listeners[key]
 
     async def _apply_pair_status_result(
         self, pairing: StoredPairing, result: PairStatusResult

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -1327,21 +1327,25 @@ async def test_request_pair_repair_then_unpair_clean_state(
         _fake_request_pair,
     )
 
-    # The spawned ``_await_pair_status_flip`` listener calls the
-    # real ``peer_link_await_pair_status`` + ``_load_offloader_identities``
-    # otherwise — that hits real DNS for ``rcv.local`` and parks
-    # the cancellation behind a thread-pool ``getaddrinfo`` until
-    # the OS resolver times out (5-30s on macOS mDNS, longer on
-    # CI). Park the listener on an asyncio.Event instead so the
-    # cancel-then-await calls below are deterministic.
+    # The spawned ``_await_pair_status_flip`` listener would
+    # otherwise call the real ``peer_link_await_pair_status`` +
+    # ``_load_offloader_identities`` — hitting real DNS for
+    # ``rcv.local``. Park each listener on an ``asyncio.Event``
+    # via the fake instead, and signal back when each listener
+    # has actually reached the parked state — the test below
+    # uses that signal to force the precise race that previously
+    # orphaned ``listener_v2``.
     park = asyncio.Event()
+    parked_signals: list[asyncio.Event] = [asyncio.Event(), asyncio.Event()]
+    park_call_index = 0
 
     async def _fake_await_pair_status(
         **_: object,
     ) -> remote_build_peer_link_client.PairStatusResult:
-        # Parks indefinitely; the test only exercises the
-        # cancel-on-respawn / cancel-on-unpair paths, so the
-        # listener never needs to return a real result.
+        nonlocal park_call_index
+        if park_call_index < len(parked_signals):
+            parked_signals[park_call_index].set()
+        park_call_index += 1
         await park.wait()
         raise AssertionError("park event should never be set in this test")
 
@@ -1367,6 +1371,20 @@ async def test_request_pair_repair_then_unpair_clean_state(
         offloader_label="off",
     )
     listener_v1 = offloader._pair_status_listeners[("rcv.local", 6055)]
+
+    # Wait until ``listener_v1`` has actually reached its
+    # ``await peer_link_await_pair_status`` parked state.
+    # Without this barrier the second ``request_pair`` below
+    # often cancels ``listener_v1`` while it's still at its
+    # initial ``run_in_executor`` await — so the cancel raises
+    # before the body's ``try`` block, ``listener_v1``'s
+    # ``finally`` never runs, and the orphan-listener bug
+    # (``listener_v1``'s ``finally`` evicting ``listener_v2``
+    # from ``_pair_status_listeners``) is masked. This was the
+    # exact CI/local divergence behind the original flake — the
+    # bug only fires when ``listener_v1`` advances past the
+    # critical section before being cancelled.
+    await parked_signals[0].wait()
 
     # Re-pair with pin2 — listener_v1 must be cancelled, listener_v2 spawned.
     await offloader.request_pair(

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -1327,6 +1327,37 @@ async def test_request_pair_repair_then_unpair_clean_state(
         _fake_request_pair,
     )
 
+    # The spawned ``_await_pair_status_flip`` listener calls the
+    # real ``peer_link_await_pair_status`` + ``_load_offloader_identities``
+    # otherwise — that hits real DNS for ``rcv.local`` and parks
+    # the cancellation behind a thread-pool ``getaddrinfo`` until
+    # the OS resolver times out (5-30s on macOS mDNS, longer on
+    # CI). Park the listener on an asyncio.Event instead so the
+    # cancel-then-await calls below are deterministic.
+    park = asyncio.Event()
+
+    async def _fake_await_pair_status(
+        **_: object,
+    ) -> remote_build_peer_link_client.PairStatusResult:
+        # Parks indefinitely; the test only exercises the
+        # cancel-on-respawn / cancel-on-unpair paths, so the
+        # listener never needs to return a real result.
+        await park.wait()
+        raise AssertionError("park event should never be set in this test")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.peer_link_await_pair_status",
+        _fake_await_pair_status,
+    )
+    fake_identity = MagicMock()
+    fake_identity.private_bytes = b"\x00" * 32
+    fake_dashboard = MagicMock()
+    fake_dashboard.dashboard_id = "dashboard-stub"
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build._load_offloader_identities",
+        lambda _config_dir: (fake_identity, fake_dashboard),
+    )
+
     # First pair lands PENDING with pin1.
     await offloader.request_pair(
         hostname="rcv.local",


### PR DESCRIPTION
# What does this implement/fix?

`tests/test_remote_build_peer_link_client.py::test_request_pair_repair_then_unpair_clean_state` was failing under pytest-timeout (added in #511, which surfaced the previously-silent hang). The first push on this PR thought the bug was real-DNS-from-the-spawned-listener and fixed it via test patches; that was wrong — the test still hung in CI on Linux + Python 3.14 + non-stable esphome with no DNS in the trace, just `selector.select(timeout=-1)` and an idle event loop. The patches were necessary to make the test fast and deterministic, but they masked the actual lifecycle race in the controller.

## Root cause

The orphan-listener race in `RemoteBuildController._await_pair_status_flip`'s `finally` clause:

1. `request_pair` #1 spawns `listener_v1`; dict slot for `(host, port)` holds v1.
2. `listener_v1` advances to its parked `await peer_link_await_pair_status`.
3. `request_pair` #2 runs `_cancel_pair_status_listener` (pops v1, calls `cancel`) then `_spawn_pair_status_listener` — dict slot now holds v2.
4. Test awaits `listener_v1`; the loop wakes v1 with `CancelledError` at the parked await. v1 enters its `finally`, which **unconditionally** popped `dict[(host, port)]` — but the slot now holds v2. v2 is silently evicted from the listener registry.
5. `unpair` calls `_cancel_pair_status_listener` — dict empty, no-op. v2 is orphaned, still parked. `await listener_v2` hangs forever (wedged loop, `selector.select(timeout=-1)`, no scheduled work — exactly what the failing pytest-timeout dump showed).

Locally the bug was masked because v1 typically gets cancelled while still parked at `run_in_executor` (its initial identity load), so the cancel raises *before* the body's `try` block — v1's `finally` never runs and never evicts v2. On Linux + Python 3.14 + beta/dev esphome the scheduling order was different: v1 had time to advance to `peer_link_await_pair_status` before being cancelled, the `finally` fired, the eviction happened, the test hung.

## Fix

`finally` now only clears the dict slot if it still points at the current task — `asyncio.current_task()` compared against the stored task is the canonical "am I still the registered listener for this key" check. Successor v2 stays in the registry, `unpair` cancels it cleanly, no orphan.

## Test

Forced the race deterministically. The fake `peer_link_await_pair_status` now sets a per-call `asyncio.Event` when it parks; the test waits on the first such event before the second `request_pair` so v1 is guaranteed to be inside the critical section when cancellation arrives. Verified that the test deterministically hangs without the controller fix (8s timeout fires) and passes in 0.04s with it. Full `tests/test_remote_build_*` suite (184 tests) is green locally.

**Related issue or feature (if applicable):**

- Surfaces under #511's pytest-timeout (the hang was previously invisible).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
