### PR TITLE
Phase 5b: push queue_status over peer-link to paired offloaders

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -156,6 +156,32 @@ class FirmwareController:
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def queue_status_snapshot(self) -> tuple[bool, bool, int]:
+        """Return ``(idle, running, queue_depth)`` for the firmware queue.
+
+        Pure synchronous read of the controller's RAM state — no
+        executor hop, no disk read. Used by the remote-build
+        controller's :meth:`_broadcast_queue_status` to compose
+        the receiver-side snapshot for paired offloaders on every
+        ``JOB_QUEUED`` / ``JOB_STARTED`` / terminal event tick.
+
+        ``running`` is ``True`` while a single job occupies the
+        single-job runner slot (``_current_job is not None``);
+        ``queue_depth`` is the count of pending jobs waiting
+        their turn (``_queue.qsize()``); ``idle`` is the
+        nothing-running-and-nothing-queued state. The three
+        fields aren't strictly redundant — the
+        ``running=False, queue_depth>0`` window exists between
+        ``await _queue.put(job)`` and the runner's ``_queue.get()``
+        landing the same item, so a phase-7 scheduler that reads
+        only ``running`` would misclassify a fully-loaded receiver
+        as accepting more work.
+        """
+        running = self._current_job is not None
+        queue_depth = self._queue.qsize()
+        idle = not running and queue_depth == 0
+        return idle, running, queue_depth
+
     async def start(self) -> None:
         """Start the queue processor and restore persisted jobs."""
         self._esphome_cmd = _find_esphome_cmd()

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -883,15 +883,21 @@ class RemoteBuildController:
             shutdown_register=self._shutdown_callbacks.append,
             name="receiver_peers",
         )
-        # Receiver-side bus-listener unsubscribers for the
-        # firmware-queue lifecycle events that drive the
-        # ``queue_status`` peer-link broadcast. Populated in
-        # :meth:`start` and walked in :meth:`stop` so the
-        # listeners don't outlive the controller. Empty at
-        # cold-start; the per-instance attribute exists so
-        # ``stop`` can run unconditionally without an
-        # ``hasattr`` dance.
-        self._unsub_job_events: list[Callable[[], None]] = []
+        # Bus-listener unsubscribers held for the lifetime of the
+        # controller. Populated in :meth:`start` and walked in
+        # :meth:`stop` so the listeners don't outlive the
+        # controller. Currently covers the receiver-side
+        # firmware-queue lifecycle listeners (``JOB_QUEUED`` /
+        # ``JOB_STARTED`` / terminal events) that drive the
+        # ``queue_status`` peer-link broadcast and the
+        # offloader-side ``OFFLOADER_QUEUE_STATUS_CHANGED``
+        # listener that updates ``_peer_queue_status``. New
+        # controller-scoped bus subscriptions should append their
+        # closer here so :meth:`stop` doesn't need a parallel
+        # collection. Empty at cold-start; the per-instance
+        # attribute exists so ``stop`` can run unconditionally
+        # without an ``hasattr`` dance.
+        self._unsub_bus_listeners: list[Callable[[], None]] = []
 
     async def start(self) -> None:
         """
@@ -992,7 +998,7 @@ class RemoteBuildController:
         # trigger a broadcast — they're per-line streaming events
         # that fire at high rates during a build, and the
         # ``queue_status`` shape doesn't change across them.
-        self._unsub_job_events = [
+        self._unsub_bus_listeners = [
             self._db.bus.add_listener(event_type, self._on_firmware_queue_transition)
             for event_type in (
                 EventType.JOB_QUEUED,
@@ -1009,7 +1015,7 @@ class RemoteBuildController:
         # state. Same teardown shape as the JOB_* listeners
         # above — append the unsub closer to the same list so
         # :meth:`stop` walks one collection.
-        self._unsub_job_events.append(
+        self._unsub_bus_listeners.append(
             self._db.bus.add_listener(
                 EventType.OFFLOADER_QUEUE_STATUS_CHANGED,
                 self._on_offloader_queue_status_changed,
@@ -1092,7 +1098,22 @@ class RemoteBuildController:
             queue_depth=queue_depth,
         )
         for session in sessions:
-            await session.send_app_frame(dict(payload))
+            # Per-session try/except so one flaky peer can't starve
+            # broadcasts to its siblings. ``send_app_frame`` already
+            # swallows the common transport / encrypt / serialise
+            # failures and returns ``False``; the bare ``except``
+            # here is the catch-all for an unexpected raise (e.g. a
+            # mock contract drift in tests, or a future code path
+            # that raises before the inner gate). Logged for
+            # visibility, then we move on — the next queue
+            # transition fires another snapshot.
+            try:
+                await session.send_app_frame(dict(payload))
+            except Exception:
+                _LOGGER.exception(
+                    "queue_status broadcast to session %s raised; continuing with siblings",
+                    session.dashboard_id,
+                )
 
     async def register_peer_link_session(self, session: PeerLinkSession) -> None:
         """
@@ -1140,16 +1161,17 @@ class RemoteBuildController:
             except Exception:
                 _LOGGER.debug("remote-build browser cancel failed", exc_info=True)
             self._browser = None
-        # Detach the firmware-queue lifecycle listeners installed
-        # in :meth:`start`. Each closer is the unsubscribe handle
-        # returned by ``EventBus.add_listener``; calling it
-        # removes the listener from the bus's per-event set so
-        # later ``JOB_*`` fires don't re-enter
-        # :meth:`_on_firmware_queue_transition` after the
-        # controller is gone.
-        for unsub in self._unsub_job_events:
+        # Detach every bus listener registered in :meth:`start`.
+        # Each closer is the unsubscribe handle returned by
+        # ``EventBus.add_listener``; calling it removes the
+        # listener from the bus's per-event set so later fires
+        # don't re-enter the controller's callbacks after it's
+        # gone. Covers both the receiver-side firmware-queue
+        # lifecycle listeners and the offloader-side
+        # ``OFFLOADER_QUEUE_STATUS_CHANGED`` listener.
+        for unsub in self._unsub_bus_listeners:
             unsub()
-        self._unsub_job_events.clear()
+        self._unsub_bus_listeners.clear()
         for task in self._tasks:
             task.cancel()
         if self._tasks:

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -86,6 +86,7 @@ from ..helpers.json import loads as json_loads
 from ..helpers.peer_link_identity import get_or_create_peer_link_identity
 from ..helpers.storage import ShutdownCallback, Store
 from ..models import (
+    TERMINAL_JOB_EVENTS,
     ErrorCode,
     EventType,
     IdentityView,
@@ -97,11 +98,14 @@ from ..models import (
     OffloaderPairStatusChangedData,
     OffloaderPeerRevokedAlert,
     OffloaderPinMismatchAlert,
+    OffloaderQueueStatusChangedData,
     OffloaderRemoteBuildSettings,
     PairingSummary,
     PairingWindowState,
+    PeerQueueStatusSnapshotEntry,
     PeerStatus,
     PeerSummary,
+    QueueStatusFrameData,
     ReceiverPeers,
     RemoteBuildHostRemovedData,
     RemoteBuildIdentityRotatedData,
@@ -832,6 +836,24 @@ class RemoteBuildController:
         # event fired still sees the alert it would have missed
         # on the live stream.
         self._offloader_alerts: dict[tuple[str, int], OffloaderAlertSnapshotEntry] = {}
+        # RAM-only offloader-side cache of the most recent
+        # ``queue_status`` snapshot received from each paired
+        # receiver, keyed on ``(receiver_hostname,
+        # receiver_port)``. Updated on every inbound
+        # ``OFFLOADER_QUEUE_STATUS_CHANGED`` (the
+        # :class:`PeerLinkClient` receive loop fires the event
+        # after parsing a wire frame). Surfaced through
+        # ``subscribe_events.initial_state.peer_queue_status`` so
+        # a tab subscribing AFTER the most recent push still
+        # sees the latest value the offloader has observed for
+        # each peer. Never persisted — the next peer-link
+        # session triggers a fresh push on its first queue
+        # transition (or on session-open via the receiver-side
+        # initial broadcast in a follow-up phase). Cleared on
+        # :meth:`unpair` for the matching key so the snapshot
+        # doesn't surface stale data for a pairing the user
+        # removed.
+        self._peer_queue_status: dict[tuple[str, int], PeerQueueStatusSnapshotEntry] = {}
         # ``Store`` registers itself with this list at construction
         # (via ``shutdown_register=...append``); the controller's
         # :meth:`stop` walks the list to flush any debounced save
@@ -861,6 +883,15 @@ class RemoteBuildController:
             shutdown_register=self._shutdown_callbacks.append,
             name="receiver_peers",
         )
+        # Receiver-side bus-listener unsubscribers for the
+        # firmware-queue lifecycle events that drive the
+        # ``queue_status`` peer-link broadcast. Populated in
+        # :meth:`start` and walked in :meth:`stop` so the
+        # listeners don't outlive the controller. Empty at
+        # cold-start; the per-instance attribute exists so
+        # ``stop`` can run unconditionally without an
+        # ``hasattr`` dance.
+        self._unsub_job_events: list[Callable[[], None]] = []
 
     async def start(self) -> None:
         """
@@ -944,6 +975,124 @@ class RemoteBuildController:
         except Exception:
             _LOGGER.exception("Could not start remote-build browser; peer discovery disabled")
             self._browser = None
+        # Subscribe to firmware-queue lifecycle events so every
+        # transition broadcasts a fresh ``queue_status`` snapshot
+        # to all paired offloaders. The transitions of interest
+        # are:
+        # * ``JOB_QUEUED``: a job entered the queue (queue_depth
+        #   bumped; running might already be true if the runner
+        #   is busy)
+        # * ``JOB_STARTED``: the runner picked up the next job
+        #   (queue_depth dropped, running flipped to true)
+        # * Terminal events (``JOB_COMPLETED`` / ``JOB_FAILED`` /
+        #   ``JOB_CANCELLED``): the runner slot is now free
+        #   (running flipped to false; queue_depth may still be
+        #   non-zero if more jobs were queued meanwhile)
+        # ``JOB_OUTPUT`` / ``JOB_PROGRESS`` deliberately don't
+        # trigger a broadcast — they're per-line streaming events
+        # that fire at high rates during a build, and the
+        # ``queue_status`` shape doesn't change across them.
+        self._unsub_job_events = [
+            self._db.bus.add_listener(event_type, self._on_firmware_queue_transition)
+            for event_type in (
+                EventType.JOB_QUEUED,
+                EventType.JOB_STARTED,
+                *TERMINAL_JOB_EVENTS,
+            )
+        ]
+        # Offloader-side: subscribe to the inbound queue-status
+        # bus event the :class:`PeerLinkClient` receive loop
+        # fires after parsing a ``queue_status`` frame. The
+        # listener mirrors the wire-shape primitives into
+        # ``_peer_queue_status`` so a late ``subscribe_events``
+        # snapshot reflects every paired peer's most recent
+        # state. Same teardown shape as the JOB_* listeners
+        # above — append the unsub closer to the same list so
+        # :meth:`stop` walks one collection.
+        self._unsub_job_events.append(
+            self._db.bus.add_listener(
+                EventType.OFFLOADER_QUEUE_STATUS_CHANGED,
+                self._on_offloader_queue_status_changed,
+            )
+        )
+
+    def _on_offloader_queue_status_changed(
+        self, event: Event[OffloaderQueueStatusChangedData]
+    ) -> None:
+        """Update the offloader-side ``_peer_queue_status`` cache.
+
+        The :class:`PeerLinkClient` receive loop validated the
+        wire shape before firing the bus event, so the payload's
+        primitive fields land in the snapshot dict without
+        re-checking. The cached entry strips the receiver-side
+        ``type`` framing — it's a snapshot of the data
+        :class:`PeerQueueStatusSnapshotEntry` describes, not the
+        on-the-wire :class:`QueueStatusFrameData`.
+        """
+        data = event.data
+        key = (data["receiver_hostname"], data["receiver_port"])
+        self._peer_queue_status[key] = PeerQueueStatusSnapshotEntry(
+            receiver_hostname=data["receiver_hostname"],
+            receiver_port=data["receiver_port"],
+            idle=data["idle"],
+            running=data["running"],
+            queue_depth=data["queue_depth"],
+        )
+
+    def peer_queue_status_snapshot(self) -> list[PeerQueueStatusSnapshotEntry]:
+        """Return the offloader-side per-peer queue-status snapshot.
+
+        Pure sync read of the in-memory cache. Used by
+        :meth:`device_builder.DeviceBuilder._cmd_subscribe_events`
+        to seed the offloader UI's per-peer queue display so a
+        tab subscribing AFTER the most recent push still sees
+        the latest value the offloader has observed for each
+        paired receiver.
+        """
+        return list(self._peer_queue_status.values())
+
+    def _on_firmware_queue_transition(self, event: Event[Any]) -> None:
+        """Bus listener: broadcast ``queue_status`` to paired offloaders.
+
+        Called on every ``JOB_QUEUED`` / ``JOB_STARTED`` /
+        terminal event. Builds a snapshot from the firmware
+        controller's RAM state (sync read, no awaitables in the
+        bus listener) and schedules a per-session broadcast as a
+        background task. The broadcast itself runs async because
+        it sends across N peer-link sessions and we don't want a
+        slow socket on one session to block other listeners
+        observing the same event.
+        """
+        if self._db.firmware is None:
+            return
+        idle, running, queue_depth = self._db.firmware.queue_status_snapshot()
+        if not self._peer_link_sessions:
+            return
+        self._db.create_background_task(self._broadcast_queue_status(idle, running, queue_depth))
+
+    async def _broadcast_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
+        """Send a ``queue_status`` frame to every active peer-link session.
+
+        Snapshot the registry to a list before iterating so a
+        concurrent register / unregister mid-walk doesn't mutate
+        the dict under us. Each ``send_app_frame`` is gated on
+        the session's ``_closing`` flag, so a ``terminate``-in-
+        progress session no-ops cleanly here without raising.
+        Per-session failures (``send_app_frame`` returns
+        ``False``) are logged at the channel layer; we don't
+        retry — a session that can't accept the latest snapshot
+        will pick up the next transition's broadcast on its
+        next successful frame.
+        """
+        sessions = list(self._peer_link_sessions.values())
+        payload = QueueStatusFrameData(
+            type="queue_status",
+            idle=idle,
+            running=running,
+            queue_depth=queue_depth,
+        )
+        for session in sessions:
+            await session.send_app_frame(dict(payload))
 
     async def register_peer_link_session(self, session: PeerLinkSession) -> None:
         """
@@ -991,6 +1140,16 @@ class RemoteBuildController:
             except Exception:
                 _LOGGER.debug("remote-build browser cancel failed", exc_info=True)
             self._browser = None
+        # Detach the firmware-queue lifecycle listeners installed
+        # in :meth:`start`. Each closer is the unsubscribe handle
+        # returned by ``EventBus.add_listener``; calling it
+        # removes the listener from the bus's per-event set so
+        # later ``JOB_*`` fires don't re-enter
+        # :meth:`_on_firmware_queue_transition` after the
+        # controller is gone.
+        for unsub in self._unsub_job_events:
+            unsub()
+        self._unsub_job_events.clear()
         for task in self._tasks:
             task.cancel()
         if self._tasks:
@@ -1055,6 +1214,7 @@ class RemoteBuildController:
         # clear (it's the offloader's local UI state, not a
         # receiver-visible row), so silent clear is fine here.
         self._pairings.clear()
+        self._peer_queue_status.clear()
         self._peers.clear()
         # Receiver-side APPROVED peers clear silently too —
         # unlike :meth:`_clear_pending_peers_on_window_close`
@@ -1598,6 +1758,16 @@ class RemoteBuildController:
         # row, so the alert about it is moot. Fires
         # ``OFFLOADER_PAIR_ALERT_DISMISSED`` for cross-tab sync.
         self._dismiss_offloader_alert(clean_host, clean_port)
+        # Drop any cached queue-status snapshot for this
+        # receiver. Without this, ``subscribe_events`` would
+        # keep surfacing a stale snapshot of a pairing the user
+        # just removed; the offloader has no live peer-link
+        # session left to refresh it from. No bus event needs
+        # firing — the ``removed`` ``OFFLOADER_PAIR_STATUS_CHANGED``
+        # already tells subscribers the row is gone, and the
+        # frontend is expected to drop derived per-peer state
+        # in step.
+        self._peer_queue_status.pop(key, None)
         return {"removed": True}
 
     def pairings_snapshot(self) -> list[PairingSummary]:

--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -213,6 +213,7 @@ class AppMessageType(StrEnum):
     PING = "ping"
     PONG = "pong"
     TERMINATE = "terminate"
+    QUEUE_STATUS = "queue_status"
 
 
 async def make_peer_link_handler(

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -52,6 +52,7 @@ from ..models import (
     IntentResponse,
     OffloaderPeerLinkClosedData,
     OffloaderPeerLinkOpenedData,
+    OffloaderQueueStatusChangedData,
     PeerLinkIntent,
 )
 from .remote_build_peer_link import (
@@ -937,6 +938,36 @@ class PeerLinkClient:
                         reason if isinstance(reason, str) else _LOCAL_CLOSE_PEER_HUNG_UP
                     )
                     break
+                if msg_type == AppMessageType.QUEUE_STATUS.value:
+                    # Receiver pushed a fresh firmware-queue
+                    # snapshot. Validate the three fields are
+                    # the expected primitive shapes before
+                    # firing — a malformed frame from a buggy
+                    # peer shouldn't land an ``OffloaderQueueStatusChangedData``
+                    # with a ``None`` ``queue_depth`` on the bus
+                    # for downstream consumers (the cache, the
+                    # ``subscribe_events`` re-broadcast). Drop
+                    # silently on shape mismatch — the receiver
+                    # will broadcast another snapshot on the
+                    # next queue transition.
+                    idle = parsed.get("idle")
+                    running = parsed.get("running")
+                    queue_depth = parsed.get("queue_depth")
+                    if (
+                        not isinstance(idle, bool)
+                        or not isinstance(running, bool)
+                        or not isinstance(queue_depth, int)
+                        or isinstance(queue_depth, bool)
+                    ):
+                        _LOGGER.debug(
+                            "peer-link client malformed queue_status frame from %s:%d: %r",
+                            self._hostname,
+                            self._port,
+                            parsed,
+                        )
+                        continue
+                    self._fire_queue_status(idle, running, queue_depth)
+                    continue
                 _LOGGER.debug(
                     "peer-link client unknown app frame type %r from %s:%d; ignoring",
                     msg_type,
@@ -963,3 +994,22 @@ class PeerLinkClient:
             "reason": reason,
         }
         self._bus.fire(EventType.OFFLOADER_PEER_LINK_CLOSED, payload)
+
+    def _fire_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
+        """Fire ``OFFLOADER_QUEUE_STATUS_CHANGED`` for an inbound snapshot.
+
+        The peer-link receive loop validates the wire shape
+        (boolean / int) before getting here, so the event
+        payload's primitive contract holds without re-checking.
+        Listeners on the bus include the offloader-side
+        ``RemoteBuildController`` cache update and the
+        ``subscribe_events`` re-broadcast.
+        """
+        payload: OffloaderQueueStatusChangedData = {
+            "receiver_hostname": self._hostname,
+            "receiver_port": self._port,
+            "idle": idle,
+            "running": running,
+            "queue_depth": queue_depth,
+        }
+        self._bus.fire(EventType.OFFLOADER_QUEUE_STATUS_CHANGED, payload)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -597,6 +597,14 @@ class DeviceBuilder:
                 # ``OFFLOADER_PAIR_ALERT_DISMISSED`` events drive
                 # subsequent mutations.
                 initial["offloader_alerts"] = list(self.remote_build.offloader_alerts_snapshot())
+                # Offloader-side per-peer queue-status snapshot
+                # (phase 5b). RAM-only on the controller;
+                # populated by inbound ``queue_status`` frames
+                # from each paired receiver. Late-subscribers
+                # pick up the most recent value the offloader
+                # has observed for each peer without waiting on
+                # the next live ``OFFLOADER_QUEUE_STATUS_CHANGED``.
+                initial["peer_queue_status"] = list(self.remote_build.peer_queue_status_snapshot())
             await client.send_event(message_id, "initial_state", initial)
             # Confirm subscription so the frontend can mark the WS
             # as live before the first event arrives.

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -258,6 +258,22 @@ class EventType(StrEnum):
     # ``subscribe_events.initial_state.offloader_alerts``.
     OFFLOADER_PAIR_ALERT_DISMISSED = "offloader_pair_alert_dismissed"
 
+    # Offloader-side cache update: a paired receiver pushed a
+    # fresh ``queue_status`` snapshot over its peer-link
+    # session. Payload: ``{receiver_hostname, receiver_port,
+    # idle, running, queue_depth}``. Fired from the
+    # offloader-side ``PeerLinkClient`` receive loop on every
+    # inbound ``queue_status`` application frame; the
+    # remote-build controller listens, updates its
+    # ``_peer_queue_status`` cache (RAM-only, keyed on
+    # ``(host, port)``), and re-broadcasts via the global
+    # ``subscribe_events`` stream so frontend clients can
+    # render the per-peer queue depth live without polling.
+    # Phase 5b is the first real application message exercising
+    # the dispatch loop end-to-end against the 5a foundation;
+    # the scheduler in phase 7 reads the same cache.
+    OFFLOADER_QUEUE_STATUS_CHANGED = "offloader_queue_status_changed"
+
 
 class StreamEvent(StrEnum):
     """Per-stream frame names sent via ``WebSocketClient.send_event``.

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -494,6 +494,77 @@ class OffloaderPeerLinkClosedData(TypedDict):
     reason: str
 
 
+class QueueStatusFrameData(TypedDict):
+    """
+    Application-frame payload for ``AppMessageType.QUEUE_STATUS``.
+
+    Wire shape sent by the receiver-side
+    :class:`RemoteBuildController` over an active peer-link
+    session whenever the firmware queue transitions
+    (``JOB_QUEUED`` / ``JOB_STARTED`` / terminal events).
+    Encrypted under the established Noise session and
+    serialised as JSON before going on the wire.
+
+    The three fields aren't strictly redundant: the
+    ``running=False, queue_depth>0`` window exists between
+    ``await _queue.put(job)`` and the runner's ``_queue.get()``
+    landing the same item, so a phase-7 scheduler that reads
+    only ``running`` would misclassify a fully-loaded receiver
+    as accepting more work. ``idle`` and ``running`` carry both
+    edges so the consumer can render any of "available",
+    "busy", "queued" without re-deriving.
+    """
+
+    type: Literal["queue_status"]
+    idle: bool
+    running: bool
+    queue_depth: int
+
+
+class OffloaderQueueStatusChangedData(TypedDict):
+    """
+    Payload for ``EventType.OFFLOADER_QUEUE_STATUS_CHANGED``.
+
+    Fired on the offloader's local bus whenever the
+    :class:`PeerLinkClient` receive loop processes an inbound
+    ``queue_status`` application frame from a paired receiver.
+    The remote-build controller listens, updates its
+    RAM-only ``_peer_queue_status`` cache (keyed on
+    ``(receiver_hostname, receiver_port)``), and re-broadcasts
+    via the global ``subscribe_events`` stream so frontend
+    clients can render per-peer queue depth without polling.
+    Phase-5b is the first real application message exercising
+    the 5a peer-link foundation end-to-end; the scheduler in
+    phase 7 reads the same cache to pick the least-busy peer
+    on each new offload.
+    """
+
+    receiver_hostname: str
+    receiver_port: int
+    idle: bool
+    running: bool
+    queue_depth: int
+
+
+class PeerQueueStatusSnapshotEntry(TypedDict):
+    """
+    Snapshot row in the offloader-side per-peer queue-status cache.
+
+    Mirror of :class:`OffloaderQueueStatusChangedData` minus the
+    event-only framing (``type``). Used by
+    ``subscribe_events.initial_state.peer_queue_status`` so a
+    tab subscribing AFTER an event fired still sees the most
+    recent value the offloader observed for each paired peer
+    without waiting for the next live event.
+    """
+
+    receiver_hostname: str
+    receiver_port: int
+    idle: bool
+    running: bool
+    queue_depth: int
+
+
 @dataclass
 class StoredPeer(DataClassORJSONMixin):
     """

--- a/tests/controllers/firmware/test_queue_status.py
+++ b/tests/controllers/firmware/test_queue_status.py
@@ -1,0 +1,75 @@
+"""Tests for ``FirmwareController.queue_status_snapshot``.
+
+The snapshot is the only public read of the firmware queue's
+RAM state — used by the remote-build controller's phase-5b
+peer-link broadcast on every queue transition. Keep the three
+state combinations (idle / queued-only / running) pinned here
+so a future refactor that splits the runner slot or queue
+representation has a one-stop check that the public shape
+stays correct.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.models import FirmwareJob, JobType
+
+
+def _make_controller() -> FirmwareController:
+    db = MagicMock()
+    return FirmwareController(db)
+
+
+def _job(job_id: str = "j1") -> FirmwareJob:
+    return FirmwareJob(job_id=job_id, configuration="kitchen.yaml", job_type=JobType.COMPILE)
+
+
+def test_queue_status_snapshot_idle() -> None:
+    """Cold controller: no current job, empty queue → idle."""
+    controller = _make_controller()
+    idle, running, queue_depth = controller.queue_status_snapshot()
+    assert idle is True
+    assert running is False
+    assert queue_depth == 0
+
+
+def test_queue_status_snapshot_running_only() -> None:
+    """Runner busy with no backlog: idle=False, running=True, depth=0."""
+    controller = _make_controller()
+    controller._current_job = _job()
+    idle, running, queue_depth = controller.queue_status_snapshot()
+    assert idle is False
+    assert running is True
+    assert queue_depth == 0
+
+
+def test_queue_status_snapshot_queued_but_not_running() -> None:
+    """The pre-pickup window: ``_queue.put`` ran but ``_queue.get`` hasn't.
+
+    Pins the asymmetry that motivated emitting all three fields:
+    a phase-7 scheduler reading only ``running`` would treat a
+    fully-loaded receiver as accepting more work during this
+    window. The combination is real on the wire because
+    ``submit_job`` puts onto the queue before the runner picks
+    up the next item.
+    """
+    controller = _make_controller()
+    controller._queue.put_nowait(_job("a"))
+    controller._queue.put_nowait(_job("b"))
+    idle, running, queue_depth = controller.queue_status_snapshot()
+    assert idle is False
+    assert running is False
+    assert queue_depth == 2
+
+
+def test_queue_status_snapshot_running_and_queued() -> None:
+    """Runner busy AND backlog: idle=False, running=True, depth>0."""
+    controller = _make_controller()
+    controller._current_job = _job("active")
+    controller._queue.put_nowait(_job("waiting"))
+    idle, running, queue_depth = controller.queue_status_snapshot()
+    assert idle is False
+    assert running is True
+    assert queue_depth == 1

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2418,16 +2418,18 @@ def test_on_firmware_queue_transition_skips_when_firmware_missing(
 @pytest.mark.asyncio
 async def test_broadcast_queue_status_continues_past_failed_session(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A session whose ``send_app_frame`` raises doesn't block sibling sessions.
 
     Phase-5b's broadcast is best-effort per session: a closed
-    session (race with concurrent terminate) or a transport
-    error on one session must not cancel the broadcast for the
-    others. The session's ``send_app_frame`` already returns
-    ``False`` on internal failure rather than raising, but
-    cover the awaitable-raises shape too in case a future
-    refactor flips the contract.
+    session (race with concurrent terminate), a transport
+    error, or any other unexpected raise on one session must
+    not cancel the broadcast for the others. The per-session
+    ``try/except`` in :meth:`_broadcast_queue_status` swallows
+    the raise (logged) and moves on. Without this contract a
+    single flaky peer would starve every paired offloader of
+    queue-status updates.
     """
     controller = _make_controller(config_dir=tmp_path)
 
@@ -2437,16 +2439,19 @@ async def test_broadcast_queue_status_continues_past_failed_session(
     controller._peer_link_sessions["alpha"] = alpha
     controller._peer_link_sessions["beta"] = beta
 
-    with pytest.raises(RuntimeError):
+    with caplog.at_level("ERROR"):
         await controller._broadcast_queue_status(idle=False, running=True, queue_depth=1)
-    # The first session raised before the second could be
-    # reached. The broadcast does NOT swallow the per-session
-    # exception today — it lets the background task runner log
-    # and discard. Pin that contract: a future change that adds
-    # a try/except around the inner await needs to update this
-    # assertion together with the production behaviour.
     alpha.send_app_frame.assert_awaited_once()
-    beta.send_app_frame.assert_not_called()
+    # Sibling session received the snapshot despite alpha raising.
+    beta.send_app_frame.assert_awaited_once_with(
+        {"type": "queue_status", "idle": False, "running": True, "queue_depth": 1}
+    )
+    # Per-session failure landed in the log so a flaky peer is
+    # visible in production rather than silently dropped.
+    assert any(
+        "queue_status broadcast to session alpha raised" in record.message
+        for record in caplog.records
+    )
 
 
 def test_on_offloader_queue_status_changed_caches_snapshot(tmp_path: Path) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2319,3 +2319,200 @@ def test_decode_pairings_recovers_to_empty_on_schema_drift(
         result = _decode_pairings(b'["unexpected", "list", "shape"]')
     assert result == OffloaderRemoteBuildSettings()
     assert any("Corrupt offloader pairings file" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5b: queue_status receiver-side broadcast + offloader-side cache
+# ---------------------------------------------------------------------------
+
+
+def _make_session_stub(dashboard_id: str) -> AsyncMock:
+    """Build a ``PeerLinkSession`` stand-in with an ``AsyncMock`` send.
+
+    Tests of the broadcast path care about (a) which sessions
+    received the frame and (b) what payload landed there. A
+    full session would require a Noise transcript; here a stub
+    that records ``send_app_frame`` calls is enough.
+    """
+    session = MagicMock()
+    session.dashboard_id = dashboard_id
+    session.send_app_frame = AsyncMock(return_value=True)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_on_firmware_queue_transition_broadcasts_to_every_session(
+    tmp_path: Path,
+) -> None:
+    """A ``JOB_STARTED`` tick broadcasts a fresh snapshot to all paired offloaders."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.firmware = MagicMock()
+    controller._db.firmware.queue_status_snapshot.return_value = (False, True, 2)
+    # ``create_background_task`` on the real ``DeviceBuilder``
+    # schedules onto the running loop; the MagicMock-backed
+    # parent here doesn't have a loop, so route through the
+    # actual event loop directly.
+    controller._db.create_background_task = asyncio.create_task
+
+    alpha = _make_session_stub("alpha")
+    beta = _make_session_stub("beta")
+    controller._peer_link_sessions["alpha"] = alpha
+    controller._peer_link_sessions["beta"] = beta
+
+    controller._on_firmware_queue_transition(
+        MagicMock(event_type=EventType.JOB_STARTED, data={"job_id": "j1"})
+    )
+    # Background task scheduled; yield until both sessions saw the send.
+    for _ in range(50):
+        if alpha.send_app_frame.await_count and beta.send_app_frame.await_count:
+            break
+        await asyncio.sleep(0)
+
+    expected_payload = {
+        "type": "queue_status",
+        "idle": False,
+        "running": True,
+        "queue_depth": 2,
+    }
+    alpha.send_app_frame.assert_awaited_once_with(expected_payload)
+    beta.send_app_frame.assert_awaited_once_with(expected_payload)
+
+
+def test_on_firmware_queue_transition_skips_when_no_sessions(tmp_path: Path) -> None:
+    """No paired offloaders → no background task scheduled."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.firmware = MagicMock()
+    controller._db.firmware.queue_status_snapshot.return_value = (True, False, 0)
+    controller._db.create_background_task = MagicMock()
+
+    controller._on_firmware_queue_transition(
+        MagicMock(event_type=EventType.JOB_COMPLETED, data={"job_id": "j1"})
+    )
+
+    controller._db.create_background_task.assert_not_called()
+
+
+def test_on_firmware_queue_transition_skips_when_firmware_missing(
+    tmp_path: Path,
+) -> None:
+    """Bus tick when ``DeviceBuilder.firmware`` is ``None`` short-circuits.
+
+    ``RemoteBuildController.start`` registers the listener
+    before :class:`DeviceBuilder` finishes wiring all
+    controllers, but the ``firmware`` attribute is set first
+    in startup; still, a partial-startup race where the bus
+    fires before ``firmware`` lands shouldn't crash. Confirm
+    the early-exit path doesn't hit the snapshot helper.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.firmware = None
+    controller._db.create_background_task = MagicMock()
+
+    controller._on_firmware_queue_transition(
+        MagicMock(event_type=EventType.JOB_QUEUED, data={"job_id": "j1"})
+    )
+
+    controller._db.create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_queue_status_continues_past_failed_session(
+    tmp_path: Path,
+) -> None:
+    """A session whose ``send_app_frame`` raises doesn't block sibling sessions.
+
+    Phase-5b's broadcast is best-effort per session: a closed
+    session (race with concurrent terminate) or a transport
+    error on one session must not cancel the broadcast for the
+    others. The session's ``send_app_frame`` already returns
+    ``False`` on internal failure rather than raising, but
+    cover the awaitable-raises shape too in case a future
+    refactor flips the contract.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+
+    alpha = _make_session_stub("alpha")
+    alpha.send_app_frame = AsyncMock(side_effect=RuntimeError("boom"))
+    beta = _make_session_stub("beta")
+    controller._peer_link_sessions["alpha"] = alpha
+    controller._peer_link_sessions["beta"] = beta
+
+    with pytest.raises(RuntimeError):
+        await controller._broadcast_queue_status(idle=False, running=True, queue_depth=1)
+    # The first session raised before the second could be
+    # reached. The broadcast does NOT swallow the per-session
+    # exception today — it lets the background task runner log
+    # and discard. Pin that contract: a future change that adds
+    # a try/except around the inner await needs to update this
+    # assertion together with the production behaviour.
+    alpha.send_app_frame.assert_awaited_once()
+    beta.send_app_frame.assert_not_called()
+
+
+def test_on_offloader_queue_status_changed_caches_snapshot(tmp_path: Path) -> None:
+    """Inbound bus event lands a per-peer snapshot in the cache."""
+    controller = _make_controller(config_dir=tmp_path)
+    payload = {
+        "receiver_hostname": "192.168.1.10",
+        "receiver_port": 6055,
+        "idle": False,
+        "running": True,
+        "queue_depth": 3,
+    }
+    controller._on_offloader_queue_status_changed(MagicMock(data=payload))
+
+    cached = controller._peer_queue_status[("192.168.1.10", 6055)]
+    assert cached["receiver_hostname"] == "192.168.1.10"
+    assert cached["receiver_port"] == 6055
+    assert cached["idle"] is False
+    assert cached["running"] is True
+    assert cached["queue_depth"] == 3
+
+
+def test_on_offloader_queue_status_changed_overwrites_prior(tmp_path: Path) -> None:
+    """A second event for the same key replaces the prior snapshot."""
+    controller = _make_controller(config_dir=tmp_path)
+    first = {
+        "receiver_hostname": "host",
+        "receiver_port": 6055,
+        "idle": True,
+        "running": False,
+        "queue_depth": 0,
+    }
+    second = {
+        "receiver_hostname": "host",
+        "receiver_port": 6055,
+        "idle": False,
+        "running": True,
+        "queue_depth": 5,
+    }
+    controller._on_offloader_queue_status_changed(MagicMock(data=first))
+    controller._on_offloader_queue_status_changed(MagicMock(data=second))
+
+    cached = controller._peer_queue_status[("host", 6055)]
+    assert cached["queue_depth"] == 5
+    assert cached["running"] is True
+    assert len(controller._peer_queue_status) == 1
+
+
+def test_peer_queue_status_snapshot_returns_list(tmp_path: Path) -> None:
+    """``peer_queue_status_snapshot`` returns a list of cached entries."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller._peer_queue_status[("a", 6055)] = {
+        "receiver_hostname": "a",
+        "receiver_port": 6055,
+        "idle": True,
+        "running": False,
+        "queue_depth": 0,
+    }
+    controller._peer_queue_status[("b", 6055)] = {
+        "receiver_hostname": "b",
+        "receiver_port": 6055,
+        "idle": False,
+        "running": True,
+        "queue_depth": 2,
+    }
+    snapshot = controller.peer_queue_status_snapshot()
+    assert len(snapshot) == 2
+    hostnames = {entry["receiver_hostname"] for entry in snapshot}
+    assert hostnames == {"a", "b"}

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -3073,3 +3073,146 @@ async def test_stop_drains_peer_link_clients(
     # with ``return_exceptions=True`` so the test absorbs each
     # task's captured ``CancelledError`` without it surfacing.
     await asyncio.gather(*tasks, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5b: queue_status receive handling on the offloader-side client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_session_loops_fires_queue_status_event_on_inbound_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``queue_status`` frame from the receiver fires ``OFFLOADER_QUEUE_STATUS_CHANGED``."""
+    initiator, responder = _build_handshake_pair()
+    closed_event = asyncio.Event()
+
+    class _QueueStatusWs(_ParkingWs):
+        def __init__(self, evt: asyncio.Event) -> None:
+            super().__init__(evt)
+            self._delivered = False
+
+        async def __anext__(self) -> Any:
+            if not self._delivered:
+                self._delivered = True
+                frame = responder.encrypt(
+                    _json.dumps(
+                        {
+                            "type": "queue_status",
+                            "idle": False,
+                            "running": True,
+                            "queue_depth": 3,
+                        }
+                    )
+                )
+                return WSMessage(type=WSMsgType.BINARY, data=frame, extra="")
+            await self._closed_event.wait()
+            raise StopAsyncIteration
+
+    ws = _QueueStatusWs(closed_event)
+    channel = PeerLinkChannel(noise=initiator, ws=ws, log_label="127.0.0.1:6055")
+
+    async def _idle_heartbeat(*, send_ping: Any, last_pong_at: Any, on_dead: Any) -> None:
+        await closed_event.wait()
+
+    monkeypatch.setattr(remote_build_peer_link_client, "run_peer_link_heartbeat", _idle_heartbeat)
+
+    bus = EventBus()
+    captured = capture_events(bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED)
+
+    client = PeerLinkClient(
+        receiver_hostname="receiver.local",
+        receiver_port=6055,
+        identity_priv=secrets.token_bytes(32),
+        dashboard_id="alpha",
+        bus=bus,
+    )
+    drive_task = asyncio.create_task(client._run_session_loops(channel))
+
+    await asyncio.wait_for(captured.received.wait(), timeout=2.0)
+    closed_event.set()
+    reason = await drive_task
+    assert reason == "peer_hung_up"
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload == {
+        "receiver_hostname": "receiver.local",
+        "receiver_port": 6055,
+        "idle": False,
+        "running": True,
+        "queue_depth": 3,
+    }
+
+
+@pytest.mark.parametrize(
+    "frame_body",
+    [
+        # idle is not bool
+        {"type": "queue_status", "idle": "no", "running": True, "queue_depth": 1},
+        # running is missing
+        {"type": "queue_status", "idle": False, "queue_depth": 1},
+        # queue_depth is a string
+        {"type": "queue_status", "idle": False, "running": True, "queue_depth": "two"},
+        # queue_depth is bool (which would otherwise pass the int check
+        # because bool is a subclass of int)
+        {"type": "queue_status", "idle": False, "running": True, "queue_depth": True},
+    ],
+    ids=[
+        "non-bool-idle",
+        "missing-running",
+        "non-int-queue-depth",
+        "bool-queue-depth",
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_session_loops_drops_malformed_queue_status(
+    monkeypatch: pytest.MonkeyPatch,
+    frame_body: dict[str, Any],
+) -> None:
+    """A malformed ``queue_status`` frame is dropped without firing the event."""
+    initiator, responder = _build_handshake_pair()
+    closed_event = asyncio.Event()
+
+    class _BadQueueStatusWs(_ParkingWs):
+        def __init__(self, evt: asyncio.Event) -> None:
+            super().__init__(evt)
+            self._delivered = False
+
+        async def __anext__(self) -> Any:
+            if not self._delivered:
+                self._delivered = True
+                frame = responder.encrypt(_json.dumps(frame_body))
+                return WSMessage(type=WSMsgType.BINARY, data=frame, extra="")
+            await self._closed_event.wait()
+            raise StopAsyncIteration
+
+    ws = _BadQueueStatusWs(closed_event)
+    channel = PeerLinkChannel(noise=initiator, ws=ws, log_label="127.0.0.1:6055")
+
+    async def _idle_heartbeat(*, send_ping: Any, last_pong_at: Any, on_dead: Any) -> None:
+        await closed_event.wait()
+
+    monkeypatch.setattr(remote_build_peer_link_client, "run_peer_link_heartbeat", _idle_heartbeat)
+
+    bus = EventBus()
+    captured = capture_events(bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED)
+
+    client = PeerLinkClient(
+        receiver_hostname="receiver.local",
+        receiver_port=6055,
+        identity_priv=secrets.token_bytes(32),
+        dashboard_id="alpha",
+        bus=bus,
+    )
+    drive_task = asyncio.create_task(client._run_session_loops(channel))
+    # Yield long enough for the malformed-frame branch to run
+    # and drop the frame; then close out cleanly.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    closed_event.set()
+    reason = await drive_task
+
+    assert reason == "peer_hung_up"
+    assert len(captured) == 0


### PR DESCRIPTION
# What does this implement/fix?

Phase 5b of the remote-build offload feature: receiver pushes a
`queue_status` snapshot to every paired offloader on every
`FirmwareController` queue transition; offloader caches the most
recent value per peer in RAM. First real application message
exercising the 5a peer-link foundation end-to-end.

**Receiver side** subscribes `JOB_QUEUED` / `JOB_STARTED` /
terminal events on the dashboard bus and broadcasts a
`{type: queue_status, idle, running, queue_depth}` Noise frame to
every active peer-link session. `JOB_OUTPUT` / `JOB_PROGRESS`
deliberately don't trigger; high-rate streaming events that don't
change the snapshot shape would just burn cipher budget.

**Offloader side** `PeerLinkClient` receive loop validates the
wire shape (bool / bool / int, with `bool` excluded from the int
check so a `queue_depth=True` typo can't sneak past) and fires
`OFFLOADER_QUEUE_STATUS_CHANGED` on the local bus.
`RemoteBuildController` caches the latest snapshot per
`(receiver_hostname, receiver_port)` in RAM; cleared on `unpair`
and `stop`, never persisted.
`subscribe_events.initial_state.peer_queue_status` carries the
cache so a tab subscribing AFTER the most recent push still
reflects current state.

The three fields aren't redundant: the
`running=False, queue_depth>0` window between `_queue.put(job)`
and the runner's `_queue.get()` landing the same item means a
phase-7 scheduler reading only `running` would misclassify a
fully-loaded receiver as accepting more work.

Frontend rendering is deferred to phase 7b alongside the rest of
the offloader Settings UI; phase 7's scheduler is the load-bearing
consumer of the cache, and a standalone diagnostic badge before
then isn't worth a separate PR.

**Related issue or feature (if applicable):**

- part of #106 (row 5b in the tracking table)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

The bus event (`OFFLOADER_QUEUE_STATUS_CHANGED`) and snapshot
field (`subscribe_events.initial_state.peer_queue_status`) are
defined now so phase 7b can consume them, but no frontend lands
in this PR.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
