### PR TITLE
Live-rebind remote-build listener on set_settings toggle

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1051,13 +1051,14 @@ class RemoteBuildController:
         the opposite of what the user intended on a security-
         sensitive toggle.
 
-        **Listener bind requires restart.** The peer-link Noise WS
-        listener is bound once in :meth:`DeviceBuilder.start` based
-        on the value at startup; flipping ``enabled`` here persists
-        the new value but does NOT live-rebind. The frontend should
-        surface a "restart required" hint to the operator. A future
-        PR can wire ``set_settings`` into the lifecycle hooks if
-        interactive toggling becomes a real UX concern.
+        Live-rebinds the peer-link Noise WS listener after the
+        write lands: a flip to ``True`` runs the same bind path
+        :meth:`DeviceBuilder._maybe_start_remote_build_site` does
+        at startup; a flip to ``False`` tears down the runner and
+        clears the mDNS pin/port advertise. Fail-soft on bind error
+        — the dashboard keeps running without a listener and a
+        subsequent ``set_settings`` retry can clear a transient
+        port conflict without a restart.
         """
         if not isinstance(enabled, bool):
             msg = "remote_build/set_settings: 'enabled' must be a boolean"
@@ -1066,7 +1067,9 @@ class RemoteBuildController:
         def _set(settings: RemoteBuildSettings) -> None:
             settings.enabled = enabled
 
-        return await self._modify_settings(_set)
+        view = await self._modify_settings(_set)
+        await self._db.apply_remote_build_enabled()
+        return view
 
     # ------------------------------------------------------------------
     # Manual hosts (phase 2b)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -260,6 +260,13 @@ class DeviceBuilder:
         # Bound only when ``RemoteBuildSettings.enabled`` is true;
         # ``None`` otherwise.
         self._remote_build_runner: web.AppRunner | None = None
+        # Serialises listener-state mutations so two clients
+        # toggling ``set_settings`` (or a ``rotate_identity``
+        # racing a toggle) can't interleave their teardown +
+        # rebind sequences. Lazy-init at first acquire so the
+        # lock binds to the running event loop, not the loop
+        # that ran ``__init__``.
+        self._remote_build_lifecycle_lock: asyncio.Lock | None = None
 
     def _install_default_executor(self) -> None:
         """Register the dashboard's executor as the loop's default.
@@ -814,6 +821,75 @@ class DeviceBuilder:
         """True iff the remote-build peer-link Noise WS listener is currently bound."""
         return self._remote_build_runner is not None
 
+    def _get_remote_build_lifecycle_lock(self) -> asyncio.Lock:
+        """Lazy-init the lock against the running loop on first acquire."""
+        if self._remote_build_lifecycle_lock is None:
+            self._remote_build_lifecycle_lock = asyncio.Lock()
+        return self._remote_build_lifecycle_lock
+
+    async def _teardown_remote_build_runner(self) -> None:
+        """
+        Stop the bound peer-link listener and clear its mDNS advertise.
+
+        Caller MUST hold :attr:`_remote_build_lifecycle_lock`. No-op
+        when the listener isn't bound. Sequencing matters: the
+        runner reference is cleared *before* awaiting cleanup so a
+        concurrent listener-state observer sees the steady "absent"
+        state from the moment we commit to teardown, and the mDNS
+        clear runs *after* cleanup so peers re-browsing during the
+        window get a TXT without ``pin_sha256`` / ``remote_build_port``
+        the moment the port stops serving traffic.
+        """
+        if self._remote_build_runner is None:
+            return
+        old_runner = self._remote_build_runner
+        self._remote_build_runner = None
+        with contextlib.suppress(Exception):
+            await old_runner.cleanup()
+        await self._publish_remote_build_advertise(
+            pin_sha256=None,
+            remote_build_port=None,
+        )
+
+    async def apply_remote_build_enabled(self) -> bool:
+        """
+        Converge the peer-link listener to the on-disk ``enabled`` flag.
+
+        Called by ``RemoteBuildController.set_settings`` after the
+        new ``enabled`` value lands on disk. Reads back from disk
+        under :attr:`_remote_build_lifecycle_lock` so the
+        last-writer-wins persisted value is always what the
+        listener converges to — two clients flipping ``enabled``
+        concurrently can't desync disk from listener state.
+
+        On disk ``enabled=True`` with the listener absent, runs the
+        same path :meth:`_maybe_start_remote_build_site` does at
+        startup (load X25519 peer-link identity, bind plain-TCP
+        TCPSite, push pin + port to mDNS). Fail-soft on bind error
+        — the dashboard keeps running without a listener, and a
+        subsequent ``set_settings`` retry can clear a transient
+        port conflict without a restart.
+
+        On disk ``enabled=False`` with the listener bound, tears
+        down the runner and clears ``pin_sha256`` + ``remote_build_port``
+        from mDNS via :meth:`_teardown_remote_build_runner`.
+
+        Returns whether the listener is bound after this call.
+        """
+        if self.loop is None:
+            return self._remote_build_runner is not None
+        loop = self.loop
+        async with self._get_remote_build_lifecycle_lock():
+            rb_settings = await loop.run_in_executor(
+                None, load_remote_build_settings, self.settings.config_dir
+            )
+            if rb_settings.enabled:
+                if self._remote_build_runner is None:
+                    await self._maybe_start_remote_build_site()
+            else:
+                await self._teardown_remote_build_runner()
+            return self._remote_build_runner is not None
+
     async def reload_remote_build_identity(self, *, pin_sha256: str) -> bool:
         """
         Rebuild the peer-link listener after a TLS cert rotation.
@@ -875,24 +951,18 @@ class DeviceBuilder:
         with).
         """
         del pin_sha256  # currently unused on this side; see docstring
-        if self._remote_build_runner is None:
-            return False
-
-        old_runner = self._remote_build_runner
-        self._remote_build_runner = None
-        with contextlib.suppress(Exception):
-            await old_runner.cleanup()
-        # Clear the advertiser so peers re-browsing during the
-        # rebuild window — or after a rebuild failure — don't
-        # see stale pin + port pointing at a listener that
-        # isn't there. ``_maybe_start_remote_build_site``
-        # re-pushes both on a successful rebuild.
-        await self._publish_remote_build_advertise(
-            pin_sha256=None,
-            remote_build_port=None,
-        )
-        await self._maybe_start_remote_build_site()
-        return self._remote_build_runner is not None
+        async with self._get_remote_build_lifecycle_lock():
+            if self._remote_build_runner is None:
+                return False
+            # ``_teardown_remote_build_runner`` clears the advertise
+            # too, so peers re-browsing during the rebuild window —
+            # or after a rebuild failure — don't see stale pin +
+            # port pointing at a listener that isn't there.
+            # ``_maybe_start_remote_build_site`` re-pushes both on
+            # a successful rebuild.
+            await self._teardown_remote_build_runner()
+            await self._maybe_start_remote_build_site()
+            return self._remote_build_runner is not None
 
     async def _build_and_start_remote_build_runner(
         self,

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -410,10 +410,18 @@ class DeviceBuilder:
         # matters less here than for zeroconf, but doing it
         # first keeps the listener from servicing a request
         # that hits a torn-down controller mid-shutdown.
-        if self._remote_build_runner is not None:
-            with contextlib.suppress(Exception):
-                await self._remote_build_runner.cleanup()
-            self._remote_build_runner = None
+        # Acquire ``_remote_build_lifecycle_lock`` so a
+        # concurrent ``apply_remote_build_enabled`` /
+        # ``reload_remote_build_identity`` can't interleave its
+        # rebind with this teardown — without the lock, an
+        # in-flight toggle could land a fresh runner *after*
+        # ``stop()`` has cleared the slot, leaking a listener
+        # past shutdown.
+        async with self._get_remote_build_lifecycle_lock():
+            if self._remote_build_runner is not None:
+                with contextlib.suppress(Exception):
+                    await self._remote_build_runner.cleanup()
+                self._remote_build_runner = None
         # Cancel the remote-build browser BEFORE devices.stop()
         # closes the zeroconf socket the browser is using. Same
         # ordering rule as the dashboard advertise just below.

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -103,6 +103,10 @@ def _make_controller(*, config_dir: Path, real_bus: bool = False) -> RemoteBuild
     # downstream; an explicit signature beats the silent failure
     # mode.
     db.settings.config_dir = config_dir
+    # ``set_settings`` calls ``apply_remote_build_enabled`` to
+    # live-rebind the listener; in-process tests don't exercise
+    # the bind path so a no-op AsyncMock is sufficient.
+    db.apply_remote_build_enabled = AsyncMock(return_value=False)
     if real_bus:
         # Long-poll tests for ``lookup_peer_for_status`` exercise the
         # bus.listening machinery for real (a MagicMock bus would

--- a/tests/test_remote_build_listener.py
+++ b/tests/test_remote_build_listener.py
@@ -29,6 +29,7 @@ from esphome_device_builder.controllers.config import (
     DashboardSettings,
     remote_build_settings_transaction,
 )
+from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.device_builder import (
     DeviceBuilder,
     _strip_server_header_middleware,
@@ -37,6 +38,7 @@ from esphome_device_builder.helpers.dashboard_identity import (
     get_or_create_identity,
     rotate_certificate,
 )
+from esphome_device_builder.helpers.event_bus import EventBus
 
 
 @pytest.mark.asyncio
@@ -481,3 +483,161 @@ async def test_reload_remote_build_identity_advertiser_refresh_failure_is_swallo
     advertiser.set_pin_sha256.assert_called_once_with(None)
     advertiser.set_remote_build_port.assert_called_once_with(None)
     assert listener_bound is False
+
+
+# ---------------------------------------------------------------------------
+# Live-toggle: ``RemoteBuildController.set_settings`` calls
+# ``DeviceBuilder.apply_remote_build_enabled`` after persisting, so
+# flipping ``enabled`` doesn't require a dashboard restart.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_remote_build_enabled_binds_when_disk_says_true(tmp_path: Path) -> None:
+    """Convergence: disk ``enabled=True`` + listener absent → bind."""
+    loop = asyncio.get_running_loop()
+
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = True
+
+    await loop.run_in_executor(None, _enable)
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build = MagicMock()
+    db.remote_build._db.settings.config_dir = tmp_path
+
+    try:
+        bound = await db.apply_remote_build_enabled()
+        assert bound is True
+        assert db._remote_build_runner is not None
+    finally:
+        if db._remote_build_runner is not None:
+            await db._remote_build_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_apply_remote_build_enabled_tears_down_when_disk_says_false(
+    tmp_path: Path,
+) -> None:
+    """Convergence: disk ``enabled=False`` + listener bound → teardown + advertiser clear."""
+    settings = DashboardSettings(config_dir=tmp_path)
+    db = DeviceBuilder(settings)
+    db.loop = asyncio.get_running_loop()
+
+    advertiser = MagicMock()
+    advertiser.refresh = AsyncMock()
+    db._dashboard_advertiser = advertiser
+
+    # Fake a bound runner without standing up a real socket.
+    old_runner = MagicMock()
+    old_runner.cleanup = AsyncMock()
+    db._remote_build_runner = old_runner
+
+    advertiser.unregister = AsyncMock()
+
+    bound = await db.apply_remote_build_enabled()
+
+    assert bound is False
+    assert db._remote_build_runner is None
+    old_runner.cleanup.assert_awaited_once()
+    # mDNS pin + port both cleared so peers re-browsing don't try
+    # to connect to a port that's no longer serving traffic.
+    advertiser.set_pin_sha256.assert_called_once_with(None)
+    advertiser.set_remote_build_port.assert_called_once_with(None)
+    # Pin the "TXT update, not unregister" contract — peer caches
+    # mustn't see the dashboard service disappear and reappear
+    # when we just want to drop pin/port from the TXT.
+    advertiser.refresh.assert_awaited_once()
+    advertiser.unregister.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_remote_build_enabled_idempotent_when_already_off(tmp_path: Path) -> None:
+    """Disk ``enabled=False`` + listener absent → no-op (no advertiser touch)."""
+    settings = DashboardSettings(config_dir=tmp_path)
+    db = DeviceBuilder(settings)
+    db.loop = asyncio.get_running_loop()
+    advertiser = MagicMock()
+    advertiser.refresh = AsyncMock()
+    db._dashboard_advertiser = advertiser
+    db._remote_build_runner = None
+
+    bound = await db.apply_remote_build_enabled()
+
+    assert bound is False
+    assert db._remote_build_runner is None
+    advertiser.set_pin_sha256.assert_not_called()
+    advertiser.set_remote_build_port.assert_not_called()
+    advertiser.refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_remote_build_enabled_idempotent_when_already_on(tmp_path: Path) -> None:
+    """Disk ``enabled=True`` + listener bound → no-op (no rebind, no advertiser churn)."""
+    loop = asyncio.get_running_loop()
+
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = True
+
+    await loop.run_in_executor(None, _enable)
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build = MagicMock()
+    db.remote_build._db.settings.config_dir = tmp_path
+
+    try:
+        await db._maybe_start_remote_build_site()
+        original_runner = db._remote_build_runner
+        assert original_runner is not None
+
+        bound = await db.apply_remote_build_enabled()
+
+        assert bound is True
+        # No rebind — the same runner instance is still serving.
+        assert db._remote_build_runner is original_runner
+    finally:
+        if db._remote_build_runner is not None:
+            await db._remote_build_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_set_settings_live_rebinds_listener(tmp_path: Path) -> None:
+    """End-to-end: ``set_settings(enabled=True)`` flips disk + binds the listener."""
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0
+    db = DeviceBuilder(settings)
+    db.loop = asyncio.get_running_loop()
+    db.bus = EventBus()
+    # ``RemoteBuildController.__init__`` builds a per-file Store
+    # under ``config_dir / .offloader_pairings.json``; needs a
+    # real Path (tmp_path is fine).
+    db.remote_build = None  # not needed — controller doesn't read it
+    controller = RemoteBuildController(db)
+    db.remote_build = controller
+    # Wire the controller's mDNS-advertiser hook to a no-op.
+    db._dashboard_advertiser = None
+
+    try:
+        view = await controller.set_settings(enabled=True)
+        assert view.enabled is True
+        # Listener bound as a side effect of set_settings.
+        assert db._remote_build_runner is not None
+
+        view = await controller.set_settings(enabled=False)
+        assert view.enabled is False
+        # Listener torn down as a side effect.
+        assert db._remote_build_runner is None
+    finally:
+        if db._remote_build_runner is not None:
+            await db._remote_build_runner.cleanup()

--- a/tests/test_remote_build_listener.py
+++ b/tests/test_remote_build_listener.py
@@ -557,6 +557,22 @@ async def test_apply_remote_build_enabled_tears_down_when_disk_says_false(
 
 
 @pytest.mark.asyncio
+async def test_apply_remote_build_enabled_no_op_before_loop_set(tmp_path: Path) -> None:
+    """No-op when the dashboard hasn't finished startup yet (``loop is None``)."""
+    settings = DashboardSettings(config_dir=tmp_path)
+    db = DeviceBuilder(settings)
+    # ``DeviceBuilder.__init__`` doesn't set ``loop``; it's wired
+    # by ``start()`` after the event loop is running. A WS command
+    # can't legitimately reach this method that early, but the
+    # guard keeps a future caller (e.g. a unit test driving the
+    # method out of band) from hitting ``run_in_executor`` on
+    # ``None``.
+    assert db.loop is None
+    bound = await db.apply_remote_build_enabled()
+    assert bound is False
+
+
+@pytest.mark.asyncio
 async def test_apply_remote_build_enabled_idempotent_when_already_off(tmp_path: Path) -> None:
     """Disk ``enabled=False`` + listener absent → no-op (no advertiser touch)."""
     settings = DashboardSettings(config_dir=tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

Flipping `RemoteBuildSettings.enabled` via `remote_build/set_settings` now binds or tears down the peer-link Noise WS listener immediately. Previously the listener was bound once at `DeviceBuilder.start` from the value on disk and the WS toggle only persisted the new value, so the operator had to restart the dashboard for the listener state to actually change — the docstring even called this out and asked the frontend to surface a "restart required" hint. After this change the toggle is self-contained: enable in Settings, the listener binds; disable, the listener tears down and the mDNS pin/port TXT entries clear.

The mDNS service itself stays advertised throughout. All toggle paths route through `DashboardAdvertiser.refresh()` which calls `async_update_service` to rewrite the TXT in place; `async_unregister_service` only fires from `DashboardAdvertiser.unregister()`, which is invoked solely from `DeviceBuilder.stop()` at full dashboard shutdown. Peer caches see the `pin_sha256` / `remote_build_port` TXT keys appear and disappear without the service record itself dropping out.

A new `_remote_build_lifecycle_lock` (lazy-init `asyncio.Lock`) serialises listener-state mutations across `apply_remote_build_enabled` and `reload_remote_build_identity`, so two clients flipping `enabled` concurrently — or a cert rotation racing a toggle — can't desync the on-disk flag from the bound state. `apply_remote_build_enabled` is convergent (reads disk under the lock, no `enabled` parameter) so last-writer-wins on the persisted value is always what the listener converges to.

The teardown-then-clear-advertise sequence is extracted into `_teardown_remote_build_runner` so `reload_remote_build_identity` and the new toggle path share one helper instead of duplicating the runner-snapshot, cleanup, and advertise-clear dance.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

No wire-shape change. The `remote_build/set_settings` request and response shapes are unchanged; only the side-effect on the bound listener changes. The frontend can drop the "restart required" hint it currently shows after the toggle whenever it picks up this backend, but that is not a coordinated requirement — the old hint is harmless on the new backend (the listener is already in the right state by the time the response returns).

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
