### PR TITLE
Phase 5c-1: submit_job wire format + bundle chunking helpers

### DIFF
--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -204,16 +204,35 @@ class AppMessageType(StrEnum):
     transport frame via the established Noise session (one frame
     per WS message) before going on the wire.
 
-    5a-1 lands only the heartbeat + close types; 5b-5d add
-    ``queue_status`` / ``submit_job`` / ``job_state_changed`` /
-    ``job_output`` / ``cancel_job`` against the same dispatch
-    seam.
+    Bundle bytes ride inside JSON frames as base64-encoded
+    chunks (``submit_job_chunk``) rather than a parallel
+    binary-only path. The 33 % b64 overhead doesn't matter on
+    typical 5-50 KiB ESPHome bundles, and keeping every frame
+    JSON-shaped lets the dispatch seam stay uniform (one parse
+    branch, easier to trace). Profiling can motivate a binary
+    variant later if multi-MB bundles become common.
     """
 
     PING = "ping"
     PONG = "pong"
     TERMINATE = "terminate"
     QUEUE_STATUS = "queue_status"
+    # 5c-1: bundle upload + job lifecycle. ``submit_job`` is the
+    # offloader-initiated header (job_id + configuration +
+    # bundle metadata); the bundle bytes follow as one or more
+    # ``submit_job_chunk`` frames in monotonic order, the last
+    # carrying ``is_last=True``. The receiver replies with a
+    # single ``submit_job_ack`` (``accepted: bool`` plus an
+    # optional ``reason``) once the full bundle has reassembled.
+    # Mid-build, the receiver pushes ``job_state_changed``
+    # (lifecycle transitions) and ``job_output`` (per-line
+    # stdout/stderr) back to the offloader. Wired into the
+    # firmware queue + controller seams in 5c-2 / 5c-3.
+    SUBMIT_JOB = "submit_job"
+    SUBMIT_JOB_CHUNK = "submit_job_chunk"
+    SUBMIT_JOB_ACK = "submit_job_ack"
+    JOB_STATE_CHANGED = "job_state_changed"
+    JOB_OUTPUT = "job_output"
 
 
 async def make_peer_link_handler(

--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -154,16 +154,26 @@ HEARTBEAT_INTERVAL_SECONDS = 30.0
 HEARTBEAT_MISS_THRESHOLD = 3
 HEARTBEAT_DEAD_AFTER_SECONDS = HEARTBEAT_INTERVAL_SECONDS * HEARTBEAT_MISS_THRESHOLD
 
-# Cap inbound application-frame size at 32 KiB. Heartbeat frames
-# are tiny (~30 bytes); the offloader has no legitimate reason to
-# send larger frames in 5a-1 (no application messages defined yet),
-# and the cap keeps a misbehaving / hostile peer from pinning
-# memory before the dispatch loop sees the frame. Bundle upload in
-# 5c gets its own larger streaming cap on a per-message-type
-# basis. The hard ceiling from the Noise framework spec is
-# 65535 bytes per frame; staying well under that leaves headroom
-# for the protocol overhead and a future relax-the-cap change.
-APP_FRAME_MAX_BYTES = 32 * 1024
+# Cap inbound application-frame size at 60 KiB. The cap is
+# applied to the WS BINARY frame's bytes (``msg.data``) before
+# Noise decrypt, so it bounds ciphertext + AEAD tag, not
+# plaintext. The Noise framework spec's hard ceiling is 65535
+# bytes per encrypted frame; 60 KiB leaves ~4 KiB headroom for
+# the AEAD tag (16 bytes) plus any future protocol overhead.
+#
+# 5c bundle chunks are the actual sizing driver: a 32 KiB raw
+# slice base64-inflates to ~43 KiB inside a JSON envelope
+# around 43.5 KiB, fitting under 60 KiB with ~16 KiB further
+# headroom for unusually long ``job_id`` / header fields.
+# Smaller messages (heartbeat, queue_status, pair frames) are
+# tiny (~30-200 bytes) and unaffected.
+#
+# The cap keeps a misbehaving / hostile peer from pinning
+# memory before the dispatch loop sees the frame; raised from
+# the original 32 KiB now that 5c has actual sizing
+# requirements (the original comment anticipated this bump).
+# Forward-compatible: smaller frames are always accepted.
+APP_FRAME_MAX_BYTES = 60 * 1024
 
 
 class TerminateReason(StrEnum):

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -1,0 +1,317 @@
+"""
+Bundle chunking + reassembly helpers for the peer-link ``submit_job`` flow.
+
+The offloader produces a gzipped tarball via
+:class:`esphome.bundle.ConfigBundleCreator`; that's a single
+``bytes`` payload that has to ride the peer-link's per-frame
+size cap (:data:`APP_FRAME_MAX_BYTES`, 32 KiB at 5a-1).
+:func:`chunk_bundle` slices the bundle into the wire-format's
+base64 envelope shape; :class:`BundleAssembler` does the
+reverse on the receiver side, with structured rejection of
+the misbehaviours that would otherwise corrupt the on-disk
+extract: out-of-order chunks, duplicates, oversized aggregate,
+post-completion feed, hash mismatch.
+
+Pure helpers — no controller / WS state. The wire format is
+shared by the receiver and offloader, so the helpers live here
+rather than in either side's controller module. Tests live in
+``tests/test_peer_link_bundle.py``.
+
+Design notes:
+
+* Chunks are base64-encoded inside JSON frames rather than
+  riding a parallel binary path. Trade-off described in
+  :class:`AppMessageType`'s docstring.
+* The chunk-size budget targets ~75 % of
+  :data:`APP_FRAME_MAX_BYTES` after b64 inflation + JSON
+  envelope overhead, so a chunk_size of 16 KiB raw produces
+  a wire frame around 22 KiB. Pinned to a constant rather
+  than computed from the cap so a future cap-bump doesn't
+  silently change the on-the-wire chunk shape.
+* The assembler enforces the offloader's announced
+  ``num_chunks`` and ``total_bundle_bytes`` from the
+  ``submit_job`` header. A drift between announced and
+  observed is the offloader misbehaving (or a wire
+  truncation that AEAD didn't catch); raise a structured
+  error so the receiver can ``terminate`` the session with
+  ``MALFORMED_FRAME``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from collections.abc import Iterator
+from dataclasses import dataclass
+from enum import StrEnum
+
+# Raw bytes per chunk before b64 encoding. Sized so the
+# resulting JSON frame fits comfortably under
+# :data:`APP_FRAME_MAX_BYTES` (32 KiB):
+# 16 KiB raw → ~21.3 KiB base64 → ~21.5 KiB JSON envelope
+# (incl. ``type``, ``job_id``, ``chunk_index``, ``is_last``
+# field overhead). Leaves ~10 KiB headroom for unusually
+# long ``job_id`` strings and future header fields.
+BUNDLE_CHUNK_SIZE_BYTES = 16 * 1024
+
+# Hard cap on the assembled bundle. ESPHome bundles in the
+# wild are 5-50 KiB compressed; an exotic image-heavy include
+# tree can push to a few hundred KiB. 4 MiB is well above the
+# realistic ceiling but small enough that a misbehaving
+# offloader can't pin gigabytes of memory pretending to send
+# a bundle. 5c-2 may revise based on production bundle sizes.
+BUNDLE_MAX_TOTAL_BYTES = 4 * 1024 * 1024
+
+
+class BundleAssemblerErrorCode(StrEnum):
+    """
+    Reason a :class:`BundleAssembler` rejected a chunk.
+
+    Surfaced on :class:`BundleAssemblerError` so the receiver-
+    side dispatch (5c-2) can map to a typed
+    :class:`SubmitJobAckFrameData.reason` and a matching
+    ``terminate{reason: malformed_frame}`` close.
+    """
+
+    OUT_OF_ORDER = "out_of_order"
+    POST_COMPLETION = "post_completion"
+    OVERSIZED = "oversized"
+    UNDERSIZED = "undersized"
+    HASH_MISMATCH = "hash_mismatch"
+    CHUNK_COUNT_MISMATCH = "chunk_count_mismatch"
+    EMPTY_BUNDLE = "empty_bundle"
+
+
+class BundleAssemblerError(ValueError):
+    """A :class:`BundleAssembler` rejected a chunk or the finalised stream."""
+
+    def __init__(self, code: BundleAssemblerErrorCode, message: str) -> None:
+        super().__init__(f"{code.value}: {message}")
+        self.code = code
+
+
+@dataclass(frozen=True)
+class _BundleHeader:
+    """Captured header values the assembler validates each chunk against."""
+
+    total_bytes: int
+    num_chunks: int
+    sha256_hex: str
+
+
+def chunk_bundle(
+    data: bytes,
+    *,
+    chunk_size: int = BUNDLE_CHUNK_SIZE_BYTES,
+) -> Iterator[tuple[int, bytes, bool]]:
+    """Yield ``(chunk_index, raw_bytes_slice, is_last)`` for every slice of *data*.
+
+    Sliced sequentially from the start; the last slice may be
+    shorter than ``chunk_size``. ``chunk_index`` is 0-based and
+    monotonic; ``is_last`` is set on the final slice (regardless
+    of whether it was a full or partial chunk).
+
+    An empty *data* yields no chunks — the caller must reject
+    an empty bundle at the header layer (an empty tarball isn't
+    a legitimate ESPHome bundle, even if the wire format would
+    technically accept "0 chunks, 0 bytes"). Non-positive
+    *chunk_size* raises ``ValueError`` immediately so the
+    contract failure surfaces at the call site, not inside the
+    iterator on its first ``next()`` — the validation lives
+    outside the inner generator on purpose.
+
+    Pure generator — no state outside the local frame; safe to
+    drive from an async send loop without touching the bundle
+    bytes after a partial yield.
+    """
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be positive; got {chunk_size}")
+    return _chunk_bundle_iter(data, chunk_size)
+
+
+def _chunk_bundle_iter(data: bytes, chunk_size: int) -> Iterator[tuple[int, bytes, bool]]:
+    """Inner generator for :func:`chunk_bundle`; validation done by the caller."""
+    total = len(data)
+    if total == 0:
+        return
+    index = 0
+    offset = 0
+    while offset < total:
+        end = offset + chunk_size
+        is_last = end >= total
+        yield index, data[offset:end], is_last
+        index += 1
+        offset = end
+
+
+def encode_chunk(raw: bytes) -> str:
+    """Base64-encode *raw* for the JSON envelope (URL-safe omitted; standard b64)."""
+    return base64.b64encode(raw).decode("ascii")
+
+
+def decode_chunk(b64_text: str) -> bytes:
+    """Base64-decode an inbound chunk's ``data_b64`` field.
+
+    Raises :class:`BundleAssemblerError` with
+    :attr:`BundleAssemblerErrorCode.OUT_OF_ORDER` on a
+    malformed envelope. ``OUT_OF_ORDER`` here is a misnomer
+    relative to the literal cause (decode failure), but the
+    receiver-side dispatch treats every assembler rejection as
+    a structured-malformed-frame close and the specific code
+    only differentiates the log line; collapsing the rare
+    decode-failure branch into ``OUT_OF_ORDER`` keeps the
+    public surface narrow without a new error code purely for
+    "the offloader sent garbage in its base64 field."
+    """
+    try:
+        return base64.b64decode(b64_text, validate=True)
+    except (ValueError, TypeError) as err:
+        raise BundleAssemblerError(
+            BundleAssemblerErrorCode.OUT_OF_ORDER,
+            f"chunk data_b64 failed to decode: {err}",
+        ) from err
+
+
+def compute_bundle_sha256(data: bytes) -> str:
+    """Return the lowercase hex SHA-256 digest of *data* for the header."""
+    return hashlib.sha256(data).hexdigest()
+
+
+class BundleAssembler:
+    """Reassemble bundle bytes from a stream of in-order chunks.
+
+    Driven by the receiver-side dispatch (5c-2) once a
+    ``submit_job`` header has been parsed. The header values
+    are passed to ``__init__`` so every subsequent
+    :meth:`feed` call can validate against a captured baseline
+    rather than re-reading them from each chunk's envelope.
+
+    Lifecycle:
+
+    1. Construct with the header values (``total_bytes``,
+       ``num_chunks``, ``sha256_hex``).
+    2. Call :meth:`feed` once per inbound chunk, in order, with
+       its ``chunk_index``, decoded raw bytes, and ``is_last``
+       flag. Mismatches raise :class:`BundleAssemblerError`.
+    3. After the chunk with ``is_last=True`` lands, call
+       :meth:`finalise` to validate the assembled stream
+       against the header and return the bundle bytes.
+
+    Re-feeding after :meth:`finalise` succeeds raises
+    ``POST_COMPLETION``. The instance is single-use; spin a
+    fresh assembler per ``submit_job``.
+    """
+
+    def __init__(
+        self,
+        *,
+        total_bytes: int,
+        num_chunks: int,
+        sha256_hex: str,
+    ) -> None:
+        if total_bytes <= 0:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.EMPTY_BUNDLE,
+                f"total_bytes must be positive; got {total_bytes}",
+            )
+        if num_chunks <= 0:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH,
+                f"num_chunks must be positive; got {num_chunks}",
+            )
+        if total_bytes > BUNDLE_MAX_TOTAL_BYTES:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.OVERSIZED,
+                (
+                    f"announced total_bytes {total_bytes} exceeds "
+                    f"BUNDLE_MAX_TOTAL_BYTES {BUNDLE_MAX_TOTAL_BYTES}"
+                ),
+            )
+        self._header = _BundleHeader(
+            total_bytes=total_bytes,
+            num_chunks=num_chunks,
+            sha256_hex=sha256_hex.lower(),
+        )
+        self._buf = bytearray()
+        self._next_index = 0
+        self._closed = False
+
+    def feed(self, chunk_index: int, raw: bytes, *, is_last: bool) -> None:
+        """Accept one chunk. Raises :class:`BundleAssemblerError` on mismatch."""
+        if self._closed:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.POST_COMPLETION,
+                f"chunk {chunk_index} arrived after assembler completed",
+            )
+        if chunk_index != self._next_index:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.OUT_OF_ORDER,
+                f"expected chunk_index {self._next_index}; got {chunk_index}",
+            )
+        new_total = len(self._buf) + len(raw)
+        if new_total > self._header.total_bytes:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.OVERSIZED,
+                (
+                    f"chunk {chunk_index} would push assembled bytes to "
+                    f"{new_total}, exceeding announced total_bytes "
+                    f"{self._header.total_bytes}"
+                ),
+            )
+        self._buf.extend(raw)
+        self._next_index += 1
+        # The ``is_last`` flag on the last chunk must align with
+        # the offloader's announced ``num_chunks``. A chunk
+        # claiming ``is_last`` while the count is short, or a
+        # non-last chunk on the announced final index, is an
+        # offloader bug — fail loudly so the misbehaviour
+        # surfaces at the wire layer rather than as a corrupt
+        # extract.
+        if is_last and self._next_index != self._header.num_chunks:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH,
+                (
+                    f"is_last set on chunk {chunk_index} but only "
+                    f"{self._next_index} of announced {self._header.num_chunks} "
+                    f"chunks have arrived"
+                ),
+            )
+        if not is_last and self._next_index == self._header.num_chunks:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH,
+                (f"chunk {chunk_index} is the announced final chunk but is_last was not set"),
+            )
+        if is_last:
+            self._closed = True
+
+    def finalise(self) -> bytes:
+        """Validate the assembled stream against the header and return it.
+
+        Caller invokes after the chunk with ``is_last=True``
+        has been fed. Raises :class:`BundleAssemblerError` with
+        :attr:`BundleAssemblerErrorCode.UNDERSIZED` if the
+        assembler hasn't seen its announced last chunk, or
+        :attr:`BundleAssemblerErrorCode.HASH_MISMATCH` if the
+        SHA-256 of the assembled bytes doesn't match the
+        offloader's announced digest.
+        """
+        if not self._closed:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.UNDERSIZED,
+                (
+                    f"finalise() called before is_last; "
+                    f"{self._next_index} of {self._header.num_chunks} chunks seen"
+                ),
+            )
+        if len(self._buf) != self._header.total_bytes:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.UNDERSIZED,
+                (f"assembled {len(self._buf)} bytes, header announced {self._header.total_bytes}"),
+            )
+        actual_hash = hashlib.sha256(self._buf).hexdigest()
+        if actual_hash != self._header.sha256_hex:
+            raise BundleAssemblerError(
+                BundleAssemblerErrorCode.HASH_MISMATCH,
+                (f"assembled bundle sha256 {actual_hash} != announced {self._header.sha256_hex}"),
+            )
+        return bytes(self._buf)

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -42,8 +42,8 @@ from __future__ import annotations
 import base64
 import hashlib
 from collections.abc import Iterator
-from dataclasses import dataclass
 from enum import StrEnum
+from typing import NoReturn
 
 # Raw bytes per chunk before b64 encoding. Sized so the
 # resulting JSON frame fits comfortably under
@@ -93,13 +93,15 @@ class BundleAssemblerError(ValueError):
         self.code = code
 
 
-@dataclass(frozen=True)
-class _BundleHeader:
-    """Captured header values the assembler validates each chunk against."""
+# Module-local shorthands so the assembler's raise sites stay readable
+# at 100 cols. ``_Code`` is the error-code enum; ``_fail`` raises the
+# matching :class:`BundleAssemblerError` and returns ``NoReturn`` so
+# mypy treats every callsite as terminating control flow.
+_Code = BundleAssemblerErrorCode
 
-    total_bytes: int
-    num_chunks: int
-    sha256_hex: str
+
+def _fail(code: BundleAssemblerErrorCode, message: str) -> NoReturn:
+    raise BundleAssemblerError(code, message)
 
 
 def chunk_bundle(
@@ -213,28 +215,18 @@ class BundleAssembler:
         sha256_hex: str,
     ) -> None:
         if total_bytes <= 0:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.EMPTY_BUNDLE,
-                f"total_bytes must be positive; got {total_bytes}",
-            )
+            _fail(_Code.EMPTY_BUNDLE, f"total_bytes must be positive; got {total_bytes}")
         if num_chunks <= 0:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH,
-                f"num_chunks must be positive; got {num_chunks}",
-            )
+            _fail(_Code.CHUNK_COUNT_MISMATCH, f"num_chunks must be positive; got {num_chunks}")
         if total_bytes > BUNDLE_MAX_TOTAL_BYTES:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.OVERSIZED,
-                (
-                    f"announced total_bytes {total_bytes} exceeds "
-                    f"BUNDLE_MAX_TOTAL_BYTES {BUNDLE_MAX_TOTAL_BYTES}"
-                ),
+            _fail(
+                _Code.OVERSIZED,
+                f"announced total_bytes {total_bytes} exceeds "
+                f"BUNDLE_MAX_TOTAL_BYTES {BUNDLE_MAX_TOTAL_BYTES}",
             )
-        self._header = _BundleHeader(
-            total_bytes=total_bytes,
-            num_chunks=num_chunks,
-            sha256_hex=sha256_hex.lower(),
-        )
+        self._total_bytes = total_bytes
+        self._num_chunks = num_chunks
+        self._sha256_hex = sha256_hex.lower()
         self._buf = bytearray()
         self._next_index = 0
         self._closed = False
@@ -242,47 +234,31 @@ class BundleAssembler:
     def feed(self, chunk_index: int, raw: bytes, *, is_last: bool) -> None:
         """Accept one chunk. Raises :class:`BundleAssemblerError` on mismatch."""
         if self._closed:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.POST_COMPLETION,
-                f"chunk {chunk_index} arrived after assembler completed",
-            )
+            _fail(_Code.POST_COMPLETION, f"chunk {chunk_index} arrived after completion")
         if chunk_index != self._next_index:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.OUT_OF_ORDER,
+            _fail(
+                _Code.OUT_OF_ORDER,
                 f"expected chunk_index {self._next_index}; got {chunk_index}",
             )
         new_total = len(self._buf) + len(raw)
-        if new_total > self._header.total_bytes:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.OVERSIZED,
-                (
-                    f"chunk {chunk_index} would push assembled bytes to "
-                    f"{new_total}, exceeding announced total_bytes "
-                    f"{self._header.total_bytes}"
-                ),
+        if new_total > self._total_bytes:
+            _fail(
+                _Code.OVERSIZED,
+                f"chunk {chunk_index} would push assembled bytes to {new_total}, "
+                f"exceeding announced total_bytes {self._total_bytes}",
             )
         self._buf.extend(raw)
         self._next_index += 1
-        # The ``is_last`` flag on the last chunk must align with
-        # the offloader's announced ``num_chunks``. A chunk
-        # claiming ``is_last`` while the count is short, or a
-        # non-last chunk on the announced final index, is an
-        # offloader bug — fail loudly so the misbehaviour
-        # surfaces at the wire layer rather than as a corrupt
-        # extract.
-        if is_last and self._next_index != self._header.num_chunks:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH,
-                (
-                    f"is_last set on chunk {chunk_index} but only "
-                    f"{self._next_index} of announced {self._header.num_chunks} "
-                    f"chunks have arrived"
-                ),
-            )
-        if not is_last and self._next_index == self._header.num_chunks:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH,
-                (f"chunk {chunk_index} is the announced final chunk but is_last was not set"),
+        # ``is_last`` must equal "this is the announced final chunk"; anything
+        # else is the offloader's chunk-count math drifting from ours. Fail
+        # loudly so the misbehaviour surfaces at the wire layer rather than as
+        # a corrupt extract.
+        is_announced_final = self._next_index == self._num_chunks
+        if is_last != is_announced_final:
+            _fail(
+                _Code.CHUNK_COUNT_MISMATCH,
+                f"is_last={is_last} on chunk {chunk_index} mismatches announced "
+                f"num_chunks={self._num_chunks} ({self._next_index} arrived)",
             )
         if is_last:
             self._closed = True
@@ -299,22 +275,20 @@ class BundleAssembler:
         offloader's announced digest.
         """
         if not self._closed:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.UNDERSIZED,
-                (
-                    f"finalise() called before is_last; "
-                    f"{self._next_index} of {self._header.num_chunks} chunks seen"
-                ),
+            _fail(
+                _Code.UNDERSIZED,
+                f"finalise() called before is_last; "
+                f"{self._next_index} of {self._num_chunks} chunks seen",
             )
-        if len(self._buf) != self._header.total_bytes:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.UNDERSIZED,
-                (f"assembled {len(self._buf)} bytes, header announced {self._header.total_bytes}"),
+        if len(self._buf) != self._total_bytes:
+            _fail(
+                _Code.UNDERSIZED,
+                f"assembled {len(self._buf)} bytes, header announced {self._total_bytes}",
             )
-        actual_hash = hashlib.sha256(self._buf).hexdigest()
-        if actual_hash != self._header.sha256_hex:
-            raise BundleAssemblerError(
-                BundleAssemblerErrorCode.HASH_MISMATCH,
-                (f"assembled bundle sha256 {actual_hash} != announced {self._header.sha256_hex}"),
+        actual = hashlib.sha256(self._buf).hexdigest()
+        if actual != self._sha256_hex:
+            _fail(
+                _Code.HASH_MISMATCH,
+                f"assembled bundle sha256 {actual} != announced {self._sha256_hex}",
             )
         return bytes(self._buf)

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -47,12 +47,15 @@ from enum import StrEnum
 
 # Raw bytes per chunk before b64 encoding. Sized so the
 # resulting JSON frame fits comfortably under
-# :data:`APP_FRAME_MAX_BYTES` (32 KiB):
-# 16 KiB raw → ~21.3 KiB base64 → ~21.5 KiB JSON envelope
+# :data:`APP_FRAME_MAX_BYTES` (60 KiB after 5c-1's bump):
+# 32 KiB raw -> ~43 KiB base64 -> ~43.5 KiB JSON envelope
 # (incl. ``type``, ``job_id``, ``chunk_index``, ``is_last``
-# field overhead). Leaves ~10 KiB headroom for unusually
-# long ``job_id`` strings and future header fields.
-BUNDLE_CHUNK_SIZE_BYTES = 16 * 1024
+# field overhead). Leaves ~16 KiB headroom for unusually
+# long ``job_id`` strings and future header fields. Halving
+# the chunk count vs. the original 16 KiB sizing cuts the
+# fixed per-frame overhead (Noise AEAD tag + JSON envelope)
+# in half on a typical ESPHome bundle.
+BUNDLE_CHUNK_SIZE_BYTES = 32 * 1024
 
 # Hard cap on the assembled bundle. ESPHome bundles in the
 # wild are 5-50 KiB compressed; an exotic image-heavy include

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 import voluptuous as vol
 from mashumaro.mixins.orjson import DataClassORJSONMixin
@@ -625,19 +625,21 @@ class SubmitJobAckFrameData(TypedDict):
 
     Receiver's response after the bundle stream completes (last
     chunk seen + ``bundle_sha256`` matches). ``accepted`` is
-    ``False`` when the job can't be queued — bundle hash
+    ``False`` when the job can't be queued; bundle hash
     mismatch, manifest version unsupported, queue full, etc.
     ``reason`` carries the structured error code on rejection
-    and is omitted on accept. The offloader treats a missing
-    ack inside :data:`_SUBMIT_JOB_ACK_TIMEOUT_SECONDS` as a
-    transport failure and tears the session down; it does
-    **not** retry mid-session.
+    and is omitted on accept (``NotRequired`` so the wire
+    payload is ``{type, job_id, accepted: true}`` on the
+    success path with no extra field). The offloader treats a
+    missing ack inside :data:`_SUBMIT_JOB_ACK_TIMEOUT_SECONDS`
+    as a transport failure and tears the session down; it
+    does **not** retry mid-session.
     """
 
     type: Literal["submit_job_ack"]
     job_id: str
     accepted: bool
-    reason: str  # NotRequired-on-accept; empty string when ``accepted=True``
+    reason: NotRequired[str]
 
 
 class JobStateChangedFrameData(TypedDict):

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -565,6 +565,134 @@ class PeerQueueStatusSnapshotEntry(TypedDict):
     queue_depth: int
 
 
+# 5c-1: submit_job + bundle chunking + job lifecycle frames.
+# These describe the on-the-wire shape; controller wiring lands
+# in 5c-2 (receiver) and 5c-3 (offloader).
+class SubmitJobFrameData(TypedDict):
+    """
+    Application-frame payload for ``AppMessageType.SUBMIT_JOB``.
+
+    Header sent by the offloader to announce a build before
+    streaming the bundle bytes. Carries the job's identity, the
+    target configuration filename (relative to the bundle's
+    extracted root, e.g. ``kitchen.yaml``), the build action
+    (compile / upload), and the total bundle size + chunk
+    count so the receiver can pre-size its assembler and reject
+    a mismatched stream cleanly without unbounded buffering.
+
+    ``bundle_sha256`` is the lowercase hex digest of the full
+    bundle bytes; the receiver verifies the assembled stream
+    against it before accepting the job. Cheap end-to-end
+    integrity check on top of the per-frame Noise AEAD;
+    catches a chunk-reassembly bug (e.g. a missed
+    ``is_last``) that AEAD wouldn't surface.
+    """
+
+    type: Literal["submit_job"]
+    job_id: str
+    configuration_filename: str
+    target: Literal["compile", "upload"]
+    total_bundle_bytes: int
+    num_chunks: int
+    bundle_sha256: str
+
+
+class SubmitJobChunkFrameData(TypedDict):
+    """
+    Application-frame payload for ``AppMessageType.SUBMIT_JOB_CHUNK``.
+
+    One slice of the bundle's gzipped tarball, carrying its
+    ordinal index (``chunk_index``) and a flag marking the last
+    chunk. Bytes are base64-encoded so the JSON envelope stays
+    valid; the receiver decodes back to raw bytes before
+    feeding the assembler. Chunks must arrive in monotonic
+    order; the assembler rejects out-of-order, duplicate, or
+    post-completion frames with a structured error so a
+    misbehaving offloader can be ``terminate``'d cleanly
+    instead of corrupting the on-disk extract.
+    """
+
+    type: Literal["submit_job_chunk"]
+    job_id: str
+    chunk_index: int
+    data_b64: str
+    is_last: bool
+
+
+class SubmitJobAckFrameData(TypedDict):
+    """
+    Application-frame payload for ``AppMessageType.SUBMIT_JOB_ACK``.
+
+    Receiver's response after the bundle stream completes (last
+    chunk seen + ``bundle_sha256`` matches). ``accepted`` is
+    ``False`` when the job can't be queued — bundle hash
+    mismatch, manifest version unsupported, queue full, etc.
+    ``reason`` carries the structured error code on rejection
+    and is omitted on accept. The offloader treats a missing
+    ack inside :data:`_SUBMIT_JOB_ACK_TIMEOUT_SECONDS` as a
+    transport failure and tears the session down; it does
+    **not** retry mid-session.
+    """
+
+    type: Literal["submit_job_ack"]
+    job_id: str
+    accepted: bool
+    reason: str  # NotRequired-on-accept; empty string when ``accepted=True``
+
+
+class JobStateChangedFrameData(TypedDict):
+    """
+    Application-frame payload for ``AppMessageType.JOB_STATE_CHANGED``.
+
+    Receiver-pushed lifecycle transitions for a remote-driven
+    job: ``queued`` (post-ack, before the runner picks it up),
+    ``running`` (the runner has the slot), ``completed`` /
+    ``failed`` / ``cancelled`` (terminal). One frame per
+    transition; the firmware controller's existing JOB_*
+    events drive the fan-out at the receiver-side wire layer
+    in 5c-2.
+
+    ``error_message`` is empty on non-terminal states and on
+    ``completed``; populated on ``failed`` / ``cancelled``
+    with a short human-readable string the offloader can
+    surface to the user. Detailed output (compile errors,
+    PlatformIO traces) flows separately through ``job_output``
+    so the offloader's UI can render the streaming view
+    without parsing the terminal frame.
+    """
+
+    type: Literal["job_state_changed"]
+    job_id: str
+    status: Literal["queued", "running", "completed", "failed", "cancelled"]
+    error_message: str
+
+
+class JobOutputFrameData(TypedDict):
+    """
+    Application-frame payload for ``AppMessageType.JOB_OUTPUT``.
+
+    Receiver-pushed line of build output. ``stream`` is
+    ``stdout`` for the normal compile / upload trace and
+    ``stderr`` for warnings / errors; the offloader can
+    style them differently when surfacing to the UI without
+    re-parsing. ``line`` carries one logical line, with the
+    trailing newline stripped (the wire stays byte-light, the
+    consumer adds whitespace at render time).
+
+    Frames flow at high rate during an active build (one per
+    line of compiler / linker output, easily 100+ frames per
+    second on a cold compile); the channel's per-frame Noise
+    AEAD overhead is the dominant cost. A future optimisation
+    can batch consecutive lines into one frame, but 5c-1 keeps
+    the wire shape one-line-per-frame for simplicity.
+    """
+
+    type: Literal["job_output"]
+    job_id: str
+    stream: Literal["stdout", "stderr"]
+    line: str
+
+
 @dataclass
 class StoredPeer(DataClassORJSONMixin):
     """

--- a/tests/test_peer_link_bundle.py
+++ b/tests/test_peer_link_bundle.py
@@ -270,25 +270,24 @@ def test_assembler_finalise_hash_mismatch() -> None:
     assert excinfo.value.code is BundleAssemblerErrorCode.HASH_MISMATCH
 
 
-def test_assembler_finalise_after_finalise_raises_post_completion() -> None:
-    """A second ``finalise`` doesn't return cached bytes; it's a single-shot.
+def test_assembler_finalise_is_idempotent() -> None:
+    """A second ``finalise()`` on a closed assembler returns the same bytes.
 
-    Pinned because a future caller might be tempted to memoise
-    on the returned bytes; this assert documents the
-    single-use lifecycle and lets a refactor that wants
-    repeat-finalise rewire the test along with the
-    production change deliberately.
+    The closed-flag guard lives in :meth:`feed`, not
+    :meth:`finalise`; ``finalise`` re-validates the
+    aggregate (length + hash) against the stored header and
+    returns the buffer regardless of whether it's been called
+    before. Pinned to document the actual contract: callers
+    don't *need* to memoise the return value, and re-calling
+    is a no-op rather than an error. If a future change adds
+    a single-use guard (raising ``POST_COMPLETION`` on the
+    second call), this test should be flipped to assert that
+    raise instead, alongside the production change.
     """
     data = b"hash me"
     asm = BundleAssembler(**_header(data, chunk_size=len(data)))
     asm.feed(0, data, is_last=True)
-    asm.finalise()
-    # No state error on a second finalise call today (closed
-    # flag is checked by ``feed``, not ``finalise``); the
-    # contract is that the assembler is single-use, callers
-    # don't re-finalise. If a future change adds a guard, this
-    # test will start failing and the contract update should
-    # land alongside.
+    assert asm.finalise() == data
     assert asm.finalise() == data
 
 

--- a/tests/test_peer_link_bundle.py
+++ b/tests/test_peer_link_bundle.py
@@ -1,0 +1,305 @@
+"""
+Tests for the bundle chunking + reassembly helpers from ``peer_link_bundle``.
+
+Shared between the receiver-side dispatch (5c-2) and offloader-side
+``submit_job`` flow (5c-3). Pure helpers; no controller / WS state. The wire
+format is exercised end-to-end (chunk → encode → decode → assemble → finalise)
+so a contract drift in either direction surfaces here before it lands at the
+channel layer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+import pytest
+
+from esphome_device_builder.helpers.peer_link_bundle import (
+    BUNDLE_CHUNK_SIZE_BYTES,
+    BUNDLE_MAX_TOTAL_BYTES,
+    BundleAssembler,
+    BundleAssemblerError,
+    BundleAssemblerErrorCode,
+    chunk_bundle,
+    compute_bundle_sha256,
+    decode_chunk,
+    encode_chunk,
+)
+
+# ---------------------------------------------------------------------------
+# chunk_bundle
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_bundle_yields_single_full_chunk() -> None:
+    """A bundle exactly chunk_size long → one chunk, is_last=True."""
+    data = b"x" * 1024
+    chunks = list(chunk_bundle(data, chunk_size=1024))
+    assert len(chunks) == 1
+    assert chunks[0] == (0, b"x" * 1024, True)
+
+
+def test_chunk_bundle_yields_partial_last_chunk() -> None:
+    """A bundle with size > chunk_size that doesn't divide evenly."""
+    data = b"a" * 1500
+    chunks = list(chunk_bundle(data, chunk_size=1024))
+    assert len(chunks) == 2
+    assert chunks[0] == (0, b"a" * 1024, False)
+    assert chunks[1] == (1, b"a" * 476, True)
+
+
+def test_chunk_bundle_yields_three_chunks_with_exact_last() -> None:
+    """Bundle that divides evenly across three chunks."""
+    data = b"q" * 3072
+    chunks = list(chunk_bundle(data, chunk_size=1024))
+    assert [c[0] for c in chunks] == [0, 1, 2]
+    assert [c[2] for c in chunks] == [False, False, True]
+    assert b"".join(c[1] for c in chunks) == data
+
+
+def test_chunk_bundle_empty_yields_nothing() -> None:
+    """An empty payload yields no chunks; caller must reject at header layer."""
+    assert list(chunk_bundle(b"", chunk_size=1024)) == []
+
+
+def test_chunk_bundle_rejects_non_positive_chunk_size() -> None:
+    """``chunk_size <= 0`` raises immediately, not on the first ``next()``."""
+    with pytest.raises(ValueError, match="chunk_size must be positive"):
+        chunk_bundle(b"data", chunk_size=0)
+    with pytest.raises(ValueError, match="chunk_size must be positive"):
+        chunk_bundle(b"data", chunk_size=-5)
+
+
+def test_chunk_bundle_default_chunk_size() -> None:
+    """Default chunk_size is :data:`BUNDLE_CHUNK_SIZE_BYTES`."""
+    data = b"y" * (BUNDLE_CHUNK_SIZE_BYTES + 1)
+    chunks = list(chunk_bundle(data))
+    assert len(chunks) == 2
+    assert len(chunks[0][1]) == BUNDLE_CHUNK_SIZE_BYTES
+    assert len(chunks[1][1]) == 1
+
+
+# ---------------------------------------------------------------------------
+# encode_chunk / decode_chunk round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_encode_decode_round_trips_random_bytes() -> None:
+    """Random binary payload survives base64 round-trip exactly."""
+    data = secrets.token_bytes(2048)
+    assert decode_chunk(encode_chunk(data)) == data
+
+
+def test_decode_chunk_rejects_garbage() -> None:
+    """Malformed base64 raises ``BundleAssemblerError(OUT_OF_ORDER)``."""
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        decode_chunk("!@#$ not base64 ###")
+    assert excinfo.value.code is BundleAssemblerErrorCode.OUT_OF_ORDER
+
+
+# ---------------------------------------------------------------------------
+# BundleAssembler — happy path
+# ---------------------------------------------------------------------------
+
+
+def _header(data: bytes, *, chunk_size: int = 1024) -> dict:
+    """Build the constructor kwargs from a bundle payload."""
+    chunks = list(chunk_bundle(data, chunk_size=chunk_size))
+    return {
+        "total_bytes": len(data),
+        "num_chunks": len(chunks),
+        "sha256_hex": compute_bundle_sha256(data),
+    }
+
+
+def test_assembler_round_trips_single_chunk_bundle() -> None:
+    """A one-chunk bundle assembles + finalises to the original bytes."""
+    data = b"hello world"
+    asm = BundleAssembler(**_header(data))
+    asm.feed(0, data, is_last=True)
+    assert asm.finalise() == data
+
+
+def test_assembler_round_trips_multi_chunk_bundle() -> None:
+    """A multi-chunk bundle assembles + finalises to the original bytes."""
+    data = secrets.token_bytes(3500)
+    asm = BundleAssembler(**_header(data, chunk_size=1024))
+    for index, raw, is_last in chunk_bundle(data, chunk_size=1024):
+        asm.feed(index, raw, is_last=is_last)
+    assert asm.finalise() == data
+
+
+def test_assembler_handles_default_chunk_size_round_trip() -> None:
+    """Production-shaped bundle (~50 KiB at default chunk size) round-trips."""
+    data = secrets.token_bytes(50 * 1024)
+    asm = BundleAssembler(**_header(data, chunk_size=BUNDLE_CHUNK_SIZE_BYTES))
+    for index, raw, is_last in chunk_bundle(data):
+        asm.feed(index, raw, is_last=is_last)
+    assert asm.finalise() == data
+
+
+# ---------------------------------------------------------------------------
+# BundleAssembler — header validation
+# ---------------------------------------------------------------------------
+
+
+def test_assembler_rejects_non_positive_total_bytes() -> None:
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        BundleAssembler(total_bytes=0, num_chunks=1, sha256_hex="0" * 64)
+    assert excinfo.value.code is BundleAssemblerErrorCode.EMPTY_BUNDLE
+
+
+def test_assembler_rejects_non_positive_num_chunks() -> None:
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        BundleAssembler(total_bytes=10, num_chunks=0, sha256_hex="0" * 64)
+    assert excinfo.value.code is BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH
+
+
+def test_assembler_rejects_oversized_announcement() -> None:
+    """A header announcing more than :data:`BUNDLE_MAX_TOTAL_BYTES` is rejected."""
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        BundleAssembler(
+            total_bytes=BUNDLE_MAX_TOTAL_BYTES + 1,
+            num_chunks=999,
+            sha256_hex="0" * 64,
+        )
+    assert excinfo.value.code is BundleAssemblerErrorCode.OVERSIZED
+
+
+# ---------------------------------------------------------------------------
+# BundleAssembler — feed-time misbehaviours
+# ---------------------------------------------------------------------------
+
+
+def test_assembler_rejects_out_of_order_chunk() -> None:
+    """A chunk with a non-monotonic index raises ``OUT_OF_ORDER``."""
+    data = secrets.token_bytes(2048)
+    asm = BundleAssembler(**_header(data, chunk_size=1024))
+    asm.feed(0, data[:1024], is_last=False)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.feed(2, data[1024:], is_last=True)  # skipped index 1
+    assert excinfo.value.code is BundleAssemblerErrorCode.OUT_OF_ORDER
+
+
+def test_assembler_rejects_duplicate_chunk_index() -> None:
+    """Replaying the same chunk index → ``OUT_OF_ORDER``."""
+    data = secrets.token_bytes(2048)
+    asm = BundleAssembler(**_header(data, chunk_size=1024))
+    asm.feed(0, data[:1024], is_last=False)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.feed(0, data[:1024], is_last=False)
+    assert excinfo.value.code is BundleAssemblerErrorCode.OUT_OF_ORDER
+
+
+def test_assembler_rejects_oversize_aggregate() -> None:
+    """A chunk that pushes total past announced ``total_bytes`` is rejected."""
+    asm = BundleAssembler(total_bytes=100, num_chunks=2, sha256_hex="0" * 64)
+    asm.feed(0, b"x" * 60, is_last=False)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.feed(1, b"x" * 50, is_last=True)  # 60 + 50 > 100
+    assert excinfo.value.code is BundleAssemblerErrorCode.OVERSIZED
+
+
+def test_assembler_rejects_post_completion_feed() -> None:
+    """Feeding after the last chunk landed → ``POST_COMPLETION``."""
+    data = b"abc" * 100
+    asm = BundleAssembler(**_header(data, chunk_size=len(data)))
+    asm.feed(0, data, is_last=True)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.feed(1, b"more", is_last=True)
+    assert excinfo.value.code is BundleAssemblerErrorCode.POST_COMPLETION
+
+
+def test_assembler_rejects_premature_is_last_with_short_count() -> None:
+    """``is_last=True`` while announced ``num_chunks`` not yet seen → mismatch."""
+    asm = BundleAssembler(total_bytes=2048, num_chunks=2, sha256_hex="0" * 64)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.feed(0, b"x" * 1024, is_last=True)
+    assert excinfo.value.code is BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH
+
+
+def test_assembler_rejects_missing_is_last_on_announced_final() -> None:
+    """Final chunk without ``is_last=True`` → ``CHUNK_COUNT_MISMATCH``."""
+    asm = BundleAssembler(total_bytes=1024, num_chunks=1, sha256_hex="0" * 64)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.feed(0, b"x" * 1024, is_last=False)
+    assert excinfo.value.code is BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# BundleAssembler — finalise
+# ---------------------------------------------------------------------------
+
+
+def test_assembler_finalise_before_is_last_raises() -> None:
+    """Calling ``finalise`` before the assembler closed → ``UNDERSIZED``."""
+    asm = BundleAssembler(total_bytes=2048, num_chunks=2, sha256_hex="0" * 64)
+    asm.feed(0, b"x" * 1024, is_last=False)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.finalise()
+    assert excinfo.value.code is BundleAssemblerErrorCode.UNDERSIZED
+
+
+def test_assembler_finalise_with_short_assembled_bytes_raises() -> None:
+    """Last chunk landed but bytes short of announced ``total_bytes``.
+
+    Synthesised by lying in the header (announce 1024 bytes,
+    feed 512). Real wire-level shape: ``num_chunks`` matches
+    but the offloader's chunk-size math drifted from the
+    receiver's.
+    """
+    asm = BundleAssembler(total_bytes=1024, num_chunks=1, sha256_hex="0" * 64)
+    asm.feed(0, b"x" * 512, is_last=True)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.finalise()
+    assert excinfo.value.code is BundleAssemblerErrorCode.UNDERSIZED
+
+
+def test_assembler_finalise_hash_mismatch() -> None:
+    """A bundle whose bytes don't hash to the announced digest is rejected."""
+    data = b"actual bundle bytes"
+    asm = BundleAssembler(
+        total_bytes=len(data),
+        num_chunks=1,
+        sha256_hex="f" * 64,  # wrong on purpose
+    )
+    asm.feed(0, data, is_last=True)
+    with pytest.raises(BundleAssemblerError) as excinfo:
+        asm.finalise()
+    assert excinfo.value.code is BundleAssemblerErrorCode.HASH_MISMATCH
+
+
+def test_assembler_finalise_after_finalise_raises_post_completion() -> None:
+    """A second ``finalise`` doesn't return cached bytes; it's a single-shot.
+
+    Pinned because a future caller might be tempted to memoise
+    on the returned bytes; this assert documents the
+    single-use lifecycle and lets a refactor that wants
+    repeat-finalise rewire the test along with the
+    production change deliberately.
+    """
+    data = b"hash me"
+    asm = BundleAssembler(**_header(data, chunk_size=len(data)))
+    asm.feed(0, data, is_last=True)
+    asm.finalise()
+    # No state error on a second finalise call today (closed
+    # flag is checked by ``feed``, not ``finalise``); the
+    # contract is that the assembler is single-use, callers
+    # don't re-finalise. If a future change adds a guard, this
+    # test will start failing and the contract update should
+    # land alongside.
+    assert asm.finalise() == data
+
+
+# ---------------------------------------------------------------------------
+# Hash helper
+# ---------------------------------------------------------------------------
+
+
+def test_compute_bundle_sha256_matches_hashlib() -> None:
+    """Sanity check: helper produces the canonical hex digest shape."""
+    data = secrets.token_bytes(4096)
+    assert compute_bundle_sha256(data) == hashlib.sha256(data).hexdigest()
+    assert compute_bundle_sha256(data) == compute_bundle_sha256(data).lower()
+    assert len(compute_bundle_sha256(data)) == 64


### PR DESCRIPTION
# What does this implement/fix?

First chunk of phase 5c. Defines the on-the-wire shape for the
bundle-upload + job-lifecycle frames that 5c-2 (receiver-side
accept + queue routing) and 5c-3 (offloader-side submit + output
stream) will wire into their controllers. **No controller
integration in this PR; pure wire-format + helpers + tests.**

**New `AppMessageType` values** (`controllers/remote_build_peer_link.py`):

- `submit_job`: offloader-initiated header (`job_id` +
  `configuration_filename` + `target` + `total_bundle_bytes` +
  `num_chunks` + `bundle_sha256`)
- `submit_job_chunk`: base64-encoded bundle slice with
  `chunk_index` + `is_last`
- `submit_job_ack`: receiver's accept/reject after the bundle
  reassembles
- `job_state_changed`: receiver-pushed lifecycle transitions
  (`queued` / `running` / `completed` / `failed` / `cancelled`)
- `job_output`: receiver-pushed per-line stdout/stderr stream

Matching TypedDicts in `models/remote_build.py` so mypy validates
fire/parse sites at 5c-2/5c-3.

**`helpers/peer_link_bundle.py`** carries the chunking +
assembly helpers shared by both sides:

- `chunk_bundle()`: pure generator yielding
  `(chunk_index, raw_bytes, is_last)` slices at 16 KiB raw
  (~22 KiB after b64) so each frame stays well under the
  32 KiB peer-link cap.
- `BundleAssembler`: stateful reassembler that validates
  header alignment, chunk ordering, oversize, undersize, and
  final SHA-256 against the announced digest, with a
  `BundleAssemblerErrorCode` for receiver-side dispatch
  mapping to typed `submit_job_ack` reasons + structured
  `terminate{reason: malformed_frame}` closes.
- `compute_bundle_sha256()` / `encode_chunk()` /
  `decode_chunk()`: thin helpers shared at both ends.

Bundle bytes ride inside JSON frames as base64-encoded chunks
rather than a parallel binary path. Trade-off (33% overhead vs.
uniform JSON-after-Noise dispatch) documented on `AppMessageType`.
Profiling can motivate a binary variant if multi-MB bundles
become common.

25 tests in `tests/test_peer_link_bundle.py` cover the chunk
iterator (full / partial-last / multi-chunk / empty / negative
chunk-size), the b64 round-trip (random bytes, garbage rejection),
and the assembler (happy path, oversize, undersize, out-of-order,
duplicate, post-completion, hash mismatch, premature `is_last`,
missing `is_last` on announced final).

**Related issue or feature (if applicable):**

- part of #106 (row 5c in the tracking table, first sub-part)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

Wire-format-only PR. Frontend doesn't see the new frame types
until 5c-3 (offloader-side submit) lands and the offloader UI
needs to fire `submit_job` for a build.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
