### PR TITLE
Surface peer-link session state on receiver-side PeerSummary

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -357,7 +357,7 @@ def _validate_hostname(
     return trimmed
 
 
-def _peer_summary(peer: StoredPeer, *, status: PeerStatus) -> PeerSummary:
+def _peer_summary(peer: StoredPeer, *, status: PeerStatus, connected: bool) -> PeerSummary:
     """Project a :class:`StoredPeer` to wire :class:`PeerSummary`.
 
     Drops the raw ``static_x25519_pub`` bytes; ``pin_sha256`` is
@@ -367,6 +367,16 @@ def _peer_summary(peer: StoredPeer, *, status: PeerStatus) -> PeerSummary:
     by the caller because :class:`StoredPeer` itself doesn't
     carry one — pending peers live in the controller's in-memory
     dict and persisted peers are implicitly approved.
+
+    ``connected`` is the snapshot-time read of
+    ``dashboard_id in self._peer_link_sessions`` (the
+    RAM-canonical receiver-side session registry the 5a-2
+    handshake populates). PENDING callers always pass
+    ``False``; the structural invariant is enforced by the
+    :meth:`RemoteBuildController.lookup_peer_for_session`
+    gate, but the parameter is explicit so a future code path
+    that legitimately tracks connection state on a non-APPROVED
+    row doesn't inherit the hardcoded default silently.
     """
     return PeerSummary(
         dashboard_id=peer.dashboard_id,
@@ -375,6 +385,7 @@ def _peer_summary(peer: StoredPeer, *, status: PeerStatus) -> PeerSummary:
         paired_at=peer.paired_at,
         status=status,
         peer_ip=peer.peer_ip,
+        connected=connected,
     )
 
 
@@ -1396,10 +1407,24 @@ class RemoteBuildController:
         )
 
     def _peer_summaries(self) -> list[PeerSummary]:
-        """Merge PENDING + APPROVED into a single ``PeerSummary`` list."""
+        """Merge PENDING + APPROVED into a single ``PeerSummary`` list.
+
+        ``connected`` is read off ``_peer_link_sessions`` per row.
+        PENDING peers always project as ``connected=False`` (the
+        peer-link dispatch refuses non-APPROVED rows; see
+        :meth:`lookup_peer_for_session`); APPROVED rows look up
+        their ``dashboard_id`` in the session registry to report
+        live connection state. The dict membership read is
+        sync, RAM-only, and constant-time per row.
+        """
+        sessions = self._peer_link_sessions
         return [
-            _peer_summary(p, status=PeerStatus.PENDING) for p in self._pending_peers.values()
-        ] + [_peer_summary(p, status=PeerStatus.APPROVED) for p in self._approved_peers.values()]
+            _peer_summary(p, status=PeerStatus.PENDING, connected=False)
+            for p in self._pending_peers.values()
+        ] + [
+            _peer_summary(p, status=PeerStatus.APPROVED, connected=p.dashboard_id in sessions)
+            for p in self._approved_peers.values()
+        ]
 
     def peers_snapshot(self) -> list[PeerSummary]:
         """

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -368,11 +368,15 @@ def _peer_summary(peer: StoredPeer, *, status: PeerStatus, connected: bool) -> P
     carry one — pending peers live in the controller's in-memory
     dict and persisted peers are implicitly approved.
 
-    ``connected`` is the snapshot-time read of
-    ``dashboard_id in self._peer_link_sessions`` (the
+    ``connected`` is the snapshot-time read the caller passes
+    in. The intended source is
+    ``dashboard_id in controller._peer_link_sessions`` (the
     RAM-canonical receiver-side session registry the 5a-2
-    handshake populates). PENDING callers always pass
-    ``False``; the structural invariant is enforced by the
+    handshake populates); the helper is module-level rather
+    than a controller method, so the caller dereferences the
+    registry and threads the bool through. PENDING callers
+    always pass ``False``; the structural invariant is
+    enforced by the
     :meth:`RemoteBuildController.lookup_peer_for_session`
     gate, but the parameter is explicit so a future code path
     that legitimately tracks connection state on a non-APPROVED

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -829,6 +829,22 @@ class PeerSummary(DataClassORJSONMixin):
     submitting a pair_request with a spoofed label or against a
     drifted dashboard_id). Empty string for legacy rows from
     receivers that pre-date the persisted ``peer_ip`` field.
+
+    ``connected`` reports whether the receiver currently has
+    an active 5a-2 peer-link session for this peer
+    (``dashboard_id`` membership in
+    :attr:`RemoteBuildController._peer_link_sessions`). The
+    field is computed at snapshot-build time from the
+    receiver's RAM-canonical session registry — not stored
+    on disk — and live updates flow through the
+    :attr:`EventType.RECEIVER_PEER_LINK_SESSION_OPENED` /
+    ``_CLOSED`` bus events so a tab subscribing AFTER an
+    open / close still sees current state from the snapshot.
+    Always ``False`` for PENDING peers: peer-link is gated on
+    APPROVED status (the receiver's
+    :meth:`RemoteBuildController.lookup_peer_for_session`
+    only returns ``OK`` for APPROVED rows), so a PENDING peer
+    can never have a registered session.
     """
 
     dashboard_id: str
@@ -837,6 +853,7 @@ class PeerSummary(DataClassORJSONMixin):
     paired_at: float
     status: PeerStatus
     peer_ip: str = ""
+    connected: bool = False
 
 
 # Bounds enforced both at the WS-command boundary (the future

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1003,6 +1003,58 @@ def test_peers_snapshot_drops_static_x25519_pub_from_wire(tmp_path: Path) -> Non
     assert serialised["pin_sha256"]  # the wire-friendly form is present
 
 
+def test_peers_snapshot_marks_approved_with_active_session_connected(
+    tmp_path: Path,
+) -> None:
+    """An APPROVED row with a registered peer-link session reports ``connected=True``.
+
+    The frontend's "Paired senders" list reads ``connected``
+    to render an online/offline indicator. Pin the snapshot
+    semantic so a future refactor that splits the session
+    registry from the peer dict can't silently drop the
+    membership read.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    _seed_peer(controller, _stored_peer(dashboard_id="alpha"))
+    _seed_peer(controller, _stored_peer(dashboard_id="beta"))
+    # Stub a session for ``alpha`` only; ``beta`` is approved
+    # but offline.
+    session = MagicMock()
+    session.dashboard_id = "alpha"
+    controller._peer_link_sessions["alpha"] = session
+
+    rows = {row.dashboard_id: row for row in controller.peers_snapshot()}
+
+    assert rows["alpha"].connected is True
+    assert rows["beta"].connected is False
+
+
+def test_peers_snapshot_pending_row_is_never_connected(tmp_path: Path) -> None:
+    """PENDING rows project as ``connected=False`` regardless of session state.
+
+    Peer-link is gated on APPROVED status (the receiver's
+    ``lookup_peer_for_session`` refuses non-APPROVED rows), so
+    a registered session with the same dashboard_id as a
+    PENDING entry shouldn't surface as ``connected=True``. The
+    invariant is the dispatch gate's responsibility, not the
+    snapshot's, but this test pins the structural default in
+    case a future code path legitimately registers a session
+    for a non-APPROVED row (it'd need to come back and lift
+    the hardcoded ``False``).
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    _seed_pending_peer(controller, _stored_peer(dashboard_id="pending"))
+    session = MagicMock()
+    session.dashboard_id = "pending"
+    controller._peer_link_sessions["pending"] = session
+
+    [row] = controller.peers_snapshot()
+
+    assert row.dashboard_id == "pending"
+    assert row.status is PeerStatus.PENDING
+    assert row.connected is False
+
+
 def test_peers_snapshot_carries_peer_ip(tmp_path: Path) -> None:
     """``peer_ip`` flows from the stored row through the wire summary.
 


### PR DESCRIPTION
# What does this implement/fix?

Adds the wire shape for a "Paired senders" online/offline
indicator on the receiver-side Settings UI. The receiver
already tracks active 5a-2 peer-link sessions in
`_peer_link_sessions` (keyed on `dashboard_id`) and already
fires `RECEIVER_PEER_LINK_SESSION_OPENED` / `_CLOSED` bus
events at register/unregister — this PR is just the missing
wire field that makes the existing state visible to the
frontend.

**Backend changes:**

- `PeerSummary.connected: bool = False` — new wire field on
  the public-facing view of `StoredPeer`. Defaults `False`
  and is computed per row at snapshot-build time from
  `dashboard_id in self._peer_link_sessions`. Sync RAM read,
  no executor hop, no race window.
- `_peer_summary()` takes `connected` as an explicit kwarg so
  a future caller that legitimately tracks connection state
  on a non-APPROVED row doesn't inherit a hardcoded default
  silently.
- `_peer_summaries()` reads `_peer_link_sessions` once and
  threads membership per row. PENDING rows always project
  `connected=False`; peer-link is gated on APPROVED status
  via `lookup_peer_for_session`, so a PENDING row can never
  legitimately have a registered session, but the structural
  invariant is asserted in tests so a future regression
  surfaces cleanly.

**Late-subscriber semantics:**

`subscribe_events.initial_state.peers` carries the new field
without any extra wiring because `peers_snapshot()` is the
sync read used by `_send_initial`. The listener attaches
BEFORE the snapshot await (existing
`stream_events`-pattern), so events fired during the snapshot
build buffer behind `initial_state` and arrive in order; a
tab opening just as a session closes still flips from
`connected=true` to `connected=false` deterministically.

**Tests:**

Two new tests in `tests/test_remote_build_controller.py`:

1. APPROVED + registered session → `connected=true`; APPROVED
   without session → `connected=false`.
2. PENDING with a same-keyed entry in `_peer_link_sessions`
   still projects `connected=false` so the dispatch gate's
   contract isn't accidentally lifted by a snapshot
   regression.

**Frontend coordination:**

Frontend rendering of the new field lands in a follow-up PR
on `device-builder-frontend`. The wire field defaults to
`false` so a new backend talking to an old frontend (or vice
versa) just renders the existing shape without the indicator;
no breaking change.

**Related issue or feature (if applicable):**

- part of #106 (receiver-side Settings UI polish; not on the
  table as a sub-row but flagged interactively)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#<TBD>

`PeerSummary` adds `connected: bool` (default `false`); the
existing `RECEIVER_PEER_LINK_SESSION_OPENED` / `_CLOSED`
events drive live updates on the same `subscribe_events`
stream. Frontend follow-up consumes both.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
