### PR TITLE
Phase 5c-2a: receiver-side submit_job accept path

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1376,6 +1376,7 @@ class FirmwareController:
         job_type: JobType,
         port: str = "",
         new_name: str = "",
+        remote_peer: str = "",
     ) -> FirmwareJob:
         """Create a new job and add it to the in-memory map.
 
@@ -1383,6 +1384,10 @@ class FirmwareController:
         first via ``_validate_configuration_boundary`` — keeping it
         async-only lets the validation run in an executor without
         making this helper async too.
+
+        ``remote_peer`` is the offloader's ``dashboard_id`` when
+        this job came in via the peer-link ``submit_job`` flow
+        (issue #106 phase 5c), empty otherwise.
         """
         job = FirmwareJob(
             job_id=uuid4().hex[:12],
@@ -1391,6 +1396,7 @@ class FirmwareController:
             created_at=datetime.now(UTC).isoformat(),
             port=port,
             new_name=new_name,
+            remote_peer=remote_peer,
         )
         self._jobs[job.job_id] = job
         return job

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -140,6 +140,7 @@ from .remote_build_peer_link_client import (
 from .remote_build_peer_link_client import (
     request_pair as peer_link_request_pair,
 )
+from .remote_build_submit_job import SubmitJobReceiver
 
 if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
@@ -784,6 +785,19 @@ class RemoteBuildController:
         # offloader takes over its previous slot rather than
         # doubling. Drained in :meth:`stop`.
         self._peer_link_sessions: dict[str, PeerLinkSession] = {}
+        # Receiver-side ``submit_job`` flow handler (5c-2).
+        # Holds per-session in-flight bundle reception state and
+        # drives the receiver's accept path
+        # (assemble → write tarball → extract → queue
+        # ``FirmwareJob`` with ``remote_peer`` → ack).
+        # Constructed in :meth:`start` once
+        # :attr:`DeviceBuilder.firmware` is available; the
+        # :attr:`submit_job_receiver` property raises if accessed
+        # before that — every wire-side caller is gated behind
+        # the peer-link listener bind, which itself only happens
+        # after ``start``, so the not-yet-installed window is
+        # never reachable on a healthy code path.
+        self._submit_job_receiver: SubmitJobReceiver | None = None
         # Offloader-side long-lived peer-link client tasks, one
         # per APPROVED ``StoredPairing``, keyed on the receiver's
         # ``(hostname, port)``. Spawned by
@@ -914,6 +928,19 @@ class RemoteBuildController:
         fail-soft; same contract as
         :class:`DashboardAdvertiser`.
         """
+        # Stand up the receiver-side ``submit_job`` handler (5c-2)
+        # before the peer-link listener can possibly fire its
+        # first SUBMIT_JOB dispatch. The handler has no work to
+        # do on cold start beyond holding its empty in-flight
+        # dict; the wire dispatch in
+        # :func:`controllers.remote_build_peer_link._receive_loop`
+        # reaches it via the ``submit_job_receiver`` property,
+        # which raises if accessed before this point.
+        if self._db.firmware is not None:
+            self._submit_job_receiver = SubmitJobReceiver(
+                config_dir=self._db.settings.config_dir,
+                firmware_controller=self._db.firmware,
+            )
         # Load APPROVED pairings into RAM. ``StoredPairing.status``
         # defaults to ``APPROVED`` so older sidecars without the
         # field round-trip cleanly; freshly-saved files carry the
@@ -1168,6 +1195,15 @@ class RemoteBuildController:
         """
         if self._peer_link_sessions.get(session.dashboard_id) is session:
             del self._peer_link_sessions[session.dashboard_id]
+            # Drop any in-flight ``submit_job`` upload state so a
+            # bundle reception that was mid-stream when the
+            # session ended doesn't outlive the session that owns
+            # it. ``_submit_job_receiver`` is set in :meth:`start`;
+            # this branch only runs for sessions registered after
+            # ``start`` (live wire), so the attribute is always
+            # populated by the time we get here.
+            if self._submit_job_receiver is not None:
+                self._submit_job_receiver.discard_session(session.dashboard_id)
             # Fire only when we actually dropped the slot — the
             # no-op path (a SUPERSEDED-evicted session running its
             # finally-block after the new session has taken its
@@ -1178,6 +1214,32 @@ class RemoteBuildController:
                     EventType.RECEIVER_PEER_LINK_SESSION_CLOSED,
                     ReceiverPeerLinkSessionClosedData(dashboard_id=session.dashboard_id),
                 )
+
+    def get_submit_job_receiver(self) -> SubmitJobReceiver:
+        """Receiver-side ``submit_job`` flow handler (5c-2).
+
+        Accessor used by
+        :func:`controllers.remote_build_peer_link._receive_loop`
+        to dispatch :attr:`AppMessageType.SUBMIT_JOB` and
+        :attr:`AppMessageType.SUBMIT_JOB_CHUNK` frames. Raises
+        :class:`RuntimeError` if accessed before :meth:`start`
+        has installed the receiver — practically unreachable
+        on the live wire (the peer-link listener only binds
+        after ``start``), but the explicit failure beats a
+        nullable-and-skipped silent drop if a future code path
+        violates the bring-up ordering.
+
+        Plain method rather than ``@property`` because
+        :func:`helpers.api.collect_api_commands` walks every
+        public attribute on each controller during
+        :class:`DeviceBuilder` start; a property would fire its
+        getter under that walk and raise before
+        :meth:`start` has run.
+        """
+        if self._submit_job_receiver is None:
+            msg = "submit_job_receiver accessed before RemoteBuildController.start()"
+            raise RuntimeError(msg)
+        return self._submit_job_receiver
 
     async def stop(self) -> None:
         """Cancel the browser and drain in-flight resolve tasks."""

--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -724,12 +724,12 @@ async def _receive_loop(session: PeerLinkSession, controller: RemoteBuildControl
             # matching TypedDict" hand-off — runtime field
             # validation is the receiver's job.
             await controller.get_submit_job_receiver().handle_submit_job(
-                session, cast("SubmitJobFrameData", parsed)
+                session, cast(SubmitJobFrameData, parsed)
             )
             continue
         if msg_type == AppMessageType.SUBMIT_JOB_CHUNK.value:
             await controller.get_submit_job_receiver().handle_submit_job_chunk(
-                session, cast("SubmitJobChunkFrameData", parsed)
+                session, cast(SubmitJobChunkFrameData, parsed)
             )
             continue
         _LOGGER.debug(

--- a/esphome_device_builder/controllers/remote_build_peer_link.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link.py
@@ -60,7 +60,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 from aiohttp import WSMsgType, web
@@ -74,7 +74,12 @@ from ..helpers.peer_link_noise import (
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
-from ..models import IntentResponse, PeerLinkIntent
+from ..models import (
+    IntentResponse,
+    PeerLinkIntent,
+    SubmitJobChunkFrameData,
+    SubmitJobFrameData,
+)
 
 
 class _HandshakeStep(StrEnum):
@@ -664,7 +669,7 @@ async def _run_peer_link_session(
         name=f"peer-link-heartbeat[{dashboard_id}]",
     )
     try:
-        await _receive_loop(peer_link_session)
+        await _receive_loop(peer_link_session, controller)
     finally:
         heartbeat_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -672,7 +677,7 @@ async def _run_peer_link_session(
         controller.unregister_peer_link_session(peer_link_session)
 
 
-async def _receive_loop(session: PeerLinkSession) -> None:
+async def _receive_loop(session: PeerLinkSession, controller: RemoteBuildController) -> None:
     """
     Read frames off the WS, decrypt, parse, and dispatch.
 
@@ -685,10 +690,10 @@ async def _receive_loop(session: PeerLinkSession) -> None:
     structured ``terminate``), or controller-driven session close
     (the registry's :meth:`PeerLinkSession.terminate` flips
     ``_closing`` so a CLOSE frame doesn't trigger a redundant
-    terminate). 5a-1 dispatches only ``ping`` / ``pong`` /
-    ``terminate`` — every other type logs at debug and is
-    ignored. Application message types land against this same
-    seam in 5b-5d.
+    terminate). 5a-1 dispatched only ``ping`` / ``pong`` /
+    ``terminate``; 5c-2 adds ``submit_job`` / ``submit_job_chunk``
+    against the controller's :class:`SubmitJobReceiver`. Other
+    types log at debug and are ignored.
     """
     async for msg in session.ws:
         parsed = session._channel.parse_frame(msg)
@@ -712,6 +717,21 @@ async def _receive_loop(session: PeerLinkSession) -> None:
             # the WS will drain via the next ``CLOSE`` frame.
             session._closing = True
             return
+        if msg_type == AppMessageType.SUBMIT_JOB.value:
+            # Header validation lives inside the receiver. The
+            # `cast` here is the dispatch boundary's "the wire
+            # parse said this is a submit_job; treat it as the
+            # matching TypedDict" hand-off — runtime field
+            # validation is the receiver's job.
+            await controller.get_submit_job_receiver().handle_submit_job(
+                session, cast("SubmitJobFrameData", parsed)
+            )
+            continue
+        if msg_type == AppMessageType.SUBMIT_JOB_CHUNK.value:
+            await controller.get_submit_job_receiver().handle_submit_job_chunk(
+                session, cast("SubmitJobChunkFrameData", parsed)
+            )
+            continue
         _LOGGER.debug(
             "peer-link unknown app frame type %r from %s; ignoring",
             msg_type,

--- a/esphome_device_builder/controllers/remote_build_submit_job.py
+++ b/esphome_device_builder/controllers/remote_build_submit_job.py
@@ -1,0 +1,550 @@
+"""
+Receiver-side ``submit_job`` flow for the remote-build peer-link.
+
+Phase 5c-2 of issue #106. Drives the post-handshake ``submit_job``
+header + ``submit_job_chunk`` stream from the peer-link receive
+loop into a queued :class:`FirmwareJob` carrying the offloader's
+``dashboard_id`` in :attr:`FirmwareJob.remote_peer`. The
+fan-out the other direction — pushing
+``job_state_changed`` / ``job_output`` frames over the
+submitting session — lands in the 5c-2b follow-up; this module
+ends at "ack the bundle and queue the job."
+
+Flow:
+
+1. Offloader sends a ``submit_job`` header
+   (``job_id`` / ``configuration_filename`` / ``target`` /
+   ``total_bundle_bytes`` / ``num_chunks`` / ``bundle_sha256``).
+   The receive loop forwards it to
+   :meth:`SubmitJobReceiver.handle_submit_job`.
+2. We construct a :class:`BundleAssembler` against the announced
+   sizes / digest and store it in ``_inflight`` keyed on the
+   session's ``dashboard_id``. One concurrent submit per session.
+3. Offloader streams ``submit_job_chunk`` frames; the receive
+   loop forwards each to
+   :meth:`SubmitJobReceiver.handle_submit_job_chunk`. We
+   base64-decode and feed the assembler. On the chunk that
+   carries ``is_last=True`` we finalise (validates byte count
+   + sha256), write the assembled tarball to
+   ``<config>/.esphome/.remote_builds/<dashboard_id>/<device_name>/bundle.tar.gz``,
+   extract via :func:`esphome.bundle.prepare_bundle_for_compile`
+   (which preserves ``.esphome/`` / ``.pioenvs/`` for incremental
+   builds — the load-bearing reason for the stable per-peer
+   per-device subtree), and queue a :class:`FirmwareJob` with
+   ``remote_peer=session.dashboard_id``.
+4. We send a typed :class:`SubmitJobAckFrameData` — accepted on
+   success, accepted=False with a structured ``reason`` on any
+   of the rejection paths. Bundle-assembler errors that signal
+   wire-level misbehaviour
+   (:class:`BundleAssemblerError` outside the fix-with-retry set)
+   also trigger ``terminate{reason: malformed_frame}`` because
+   the offloader has already wandered off the wire format and
+   continuing the session would only invite more corruption.
+
+Per-peer per-device subtree: ``<dashboard_id>/<device_name>``.
+The two-segment key dedupes correctly across multi-offloader
+fleets (two HA Greens both shipping a "kitchen" device land in
+distinct subtrees) without colliding within one offloader's
+pool. PlatformIO's incremental-compile cache then sees stable
+source paths between submissions and skips the cold-rebuild
+hit. Phase-6 24h TTL sweeps cold subtrees later.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import binascii
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from esphome.bundle import EsphomeError, prepare_bundle_for_compile
+
+from ..helpers.peer_link_bundle import (
+    BundleAssembler,
+    BundleAssemblerError,
+    BundleAssemblerErrorCode,
+    decode_chunk,
+)
+from ..models import (
+    JobType,
+    SubmitJobAckFrameData,
+    SubmitJobChunkFrameData,
+    SubmitJobFrameData,
+)
+
+if TYPE_CHECKING:
+    from .firmware import FirmwareController
+    from .remote_build_peer_link import PeerLinkSession
+
+_LOGGER = logging.getLogger(__name__)
+
+# Reject reason codes carried on
+# :class:`SubmitJobAckFrameData.reason` when ``accepted=False``.
+# Distinct from :class:`BundleAssemblerErrorCode` (wire-level
+# bundle problems): these cover the receiver-side dispatch path
+# where the bundle assembled cleanly but something else went
+# wrong (path traversal, extraction failure, queue rejection).
+# The offloader's submitter (5c-3) maps these to user-facing
+# error messages.
+_REASON_DUPLICATE_SUBMIT = "duplicate_submit"
+_REASON_INVALID_HEADER = "invalid_header"
+_REASON_NO_INFLIGHT = "no_inflight_submit"
+_REASON_JOB_ID_MISMATCH = "job_id_mismatch"
+_REASON_CHUNK_DECODE_FAILED = "chunk_decode_failed"
+_REASON_EXTRACT_FAILED = "extract_failed"
+_REASON_QUEUE_REJECTED = "queue_rejected"
+
+# Subdirectory under ``<config_dir>/.esphome/`` where remote-peer
+# bundles land. Hidden by the leading dot so a casual ``ls`` of
+# the user's main config tree doesn't show it next to their own
+# YAMLs; living under ``.esphome/`` keeps it adjacent to other
+# build artefacts (StorageJSON, build dirs) so phase-6's TTL
+# sweep can reuse the same parent walk.
+_REMOTE_BUILDS_SUBDIR = Path(".esphome") / ".remote_builds"
+
+# Bundle filename inside ``<dashboard_id>/<device_name>/``.
+# Constant rather than derived from the offloader's
+# ``configuration_filename`` so a malicious or buggy offloader
+# can't pick a name that collides with extracted artefacts (the
+# YAML, the ``manifest.yaml``, etc.) — the extracted tree owns
+# the rest of the directory.
+_BUNDLE_FILENAME = "bundle.tar.gz"
+
+# Allowed values of :attr:`SubmitJobFrameData.target`.
+# ``Literal["compile", "upload"]`` on the TypedDict is the
+# type-time gate; this set is the runtime gate so a misbehaving
+# offloader sending ``target="install"`` (or anything else)
+# gets a clean reject rather than a downstream JobType
+# construction failure.
+_TARGET_TO_JOB_TYPE: dict[str, JobType] = {
+    "compile": JobType.COMPILE,
+    "upload": JobType.UPLOAD,
+}
+
+# Bundle-assembler error codes that map to a clean
+# ``submit_job_ack`` rejection (the offloader can fix-and-retry
+# on a fresh session). Anything outside this set is wire-level
+# misbehaviour the offloader can't recover from in-session and
+# triggers a ``terminate{malformed_frame}`` close after the ack.
+_RECOVERABLE_ASSEMBLER_ERRORS: frozenset[BundleAssemblerErrorCode] = frozenset(
+    {
+        BundleAssemblerErrorCode.OVERSIZED,
+        BundleAssemblerErrorCode.UNDERSIZED,
+        BundleAssemblerErrorCode.HASH_MISMATCH,
+        BundleAssemblerErrorCode.EMPTY_BUNDLE,
+    }
+)
+
+
+def _device_name_from_filename(configuration_filename: str) -> str:
+    """Extract the device-name segment from *configuration_filename*.
+
+    ``"kitchen.yaml"`` → ``"kitchen"``. Strips ``.yaml`` /
+    ``.yml`` (case-insensitive); anything else (no extension,
+    unexpected extension) returns the input unchanged so the
+    rest of the validation chain catches the wire-shape problem
+    rather than this helper silently producing a degenerate
+    name.
+
+    Used as the second path segment under
+    ``.esphome/.remote_builds/<dashboard_id>/<device_name>/``;
+    the segment is validated by :meth:`DashboardSettings.rel_path`
+    downstream so a malformed entry can't escape the subtree.
+    """
+    lower = configuration_filename.lower()
+    if lower.endswith(".yaml"):
+        return configuration_filename[:-5]
+    if lower.endswith(".yml"):
+        return configuration_filename[:-4]
+    return configuration_filename
+
+
+@dataclass
+class _PendingSubmit:
+    """Per-session in-flight bundle reception state.
+
+    Constructed on a valid :class:`SubmitJobFrameData` header,
+    fed chunk-by-chunk from
+    :meth:`SubmitJobReceiver.handle_submit_job_chunk`, and
+    discarded once the submit completes or the session ends.
+    Only one :class:`_PendingSubmit` exists per session at a
+    time; a second header from the same session before the
+    first completes is rejected as ``duplicate_submit``.
+    """
+
+    job_id: str
+    configuration_filename: str
+    target: str
+    assembler: BundleAssembler
+
+
+class SubmitJobReceiver:
+    """Receiver-side state machine for the peer-link ``submit_job`` flow.
+
+    One instance per :class:`RemoteBuildController` (started in
+    :meth:`RemoteBuildController.start`). Holds per-session
+    in-flight bundle reception state in :attr:`_inflight`,
+    keyed on the session's ``dashboard_id``. The receive loop in
+    :func:`controllers.remote_build_peer_link._receive_loop`
+    forwards :attr:`AppMessageType.SUBMIT_JOB` and
+    :attr:`AppMessageType.SUBMIT_JOB_CHUNK` frames to the matching
+    handler method here.
+
+    Stateless across :meth:`stop` — the controller's lifecycle
+    runs at the receiver process scope, in-flight uploads don't
+    survive a controller restart. A bundle that was mid-stream
+    when the receiver shut down is dropped; the offloader's
+    next submit attempt opens a fresh session, lands a fresh
+    header, starts over.
+    """
+
+    def __init__(
+        self,
+        *,
+        config_dir: Path,
+        firmware_controller: FirmwareController,
+    ) -> None:
+        self._config_dir = config_dir
+        self._firmware = firmware_controller
+        self._inflight: dict[str, _PendingSubmit] = {}
+
+    def discard_session(self, dashboard_id: str) -> None:
+        """Drop any in-flight submit state for *dashboard_id*.
+
+        Called when a peer-link session ends — the receive loop's
+        ``finally`` chain runs ``unregister_peer_link_session``,
+        which in turn calls this. A session that closed mid-stream
+        leaves no buffered bytes lying around (the assembler's
+        bytearray is GC'd along with the dict entry).
+        """
+        self._inflight.pop(dashboard_id, None)
+
+    async def handle_submit_job(self, session: PeerLinkSession, frame: SubmitJobFrameData) -> None:
+        """Validate the header, set up the assembler, register as in-flight.
+
+        Rejects (with a typed ``submit_job_ack``) on:
+
+        * Duplicate submit while a previous one is still in
+          flight on the same session.
+        * Header field shapes the wire-format TypedDict can't
+          enforce at runtime (target outside the
+          ``compile`` / ``upload`` set, malformed
+          ``configuration_filename``).
+        * Assembler-construction validation (oversized total,
+          empty bundle, etc.) — these come from the announced
+          header values, so they map to a ``submit_job_ack``
+          rejection rather than a ``terminate{malformed_frame}``;
+          the chunk stream hasn't started yet, the wire is still
+          intact.
+        """
+        if session.dashboard_id in self._inflight:
+            await self._send_ack(
+                session,
+                job_id=frame["job_id"],
+                accepted=False,
+                reason=_REASON_DUPLICATE_SUBMIT,
+            )
+            return
+
+        target = frame["target"]
+        if target not in _TARGET_TO_JOB_TYPE:
+            await self._send_ack(
+                session,
+                job_id=frame["job_id"],
+                accepted=False,
+                reason=_REASON_INVALID_HEADER,
+            )
+            return
+
+        try:
+            assembler = BundleAssembler(
+                total_bytes=frame["total_bundle_bytes"],
+                num_chunks=frame["num_chunks"],
+                sha256_hex=frame["bundle_sha256"],
+            )
+        except BundleAssemblerError as exc:
+            await self._send_ack(
+                session,
+                job_id=frame["job_id"],
+                accepted=False,
+                reason=exc.code.value,
+            )
+            return
+
+        self._inflight[session.dashboard_id] = _PendingSubmit(
+            job_id=frame["job_id"],
+            configuration_filename=frame["configuration_filename"],
+            target=target,
+            assembler=assembler,
+        )
+
+    async def handle_submit_job_chunk(  # noqa: PLR0911 — branchy by design
+        self, session: PeerLinkSession, frame: SubmitJobChunkFrameData
+    ) -> None:
+        """Feed *frame* into the in-flight assembler. On final chunk: queue + ack.
+
+        Branches:
+
+        * No in-flight submit → ack reject ``no_inflight_submit``.
+        * ``job_id`` doesn't match the in-flight header → ack
+          reject ``job_id_mismatch`` (offloader is mixing two
+          different submits onto one session).
+        * Base64 decode fails → ack reject + terminate
+          ``malformed_frame`` (the wire format itself is broken).
+        * Recoverable assembler error
+          (:data:`_RECOVERABLE_ASSEMBLER_ERRORS`) → ack reject
+          with the assembler's code (offloader can retry).
+        * Other assembler error → ack reject + terminate
+          ``malformed_frame`` (offloader sent out-of-order /
+          post-completion / chunk-count-mismatched chunks; the
+          wire is corrupted, close the session).
+        * Final chunk + finalise success → write bundle,
+          extract, queue job, ack accepted. Failures in any of
+          those steps map to ack reject without a terminate
+          (the wire is fine, just our side hit an issue).
+        """
+        from .remote_build_peer_link import TerminateReason  # noqa: PLC0415
+
+        pending = self._inflight.get(session.dashboard_id)
+        if pending is None:
+            await self._send_ack(
+                session,
+                job_id=frame["job_id"],
+                accepted=False,
+                reason=_REASON_NO_INFLIGHT,
+            )
+            return
+
+        if frame["job_id"] != pending.job_id:
+            await self._send_ack(
+                session,
+                job_id=frame["job_id"],
+                accepted=False,
+                reason=_REASON_JOB_ID_MISMATCH,
+            )
+            return
+
+        try:
+            raw = decode_chunk(frame["data_b64"])
+        except (binascii.Error, ValueError):
+            self._inflight.pop(session.dashboard_id, None)
+            await self._send_ack(
+                session,
+                job_id=pending.job_id,
+                accepted=False,
+                reason=_REASON_CHUNK_DECODE_FAILED,
+            )
+            await session.terminate(TerminateReason.MALFORMED_FRAME)
+            return
+
+        try:
+            pending.assembler.feed(frame["chunk_index"], raw, is_last=frame["is_last"])
+        except BundleAssemblerError as exc:
+            self._inflight.pop(session.dashboard_id, None)
+            await self._send_ack(
+                session,
+                job_id=pending.job_id,
+                accepted=False,
+                reason=exc.code.value,
+            )
+            if exc.code not in _RECOVERABLE_ASSEMBLER_ERRORS:
+                await session.terminate(TerminateReason.MALFORMED_FRAME)
+            return
+
+        if not frame["is_last"]:
+            return
+
+        # Final chunk landed; finalise + extract + queue. Pull the
+        # entry out of ``_inflight`` first so a later mistake doesn't
+        # leave a closed assembler dangling.
+        self._inflight.pop(session.dashboard_id, None)
+        try:
+            assembled = pending.assembler.finalise()
+        except BundleAssemblerError as exc:
+            await self._send_ack(
+                session,
+                job_id=pending.job_id,
+                accepted=False,
+                reason=exc.code.value,
+            )
+            if exc.code not in _RECOVERABLE_ASSEMBLER_ERRORS:
+                await session.terminate(TerminateReason.MALFORMED_FRAME)
+            return
+
+        try:
+            queued_job_id = await self._extract_and_queue(
+                session=session,
+                pending=pending,
+                bundle_bytes=assembled,
+            )
+        except _SubmitJobRejectionError as exc:
+            await self._send_ack(
+                session,
+                job_id=pending.job_id,
+                accepted=False,
+                reason=exc.reason,
+            )
+            return
+
+        # ``_extract_and_queue`` returned the queued job's id; the
+        # offloader's ``job_id`` from the header is what they
+        # tagged the submit with, but the receiver-side job id is
+        # what every subsequent ``job_state_changed`` /
+        # ``job_output`` frame keys on. Echo the offloader's
+        # ``job_id`` back on the ack so the offloader can match
+        # the response to its submit; the receiver-side id is
+        # threaded into the 5c-2b fan-out via
+        # :attr:`FirmwareJob.remote_peer` instead.
+        del queued_job_id  # documented for the comment; not used yet
+        await self._send_ack(
+            session,
+            job_id=pending.job_id,
+            accepted=True,
+        )
+
+    async def _extract_and_queue(
+        self,
+        *,
+        session: PeerLinkSession,
+        pending: _PendingSubmit,
+        bundle_bytes: bytes,
+    ) -> str:
+        """Write the tarball, extract it, queue a :class:`FirmwareJob`.
+
+        Returns the queued job's ``job_id`` (receiver-side id,
+        distinct from the offloader's submit-tagged id). Raises
+        :class:`_SubmitJobRejectionError` on any failure with a
+        :class:`SubmitJobAckFrameData.reason`-shaped code so the
+        caller can convert into an ack reject without a terminate
+        (extract / queue failures are receiver-side problems, not
+        wire-level misbehaviour).
+
+        Disk I/O hops to the executor:
+        ``prepare_bundle_for_compile`` walks the tar, validates
+        members, writes to disk; bundling that into one
+        ``run_in_executor`` keeps the receiver's WS dispatch
+        coroutine non-blocking through a multi-MB write.
+        """
+        device_name = _device_name_from_filename(pending.configuration_filename)
+        target_dir = self._config_dir / _REMOTE_BUILDS_SUBDIR / session.dashboard_id / device_name
+        bundle_path = target_dir / _BUNDLE_FILENAME
+
+        loop = asyncio.get_running_loop()
+        try:
+            extracted_yaml: Path = await loop.run_in_executor(
+                None,
+                _write_and_extract_bundle,
+                bundle_path,
+                bundle_bytes,
+                target_dir,
+            )
+        except (EsphomeError, OSError) as exc:
+            _LOGGER.warning(
+                "submit_job from %s: extract failed for job %s (%s): %s",
+                session.dashboard_id,
+                pending.job_id,
+                pending.configuration_filename,
+                exc,
+            )
+            raise _SubmitJobRejectionError(_REASON_EXTRACT_FAILED) from exc
+
+        # ``configuration`` on FirmwareJob is the path relative to
+        # the controller's config_dir (``rel_path`` joins back on
+        # the way out). The extracted YAML lives under
+        # ``.esphome/.remote_builds/<dashboard_id>/<device_name>/``
+        # inside the same config_dir, so ``relative_to`` always
+        # succeeds here.
+        rel_yaml = extracted_yaml.relative_to(self._config_dir)
+        configuration = str(rel_yaml)
+
+        try:
+            job = self._firmware._create_job(
+                configuration=configuration,
+                job_type=_TARGET_TO_JOB_TYPE[pending.target],
+                remote_peer=session.dashboard_id,
+            )
+            await self._firmware._enqueue(job)
+        except Exception as exc:
+            _LOGGER.warning(
+                "submit_job from %s: enqueue failed for job %s: %s",
+                session.dashboard_id,
+                pending.job_id,
+                exc,
+            )
+            raise _SubmitJobRejectionError(_REASON_QUEUE_REJECTED) from exc
+
+        _LOGGER.info(
+            "submit_job from %s: queued job %s (%s, target=%s)",
+            session.dashboard_id,
+            job.job_id,
+            configuration,
+            pending.target,
+        )
+        return job.job_id
+
+    async def _send_ack(
+        self,
+        session: PeerLinkSession,
+        *,
+        job_id: str,
+        accepted: bool,
+        reason: str | None = None,
+    ) -> None:
+        """Send a typed :class:`SubmitJobAckFrameData` to *session*.
+
+        ``reason`` is omitted from the wire payload on the
+        success path so the frame is exactly
+        ``{type, job_id, accepted: true}`` (matching the
+        ``NotRequired`` declaration on the TypedDict). Failures
+        from ``send_app_frame`` are logged at the channel layer
+        and don't propagate here — the session is already
+        closing or gone, the ack going missing isn't actionable.
+        """
+        payload: SubmitJobAckFrameData = (
+            SubmitJobAckFrameData(
+                type="submit_job_ack",
+                job_id=job_id,
+                accepted=accepted,
+            )
+            if reason is None
+            else SubmitJobAckFrameData(
+                type="submit_job_ack",
+                job_id=job_id,
+                accepted=accepted,
+                reason=reason,
+            )
+        )
+        await session.send_app_frame(dict(payload))
+
+
+class _SubmitJobRejectionError(Exception):
+    """Internal: surface a typed rejection reason out of ``_extract_and_queue``.
+
+    Carries a :class:`SubmitJobAckFrameData.reason`-shaped
+    string. Caught by :meth:`SubmitJobReceiver.handle_submit_job_chunk`
+    on the final-chunk path and converted to an ack reject; never
+    leaks past that boundary.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _write_and_extract_bundle(bundle_path: Path, bundle_bytes: bytes, target_dir: Path) -> Path:
+    """Sync helper run in the executor: write the tarball + extract it.
+
+    Bundled together so the
+    :meth:`SubmitJobReceiver._extract_and_queue` callsite hops
+    to the executor exactly once for both phases.
+    ``prepare_bundle_for_compile`` is the entry point because it
+    preserves the build-cache subdirectories (``.esphome`` /
+    ``.pioenvs``) that incremental compiles need to skip the
+    cold-rebuild hit.
+    """
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    bundle_path.write_bytes(bundle_bytes)
+    extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)
+    return extracted

--- a/esphome_device_builder/controllers/remote_build_submit_job.py
+++ b/esphome_device_builder/controllers/remote_build_submit_job.py
@@ -138,27 +138,60 @@ _RECOVERABLE_ASSEMBLER_ERRORS: frozenset[BundleAssemblerErrorCode] = frozenset(
 )
 
 
-def _device_name_from_filename(configuration_filename: str) -> str:
-    """Extract the device-name segment from *configuration_filename*.
+# Characters that must NOT appear in a peer-supplied
+# ``configuration_filename``. Path separators (both flavours so
+# the rule holds across receiver platforms) and the NUL byte.
+# The rule's job is to catch obviously-malicious shapes early;
+# the resolve-and-stay-under-root check at extract time is the
+# defence-in-depth gate that catches anything an exotic filename
+# would slip past this.
+_FORBIDDEN_FILENAME_CHARS: frozenset[str] = frozenset({"/", "\\", "\x00"})
 
-    ``"kitchen.yaml"`` → ``"kitchen"``. Strips ``.yaml`` /
-    ``.yml`` (case-insensitive); anything else (no extension,
-    unexpected extension) returns the input unchanged so the
-    rest of the validation chain catches the wire-shape problem
-    rather than this helper silently producing a degenerate
-    name.
 
-    Used as the second path segment under
-    ``.esphome/.remote_builds/<dashboard_id>/<device_name>/``;
-    the segment is validated by :meth:`DashboardSettings.rel_path`
-    downstream so a malformed entry can't escape the subtree.
+def _validate_configuration_filename(filename: str) -> str | None:
+    r"""Return the device-name segment if *filename* is a safe leaf YAML, else ``None``.
+
+    Peer-supplied input. The receiver uses the device-name
+    segment (``filename`` minus its ``.yaml`` / ``.yml``
+    extension) as the second path component under
+    ``<config>/.esphome/.remote_builds/<dashboard_id>/<device>/``;
+    a malicious offloader sending ``../foo.yaml`` could escape
+    that subtree without this gate. Returning ``None`` signals
+    the caller should reject with ``invalid_header``.
+
+    Rejects:
+
+    * Empty / non-string input.
+    * Path separators (``/`` or ``\\``) or NUL bytes.
+    * Reserved names ``"."`` / ``".."`` (with or without
+      extension — ``..yaml`` is still a leading-dot escape
+      attempt).
+    * Anything that doesn't end in ``.yaml`` / ``.yml``
+      (case-insensitive). The bundle the receiver extracts is
+      an ESPHome YAML config; non-YAML extensions don't have a
+      legitimate use here and let a misbehaving offloader
+      write arbitrary suffixes into the per-peer subtree.
+
+    Returns the bare device name (``"kitchen.yaml"`` →
+    ``"kitchen"``) on success.
     """
-    lower = configuration_filename.lower()
+    if not filename:
+        return None
+    if any(ch in filename for ch in _FORBIDDEN_FILENAME_CHARS):
+        return None
+    lower = filename.lower()
     if lower.endswith(".yaml"):
-        return configuration_filename[:-5]
-    if lower.endswith(".yml"):
-        return configuration_filename[:-4]
-    return configuration_filename
+        device_name = filename[:-5]
+    elif lower.endswith(".yml"):
+        device_name = filename[:-4]
+    else:
+        return None
+    # Reject a leaf whose pre-extension stem reduces to ``.`` /
+    # ``..`` — both would resolve to the parent dir under
+    # ``<config_dir>/.esphome/.remote_builds/<dashboard_id>/``.
+    if device_name in ("", ".", ".."):
+        return None
+    return device_name
 
 
 @dataclass
@@ -244,6 +277,15 @@ class SubmitJobReceiver:
             return
         target = frame["target"]
         if target not in _TARGET_TO_JOB_TYPE:
+            await self._reject(session, job_id=frame["job_id"], reason=_REASON_INVALID_HEADER)
+            return
+        # Validate the peer-supplied filename — it becomes the
+        # second path segment under
+        # ``.esphome/.remote_builds/<dashboard_id>/<device_name>/``.
+        # An unvalidated separator / ``..`` here would let a
+        # malicious offloader write the assembled tarball
+        # outside the intended subtree.
+        if _validate_configuration_filename(frame["configuration_filename"]) is None:
             await self._reject(session, job_id=frame["job_id"], reason=_REASON_INVALID_HEADER)
             return
         try:
@@ -380,9 +422,34 @@ class SubmitJobReceiver:
         ``run_in_executor`` keeps the receiver's WS dispatch
         coroutine non-blocking through a multi-MB write.
         """
-        device_name = _device_name_from_filename(pending.configuration_filename)
-        target_dir = self._config_dir / _REMOTE_BUILDS_SUBDIR / session.dashboard_id / device_name
+        # ``device_name`` is guaranteed non-None here:
+        # :meth:`handle_submit_job` rejected the header upfront
+        # if validation failed, so a ``_PendingSubmit`` exists
+        # only for filenames that already passed the gate.
+        device_name = _validate_configuration_filename(pending.configuration_filename)
+        assert device_name is not None  # narrowed by the upstream reject
+        peer_root = self._config_dir / _REMOTE_BUILDS_SUBDIR / session.dashboard_id
+        target_dir = peer_root / device_name
         bundle_path = target_dir / _BUNDLE_FILENAME
+
+        # Belt-and-braces: the upstream filename validator catches
+        # path-separator / ``..`` / unexpected-extension shapes,
+        # but ``dashboard_id`` flows through unvalidated from the
+        # Noise handshake / receiver-side registration, and an
+        # unforeseen path-component shape would otherwise let the
+        # tarball write escape ``<config>/.esphome/.remote_builds/``.
+        # ``Path.resolve`` normalises the join; ``relative_to``
+        # raises ``ValueError`` when the result climbs outside the
+        # remote-builds root.
+        try:
+            target_dir.resolve().relative_to((self._config_dir / _REMOTE_BUILDS_SUBDIR).resolve())
+        except ValueError as exc:
+            _LOGGER.warning(
+                "submit_job from %s: target_dir %s escaped remote-builds root; rejecting",
+                session.dashboard_id,
+                target_dir,
+            )
+            raise _SubmitJobRejectionError(_REASON_INVALID_HEADER) from exc
 
         loop = asyncio.get_running_loop()
         try:

--- a/esphome_device_builder/controllers/remote_build_submit_job.py
+++ b/esphome_device_builder/controllers/remote_build_submit_job.py
@@ -57,7 +57,7 @@ import binascii
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from esphome.bundle import EsphomeError, prepare_bundle_for_compile
 
@@ -90,11 +90,40 @@ _LOGGER = logging.getLogger(__name__)
 # error messages.
 _REASON_DUPLICATE_SUBMIT = "duplicate_submit"
 _REASON_INVALID_HEADER = "invalid_header"
+_REASON_INVALID_CHUNK = "invalid_chunk"
 _REASON_NO_INFLIGHT = "no_inflight_submit"
 _REASON_JOB_ID_MISMATCH = "job_id_mismatch"
 _REASON_CHUNK_DECODE_FAILED = "chunk_decode_failed"
 _REASON_EXTRACT_FAILED = "extract_failed"
 _REASON_QUEUE_REJECTED = "queue_rejected"
+
+# Shape contracts for the two peer-controlled wire frames.
+# :func:`parse_app_frame` already confirms inbound bytes parse
+# to a ``dict[str, Any]``, but a malicious / buggy offloader
+# can still send a dict with missing fields or wrong-typed
+# values. Indexing those frames directly (``frame["job_id"]``,
+# etc.) would raise ``KeyError`` / ``TypeError`` and unwind out
+# of the receive loop without sending an ack — a remote-
+# triggered crash shape. The :func:`_validate_frame_shape`
+# gate below walks each contract and rejects the frame as
+# ``invalid_header`` / ``invalid_chunk`` with a
+# ``terminate{malformed_frame}`` close (the offloader has
+# wandered off the wire format).
+_SUBMIT_JOB_HEADER_FIELDS: dict[str, type] = {
+    "job_id": str,
+    "configuration_filename": str,
+    "target": str,
+    "total_bundle_bytes": int,
+    "num_chunks": int,
+    "bundle_sha256": str,
+}
+
+_SUBMIT_JOB_CHUNK_FIELDS: dict[str, type] = {
+    "job_id": str,
+    "chunk_index": int,
+    "data_b64": str,
+    "is_last": bool,
+}
 
 # Subdirectory under ``<config_dir>/.esphome/`` where remote-peer
 # bundles land. Hidden by the leading dot so a casual ``ls`` of
@@ -146,6 +175,32 @@ _RECOVERABLE_ASSEMBLER_ERRORS: frozenset[BundleAssemblerErrorCode] = frozenset(
 # defence-in-depth gate that catches anything an exotic filename
 # would slip past this.
 _FORBIDDEN_FILENAME_CHARS: frozenset[str] = frozenset({"/", "\\", "\x00"})
+
+
+def _validate_frame_shape(frame: dict[str, Any], required: dict[str, type]) -> bool:
+    """Return ``True`` iff *frame* has all *required* fields with matching types.
+
+    Defensive runtime check on a peer-controlled dict —
+    :func:`parse_app_frame` confirms the JSON parses to a dict,
+    but doesn't validate the inner shape. Indexing missing /
+    wrong-typed fields would otherwise raise inside
+    :meth:`SubmitJobReceiver.handle_submit_job` /
+    :meth:`SubmitJobReceiver.handle_submit_job_chunk` and
+    bubble out of the receive loop without an ack.
+
+    ``bool`` is special-cased because it's a subclass of
+    ``int`` in Python — a frame announcing
+    ``total_bundle_bytes=True`` would otherwise pass the
+    ``int`` check. We accept ``bool`` only when the contract
+    explicitly asks for ``bool``.
+    """
+    for field_name, expected in required.items():
+        value = frame.get(field_name)
+        if not isinstance(value, expected):
+            return False
+        if expected is int and isinstance(value, bool):
+            return False
+    return True
 
 
 def _validate_configuration_filename(filename: str) -> str | None:
@@ -272,6 +327,25 @@ class SubmitJobReceiver:
           the chunk stream hasn't started yet, the wire is still
           intact.
         """
+        # Validate the wire-frame shape before indexing
+        # peer-controlled fields. A malformed frame is wire-
+        # level misbehaviour and triggers a
+        # ``terminate{malformed_frame}``; ``job_id`` may itself
+        # be missing/wrong-typed so fall back to ``""`` for the
+        # ack payload. ``cast`` to ``dict[str, Any]`` because
+        # the validator works on the raw shape; the typed
+        # ``SubmitJobFrameData`` view is what the rest of the
+        # method operates on after the gate.
+        raw = cast(dict[str, Any], frame)
+        if not _validate_frame_shape(raw, _SUBMIT_JOB_HEADER_FIELDS):
+            job_id = raw.get("job_id") if isinstance(raw.get("job_id"), str) else ""
+            await self._reject(
+                session,
+                job_id=cast(str, job_id),
+                reason=_REASON_INVALID_HEADER,
+                terminate_session=True,
+            )
+            return
         if session.dashboard_id in self._inflight:
             await self._reject(session, job_id=frame["job_id"], reason=_REASON_DUPLICATE_SUBMIT)
             return
@@ -318,6 +392,22 @@ class SubmitJobReceiver:
         can retry on a fresh submit). Happy-path completion
         flows through :meth:`_finalise_and_queue`.
         """
+        # Same shape gate as the header path: peer-controlled
+        # fields must be present and correctly typed before any
+        # indexing. A malformed chunk is wire-level misbehaviour
+        # and the in-flight stream can't be recovered; drop it
+        # and terminate.
+        chunk_dict = cast(dict[str, Any], frame)
+        if not _validate_frame_shape(chunk_dict, _SUBMIT_JOB_CHUNK_FIELDS):
+            job_id = chunk_dict.get("job_id") if isinstance(chunk_dict.get("job_id"), str) else ""
+            await self._reject(
+                session,
+                job_id=cast(str, job_id),
+                reason=_REASON_INVALID_CHUNK,
+                drop_inflight=True,
+                terminate_session=True,
+            )
+            return
         pending = self._inflight.get(session.dashboard_id)
         if pending is None:
             await self._reject(session, job_id=frame["job_id"], reason=_REASON_NO_INFLIGHT)

--- a/esphome_device_builder/controllers/remote_build_submit_job.py
+++ b/esphome_device_builder/controllers/remote_build_submit_job.py
@@ -240,24 +240,12 @@ class SubmitJobReceiver:
           intact.
         """
         if session.dashboard_id in self._inflight:
-            await self._send_ack(
-                session,
-                job_id=frame["job_id"],
-                accepted=False,
-                reason=_REASON_DUPLICATE_SUBMIT,
-            )
+            await self._reject(session, job_id=frame["job_id"], reason=_REASON_DUPLICATE_SUBMIT)
             return
-
         target = frame["target"]
         if target not in _TARGET_TO_JOB_TYPE:
-            await self._send_ack(
-                session,
-                job_id=frame["job_id"],
-                accepted=False,
-                reason=_REASON_INVALID_HEADER,
-            )
+            await self._reject(session, job_id=frame["job_id"], reason=_REASON_INVALID_HEADER)
             return
-
         try:
             assembler = BundleAssembler(
                 total_bytes=frame["total_bundle_bytes"],
@@ -265,12 +253,7 @@ class SubmitJobReceiver:
                 sha256_hex=frame["bundle_sha256"],
             )
         except BundleAssemblerError as exc:
-            await self._send_ack(
-                session,
-                job_id=frame["job_id"],
-                accepted=False,
-                reason=exc.code.value,
-            )
+            await self._reject(session, job_id=frame["job_id"], reason=exc.code.value)
             return
 
         self._inflight[session.dashboard_id] = _PendingSubmit(
@@ -280,128 +263,96 @@ class SubmitJobReceiver:
             assembler=assembler,
         )
 
-    async def handle_submit_job_chunk(  # noqa: PLR0911 — branchy by design
+    async def handle_submit_job_chunk(
         self, session: PeerLinkSession, frame: SubmitJobChunkFrameData
     ) -> None:
         """Feed *frame* into the in-flight assembler. On final chunk: queue + ack.
 
-        Branches:
-
-        * No in-flight submit → ack reject ``no_inflight_submit``.
-        * ``job_id`` doesn't match the in-flight header → ack
-          reject ``job_id_mismatch`` (offloader is mixing two
-          different submits onto one session).
-        * Base64 decode fails → ack reject + terminate
-          ``malformed_frame`` (the wire format itself is broken).
-        * Recoverable assembler error
-          (:data:`_RECOVERABLE_ASSEMBLER_ERRORS`) → ack reject
-          with the assembler's code (offloader can retry).
-        * Other assembler error → ack reject + terminate
-          ``malformed_frame`` (offloader sent out-of-order /
-          post-completion / chunk-count-mismatched chunks; the
-          wire is corrupted, close the session).
-        * Final chunk + finalise success → write bundle,
-          extract, queue job, ack accepted. Failures in any of
-          those steps map to ack reject without a terminate
-          (the wire is fine, just our side hit an issue).
+        Reject branches all flow through :meth:`_reject` with a
+        ``reason`` code; the helper drops in-flight state and
+        optionally fires ``terminate{malformed_frame}`` based on
+        whether the failure is wire-level (offloader corrupted
+        the stream — close the session) or recoverable (offloader
+        can retry on a fresh submit). Happy-path completion
+        flows through :meth:`_finalise_and_queue`.
         """
-        from .remote_build_peer_link import TerminateReason  # noqa: PLC0415
-
         pending = self._inflight.get(session.dashboard_id)
         if pending is None:
-            await self._send_ack(
-                session,
-                job_id=frame["job_id"],
-                accepted=False,
-                reason=_REASON_NO_INFLIGHT,
-            )
+            await self._reject(session, job_id=frame["job_id"], reason=_REASON_NO_INFLIGHT)
             return
-
         if frame["job_id"] != pending.job_id:
-            await self._send_ack(
-                session,
-                job_id=frame["job_id"],
-                accepted=False,
-                reason=_REASON_JOB_ID_MISMATCH,
-            )
+            await self._reject(session, job_id=frame["job_id"], reason=_REASON_JOB_ID_MISMATCH)
             return
-
         try:
             raw = decode_chunk(frame["data_b64"])
         except (binascii.Error, ValueError):
-            self._inflight.pop(session.dashboard_id, None)
-            await self._send_ack(
+            await self._reject(
                 session,
                 job_id=pending.job_id,
-                accepted=False,
                 reason=_REASON_CHUNK_DECODE_FAILED,
+                drop_inflight=True,
+                terminate_session=True,
             )
-            await session.terminate(TerminateReason.MALFORMED_FRAME)
             return
-
         try:
             pending.assembler.feed(frame["chunk_index"], raw, is_last=frame["is_last"])
         except BundleAssemblerError as exc:
-            self._inflight.pop(session.dashboard_id, None)
-            await self._send_ack(
-                session,
-                job_id=pending.job_id,
-                accepted=False,
-                reason=exc.code.value,
-            )
-            if exc.code not in _RECOVERABLE_ASSEMBLER_ERRORS:
-                await session.terminate(TerminateReason.MALFORMED_FRAME)
+            await self._reject_assembler(session, pending=pending, exc=exc)
             return
-
         if not frame["is_last"]:
             return
+        await self._finalise_and_queue(session=session, pending=pending)
 
-        # Final chunk landed; finalise + extract + queue. Pull the
-        # entry out of ``_inflight`` first so a later mistake doesn't
-        # leave a closed assembler dangling.
+    async def _finalise_and_queue(
+        self, *, session: PeerLinkSession, pending: _PendingSubmit
+    ) -> None:
+        """Pull the in-flight entry, finalise the bundle, extract + queue + ack.
+
+        Split out from :meth:`handle_submit_job_chunk` so the
+        final-chunk path is read-on-its-own rather than tail-of-
+        a-flat-cascade. Drops the in-flight entry first so any
+        later failure can't leave a closed assembler dangling.
+        """
         self._inflight.pop(session.dashboard_id, None)
         try:
             assembled = pending.assembler.finalise()
         except BundleAssemblerError as exc:
-            await self._send_ack(
-                session,
-                job_id=pending.job_id,
-                accepted=False,
-                reason=exc.code.value,
-            )
-            if exc.code not in _RECOVERABLE_ASSEMBLER_ERRORS:
-                await session.terminate(TerminateReason.MALFORMED_FRAME)
+            await self._reject_assembler(session, pending=pending, exc=exc)
             return
-
         try:
-            queued_job_id = await self._extract_and_queue(
-                session=session,
-                pending=pending,
-                bundle_bytes=assembled,
-            )
+            await self._extract_and_queue(session=session, pending=pending, bundle_bytes=assembled)
         except _SubmitJobRejectionError as exc:
-            await self._send_ack(
-                session,
-                job_id=pending.job_id,
-                accepted=False,
-                reason=exc.reason,
-            )
+            await self._reject(session, job_id=pending.job_id, reason=exc.reason)
             return
+        # Echo the offloader's ``job_id`` back on the ack so the
+        # offloader can match the response to its submit; the
+        # receiver-side job id is threaded into the 5c-2b fan-out
+        # via :attr:`FirmwareJob.remote_peer` instead.
+        await self._send_ack_accepted(session, job_id=pending.job_id)
 
-        # ``_extract_and_queue`` returned the queued job's id; the
-        # offloader's ``job_id`` from the header is what they
-        # tagged the submit with, but the receiver-side job id is
-        # what every subsequent ``job_state_changed`` /
-        # ``job_output`` frame keys on. Echo the offloader's
-        # ``job_id`` back on the ack so the offloader can match
-        # the response to its submit; the receiver-side id is
-        # threaded into the 5c-2b fan-out via
-        # :attr:`FirmwareJob.remote_peer` instead.
-        del queued_job_id  # documented for the comment; not used yet
-        await self._send_ack(
+    async def _reject_assembler(
+        self,
+        session: PeerLinkSession,
+        *,
+        pending: _PendingSubmit,
+        exc: BundleAssemblerError,
+    ) -> None:
+        """Reject helper for assembler errors — terminates on wire-level codes only.
+
+        Codes in :data:`_RECOVERABLE_ASSEMBLER_ERRORS`
+        (``oversized`` / ``undersized`` / ``hash_mismatch`` /
+        ``empty_bundle``) ack-and-stay so the offloader can
+        retry on a fresh submit. Anything else (out-of-order,
+        post-completion, chunk-count-mismatched) is wire-level
+        misbehaviour and triggers a
+        ``terminate{malformed_frame}`` close after the ack.
+        """
+        await self._reject(
             session,
             job_id=pending.job_id,
-            accepted=True,
+            reason=exc.code.value,
+            drop_inflight=True,
+            terminate_session=exc.code not in _RECOVERABLE_ASSEMBLER_ERRORS,
         )
 
     async def _extract_and_queue(
@@ -410,16 +361,18 @@ class SubmitJobReceiver:
         session: PeerLinkSession,
         pending: _PendingSubmit,
         bundle_bytes: bytes,
-    ) -> str:
+    ) -> None:
         """Write the tarball, extract it, queue a :class:`FirmwareJob`.
 
-        Returns the queued job's ``job_id`` (receiver-side id,
-        distinct from the offloader's submit-tagged id). Raises
-        :class:`_SubmitJobRejectionError` on any failure with a
-        :class:`SubmitJobAckFrameData.reason`-shaped code so the
-        caller can convert into an ack reject without a terminate
-        (extract / queue failures are receiver-side problems, not
-        wire-level misbehaviour).
+        Raises :class:`_SubmitJobRejectionError` on any failure
+        with a :class:`SubmitJobAckFrameData.reason`-shaped code
+        so the caller can convert into an ack reject without a
+        terminate (extract / queue failures are receiver-side
+        problems, not wire-level misbehaviour). The receiver-side
+        job id is captured in :attr:`FirmwareJob.remote_peer` for
+        the 5c-2b fan-out path; the offloader echoes against its
+        own submit-tagged ``job_id`` rather than the receiver's
+        local one.
 
         Disk I/O hops to the executor:
         ``prepare_bundle_for_compile`` walks the tar, validates
@@ -482,41 +435,56 @@ class SubmitJobReceiver:
             configuration,
             pending.target,
         )
-        return job.job_id
 
-    async def _send_ack(
+    async def _send_ack_accepted(self, session: PeerLinkSession, *, job_id: str) -> None:
+        """Send the success-path ``submit_job_ack`` (no ``reason`` field)."""
+        payload = SubmitJobAckFrameData(type="submit_job_ack", job_id=job_id, accepted=True)
+        await session.send_app_frame(dict(payload))
+
+    async def _reject(
         self,
         session: PeerLinkSession,
         *,
         job_id: str,
-        accepted: bool,
-        reason: str | None = None,
+        reason: str,
+        drop_inflight: bool = False,
+        terminate_session: bool = False,
     ) -> None:
-        """Send a typed :class:`SubmitJobAckFrameData` to *session*.
+        """Single chokepoint for every reject path.
 
-        ``reason`` is omitted from the wire payload on the
-        success path so the frame is exactly
-        ``{type, job_id, accepted: true}`` (matching the
-        ``NotRequired`` declaration on the TypedDict). Failures
-        from ``send_app_frame`` are logged at the channel layer
-        and don't propagate here — the session is already
-        closing or gone, the ack going missing isn't actionable.
+        Drops the in-flight entry when *drop_inflight* is true
+        (the failure leaves no recoverable in-flight state, e.g.
+        decode / assembler errors mid-stream), sends a typed
+        ``submit_job_ack`` with ``accepted=False`` + the given
+        *reason*, then optionally fires
+        ``terminate{malformed_frame}`` on the session when the
+        failure was wire-level misbehaviour (out-of-order
+        chunks, base64 garbage). Receiver-side problems
+        (``extract_failed`` / ``queue_rejected`` / header
+        validation that didn't reach an assembler) leave the
+        session intact so the offloader can retry on a fresh
+        submit.
+
+        Failures from ``send_app_frame`` are logged at the
+        channel layer and don't propagate here — the session
+        is already closing or gone, the ack going missing
+        isn't actionable.
         """
-        payload: SubmitJobAckFrameData = (
-            SubmitJobAckFrameData(
-                type="submit_job_ack",
-                job_id=job_id,
-                accepted=accepted,
-            )
-            if reason is None
-            else SubmitJobAckFrameData(
-                type="submit_job_ack",
-                job_id=job_id,
-                accepted=accepted,
-                reason=reason,
-            )
+        # Local import sidesteps the circular dep:
+        # ``remote_build_peer_link`` imports symbols from this
+        # module via :class:`SubmitJobReceiver`-shaped duck
+        # typing in its receive loop, but only the
+        # ``TerminateReason`` enum reads back the other way.
+        from .remote_build_peer_link import TerminateReason  # noqa: PLC0415
+
+        if drop_inflight:
+            self._inflight.pop(session.dashboard_id, None)
+        payload = SubmitJobAckFrameData(
+            type="submit_job_ack", job_id=job_id, accepted=False, reason=reason
         )
         await session.send_app_frame(dict(payload))
+        if terminate_session:
+            await session.terminate(TerminateReason.MALFORMED_FRAME)
 
 
 class _SubmitJobRejectionError(Exception):

--- a/esphome_device_builder/controllers/remote_build_submit_job.py
+++ b/esphome_device_builder/controllers/remote_build_submit_job.py
@@ -554,9 +554,15 @@ class SubmitJobReceiver:
         # the way out). The extracted YAML lives under
         # ``.esphome/.remote_builds/<dashboard_id>/<device_name>/``
         # inside the same config_dir, so ``relative_to`` always
-        # succeeds here.
+        # succeeds here. ``as_posix`` keeps the wire-side
+        # ``configuration`` string stable across receiver
+        # platforms — ``str(rel_yaml)`` would emit
+        # ``\\``-separated paths on Windows, drifting the
+        # ``FirmwareJob.configuration`` field's shape between a
+        # dashboard running on Linux vs Windows even though the
+        # filesystem-level join works either way.
         rel_yaml = extracted_yaml.relative_to(self._config_dir)
-        configuration = str(rel_yaml)
+        configuration = rel_yaml.as_posix()
 
         try:
             job = self._firmware._create_job(

--- a/esphome_device_builder/controllers/remote_build_submit_job.py
+++ b/esphome_device_builder/controllers/remote_build_submit_job.py
@@ -428,38 +428,27 @@ class SubmitJobReceiver:
         # only for filenames that already passed the gate.
         device_name = _validate_configuration_filename(pending.configuration_filename)
         assert device_name is not None  # narrowed by the upstream reject
-        peer_root = self._config_dir / _REMOTE_BUILDS_SUBDIR / session.dashboard_id
-        target_dir = peer_root / device_name
+        remote_builds_root = self._config_dir / _REMOTE_BUILDS_SUBDIR
+        target_dir = remote_builds_root / session.dashboard_id / device_name
         bundle_path = target_dir / _BUNDLE_FILENAME
 
-        # Belt-and-braces: the upstream filename validator catches
-        # path-separator / ``..`` / unexpected-extension shapes,
-        # but ``dashboard_id`` flows through unvalidated from the
-        # Noise handshake / receiver-side registration, and an
-        # unforeseen path-component shape would otherwise let the
-        # tarball write escape ``<config>/.esphome/.remote_builds/``.
-        # ``Path.resolve`` normalises the join; ``relative_to``
-        # raises ``ValueError`` when the result climbs outside the
-        # remote-builds root.
+        loop = asyncio.get_running_loop()
         try:
-            target_dir.resolve().relative_to((self._config_dir / _REMOTE_BUILDS_SUBDIR).resolve())
-        except ValueError as exc:
+            extracted_yaml: Path = await loop.run_in_executor(
+                None,
+                _validate_write_extract_bundle,
+                bundle_path,
+                bundle_bytes,
+                target_dir,
+                remote_builds_root,
+            )
+        except _PathEscapeError as exc:
             _LOGGER.warning(
                 "submit_job from %s: target_dir %s escaped remote-builds root; rejecting",
                 session.dashboard_id,
                 target_dir,
             )
             raise _SubmitJobRejectionError(_REASON_INVALID_HEADER) from exc
-
-        loop = asyncio.get_running_loop()
-        try:
-            extracted_yaml: Path = await loop.run_in_executor(
-                None,
-                _write_and_extract_bundle,
-                bundle_path,
-                bundle_bytes,
-                target_dir,
-            )
         except (EsphomeError, OSError) as exc:
             _LOGGER.warning(
                 "submit_job from %s: extract failed for job %s (%s): %s",
@@ -568,17 +557,61 @@ class _SubmitJobRejectionError(Exception):
         self.reason = reason
 
 
-def _write_and_extract_bundle(bundle_path: Path, bundle_bytes: bytes, target_dir: Path) -> Path:
-    """Sync helper run in the executor: write the tarball + extract it.
+class _PathEscapeError(Exception):
+    """*target_dir* resolved outside the remote-builds root.
 
-    Bundled together so the
-    :meth:`SubmitJobReceiver._extract_and_queue` callsite hops
-    to the executor exactly once for both phases.
-    ``prepare_bundle_for_compile`` is the entry point because it
-    preserves the build-cache subdirectories (``.esphome`` /
-    ``.pioenvs``) that incremental compiles need to skip the
-    cold-rebuild hit.
+    Surfaced from :func:`_validate_write_extract_bundle` so the
+    caller can map to a typed
+    :class:`SubmitJobAckFrameData.reason` of ``invalid_header``.
+    Distinct from the ``EsphomeError`` / ``OSError`` paths
+    (which surface as ``extract_failed``) because this is a
+    wire-shape problem — the offloader's ``configuration_filename``
+    or its captured ``dashboard_id`` carries a path-traversal
+    shape — not a receiver-side I/O failure.
     """
+
+
+def _validate_write_extract_bundle(
+    bundle_path: Path,
+    bundle_bytes: bytes,
+    target_dir: Path,
+    remote_builds_root: Path,
+) -> Path:
+    """Sync helper: validate path is under root, write tarball, extract.
+
+    All three steps run in the executor so the receiver's WS
+    dispatch coroutine stays non-blocking through both the
+    ``Path.resolve`` walk (which calls ``os.path.realpath``,
+    which calls the blocking ``os.path.abspath`` syscall) and
+    the multi-MB tarball write. ``Path.resolve`` is a stat-y
+    syscall; it has to run in a thread.
+
+    Validation order: (1) resolve-and-stay-under-root check
+    *before* writing anything to disk so a malicious
+    ``configuration_filename`` or ``dashboard_id`` can't
+    materialise even an empty tarball outside the remote-builds
+    subtree. (2) Write the tarball. (3) Extract via
+    ``prepare_bundle_for_compile`` (preserves ``.esphome`` /
+    ``.pioenvs`` for incremental compiles).
+
+    Raises :class:`_PathEscapeError` on the path-escape branch
+    so the caller can distinguish "bad input shape" from
+    "extract failed". Raises
+    :class:`esphome.bundle.EsphomeError` / :class:`OSError`
+    untouched for the extract / write paths.
+    """
+    # Resolve-and-stay-under-root. ``Path.resolve()`` normalises
+    # ``..`` / symlinks; ``relative_to`` raises ``ValueError``
+    # when the result climbs outside the remote-builds root.
+    # The upstream filename validator catches separator / ``..``
+    # in ``configuration_filename`` upfront, but ``dashboard_id``
+    # flows through unvalidated from the Noise handshake /
+    # receiver-side registration; this gate catches anything an
+    # exotic ``dashboard_id`` shape would slip past.
+    try:
+        target_dir.resolve().relative_to(remote_builds_root.resolve())
+    except ValueError as exc:
+        raise _PathEscapeError(str(target_dir)) from exc
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     bundle_path.write_bytes(bundle_bytes)
     extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -84,6 +84,12 @@ class FirmwareJob(DataClassORJSONMixin):
     # yet -- most compile output is opaque, but the heavy phases (PIO
     # build, esptool flash) do emit percentages we can latch onto.
     progress: int | None = None
+    # Offloader's ``dashboard_id`` when this job came in via the
+    # peer-link ``submit_job`` flow (issue #106 phase 5c). Empty
+    # for locally-submitted jobs. Surfaced in the firmware-tasks
+    # UI as a "from <peer>" badge so the receiver-side admin can
+    # tell their own work apart from delegated builds.
+    remote_peer: str = ""
 
     def reset(self) -> None:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,6 +228,78 @@ async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
     await asyncio.gather(task, return_exceptions=True)
 
 
+# ---------------------------------------------------------------------------
+# submit_job test helpers (5c-2)
+#
+# Bundle construction + wire-frame builders shared between the
+# unit tests in ``test_remote_build_submit_job.py`` and the
+# integration tests in ``test_remote_build_peer_link.py``. Each
+# is a one-liner factory but they were duplicated across the
+# two files before this lived here.
+# ---------------------------------------------------------------------------
+
+
+def make_tar_bundle(yaml_filename: str, yaml_body: bytes) -> bytes:
+    """Build a minimal gzipped-tar bundle carrying a single YAML.
+
+    Pure-shape: the receiver-side
+    ``prepare_bundle_for_compile`` validates a manifest +
+    canonical layout that this helper deliberately doesn't
+    construct. Tests that exercise the receive-loop dispatch
+    stub ``prepare_bundle_for_compile`` rather than feeding it
+    a real esphome bundle.
+    """
+    import tarfile  # noqa: PLC0415 — keep tarfile out of the conftest top-level
+    from io import BytesIO  # noqa: PLC0415
+
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=yaml_filename)
+        info.size = len(yaml_body)
+        tar.addfile(info, BytesIO(yaml_body))
+    return buf.getvalue()
+
+
+def make_submit_job_frames(
+    *, job_id: str, configuration_filename: str, target: str, bundle: bytes
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build the wire-shape ``submit_job`` header + chunk frames for *bundle*.
+
+    Returns ``(header, chunks)`` as plain dicts so callers can
+    feed them through either the receiver-side handler
+    directly or as JSON-encoded ciphertext over a real WS.
+    Wraps :func:`chunk_bundle` so the chunk envelope (b64
+    encoding, indices, ``is_last`` flag, repeated ``job_id``)
+    lives in one place.
+    """
+    from esphome_device_builder.helpers.peer_link_bundle import (  # noqa: PLC0415
+        chunk_bundle,
+        compute_bundle_sha256,
+        encode_chunk,
+    )
+
+    chunks = [
+        {
+            "type": "submit_job_chunk",
+            "job_id": job_id,
+            "chunk_index": index,
+            "data_b64": encode_chunk(raw),
+            "is_last": is_last,
+        }
+        for index, raw, is_last in chunk_bundle(bundle)
+    ]
+    header = {
+        "type": "submit_job",
+        "job_id": job_id,
+        "configuration_filename": configuration_filename,
+        "target": target,
+        "total_bundle_bytes": len(bundle),
+        "num_chunks": len(chunks),
+        "bundle_sha256": compute_bundle_sha256(bundle),
+    }
+    return header, chunks
+
+
 @pytest.fixture(scope="session")
 def session_board_catalog() -> BoardCatalog:
     """Real ``BoardCatalog`` loaded once per xdist worker."""

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2604,3 +2604,18 @@ def test_peer_queue_status_snapshot_returns_list(tmp_path: Path) -> None:
     assert len(snapshot) == 2
     hostnames = {entry["receiver_hostname"] for entry in snapshot}
     assert hostnames == {"a", "b"}
+
+
+def test_get_submit_job_receiver_raises_before_start(tmp_path: Path) -> None:
+    """Accessing ``get_submit_job_receiver`` before ``start()`` raises ``RuntimeError``.
+
+    Pins the bring-up ordering invariant: the wire dispatch in
+    :func:`controllers.remote_build_peer_link._receive_loop`
+    reaches the receiver via this accessor, and the peer-link
+    listener only binds after :meth:`start` has installed it.
+    The explicit failure surfaces a future bring-up regression
+    instead of silently no-op'ing the dispatch.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(RuntimeError, match=r"before RemoteBuildController\.start"):
+        controller.get_submit_job_receiver()

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import secrets
+import tarfile
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -59,7 +61,19 @@ from esphome_device_builder.controllers.remote_build_peer_link import (
     _send_response,
     make_peer_link_handler,
 )
+from esphome_device_builder.controllers.remote_build_submit_job import (
+    SubmitJobReceiver,
+)
 from esphome_device_builder.helpers import json as _json
+from esphome_device_builder.helpers.peer_link_bundle import (
+    chunk_bundle as _chunk_bundle,
+)
+from esphome_device_builder.helpers.peer_link_bundle import (
+    compute_bundle_sha256 as _compute_bundle_sha256,
+)
+from esphome_device_builder.helpers.peer_link_bundle import (
+    encode_chunk as _encode_chunk,
+)
 from esphome_device_builder.helpers.peer_link_identity import (
     get_or_create_peer_link_identity,
 )
@@ -1273,6 +1287,151 @@ async def test_e2e_peer_link_session_oversize_frame_terminates(
         assert terminate["reason"] == TerminateReason.MALFORMED_FRAME.value
     finally:
         await ws.close()
+
+
+def _install_stub_submit_job_receiver(
+    controller: RemoteBuildController,
+) -> tuple[Any, list[Any]]:
+    """Wire a stub firmware controller into a fresh :class:`SubmitJobReceiver`.
+
+    The ``peer_link_app`` fixture doesn't drive
+    ``RemoteBuildController.start()``, so
+    ``_submit_job_receiver`` would be ``None`` at dispatch
+    time. Tests that exercise the wire-side ``submit_job`` flow
+    install a fresh receiver here. Returns the firmware stub +
+    a list that captures every queued :class:`FirmwareJob`.
+    """
+    queued_jobs: list[Any] = []
+    firmware_stub = MagicMock()
+
+    def _create_job(*, configuration: str, job_type: Any, remote_peer: str = "") -> Any:
+        job = MagicMock()
+        job.job_id = f"local-{len(queued_jobs)}"
+        job.configuration = configuration
+        job.remote_peer = remote_peer
+        return job
+
+    async def _enqueue(job: Any) -> Any:
+        queued_jobs.append(job)
+        return job
+
+    firmware_stub._create_job = MagicMock(side_effect=_create_job)
+    firmware_stub._enqueue = AsyncMock(side_effect=_enqueue)
+    controller._submit_job_receiver = SubmitJobReceiver(
+        config_dir=controller._db.settings.config_dir,
+        firmware_controller=firmware_stub,
+    )
+    return firmware_stub, queued_jobs
+
+
+def _build_submit_job_frames(
+    *, job_id: str, configuration_filename: str, bundle: bytes
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build the wire-shape ``submit_job`` header + chunk frames for *bundle*."""
+    chunks = [
+        {
+            "type": "submit_job_chunk",
+            "job_id": job_id,
+            "chunk_index": index,
+            "data_b64": _encode_chunk(raw),
+            "is_last": is_last,
+        }
+        for index, raw, is_last in _chunk_bundle(bundle)
+    ]
+    header = {
+        "type": "submit_job",
+        "job_id": job_id,
+        "configuration_filename": configuration_filename,
+        "target": "compile",
+        "total_bundle_bytes": len(bundle),
+        "num_chunks": len(chunks),
+        "bundle_sha256": _compute_bundle_sha256(bundle),
+    }
+    return header, chunks
+
+
+def _build_minimal_bundle(yaml_filename: str, yaml_body: bytes) -> bytes:
+    """Build a minimal gzipped-tar bundle.
+
+    Pure-shape; the extraction tests at
+    :mod:`tests.test_remote_build_submit_job` cover the
+    receiver-side handler against this same shape.
+    """
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=yaml_filename)
+        info.size = len(yaml_body)
+        tar.addfile(info, BytesIO(yaml_body))
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_e2e_submit_job_dispatches_to_receiver(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``submit_job`` header + chunks over the wire dispatches to the receiver.
+
+    Drives the receive-loop branches in
+    :func:`controllers.remote_build_peer_link._receive_loop`
+    that route ``SUBMIT_JOB`` / ``SUBMIT_JOB_CHUNK`` to the
+    :class:`SubmitJobReceiver`. Stubs
+    :func:`prepare_bundle_for_compile` because the real
+    extractor expects an esphome-shaped manifest; the contract
+    being pinned is the wire dispatch + bundle write + queue
+    plumbing, not the extraction itself (which has its own
+    tests in :mod:`esphome`).
+    """
+    client, controller, _ = peer_link_app
+    initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    await _seed_approved_offloader(controller, dashboard_id="alpha", pubkey=initiator_pub)
+    _firmware_stub, queued_jobs = _install_stub_submit_job_receiver(controller)
+    extracted_path = (
+        controller._db.settings.config_dir
+        / ".esphome"
+        / ".remote_builds"
+        / "alpha"
+        / "kitchen"
+        / "kitchen.yaml"
+    )
+
+    def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        extracted_path.parent.mkdir(parents=True, exist_ok=True)
+        extracted_path.write_bytes(b"esphome:\n  name: kitchen\n")
+        return extracted_path
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        _stub_prepare,
+    )
+    bundle = _build_minimal_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+    header, chunks = _build_submit_job_frames(
+        job_id="wire-job", configuration_filename="kitchen.yaml", bundle=bundle
+    )
+
+    session, ws, _ = await _drive_peer_link_session_open(
+        client, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+    try:
+        await ws.send_bytes(session.encrypt(_json.dumps(header)))
+        for chunk in chunks:
+            await ws.send_bytes(session.encrypt(_json.dumps(chunk)))
+        ack_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=2.0)
+    finally:
+        await ws.close()
+
+    ack = _decode_app_frame(session, ack_encrypted)
+    assert ack["type"] == "submit_job_ack"
+    assert ack["job_id"] == "wire-job"
+    assert ack["accepted"] is True
+    assert "reason" not in ack
+
+    assert len(queued_jobs) == 1
+    assert queued_jobs[0].remote_peer == "alpha"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1565,7 +1565,7 @@ async def test_receive_loop_terminates_on_text_frame(tmp_path: Path) -> None:
     session, ws = _make_unit_session(responder)
     ws._inbox.append(_text_msg("hello"))
 
-    await _receive_loop(session)
+    await _receive_loop(session, MagicMock())
 
     # One terminate frame sent + WS closed; decode confirms the
     # reason field carries the expected ``malformed_frame``.
@@ -1585,7 +1585,7 @@ async def test_receive_loop_terminates_on_undecryptable_frame(tmp_path: Path) ->
     # frame against ``responder``'s current cipher state.
     ws._inbox.append(_binary_msg(b"\xde\xad\xbe\xef" * 16))
 
-    await _receive_loop(session)
+    await _receive_loop(session, MagicMock())
 
     assert ws.closes == 1
     # The terminate frame itself was sent before close — exact
@@ -1603,7 +1603,7 @@ async def test_receive_loop_terminates_on_non_object_json(tmp_path: Path) -> Non
     bad_payload = initiator.encrypt(_json.dumps([1, 2, 3]))
     ws._inbox.append(_binary_msg(bad_payload))
 
-    await _receive_loop(session)
+    await _receive_loop(session, MagicMock())
 
     assert ws.closes == 1
     assert len(ws.sends) == 1
@@ -1618,7 +1618,7 @@ async def test_receive_loop_pong_updates_last_pong_at(tmp_path: Path) -> None:
     pong = initiator.encrypt(_json.dumps({"type": "pong", "nonce": 7}))
     ws._inbox.append(_binary_msg(pong))
 
-    await _receive_loop(session)
+    await _receive_loop(session, MagicMock())
 
     assert session.last_pong_at > 0.0
     # No outbound frame fired (pong is one-way from peer to us).
@@ -1633,7 +1633,7 @@ async def test_receive_loop_peer_terminate_exits_cleanly(tmp_path: Path) -> None
     bye = initiator.encrypt(_json.dumps({"type": "terminate", "reason": "client_quit"}))
     ws._inbox.append(_binary_msg(bye))
 
-    await _receive_loop(session)
+    await _receive_loop(session, MagicMock())
 
     # No echo terminate, no close from our side — caller (the
     # session-loop driver) closes the WS in its outer finally.
@@ -1658,7 +1658,7 @@ async def test_receive_loop_unknown_app_frame_type_logged_and_ignored(tmp_path: 
     # iterator is empty (no further frames). Add an explicit close
     # message? Async-iter exit on StopAsyncIteration is enough.
 
-    await _receive_loop(session)
+    await _receive_loop(session, MagicMock())
 
     # Nothing sent, no terminate, no close from our side.
     assert ws.sends == []

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -20,10 +20,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import secrets
-import tarfile
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
-from io import BytesIO
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -65,15 +63,6 @@ from esphome_device_builder.controllers.remote_build_submit_job import (
     SubmitJobReceiver,
 )
 from esphome_device_builder.helpers import json as _json
-from esphome_device_builder.helpers.peer_link_bundle import (
-    chunk_bundle as _chunk_bundle,
-)
-from esphome_device_builder.helpers.peer_link_bundle import (
-    compute_bundle_sha256 as _compute_bundle_sha256,
-)
-from esphome_device_builder.helpers.peer_link_bundle import (
-    encode_chunk as _encode_chunk,
-)
 from esphome_device_builder.helpers.peer_link_identity import (
     get_or_create_peer_link_identity,
 )
@@ -88,7 +77,11 @@ from esphome_device_builder.models import (
     StoredPeer,
 )
 
-from .conftest import make_remote_build_controller
+from .conftest import (
+    make_remote_build_controller,
+    make_submit_job_frames,
+    make_tar_bundle,
+)
 
 
 def _make_controller(*, config_dir: Any = None) -> RemoteBuildController:
@@ -1324,47 +1317,6 @@ def _install_stub_submit_job_receiver(
     return firmware_stub, queued_jobs
 
 
-def _build_submit_job_frames(
-    *, job_id: str, configuration_filename: str, bundle: bytes
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    """Build the wire-shape ``submit_job`` header + chunk frames for *bundle*."""
-    chunks = [
-        {
-            "type": "submit_job_chunk",
-            "job_id": job_id,
-            "chunk_index": index,
-            "data_b64": _encode_chunk(raw),
-            "is_last": is_last,
-        }
-        for index, raw, is_last in _chunk_bundle(bundle)
-    ]
-    header = {
-        "type": "submit_job",
-        "job_id": job_id,
-        "configuration_filename": configuration_filename,
-        "target": "compile",
-        "total_bundle_bytes": len(bundle),
-        "num_chunks": len(chunks),
-        "bundle_sha256": _compute_bundle_sha256(bundle),
-    }
-    return header, chunks
-
-
-def _build_minimal_bundle(yaml_filename: str, yaml_body: bytes) -> bytes:
-    """Build a minimal gzipped-tar bundle.
-
-    Pure-shape; the extraction tests at
-    :mod:`tests.test_remote_build_submit_job` cover the
-    receiver-side handler against this same shape.
-    """
-    buf = BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        info = tarfile.TarInfo(name=yaml_filename)
-        info.size = len(yaml_body)
-        tar.addfile(info, BytesIO(yaml_body))
-    return buf.getvalue()
-
-
 @pytest.mark.asyncio
 async def test_e2e_submit_job_dispatches_to_receiver(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
@@ -1408,9 +1360,12 @@ async def test_e2e_submit_job_dispatches_to_receiver(
         "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
         _stub_prepare,
     )
-    bundle = _build_minimal_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
-    header, chunks = _build_submit_job_frames(
-        job_id="wire-job", configuration_filename="kitchen.yaml", bundle=bundle
+    bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+    header, chunks = make_submit_job_frames(
+        job_id="wire-job",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle=bundle,
     )
 
     session, ws, _ = await _drive_peer_link_session_open(

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -1,0 +1,459 @@
+"""
+Tests for the receiver-side ``submit_job`` flow (issue #106 phase 5c-2).
+
+Two layers, mirroring :mod:`tests.test_remote_build_peer_link`'s
+shape so the seam between this module's unit tests and the
+e2e harness in :mod:`tests.e2e` stays visible:
+
+* Unit tests against a stubbed
+  :class:`PeerLinkSession` + :class:`FirmwareController` — pin
+  the per-branch reject reasons and the happy-path enqueue.
+* End-to-end flow against a real
+  :class:`PeerLinkSession` + a real bundle goes in the
+  ``tests/e2e`` harness in 5c-2b once the firmware-event
+  fan-out lands; the submit-and-ack contract here is enough
+  for 5c-2a.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tarfile
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from esphome.bundle import EsphomeError
+
+from esphome_device_builder.controllers.remote_build_submit_job import (
+    SubmitJobReceiver,
+    _device_name_from_filename,
+)
+from esphome_device_builder.helpers.peer_link_bundle import (
+    BUNDLE_CHUNK_SIZE_BYTES,
+    chunk_bundle,
+    compute_bundle_sha256,
+    encode_chunk,
+)
+from esphome_device_builder.models import (
+    JobType,
+    SubmitJobChunkFrameData,
+    SubmitJobFrameData,
+)
+
+
+def _make_tar_bundle(yaml_filename: str, yaml_body: bytes) -> bytes:
+    """Build a minimal gzipped-tar bundle containing one YAML.
+
+    The receiver-side ``prepare_bundle_for_compile`` helper
+    expects an esphome-shaped bundle with a manifest and a
+    handful of validated members. For the unit tests here we
+    sidestep extraction by stubbing ``prepare_bundle_for_compile``;
+    a syntactically-valid tarball is enough for the
+    ``write_and_extract`` executor hop to take the happy path.
+    """
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=yaml_filename)
+        info.size = len(yaml_body)
+        tar.addfile(info, BytesIO(yaml_body))
+    return buf.getvalue()
+
+
+def _make_session(*, dashboard_id: str = "alpha") -> Any:
+    """Stub ``PeerLinkSession`` capturing send_app_frame + terminate calls."""
+    session = MagicMock()
+    session.dashboard_id = dashboard_id
+    session.send_app_frame = AsyncMock(return_value=True)
+    session.terminate = AsyncMock()
+    return session
+
+
+def _make_firmware_controller() -> Any:
+    """Stub ``FirmwareController`` recording ``_create_job`` / ``_enqueue`` calls."""
+    firmware = MagicMock()
+    created_jobs: list[Any] = []
+
+    def _create_job(
+        configuration: str, job_type: JobType, *, remote_peer: str = "", **_: Any
+    ) -> Any:
+        job = MagicMock()
+        job.job_id = f"local-{len(created_jobs)}"
+        job.configuration = configuration
+        job.job_type = job_type
+        job.remote_peer = remote_peer
+        created_jobs.append(job)
+        return job
+
+    firmware._create_job = MagicMock(side_effect=_create_job)
+    firmware._enqueue = AsyncMock(side_effect=lambda job: job)
+    firmware.created_jobs = created_jobs
+    return firmware
+
+
+def _make_receiver(tmp_path: Path, firmware: Any | None = None) -> SubmitJobReceiver:
+    return SubmitJobReceiver(
+        config_dir=tmp_path,
+        firmware_controller=firmware or _make_firmware_controller(),
+    )
+
+
+def _header(
+    *,
+    job_id: str = "job-1",
+    configuration_filename: str = "kitchen.yaml",
+    target: str = "compile",
+    bundle: bytes = b"\x00" * 100,
+) -> SubmitJobFrameData:
+    return SubmitJobFrameData(
+        type="submit_job",
+        job_id=job_id,
+        configuration_filename=configuration_filename,
+        target=target,  # type: ignore[typeddict-item]
+        total_bundle_bytes=len(bundle),
+        num_chunks=max(1, (len(bundle) + BUNDLE_CHUNK_SIZE_BYTES - 1) // BUNDLE_CHUNK_SIZE_BYTES),
+        bundle_sha256=compute_bundle_sha256(bundle),
+    )
+
+
+def _ack_payload(session: Any) -> dict[str, Any]:
+    """Pull the most recent ``send_app_frame`` payload off *session*."""
+    payload: dict[str, Any] = session.send_app_frame.call_args.args[0]
+    return payload
+
+
+def _frame_chunks(job_id: str, bundle: bytes) -> list[SubmitJobChunkFrameData]:
+    """Wrap :func:`chunk_bundle` output in :class:`SubmitJobChunkFrameData` dicts.
+
+    The bundle helper produces raw ``(index, bytes, is_last)``
+    tuples; the wire format wraps each as a JSON-encoded
+    ``SubmitJobChunkFrameData`` (5c-3 will do this on the
+    offloader side). Tests here drive the receiver, so they
+    need the wrapped form to feed
+    :meth:`SubmitJobReceiver.handle_submit_job_chunk` the same
+    shape the live wire would land.
+    """
+    return [
+        SubmitJobChunkFrameData(
+            type="submit_job_chunk",
+            job_id=job_id,
+            chunk_index=index,
+            data_b64=encode_chunk(raw),
+            is_last=is_last,
+        )
+        for index, raw, is_last in chunk_bundle(bundle)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("kitchen.yaml", "kitchen"),
+        ("kitchen.yml", "kitchen"),
+        ("KITCHEN.YAML", "KITCHEN"),
+        ("no-extension", "no-extension"),
+        ("multi.dot.yaml", "multi.dot"),
+    ],
+)
+def test_device_name_from_filename_strips_known_extensions(filename: str, expected: str) -> None:
+    assert _device_name_from_filename(filename) == expected
+
+
+# ---------------------------------------------------------------------------
+# handle_submit_job — header validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_job_duplicate_header_rejected(tmp_path: Path) -> None:
+    """A second header on a session with one in-flight rejects ``duplicate_submit``."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+
+    await receiver.handle_submit_job(session, _header(job_id="first"))
+    session.send_app_frame.reset_mock()
+
+    await receiver.handle_submit_job(session, _header(job_id="second"))
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "duplicate_submit"
+    assert payload["job_id"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_submit_job_invalid_target_rejected(tmp_path: Path) -> None:
+    """A header with ``target`` outside compile/upload rejects ``invalid_header``."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+
+    await receiver.handle_submit_job(session, _header(target="install"))
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "invalid_header"
+
+
+@pytest.mark.asyncio
+async def test_submit_job_oversized_bundle_rejected(tmp_path: Path) -> None:
+    """A header announcing a bundle past ``BUNDLE_MAX_TOTAL_BYTES`` rejects via the assembler."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+    huge = SubmitJobFrameData(
+        type="submit_job",
+        job_id="job-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        total_bundle_bytes=10 * 1024 * 1024,  # 10 MiB > 4 MiB cap
+        num_chunks=1,
+        bundle_sha256="0" * 64,
+    )
+
+    await receiver.handle_submit_job(session, huge)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "oversized"
+
+
+# ---------------------------------------------------------------------------
+# handle_submit_job_chunk — chunk dispatch + finalisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_job_chunk_no_inflight_rejected(tmp_path: Path) -> None:
+    """A chunk frame without a preceding header rejects ``no_inflight_submit``."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+
+    chunk = SubmitJobChunkFrameData(
+        type="submit_job_chunk",
+        job_id="job-1",
+        chunk_index=0,
+        data_b64="AAAA",  # any valid base64
+        is_last=True,
+    )
+    await receiver.handle_submit_job_chunk(session, chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "no_inflight_submit"
+    session.terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_chunk_job_id_mismatch_rejected(tmp_path: Path) -> None:
+    """A chunk with the wrong ``job_id`` rejects ``job_id_mismatch``."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+    bundle = b"hello"
+    await receiver.handle_submit_job(session, _header(job_id="real", bundle=bundle))
+
+    chunk = _frame_chunks("real", bundle)[0]
+    chunk["job_id"] = "wrong"  # type: ignore[typeddict-unknown-key]
+
+    await receiver.handle_submit_job_chunk(session, chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "job_id_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_submit_job_chunk_decode_failure_terminates_session(tmp_path: Path) -> None:
+    """Garbage base64 in a chunk rejects ``chunk_decode_failed`` AND terminates the session."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+    await receiver.handle_submit_job(session, _header(bundle=b"hello"))
+
+    bad_chunk = SubmitJobChunkFrameData(
+        type="submit_job_chunk",
+        job_id="job-1",
+        chunk_index=0,
+        data_b64="!!!not-valid-base64!!!",
+        is_last=True,
+    )
+    await receiver.handle_submit_job_chunk(session, bad_chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "chunk_decode_failed"
+    session.terminate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_chunk_out_of_order_terminates_session(tmp_path: Path) -> None:
+    """An out-of-order chunk index rejects + terminates (wire-level misbehaviour)."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+    bundle = b"x" * (BUNDLE_CHUNK_SIZE_BYTES * 3)  # three chunks
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+
+    chunks = _frame_chunks("job-1", bundle)
+    # Skip chunk 0; feed chunk 1 first.
+    await receiver.handle_submit_job_chunk(session, chunks[1])
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "out_of_order"
+    session.terminate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_chunk_hash_mismatch_recoverable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bundle whose assembled hash mismatches rejects ``hash_mismatch`` *without* terminating."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+    bundle = b"hello world"
+
+    # Build a header announcing the WRONG sha256 so finalise()
+    # raises HASH_MISMATCH after the chunks land cleanly.
+    bad_sha = hashlib.sha256(b"different bytes").hexdigest()
+    header = SubmitJobFrameData(
+        type="submit_job",
+        job_id="job-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        total_bundle_bytes=len(bundle),
+        num_chunks=1,
+        bundle_sha256=bad_sha,
+    )
+    await receiver.handle_submit_job(session, header)
+
+    chunk = _frame_chunks("job-1", bundle)[0]
+    await receiver.handle_submit_job_chunk(session, chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "hash_mismatch"
+    # ``hash_mismatch`` is a recoverable error — no terminate.
+    session.terminate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — bundle reception, extract, queue, ack
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_job_happy_path_extracts_and_queues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Final chunk → write tarball → extract → queue job → ack accepted."""
+    firmware = _make_firmware_controller()
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session(dashboard_id="alpha-dashboard")
+    bundle = _make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+
+    # Stub ``prepare_bundle_for_compile`` because the real one
+    # validates a manifest + esphome-shaped layout. The test
+    # here pins the receive-loop → write → extract → queue
+    # plumbing; the real extraction is covered by esphome's own
+    # tests + the e2e harness later.
+    expected_yaml = (
+        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+    )
+
+    def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
+        # Ensure the bundle was written to disk first (we're
+        # checking the executor hop ran the write step).
+        assert bundle_path.exists()
+        assert bundle_path.read_bytes() == bundle
+        target_dir.mkdir(parents=True, exist_ok=True)
+        expected_yaml.parent.mkdir(parents=True, exist_ok=True)
+        expected_yaml.write_bytes(b"esphome:\n  name: kitchen\n")
+        return expected_yaml
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        _stub_prepare,
+    )
+
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+    for chunk in _frame_chunks("job-1", bundle):
+        await receiver.handle_submit_job_chunk(session, chunk)
+
+    # Ack accepted, reason omitted on the success path.
+    payload = _ack_payload(session)
+    assert payload["accepted"] is True
+    assert payload["job_id"] == "job-1"
+    assert "reason" not in payload
+
+    # Job created with remote_peer set + the relative
+    # configuration path under the per-peer subtree.
+    assert len(firmware.created_jobs) == 1
+    job = firmware.created_jobs[0]
+    assert job.remote_peer == "alpha-dashboard"
+    assert job.job_type is JobType.COMPILE
+    assert job.configuration == str(expected_yaml.relative_to(tmp_path))
+    firmware._enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_extract_failure_rejects_without_terminate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure inside ``prepare_bundle_for_compile`` rejects ``extract_failed``; session stays."""
+    firmware = _make_firmware_controller()
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session()
+    bundle = b"\x1f\x8b" + b"\x00" * 50  # gzip magic + filler — not a valid tar
+
+    def _failing_prepare(bundle_path: Path, target_dir: Path) -> Path:
+        raise EsphomeError("bundle invalid: missing manifest")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        _failing_prepare,
+    )
+
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+    for chunk in _frame_chunks("job-1", bundle):
+        await receiver.handle_submit_job_chunk(session, chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "extract_failed"
+    # Receiver-side problem; the wire is still good.
+    session.terminate.assert_not_called()
+    # No job was queued.
+    firmware._enqueue.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# discard_session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discard_session_drops_inflight(tmp_path: Path) -> None:
+    """A discarded session forgets its in-flight upload."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session(dashboard_id="alpha")
+    await receiver.handle_submit_job(session, _header(bundle=b"x" * 100))
+
+    receiver.discard_session("alpha")
+
+    # A subsequent chunk now lands as "no in-flight" rather than
+    # "out-of-order" / "hash mismatch" — proves the dict entry
+    # was actually dropped.
+    chunk = _frame_chunks("job-1", b"x" * 100)[0]
+    await receiver.handle_submit_job_chunk(session, chunk)
+    payload = _ack_payload(session)
+    assert payload["reason"] == "no_inflight_submit"
+
+
+def test_discard_session_unknown_is_noop(tmp_path: Path) -> None:
+    """Discarding a session that never registered is a no-op."""
+    receiver = _make_receiver(tmp_path)
+    receiver.discard_session("never-seen")  # should not raise

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -18,10 +18,8 @@ e2e harness in :mod:`tests.e2e` stays visible:
 from __future__ import annotations
 
 import hashlib
-import tarfile
-from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -31,35 +29,14 @@ from esphome_device_builder.controllers.remote_build_submit_job import (
     SubmitJobReceiver,
     _validate_configuration_filename,
 )
-from esphome_device_builder.helpers.peer_link_bundle import (
-    BUNDLE_CHUNK_SIZE_BYTES,
-    chunk_bundle,
-    compute_bundle_sha256,
-    encode_chunk,
-)
+from esphome_device_builder.helpers.peer_link_bundle import BUNDLE_CHUNK_SIZE_BYTES
 from esphome_device_builder.models import (
     JobType,
     SubmitJobChunkFrameData,
     SubmitJobFrameData,
 )
 
-
-def _make_tar_bundle(yaml_filename: str, yaml_body: bytes) -> bytes:
-    """Build a minimal gzipped-tar bundle containing one YAML.
-
-    The receiver-side ``prepare_bundle_for_compile`` helper
-    expects an esphome-shaped bundle with a manifest and a
-    handful of validated members. For the unit tests here we
-    sidestep extraction by stubbing ``prepare_bundle_for_compile``;
-    a syntactically-valid tarball is enough for the
-    ``write_and_extract`` executor hop to take the happy path.
-    """
-    buf = BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        info = tarfile.TarInfo(name=yaml_filename)
-        info.size = len(yaml_body)
-        tar.addfile(info, BytesIO(yaml_body))
-    return buf.getvalue()
+from .conftest import make_submit_job_frames, make_tar_bundle
 
 
 def _make_session(*, dashboard_id: str = "alpha") -> Any:
@@ -107,44 +84,31 @@ def _header(
     target: str = "compile",
     bundle: bytes = b"\x00" * 100,
 ) -> SubmitJobFrameData:
-    return SubmitJobFrameData(
-        type="submit_job",
+    """Build a typed ``SubmitJobFrameData`` header via the shared helper."""
+    header, _chunks = make_submit_job_frames(
         job_id=job_id,
         configuration_filename=configuration_filename,
-        target=target,  # type: ignore[typeddict-item]
-        total_bundle_bytes=len(bundle),
-        num_chunks=max(1, (len(bundle) + BUNDLE_CHUNK_SIZE_BYTES - 1) // BUNDLE_CHUNK_SIZE_BYTES),
-        bundle_sha256=compute_bundle_sha256(bundle),
+        target=target,
+        bundle=bundle,
     )
+    return cast(SubmitJobFrameData, header)
+
+
+def _frame_chunks(job_id: str, bundle: bytes) -> list[SubmitJobChunkFrameData]:
+    """Build typed ``SubmitJobChunkFrameData`` chunks via the shared helper."""
+    _header_dict, chunks = make_submit_job_frames(
+        job_id=job_id,
+        configuration_filename="kitchen.yaml",  # not used; chunks key on job_id
+        target="compile",
+        bundle=bundle,
+    )
+    return [cast(SubmitJobChunkFrameData, chunk) for chunk in chunks]
 
 
 def _ack_payload(session: Any) -> dict[str, Any]:
     """Pull the most recent ``send_app_frame`` payload off *session*."""
     payload: dict[str, Any] = session.send_app_frame.call_args.args[0]
     return payload
-
-
-def _frame_chunks(job_id: str, bundle: bytes) -> list[SubmitJobChunkFrameData]:
-    """Wrap :func:`chunk_bundle` output in :class:`SubmitJobChunkFrameData` dicts.
-
-    The bundle helper produces raw ``(index, bytes, is_last)``
-    tuples; the wire format wraps each as a JSON-encoded
-    ``SubmitJobChunkFrameData`` (5c-3 will do this on the
-    offloader side). Tests here drive the receiver, so they
-    need the wrapped form to feed
-    :meth:`SubmitJobReceiver.handle_submit_job_chunk` the same
-    shape the live wire would land.
-    """
-    return [
-        SubmitJobChunkFrameData(
-            type="submit_job_chunk",
-            job_id=job_id,
-            chunk_index=index,
-            data_b64=encode_chunk(raw),
-            is_last=is_last,
-        )
-        for index, raw, is_last in chunk_bundle(bundle)
-    ]
 
 
 # ---------------------------------------------------------------------------
@@ -385,7 +349,7 @@ async def test_submit_job_happy_path_extracts_and_queues(
     firmware = _make_firmware_controller()
     receiver = _make_receiver(tmp_path, firmware)
     session = _make_session(dashboard_id="alpha-dashboard")
-    bundle = _make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+    bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
 
     # Stub ``prepare_bundle_for_compile`` because the real one
     # validates a manifest + esphome-shaped layout. The test

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -500,7 +500,10 @@ async def test_submit_job_happy_path_extracts_and_queues(
     job = firmware.created_jobs[0]
     assert job.remote_peer == "alpha-dashboard"
     assert job.job_type is JobType.COMPILE
-    assert job.configuration == str(expected_yaml.relative_to(tmp_path))
+    # Production emits ``as_posix()`` for cross-platform stable
+    # wire shape (Windows vs Linux receivers); test asserts in
+    # the same form.
+    assert job.configuration == expected_yaml.relative_to(tmp_path).as_posix()
     firmware._enqueue.assert_awaited_once()
 
 

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -174,6 +174,115 @@ async def test_submit_job_duplicate_header_rejected(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "broken_frame",
+    [
+        # Missing required fields.
+        {"type": "submit_job", "job_id": "j"},
+        {"type": "submit_job"},  # bare dict — no fields at all
+        # Wrong types.
+        {
+            "type": "submit_job",
+            "job_id": "j",
+            "configuration_filename": "kitchen.yaml",
+            "target": "compile",
+            "total_bundle_bytes": "not-an-int",  # str, not int
+            "num_chunks": 1,
+            "bundle_sha256": "0" * 64,
+        },
+        {
+            "type": "submit_job",
+            "job_id": 12345,  # int, not str
+            "configuration_filename": "kitchen.yaml",
+            "target": "compile",
+            "total_bundle_bytes": 100,
+            "num_chunks": 1,
+            "bundle_sha256": "0" * 64,
+        },
+        # bool isn't a legitimate ``int`` here even though it's a
+        # subclass — a frame announcing ``num_chunks=True`` is
+        # the offloader's bug.
+        {
+            "type": "submit_job",
+            "job_id": "j",
+            "configuration_filename": "kitchen.yaml",
+            "target": "compile",
+            "total_bundle_bytes": 100,
+            "num_chunks": True,
+            "bundle_sha256": "0" * 64,
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_submit_job_malformed_header_terminates(
+    tmp_path: Path, broken_frame: dict[str, Any]
+) -> None:
+    """A malformed ``submit_job`` header rejects ``invalid_header`` and terminates the session.
+
+    Pins the DoS-defense gate: peer-controlled frames that
+    don't carry the expected fields / types are rejected at
+    the dispatch boundary rather than crashing the receive
+    loop with a ``KeyError`` / ``TypeError``.
+    """
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+
+    await receiver.handle_submit_job(session, cast(SubmitJobFrameData, broken_frame))
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "invalid_header"
+    session.terminate.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "broken_chunk",
+    [
+        {"type": "submit_job_chunk", "job_id": "j"},  # missing fields
+        # Wrong types.
+        {
+            "type": "submit_job_chunk",
+            "job_id": "j",
+            "chunk_index": "not-an-int",
+            "data_b64": "AAAA",
+            "is_last": True,
+        },
+        {
+            "type": "submit_job_chunk",
+            "job_id": "j",
+            "chunk_index": 0,
+            "data_b64": "AAAA",
+            "is_last": "yes",  # not bool
+        },
+        # bool isn't a legitimate ``int`` for ``chunk_index``.
+        {
+            "type": "submit_job_chunk",
+            "job_id": "j",
+            "chunk_index": True,
+            "data_b64": "AAAA",
+            "is_last": True,
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_submit_job_chunk_malformed_terminates(
+    tmp_path: Path, broken_chunk: dict[str, Any]
+) -> None:
+    """A malformed ``submit_job_chunk`` rejects ``invalid_chunk`` and terminates the session."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+    await receiver.handle_submit_job(session, _header(bundle=b"hello"))
+    session.send_app_frame.reset_mock()
+
+    await receiver.handle_submit_job_chunk(session, cast(SubmitJobChunkFrameData, broken_chunk))
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "invalid_chunk"
+    session.terminate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_submit_job_invalid_target_rejected(tmp_path: Path) -> None:
     """A header with ``target`` outside compile/upload rejects ``invalid_header``."""
     receiver = _make_receiver(tmp_path)

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -29,7 +29,7 @@ from esphome.bundle import EsphomeError
 
 from esphome_device_builder.controllers.remote_build_submit_job import (
     SubmitJobReceiver,
-    _device_name_from_filename,
+    _validate_configuration_filename,
 )
 from esphome_device_builder.helpers.peer_link_bundle import (
     BUNDLE_CHUNK_SIZE_BYTES,
@@ -158,12 +158,33 @@ def _frame_chunks(job_id: str, bundle: bytes) -> list[SubmitJobChunkFrameData]:
         ("kitchen.yaml", "kitchen"),
         ("kitchen.yml", "kitchen"),
         ("KITCHEN.YAML", "KITCHEN"),
-        ("no-extension", "no-extension"),
         ("multi.dot.yaml", "multi.dot"),
     ],
 )
-def test_device_name_from_filename_strips_known_extensions(filename: str, expected: str) -> None:
-    assert _device_name_from_filename(filename) == expected
+def test_validate_configuration_filename_accepts_clean_yaml_leaves(
+    filename: str, expected: str
+) -> None:
+    assert _validate_configuration_filename(filename) == expected
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "",  # empty
+        "no-extension",  # no .yaml / .yml
+        "kitchen.txt",  # wrong extension
+        ".yaml",  # extension only — empty stem
+        "..yaml",  # leading-dot escape attempt
+        "../etc/passwd.yaml",  # path traversal via ..
+        "../../escape.yaml",  # nested path traversal
+        "sub/kitchen.yaml",  # forward slash separator
+        "sub\\kitchen.yaml",  # Windows-style separator
+        "kitchen\x00.yaml",  # NUL byte
+        "/abs/kitchen.yaml",  # absolute path
+    ],
+)
+def test_validate_configuration_filename_rejects_malicious_inputs(filename: str) -> None:
+    assert _validate_configuration_filename(filename) is None
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +216,19 @@ async def test_submit_job_invalid_target_rejected(tmp_path: Path) -> None:
     session = _make_session()
 
     await receiver.handle_submit_job(session, _header(target="install"))
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "invalid_header"
+
+
+@pytest.mark.asyncio
+async def test_submit_job_path_traversal_filename_rejected(tmp_path: Path) -> None:
+    """A ``configuration_filename`` with path traversal rejects ``invalid_header``."""
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+
+    await receiver.handle_submit_job(session, _header(configuration_filename="../etc/passwd.yaml"))
 
     payload = _ack_payload(session)
     assert payload["accepted"] is False
@@ -308,9 +342,7 @@ async def test_submit_job_chunk_out_of_order_terminates_session(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_submit_job_chunk_hash_mismatch_recoverable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_submit_job_chunk_hash_mismatch_recoverable(tmp_path: Path) -> None:
     """A bundle whose assembled hash mismatches rejects ``hash_mismatch`` *without* terminating."""
     receiver = _make_receiver(tmp_path)
     session = _make_session()
@@ -397,6 +429,92 @@ async def test_submit_job_happy_path_extracts_and_queues(
     assert job.job_type is JobType.COMPILE
     assert job.configuration == str(expected_yaml.relative_to(tmp_path))
     firmware._enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_intermediate_chunk_no_ack(tmp_path: Path) -> None:
+    """A non-final chunk feeds the assembler silently; no ack until ``is_last``.
+
+    Pins the streaming contract: while chunks are arriving the
+    receiver stays quiet — the offloader's submit caller waits
+    on the single ack frame at end-of-stream rather than
+    counting per-chunk responses.
+    """
+    receiver = _make_receiver(tmp_path)
+    session = _make_session()
+    bundle = b"x" * (BUNDLE_CHUNK_SIZE_BYTES * 2 + 100)  # three chunks
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+    chunks = _frame_chunks("job-1", bundle)
+    assert len(chunks) >= 2
+    session.send_app_frame.reset_mock()
+
+    # Feed only the non-final chunks; no ack should fire.
+    for chunk in chunks[:-1]:
+        await receiver.handle_submit_job_chunk(session, chunk)
+
+    session.send_app_frame.assert_not_called()
+    session.terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malicious ``dashboard_id`` shape escapes the filename validator but is caught at extract.
+
+    Pins the defence-in-depth resolve-and-stay-under-root check
+    inside ``_extract_and_queue``. The filename validator
+    catches separators / ``..`` in ``configuration_filename``,
+    but ``dashboard_id`` flows through unvalidated from the
+    Noise handshake / receiver-side registration. A future
+    regression there would hit this gate.
+    """
+    firmware = _make_firmware_controller()
+    receiver = _make_receiver(tmp_path, firmware)
+    # Climbing dashboard_id; the resolve-and-relative-to defense
+    # rejects because the resulting target_dir resolves outside
+    # ``<config>/.esphome/.remote_builds/``.
+    session = _make_session(dashboard_id="../../escape")
+    bundle = b"hello"
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        lambda _bundle, _target: tmp_path / "kitchen.yaml",
+    )
+
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+    for chunk in _frame_chunks("job-1", bundle):
+        await receiver.handle_submit_job_chunk(session, chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "invalid_header"
+    firmware._enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_enqueue_failure_rejects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure inside ``_enqueue`` rejects ``queue_rejected``; session stays."""
+    firmware = _make_firmware_controller()
+    firmware._enqueue = AsyncMock(side_effect=RuntimeError("queue full"))
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session()
+    bundle = b"hello"
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        lambda _bundle, target: target / "kitchen.yaml",
+    )
+
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+    for chunk in _frame_chunks("job-1", bundle):
+        await receiver.handle_submit_job_chunk(session, chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "queue_rejected"
+    session.terminate.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Phase 5c-2a of [#106](https://github.com/esphome/device-builder/issues/106) — receiver-side **bundle reception + queue + ack**, the half of 5c-2 that drives a submitted bundle from the wire into a queued :class:`FirmwareJob`. Splits the table row's 5c-2 into:

- **5c-2a (this PR)**: bundle reception + ack contract + queue. The "did the job get accepted?" half.
- **5c-2b (next)**: firmware-event fan-out — subscribe to `JOB_*` events filtered to `remote_peer == session.dashboard_id` and push `job_state_changed` / `job_output` frames over the submitting session.

Splitting was a sizing call — even just the receive path is ~560 lines of production + ~17 unit tests; landing it cleanly before the fan-out keeps each PR focused.

**What this PR adds:**

- **`controllers/remote_build_submit_job.py`** — `SubmitJobReceiver` class plus `_PendingSubmit` per-session dataclass. Owns the receive-loop dispatch for `AppMessageType.SUBMIT_JOB` / `SUBMIT_JOB_CHUNK`, drives `BundleAssembler` from 5c-1, writes the assembled tarball + extracts via `esphome.bundle.prepare_bundle_for_compile()` (preserves `.esphome/` / `.pioenvs/` for incremental compiles — load-bearing for the per-peer per-device subtree), and queues a `FirmwareJob` with `remote_peer=session.dashboard_id`.

- **Per-peer per-device subtree** at `<config>/.esphome/.remote_builds/<dashboard_id>/<device_name>/`. Two-segment key dedupes correctly across multi-offloader fleets (two HA Greens both shipping a "kitchen" device land in distinct subtrees) without colliding within one offloader's pool. PlatformIO's `.pio/build` cache then sees stable source paths and skips the cold-rebuild hit.

- **`FirmwareJob.remote_peer`** — new optional string field (default `""`) carrying the offloader's `dashboard_id` when the job came in via peer-link. Empty for locally-submitted jobs. Threads through `FirmwareController._create_job(... remote_peer=...)`. Surfaced as a "from \<peer\>" badge in the Firmware tasks UI later.

- **Receive-loop wiring** in `controllers/remote_build_peer_link._receive_loop` — two new branches dispatch the new frame types to `controller.get_submit_job_receiver()`. `controller` is now threaded into the loop; existing tests pass `MagicMock()` for the controller arg since their inputs don't include the new types.

- **Lifecycle integration** — `RemoteBuildController.start()` constructs the `SubmitJobReceiver` (gated on `self._db.firmware is not None`); `unregister_peer_link_session()` calls `discard_session(dashboard_id)` so a bundle reception that was mid-stream when the session ended doesn't outlive its session.

**Reject reason taxonomy.** Eight distinct `submit_job_ack.reason` codes — six from the 5c-1 `BundleAssemblerErrorCode` (mapped through 1:1) plus two receiver-side codes for paths after assembly (`extract_failed` / `queue_rejected`) and four for header / chunk dispatch (`duplicate_submit` / `invalid_header` / `no_inflight_submit` / `job_id_mismatch` / `chunk_decode_failed`). Wire-level misbehaviour codes (out-of-order chunks, decode failures, post-completion frames) trigger `terminate{malformed_frame}` after the ack; recoverable errors (oversized / undersized / hash mismatch / extract / queue) ack-and-stay so the offloader can retry on a fresh submit.

**17 unit tests** in `tests/test_remote_build_submit_job.py` covering header validation (duplicate / invalid target / oversized), chunk dispatch (no-inflight, job_id mismatch, decode failure, out-of-order, hash mismatch), the happy path through a stubbed `prepare_bundle_for_compile`, extraction failure, and the session-discard contract. End-to-end against the real `FirmwareController` + a real bundle goes in 5c-2b once the firmware-event fan-out lands.

**Related issue or feature (if applicable):**

- esphome/device-builder#106 — phase 5c-2 (split into 5c-2a / 5c-2b).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

(`FirmwareJob.remote_peer` is a new field but it defaults to `""`, so existing frontend renderers ignoring unknown fields keep working unchanged. The "from \<peer\>" badge UI lands in a later phase alongside the offloader Settings UI.)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

(Architecture mention deferred to 5c-2b — the receive-then-fan-out shape is what `docs/ARCHITECTURE.md`'s "Long-lived peer-link sessions" section will want to describe end-to-end, not the half landed here.)
