### PR TITLE
Phase 4a-o part 5: pin-check the receiver on every peer-link handshake

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1038,6 +1038,46 @@ class RemoteBuildController:
                 self._on_offloader_queue_status_changed,
             )
         )
+        # Mirror :class:`PeerLinkClient`-fired pin-mismatch
+        # events into the RAM-only ``_offloader_alerts`` dict so
+        # the snapshot path
+        # (``subscribe_events.initial_state.offloader_alerts``)
+        # picks up alerts that fired from the long-lived
+        # peer-link path (peer-link handshake observed a
+        # different responder pubkey than the OOB-confirmed
+        # pin). Idempotent vs. the synchronous mutation in
+        # :meth:`_apply_pair_status_result`'s pin-drift branch
+        # — both paths land the same shape under the same key,
+        # so a same-tick fire from the pair-status listener
+        # ends with the listener overwriting a value the
+        # caller already wrote (no behaviour change there).
+        self._unsub_bus_listeners.append(
+            self._db.bus.add_listener(
+                EventType.OFFLOADER_PAIR_PIN_MISMATCH,
+                self._on_offloader_pair_pin_mismatch,
+            )
+        )
+
+    def _on_offloader_pair_pin_mismatch(self, event: Event[OffloaderPairPinMismatchData]) -> None:
+        """Cache the alert in ``_offloader_alerts`` for late-subscriber snapshot.
+
+        Receiver hostname / port form the dict key (matches the
+        synchronous mutation site in
+        :meth:`_apply_pair_status_result`). The alert payload
+        adds ``kind`` + ``fired_at`` to the bus event's wire
+        fields so the snapshot row survives the event drop.
+        """
+        data = event.data
+        key = (data["receiver_hostname"], data["receiver_port"])
+        self._offloader_alerts[key] = {
+            "kind": "pin_mismatch",
+            "receiver_hostname": data["receiver_hostname"],
+            "receiver_port": data["receiver_port"],
+            "receiver_label": data["receiver_label"],
+            "expected_pin": data["expected_pin"],
+            "observed_pin": data["observed_pin"],
+            "fired_at": time.time(),
+        }
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]
@@ -1998,6 +2038,13 @@ class RemoteBuildController:
             receiver_port=pairing.receiver_port,
             identity_priv=self._offloader_peer_link_priv,
             dashboard_id=self._offloader_dashboard_id,
+            # Pin the receiver's static pubkey from the
+            # OOB-verified pair flow so the long-lived peer-link
+            # handshake fails fast on identity drift instead of
+            # admitting an attacker with their own keypair to
+            # the application channel.
+            pinned_static_x25519_pub=pairing.static_x25519_pub,
+            receiver_label=pairing.label,
             bus=self._db.bus,
         )
         self._peer_link_clients[key] = asyncio.create_task(

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -1069,7 +1069,14 @@ class RemoteBuildController:
         """
         data = event.data
         key = (data["receiver_hostname"], data["receiver_port"])
-        self._offloader_alerts[key] = {
+        # Build the typed alert explicitly rather than as a bare
+        # dict literal: ``_offloader_alerts`` is typed
+        # ``dict[..., OffloaderAlertSnapshotEntry]`` (a union of
+        # ``OffloaderPinMismatchAlert`` / ``OffloaderPeerRevokedAlert``
+        # discriminated by ``kind``), and a bare literal under
+        # strict mypy can fall back to ``dict[str, object]``
+        # rather than narrowing into the right TypedDict variant.
+        alert: OffloaderPinMismatchAlert = {
             "kind": "pin_mismatch",
             "receiver_hostname": data["receiver_hostname"],
             "receiver_port": data["receiver_port"],
@@ -1078,6 +1085,7 @@ class RemoteBuildController:
             "observed_pin": data["observed_pin"],
             "fired_at": time.time(),
         }
+        self._offloader_alerts[key] = alert
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -728,11 +728,25 @@ class PeerLinkClient:
 
     @property
     def is_orphaned(self) -> bool:
-        """True if a ``superseded`` close has poisoned this client.
+        """True if the run loop has been poisoned and won't reconnect.
 
-        See the class docstring for the rationale; the
-        controller's restart path (a fresh :meth:`run`) clears
-        the flag.
+        Set in two cases, both of which mean reconnecting would
+        just hammer the wrong endpoint:
+
+        * Receiver-side ``terminate{reason: superseded}`` close
+          — a newer offloader instance with the same
+          ``dashboard_id`` has taken our slot. Reconnecting
+          would collide with that instance.
+        * Pin-mismatch on the post-handshake pin-check (4a-o
+          part 5) — ``session.remote_static_pub`` didn't match
+          the OOB-confirmed pubkey, so we're talking to a
+          rotated-but-legitimate receiver or to an attacker.
+          Either way the operator's resolution (re-pair to
+          confirm the new identity, or unpair) is the only
+          path forward.
+
+        The controller's restart path (a fresh :meth:`run`)
+        clears the flag.
         """
         return self._orphaned
 

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -50,6 +50,7 @@ from ..helpers.peer_link_noise import (
 from ..models import (
     EventType,
     IntentResponse,
+    OffloaderPairPinMismatchData,
     OffloaderPeerLinkClosedData,
     OffloaderPeerLinkOpenedData,
     OffloaderQueueStatusChangedData,
@@ -603,6 +604,18 @@ _LOCAL_CLOSE_HEARTBEAT_TIMEOUT = "heartbeat_timeout"
 _LOCAL_CLOSE_CLIENT_STOPPED = "client_stopped"
 _LOCAL_CLOSE_PEER_HUNG_UP = "peer_hung_up"
 _LOCAL_CLOSE_AUTH_REJECTED = "auth_rejected"
+# Receiver's static X25519 pubkey hash (from the live Noise XX
+# handshake) didn't match the value the offloader OOB-confirmed
+# at pair time. Either the receiver's identity legitimately
+# rotated, or an attacker has interposed (e.g. mDNS spoof
+# pointing the offloader at an attacker-controlled host that
+# completed the handshake with its own keypair). The
+# :class:`PeerLinkClient` aborts the connection before any
+# application frames flow and orphans itself so the reconnect
+# loop doesn't hammer the wrong endpoint; the operator's
+# resolution is to re-pair (clearing the alert) or unpair
+# (removing the row).
+_LOCAL_CLOSE_PIN_MISMATCH = "pin_mismatch"
 
 
 @dataclass
@@ -667,12 +680,25 @@ class PeerLinkClient:
         receiver_port: int,
         identity_priv: bytes,
         dashboard_id: str,
+        pinned_static_x25519_pub: bytes,
+        receiver_label: str,
         bus: EventBus,
     ) -> None:
         self._hostname = receiver_hostname
         self._port = receiver_port
         self._identity_priv = identity_priv
         self._dashboard_id = dashboard_id
+        # Pinned receiver pubkey from the OOB-verified pair flow,
+        # captured during ``preview_pair`` and stored on
+        # :class:`StoredPairing.static_x25519_pub`. Compared
+        # against ``session.remote_static_pub`` post-handshake on
+        # every connect so an attacker with their own X25519
+        # keypair can't complete Noise XX against this client and
+        # reach the application channel. ``receiver_label`` is
+        # carried so the pin-mismatch alert can name the row at
+        # firing time.
+        self._pinned_static_x25519_pub = pinned_static_x25519_pub
+        self._receiver_label = receiver_label
         self._bus = bus
         # Set to True when we observe a receiver-side
         # ``terminate{reason: superseded}`` close — means a
@@ -747,6 +773,26 @@ class PeerLinkClient:
                     )
                     self._orphaned = True
                     return
+                if close_reason == _LOCAL_CLOSE_PIN_MISMATCH:
+                    # Pin drift means we're either talking to a
+                    # rotated-but-legitimate receiver or to an
+                    # attacker; in both cases reconnecting just
+                    # hammers the wrong endpoint. The bus event
+                    # ``OFFLOADER_PAIR_PIN_MISMATCH`` already
+                    # fired from ``_run_one_session`` carries the
+                    # diagnostic payload, and the controller's
+                    # listener has populated the alerts dict so
+                    # the operator sees the warning. Resolution is
+                    # user-driven: re-pair (clears the alert) or
+                    # unpair (drops the row).
+                    _LOGGER.warning(
+                        "peer-link client to %s:%d observed pin drift; orphaning "
+                        "until the operator re-pairs or unpairs",
+                        self._hostname,
+                        self._port,
+                    )
+                    self._orphaned = True
+                    return
                 # Reset backoff after a session that actually
                 # reached ``intent_response: ok`` so a flaky path
                 # doesn't permanently degrade to the cap. If we
@@ -811,6 +857,19 @@ class PeerLinkClient:
                     msg3_payload=msg3_payload,
                     read_timeout_seconds=_DEFAULT_TIMEOUT_SECONDS,
                 )
+                # Pin-check the receiver's static pubkey BEFORE
+                # decrypting / acting on the response. Noise XX
+                # authenticates that the responder holds the
+                # private key matching the pubkey it advertised,
+                # so a mismatched pubkey here means we connected
+                # to a different identity than the one we
+                # OOB-confirmed at pair time. Could be a
+                # legitimate receiver-side rotation or a MITM /
+                # mDNS spoof; either way we abort before any
+                # application frames flow.
+                if session.remote_static_pub != self._pinned_static_x25519_pub:
+                    self._fire_pin_mismatch(observed=session.remote_static_pub)
+                    return _LOCAL_CLOSE_PIN_MISMATCH
                 response = _json.loads(session.decrypt(response_ct))
                 if (
                     not isinstance(response, dict)
@@ -994,6 +1053,31 @@ class PeerLinkClient:
             "reason": reason,
         }
         self._bus.fire(EventType.OFFLOADER_PEER_LINK_CLOSED, payload)
+
+    def _fire_pin_mismatch(self, *, observed: bytes) -> None:
+        """Fire ``OFFLOADER_PAIR_PIN_MISMATCH`` after a peer-link pin drift.
+
+        Same event shape the pair-status listener already fires
+        from :meth:`RemoteBuildController._apply_pair_status_result`
+        on its own pin-drift branch. The controller listens for
+        the event and stores the alert in
+        ``_offloader_alerts`` so the snapshot path
+        (``subscribe_events.initial_state.offloader_alerts``)
+        carries it for late-subscribing tabs.
+
+        ``expected_pin`` / ``observed_pin`` are the
+        SHA-256 hashes of the pinned + observed pubkeys, in the
+        same lowercase-hex form
+        :class:`StoredPairing.pin_sha256` uses on disk.
+        """
+        payload: OffloaderPairPinMismatchData = {
+            "receiver_hostname": self._hostname,
+            "receiver_port": self._port,
+            "receiver_label": self._receiver_label,
+            "expected_pin": pin_sha256_for_pubkey(self._pinned_static_x25519_pub),
+            "observed_pin": pin_sha256_for_pubkey(observed),
+        }
+        self._bus.fire(EventType.OFFLOADER_PAIR_PIN_MISMATCH, payload)
 
     def _fire_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
         """Fire ``OFFLOADER_QUEUE_STATUS_CHANGED`` for an inbound snapshot.

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2506,6 +2506,37 @@ async def test_broadcast_queue_status_continues_past_failed_session(
     )
 
 
+def test_on_offloader_pair_pin_mismatch_caches_alert(tmp_path: Path) -> None:
+    """``OFFLOADER_PAIR_PIN_MISMATCH`` listener caches the alert in ``_offloader_alerts``.
+
+    The peer-link path's pin-check (4a-o part 5) fires
+    ``OFFLOADER_PAIR_PIN_MISMATCH`` from the
+    :class:`PeerLinkClient` when ``session.remote_static_pub``
+    drifts from the pinned pubkey. The controller listens and
+    populates ``_offloader_alerts`` with a snapshot row so the
+    ``initial_state.offloader_alerts`` push picks it up for
+    late-subscribing tabs.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    payload = {
+        "receiver_hostname": "host.local",
+        "receiver_port": 6055,
+        "receiver_label": "my-laptop",
+        "expected_pin": "a" * 64,
+        "observed_pin": "b" * 64,
+    }
+    controller._on_offloader_pair_pin_mismatch(MagicMock(data=payload))
+
+    cached = controller._offloader_alerts[("host.local", 6055)]
+    assert cached["kind"] == "pin_mismatch"
+    assert cached["receiver_hostname"] == "host.local"
+    assert cached["receiver_port"] == 6055
+    assert cached["receiver_label"] == "my-laptop"
+    assert cached["expected_pin"] == "a" * 64
+    assert cached["observed_pin"] == "b" * 64
+    assert "fired_at" in cached  # set by the listener at fire-time
+
+
 def test_on_offloader_queue_status_changed_caches_snapshot(tmp_path: Path) -> None:
     """Inbound bus event lands a per-peer snapshot in the cache."""
     controller = _make_controller(config_dir=tmp_path)

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -81,8 +81,15 @@ def _make_controller(*, config_dir: Path) -> RemoteBuildController:
 @pytest.fixture
 async def receiver_server(
     tmp_path: Path,
-) -> AsyncGenerator[tuple[TestServer, RemoteBuildController, str], None]:
-    """Spin up an in-process receiver. Yields (server, controller, expected_pin)."""
+) -> AsyncGenerator[tuple[TestServer, RemoteBuildController, str, bytes], None]:
+    """Spin up an in-process receiver. Yields (server, controller, expected_pin, pub).
+
+    The fourth element is the receiver's static X25519 pubkey
+    bytes so tests constructing :class:`PeerLinkClient` can pass
+    it as ``pinned_static_x25519_pub`` (the security pin-check
+    added in 4a-o part 5 rejects the connect when the captured
+    pubkey doesn't match this value).
+    """
     controller = _make_controller(config_dir=tmp_path)
     controller._db.bus = MagicMock()
 
@@ -95,7 +102,12 @@ async def receiver_server(
     server = TestServer(app)
     await server.start_server()
     try:
-        yield server, controller, pin_sha256_for_pubkey(identity.public_bytes)
+        yield (
+            server,
+            controller,
+            pin_sha256_for_pubkey(identity.public_bytes),
+            identity.public_bytes,
+        )
     finally:
         await server.close()
         await controller.stop()
@@ -108,11 +120,11 @@ async def receiver_server(
 
 @pytest.mark.asyncio
 async def test_preview_pair_returns_receivers_pin(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     tmp_path: Path,
 ) -> None:
     """The captured pin from the handshake matches the receiver's actual identity."""
-    server, _, expected_pin = receiver_server
+    server, _, expected_pin, _ = receiver_server
     initiator_priv = secrets.token_bytes(32)
 
     pin = await preview_pair(
@@ -126,7 +138,7 @@ async def test_preview_pair_returns_receivers_pin(
 
 @pytest.mark.asyncio
 async def test_preview_pair_does_not_persist_state_on_receiver(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """``intent="preview"`` returns ``OK`` without creating a peer row.
 
@@ -135,7 +147,7 @@ async def test_preview_pair_does_not_persist_state_on_receiver(
     the user has decided whether to trust the receiver, so
     receiver-side bookkeeping must not happen yet.
     """
-    server, controller, _ = receiver_server
+    server, controller, _, _ = receiver_server
     initiator_priv = secrets.token_bytes(32)
 
     await preview_pair(
@@ -374,7 +386,7 @@ async def test_drive_initiator_round_trip_missing_intent_response_raises_client_
 
 @pytest.mark.asyncio
 async def test_drive_initiator_round_trip_handshake_not_complete_raises_client_error(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Defensive: ``remote_static_pub`` raising ``HandshakeNotCompleteError`` is mapped.
@@ -394,7 +406,7 @@ async def test_drive_initiator_round_trip_handshake_not_complete_raises_client_e
     the documented ``PeerLinkClientError`` → ``UNAVAILABLE``
     shape.
     """
-    server, _, _ = receiver_server
+    server, _, _, _ = receiver_server
     initiator_priv = secrets.token_bytes(32)
 
     class _BrokenInitiator(PeerLinkNoiseSession):
@@ -534,10 +546,10 @@ async def test_drive_initiator_round_trip_maps_pathological_host_to_client_error
 
 @pytest.mark.asyncio
 async def test_request_pair_open_window_returns_pending(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """Request_pair against an open pairing window returns PENDING + lands a peer row."""
-    server, controller, expected_pin = receiver_server
+    server, controller, expected_pin, _ = receiver_server
     await controller.set_pairing_window(open=True, client="test-tab")
     initiator_priv = secrets.token_bytes(32)
 
@@ -566,10 +578,10 @@ async def test_request_pair_open_window_returns_pending(
 
 @pytest.mark.asyncio
 async def test_request_pair_closed_window_returns_no_pairing_window(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """Request_pair when the receiver window is closed returns NO_PAIRING_WINDOW."""
-    server, _, _ = receiver_server
+    server, _, _, _ = receiver_server
     initiator_priv = secrets.token_bytes(32)
 
     result = await request_pair(
@@ -669,11 +681,11 @@ async def _saved_pairings(offloader: RemoteBuildController) -> list[StoredPairin
 
 @pytest.mark.asyncio
 async def test_controller_preview_pair_returns_receiver_pin(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     offloader_controller_dir: Path,
 ) -> None:
     """End-to-end: ``RemoteBuildController.preview_pair`` returns the receiver's pin."""
-    server, _, expected_pin = receiver_server
+    server, _, expected_pin, _ = receiver_server
 
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
@@ -708,11 +720,11 @@ async def test_controller_preview_pair_unavailable_on_unreachable_receiver(
 
 @pytest.mark.asyncio
 async def test_controller_request_pair_persists_pending_row(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     offloader_controller_dir: Path,
 ) -> None:
     """End-to-end: ``RemoteBuildController.request_pair`` persists a PENDING StoredPairing."""
-    server, receiver_controller, expected_pin = receiver_server
+    server, receiver_controller, expected_pin, _ = receiver_server
     await receiver_controller.set_pairing_window(open=True, client="test-tab")
 
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -740,7 +752,7 @@ async def test_controller_request_pair_persists_pending_row(
 
 @pytest.mark.asyncio
 async def test_controller_request_pair_pin_mismatch_raises_precondition_failed(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     offloader_controller_dir: Path,
 ) -> None:
     """User-supplied pin doesn't match the handshake → PRECONDITION_FAILED.
@@ -748,7 +760,7 @@ async def test_controller_request_pair_pin_mismatch_raises_precondition_failed(
     A receiver-side identity rotation between preview and request would land here
     in production; the test forces the same shape by passing a wrong pin.
     """
-    server, receiver_controller, _ = receiver_server
+    server, receiver_controller, _, _ = receiver_server
     await receiver_controller.set_pairing_window(open=True, client="test-tab")
 
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -769,11 +781,11 @@ async def test_controller_request_pair_pin_mismatch_raises_precondition_failed(
 
 @pytest.mark.asyncio
 async def test_controller_request_pair_closed_window_raises_no_pairing_window(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     offloader_controller_dir: Path,
 ) -> None:
     """Receiver window closed → CommandError(NO_PAIRING_WINDOW)."""
-    server, _, expected_pin = receiver_server
+    server, _, expected_pin, _ = receiver_server
     # Don't open the pairing window; receiver replies no_pairing_window.
 
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -1744,7 +1756,7 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
 
 @pytest.mark.asyncio
 async def test_request_pair_already_approved_persists_to_disk(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     offloader_controller_dir: Path,
 ) -> None:
     """Re-pair against an already-approved row persists APPROVED, no listener spawn.
@@ -1755,7 +1767,7 @@ async def test_request_pair_already_approved_persists_to_disk(
     ``intent_response=approved`` immediately and writes the row
     to the offloader's persistent file.
     """
-    server, receiver_controller, expected_pin = receiver_server
+    server, receiver_controller, expected_pin, _ = receiver_server
     await receiver_controller.set_pairing_window(open=True, client="receiver-tab")
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
@@ -1801,7 +1813,7 @@ async def test_request_pair_already_approved_persists_to_disk(
 
 @pytest.mark.asyncio
 async def test_lookup_peer_for_status_pending_dict_pin_mismatch_returns_rejected(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """An offloader presenting a wrong pin against a PENDING dict entry → REJECTED.
 
@@ -1810,7 +1822,7 @@ async def test_lookup_peer_for_status_pending_dict_pin_mismatch_returns_rejected
     mismatch (not PENDING) so a peer with a stale / impersonated
     pubkey can't pretend to be a legitimate pending offloader.
     """
-    _, controller, _ = receiver_server
+    _, controller, _, _ = receiver_server
     pubkey = b"\x44" * 32
     real_pin = "a" * 64
     await controller.set_pairing_window(open=True, client="receiver-tab")
@@ -1836,11 +1848,11 @@ async def test_lookup_peer_for_status_pending_dict_pin_mismatch_returns_rejected
 
 @pytest.mark.asyncio
 async def test_await_pair_status_returns_approved_when_receiver_approved(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     offloader_controller_dir: Path,
 ) -> None:
     """await_pair_status against an APPROVED receiver row returns APPROVED + receiver pin."""
-    server, controller, expected_pin = receiver_server
+    server, controller, expected_pin, _ = receiver_server
     pubkey = b"\x55" * 32
     pair_pin = hashlib.sha256(pubkey).hexdigest()
     # Seed the receiver with an approved peer matching the
@@ -1880,10 +1892,10 @@ async def test_await_pair_status_returns_approved_when_receiver_approved(
 
 @pytest.mark.asyncio
 async def test_await_pair_status_unknown_dashboard_id_returns_rejected(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """await_pair_status against an unknown dashboard_id returns REJECTED."""
-    server, _, _ = receiver_server
+    server, _, _, _ = receiver_server
     offloader_id_priv = secrets.token_bytes(32)
 
     result = await remote_build_peer_link_client.await_pair_status(
@@ -2158,10 +2170,10 @@ async def _seed_approved_peer_for_initiator(
 
 @pytest.mark.asyncio
 async def test_peer_link_client_fires_opened_after_handshake(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """A real PeerLinkClient against a real receiver fires OFFLOADER_PEER_LINK_OPENED."""
-    server, receiver, _ = receiver_server
+    server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)
     await _seed_approved_peer_for_initiator(
         receiver, dashboard_id="alpha", initiator_priv=initiator_priv
@@ -2175,6 +2187,8 @@ async def test_peer_link_client_fires_opened_after_handshake(
         receiver_port=server.port,
         identity_priv=initiator_priv,
         dashboard_id="alpha",
+        pinned_static_x25519_pub=receiver_pub,
+        receiver_label="test-receiver",
         bus=bus,
     )
     task = asyncio.create_task(client.run())
@@ -2189,10 +2203,10 @@ async def test_peer_link_client_fires_opened_after_handshake(
 
 @pytest.mark.asyncio
 async def test_peer_link_client_fires_closed_on_cancel(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """Cancelling the client task fires OFFLOADER_PEER_LINK_CLOSED with client_stopped."""
-    server, receiver, _ = receiver_server
+    server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)
     await _seed_approved_peer_for_initiator(
         receiver, dashboard_id="alpha", initiator_priv=initiator_priv
@@ -2208,6 +2222,8 @@ async def test_peer_link_client_fires_closed_on_cancel(
         receiver_port=server.port,
         identity_priv=initiator_priv,
         dashboard_id="alpha",
+        pinned_static_x25519_pub=receiver_pub,
+        receiver_label="test-receiver",
         bus=bus,
     )
     task = asyncio.create_task(client.run())
@@ -2224,7 +2240,7 @@ async def test_peer_link_client_fires_closed_on_cancel(
 
 @pytest.mark.asyncio
 async def test_peer_link_client_orphans_on_superseded(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """A receiver-side ``terminate{reason: superseded}`` orphans the client.
 
@@ -2235,7 +2251,7 @@ async def test_peer_link_client_orphans_on_superseded(
     kicks the first via ``terminate{reason: superseded}``, the
     first's run loop sees that and orphans rather than retrying.
     """
-    server, receiver, _ = receiver_server
+    server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)
     await _seed_approved_peer_for_initiator(
         receiver, dashboard_id="alpha", initiator_priv=initiator_priv
@@ -2259,6 +2275,8 @@ async def test_peer_link_client_orphans_on_superseded(
         receiver_port=server.port,
         identity_priv=initiator_priv,
         dashboard_id="alpha",
+        pinned_static_x25519_pub=receiver_pub,
+        receiver_label="test-receiver",
         bus=bus,
     )
     task1 = asyncio.create_task(client1.run())
@@ -2269,6 +2287,8 @@ async def test_peer_link_client_orphans_on_superseded(
         receiver_port=server.port,
         identity_priv=initiator_priv,
         dashboard_id="alpha",
+        pinned_static_x25519_pub=receiver_pub,
+        receiver_label="test-receiver",
         bus=bus,
     )
     task2 = asyncio.create_task(client2.run())
@@ -2291,7 +2311,7 @@ async def test_peer_link_client_orphans_on_superseded(
 @pytest.mark.asyncio
 async def test_peer_link_client_reconnects_on_transport_error(
     monkeypatch: pytest.MonkeyPatch,
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """A failed connect retries with backoff; succeed on second attempt.
 
@@ -2304,7 +2324,7 @@ async def test_peer_link_client_reconnects_on_transport_error(
     """
     monkeypatch.setattr(remote_build_peer_link_client, "_RECONNECT_INITIAL_BACKOFF_SECONDS", 0.01)
 
-    server, receiver, _ = receiver_server
+    server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)
     await _seed_approved_peer_for_initiator(
         receiver, dashboard_id="alpha", initiator_priv=initiator_priv
@@ -2334,6 +2354,8 @@ async def test_peer_link_client_reconnects_on_transport_error(
         receiver_port=1,  # privileged + closed; ECONNREFUSED
         identity_priv=initiator_priv,
         dashboard_id="alpha",
+        pinned_static_x25519_pub=receiver_pub,
+        receiver_label="test-receiver",
         bus=bus,
     )
     task = asyncio.create_task(client.run())
@@ -2384,6 +2406,8 @@ async def test_run_session_loops_send_ping_routes_through_channel(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=EventBus(),
     )
     drive_task = asyncio.create_task(client._run_session_loops(channel))
@@ -2433,6 +2457,8 @@ async def test_run_session_loops_returns_heartbeat_timeout_when_dead(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=EventBus(),
     )
 
@@ -2482,6 +2508,8 @@ async def test_peer_link_client_backoff_advances_when_session_never_opens(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=bus,
     )
 
@@ -2523,6 +2551,8 @@ def test_peer_link_client_exposes_receiver_coordinates() -> None:
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=EventBus(),
     )
     assert client.receiver_hostname == "10.0.0.5"
@@ -2531,7 +2561,7 @@ def test_peer_link_client_exposes_receiver_coordinates() -> None:
 
 @pytest.mark.asyncio
 async def test_peer_link_client_returns_transport_error_on_type_error(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A ``TypeError`` from the handshake (e.g. non-binary frame) maps to ``transport_error``.
@@ -2544,7 +2574,7 @@ async def test_peer_link_client_returns_transport_error_on_type_error(
     would bubble out and kill the long-lived task instead of
     triggering a reconnect.
     """
-    server, _receiver, _ = receiver_server
+    server, _receiver, _, _ = receiver_server
 
     async def _typeerror_handshake(**kwargs: Any) -> bytes:
         raise TypeError("Received non-binary message")
@@ -2563,6 +2593,8 @@ async def test_peer_link_client_returns_transport_error_on_type_error(
         receiver_port=server.port,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=bus,
     )
     task = asyncio.create_task(client.run())
@@ -2575,7 +2607,7 @@ async def test_peer_link_client_returns_transport_error_on_type_error(
 
 @pytest.mark.asyncio
 async def test_peer_link_client_returns_transport_error_on_noise_failure(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A Noise-side failure during the handshake maps to ``transport_error``.
@@ -2586,7 +2618,7 @@ async def test_peer_link_client_returns_transport_error_on_noise_failure(
     :class:`NoiseInvalidMessage` — any of the
     :data:`NOISE_ERRORS` tuple's types is sufficient.
     """
-    server, _receiver, _ = receiver_server
+    server, _receiver, _, _ = receiver_server
 
     async def _bad_handshake(**kwargs: Any) -> bytes:
         raise NoiseInvalidMessage("forced for test")
@@ -2605,6 +2637,8 @@ async def test_peer_link_client_returns_transport_error_on_noise_failure(
         receiver_port=server.port,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=bus,
     )
     task = asyncio.create_task(client.run())
@@ -2617,7 +2651,7 @@ async def test_peer_link_client_returns_transport_error_on_noise_failure(
 
 @pytest.mark.asyncio
 async def test_peer_link_client_auth_rejected_when_dashboard_id_unknown(
-    receiver_server: tuple[TestServer, RemoteBuildController, str],
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
 ) -> None:
     """An unapproved dashboard_id fires CLOSED with auth_rejected.
 
@@ -2627,7 +2661,7 @@ async def test_peer_link_client_auth_rejected_when_dashboard_id_unknown(
     that as the offloader-side ``auth_rejected`` reason on
     ``OFFLOADER_PEER_LINK_CLOSED``.
     """
-    server, _receiver, _ = receiver_server
+    server, _receiver, _, receiver_pub = receiver_server
     bus = EventBus()
     closed = capture_events(bus, EventType.OFFLOADER_PEER_LINK_CLOSED)
 
@@ -2636,12 +2670,91 @@ async def test_peer_link_client_auth_rejected_when_dashboard_id_unknown(
         receiver_port=server.port,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="never-paired",
+        pinned_static_x25519_pub=receiver_pub,
+        receiver_label="test-receiver",
         bus=bus,
     )
     task = asyncio.create_task(client.run())
     try:
         await asyncio.wait_for(closed.received.wait(), timeout=2.0)
         assert closed[0]["reason"] == "auth_rejected"
+    finally:
+        await cancel_and_drain(task)
+
+
+@pytest.mark.asyncio
+async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
+    receiver_server: tuple[TestServer, RemoteBuildController, str, bytes],
+) -> None:
+    """A pinned pubkey that doesn't match the receiver's actual key aborts the connect.
+
+    Pin-check (4a-o part 5) — the offloader's outbound
+    ``peer_link`` handshake must compare ``session.remote_static_pub``
+    against the value OOB-confirmed during preview. Drives a
+    real handshake against the receiver but passes the WRONG
+    ``pinned_static_x25519_pub``: the server's static key is
+    legitimate, but the client thinks it's expecting a different
+    one (simulating an mDNS spoof or an attacker on the wire).
+
+    The client must:
+
+    1. Fire ``OFFLOADER_PAIR_PIN_MISMATCH`` with the diagnostic
+       payload (expected vs. observed pin).
+    2. Fire ``OFFLOADER_PEER_LINK_CLOSED`` with ``reason="pin_mismatch"``.
+    3. Orphan itself so the reconnect loop doesn't keep
+       hammering whatever's at the wrong endpoint.
+    4. NOT fire ``OFFLOADER_PEER_LINK_OPENED`` — application
+       frames must not flow against the wrong identity.
+    """
+    server, receiver, _, receiver_pub = receiver_server
+    initiator_priv = secrets.token_bytes(32)
+    await _seed_approved_peer_for_initiator(
+        receiver, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+
+    bus = EventBus()
+    opened = capture_events(bus, EventType.OFFLOADER_PEER_LINK_OPENED)
+    closed = capture_events(bus, EventType.OFFLOADER_PEER_LINK_CLOSED)
+    pin_mismatch = capture_events(bus, EventType.OFFLOADER_PAIR_PIN_MISMATCH)
+
+    # Wrong pinned pubkey; must differ from the receiver's
+    # actual ``identity.public_bytes``.
+    wrong_pub = bytes(reversed(receiver_pub))
+    assert wrong_pub != receiver_pub
+
+    client = PeerLinkClient(
+        receiver_hostname="127.0.0.1",
+        receiver_port=server.port,
+        identity_priv=initiator_priv,
+        dashboard_id="alpha",
+        pinned_static_x25519_pub=wrong_pub,
+        receiver_label="my-laptop",
+        bus=bus,
+    )
+    task = asyncio.create_task(client.run())
+    try:
+        # Pin-mismatch fires before close; close fires before
+        # orphaning. Wait on close (the terminal signal).
+        await asyncio.wait_for(closed.received.wait(), timeout=2.0)
+        # Yield once so any pending ``run`` post-close work
+        # (orphan flag set, return) finishes before we assert.
+        for _ in range(10):
+            if task.done():
+                break
+            await asyncio.sleep(0)
+
+        assert closed[0]["reason"] == "pin_mismatch"
+        assert len(pin_mismatch) == 1
+        assert pin_mismatch[0]["receiver_hostname"] == "127.0.0.1"
+        assert pin_mismatch[0]["receiver_label"] == "my-laptop"
+        assert pin_mismatch[0]["expected_pin"] != pin_mismatch[0]["observed_pin"]
+        # Application channel never opened — bundles can't flow
+        # against the wrong identity.
+        assert len(opened) == 0
+        # Client orphaned: reconnect loop exits without further
+        # backoff. ``run`` has returned, so the task is done.
+        assert task.done()
+        assert client.is_orphaned is True
     finally:
         await cancel_and_drain(task)
 
@@ -2687,6 +2800,8 @@ async def test_run_session_loops_responds_to_peer_ping(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=EventBus(),
     )
 
@@ -2746,6 +2861,8 @@ async def test_run_session_loops_bumps_last_pong_on_pong(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=EventBus(),
     )
     drive_task = asyncio.create_task(client._run_session_loops(channel))
@@ -2797,6 +2914,8 @@ async def test_run_session_loops_returns_transport_error_on_malformed_frame(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=EventBus(),
     )
     reason = await client._run_session_loops(channel)
@@ -2837,6 +2956,8 @@ async def test_run_session_loops_ignores_unknown_msg_type(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=EventBus(),
     )
     drive_task = asyncio.create_task(client._run_session_loops(channel))
@@ -2896,6 +3017,8 @@ async def test_run_session_loops_on_dead_swallows_aiohttp_close_error(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=EventBus(),
     )
 
@@ -3126,6 +3249,8 @@ async def test_run_session_loops_fires_queue_status_event_on_inbound_frame(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=bus,
     )
     drive_task = asyncio.create_task(client._run_session_loops(channel))
@@ -3204,6 +3329,8 @@ async def test_run_session_loops_drops_malformed_queue_status(
         receiver_port=6055,
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        receiver_label="test-receiver",
         bus=bus,
     )
     drive_task = asyncio.create_task(client._run_session_loops(channel))

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -2717,9 +2717,12 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
     closed = capture_events(bus, EventType.OFFLOADER_PEER_LINK_CLOSED)
     pin_mismatch = capture_events(bus, EventType.OFFLOADER_PAIR_PIN_MISMATCH)
 
-    # Wrong pinned pubkey; must differ from the receiver's
-    # actual ``identity.public_bytes``.
-    wrong_pub = bytes(reversed(receiver_pub))
+    # Wrong pinned pubkey: flip one bit of the receiver's actual
+    # pubkey so the result is guaranteed-different. Reversing the
+    # bytes would have a vanishingly small but non-zero chance of
+    # producing the same value on a self-palindromic key; the
+    # XOR-with-0x01 form has none.
+    wrong_pub = bytes([receiver_pub[0] ^ 0x01]) + receiver_pub[1:]
     assert wrong_pub != receiver_pub
 
     client = PeerLinkClient(


### PR DESCRIPTION
# What does this implement/fix?

Phase 4a-o part 5 from
[#106](https://github.com/esphome/device-builder/issues/106) —
the security fix that pin-checks the receiver's static pubkey on
every offloader-side peer-link handshake.

## Today's gap

`PeerLinkClient.__init__` took
`receiver_hostname / receiver_port / identity_priv / dashboard_id / bus`
— no `static_x25519_pub` or `pin_sha256`. The Noise XX handshake
completed, msg2 decrypted the responder's static pubkey, the
post-handshake response carried `intent_response: ok`, and the
offloader proceeded straight to the application channel.
**Nothing compared the captured responder pubkey against the
value the offloader OOB-confirmed during preview.**

That meant an attacker with their own X25519 keypair, reachable
via mDNS spoofing the receiver's hostname or a network-level
MITM, could complete the handshake against the offloader and
reach the application channel. Once 5c-3 ships (offloader-side
bundle submit), that's enough to pull bundles containing user
YAML + secrets.

## What this PR does

- `PeerLinkClient.__init__` gains `pinned_static_x25519_pub`
  and `receiver_label` kwargs.
- After `_drive_initiator_handshake_and_read_response` returns,
  before any application frame flows,
  `session.remote_static_pub` is compared against
  `self._pinned_static_x25519_pub`. Mismatch returns
  `_LOCAL_CLOSE_PIN_MISMATCH`.
- The run loop treats `pin_mismatch` close as orphan-triggering
  (alongside `superseded`); reconnect would just hammer whatever's
  at the wrong endpoint. Resolution is user-driven: re-pair
  (clears the alert) or unpair (drops the row).
- Mismatch fires the existing `OFFLOADER_PAIR_PIN_MISMATCH`
  event with the diagnostic payload (expected vs. observed pin,
  receiver_label). Same wire shape the pair-status listener
  already fires on its own pin-drift branch in
  `_apply_pair_status_result`.
- `RemoteBuildController` adds a listener for
  `OFFLOADER_PAIR_PIN_MISMATCH` that mirrors the alert into
  `_offloader_alerts` so the snapshot path
  (`subscribe_events.initial_state.offloader_alerts`) carries it
  for late-subscribing tabs. Idempotent vs. the synchronous
  mutation in `_apply_pair_status_result`'s pin-drift branch.
- `_spawn_peer_link_client` threads
  `pairing.static_x25519_pub` and `pairing.label` into the
  client.

**Symmetry:** receiver-side `lookup_peer_for_session` already
pin-checks the offloader's identity; this fix brings the
offloader side to parity.

## Tests

- `test_peer_link_client_pin_mismatch_aborts_and_orphans`:
  drives a real handshake against `receiver_server` with a
  deliberately wrong pinned pubkey. Asserts
  `OFFLOADER_PAIR_PIN_MISMATCH` fires with the diagnostic
  payload, `OFFLOADER_PEER_LINK_CLOSED` carries
  `reason="pin_mismatch"`, `OFFLOADER_PEER_LINK_OPENED` never
  fires (application channel never opened), and the client
  orphans (`is_orphaned == True`).
- `test_on_offloader_pair_pin_mismatch_caches_alert`: pins the
  controller listener's mutation contract.
- The `receiver_server` fixture grew a fourth tuple element
  exposing the receiver's `identity.public_bytes` so
  handshake-driving tests can thread it through as
  `pinned_static_x25519_pub`. Every existing destructure
  updated. Mock-WS tests pass a 32-byte placeholder.

**Related issue or feature (if applicable):**

- part of #106 (4a-o part 5).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

The new `OFFLOADER_PAIR_PIN_MISMATCH` event from this path uses
the existing wire shape the frontend already handles (4b-4
alert plumbing). No new types or rendering needed; the alert
appears in the same UI surface as the pair-status drift case.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
