### PR TITLE
Phase 5a-1: persistent peer-link session foundation

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -767,7 +767,7 @@ class RemoteBuildController:
         # cleared on session exit (peer close / heartbeat
         # timeout / shutdown). One entry per dashboard_id —
         # a duplicate connect kicks the older session via
-        # ``_TerminateReason.SUPERSEDED`` so a restarted
+        # ``TerminateReason.SUPERSEDED`` so a restarted
         # offloader takes over its previous slot rather than
         # doubling. Drained in :meth:`stop`.
         self._peer_link_sessions: dict[str, PeerLinkSession] = {}

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -113,6 +113,7 @@ from .config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
 )
+from .remote_build_peer_link import PeerLinkSession, TerminateReason
 from .remote_build_peer_link_client import (
     PairStatusResult,
     PeerLinkClientError,
@@ -759,6 +760,17 @@ class RemoteBuildController:
         # would expose is closed structurally. Cleared in
         # :meth:`stop` for shutdown ordering.
         self._approved_peers: dict[str, StoredPeer] = {}
+        # Active long-lived peer-link sessions, keyed on the
+        # offloader's ``dashboard_id``. Populated by
+        # :meth:`register_peer_link_session` after a successful
+        # ``intent="peer_link"`` Noise handshake (5a-1) and
+        # cleared on session exit (peer close / heartbeat
+        # timeout / shutdown). One entry per dashboard_id —
+        # a duplicate connect kicks the older session via
+        # ``_TerminateReason.SUPERSEDED`` so a restarted
+        # offloader takes over its previous slot rather than
+        # doubling. Drained in :meth:`stop`.
+        self._peer_link_sessions: dict[str, PeerLinkSession] = {}
         # Single offloader-side ``StoredPairing`` map: contains both
         # PENDING and APPROVED rows, keyed on
         # ``(receiver_hostname, receiver_port)``. Source of truth at
@@ -863,6 +875,44 @@ class RemoteBuildController:
             _LOGGER.exception("Could not start remote-build browser; peer discovery disabled")
             self._browser = None
 
+    async def register_peer_link_session(self, session: PeerLinkSession) -> None:
+        """
+        Register *session* in the active peer-link registry.
+
+        If a session already exists for the same ``dashboard_id``,
+        it's evicted via :class:`TerminateReason.SUPERSEDED` —
+        a restarted offloader takes over its previous slot
+        rather than doubling. The eviction's ``terminate`` frame
+        is best-effort: a peer that has already gone away won't
+        receive it, but the WS close still drains the old
+        session's receive loop and unregistration runs in its
+        ``finally``. The new session installs into the registry
+        synchronously *before* this awaitable suspends so a
+        subsequent dispatch lookup sees the freshest entry.
+        """
+        existing = self._peer_link_sessions.get(session.dashboard_id)
+        # Install the new session first so a concurrent dispatch
+        # sees it; the old session's terminate is the slow
+        # awaitable path.
+        self._peer_link_sessions[session.dashboard_id] = session
+        if existing is not None and existing is not session:
+            await existing.terminate(TerminateReason.SUPERSEDED)
+
+    def unregister_peer_link_session(self, session: PeerLinkSession) -> None:
+        """
+        Drop *session* from the active peer-link registry.
+
+        No-op when a different session has taken the slot (the
+        :meth:`register_peer_link_session` dedupe path replaces
+        the entry before the old session's loop unwinds; the old
+        loop's ``finally`` calls this and would otherwise evict
+        the new entry). Sync because it's just a dict pop — the
+        actual WS close + Noise teardown happens in the session
+        loop's ``finally`` chain.
+        """
+        if self._peer_link_sessions.get(session.dashboard_id) is session:
+            del self._peer_link_sessions[session.dashboard_id]
+
     async def stop(self) -> None:
         """Cancel the browser and drain in-flight resolve tasks."""
         if self._browser is not None:
@@ -891,6 +941,18 @@ class RemoteBuildController:
             self._pairing_window_handle.cancel()
             self._pairing_window_handle = None
         self._pairing_window_clients.clear()
+        # Drain every active peer-link session before the rest
+        # of the controller-state cleanup runs. ``terminate``
+        # sends a structured ``terminate{reason: server_shutting_down}``
+        # frame and closes the WS; the session's loop unwinds via
+        # ``unregister_peer_link_session`` in its ``finally``,
+        # which mutates ``self._peer_link_sessions`` — snapshot
+        # to a list first so the iteration doesn't race the dict
+        # mutation. Each terminate is best-effort (a peer that
+        # has already gone away just gets the close).
+        for peer_link_session in list(self._peer_link_sessions.values()):
+            await peer_link_session.terminate(TerminateReason.SERVER_SHUTTING_DOWN)
+        self._peer_link_sessions.clear()
         # Route the receiver-side PENDING clear through the same
         # helper the auto-close + explicit-close paths use, so
         # any in-flight pair_status long-poll on a still-alive bus

--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -559,38 +559,8 @@ async def _receive_loop(session: PeerLinkSession) -> None:
     seam in 5b-5d.
     """
     async for msg in session.ws:
-        if msg.type != WSMsgType.BINARY:
-            _LOGGER.debug(
-                "peer-link expected binary frame from %s; got %s",
-                session.dashboard_id,
-                msg.type,
-            )
-            await session.terminate(TerminateReason.MALFORMED_FRAME)
-            return
-        if len(msg.data) > _APP_FRAME_MAX_BYTES:
-            _LOGGER.warning(
-                "peer-link oversize frame from %s (%d bytes); closing",
-                session.dashboard_id,
-                len(msg.data),
-            )
-            await session.terminate(TerminateReason.MALFORMED_FRAME)
-            return
-        try:
-            plaintext = session.noise.decrypt(msg.data)
-        except NOISE_ERRORS:
-            _LOGGER.warning(
-                "peer-link Noise decrypt failed from %s",
-                session.dashboard_id,
-                exc_info=True,
-            )
-            await session.terminate(TerminateReason.MALFORMED_FRAME)
-            return
-        parsed = _parse_json(plaintext)
-        if not isinstance(parsed, dict):
-            _LOGGER.debug(
-                "peer-link frame from %s did not decode to a JSON object",
-                session.dashboard_id,
-            )
+        parsed = _parse_app_frame(session, msg)
+        if parsed is None:
             await session.terminate(TerminateReason.MALFORMED_FRAME)
             return
         msg_type = parsed.get("type")
@@ -617,6 +587,51 @@ async def _receive_loop(session: PeerLinkSession) -> None:
         )
 
 
+def _parse_app_frame(session: PeerLinkSession, msg: Any) -> dict[str, Any] | None:
+    """
+    Validate, decrypt, and JSON-parse one inbound frame.
+
+    Returns the parsed dict on success or ``None`` on any of the
+    malformed-frame branches: wrong WS message type (not BINARY),
+    oversize body, Noise decrypt failure, or post-decrypt JSON
+    that isn't an object. The caller (``_receive_loop``) responds
+    to ``None`` with a structured ``terminate{malformed_frame}``
+    close — concentrating the per-branch logging here keeps the
+    dispatch loop a single straight line.
+    """
+    if msg.type != WSMsgType.BINARY:
+        _LOGGER.debug(
+            "peer-link expected binary frame from %s; got %s",
+            session.dashboard_id,
+            msg.type,
+        )
+        return None
+    if len(msg.data) > _APP_FRAME_MAX_BYTES:
+        _LOGGER.warning(
+            "peer-link oversize frame from %s (%d bytes); closing",
+            session.dashboard_id,
+            len(msg.data),
+        )
+        return None
+    try:
+        plaintext = session.noise.decrypt(msg.data)
+    except NOISE_ERRORS:
+        _LOGGER.warning(
+            "peer-link Noise decrypt failed from %s",
+            session.dashboard_id,
+            exc_info=True,
+        )
+        return None
+    parsed = _parse_json(plaintext)
+    if not isinstance(parsed, dict):
+        _LOGGER.debug(
+            "peer-link frame from %s did not decode to a JSON object",
+            session.dashboard_id,
+        )
+        return None
+    return parsed
+
+
 async def _heartbeat_loop(session: PeerLinkSession) -> None:
     """
     Receiver-driven heartbeat: ping every interval, close on missed-pong threshold.
@@ -631,10 +646,13 @@ async def _heartbeat_loop(session: PeerLinkSession) -> None:
     session.last_pong_at = _monotonic()
     nonce = 0
     while True:
-        try:
-            await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
-        except asyncio.CancelledError:
-            return
+        # CancelledError from sleep() propagates out — the
+        # parent coroutine in :func:`_run_peer_link_session`
+        # cancels this task in its ``finally`` and awaits it
+        # under ``contextlib.suppress(CancelledError)``.
+        # Catching here would swallow the cancellation signal
+        # at the wrong layer.
+        await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
         # Liveness check first — if we haven't heard a pong in
         # the threshold window, bail before sending another ping.
         if _monotonic() - session.last_pong_at > _HEARTBEAT_DEAD_AFTER_SECONDS:

--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -26,10 +26,23 @@ that ``helpers.peer_link_noise`` documents):
 
 After the handshake completes, the receiver sends one
 post-handshake transport frame carrying
-``{"intent_response": "..."}`` and (for now) closes the WS. Phase
-5+ extends the ``intent="peer_link"`` happy path to keep the WS
-open for application messages (bundle upload, build trigger,
-firmware download); part 4 just lays the dispatch foundation.
+``{"intent_response": "..."}``. For ``intent="preview"`` /
+``"pair_request"`` / ``"pair_status"`` the receiver then closes
+the WS — those intents are one-shot. For ``intent="peer_link"``
+on a successful auth (``IntentResponse.OK``), the receiver
+*keeps the WS open* and runs a long-lived application session
+on top of the same Noise transport: every subsequent frame is
+JSON-encoded then ChaCha20-Poly1305-encrypted via
+:meth:`PeerLinkNoiseSession.encrypt` /
+:meth:`PeerLinkNoiseSession.decrypt`. Phase 5a-1 lands the
+session loop with heartbeat (encrypted ``ping`` / ``pong``,
+30s tick + 90s miss threshold) and a controller-side session
+registry that dedupes by ``dashboard_id`` (a duplicate connect
+kicks the older session via a ``terminate`` frame so a restarted
+offloader takes over its previous slot rather than doubling).
+Application message types (``submit_job``, ``job_state_changed``,
+``queue_status``, …) land in subsequent 5b-5d PRs against this
+foundation.
 
 Timeouts: handshake reads have an explicit timeout so a peer that
 opens a TCP connection and never sends the first frame can't pin
@@ -41,9 +54,10 @@ round-trip costs anything, and that's bounded by LAN latency.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -125,6 +139,79 @@ _HANDSHAKE_READ_TIMEOUT_SECONDS = 10.0
 # to fail pairing. 128 chars matches the cap the legacy token-label
 # path uses (``_TOKEN_LABEL_MAX`` in :mod:`controllers.remote_build`).
 _PEER_LABEL_MAX_CHARS = 128
+
+# Heartbeat cadence for the long-lived peer-link session. The
+# receiver sends an encrypted ``ping`` frame every 30s and expects
+# the offloader to echo it back with a ``pong`` carrying the same
+# ``nonce``. Three consecutive missed pongs (90s of silence) close
+# the session so a half-open TCP connection — common on LANs with
+# dropped routes / sleeping middleboxes — doesn't pin a session
+# slot indefinitely. Picked to match the receiver-pinged 30s /
+# 90s-miss pattern called out in the issue's "Connection
+# lifecycle" section.
+_HEARTBEAT_INTERVAL_SECONDS = 30.0
+_HEARTBEAT_MISS_THRESHOLD = 3
+_HEARTBEAT_DEAD_AFTER_SECONDS = _HEARTBEAT_INTERVAL_SECONDS * _HEARTBEAT_MISS_THRESHOLD
+
+# Cap inbound application-frame size at 32 KiB. Heartbeat frames
+# are tiny (~30 bytes); the offloader has no legitimate reason to
+# send larger frames in 5a-1 (no application messages defined yet),
+# and the cap keeps a misbehaving / hostile peer from pinning
+# memory before the dispatch loop sees the frame. Bundle upload in
+# 5c gets its own larger streaming cap on a per-message-type
+# basis. The hard ceiling from the Noise framework spec is
+# 65535 bytes per frame; staying well under that leaves headroom
+# for the protocol overhead and a future relax-the-cap change.
+_APP_FRAME_MAX_BYTES = 32 * 1024
+
+
+class TerminateReason(StrEnum):
+    """
+    Wire ``reason`` value on a structured ``terminate`` close frame.
+
+    Sent inside an :attr:`_AppMessageType.TERMINATE` application
+    frame so the offloader's reconnect logic (5a-2) can branch
+    on the reason rather than guessing from the WS close code.
+
+    * ``SUPERSEDED`` — a fresh peer-link connect from the same
+      ``dashboard_id`` displaces this older session. Standard
+      "restarted offloader" path.
+    * ``HEARTBEAT_TIMEOUT`` — three pings in a row without a
+      matching pong. The session loop closes itself; the wire
+      frame may not actually reach the peer (TCP is presumed
+      dead) but the WS close is still graceful from the
+      receiver's side.
+    * ``SERVER_SHUTTING_DOWN`` — the receiver controller is
+      stopping. Sent to every active session before
+      :meth:`RemoteBuildController.stop` returns.
+    * ``MALFORMED_FRAME`` — a frame fails Noise decrypt /
+      JSON parse / shape validation. Closes the session
+      immediately; peer can reconnect after the next handshake.
+    """
+
+    SUPERSEDED = "superseded"
+    HEARTBEAT_TIMEOUT = "heartbeat_timeout"
+    SERVER_SHUTTING_DOWN = "server_shutting_down"
+    MALFORMED_FRAME = "malformed_frame"
+
+
+class _AppMessageType(StrEnum):
+    """
+    Wire ``type`` discriminator on post-handshake application frames.
+
+    JSON-encoded plaintext is wrapped in a ChaCha20-Poly1305
+    transport frame via the established Noise session (one frame
+    per WS message) before going on the wire.
+
+    5a-1 lands only the heartbeat + close types; 5b-5d add
+    ``queue_status`` / ``submit_job`` / ``job_state_changed`` /
+    ``job_output`` / ``cancel_job`` against the same dispatch
+    seam.
+    """
+
+    PING = "ping"
+    PONG = "pong"
+    TERMINATE = "terminate"
 
 
 async def make_peer_link_handler(
@@ -237,6 +324,19 @@ async def _drive_peer_link_session(  # noqa: PLR0911 — the early-returns are t
     )
     await _send_response(session, ws, response)
 
+    # Hand off to the long-lived application session for
+    # ``intent="peer_link"`` on a successful auth. Every other
+    # intent — including a ``REJECTED`` peer_link — closes the WS
+    # via the handler's ``finally`` (the legacy one-shot shape).
+    if intent is PeerLinkIntent.PEER_LINK and response is IntentResponse.OK:
+        await _run_peer_link_session(
+            controller=controller,
+            ws=ws,
+            session=session,
+            dashboard_id=dashboard_id,
+            peer_ip=peer_ip,
+        )
+
 
 async def _dispatch_intent(
     controller: RemoteBuildController,
@@ -297,6 +397,261 @@ async def _dispatch_intent(
     return await controller.lookup_peer_for_status(
         dashboard_id=inp.dashboard_id, pin_sha256=inp.pin_sha256
     )
+
+
+# ---------------------------------------------------------------------------
+# Long-lived peer-link session (post-handshake, ``intent="peer_link"`` only)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PeerLinkSession:
+    """
+    State for one active receiver-side peer-link WS session.
+
+    Owned by :class:`RemoteBuildController` (registered via
+    :meth:`register_peer_link_session`, dropped via
+    :meth:`unregister_peer_link_session`). Held while the
+    underlying handler coroutine is running its receive loop;
+    cleared the moment the loop returns.
+
+    The Noise session is the post-handshake instance that already
+    burned msg1 / msg2 / msg3 — every subsequent
+    :meth:`PeerLinkNoiseSession.encrypt` /
+    :meth:`PeerLinkNoiseSession.decrypt` call wraps a
+    ChaCha20-Poly1305 transport frame on a fresh nonce. The
+    session is single-threaded by virtue of the asyncio loop;
+    application sends from the receiver controller (queue_status
+    pushes in 5b, etc.) need to await :meth:`send_app_frame` so
+    the encrypt + WS-write pair is atomic.
+    """
+
+    dashboard_id: str
+    ws: web.WebSocketResponse
+    noise: PeerLinkNoiseSession
+    peer_ip: str
+    # Loop-monotonic timestamp of the most recent pong (or session
+    # start if no pong has landed yet). The heartbeat loop seeds
+    # this just before its first sleep so a slow first pong
+    # doesn't trip the miss threshold instantly.
+    last_pong_at: float = 0.0
+    # Set by :meth:`terminate` when something other than the
+    # session loop's natural exit (peer close, heartbeat timeout)
+    # closes the session — used by the loop to skip the
+    # heartbeat-timeout terminate frame on a path where the
+    # caller already sent its own.
+    _closing: bool = False
+    _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def send_app_frame(self, payload: dict[str, Any]) -> bool:
+        """
+        Encrypt *payload* (JSON-encoded) and send it as a binary WS frame.
+
+        Returns ``True`` on success, ``False`` on encrypt error /
+        WS-side failure. The send lock serialises concurrent
+        callers (heartbeat + future application-message senders)
+        so the Noise nonce advances in one direction only — the
+        Noise cipher state is not safe to share across concurrent
+        encrypts.
+        """
+        try:
+            plaintext = _json.dumps(payload)
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "peer-link app frame for %s failed JSON encode", self.dashboard_id, exc_info=True
+            )
+            return False
+        async with self._send_lock:
+            try:
+                ciphertext = self.noise.encrypt(plaintext)
+            except NOISE_ERRORS:
+                _LOGGER.warning(
+                    "peer-link app frame for %s failed Noise encrypt",
+                    self.dashboard_id,
+                    exc_info=True,
+                )
+                return False
+            return await _send_bytes_safely(self.ws, ciphertext, log_label="app frame")
+
+    async def terminate(self, reason: TerminateReason) -> None:
+        """
+        Send a ``terminate`` frame and close the WS.
+
+        Idempotent. Used by the controller's session-registry
+        dedupe path (kick the older session on a duplicate
+        connect) and by ``stop()`` (drain everything before
+        shutdown). Best-effort — a peer that has already gone
+        away won't receive the frame, and the close itself
+        swallows transport errors.
+        """
+        if self._closing:
+            return
+        self._closing = True
+        await self.send_app_frame({"type": _AppMessageType.TERMINATE.value, "reason": reason.value})
+        with contextlib.suppress(Exception):
+            await self.ws.close()
+
+
+async def _run_peer_link_session(
+    controller: RemoteBuildController,
+    ws: web.WebSocketResponse,
+    session: PeerLinkNoiseSession,
+    dashboard_id: str,
+    peer_ip: str,
+) -> None:
+    """
+    Run the post-handshake receive loop + heartbeat for one peer-link session.
+
+    Returns when the session ends — peer close, heartbeat
+    timeout, controller shutdown, or a malformed frame. Always
+    cleans up the controller-side registration in its ``finally``
+    so a session is unregistered the moment its coroutine exits,
+    even on uncaught exceptions.
+
+    Heartbeat is receiver-driven (per the issue's "Connection
+    lifecycle" spec): the receiver pings every
+    :data:`_HEARTBEAT_INTERVAL_SECONDS`, the offloader replies
+    with a ``pong`` carrying the same ``nonce``, three consecutive
+    misses (:data:`_HEARTBEAT_DEAD_AFTER_SECONDS` of silence) close
+    the session.
+    """
+    peer_link_session = PeerLinkSession(
+        dashboard_id=dashboard_id,
+        ws=ws,
+        noise=session,
+        peer_ip=peer_ip,
+    )
+    # Register before spawning the heartbeat — a duplicate connect
+    # arriving in the same loop tick MUST find this session in the
+    # registry so it can kick it. The dedupe runs synchronously
+    # inside :meth:`register_peer_link_session` so the
+    # registration is observed atomically.
+    await controller.register_peer_link_session(peer_link_session)
+    heartbeat_task = asyncio.create_task(
+        _heartbeat_loop(peer_link_session),
+        name=f"peer-link-heartbeat[{dashboard_id}]",
+    )
+    try:
+        await _receive_loop(peer_link_session)
+    finally:
+        heartbeat_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await heartbeat_task
+        controller.unregister_peer_link_session(peer_link_session)
+
+
+async def _receive_loop(session: PeerLinkSession) -> None:
+    """
+    Read frames off the WS, decrypt, parse, and dispatch.
+
+    aiohttp's ``WebSocketResponse`` is async-iterable; the
+    iterator yields only message frames (BINARY / TEXT / PING /
+    PONG) and exits cleanly on CLOSE / CLOSING / ERROR, so we
+    don't have to spell those transitions out.
+
+    Returns on peer close, malformed frame (after firing the
+    structured ``terminate``), or controller-driven session close
+    (the registry's :meth:`PeerLinkSession.terminate` flips
+    ``_closing`` so a CLOSE frame doesn't trigger a redundant
+    terminate). 5a-1 dispatches only ``ping`` / ``pong`` /
+    ``terminate`` — every other type logs at debug and is
+    ignored. Application message types land against this same
+    seam in 5b-5d.
+    """
+    async for msg in session.ws:
+        if msg.type != WSMsgType.BINARY:
+            _LOGGER.debug(
+                "peer-link expected binary frame from %s; got %s",
+                session.dashboard_id,
+                msg.type,
+            )
+            await session.terminate(TerminateReason.MALFORMED_FRAME)
+            return
+        if len(msg.data) > _APP_FRAME_MAX_BYTES:
+            _LOGGER.warning(
+                "peer-link oversize frame from %s (%d bytes); closing",
+                session.dashboard_id,
+                len(msg.data),
+            )
+            await session.terminate(TerminateReason.MALFORMED_FRAME)
+            return
+        try:
+            plaintext = session.noise.decrypt(msg.data)
+        except NOISE_ERRORS:
+            _LOGGER.warning(
+                "peer-link Noise decrypt failed from %s",
+                session.dashboard_id,
+                exc_info=True,
+            )
+            await session.terminate(TerminateReason.MALFORMED_FRAME)
+            return
+        parsed = _parse_json(plaintext)
+        if not isinstance(parsed, dict):
+            _LOGGER.debug(
+                "peer-link frame from %s did not decode to a JSON object",
+                session.dashboard_id,
+            )
+            await session.terminate(TerminateReason.MALFORMED_FRAME)
+            return
+        msg_type = parsed.get("type")
+        if msg_type == _AppMessageType.PONG.value:
+            session.last_pong_at = _monotonic()
+            continue
+        if msg_type == _AppMessageType.PING.value:
+            # Mirror the offloader's ping nonce so a peer that
+            # also runs heartbeat from its end (5a-2) gets pong
+            # parity without us defining a separate keepalive
+            # protocol per direction.
+            nonce = parsed.get("nonce")
+            await session.send_app_frame({"type": _AppMessageType.PONG.value, "nonce": nonce})
+            continue
+        if msg_type == _AppMessageType.TERMINATE.value:
+            # Peer-initiated close. Don't echo a terminate back;
+            # the WS will drain via the next ``CLOSE`` frame.
+            session._closing = True
+            return
+        _LOGGER.debug(
+            "peer-link unknown app frame type %r from %s; ignoring",
+            msg_type,
+            session.dashboard_id,
+        )
+
+
+async def _heartbeat_loop(session: PeerLinkSession) -> None:
+    """
+    Receiver-driven heartbeat: ping every interval, close on missed-pong threshold.
+
+    Uses an integer ``nonce`` that bumps per ping so a future
+    debug surface can correlate ping → pong (5a-1 doesn't read
+    it, but echoing it is part of the contract). The pong landing
+    sets :attr:`PeerLinkSession.last_pong_at`; if the gap from
+    "now" exceeds :data:`_HEARTBEAT_DEAD_AFTER_SECONDS` after a
+    ping, terminate with :attr:`TerminateReason.HEARTBEAT_TIMEOUT`.
+    """
+    session.last_pong_at = _monotonic()
+    nonce = 0
+    while True:
+        try:
+            await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            return
+        # Liveness check first — if we haven't heard a pong in
+        # the threshold window, bail before sending another ping.
+        if _monotonic() - session.last_pong_at > _HEARTBEAT_DEAD_AFTER_SECONDS:
+            await session.terminate(TerminateReason.HEARTBEAT_TIMEOUT)
+            return
+        nonce += 1
+        sent = await session.send_app_frame({"type": _AppMessageType.PING.value, "nonce": nonce})
+        if not sent:
+            # send_app_frame already logs; the WS is presumed
+            # dead so close the session.
+            await session.terminate(TerminateReason.HEARTBEAT_TIMEOUT)
+            return
+
+
+def _monotonic() -> float:
+    """Indirection so tests can monkey-patch the clock under the heartbeat loop."""
+    return asyncio.get_running_loop().time()
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -453,6 +453,26 @@ class PeerLinkSession:
         so the Noise nonce advances in one direction only — the
         Noise cipher state is not safe to share across concurrent
         encrypts.
+
+        Short-circuits to ``False`` once :meth:`terminate` has set
+        :attr:`_closing` so a heartbeat / app sender that wakes
+        from ``asyncio.sleep`` after the controller-driven close
+        decision can't race a final ``ping`` onto the wire after
+        the ``terminate`` frame has already gone out. The
+        ``terminate`` frame itself bypasses this gate via
+        :meth:`_send_app_frame_unchecked`.
+        """
+        if self._closing:
+            return False
+        return await self._send_app_frame_unchecked(payload)
+
+    async def _send_app_frame_unchecked(self, payload: dict[str, Any]) -> bool:
+        """Encrypt + send without the ``_closing`` short-circuit.
+
+        Internal helper for :meth:`terminate` so the structured
+        close frame still goes out even after ``_closing`` is
+        set. Public application sends route through
+        :meth:`send_app_frame`.
         """
         try:
             plaintext = _json.dumps(payload)
@@ -483,12 +503,25 @@ class PeerLinkSession:
         shutdown). Best-effort — a peer that has already gone
         away won't receive the frame, and the close itself
         swallows transport errors.
+
+        Sets :attr:`_closing` *before* sending the terminate
+        frame so any racing :meth:`send_app_frame` call
+        short-circuits cleanly; the terminate-frame send itself
+        bypasses the gate via :meth:`_send_app_frame_unchecked`.
         """
         if self._closing:
             return
         self._closing = True
-        await self.send_app_frame({"type": _AppMessageType.TERMINATE.value, "reason": reason.value})
-        with contextlib.suppress(Exception):
+        await self._send_app_frame_unchecked(
+            {"type": _AppMessageType.TERMINATE.value, "reason": reason.value}
+        )
+        # Narrow suppress to transport-level errors. Python 3.8+
+        # made ``CancelledError`` inherit from ``BaseException``
+        # so ``Exception`` already wouldn't catch it, but being
+        # explicit about which classes we expect on a
+        # closing-an-already-dead-WS path keeps the intent
+        # legible.
+        with contextlib.suppress(OSError, RuntimeError):
             await self.ws.close()
 
 

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -34,8 +34,11 @@ from noise.exceptions import NoiseInvalidMessage
 
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.controllers.remote_build_peer_link import (
+    _APP_FRAME_MAX_BYTES,
     _PEER_LABEL_MAX_CHARS,
     PEER_LINK_PATH,
+    PeerLinkSession,
+    TerminateReason,
     _dispatch_intent,
     _DispatchInput,
     _drive_peer_link_session,
@@ -966,3 +969,447 @@ async def test_e2e_garbage_msg1_payload_handled_gracefully(
         await ws.close()
 
     assert _decode_intent_response(session, encrypted) == IntentResponse.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# Phase 5a-1 — long-lived peer-link session: keep WS open after intent_response,
+# encrypted ping/pong heartbeat, structured terminate close, controller-side
+# session registry.
+# ---------------------------------------------------------------------------
+
+
+async def _drive_peer_link_session_open(
+    client: TestClient,
+    *,
+    dashboard_id: str,
+    initiator_priv: bytes | None = None,
+) -> tuple[PeerLinkNoiseSession, Any, bytes]:
+    """
+    Run the handshake + intent_response and return the still-open WS.
+
+    Caller is responsible for closing the WS. Use this for tests
+    that need to drive application frames after the OK response.
+    Returns ``(session, ws, initiator_pub)``.
+    """
+    if initiator_priv is None:
+        initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    session = PeerLinkNoiseSession.initiator(initiator_priv)
+    ws = await client.ws_connect(PEER_LINK_PATH)
+    msg1 = session.write_handshake_message(_json.dumps({"intent": "peer_link"}))
+    await ws.send_bytes(msg1)
+    msg2 = await ws.receive_bytes()
+    session.read_handshake_message(msg2)
+    msg3 = session.write_handshake_message(_json.dumps({"dashboard_id": dashboard_id}))
+    await ws.send_bytes(msg3)
+    encrypted_response = await ws.receive_bytes()
+    assert _decode_intent_response(session, encrypted_response) == IntentResponse.OK
+    return session, ws, initiator_pub
+
+
+async def _seed_approved_offloader(
+    controller: RemoteBuildController,
+    *,
+    dashboard_id: str,
+    pubkey: bytes,
+) -> None:
+    """Seed an APPROVED ``StoredPeer`` whose pubkey matches *pubkey*."""
+    pin = hashlib.sha256(pubkey).hexdigest()
+    _seed_peer(
+        controller,
+        StoredPeer(
+            dashboard_id=dashboard_id,
+            pin_sha256=pin,
+            static_x25519_pub=pubkey,
+            label=dashboard_id,
+            paired_at=1.0,
+        ),
+    )
+
+
+def _decode_app_frame(session: PeerLinkNoiseSession, encrypted: bytes) -> dict[str, Any]:
+    """Decrypt + JSON-parse a post-handshake application frame."""
+    parsed = _json.loads(session.decrypt(encrypted))
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+@pytest.mark.asyncio
+async def test_e2e_peer_link_session_stays_open_after_intent_response(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+) -> None:
+    """The receiver doesn't close the WS after ``intent_response: ok`` for ``intent="peer_link"``.
+
+    Pins the foundational 5a-1 contract: a successful peer_link
+    auth keeps the session open for application messages
+    (5b-5d). Pre-5a-1 the receiver closed immediately; this test
+    catches a regression to that shape.
+    """
+    client, controller, _ = peer_link_app
+    initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    await _seed_approved_offloader(controller, dashboard_id="alpha", pubkey=initiator_pub)
+
+    _session, ws, _ = await _drive_peer_link_session_open(
+        client, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+    try:
+        # Allow the handler enough loop ticks to drop into the
+        # receive loop. If the WS closed, ``ws.closed`` would
+        # flip; if it's still open, we're in the session loop.
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if ws.closed:
+                break
+        assert not ws.closed
+        # Controller registered the session.
+        assert "alpha" in controller._peer_link_sessions
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_e2e_peer_link_session_responds_to_offloader_ping(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+) -> None:
+    """An offloader-side ``ping`` gets a ``pong`` echoing the same nonce.
+
+    The receiver is also sending its own pings (5a-1's heartbeat
+    loop), but the offloader-driven ping path is what the 5a-2
+    client side will rely on if it picks up bidirectional
+    keepalive — pin the parity now so 5a-2 doesn't have to
+    rediscover it.
+    """
+    client, controller, _ = peer_link_app
+    initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    await _seed_approved_offloader(controller, dashboard_id="alpha", pubkey=initiator_pub)
+
+    session, ws, _ = await _drive_peer_link_session_open(
+        client, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+    try:
+        ping = session.encrypt(_json.dumps({"type": "ping", "nonce": 42}))
+        await ws.send_bytes(ping)
+        pong_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=2.0)
+    finally:
+        await ws.close()
+
+    pong = _decode_app_frame(session, pong_encrypted)
+    assert pong["type"] == "pong"
+    assert pong["nonce"] == 42
+
+
+@pytest.mark.asyncio
+async def test_e2e_peer_link_session_kicks_old_on_duplicate_connect(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+) -> None:
+    """A second connect from the same dashboard_id terminates the older session.
+
+    Both sessions share the same ``dashboard_id``; the receiver
+    can have at most one active session per peer (issue's
+    "Connection lifecycle" spec). The duplicate-connect path
+    sends ``terminate{reason: superseded}`` to the older
+    session and closes its WS, freeing the registry slot for
+    the new connect. A restarted offloader gets its slot back
+    rather than doubling.
+    """
+    client, controller, _ = peer_link_app
+    # Both sessions present the SAME initiator pubkey because
+    # the same dashboard_id has to map to the same stored peer
+    # (the receiver pins on pubkey-hash, not dashboard_id alone).
+    initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    await _seed_approved_offloader(controller, dashboard_id="alpha", pubkey=initiator_pub)
+
+    old_session, old_ws, _ = await _drive_peer_link_session_open(
+        client, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+    _new_session, new_ws, _ = await _drive_peer_link_session_open(
+        client, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+    try:
+        # The old session should receive a ``terminate`` frame
+        # carrying ``reason: superseded`` before the WS closes.
+        terminate_encrypted = await asyncio.wait_for(old_ws.receive_bytes(), timeout=2.0)
+        terminate = _decode_app_frame(old_session, terminate_encrypted)
+        assert terminate["type"] == "terminate"
+        assert terminate["reason"] == TerminateReason.SUPERSEDED.value
+        # Receive one more frame to drive the WS through the
+        # CLOSE transition; aiohttp's client side only flips
+        # ``closed`` on the next ``receive()``-style call.
+        close_msg = await asyncio.wait_for(old_ws.receive(), timeout=2.0)
+        assert close_msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING)
+        # The registry now holds the NEW session; the old one is gone.
+        assert "alpha" in controller._peer_link_sessions
+    finally:
+        await new_ws.close()
+
+
+@pytest.mark.asyncio
+async def test_e2e_peer_link_session_unregistered_on_peer_close(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+) -> None:
+    """Closing the WS from the offloader side drops the registry entry."""
+    client, controller, _ = peer_link_app
+    initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    await _seed_approved_offloader(controller, dashboard_id="alpha", pubkey=initiator_pub)
+
+    _session, ws, _ = await _drive_peer_link_session_open(
+        client, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+    # Wait for the registry to settle.
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if "alpha" in controller._peer_link_sessions:
+            break
+    assert "alpha" in controller._peer_link_sessions
+
+    await ws.close()
+
+    # The receiver's session loop sees the close, exits, and
+    # ``unregister_peer_link_session`` runs in its ``finally``.
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if "alpha" not in controller._peer_link_sessions:
+            break
+    assert "alpha" not in controller._peer_link_sessions
+
+
+@pytest.mark.asyncio
+async def test_e2e_peer_link_session_drained_on_controller_stop(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+) -> None:
+    """``RemoteBuildController.stop()`` terminates active peer-link sessions.
+
+    The shutdown path snapshots the session dict, sends a
+    structured ``terminate{reason: server_shutting_down}`` to
+    each, and closes the WS. The session loop's ``finally``
+    runs ``unregister``; ``stop()`` then ``clear()``s the dict
+    belt-and-braces.
+    """
+    client, controller, _ = peer_link_app
+    initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    await _seed_approved_offloader(controller, dashboard_id="alpha", pubkey=initiator_pub)
+
+    session, ws, _ = await _drive_peer_link_session_open(
+        client, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+    try:
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if "alpha" in controller._peer_link_sessions:
+                break
+        assert "alpha" in controller._peer_link_sessions
+
+        # ``stop()`` runs in the same loop; the test fixture
+        # also calls ``stop()`` on teardown but we drive it
+        # explicitly here so we can assert on the terminate
+        # frame the offloader sees.
+        stop_task = asyncio.create_task(controller.stop())
+
+        terminate_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=2.0)
+        terminate = _decode_app_frame(session, terminate_encrypted)
+        assert terminate["type"] == "terminate"
+        assert terminate["reason"] == TerminateReason.SERVER_SHUTTING_DOWN.value
+
+        await stop_task
+        assert controller._peer_link_sessions == {}
+    finally:
+        await ws.close()
+
+
+@pytest.mark.asyncio
+async def test_e2e_peer_link_session_oversize_frame_terminates(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+) -> None:
+    """A frame past ``_APP_FRAME_MAX_BYTES`` triggers ``terminate{malformed_frame}``.
+
+    Closes a misbehaving / hostile peer at the dispatch seam
+    rather than letting an unbounded ciphertext pin memory.
+    Sized via ``ws_connect(max_msg_size=...)`` because aiohttp's
+    default 4 MiB cap would catch this before the application
+    layer does — we want to verify *our* check fires.
+    """
+    client, controller, _ = peer_link_app
+    initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    await _seed_approved_offloader(controller, dashboard_id="alpha", pubkey=initiator_pub)
+
+    session, ws, _ = await _drive_peer_link_session_open(
+        client, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+    try:
+        # Encrypt a payload larger than the cap. ChaCha20 adds a
+        # 16-byte auth tag; the encrypted size is plaintext + 16.
+        oversize = session.encrypt(b"x" * (_APP_FRAME_MAX_BYTES + 1))
+        await ws.send_bytes(oversize)
+        terminate_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=2.0)
+        terminate = _decode_app_frame(session, terminate_encrypted)
+        assert terminate["type"] == "terminate"
+        assert terminate["reason"] == TerminateReason.MALFORMED_FRAME.value
+    finally:
+        await ws.close()
+
+
+# ---------------------------------------------------------------------------
+# Pure-unit tests: PeerLinkSession.send_app_frame, registry methods
+# ---------------------------------------------------------------------------
+
+
+def _noise_pair() -> tuple[PeerLinkNoiseSession, PeerLinkNoiseSession]:
+    """Drive a 3-message Noise XX handshake against itself.
+
+    Returns ``(initiator, responder)`` with the handshake
+    finalised on both sides — application encrypts on either
+    side decrypt cleanly on the other. Drops the static pubkey
+    parity assertion to stay focused; tests that care about
+    the captured pubkey assert it themselves.
+    """
+    initiator = PeerLinkNoiseSession.initiator(secrets.token_bytes(32))
+    responder = PeerLinkNoiseSession.responder(secrets.token_bytes(32))
+    msg1 = initiator.write_handshake_message(b"")
+    responder.read_handshake_message(msg1)
+    msg2 = responder.write_handshake_message(b"")
+    initiator.read_handshake_message(msg2)
+    msg3 = initiator.write_handshake_message(b"")
+    responder.read_handshake_message(msg3)
+    return initiator, responder
+
+
+class _FakeWs:
+    """In-memory ``WebSocketResponse`` stand-in for unit tests.
+
+    Captures every ``send_bytes`` payload + counts ``close``
+    calls so tests can assert on the number / shape of sends
+    without standing up an aiohttp test server.
+    """
+
+    def __init__(self) -> None:
+        self.sends: list[bytes] = []
+        self.closes: int = 0
+        self.closed: bool = False
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sends.append(data)
+
+    async def close(self) -> None:
+        self.closes += 1
+        self.closed = True
+
+
+def _make_unit_session(noise: PeerLinkNoiseSession) -> tuple[PeerLinkSession, _FakeWs]:
+    """Build a :class:`PeerLinkSession` wired against a fresh :class:`_FakeWs`."""
+    ws = _FakeWs()
+    return PeerLinkSession(
+        dashboard_id="alpha",
+        ws=ws,  # type: ignore[arg-type]
+        noise=noise,
+        peer_ip="127.0.0.1",
+    ), ws
+
+
+@pytest.mark.asyncio
+async def test_peer_link_session_send_app_frame_is_serialised(tmp_path: Path) -> None:
+    """The session's send lock keeps concurrent encrypts from interleaving.
+
+    Noise's cipher state advances its nonce per encrypt and is
+    not safe to share across concurrent calls. The send lock
+    serialises encrypt + ws-write so the wire order matches the
+    encrypt order (which is what the peer's decrypt-by-position
+    requires).
+    """
+    initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+
+    # Fire two concurrent send_app_frame calls; the lock should
+    # serialise them so the responder's encrypt nonce advances
+    # in order, and decoding from the initiator side returns the
+    # frames in send-order.
+    await asyncio.gather(
+        session.send_app_frame({"type": "ping", "n": 1}),
+        session.send_app_frame({"type": "ping", "n": 2}),
+    )
+    assert len(ws.sends) == 2
+    decoded = [_json.loads(initiator.decrypt(frame)) for frame in ws.sends]
+    assert {entry["n"] for entry in decoded} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_peer_link_session_terminate_idempotent(tmp_path: Path) -> None:
+    """Calling ``terminate`` twice doesn't double-send the frame or double-close the WS."""
+    _initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+
+    await session.terminate(TerminateReason.SUPERSEDED)
+    await session.terminate(TerminateReason.SUPERSEDED)
+    assert len(ws.sends) == 1
+    assert ws.closes == 1
+
+
+@pytest.mark.asyncio
+async def test_register_peer_link_session_kicks_existing(tmp_path: Path) -> None:
+    """Registering a new session for the same dashboard_id terminates the existing one."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+
+    # Stub two sessions with mocked terminate.
+    old = MagicMock(spec=PeerLinkSession)
+    old.dashboard_id = "alpha"
+    old.terminate = AsyncMock()
+    new = MagicMock(spec=PeerLinkSession)
+    new.dashboard_id = "alpha"
+    new.terminate = AsyncMock()
+
+    await controller.register_peer_link_session(old)
+    assert controller._peer_link_sessions["alpha"] is old
+    old.terminate.assert_not_called()
+
+    await controller.register_peer_link_session(new)
+    assert controller._peer_link_sessions["alpha"] is new
+    old.terminate.assert_awaited_once_with(TerminateReason.SUPERSEDED)
+    new.terminate.assert_not_called()
+
+
+def test_unregister_peer_link_session_no_op_when_replaced(tmp_path: Path) -> None:
+    """Unregistering a session that has already been replaced doesn't evict the new one."""
+    controller = _make_controller(config_dir=tmp_path)
+
+    old = MagicMock(spec=PeerLinkSession)
+    old.dashboard_id = "alpha"
+    new = MagicMock(spec=PeerLinkSession)
+    new.dashboard_id = "alpha"
+
+    controller._peer_link_sessions["alpha"] = new
+    controller.unregister_peer_link_session(old)
+    # New session still in place — the old session's late
+    # cleanup didn't evict the replacement.
+    assert controller._peer_link_sessions["alpha"] is new
+
+
+def test_unregister_peer_link_session_removes_when_current(tmp_path: Path) -> None:
+    """Unregistering the currently-registered session drops the entry."""
+    controller = _make_controller(config_dir=tmp_path)
+
+    session = MagicMock(spec=PeerLinkSession)
+    session.dashboard_id = "alpha"
+    controller._peer_link_sessions["alpha"] = session
+
+    controller.unregister_peer_link_session(session)
+    assert controller._peer_link_sessions == {}

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1383,6 +1383,30 @@ async def test_peer_link_session_terminate_idempotent(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_app_frame_short_circuits_after_terminate(tmp_path: Path) -> None:
+    """A late ``send_app_frame`` after ``terminate`` returns False without a wire frame.
+
+    Pins the no-race contract: the heartbeat task or a future
+    application sender that wakes from ``asyncio.sleep`` after
+    the controller flipped ``_closing`` mustn't push a final
+    ``ping`` onto the wire after the ``terminate`` frame has
+    already gone out. The frame count after ``terminate`` is
+    exactly 1 (the terminate frame itself).
+    """
+    _initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+
+    await session.terminate(TerminateReason.SUPERSEDED)
+    assert len(ws.sends) == 1  # the terminate frame
+
+    sent = await session.send_app_frame({"type": "ping", "nonce": 99})
+    assert sent is False
+    # Still just the one frame from terminate; the late ping
+    # didn't sneak through.
+    assert len(ws.sends) == 1
+
+
+@pytest.mark.asyncio
 async def test_register_peer_link_session_kicks_existing(tmp_path: Path) -> None:
     """Registering a new session for the same dashboard_id terminates the existing one."""
     controller = _make_controller(config_dir=tmp_path)

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -31,7 +31,11 @@ from aiohttp import WSMessage, WSMsgType, web
 from aiohttp.test_utils import TestClient, TestServer
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from noise.exceptions import NoiseInvalidMessage
+from noise.exceptions import NoiseInvalidMessage as _NoiseInvalidMessage
 
+from esphome_device_builder.controllers import (
+    remote_build_peer_link as _peer_link_module,
+)
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.controllers.remote_build_peer_link import (
     _APP_FRAME_MAX_BYTES,
@@ -47,6 +51,7 @@ from esphome_device_builder.controllers.remote_build_peer_link import (
     _parse_intent,
     _parse_json,
     _read_handshake_message,
+    _receive_loop,
     _send_bytes_safely,
     _send_handshake_message,
     _send_response,
@@ -1298,13 +1303,19 @@ class _FakeWs:
 
     Captures every ``send_bytes`` payload + counts ``close``
     calls so tests can assert on the number / shape of sends
-    without standing up an aiohttp test server.
+    without standing up an aiohttp test server. Async-iterable
+    so :func:`_receive_loop` can iterate it directly: pre-load
+    ``inbox`` with the script of inbound :class:`WSMessage`
+    frames; the iterator yields each in order and then exits
+    (mirrors aiohttp's natural CLOSE-on-iterator-exhaustion
+    behaviour).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, inbox: list[WSMessage] | None = None) -> None:
         self.sends: list[bytes] = []
         self.closes: int = 0
         self.closed: bool = False
+        self._inbox: list[WSMessage] = list(inbox) if inbox else []
 
     async def send_bytes(self, data: bytes) -> None:
         self.sends.append(data)
@@ -1312,6 +1323,14 @@ class _FakeWs:
     async def close(self) -> None:
         self.closes += 1
         self.closed = True
+
+    def __aiter__(self) -> _FakeWs:
+        return self
+
+    async def __anext__(self) -> WSMessage:
+        if not self._inbox:
+            raise StopAsyncIteration
+        return self._inbox.pop(0)
 
 
 def _make_unit_session(noise: PeerLinkNoiseSession) -> tuple[PeerLinkSession, _FakeWs]:
@@ -1413,3 +1432,253 @@ def test_unregister_peer_link_session_removes_when_current(tmp_path: Path) -> No
 
     controller.unregister_peer_link_session(session)
     assert controller._peer_link_sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_send_app_frame_returns_false_on_unserialisable_payload(tmp_path: Path) -> None:
+    """A payload with a non-JSON-encodable value short-circuits before encrypting."""
+    _initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+
+    # ``object()`` is not JSON-serialisable — orjson raises TypeError.
+    sent = await session.send_app_frame({"type": "ping", "junk": object()})
+    assert sent is False
+    assert ws.sends == []
+
+
+@pytest.mark.asyncio
+async def test_send_app_frame_returns_false_on_noise_encrypt_failure(tmp_path: Path) -> None:
+    """A Noise-side failure surfaces as ``False``, not an unhandled exception.
+
+    Forces the failure by bumping the Noise nonce past its 2^64
+    cap is impractical; just monkey-patch ``noise.encrypt`` to
+    raise. The branch we're covering is the ``except NOISE_ERRORS``
+    block — any of the ``NOISE_ERRORS`` tuple's exception types
+    is sufficient.
+    """
+    _initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+
+    real_encrypt = responder.encrypt
+
+    def _encrypt_fails(plaintext: bytes) -> bytes:
+        raise _NoiseInvalidMessage("test stub")
+
+    responder.encrypt = _encrypt_fails  # type: ignore[method-assign]
+    try:
+        sent = await session.send_app_frame({"type": "ping"})
+    finally:
+        responder.encrypt = real_encrypt  # type: ignore[method-assign]
+    assert sent is False
+    assert ws.sends == []
+
+
+# ---------------------------------------------------------------------------
+# Receive loop unit tests — drive ``_receive_loop`` against a scripted ``_FakeWs``
+# so each malformed-frame branch fires its terminate cleanly.
+# ---------------------------------------------------------------------------
+
+
+def _binary_msg(data: bytes) -> WSMessage:
+    """Construct an aiohttp ``WSMessage`` carrying *data* as a BINARY frame."""
+    return WSMessage(type=WSMsgType.BINARY, data=data, extra="")
+
+
+def _text_msg(data: str) -> WSMessage:
+    """Construct a TEXT-typed ``WSMessage``."""
+    return WSMessage(type=WSMsgType.TEXT, data=data, extra="")
+
+
+@pytest.mark.asyncio
+async def test_receive_loop_terminates_on_text_frame(tmp_path: Path) -> None:
+    """A TEXT message (not BINARY) triggers ``terminate{malformed_frame}``."""
+    initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+    ws._inbox.append(_text_msg("hello"))
+
+    await _receive_loop(session)
+
+    # One terminate frame sent + WS closed; decode confirms the
+    # reason field carries the expected ``malformed_frame``.
+    assert len(ws.sends) == 1
+    assert ws.closes == 1
+    decoded = _json.loads(initiator.decrypt(ws.sends[0]))
+    assert decoded["type"] == "terminate"
+    assert decoded["reason"] == TerminateReason.MALFORMED_FRAME.value
+
+
+@pytest.mark.asyncio
+async def test_receive_loop_terminates_on_undecryptable_frame(tmp_path: Path) -> None:
+    """Random bytes that fail Noise decrypt trigger ``terminate{malformed_frame}``."""
+    _initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+    # 64 bytes of random garbage — not a valid ChaCha20-Poly1305
+    # frame against ``responder``'s current cipher state.
+    ws._inbox.append(_binary_msg(b"\xde\xad\xbe\xef" * 16))
+
+    await _receive_loop(session)
+
+    assert ws.closes == 1
+    # The terminate frame itself was sent before close — exact
+    # decryption check is in the e2e tests; here we just pin the
+    # branch ran.
+    assert len(ws.sends) == 1
+
+
+@pytest.mark.asyncio
+async def test_receive_loop_terminates_on_non_object_json(tmp_path: Path) -> None:
+    """Encrypted JSON that isn't an object (e.g. a list) triggers terminate."""
+    initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+    # Valid Noise frame carrying ``[1,2,3]`` plaintext.
+    bad_payload = initiator.encrypt(_json.dumps([1, 2, 3]))
+    ws._inbox.append(_binary_msg(bad_payload))
+
+    await _receive_loop(session)
+
+    assert ws.closes == 1
+    assert len(ws.sends) == 1
+
+
+@pytest.mark.asyncio
+async def test_receive_loop_pong_updates_last_pong_at(tmp_path: Path) -> None:
+    """A ``pong`` frame from the peer bumps ``session.last_pong_at``."""
+    initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+    session.last_pong_at = 0.0
+    pong = initiator.encrypt(_json.dumps({"type": "pong", "nonce": 7}))
+    ws._inbox.append(_binary_msg(pong))
+
+    await _receive_loop(session)
+
+    assert session.last_pong_at > 0.0
+    # No outbound frame fired (pong is one-way from peer to us).
+    assert ws.sends == []
+
+
+@pytest.mark.asyncio
+async def test_receive_loop_peer_terminate_exits_cleanly(tmp_path: Path) -> None:
+    """A peer-side ``terminate`` exits the loop without sending our own."""
+    initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+    bye = initiator.encrypt(_json.dumps({"type": "terminate", "reason": "client_quit"}))
+    ws._inbox.append(_binary_msg(bye))
+
+    await _receive_loop(session)
+
+    # No echo terminate, no close from our side — caller (the
+    # session-loop driver) closes the WS in its outer finally.
+    assert ws.sends == []
+    assert ws.closes == 0
+    assert session._closing is True
+
+
+@pytest.mark.asyncio
+async def test_receive_loop_unknown_app_frame_type_logged_and_ignored(tmp_path: Path) -> None:
+    """An unknown ``type`` field in a well-formed encrypted frame is logged at debug, not fatal.
+
+    Pins forward-compat: a future application message type from a
+    newer offloader must not crash an older receiver — we just
+    skip it. 5b-5d adding new types lands fine against this seam.
+    """
+    initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+    unknown = initiator.encrypt(_json.dumps({"type": "from_the_future"}))
+    ws._inbox.append(_binary_msg(unknown))
+    # Loop should consume the unknown frame and then exit when the
+    # iterator is empty (no further frames). Add an explicit close
+    # message? Async-iter exit on StopAsyncIteration is enough.
+
+    await _receive_loop(session)
+
+    # Nothing sent, no terminate, no close from our side.
+    assert ws.sends == []
+    assert ws.closes == 0
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat loop unit tests — fast clock + monkey-patched sleep so the test
+# doesn't actually wait 30s.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_terminates_on_pong_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The heartbeat loop closes the session when no pong lands in the threshold window.
+
+    Shrinks the heartbeat interval to a few ms so the test
+    finishes quickly (real ``asyncio.sleep``, no stubbing — that
+    avoids recursion loops if a future ``_heartbeat_loop`` body
+    calls ``asyncio.sleep`` from anywhere else). Drives the
+    clock past the miss threshold on the second
+    :func:`_monotonic` read so the very first iteration trips
+    the timeout branch.
+    """
+    _initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+
+    monkeypatch.setattr(_peer_link_module, "_HEARTBEAT_INTERVAL_SECONDS", 0.001)
+    monkeypatch.setattr(_peer_link_module, "_HEARTBEAT_DEAD_AFTER_SECONDS", 0.0)
+    # First call seeds last_pong_at = 0; second call returns a
+    # large value so the gap exceeds the (zero-sized) threshold.
+    ticks = iter([0.0, 1000.0])
+    monkeypatch.setattr(_peer_link_module, "_monotonic", lambda: next(ticks))
+
+    await _peer_link_module._heartbeat_loop(session)
+
+    assert len(ws.sends) == 1
+    assert ws.closes == 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_terminates_on_send_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If ``send_app_frame`` reports failure (WS dead), heartbeat terminates the session."""
+    _initiator, responder = _noise_pair()
+    session, ws = _make_unit_session(responder)
+
+    monkeypatch.setattr(_peer_link_module, "_HEARTBEAT_INTERVAL_SECONDS", 0.001)
+    # Clock stays inside the threshold so the timeout branch
+    # doesn't fire; only the send-failure path does.
+    monkeypatch.setattr(_peer_link_module, "_monotonic", lambda: 0.0)
+
+    async def _fail_send(_payload: dict[str, Any]) -> bool:
+        return False
+
+    monkeypatch.setattr(session, "send_app_frame", _fail_send)
+
+    await _peer_link_module._heartbeat_loop(session)
+
+    # ``terminate`` calls ``send_app_frame`` (which our stub
+    # makes False) but always closes the WS regardless.
+    assert ws.closes == 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_propagates_cancellation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Cancelling the heartbeat task surfaces as ``CancelledError``, not a silent return.
+
+    Pin the no-swallow contract: catching ``CancelledError``
+    inside the loop would hide the cancellation signal from the
+    parent coroutine. The parent's ``contextlib.suppress(CancelledError)``
+    is the right layer to absorb it.
+    """
+    _initiator, responder = _noise_pair()
+    session, _ws = _make_unit_session(responder)
+
+    # Use a long interval so the task is reliably parked in
+    # ``asyncio.sleep`` when we cancel.
+    monkeypatch.setattr(_peer_link_module, "_HEARTBEAT_INTERVAL_SECONDS", 10.0)
+    monkeypatch.setattr(_peer_link_module, "_monotonic", lambda: 0.0)
+
+    task = asyncio.create_task(_peer_link_module._heartbeat_loop(session))
+    # Yield once so the task enters its sleep; then cancel.
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
# What does this implement/fix?

Phase 5a-1 of esphome/device-builder#106. The foundational chunk of phase 5: extends the receiver-side `intent="peer_link"` happy path so the WS stays open after the post-handshake `intent_response: ok` frame instead of closing. Builds the seam application message types (`queue_status` / `submit_job` / `job_state_changed` / `job_output` / `cancel_job`) will land against in 5b–5d.

**Phase 5 sub-phasing** (proposed in the issue's tracking table — splitting "the meat" into landable chunks):

- **5a-1 (this PR)**: receiver-side persistent session, heartbeat, `terminate` close, session registry. Foundation only — no application messages yet.
- **5a-2**: offloader-side `PeerLinkClient` long-lived session task. Connect, run handshake, park on receive loop, auto-reconnect with exponential backoff.
- **5b**: `queue_status` push from receiver to offloader on every `FirmwareController` queue transition. The first real application message — proves the dispatch loop delivers a payload end-to-end.
- **5c**: `submit_job` (header + bundle bytes chunked) + `job_state_changed` + `job_output`. Build runs in `<config>/.esphome/.remote_builds/<job_id>/`; receiver routes through the existing single-job firmware queue with a new `FirmwareJob.remote_peer` field.
- **5d**: `cancel_job` reverse-direction control message.

**What this PR adds:**

- **JSON-over-Noise application-frame format.** Post-handshake frames are JSON objects encrypted through the established `PeerLinkNoiseSession`'s ChaCha20-Poly1305 transport state. The receive loop iterates `async for msg in ws` so aiohttp's built-in CLOSE / CLOSING transition handling unwinds the loop cleanly.
- **Receiver-driven heartbeat.** Encrypted `ping` every 30s, `pong` required within 90s (3-missed-pong threshold), close via structured `terminate{reason: heartbeat_timeout}` on miss. Application-level (Noise-encrypted) rather than aiohttp's WS-protocol-level `heartbeat=` so the keepalive flows through the same cipher state as application traffic — a peer with a corrupted Noise state or a frame-stealing middlebox is detected by the heartbeat itself, not just dead TCP.
- **Structured `terminate` close** with reason enum: `superseded` / `heartbeat_timeout` / `server_shutting_down` / `malformed_frame`. The offloader's reconnect logic (5a-2) branches on this.
- **Receiver-side session registry** on `RemoteBuildController._peer_link_sessions`, keyed on `dashboard_id`. Duplicate connect kicks the older session via `terminate{reason: superseded}` (the new session installs into the registry synchronously *before* the old's terminate awaits, so a concurrent dispatch sees the freshest entry). `stop()` snapshots the dict and drains every session with `terminate{reason: server_shutting_down}` before returning.
- **Frame-size cap** of 32 KiB on inbound application frames so a hostile peer can't pin memory at the dispatch seam. Below the Noise framework's 65535-byte hard limit. Bundle upload in 5c lands its own larger streaming cap on a per-message-type basis.
- **Send-side serialisation** via `PeerLinkSession._send_lock` — the Noise cipher state advances its nonce per encrypt and is not safe to share across concurrent encrypt calls. Pre-5b only the heartbeat task sends frames, but the lock matters the moment a second sender lands (`queue_status` push in 5b).

**Why application-level heartbeat over aiohttp's `heartbeat=`?** aiohttp's built-in WS heartbeat sends WS-protocol PING frames in cleartext — fast TCP liveness detection, but doesn't satisfy the issue's design spec ("heartbeat via Noise-encrypted ping frames, missed-pong threshold"). The two would be parallel timeouts to reason about. Since `ws.close()` from the heartbeat task wakes `ws.receive()` cleanly anyway, the application-level heartbeat alone is sufficient.

11 new tests (6 e2e through `aiohttp.test_utils`, 5 unit-level): WS stays open after `intent_response`, ping/pong round-trip, duplicate-connect kicks the older session, peer-close unregisters from the registry, controller stop drains active sessions with `server_shutting_down`, oversize frame triggers `malformed_frame` close, send-frame serialisation under concurrent `gather`, terminate idempotency, registry register-kicks-existing, register-doesn't-evict-after-replace, register-removes-current.

**Related issue or feature (if applicable):**

- esphome/device-builder#106 phase 5a-1.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

No frontend change. 5a-1 ships only the receiver-side foundation; the offloader-side `PeerLinkClient` (5a-2) is the next backend chunk and `peer_link_status` events for the offloader's frontend Settings UI land alongside that. No new WS commands, no model shape changes the frontend consumes.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#&lt;number&gt;

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

(Doc-update deferred — the wire shape isn't user-visible until the offloader-side `PeerLinkClient` and at least one application message type land in 5a-2 / 5b. Will update `docs/API.md` once the protocol surface stabilises.)
