### PR TITLE
Surface peer-link session state on offloader-side PairingSummary

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -96,6 +96,8 @@ from ..models import (
     OffloaderPairPeerRevokedData,
     OffloaderPairPinMismatchData,
     OffloaderPairStatusChangedData,
+    OffloaderPeerLinkClosedData,
+    OffloaderPeerLinkOpenedData,
     OffloaderPeerRevokedAlert,
     OffloaderPinMismatchAlert,
     OffloaderQueueStatusChangedData,
@@ -394,7 +396,7 @@ def _peer_summary(peer: StoredPeer, *, status: PeerStatus, connected: bool) -> P
     )
 
 
-def _pairing_summary(pairing: StoredPairing) -> PairingSummary:
+def _pairing_summary(pairing: StoredPairing, *, connected: bool) -> PairingSummary:
     """Project a :class:`StoredPairing` to wire :class:`PairingSummary`.
 
     Mirror of :func:`_peer_summary` for the offloader side. Drops
@@ -402,6 +404,19 @@ def _pairing_summary(pairing: StoredPairing) -> PairingSummary:
     row — the unified in-RAM ``_pairings`` dict carries both
     PENDING and APPROVED rows, with the disk filter stripping
     PENDING at serialise time.
+
+    ``connected`` is the snapshot-time read the caller passes
+    in. The intended source is
+    ``pairing.pin_sha256 in controller._open_peer_links``, the
+    RAM-canonical set the controller maintains from
+    :class:`PeerLinkClient`-fired
+    :attr:`EventType.OFFLOADER_PEER_LINK_OPENED` /
+    :attr:`EventType.OFFLOADER_PEER_LINK_CLOSED` events. The
+    helper is module-level so the registry isn't reachable
+    from here directly; the caller dereferences and threads
+    the bool through. PENDING callers pass ``False``; the
+    offloader doesn't spawn a peer-link client until the
+    receiver flips the row to APPROVED.
     """
     return PairingSummary(
         receiver_hostname=pairing.receiver_hostname,
@@ -410,6 +425,7 @@ def _pairing_summary(pairing: StoredPairing) -> PairingSummary:
         label=pairing.label,
         paired_at=pairing.paired_at,
         status=pairing.status,
+        connected=connected,
     )
 
 
@@ -827,6 +843,22 @@ class RemoteBuildController:
         # the connect-handshake-park-reconnect loop in
         # :meth:`PeerLinkClient.run`.
         self._peer_link_clients: dict[str, asyncio.Task[None]] = {}
+        # RAM-only set of ``pin_sha256`` strings whose
+        # offloader-side peer-link sessions are currently open.
+        # Mutated by listeners on ``OFFLOADER_PEER_LINK_OPENED``
+        # (add) / ``OFFLOADER_PEER_LINK_CLOSED`` (discard) the
+        # :class:`PeerLinkClient` already fires from
+        # :meth:`_fire_opened` / :meth:`_fire_closed`. Read at
+        # :meth:`pairings_snapshot` time to populate
+        # :attr:`PairingSummary.connected` so the offloader-side
+        # Settings UI's "Paired build servers" list can render a
+        # connected/disconnected indicator. Cleared on
+        # :meth:`unpair` for the matching pin (the row's gone;
+        # any stale "true" carried over a removal would land a
+        # phantom indicator on a re-pair before the handshake
+        # actually completes), and on :meth:`stop` along with
+        # the rest of controller-scoped state.
+        self._open_peer_links: set[str] = set()
         # Identities cached once at :meth:`start` so each
         # peer-link client can pick them up without an executor
         # hop on every spawn. ``_offloader_dashboard_id`` is the
@@ -1094,15 +1126,34 @@ class RemoteBuildController:
                 self._on_offloader_pair_pin_mismatch,
             )
         )
+        # Maintain ``_open_peer_links`` from the lifecycle
+        # events :class:`PeerLinkClient` fires; the snapshot
+        # at :meth:`pairings_snapshot` reads off the same set.
+        # Two listeners (one per direction) rather than one
+        # multi-event listener so each callback is straight-line
+        # (add vs. discard) without an event-type branch on the
+        # hot path.
+        self._unsub_bus_listeners.append(
+            self._db.bus.add_listener(
+                EventType.OFFLOADER_PEER_LINK_OPENED,
+                self._on_offloader_peer_link_opened,
+            )
+        )
+        self._unsub_bus_listeners.append(
+            self._db.bus.add_listener(
+                EventType.OFFLOADER_PEER_LINK_CLOSED,
+                self._on_offloader_peer_link_closed,
+            )
+        )
 
     def _on_offloader_pair_pin_mismatch(self, event: Event[OffloaderPairPinMismatchData]) -> None:
         """Cache the alert in ``_offloader_alerts`` for late-subscriber snapshot.
 
-        Receiver hostname / port form the dict key (matches the
-        synchronous mutation site in
-        :meth:`_apply_pair_status_result`). The alert payload
-        adds ``kind`` + ``fired_at`` to the bus event's wire
-        fields so the snapshot row survives the event drop.
+        Keyed on ``pin_sha256`` (matches the synchronous
+        mutation site in :meth:`_apply_pair_status_result`).
+        The alert payload adds ``kind`` + ``fired_at`` to the
+        bus event's wire fields so the snapshot row survives
+        the event drop.
         """
         data = event.data
         # Build the typed alert explicitly rather than as a bare
@@ -1123,6 +1174,19 @@ class RemoteBuildController:
             "fired_at": time.time(),
         }
         self._offloader_alerts[data["pin_sha256"]] = alert
+
+    def _on_offloader_peer_link_opened(self, event: Event[OffloaderPeerLinkOpenedData]) -> None:
+        """Add ``pin_sha256`` to ``_open_peer_links`` on session open."""
+        self._open_peer_links.add(event.data["pin_sha256"])
+
+    def _on_offloader_peer_link_closed(self, event: Event[OffloaderPeerLinkClosedData]) -> None:
+        """Discard ``pin_sha256`` from ``_open_peer_links`` on session close.
+
+        ``discard`` rather than ``remove`` so a CLOSED event
+        for a key we never saw OPENED for (cold-start race,
+        unpair-mid-handshake) is a no-op rather than raising.
+        """
+        self._open_peer_links.discard(event.data["pin_sha256"])
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]
@@ -1398,6 +1462,7 @@ class RemoteBuildController:
         # receiver-visible row), so silent clear is fine here.
         self._pairings.clear()
         self._peer_queue_status.clear()
+        self._open_peer_links.clear()
         self._peers.clear()
         # Receiver-side APPROVED peers clear silently too —
         # unlike :meth:`_clear_pending_peers_on_window_close`
@@ -1885,14 +1950,21 @@ class RemoteBuildController:
             # via the pair_request; the client just opens a
             # peer_link session against the same coordinates.
             self._spawn_peer_link_client(pairing)
-            return _pairing_summary(pairing)
+            # ``connected=False`` because the peer-link client
+            # task was just spawned; the actual WS handshake
+            # hasn't completed yet, and ``_open_peer_links``
+            # only flips to ``True`` on the
+            # ``OFFLOADER_PEER_LINK_OPENED`` listener fire. The
+            # next snapshot read after the handshake completes
+            # will report ``True``.
+            return _pairing_summary(pairing, connected=False)
         # PENDING: in-memory only, bounded by the receiver-side
         # pairing window. The listener observes the eventual flip
         # (admin Accept) and promotes the row in
         # ``_apply_pair_status_result`` — which mutates the dict
         # entry's ``status`` and schedules a save.
         self._spawn_pair_status_listener(pairing)
-        return _pairing_summary(pairing)
+        return _pairing_summary(pairing, connected=False)
 
     @api_command("remote_build/unpair")
     async def unpair(
@@ -1983,6 +2055,13 @@ class RemoteBuildController:
         # frontend is expected to drop derived per-peer state
         # in step.
         self._peer_queue_status.pop(key, None)
+        # Same rationale for ``_open_peer_links`` — the row is
+        # gone, so any stale "true" carried over the removal
+        # would land a phantom indicator on a re-pair before
+        # the new peer-link client's handshake actually
+        # completes. ``discard`` is no-op if the key wasn't
+        # present (PENDING removal, never-connected APPROVED).
+        self._open_peer_links.discard(key)
         return {"removed": True}
 
     def pairings_snapshot(self) -> list[PairingSummary]:
@@ -2007,7 +2086,11 @@ class RemoteBuildController:
         on app-startup, so a separate snapshot read would just be
         a redundant round-trip.
         """
-        return [_pairing_summary(p) for p in self._pairings.values()]
+        open_links = self._open_peer_links
+        return [
+            _pairing_summary(p, connected=p.pin_sha256 in open_links)
+            for p in self._pairings.values()
+        ]
 
     def offloader_alerts_snapshot(self) -> list[OffloaderAlertSnapshotEntry]:
         """Return the in-memory offloader pair alerts snapshot.
@@ -2200,6 +2283,7 @@ class RemoteBuildController:
             self._cancel_pair_status_listener(stale_pin)
             self._cancel_peer_link_client(stale_pin)
             self._peer_queue_status.pop(stale_pin, None)
+            self._open_peer_links.discard(stale_pin)
         # Alerts can outlive pairings — sweep them in a second
         # pass keyed on the alert's stored ``receiver_hostname``
         # / ``receiver_port`` (also walks the pin-keyed dict so

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1066,6 +1066,21 @@ class PairingSummary(DataClassORJSONMixin):
     seam on the receiver side so a future "store extra
     offloader-only fields on the row" change can't leak those
     by accident.
+
+    ``connected`` is the offloader-side mirror of
+    :attr:`PeerSummary.connected`: it reports whether the
+    offloader's per-pairing :class:`PeerLinkClient` task
+    currently has an open peer-link session against the
+    receiver. Computed at snapshot-build time from
+    :attr:`RemoteBuildController._open_peer_links`
+    (a ``set[(host, port)]`` populated by listeners on
+    :attr:`EventType.OFFLOADER_PEER_LINK_OPENED` /
+    :attr:`EventType.OFFLOADER_PEER_LINK_CLOSED` that
+    :class:`PeerLinkClient` already fires from
+    :meth:`_fire_opened` / :meth:`_fire_closed`). Always
+    ``False`` for PENDING rows — the offloader doesn't spawn
+    a peer-link client until the receiver flips the row to
+    APPROVED.
     """
 
     receiver_hostname: str
@@ -1074,6 +1089,7 @@ class PairingSummary(DataClassORJSONMixin):
     label: str
     paired_at: float
     status: PeerStatus
+    connected: bool = False
 
 
 @dataclass

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2316,12 +2316,13 @@ def test_enforce_pin_match_raises_precondition_failed_on_drift() -> None:
 def test_pairing_summary_drops_static_pubkey() -> None:
     """Wire view drops ``static_x25519_pub`` so the raw pubkey stays server-side."""
     pairing = _valid_stored_pairing(status=PeerStatus.PENDING)
-    summary = _pairing_summary(pairing)
+    summary = _pairing_summary(pairing, connected=False)
     assert isinstance(summary, PairingSummary)
     assert summary.receiver_hostname == "build.local"
     assert summary.pin_sha256 == "a" * 64
     assert summary.label == "desktop"
     assert summary.status is PeerStatus.PENDING
+    assert summary.connected is False
     # PairingSummary doesn't carry the raw bytes.
     assert not hasattr(summary, "static_x25519_pub")
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -65,6 +65,8 @@ from esphome_device_builder.models import (
     ErrorCode,
     EventType,
     IntentResponse,
+    OffloaderPeerLinkClosedData,
+    OffloaderPeerLinkOpenedData,
     PeerLinkIntent,
     PeerStatus,
     StoredPairing,
@@ -1028,6 +1030,80 @@ async def test_pairings_snapshot_returns_ram_dict(
     by_host = {row.receiver_hostname: row for row in rows}
     assert by_host["pending.local"].status is PeerStatus.PENDING
     assert by_host["approved.local"].status is PeerStatus.APPROVED
+
+
+@pytest.mark.asyncio
+async def test_pairings_snapshot_marks_open_link_as_connected(
+    offloader_controller_dir: Path,
+) -> None:
+    """An APPROVED row whose ``(host, port)`` is in ``_open_peer_links`` reports ``connected=True``.
+
+    Mirror of the receiver-side
+    ``test_peers_snapshot_marks_approved_with_active_session_connected``;
+    pin the snapshot semantic so a future refactor that splits
+    the open-link tracking from the snapshot read can't
+    silently drop the membership check.
+    """
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+    a = _stub_pairing(
+        receiver_hostname="a.local",
+        receiver_port=6055,
+        label="a",
+        status=PeerStatus.APPROVED,
+    )
+    b = _stub_pairing(
+        receiver_hostname="b.local",
+        receiver_port=6055,
+        label="b",
+        status=PeerStatus.APPROVED,
+    )
+    offloader._pairings[("a.local", 6055)] = a
+    offloader._pairings[("b.local", 6055)] = b
+    # Only ``a`` has an open peer-link session.
+    offloader._open_peer_links.add(("a.local", 6055))
+
+    rows = {row.receiver_hostname: row for row in offloader.pairings_snapshot()}
+
+    assert rows["a.local"].connected is True
+    assert rows["b.local"].connected is False
+
+
+@pytest.mark.asyncio
+async def test_offloader_peer_link_event_listeners_update_open_set(
+    offloader_controller_dir: Path,
+) -> None:
+    """OPENED adds + CLOSED discards from ``_open_peer_links``.
+
+    The two callbacks are wired on real bus subscriptions in
+    :meth:`start`, but the listeners themselves are sync and
+    can be exercised directly with synthesised ``Event``
+    payloads — that keeps the test focused on the set-mutation
+    contract without standing up the full controller startup.
+    """
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+
+    opened: OffloaderPeerLinkOpenedData = {
+        "receiver_hostname": "host.local",
+        "receiver_port": 6055,
+    }
+    offloader._on_offloader_peer_link_opened(MagicMock(data=opened))
+    assert ("host.local", 6055) in offloader._open_peer_links
+
+    closed: OffloaderPeerLinkClosedData = {
+        "receiver_hostname": "host.local",
+        "receiver_port": 6055,
+        "reason": "peer_hung_up",
+    }
+    offloader._on_offloader_peer_link_closed(MagicMock(data=closed))
+    assert ("host.local", 6055) not in offloader._open_peer_links
+
+    # ``discard`` semantics: a CLOSED for a key we never saw
+    # OPENED is a no-op rather than raising. Covers the
+    # cold-start race where a stale CLOSED arrives before the
+    # listener is ready.
+    offloader._on_offloader_peer_link_closed(MagicMock(data=closed))
+    assert ("host.local", 6055) not in offloader._open_peer_links
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -1036,7 +1036,7 @@ async def test_pairings_snapshot_returns_ram_dict(
 async def test_pairings_snapshot_marks_open_link_as_connected(
     offloader_controller_dir: Path,
 ) -> None:
-    """An APPROVED row whose ``(host, port)`` is in ``_open_peer_links`` reports ``connected=True``.
+    """An APPROVED row whose ``pin_sha256`` is in ``_open_peer_links`` reports ``connected=True``.
 
     Mirror of the receiver-side
     ``test_peers_snapshot_marks_approved_with_active_session_connected``;
@@ -1046,22 +1046,26 @@ async def test_pairings_snapshot_marks_open_link_as_connected(
     """
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
+    pin_a = "a" * 64
+    pin_b = "b" * 64
     a = _stub_pairing(
         receiver_hostname="a.local",
         receiver_port=6055,
         label="a",
+        pin_sha256=pin_a,
         status=PeerStatus.APPROVED,
     )
     b = _stub_pairing(
         receiver_hostname="b.local",
         receiver_port=6055,
         label="b",
+        pin_sha256=pin_b,
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[("a.local", 6055)] = a
-    offloader._pairings[("b.local", 6055)] = b
+    offloader._pairings[pin_a] = a
+    offloader._pairings[pin_b] = b
     # Only ``a`` has an open peer-link session.
-    offloader._open_peer_links.add(("a.local", 6055))
+    offloader._open_peer_links.add(pin_a)
 
     rows = {row.receiver_hostname: row for row in offloader.pairings_snapshot()}
 
@@ -1082,28 +1086,31 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
     contract without standing up the full controller startup.
     """
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    pin = "a" * 64
 
     opened: OffloaderPeerLinkOpenedData = {
         "receiver_hostname": "host.local",
         "receiver_port": 6055,
+        "pin_sha256": pin,
     }
     offloader._on_offloader_peer_link_opened(MagicMock(data=opened))
-    assert ("host.local", 6055) in offloader._open_peer_links
+    assert pin in offloader._open_peer_links
 
     closed: OffloaderPeerLinkClosedData = {
         "receiver_hostname": "host.local",
         "receiver_port": 6055,
+        "pin_sha256": pin,
         "reason": "peer_hung_up",
     }
     offloader._on_offloader_peer_link_closed(MagicMock(data=closed))
-    assert ("host.local", 6055) not in offloader._open_peer_links
+    assert pin not in offloader._open_peer_links
 
     # ``discard`` semantics: a CLOSED for a key we never saw
     # OPENED is a no-op rather than raising. Covers the
     # cold-start race where a stale CLOSED arrives before the
     # listener is ready.
     offloader._on_offloader_peer_link_closed(MagicMock(data=closed))
-    assert ("host.local", 6055) not in offloader._open_peer_links
+    assert pin not in offloader._open_peer_links
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Mirror of [#527](https://github.com/esphome/device-builder/pull/527)
for the other side of the pairing. Adds `connected: bool` to
`PairingSummary` so the offloader's "Paired build servers"
Settings list can render an online/offline indicator next to
each row, symmetric to the receiver-side "Paired senders"
indicator.

The offloader's `PeerLinkClient` already fires
`OFFLOADER_PEER_LINK_OPENED` / `_CLOSED` from `_fire_opened` /
`_fire_closed`; this PR adds the wire field that makes the
existing state visible to the frontend.

**Backend changes:**

- `PairingSummary.connected: bool = False` (default).
- New `_open_peer_links: set[(host, port)]` on
  `RemoteBuildController`, mutated by listeners on
  `OFFLOADER_PEER_LINK_OPENED` (add) /
  `OFFLOADER_PEER_LINK_CLOSED` (discard). Two listeners (one
  per direction) rather than one multi-event listener so each
  callback is straight-line (add vs. discard) without an
  event-type branch on the hot path.
- `_pairing_summary` takes `connected` as an explicit kwarg
  (mirrors the receiver-side `_peer_summary` shape);
  `pairings_snapshot` reads `_open_peer_links` once and
  threads membership per row.
- `unpair` discards the key from `_open_peer_links` so a
  re-pair before the new client's handshake completes can't
  inherit a stale "true" indicator.
- `stop` clears `_open_peer_links` along with the rest of the
  controller-scoped RAM state.

**Tests:**

Three new tests cover the new behaviour:

1. APPROVED + key in `_open_peer_links` → `connected=true`;
   APPROVED with no entry → `connected=false`.
2. The OPENED / CLOSED listener callbacks add and discard
   from the set; a stray CLOSED for an unseen key is a no-op
   (`discard` semantics, not `remove`).
3. The existing `test_pairing_summary_drops_static_pubkey`
   updated to pass `connected=False` explicitly and assert
   the new field projects through.

**Stacking:**

This branch is stacked on `receiver-peer-connection-state`
(PR [#527](https://github.com/esphome/device-builder/pull/527),
not yet merged) — both add `connected` to their respective
wire summaries with parallel patterns; this one carries the
receiver-side commit too. Land #527 first, then merge into
main; this PR will rebase cleanly.

**Frontend coordination:**

Frontend rendering of the new offloader-side `connected`
field + handling of `OFFLOADER_PEER_LINK_OPENED` / `_CLOSED`
events lands in a follow-up. Default `false` keeps the wire
shape backwards-compatible.

**Related issue or feature (if applicable):**

- part of #106 (offloader-side Settings UI polish).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
