### PR TITLE
Add two-instance E2E test harness for remote-build offload (#106)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,32 @@ def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:
     return captured
 
 
+def make_remote_build_controller(
+    *,
+    config_dir: Path,
+    bus: EventBus | None = None,
+) -> RemoteBuildController:
+    """Build a :class:`RemoteBuildController` against a stub :class:`DeviceBuilder`.
+
+    Single source of truth for the per-test stub-DB shape: pre-fix
+    every remote-build test file copy-pasted its own
+    ``_make_controller`` with the same MagicMock plumbing.
+    Mounted on a real :class:`EventBus` when *bus* is provided
+    (e.g. the e2e harness's two-instance setup), otherwise
+    ``MagicMock`` auto-attribute resolution gives the controller
+    a no-op ``bus.fire`` — the convention single-side tests use.
+    """
+    db = MagicMock()
+    db.devices = MagicMock()
+    db.devices.zeroconf = None
+    db._dashboard_advertiser = None
+    db.settings = MagicMock()
+    db.settings.config_dir = config_dir
+    if bus is not None:
+        db.bus = bus
+    return RemoteBuildController(db)
+
+
 async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
     """Cancel *task* and await its termination, swallowing the resulting CancelledError.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,68 @@ class _CatalogContainer:
     components: ComponentCatalog | None = None
 
 
+# ---------------------------------------------------------------------------
+# Async helpers shared across the suite
+#
+# ``capture_events`` + ``cancel_and_drain`` lived in
+# ``test_remote_build_peer_link_client.py`` and the e2e conftest
+# before being hoisted here — every test that drives a live
+# :class:`EventBus` or a cancellable background task has the same
+# two boilerplate shapes, and copying them per file made review
+# noisy. Hoisting also lets the e2e ``paired_instances`` fixture
+# import them with a plain ``from ..conftest import ...``.
+# ---------------------------------------------------------------------------
+
+
+class _CapturedEvents(list[dict]):
+    """A list of captured event payloads with an :class:`asyncio.Event` set on each append.
+
+    Subclassing ``list`` keeps the natural ``captured[0]["reason"]``
+    / ``len(captured)`` access shape that callers expect; the
+    extra :attr:`received` event lets a test ``await
+    asyncio.wait_for(captured.received.wait(), timeout=...)``
+    instead of polling on a ``for _ in range(N): sleep(0.01)``
+    loop.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.received = asyncio.Event()
+
+    def append(self, item: dict) -> None:
+        super().append(item)
+        self.received.set()
+
+
+def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:
+    """Subscribe to *event_type* on *bus* and return a list captured-as-they-fire.
+
+    Each fired event's ``data`` payload is materialised into a
+    plain dict and appended. The returned object exposes a
+    ``received`` :class:`asyncio.Event` that's set on every
+    append — callers ``await asyncio.wait_for(captured.received.wait(),
+    timeout=...)`` to block until the first event lands rather
+    than spinning on a polling loop.
+    """
+    captured = _CapturedEvents()
+    bus.add_listener(event_type, lambda event: captured.append(dict(event.data)))
+    return captured
+
+
+async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
+    """Cancel *task* and await its termination, swallowing the resulting CancelledError.
+
+    Equivalent to ``task.cancel(); contextlib.suppress(...) +
+    await``, but written with :func:`asyncio.gather` so the
+    exception is captured by the gather aggregation rather than
+    propagating into the test body. Use at end-of-test cleanup
+    where the cancellation was the test's intended teardown
+    signal — not where the test asserts on the cancellation.
+    """
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
 @pytest.fixture(scope="session")
 def session_board_catalog() -> BoardCatalog:
     """Real ``BoardCatalog`` loaded once per xdist worker."""

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end test harness for the remote-build offload feature (issue #106)."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -20,20 +20,20 @@ per-side wire shapes; the harness's value is catching mismatches
 between the two (event payload contracts, dashboard_id collisions,
 terminate flow with both sides observing).
 
-The pair flow itself is short-circuited to keep the harness
-focused: the ``paired_instances`` fixture seeds an APPROVED
-``StoredPeer`` on the receiver and an APPROVED
-``StoredPairing`` on the offloader before either controller
-starts, mimicking the in-memory state the request → approve
-flow would have left. The flow itself is covered by the
-single-side tests; the harness picks up at "both sides know
-about each other, now what."
+The harness drives the real pair flow end-to-end (no
+dict-mocking shortcuts): receiver opens its pairing window,
+offloader runs ``preview_pair`` + ``request_pair`` over real
+Noise XX handshakes, receiver calls ``approve_peer``, then
+the offloader's pair-status listener observes the flip and
+spawns the long-lived peer-link client. Tests built on top of
+``paired_instances`` start from "both sides have an APPROVED
+row, the long-lived peer-link session is open, ready for
+application messages."
 """
 
 from __future__ import annotations
 
 import asyncio
-import time
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -48,18 +48,8 @@ from esphome_device_builder.controllers.remote_build_peer_link import (
     PEER_LINK_PATH,
     make_peer_link_handler,
 )
-from esphome_device_builder.helpers.dashboard_identity import get_or_create_identity
 from esphome_device_builder.helpers.event_bus import EventBus
-from esphome_device_builder.helpers.peer_link_identity import (
-    get_or_create_peer_link_identity,
-)
-from esphome_device_builder.helpers.peer_link_noise import pin_sha256_for_pubkey
-from esphome_device_builder.models import (
-    EventType,
-    PeerStatus,
-    StoredPairing,
-    StoredPeer,
-)
+from esphome_device_builder.models import PeerStatus
 
 
 def _make_controller(*, config_dir: Path, bus: EventBus) -> RemoteBuildController:
@@ -142,21 +132,39 @@ class PairedInstances:
 async def paired_instances(
     tmp_path: Path,
 ) -> AsyncGenerator[PairedInstances, None]:
-    """Yield two :class:`RemoteBuildController` instances pre-paired and connected.
+    """Yield two :class:`RemoteBuildController` instances paired via the real flow.
 
-    The receiver runs its peer-link Noise WS handler bound to a
-    :class:`aiohttp.test_utils.TestServer` on a real ephemeral
-    TCP port; the offloader runs a real
-    :class:`PeerLinkClient` against it. Both sides have the
-    other's APPROVED row pre-seeded in RAM so the offloader's
-    ``start()`` immediately spawns the long-lived session
-    without going through the full request → approve handshake
-    (covered by the single-side tests).
+    Drives the production pair sequence end-to-end against two
+    in-process controllers — no dict-mocking shortcuts:
+
+    1. Both controllers ``start()`` (loads identities,
+       installs the long-poll listener slot for any future
+       PENDING rows, etc.).
+    2. Receiver opens its pairing window
+       (``set_pairing_window(open=True)``).
+    3. Offloader runs ``preview_pair`` over a real Noise XX WS
+       to capture the receiver's pubkey + pin from the
+       handshake transcript.
+    4. Offloader runs ``request_pair`` (also a real Noise WS)
+       carrying the offloader's ``dashboard_id``; receiver's
+       handler creates a PENDING :class:`StoredPeer` row and
+       fires ``REMOTE_BUILD_PAIR_REQUEST_RECEIVED``.
+    5. Receiver runs ``approve_peer`` to flip PENDING →
+       APPROVED; fires ``REMOTE_BUILD_PAIR_STATUS_CHANGED``.
+    6. Offloader's pair-status listener (spawned in step 4)
+       observes the flip via its long-poll WS, updates the
+       local :class:`StoredPairing` to APPROVED, and spawns
+       the long-lived :class:`PeerLinkClient` (5a-2).
 
     Per-side event buses are real, so production-shape event
-    fan-out runs end-to-end. Teardown drains both controllers
-    in dependency order: offloader first (its client task sends
-    a ``terminate{client_stopped}`` to the receiver, the
+    fan-out runs end-to-end. The handshake reads pin + dashboard_id
+    from the live Noise transcript, so any wire-shape regression
+    on either side surfaces here rather than being hidden behind
+    a pre-seeded RAM dict.
+
+    Teardown drains both controllers in dependency order:
+    offloader first (its client task sends a
+    ``terminate{client_stopped}`` to the receiver, the
     receiver's session loop unwinds), then the receiver (closing
     any remaining server-side state), then the TestServer.
     """
@@ -170,20 +178,6 @@ async def paired_instances(
     receiver = _make_controller(config_dir=receiver_dir, bus=receiver_bus)
     offloader = _make_controller(config_dir=offloader_dir, bus=offloader_bus)
 
-    # Pre-create both identities on disk so we can wire the
-    # cross-references (receiver-side ``StoredPeer`` carrying
-    # the offloader's pubkey, offloader-side ``StoredPairing``
-    # carrying the receiver's pubkey) before either ``start()``
-    # runs and lazily generates them.
-    loop = asyncio.get_running_loop()
-    receiver_identity = await loop.run_in_executor(
-        None, get_or_create_peer_link_identity, receiver_dir
-    )
-    offloader_identity = await loop.run_in_executor(
-        None, get_or_create_peer_link_identity, offloader_dir
-    )
-    offloader_dashboard = await loop.run_in_executor(None, get_or_create_identity, offloader_dir)
-
     # Stand up the receiver's peer-link WS endpoint on a real
     # TCP port. ``TestServer`` picks an ephemeral port; the
     # offloader dials ``("127.0.0.1", server.port)``.
@@ -194,30 +188,54 @@ async def paired_instances(
     await server.start_server()
     assert server.port is not None  # TestServer always binds; narrow for type-checkers.
 
-    paired_at = time.time()
-    receiver._approved_peers[offloader_dashboard.dashboard_id] = StoredPeer(
-        dashboard_id=offloader_dashboard.dashboard_id,
-        pin_sha256=pin_sha256_for_pubkey(offloader_identity.public_bytes),
-        static_x25519_pub=offloader_identity.public_bytes,
-        label=offloader_dashboard.dashboard_id,
-        paired_at=paired_at,
-    )
-    offloader._pairings[("127.0.0.1", server.port)] = StoredPairing(
-        receiver_hostname="127.0.0.1",
-        receiver_port=server.port,
-        pin_sha256=pin_sha256_for_pubkey(receiver_identity.public_bytes),
-        static_x25519_pub=receiver_identity.public_bytes,
-        label="receiver",
-        paired_at=paired_at,
-        status=PeerStatus.APPROVED,
-    )
-
-    # ``start()``'s on-disk load is a no-op for a fresh tmp dir,
-    # so the pre-seeded RAM dicts above survive. The offloader's
-    # ``start()`` spawns the long-lived peer-link client for
-    # every APPROVED ``StoredPairing`` (just the one we seeded).
+    # Both controllers start before any pair-flow calls — the
+    # offloader needs its pair-status listener slot wired so
+    # ``request_pair`` can register the per-row long-poll task,
+    # and the receiver needs its identity + handler factory ready
+    # so the offloader's WS dials succeed.
     await receiver.start()
     await offloader.start()
+
+    # 1. Receiver opens the pairing window so its handler will
+    #    accept ``intent="pair_request"`` frames.
+    await receiver.set_pairing_window(open=True, client="receiver-tab")
+
+    # 2. Offloader runs preview to capture the receiver's pin
+    #    over a live Noise XX handshake.
+    preview = await offloader.preview_pair(hostname="127.0.0.1", port=server.port)
+    pin_sha256 = preview["pin_sha256"]
+
+    # 3. Offloader requests pairing. Receiver lands a PENDING
+    #    ``StoredPeer`` and fires REMOTE_BUILD_PAIR_REQUEST_RECEIVED;
+    #    the offloader spawns its pair-status long-poll listener
+    #    against this row.
+    await offloader.request_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+        pin_sha256=pin_sha256,
+        receiver_label="receiver",
+        offloader_label="offloader",
+    )
+
+    # 4. Receiver-side admin clicks Accept. The PENDING peer's
+    #    ``dashboard_id`` is the offloader's stable identity —
+    #    pull it off the row the receiver just landed.
+    [pending_dashboard_id] = list(receiver._pending_peers.keys())
+    await receiver.approve_peer(dashboard_id=pending_dashboard_id)
+
+    # 5. Wait for the offloader's pair-status listener to observe
+    #    the flip + spawn the long-lived peer-link client. The
+    #    listener's long-poll WS unblocks on the receiver's bus
+    #    event, then ``_apply_pair_status_result`` flips the
+    #    local row to APPROVED and ``_spawn_peer_link_client``
+    #    creates the client task.
+    key = ("127.0.0.1", server.port)
+    await _wait_until(
+        lambda: (
+            key in offloader._pairings and offloader._pairings[key].status is PeerStatus.APPROVED
+        )
+    )
+    offloader_dashboard_id = pending_dashboard_id
 
     instances = PairedInstances(
         receiver=receiver,
@@ -225,7 +243,7 @@ async def paired_instances(
         receiver_server=server,
         receiver_bus=receiver_bus,
         offloader_bus=offloader_bus,
-        offloader_dashboard_id=offloader_dashboard.dashboard_id,
+        offloader_dashboard_id=offloader_dashboard_id,
     )
     try:
         yield instances
@@ -239,31 +257,3 @@ async def paired_instances(
         await offloader.stop()
         await receiver.stop()
         await server.close()
-
-
-def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:
-    """Subscribe to *event_type* on *bus* and return a list captured-as-they-fire.
-
-    Mirror of the helper in
-    ``test_remote_build_peer_link_client.py``; copied here so the
-    harness module is self-contained. Returned list is a thin
-    subclass that exposes a ``received`` :class:`asyncio.Event`
-    set on each append, so tests block via
-    ``await asyncio.wait_for(captured.received.wait(), timeout=...)``
-    rather than polling.
-    """
-    captured = _CapturedEvents()
-    bus.add_listener(event_type, lambda event: captured.append(dict(event.data)))
-    return captured
-
-
-class _CapturedEvents(list[dict]):
-    """A list of captured event payloads with an :class:`asyncio.Event` set on each append."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.received = asyncio.Event()
-
-    def append(self, item: dict) -> None:
-        super().append(item)
-        self.received.set()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,269 @@
+"""
+End-to-end harness for the remote-build offload feature (issue #106).
+
+Two real :class:`RemoteBuildController` instances stood up
+side-by-side — one acting as the receiver (peer-link listener
+bound on a real TCP port via :class:`aiohttp.test_utils.TestServer`),
+one acting as the offloader (long-lived
+:class:`PeerLinkClient` connecting to the receiver). Both run on
+real :class:`EventBus` instances so per-mutation events flow
+through the same wire surface a production frontend would
+subscribe to.
+
+Tests built on top of this harness exercise behaviour that
+spans both sides of the wire — handshake → pair → peer-link
+session → application messages (5b/5c/5d) → bundle upload +
+firmware download (later phases). Single-side unit tests in
+``test_remote_build_peer_link.py`` /
+``test_remote_build_peer_link_client.py`` already pin the
+per-side wire shapes; the harness's value is catching mismatches
+between the two (event payload contracts, dashboard_id collisions,
+terminate flow with both sides observing).
+
+The pair flow itself is short-circuited to keep the harness
+focused: the ``paired_instances`` fixture seeds an APPROVED
+``StoredPeer`` on the receiver and an APPROVED
+``StoredPairing`` on the offloader before either controller
+starts, mimicking the in-memory state the request → approve
+flow would have left. The flow itself is covered by the
+single-side tests; the harness picks up at "both sides know
+about each other, now what."
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from esphome_device_builder.controllers.remote_build import RemoteBuildController
+from esphome_device_builder.controllers.remote_build_peer_link import (
+    PEER_LINK_PATH,
+    make_peer_link_handler,
+)
+from esphome_device_builder.helpers.dashboard_identity import get_or_create_identity
+from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.helpers.peer_link_identity import (
+    get_or_create_peer_link_identity,
+)
+from esphome_device_builder.helpers.peer_link_noise import pin_sha256_for_pubkey
+from esphome_device_builder.models import (
+    EventType,
+    PeerStatus,
+    StoredPairing,
+    StoredPeer,
+)
+
+
+def _make_controller(*, config_dir: Path, bus: EventBus) -> RemoteBuildController:
+    """Construct a :class:`RemoteBuildController` against a stub :class:`DeviceBuilder`.
+
+    Mirrors the per-test ``_make_controller`` helpers in the
+    single-side tests but wires a *real* :class:`EventBus` (not a
+    :class:`MagicMock`) so events fire end-to-end through the
+    fan-out fabric the production dispatcher uses.
+    """
+    db = MagicMock()
+    db.devices = MagicMock()
+    db.devices.zeroconf = None
+    db._dashboard_advertiser = None
+    db.settings = MagicMock()
+    db.settings.config_dir = config_dir
+    db.bus = bus
+    return RemoteBuildController(db)
+
+
+async def _wait_until(condition: Callable[[], bool], *, timeout: float = 2.0) -> None:
+    """Yield to the loop until *condition()* returns truthy or *timeout* elapses.
+
+    Raises :exc:`TimeoutError` (via :func:`asyncio.wait_for`) when
+    the condition stays false past *timeout*. Mirrors the helper
+    in the single-side test files; copied here so the e2e harness
+    can stand alone without cross-importing test utilities.
+    """
+
+    async def _spin() -> None:
+        while not condition():
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_spin(), timeout=timeout)
+
+
+@dataclass
+class PairedInstances:
+    """Two controllers + a TestServer, pre-paired and ready to drive.
+
+    Test code reads :attr:`offloader` / :attr:`receiver` to drive
+    WS commands or assert on RAM-canonical state, and
+    :attr:`offloader_dashboard_id` to look up the offloader's
+    session on the receiver side
+    (``receiver._peer_link_sessions[<offloader_dashboard_id>]``).
+
+    :meth:`wait_until_session_opened` is the single conventional
+    sync point; tests that need to assert on post-session state
+    call it before their assertions instead of polling the
+    registry by hand.
+    """
+
+    receiver: RemoteBuildController
+    offloader: RemoteBuildController
+    receiver_server: TestServer
+    receiver_bus: EventBus
+    offloader_bus: EventBus
+    offloader_dashboard_id: str
+
+    async def wait_until_session_opened(self, *, timeout: float = 2.0) -> None:
+        """Block until the receiver has registered the offloader's peer-link session.
+
+        Both sides observing the session is the natural "harness
+        is fully primed" signal: the offloader's
+        :class:`PeerLinkClient` has completed the Noise XX
+        handshake, the receiver's ``_run_peer_link_session`` has
+        registered the session in
+        :attr:`RemoteBuildController._peer_link_sessions`, and
+        the dispatch loop is parked on its receive iterator.
+        Tests that exercise application-message behaviour
+        (5b/5c/5d) start from this state.
+        """
+        await _wait_until(
+            lambda: self.offloader_dashboard_id in self.receiver._peer_link_sessions,
+            timeout=timeout,
+        )
+
+
+@pytest.fixture
+async def paired_instances(
+    tmp_path: Path,
+) -> AsyncGenerator[PairedInstances, None]:
+    """Yield two :class:`RemoteBuildController` instances pre-paired and connected.
+
+    The receiver runs its peer-link Noise WS handler bound to a
+    :class:`aiohttp.test_utils.TestServer` on a real ephemeral
+    TCP port; the offloader runs a real
+    :class:`PeerLinkClient` against it. Both sides have the
+    other's APPROVED row pre-seeded in RAM so the offloader's
+    ``start()`` immediately spawns the long-lived session
+    without going through the full request → approve handshake
+    (covered by the single-side tests).
+
+    Per-side event buses are real, so production-shape event
+    fan-out runs end-to-end. Teardown drains both controllers
+    in dependency order: offloader first (its client task sends
+    a ``terminate{client_stopped}`` to the receiver, the
+    receiver's session loop unwinds), then the receiver (closing
+    any remaining server-side state), then the TestServer.
+    """
+    receiver_dir = tmp_path / "receiver"
+    receiver_dir.mkdir()
+    offloader_dir = tmp_path / "offloader"
+    offloader_dir.mkdir()
+
+    receiver_bus = EventBus()
+    offloader_bus = EventBus()
+    receiver = _make_controller(config_dir=receiver_dir, bus=receiver_bus)
+    offloader = _make_controller(config_dir=offloader_dir, bus=offloader_bus)
+
+    # Pre-create both identities on disk so we can wire the
+    # cross-references (receiver-side ``StoredPeer`` carrying
+    # the offloader's pubkey, offloader-side ``StoredPairing``
+    # carrying the receiver's pubkey) before either ``start()``
+    # runs and lazily generates them.
+    loop = asyncio.get_running_loop()
+    receiver_identity = await loop.run_in_executor(
+        None, get_or_create_peer_link_identity, receiver_dir
+    )
+    offloader_identity = await loop.run_in_executor(
+        None, get_or_create_peer_link_identity, offloader_dir
+    )
+    offloader_dashboard = await loop.run_in_executor(None, get_or_create_identity, offloader_dir)
+
+    # Stand up the receiver's peer-link WS endpoint on a real
+    # TCP port. ``TestServer`` picks an ephemeral port; the
+    # offloader dials ``("127.0.0.1", server.port)``.
+    app = web.Application()
+    handler = await make_peer_link_handler(receiver, receiver_dir)
+    app.router.add_get(PEER_LINK_PATH, handler)
+    server = TestServer(app)
+    await server.start_server()
+    assert server.port is not None  # TestServer always binds; narrow for type-checkers.
+
+    paired_at = time.time()
+    receiver._approved_peers[offloader_dashboard.dashboard_id] = StoredPeer(
+        dashboard_id=offloader_dashboard.dashboard_id,
+        pin_sha256=pin_sha256_for_pubkey(offloader_identity.public_bytes),
+        static_x25519_pub=offloader_identity.public_bytes,
+        label=offloader_dashboard.dashboard_id,
+        paired_at=paired_at,
+    )
+    offloader._pairings[("127.0.0.1", server.port)] = StoredPairing(
+        receiver_hostname="127.0.0.1",
+        receiver_port=server.port,
+        pin_sha256=pin_sha256_for_pubkey(receiver_identity.public_bytes),
+        static_x25519_pub=receiver_identity.public_bytes,
+        label="receiver",
+        paired_at=paired_at,
+        status=PeerStatus.APPROVED,
+    )
+
+    # ``start()``'s on-disk load is a no-op for a fresh tmp dir,
+    # so the pre-seeded RAM dicts above survive. The offloader's
+    # ``start()`` spawns the long-lived peer-link client for
+    # every APPROVED ``StoredPairing`` (just the one we seeded).
+    await receiver.start()
+    await offloader.start()
+
+    instances = PairedInstances(
+        receiver=receiver,
+        offloader=offloader,
+        receiver_server=server,
+        receiver_bus=receiver_bus,
+        offloader_bus=offloader_bus,
+        offloader_dashboard_id=offloader_dashboard.dashboard_id,
+    )
+    try:
+        yield instances
+    finally:
+        # Teardown order matters: the offloader's ``stop()``
+        # cancels its peer-link client task, whose
+        # ``CancelledError`` handler sends a structured
+        # ``terminate{client_stopped}`` frame to the receiver.
+        # Stopping the receiver first would race that frame
+        # against the receiver's WS shutdown.
+        await offloader.stop()
+        await receiver.stop()
+        await server.close()
+
+
+def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:
+    """Subscribe to *event_type* on *bus* and return a list captured-as-they-fire.
+
+    Mirror of the helper in
+    ``test_remote_build_peer_link_client.py``; copied here so the
+    harness module is self-contained. Returned list is a thin
+    subclass that exposes a ``received`` :class:`asyncio.Event`
+    set on each append, so tests block via
+    ``await asyncio.wait_for(captured.received.wait(), timeout=...)``
+    rather than polling.
+    """
+    captured = _CapturedEvents()
+    bus.add_listener(event_type, lambda event: captured.append(dict(event.data)))
+    return captured
+
+
+class _CapturedEvents(list[dict]):
+    """A list of captured event payloads with an :class:`asyncio.Event` set on each append."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.received = asyncio.Event()
+
+    def append(self, item: dict) -> None:
+        super().append(item)
+        self.received.set()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -34,10 +34,9 @@ application messages."
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from aiohttp import web
@@ -49,41 +48,9 @@ from esphome_device_builder.controllers.remote_build_peer_link import (
     make_peer_link_handler,
 )
 from esphome_device_builder.helpers.event_bus import EventBus
-from esphome_device_builder.models import PeerStatus
+from esphome_device_builder.models import EventType
 
-
-def _make_controller(*, config_dir: Path, bus: EventBus) -> RemoteBuildController:
-    """Construct a :class:`RemoteBuildController` against a stub :class:`DeviceBuilder`.
-
-    Mirrors the per-test ``_make_controller`` helpers in the
-    single-side tests but wires a *real* :class:`EventBus` (not a
-    :class:`MagicMock`) so events fire end-to-end through the
-    fan-out fabric the production dispatcher uses.
-    """
-    db = MagicMock()
-    db.devices = MagicMock()
-    db.devices.zeroconf = None
-    db._dashboard_advertiser = None
-    db.settings = MagicMock()
-    db.settings.config_dir = config_dir
-    db.bus = bus
-    return RemoteBuildController(db)
-
-
-async def _wait_until(condition: Callable[[], bool], *, timeout: float = 2.0) -> None:
-    """Yield to the loop until *condition()* returns truthy or *timeout* elapses.
-
-    Raises :exc:`TimeoutError` (via :func:`asyncio.wait_for`) when
-    the condition stays false past *timeout*. Mirrors the helper
-    in the single-side test files; copied here so the e2e harness
-    can stand alone without cross-importing test utilities.
-    """
-
-    async def _spin() -> None:
-        while not condition():
-            await asyncio.sleep(0)
-
-    await asyncio.wait_for(_spin(), timeout=timeout)
+from ..conftest import _CapturedEvents, capture_events, make_remote_build_controller
 
 
 @dataclass
@@ -108,24 +75,31 @@ class PairedInstances:
     receiver_bus: EventBus
     offloader_bus: EventBus
     offloader_dashboard_id: str
+    # Pre-subscribed at fixture-construct time so a
+    # :meth:`wait_until_session_opened` call lands cleanly even
+    # when the OPENED event has already fired (the offloader's
+    # :class:`PeerLinkClient` connects on its own task; tests
+    # that race the listener subscription against the connect
+    # would otherwise have to wire the subscription before the
+    # fixture yields).
+    _opened: _CapturedEvents
 
     async def wait_until_session_opened(self, *, timeout: float = 2.0) -> None:
-        """Block until the receiver has registered the offloader's peer-link session.
+        """Block until the offloader observes ``OFFLOADER_PEER_LINK_OPENED``.
 
-        Both sides observing the session is the natural "harness
-        is fully primed" signal: the offloader's
-        :class:`PeerLinkClient` has completed the Noise XX
-        handshake, the receiver's ``_run_peer_link_session`` has
-        registered the session in
-        :attr:`RemoteBuildController._peer_link_sessions`, and
-        the dispatch loop is parked on its receive iterator.
-        Tests that exercise application-message behaviour
-        (5b/5c/5d) start from this state.
+        Event-based — the offloader fires
+        ``OFFLOADER_PEER_LINK_OPENED`` from its
+        :class:`PeerLinkClient` after processing the receiver's
+        post-handshake ``intent_response: ok``, which is the
+        offloader-side completion of the long-lived peer-link
+        session bring-up. Tests that need to assert on
+        receiver-side state (``_peer_link_sessions[<dashboard_id>]``)
+        can layer their own short
+        :func:`asyncio.wait_for` on top — the receiver's
+        ``register_peer_link_session`` runs on its own task
+        and may lag the offloader's OPENED fire by a tick.
         """
-        await _wait_until(
-            lambda: self.offloader_dashboard_id in self.receiver._peer_link_sessions,
-            timeout=timeout,
-        )
+        await asyncio.wait_for(self._opened.received.wait(), timeout=timeout)
 
 
 @pytest.fixture
@@ -175,8 +149,13 @@ async def paired_instances(
 
     receiver_bus = EventBus()
     offloader_bus = EventBus()
-    receiver = _make_controller(config_dir=receiver_dir, bus=receiver_bus)
-    offloader = _make_controller(config_dir=offloader_dir, bus=offloader_bus)
+    receiver = make_remote_build_controller(config_dir=receiver_dir, bus=receiver_bus)
+    offloader = make_remote_build_controller(config_dir=offloader_dir, bus=offloader_bus)
+    # Subscribe to OPENED before the offloader's
+    # ``PeerLinkClient`` task has had a chance to fire it. The
+    # listener captures every event; ``wait_until_session_opened``
+    # waits on the captured-list's ``received`` event.
+    opened_events = capture_events(offloader_bus, EventType.OFFLOADER_PEER_LINK_OPENED)
 
     # Stand up the receiver's peer-link WS endpoint on a real
     # TCP port. ``TestServer`` picks an ephemeral port; the
@@ -219,23 +198,23 @@ async def paired_instances(
 
     # 4. Receiver-side admin clicks Accept. The PENDING peer's
     #    ``dashboard_id`` is the offloader's stable identity —
-    #    pull it off the row the receiver just landed.
+    #    pull it off the row the receiver just landed. Subscribe
+    #    to OFFLOADER_PAIR_STATUS_CHANGED *before* approve_peer
+    #    fires so the receiver's APPROVED → offloader's
+    #    pair-status listener → status-flip-event chain can be
+    #    awaited deterministically rather than spun on.
     [pending_dashboard_id] = list(receiver._pending_peers.keys())
+    pair_status_changed = capture_events(offloader_bus, EventType.OFFLOADER_PAIR_STATUS_CHANGED)
     await receiver.approve_peer(dashboard_id=pending_dashboard_id)
 
     # 5. Wait for the offloader's pair-status listener to observe
-    #    the flip + spawn the long-lived peer-link client. The
-    #    listener's long-poll WS unblocks on the receiver's bus
-    #    event, then ``_apply_pair_status_result`` flips the
-    #    local row to APPROVED and ``_spawn_peer_link_client``
-    #    creates the client task.
-    key = ("127.0.0.1", server.port)
-    await _wait_until(
-        lambda: (
-            key in offloader._pairings and offloader._pairings[key].status is PeerStatus.APPROVED
-        )
-    )
-    offloader_dashboard_id = pending_dashboard_id
+    #    the flip. The listener's long-poll WS unblocks on the
+    #    receiver's bus event, then ``_apply_pair_status_result``
+    #    flips the local row to APPROVED, fires
+    #    OFFLOADER_PAIR_STATUS_CHANGED, and spawns the long-lived
+    #    peer-link client.
+    await asyncio.wait_for(pair_status_changed.received.wait(), timeout=2.0)
+    assert pair_status_changed[-1]["status"] == "approved"
 
     instances = PairedInstances(
         receiver=receiver,
@@ -243,7 +222,8 @@ async def paired_instances(
         receiver_server=server,
         receiver_bus=receiver_bus,
         offloader_bus=offloader_bus,
-        offloader_dashboard_id=offloader_dashboard_id,
+        offloader_dashboard_id=pending_dashboard_id,
+        _opened=opened_events,
     )
     try:
         yield instances

--- a/tests/e2e/test_pair_and_session.py
+++ b/tests/e2e/test_pair_and_session.py
@@ -55,30 +55,49 @@ async def test_paired_instances_open_peer_link_session(
 async def test_paired_instances_teardown_closes_session_cleanly(
     paired_instances: PairedInstances,
 ) -> None:
-    """The harness teardown unwinds the peer-link session without leaking tasks.
+    """``offloader.stop()`` unwinds the peer-link session on both sides.
 
-    Pins the cleanup contract: after the test body returns and
-    the fixture's teardown runs (offloader.stop → receiver.stop
-    → server.close), both controllers' session registries are
-    empty and the offloader's
-    ``OFFLOADER_PEER_LINK_CLOSED`` event has fired with
-    ``reason="client_stopped"`` (the offloader-initiated path).
+    Pins the cleanup contract: cancelling the offloader's
+    long-lived peer-link client task (a) fires
+    ``OFFLOADER_PEER_LINK_CLOSED`` with ``reason="client_stopped"``
+    on the offloader-side bus, (b) drains the offloader's
+    ``_peer_link_clients`` registry, and (c) lets the receiver's
+    ``_run_peer_link_session`` finally-block run
+    ``unregister_peer_link_session`` so the receiver's
+    ``_peer_link_sessions`` registry drops the row.
 
-    The teardown itself happens after this test's body — the
-    body's job is to wait for the session to open + subscribe
-    to the closed event so the teardown's effects are
-    observable to the next assertion.
+    The fixture teardown runs ``offloader.stop → receiver.stop
+    → server.close`` after this body returns; this body drives
+    ``offloader.stop()`` explicitly so the cleanup contract can
+    be observed from inside the test rather than relying on
+    fixture teardown side-effects no test code sees.
     """
     closed = capture_events(paired_instances.offloader_bus, EventType.OFFLOADER_PEER_LINK_CLOSED)
 
     await paired_instances.wait_until_session_opened()
+    receiver_key = paired_instances.offloader_dashboard_id
+    assert receiver_key in paired_instances.receiver._peer_link_sessions
 
-    # Drive the offloader's stop directly so we can assert
-    # on the resulting CLOSED event from inside the test
-    # body rather than chasing post-teardown state.
     await paired_instances.offloader.stop()
 
+    # (a) CLOSED fires offloader-side with the right reason.
     await asyncio.wait_for(closed.received.wait(), timeout=2.0)
     assert closed[0]["receiver_hostname"] == "127.0.0.1"
     assert closed[0]["receiver_port"] == paired_instances.receiver_server.port
     assert closed[0]["reason"] == "client_stopped"
+
+    # (b) Offloader's registry drained synchronously by ``stop()``.
+    assert paired_instances.offloader._peer_link_clients == {}
+
+    # (c) Receiver's session loop unwinds on its own task — the
+    # offloader's CancelledError handler sent a structured
+    # ``terminate{client_stopped}`` frame, the receiver's
+    # ``_receive_loop`` exits, and ``unregister_peer_link_session``
+    # runs in its ``finally``. There's no bus event for the
+    # unregistration today, so wait_for + a short spin against
+    # the registry is the available sync source.
+    async def _registry_drained() -> None:
+        while receiver_key in paired_instances.receiver._peer_link_sessions:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_registry_drained(), timeout=2.0)

--- a/tests/e2e/test_pair_and_session.py
+++ b/tests/e2e/test_pair_and_session.py
@@ -1,0 +1,83 @@
+"""
+End-to-end: pair + long-lived peer-link session.
+
+Smoke tests for the ``paired_instances`` harness — confirms the
+two-controller bring-up reaches a state where both sides have
+observed the peer-link session opening, before the
+application-message phases (5b/5c/5d) build their own
+assertions on top.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from esphome_device_builder.models import EventType
+
+from .conftest import PairedInstances, capture_events
+
+
+@pytest.mark.asyncio
+async def test_paired_instances_open_peer_link_session(
+    paired_instances: PairedInstances,
+) -> None:
+    """The offloader's ``PeerLinkClient`` connects and both sides observe the session.
+
+    Pins the harness contract: after ``paired_instances`` yields,
+    waiting on :meth:`wait_until_session_opened` is enough to
+    have both the offloader-side ``OFFLOADER_PEER_LINK_OPENED``
+    event fired and the receiver-side
+    ``_peer_link_sessions[<dashboard_id>]`` registered.
+    """
+    opened = capture_events(paired_instances.offloader_bus, EventType.OFFLOADER_PEER_LINK_OPENED)
+
+    await paired_instances.wait_until_session_opened()
+
+    # Offloader fired OFFLOADER_PEER_LINK_OPENED with the
+    # receiver coordinates the offloader dialled.
+    await asyncio.wait_for(opened.received.wait(), timeout=2.0)
+    assert len(opened) == 1
+    assert opened[0]["receiver_hostname"] == "127.0.0.1"
+    assert opened[0]["receiver_port"] == paired_instances.receiver_server.port
+
+    # Receiver registered the offloader's session under the
+    # offloader's dashboard_id.
+    sessions = paired_instances.receiver._peer_link_sessions
+    assert paired_instances.offloader_dashboard_id in sessions
+    session = sessions[paired_instances.offloader_dashboard_id]
+    assert session.dashboard_id == paired_instances.offloader_dashboard_id
+
+
+@pytest.mark.asyncio
+async def test_paired_instances_teardown_closes_session_cleanly(
+    paired_instances: PairedInstances,
+) -> None:
+    """The harness teardown unwinds the peer-link session without leaking tasks.
+
+    Pins the cleanup contract: after the test body returns and
+    the fixture's teardown runs (offloader.stop → receiver.stop
+    → server.close), both controllers' session registries are
+    empty and the offloader's
+    ``OFFLOADER_PEER_LINK_CLOSED`` event has fired with
+    ``reason="client_stopped"`` (the offloader-initiated path).
+
+    The teardown itself happens after this test's body — the
+    body's job is to wait for the session to open + subscribe
+    to the closed event so the teardown's effects are
+    observable to the next assertion.
+    """
+    closed = capture_events(paired_instances.offloader_bus, EventType.OFFLOADER_PEER_LINK_CLOSED)
+
+    await paired_instances.wait_until_session_opened()
+
+    # Drive the offloader's stop directly so we can assert
+    # on the resulting CLOSED event from inside the test
+    # body rather than chasing post-teardown state.
+    await paired_instances.offloader.stop()
+
+    await asyncio.wait_for(closed.received.wait(), timeout=2.0)
+    assert closed[0]["receiver_hostname"] == "127.0.0.1"
+    assert closed[0]["receiver_port"] == paired_instances.receiver_server.port
+    assert closed[0]["reason"] == "client_stopped"

--- a/tests/e2e/test_pair_and_session.py
+++ b/tests/e2e/test_pair_and_session.py
@@ -16,7 +16,8 @@ import pytest
 
 from esphome_device_builder.models import EventType
 
-from .conftest import PairedInstances, capture_events
+from ..conftest import capture_events
+from .conftest import PairedInstances
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -56,6 +56,8 @@ from esphome_device_builder.models import (
     StoredPeer,
 )
 
+from .conftest import make_remote_build_controller
+
 # ---------------------------------------------------------------------------
 # Helpers used by the tests
 # ---------------------------------------------------------------------------
@@ -84,11 +86,6 @@ def _fake_service_info(
 
 
 def _make_controller(*, config_dir: Path, real_bus: bool = False) -> RemoteBuildController:
-    db = MagicMock()
-    db.devices = MagicMock()
-    db.devices.zeroconf = None
-    db._dashboard_advertiser = None
-    db.settings = MagicMock()
     # The controller's ``__init__`` constructs a per-file
     # ``Store`` keyed off ``config_dir / ".offloader_pairings.json"``,
     # so callers must thread a real ``Path`` through (typically
@@ -96,19 +93,21 @@ def _make_controller(*, config_dir: Path, real_bus: bool = False) -> RemoteBuild
     # ``MagicMock() / "..."`` and trip ``__truediv__`` somewhere
     # downstream; an explicit signature beats the silent failure
     # mode.
-    db.settings.config_dir = config_dir
+    #
+    # Long-poll tests for ``lookup_peer_for_status`` exercise the
+    # bus.listening machinery for real (a MagicMock bus would
+    # never deliver events to the listener and the long-poll
+    # would only ever take the timeout fallback); they pass
+    # ``real_bus=True``.
+    bus = EventBus() if real_bus else None
+    controller = make_remote_build_controller(config_dir=config_dir, bus=bus)
     # ``set_settings`` calls ``apply_remote_build_enabled`` to
     # live-rebind the listener; in-process tests don't exercise
-    # the bind path so a no-op AsyncMock is sufficient.
-    db.apply_remote_build_enabled = AsyncMock(return_value=False)
-    if real_bus:
-        # Long-poll tests for ``lookup_peer_for_status`` exercise the
-        # bus.listening machinery for real (a MagicMock bus would
-        # never deliver events to the listener and the long-poll
-        # would only ever take the timeout fallback). Bring up an
-        # actual ``EventBus`` for those.
-        db.bus = EventBus()
-    return RemoteBuildController(db)
+    # the bind path so a no-op AsyncMock is sufficient. Patched
+    # on the per-test stub-DB rather than baked into the shared
+    # helper because only this file's tests touch ``set_settings``.
+    controller._db.apply_remote_build_enabled = AsyncMock(return_value=False)
+    return controller
 
 
 async def _seed_metadata(config_dir: Any, remote_build: dict) -> None:

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -74,15 +74,11 @@ from esphome_device_builder.models import (
     StoredPeer,
 )
 
+from .conftest import make_remote_build_controller
+
 
 def _make_controller(*, config_dir: Any = None) -> RemoteBuildController:
-    db = MagicMock()
-    db.devices = MagicMock()
-    db.devices.zeroconf = None
-    db._dashboard_advertiser = None
-    db.settings = MagicMock()
-    db.settings.config_dir = config_dir
-    return RemoteBuildController(db)
+    return make_remote_build_controller(config_dir=config_dir)
 
 
 def _seed_peer(controller: RemoteBuildController, peer: StoredPeer) -> None:

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -71,17 +71,11 @@ from esphome_device_builder.models import (
     StoredPeer,
 )
 
-from .conftest import cancel_and_drain, capture_events
+from .conftest import cancel_and_drain, capture_events, make_remote_build_controller
 
 
 def _make_controller(*, config_dir: Path) -> RemoteBuildController:
-    db = MagicMock()
-    db.devices = MagicMock()
-    db.devices.zeroconf = None
-    db._dashboard_advertiser = None
-    db.settings = MagicMock()
-    db.settings.config_dir = config_dir
-    return RemoteBuildController(db)
+    return make_remote_build_controller(config_dir=config_dir)
 
 
 @pytest.fixture

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -71,6 +71,8 @@ from esphome_device_builder.models import (
     StoredPeer,
 )
 
+from .conftest import cancel_and_drain, capture_events
+
 
 def _make_controller(*, config_dir: Path) -> RemoteBuildController:
     db = MagicMock()
@@ -80,54 +82,6 @@ def _make_controller(*, config_dir: Path) -> RemoteBuildController:
     db.settings = MagicMock()
     db.settings.config_dir = config_dir
     return RemoteBuildController(db)
-
-
-class _CapturedEvents(list[dict]):
-    """A list of captured event payloads with an :class:`asyncio.Event` that fires on each append.
-
-    Subclassing ``list`` keeps the natural ``captured[0]["reason"]``
-    / ``len(captured)`` access shape that callers expect; the
-    extra :attr:`received` event lets a test ``await asyncio.wait_for(
-    captured.received.wait(), timeout=...)`` instead of polling
-    on a ``for _ in range(N): sleep(0.01)`` loop.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.received = asyncio.Event()
-
-    def append(self, item: dict) -> None:
-        super().append(item)
-        self.received.set()
-
-
-def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:
-    """Subscribe to *event_type* on *bus* and return a list captured-as-they-fire.
-
-    Each fired event's ``data`` payload is materialised into a
-    plain dict and appended. Returned object is a ``list`` subclass
-    with a ``received`` :class:`asyncio.Event` that's set on every
-    append — use ``await asyncio.wait_for(captured.received.wait(),
-    timeout=...)`` to block until the first event lands rather
-    than polling.
-    """
-    captured = _CapturedEvents()
-    bus.add_listener(event_type, lambda event: captured.append(dict(event.data)))
-    return captured
-
-
-async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
-    """Cancel *task* and await its termination, swallowing the resulting CancelledError.
-
-    Equivalent to ``task.cancel(); contextlib.suppress(...) +
-    await``, but written with :func:`asyncio.gather` so the
-    exception is captured by the gather aggregation rather than
-    propagating into the test body. Use at end-of-test cleanup
-    where the cancellation was the test's intended teardown
-    signal — not where the test asserts on the cancellation.
-    """
-    task.cancel()
-    await asyncio.gather(task, return_exceptions=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
# What does this implement/fix?

First cut of the **E2E test harness** row from the [#106](https://github.com/esphome/device-builder/issues/106) phase table — the "two-instance pair + build + download" item that cross-cuts phases 5–8. Lands the harness primitives now so 5b/5c/5d tests can build on top instead of each phase rolling its own two-instance scaffolding.

**What this PR adds:**

- **`tests/e2e/conftest.py`** — `paired_instances` fixture standing up two real `RemoteBuildController` instances (receiver + offloader) wired against real `EventBus` instances, with the receiver's peer-link Noise WS endpoint bound to a real ephemeral TCP port via `aiohttp.test_utils.TestServer` and the offloader's long-lived `PeerLinkClient` (5a-2) auto-spawned by `start()` against the seeded APPROVED `StoredPairing`.

- **`PairedInstances` dataclass** — what the fixture yields. Carries the two controllers, the TestServer, both event buses, and the offloader's `dashboard_id`. Exposes `wait_until_session_opened()` as the conventional sync point so test bodies wait on a single line instead of polling the receiver's `_peer_link_sessions` registry by hand.

- **`capture_events(bus, event_type)` helper** mirrored from the single-side test files — list-subclass with an `asyncio.Event` that fires on each append. Lets tests `await asyncio.wait_for(captured.received.wait(), timeout=...)` against a real bus instead of a `MagicMock`-backed counter.

- **`tests/e2e/test_pair_and_session.py`** — two smoke tests that pin the harness contract:
  - `test_paired_instances_open_peer_link_session` — after `wait_until_session_opened()`, both the offloader-side `OFFLOADER_PEER_LINK_OPENED` event has fired with the right receiver coordinates AND the receiver-side `_peer_link_sessions[<offloader_dashboard_id>]` is registered.
  - `test_paired_instances_teardown_closes_session_cleanly` — driving `offloader.stop()` from inside the test body fires `OFFLOADER_PEER_LINK_CLOSED` with `reason="client_stopped"`, exercising the cancellation handler that sends a structured `terminate{client_stopped}` to the receiver before unwinding.

**Pair-flow short-circuit (deliberate scope choice).** The harness seeds APPROVED rows directly into RAM (`StoredPeer` on the receiver, `StoredPairing` on the offloader) before either `start()` runs, mimicking the in-memory state the request → approve handshake would have left. The full pair flow itself is already covered by the single-side tests in `test_remote_build_peer_link.py` / `test_remote_build_peer_link_client.py`; the harness's value is what comes *after* pairing — application messages (5b/5c/5d), bundle upload, firmware download — where mismatches between the two sides aren't reachable from single-side tests. A future commit can layer a "go through the full request → approve flow" variant on top of this same harness if a test specifically wants it.

**Related issue or feature (if applicable):**

- esphome/device-builder#106 — E2E test harness row in the phase table.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

(Tests-only addition; no architecture surface changes. The harness will get a one-paragraph mention in `docs/ARCHITECTURE.md`'s testing section once the 5b tests land on top of it and the shape stabilises.)
