### PR TITLE
Phase 4a-o part 6: re-key offloader-side state on pin_sha256

### DIFF
--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -753,9 +753,12 @@ class RemoteBuildController:
         # ``subscribe_events`` stream — no separate
         # ``subscribe_pairings`` channel needed.
         #
-        # Keyed on ``(receiver_hostname, receiver_port)`` to match
-        # the unified ``_pairings`` dict.
-        self._pair_status_listeners: dict[tuple[str, int], asyncio.Task[None]] = {}
+        # Keyed on ``pin_sha256`` to match the unified
+        # ``_pairings`` dict (4a-o part 6 — re-keyed offloader
+        # state from ``(host, port)`` to pin so a receiver
+        # rename is a one-line value mutation rather than a
+        # multi-dict atomic remap).
+        self._pair_status_listeners: dict[str, asyncio.Task[None]] = {}
         # PENDING StoredPeer rows live here, keyed on dashboard_id.
         # Never persisted — the per-file ``_peers_store``
         # (``.receiver_peers.json``) only stores APPROVED rows.
@@ -800,8 +803,8 @@ class RemoteBuildController:
         # doubling. Drained in :meth:`stop`.
         self._peer_link_sessions: dict[str, PeerLinkSession] = {}
         # Offloader-side long-lived peer-link client tasks, one
-        # per APPROVED ``StoredPairing``, keyed on the receiver's
-        # ``(hostname, port)``. Spawned by
+        # per APPROVED ``StoredPairing``, keyed on the
+        # receiver's ``pin_sha256``. Spawned by
         # :meth:`_spawn_peer_link_client` from :meth:`start`'s
         # cold-start path and from
         # :meth:`_apply_pair_status_result` flipping a row to
@@ -809,7 +812,7 @@ class RemoteBuildController:
         # on ``unpair``; drained in :meth:`stop`. Each task runs
         # the connect-handshake-park-reconnect loop in
         # :meth:`PeerLinkClient.run`.
-        self._peer_link_clients: dict[tuple[str, int], asyncio.Task[None]] = {}
+        self._peer_link_clients: dict[str, asyncio.Task[None]] = {}
         # Identities cached once at :meth:`start` so each
         # peer-link client can pick them up without an executor
         # hop on every spawn. ``_offloader_dashboard_id`` is the
@@ -822,27 +825,34 @@ class RemoteBuildController:
         self._offloader_peer_link_priv: bytes | None = None
         # Single offloader-side ``StoredPairing`` map: contains both
         # PENDING and APPROVED rows, keyed on
-        # ``(receiver_hostname, receiver_port)``. Source of truth at
-        # runtime; the disk filter at serialise time strips PENDING
-        # rows so the on-disk shape stays APPROVED-only. Loaded once
-        # at :meth:`start` and mutated in-place on every
+        # :attr:`StoredPairing.pin_sha256`. The pin is the
+        # stable cryptographic identity (hash of the receiver's
+        # static X25519 pubkey, OOB-confirmed during preview);
+        # ``(receiver_hostname, receiver_port)`` are routing
+        # hints stored as fields on the value rather than the
+        # primary key, so a receiver rename is a one-line
+        # value mutation rather than a multi-dict atomic
+        # remap. Source of truth at runtime; the disk filter at
+        # serialise time strips PENDING rows so the on-disk
+        # shape stays APPROVED-only. Loaded once at
+        # :meth:`start` and mutated in-place on every
         # ``request_pair`` / ``unpair`` /
-        # ``_apply_pair_status_result`` — saves debounce through
-        # :attr:`_pairings_store`.
-        self._pairings: dict[tuple[str, int], StoredPairing] = {}
-        # RAM-only offloader-side pair alerts. Keyed on the same
-        # ``(hostname, port)`` shape ``_pairings`` uses.
+        # ``_apply_pair_status_result`` — saves debounce
+        # through :attr:`_pairings_store`.
+        self._pairings: dict[str, StoredPairing] = {}
+        # RAM-only offloader-side pair alerts. Keyed on
+        # ``pin_sha256`` to match ``_pairings`` (4a-o part 6).
         # Populated by ``_apply_pair_status_result`` when a
         # pair-status round-trip detects a pin drift
         # (pin_mismatch) or a receiver-side rejection
         # (peer_revoked); cleared only by the two resolution
         # paths that fix the underlying broken state:
-        # ``request_pair`` succeeding for the same
-        # ``(hostname, port)`` (auto-resolve on re-pair) and
-        # ``unpair`` (user removed the row outright). There is
-        # no operator-driven dismiss surface — clicking "OK got
-        # it" without acting would just hide a broken pairing
-        # the next peer-link session would still fail against.
+        # ``request_pair`` succeeding for the same pin
+        # (auto-resolve on re-pair) and ``unpair`` (user
+        # removed the row outright). There is no operator-
+        # driven dismiss surface — clicking "OK got it"
+        # without acting would just hide a broken pairing the
+        # next peer-link session would still fail against.
         # Never persisted: the alert describes a transient
         # detection, and a process restart with the row still
         # gone leaves nothing for the listener to re-detect
@@ -852,12 +862,12 @@ class RemoteBuildController:
         # carries the snapshot so a tab subscribing AFTER the
         # event fired still sees the alert it would have missed
         # on the live stream.
-        self._offloader_alerts: dict[tuple[str, int], OffloaderAlertSnapshotEntry] = {}
+        self._offloader_alerts: dict[str, OffloaderAlertSnapshotEntry] = {}
         # RAM-only offloader-side cache of the most recent
         # ``queue_status`` snapshot received from each paired
-        # receiver, keyed on ``(receiver_hostname,
-        # receiver_port)``. Updated on every inbound
-        # ``OFFLOADER_QUEUE_STATUS_CHANGED`` (the
+        # receiver, keyed on ``pin_sha256`` (4a-o part 6 —
+        # mirrors ``_pairings`` keying). Updated on every
+        # inbound ``OFFLOADER_QUEUE_STATUS_CHANGED`` (the
         # :class:`PeerLinkClient` receive loop fires the event
         # after parsing a wire frame). Surfaced through
         # ``subscribe_events.initial_state.peer_queue_status`` so
@@ -870,7 +880,7 @@ class RemoteBuildController:
         # :meth:`unpair` for the matching key so the snapshot
         # doesn't surface stale data for a pairing the user
         # removed.
-        self._peer_queue_status: dict[tuple[str, int], PeerQueueStatusSnapshotEntry] = {}
+        self._peer_queue_status: dict[str, PeerQueueStatusSnapshotEntry] = {}
         # ``Store`` registers itself with this list at construction
         # (via ``shutdown_register=...append``); the controller's
         # :meth:`stop` walks the list to flush any debounced save
@@ -939,7 +949,7 @@ class RemoteBuildController:
         # dict stays empty.
         if (settings := await self._pairings_store.async_load()) is not None:
             for pairing in settings.pairings:
-                self._pairings[(pairing.receiver_hostname, pairing.receiver_port)] = pairing
+                self._pairings[pairing.pin_sha256] = pairing
         # Seed the RAM-canonical APPROVED peer dict from the
         # per-file peers store. Mirrors the offloader-side
         # ``_pairings_store`` load above; RAM is canonical from
@@ -1068,7 +1078,6 @@ class RemoteBuildController:
         fields so the snapshot row survives the event drop.
         """
         data = event.data
-        key = (data["receiver_hostname"], data["receiver_port"])
         # Build the typed alert explicitly rather than as a bare
         # dict literal: ``_offloader_alerts`` is typed
         # ``dict[..., OffloaderAlertSnapshotEntry]`` (a union of
@@ -1080,12 +1089,13 @@ class RemoteBuildController:
             "kind": "pin_mismatch",
             "receiver_hostname": data["receiver_hostname"],
             "receiver_port": data["receiver_port"],
+            "pin_sha256": data["pin_sha256"],
             "receiver_label": data["receiver_label"],
             "expected_pin": data["expected_pin"],
             "observed_pin": data["observed_pin"],
             "fired_at": time.time(),
         }
-        self._offloader_alerts[key] = alert
+        self._offloader_alerts[data["pin_sha256"]] = alert
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]
@@ -1101,10 +1111,10 @@ class RemoteBuildController:
         on-the-wire :class:`QueueStatusFrameData`.
         """
         data = event.data
-        key = (data["receiver_hostname"], data["receiver_port"])
-        self._peer_queue_status[key] = PeerQueueStatusSnapshotEntry(
+        self._peer_queue_status[data["pin_sha256"]] = PeerQueueStatusSnapshotEntry(
             receiver_hostname=data["receiver_hostname"],
             receiver_port=data["receiver_port"],
+            pin_sha256=data["pin_sha256"],
             idle=data["idle"],
             running=data["running"],
             queue_depth=data["queue_depth"],
@@ -1771,24 +1781,35 @@ class RemoteBuildController:
             paired_at=time.time(),
             status=target_status,
         )
-        key = (clean_host, clean_port)
-        # Re-pair against an existing entry (same ``(host, port)``
-        # but possibly a different pin / pubkey because the
-        # receiver rotated its peer-link key between pair attempts)
-        # replaces the dict entry; the *existing* listener task
-        # captured the old pairing in its closure and would compare
-        # incoming pin_sha256 against the stale value, so cancel it
-        # explicitly here before deciding whether to spawn a fresh
-        # listener. The cancelled task self-removes from
+        key = result.pin_sha256
+        # Sweep any stale entry at the same ``(host, port)`` but
+        # under a different pin (rotation, or the user moved a
+        # different receiver to this hostname): drop the row,
+        # cancel its listener + peer-link client, drop its
+        # alert. Without this, a re-pair under a fresh pin
+        # would leave the old pin's row + listener orphaned.
+        # The pin-keyed lookup of the *new* row happens after,
+        # so the freshly-keyed entry isn't accidentally evicted
+        # if the new pin happens to equal the swept one (in
+        # which case the loop's ``key != ...`` guard skips it).
+        self._sweep_stale_pairings_at_endpoint(clean_host, clean_port, keep_pin_sha256=key)
+        # Re-pair against an existing entry under the SAME pin
+        # (the receiver hasn't rotated; user just re-confirmed
+        # the same identity) means we update the row in place;
+        # the *existing* listener task captured the old pairing
+        # in its closure and would compare incoming pin_sha256
+        # against the stale value, so cancel it explicitly here
+        # before deciding whether to spawn a fresh listener.
+        # The cancelled task self-removes from
         # ``_pair_status_listeners`` via its ``finally`` clause.
         self._pairings[key] = pairing
-        self._cancel_pair_status_listener(clean_host, clean_port)
+        self._cancel_pair_status_listener(key)
         # Auto-resolve any prior pin_mismatch / peer_revoked
         # alert for this receiver: the user just successfully
         # re-paired (the new row is in ``_pairings`` above), so
         # the alert is stale. Fires
         # ``OFFLOADER_PAIR_ALERT_DISMISSED`` for cross-tab sync.
-        self._dismiss_offloader_alert(clean_host, clean_port)
+        self._dismiss_offloader_alert(key, clean_host, clean_port)
         if target_status is PeerStatus.APPROVED:
             # Persisted trust anchor that survives restart. Schedule
             # the debounced disk write; the controller's ``stop()``
@@ -1815,16 +1836,23 @@ class RemoteBuildController:
     async def unpair(
         self,
         *,
-        hostname: str,
-        port: int,
+        pin_sha256: str,
         **kwargs: Any,
     ) -> dict[str, bool]:
-        """Drop the local :class:`StoredPairing` row for ``(hostname, port)``.
+        """Drop the local :class:`StoredPairing` row keyed on *pin_sha256*.
 
         Idempotent: returns ``{"removed": False}`` when no row matches
         rather than raising — the frontend's "Unpair" button should
         always succeed visually even when the row was already gone
         (race with a concurrent listener-driven flip-to-removed).
+
+        4a-o part 6 changed the WS arg from ``(hostname, port)`` to
+        ``pin_sha256`` so the receiver-side identity (not the
+        routing coordinates) is the lookup key — this keeps unpair
+        consistent across a hostname change. The frontend already
+        carries ``pin_sha256`` on every :class:`PairingSummary`,
+        so the user-clicks-Unpair path threads that value
+        directly.
 
         Receiver-side state is *not* notified. The receiver's
         :class:`StoredPeer` row stays until the receiver's admin
@@ -1841,9 +1869,7 @@ class RemoteBuildController:
         promptly so the offloader's open Noise WS to the receiver
         closes cleanly rather than waiting on a now-irrelevant flip.
         """
-        clean_host = _validate_hostname(hostname, context=_HostFieldContext.RECEIVER)
-        clean_port = _validate_port(port, context=_HostFieldContext.RECEIVER)
-        key = (clean_host, clean_port)
+        key = _validate_pin_sha256(pin_sha256)
 
         # Cancel BEFORE mutating the dict: the listener task holds
         # an open Noise WS to the receiver, and we want it closed
@@ -1856,11 +1882,11 @@ class RemoteBuildController:
         # its ``self._pairings.pop(key, None)`` returns None (we
         # just popped) and the listener exits terminal without
         # promoting — no row resurrection.
-        self._cancel_pair_status_listener(clean_host, clean_port)
+        self._cancel_pair_status_listener(key)
         # Cancel the long-lived peer-link client too — same
         # rationale (the client holds an open Noise WS that
         # should close promptly on user-clicks-Unpair).
-        self._cancel_peer_link_client(clean_host, clean_port)
+        self._cancel_peer_link_client(key)
         # Single in-RAM dict carries both PENDING and APPROVED.
         previous = self._pairings.pop(key, None)
         if previous is None:
@@ -1877,12 +1903,14 @@ class RemoteBuildController:
         # ``subscribe_events`` stream see the removal without
         # re-fetching the pairings snapshot. Mirrors the
         # receiver-side ``remove_peer`` firing the same shape.
-        self._fire_offloader_pair_status_changed(clean_host, clean_port, "removed")
+        self._fire_offloader_pair_status_changed(
+            previous.receiver_hostname, previous.receiver_port, key, "removed"
+        )
         # Drop any pending pin_mismatch / peer_revoked alert
         # for this receiver — the user explicitly removed the
         # row, so the alert about it is moot. Fires
         # ``OFFLOADER_PAIR_ALERT_DISMISSED`` for cross-tab sync.
-        self._dismiss_offloader_alert(clean_host, clean_port)
+        self._dismiss_offloader_alert(key, previous.receiver_hostname, previous.receiver_port)
         # Drop any cached queue-status snapshot for this
         # receiver. Without this, ``subscribe_events`` would
         # keep surfacing a stale snapshot of a pairing the user
@@ -1942,8 +1970,8 @@ class RemoteBuildController:
         """
         return list(self._offloader_alerts.values())
 
-    def _dismiss_offloader_alert(self, hostname: str, port: int) -> bool:
-        """Drop the alert for ``(hostname, port)`` and fire DISMISSED.
+    def _dismiss_offloader_alert(self, pin_sha256: str, hostname: str, port: int) -> bool:
+        """Drop the alert for *pin_sha256* and fire DISMISSED.
 
         Called only by the two resolution paths that fix the
         underlying broken state: :meth:`request_pair` (the user
@@ -1955,18 +1983,24 @@ class RemoteBuildController:
         fail against, so the only ways out are re-pair or
         unpair.
 
+        ``hostname`` / ``port`` are passed alongside the pin
+        because the dismissed event still carries them as
+        display fields (the frontend's alert list keys on
+        ``${hostname}:${port}`` until it migrates to pin-keying
+        in the follow-up frontend PR).
+
         Returns ``True`` when an alert was actually dropped so
         callers can avoid firing the bus event when there's no
         row to flip. The event fire keeps other subscribed tabs
         in sync with the auto-clear without re-fetching the
         snapshot.
         """
-        key = (hostname, port)
-        if self._offloader_alerts.pop(key, None) is None:
+        if self._offloader_alerts.pop(pin_sha256, None) is None:
             return False
         payload: OffloaderPairAlertDismissedData = {
             "receiver_hostname": hostname,
             "receiver_port": port,
+            "pin_sha256": pin_sha256,
         }
         self._db.bus.fire(EventType.OFFLOADER_PAIR_ALERT_DISMISSED, payload)
         return True
@@ -2003,22 +2037,22 @@ class RemoteBuildController:
         method on a re-pair after the prior listener was
         cancelled to avoid stale-pin closure capture). Idempotent
         on already-running listeners — returns early if a
-        listener for ``(host, port)`` already exists and isn't
-        done. Cold start has no PENDING entries to spawn against,
-        so this isn't called from :meth:`start`.
+        listener for the row's ``pin_sha256`` already exists and
+        isn't done. Cold start has no PENDING entries to spawn
+        against, so this isn't called from :meth:`start`.
         """
-        key = (pairing.receiver_hostname, pairing.receiver_port)
+        key = pairing.pin_sha256
         existing = self._pair_status_listeners.get(key)
         if existing is not None and not existing.done():
             return
         self._pair_status_listeners[key] = asyncio.create_task(
             self._await_pair_status_flip(pairing),
-            name=f"pair-status-{key[0]}:{key[1]}",
+            name=f"pair-status-{pairing.receiver_hostname}:{pairing.receiver_port}",
         )
 
-    def _cancel_pair_status_listener(self, hostname: str, port: int) -> None:
-        """Cancel the listener at ``(host, port)``. No-op if none running."""
-        task = self._pair_status_listeners.pop((hostname, port), None)
+    def _cancel_pair_status_listener(self, pin_sha256: str) -> None:
+        """Cancel the listener for *pin_sha256*. No-op if none running."""
+        task = self._pair_status_listeners.pop(pin_sha256, None)
         if task is not None and not task.done():
             task.cancel()
 
@@ -2026,10 +2060,11 @@ class RemoteBuildController:
         """Spawn the long-lived peer-link client for *pairing*.
 
         Idempotent on already-running clients — returns early if
-        a client for ``(host, port)`` is still alive. Skips if
-        the offloader-side identities haven't been loaded yet
-        (start order: identities load before any spawn). Skips
-        if the bus isn't wired (e.g. a unit test path).
+        a client for the row's ``pin_sha256`` is still alive.
+        Skips if the offloader-side identities haven't been
+        loaded yet (start order: identities load before any
+        spawn). Skips if the bus isn't wired (e.g. a unit test
+        path).
         """
         if (
             self._offloader_dashboard_id is None
@@ -2037,7 +2072,7 @@ class RemoteBuildController:
             or self._db.bus is None
         ):
             return
-        key = (pairing.receiver_hostname, pairing.receiver_port)
+        key = pairing.pin_sha256
         existing = self._peer_link_clients.get(key)
         if existing is not None and not existing.done():
             return
@@ -2052,19 +2087,68 @@ class RemoteBuildController:
             # admitting an attacker with their own keypair to
             # the application channel.
             pinned_static_x25519_pub=pairing.static_x25519_pub,
+            pin_sha256=pairing.pin_sha256,
             receiver_label=pairing.label,
             bus=self._db.bus,
         )
         self._peer_link_clients[key] = asyncio.create_task(
             client.run(),
-            name=f"peer-link-client-{key[0]}:{key[1]}",
+            name=f"peer-link-client-{pairing.receiver_hostname}:{pairing.receiver_port}",
         )
 
-    def _cancel_peer_link_client(self, hostname: str, port: int) -> None:
-        """Cancel the peer-link client at ``(host, port)``. No-op if none running."""
-        task = self._peer_link_clients.pop((hostname, port), None)
+    def _cancel_peer_link_client(self, pin_sha256: str) -> None:
+        """Cancel the peer-link client for *pin_sha256*. No-op if none running."""
+        task = self._peer_link_clients.pop(pin_sha256, None)
         if task is not None and not task.done():
             task.cancel()
+
+    def _sweep_stale_pairings_at_endpoint(
+        self, hostname: str, port: int, *, keep_pin_sha256: str
+    ) -> None:
+        """Drop any pairing or alert at ``(hostname, port)`` whose pin isn't *keep_pin_sha256*.
+
+        Called from :meth:`request_pair` to clean up stale rows
+        when the user re-pairs against the same network
+        coordinates under a fresh pin (receiver rotated
+        identity, or a different receiver moved to that
+        hostname). Without this sweep, the old row + its
+        listener task + alert would leak under pin-keying — the
+        new entry lands at the new pin, and the old pin's slot
+        keeps pointing at a stale row nobody references.
+
+        ``keep_pin_sha256`` is the pin of the row the caller is
+        about to install; rows under that pin are skipped (the
+        caller's own write is the source of truth).
+
+        Walks both ``_pairings`` and ``_offloader_alerts``: an
+        alert can outlive its pairing in some race paths (e.g.
+        ``_apply_pair_status_result``'s pin-drift branch
+        registered the alert and dropped the pairing under the
+        old pin), so dropping by pin alone wouldn't cover the
+        re-pair-clears-old-alert contract. Snapshots the dicts
+        to lists before iterating so the in-loop pop doesn't
+        mutate-during-iteration.
+        """
+        for stale_pin, pairing in list(self._pairings.items()):
+            if stale_pin == keep_pin_sha256:
+                continue
+            if pairing.receiver_hostname != hostname or pairing.receiver_port != port:
+                continue
+            self._pairings.pop(stale_pin, None)
+            self._cancel_pair_status_listener(stale_pin)
+            self._cancel_peer_link_client(stale_pin)
+            self._peer_queue_status.pop(stale_pin, None)
+        # Alerts can outlive pairings — sweep them in a second
+        # pass keyed on the alert's stored ``receiver_hostname``
+        # / ``receiver_port`` (also walks the pin-keyed dict so
+        # an alert under the keep_pin_sha256 stays put if the
+        # user is re-confirming the same identity).
+        for stale_pin, alert in list(self._offloader_alerts.items()):
+            if stale_pin == keep_pin_sha256:
+                continue
+            if alert["receiver_hostname"] != hostname or alert["receiver_port"] != port:
+                continue
+            self._dismiss_offloader_alert(stale_pin, hostname, port)
 
     async def _await_pair_status_flip(self, pairing: StoredPairing) -> None:
         """Hold a Noise WS to the receiver until the row flips status.
@@ -2120,7 +2204,7 @@ class RemoteBuildController:
             # ``pop()``-ing here would evict the replacement and
             # orphan it (no entry left for ``unpair`` to cancel,
             # the new listener parks forever).
-            key = (pairing.receiver_hostname, pairing.receiver_port)
+            key = pairing.pin_sha256
             if self._pair_status_listeners.get(key) is asyncio.current_task():
                 del self._pair_status_listeners[key]
 
@@ -2171,7 +2255,7 @@ class RemoteBuildController:
         # offloader-side label after the row's been popped.
         label = pairing.label
         stored_pin = pairing.pin_sha256
-        key = (host, port)
+        key = pairing.pin_sha256
         if result.status is IntentResponse.APPROVED:
             if result.pin_sha256 != pairing.pin_sha256:
                 _LOGGER.warning(
@@ -2196,6 +2280,7 @@ class RemoteBuildController:
                         "kind": "pin_mismatch",
                         "receiver_hostname": host,
                         "receiver_port": port,
+                        "pin_sha256": stored_pin,
                         "receiver_label": label,
                         "expected_pin": stored_pin,
                         "observed_pin": result.pin_sha256,
@@ -2209,9 +2294,9 @@ class RemoteBuildController:
                     # events ride the same global subscribe stream
                     # so order is preserved end-to-end.
                     self._fire_offloader_pair_pin_mismatch(
-                        host, port, label, stored_pin, result.pin_sha256
+                        host, port, key, label, stored_pin, result.pin_sha256
                     )
-                    self._fire_offloader_pair_status_changed(host, port, "removed")
+                    self._fire_offloader_pair_status_changed(host, port, key, "removed")
                 return True
             # Promote PENDING → APPROVED in place. ``unpair``
             # between our ``await await_pair_status(...)`` and this
@@ -2229,7 +2314,7 @@ class RemoteBuildController:
             self._pairings_store.async_delay_save(
                 self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
             )
-            self._fire_offloader_pair_status_changed(host, port, "approved")
+            self._fire_offloader_pair_status_changed(host, port, key, "approved")
             # Spawn the long-lived peer-link client now that the
             # receiver has approved us. The client's
             # connect-handshake-park-reconnect loop owns the
@@ -2248,6 +2333,7 @@ class RemoteBuildController:
                     "kind": "peer_revoked",
                     "receiver_hostname": host,
                     "receiver_port": port,
+                    "pin_sha256": stored_pin,
                     "receiver_label": label,
                     "fired_at": time.time(),
                 }
@@ -2256,8 +2342,8 @@ class RemoteBuildController:
                 # pin-mismatch branch above: subscribers see the
                 # peer-revoked diagnostic before the
                 # ``status_changed("removed")`` drops the row.
-                self._fire_offloader_pair_peer_revoked(host, port, label)
-                self._fire_offloader_pair_status_changed(host, port, "removed")
+                self._fire_offloader_pair_peer_revoked(host, port, key, label)
+                self._fire_offloader_pair_status_changed(host, port, key, "removed")
             return True
         _LOGGER.warning(
             "pair-status returned unexpected status %r for %s:%s",
@@ -2271,6 +2357,7 @@ class RemoteBuildController:
         self,
         receiver_hostname: str,
         receiver_port: int,
+        pin_sha256: str,
         status: Literal["approved", "removed"],
     ) -> None:
         """Fire ``OFFLOADER_PAIR_STATUS_CHANGED`` for a pairing flip.
@@ -2278,10 +2365,14 @@ class RemoteBuildController:
         Mirrors :meth:`_fire_pair_status_changed` (receiver-side)
         for shape; both methods are the named-intent boundary
         between controller logic and the bus payload format.
+        ``pin_sha256`` is the canonical row identifier (4a-o
+        part 6 — re-keyed offloader state on pin); receiver
+        coords stay on the payload as display fields.
         """
         payload: OffloaderPairStatusChangedData = {
             "receiver_hostname": receiver_hostname,
             "receiver_port": receiver_port,
+            "pin_sha256": pin_sha256,
             "status": status,
         }
         self._db.bus.fire(EventType.OFFLOADER_PAIR_STATUS_CHANGED, payload)
@@ -2290,6 +2381,7 @@ class RemoteBuildController:
         self,
         receiver_hostname: str,
         receiver_port: int,
+        pin_sha256: str,
         receiver_label: str,
         expected_pin: str,
         observed_pin: str,
@@ -2303,12 +2395,16 @@ class RemoteBuildController:
         event carries the diagnostic detail the frontend's
         4b-4 alert plumbing reshape uses to surface a "re-pair
         to confirm the new identity" CTA distinct from the
-        peer-revocation path.
+        peer-revocation path. ``pin_sha256`` is the row's
+        primary key (= ``expected_pin``); duplicated as a
+        separate field so the controller's listener has a
+        direct lookup without parsing ``expected_pin``.
         """
         payload: OffloaderPairPinMismatchData = {
             "receiver_hostname": receiver_hostname,
             "receiver_port": receiver_port,
             "receiver_label": receiver_label,
+            "pin_sha256": pin_sha256,
             "expected_pin": expected_pin,
             "observed_pin": observed_pin,
         }
@@ -2318,6 +2414,7 @@ class RemoteBuildController:
         self,
         receiver_hostname: str,
         receiver_port: int,
+        pin_sha256: str,
         receiver_label: str,
     ) -> None:
         """Fire ``OFFLOADER_PAIR_PEER_REVOKED`` for a REJECTED pair_status.
@@ -2328,12 +2425,15 @@ class RemoteBuildController:
         close, identity rotation, row never existed) collapse
         to "the receiver isn't going to talk to us"; the alert
         copy stays generic. Fires alongside
-        ``status="removed"``.
+        ``status="removed"``. ``pin_sha256`` is the canonical
+        row identifier (4a-o part 6); receiver coords stay on
+        the payload as display fields.
         """
         payload: OffloaderPairPeerRevokedData = {
             "receiver_hostname": receiver_hostname,
             "receiver_port": receiver_port,
             "receiver_label": receiver_label,
+            "pin_sha256": pin_sha256,
         }
         self._db.bus.fire(EventType.OFFLOADER_PAIR_PEER_REVOKED, payload)
 

--- a/esphome_device_builder/controllers/remote_build_peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build_peer_link_client.py
@@ -681,6 +681,7 @@ class PeerLinkClient:
         identity_priv: bytes,
         dashboard_id: str,
         pinned_static_x25519_pub: bytes,
+        pin_sha256: str,
         receiver_label: str,
         bus: EventBus,
     ) -> None:
@@ -694,10 +695,15 @@ class PeerLinkClient:
         # against ``session.remote_static_pub`` post-handshake on
         # every connect so an attacker with their own X25519
         # keypair can't complete Noise XX against this client and
-        # reach the application channel. ``receiver_label`` is
-        # carried so the pin-mismatch alert can name the row at
-        # firing time.
+        # reach the application channel. ``pin_sha256`` is the
+        # SHA-256 of the same pubkey, carried on every event the
+        # client fires so the controller's listener can key into
+        # ``_open_peer_links`` / ``_offloader_alerts`` /
+        # ``_peer_queue_status`` (4a-o part 6 — pin-keyed
+        # offloader state). ``receiver_label`` is carried so
+        # the pin-mismatch alert can name the row at firing time.
         self._pinned_static_x25519_pub = pinned_static_x25519_pub
+        self._pin_sha256 = pin_sha256
         self._receiver_label = receiver_label
         self._bus = bus
         # Set to True when we observe a receiver-side
@@ -1057,6 +1063,7 @@ class PeerLinkClient:
         payload: OffloaderPeerLinkOpenedData = {
             "receiver_hostname": self._hostname,
             "receiver_port": self._port,
+            "pin_sha256": self._pin_sha256,
         }
         self._bus.fire(EventType.OFFLOADER_PEER_LINK_OPENED, payload)
 
@@ -1064,6 +1071,7 @@ class PeerLinkClient:
         payload: OffloaderPeerLinkClosedData = {
             "receiver_hostname": self._hostname,
             "receiver_port": self._port,
+            "pin_sha256": self._pin_sha256,
             "reason": reason,
         }
         self._bus.fire(EventType.OFFLOADER_PEER_LINK_CLOSED, payload)
@@ -1088,6 +1096,7 @@ class PeerLinkClient:
             "receiver_hostname": self._hostname,
             "receiver_port": self._port,
             "receiver_label": self._receiver_label,
+            "pin_sha256": self._pin_sha256,
             "expected_pin": pin_sha256_for_pubkey(self._pinned_static_x25519_pub),
             "observed_pin": pin_sha256_for_pubkey(observed),
         }
@@ -1106,6 +1115,7 @@ class PeerLinkClient:
         payload: OffloaderQueueStatusChangedData = {
             "receiver_hostname": self._hostname,
             "receiver_port": self._port,
+            "pin_sha256": self._pin_sha256,
             "idle": idle,
             "running": running,
             "queue_depth": queue_depth,

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -229,16 +229,16 @@ class OffloaderPairStatusChangedData(TypedDict):
     ``subscribe_events`` stream — no separate subscription
     channel.
 
-    The two events have the same wire shape but live on
-    different buses (receiver vs offloader) and key on
-    different identifiers — the offloader's
-    :class:`StoredPairing` never stores the receiver's
-    ``dashboard_id``, so the receiver coordinates are the
-    ``(hostname, port)`` the user originally dialled.
+    Carries ``pin_sha256`` as the canonical identifier (4a-o
+    part 6 re-keyed offloader-side state on pin instead of
+    ``(hostname, port)``); receiver coords stay on the payload
+    as display fields the frontend can show without a
+    follow-up lookup.
     """
 
     receiver_hostname: str
     receiver_port: int
+    pin_sha256: str
     status: Literal["approved", "removed"]
 
 
@@ -272,11 +272,18 @@ class OffloaderPairPinMismatchData(TypedDict):
     its own pin drift, and the symmetric "offloader rotated"
     case lands as a fresh PENDING row on the receiver's inbox
     via :attr:`EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED`.
+
+    ``pin_sha256`` is the **stored** pin the row was keyed on
+    (same value as ``expected_pin``); duplicated as a separate
+    field so the controller's listener has a direct primary
+    key for ``_offloader_alerts`` lookup without parsing
+    ``expected_pin``.
     """
 
     receiver_hostname: str
     receiver_port: int
     receiver_label: str
+    pin_sha256: str
     expected_pin: str
     observed_pin: str
 
@@ -298,15 +305,17 @@ class OffloaderPairAlertDismissedData(TypedDict):
     on the global ``subscribe_events`` stream sync their local
     alerts list without re-fetching the snapshot.
 
-    The shape carries only the receiver coordinates the alert
-    was keyed on; subscribers find the row in their local
-    alerts map by ``${hostname}:${port}``. No discriminator on
-    *which* resolution path got us here — the user-facing
-    outcome (the alert disappears) is the same either way.
+    Carries ``pin_sha256`` as the canonical row identifier (4a-o
+    part 6 re-keyed `_offloader_alerts` on pin); receiver
+    coordinates stay on the payload as display fields. No
+    discriminator on *which* resolution path got us here — the
+    user-facing outcome (the alert disappears) is the same
+    either way.
     """
 
     receiver_hostname: str
     receiver_port: int
+    pin_sha256: str
 
 
 class OffloaderPinMismatchAlert(TypedDict):
@@ -331,6 +340,7 @@ class OffloaderPinMismatchAlert(TypedDict):
     kind: Literal["pin_mismatch"]
     receiver_hostname: str
     receiver_port: int
+    pin_sha256: str
     receiver_label: str
     expected_pin: str
     observed_pin: str
@@ -349,6 +359,7 @@ class OffloaderPeerRevokedAlert(TypedDict):
     kind: Literal["peer_revoked"]
     receiver_hostname: str
     receiver_port: int
+    pin_sha256: str
     receiver_label: str
     fired_at: float
 
@@ -384,16 +395,19 @@ class OffloaderPairPeerRevokedData(TypedDict):
     operator action differs.
 
     The ``receiver_label`` is carried so the alert can name the
-    row even after the pairings list has dropped it. No extra
-    diagnostic detail; the receiver doesn't tell us *why*
-    REJECTED, and the offloader can't distinguish
-    admin-Reject from window-close from row-never-existed at
-    this layer.
+    row even after the pairings list has dropped it.
+    ``pin_sha256`` carries the row's primary key (4a-o part 6
+    re-keyed offloader-side state on pin) so the controller's
+    listener has a direct lookup. No extra diagnostic detail;
+    the receiver doesn't tell us *why* REJECTED, and the
+    offloader can't distinguish admin-Reject from window-close
+    from row-never-existed at this layer.
     """
 
     receiver_hostname: str
     receiver_port: int
     receiver_label: str
+    pin_sha256: str
 
 
 class RemoteBuildPairingWindowChangedData(TypedDict):
@@ -458,13 +472,15 @@ class OffloaderPeerLinkOpenedData(TypedDict):
     offloader's frontend Settings UI) update the
     per-receiver "connected" indicator on this event.
 
-    Keys on the receiver's ``(hostname, port)`` because the
-    offloader's :class:`StoredPairing` keys on the same — the
-    receiver's ``dashboard_id`` isn't tracked offloader-side.
+    ``pin_sha256`` is the canonical offloader-side row key
+    (4a-o part 6 re-keyed offloader state on pin); receiver
+    coords stay on the payload as display fields the frontend
+    can render without a follow-up lookup.
     """
 
     receiver_hostname: str
     receiver_port: int
+    pin_sha256: str
 
 
 class OffloaderPeerLinkClosedData(TypedDict):
@@ -487,10 +503,15 @@ class OffloaderPeerLinkClosedData(TypedDict):
     means a newer offloader instance with the same
     ``dashboard_id`` already took our slot, so reconnecting
     would just collide; the client orphans rather than retrying.
+
+    ``pin_sha256`` is the canonical offloader-side row key
+    (4a-o part 6 re-keyed offloader state on pin); receiver
+    coords stay on the payload as display fields.
     """
 
     receiver_hostname: str
     receiver_port: int
+    pin_sha256: str
     reason: str
 
 
@@ -566,17 +587,18 @@ class OffloaderQueueStatusChangedData(TypedDict):
     ``queue_status`` application frame from a paired receiver.
     The remote-build controller listens, updates its
     RAM-only ``_peer_queue_status`` cache (keyed on
-    ``(receiver_hostname, receiver_port)``), and re-broadcasts
-    via the global ``subscribe_events`` stream so frontend
-    clients can render per-peer queue depth without polling.
-    Phase-5b is the first real application message exercising
-    the 5a peer-link foundation end-to-end; the scheduler in
-    phase 7 reads the same cache to pick the least-busy peer
-    on each new offload.
+    ``pin_sha256`` since 4a-o part 6), and re-broadcasts via
+    the global ``subscribe_events`` stream so frontend clients
+    can render per-peer queue depth without polling. Phase-5b
+    is the first real application message exercising the 5a
+    peer-link foundation end-to-end; the scheduler in phase 7
+    reads the same cache to pick the least-busy peer on each
+    new offload.
     """
 
     receiver_hostname: str
     receiver_port: int
+    pin_sha256: str
     idle: bool
     running: bool
     queue_depth: int
@@ -596,6 +618,7 @@ class PeerQueueStatusSnapshotEntry(TypedDict):
 
     receiver_hostname: str
     receiver_port: int
+    pin_sha256: str
     idle: bool
     running: bool
     queue_depth: int

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2522,15 +2522,17 @@ def test_on_offloader_pair_pin_mismatch_caches_alert(tmp_path: Path) -> None:
         "receiver_hostname": "host.local",
         "receiver_port": 6055,
         "receiver_label": "my-laptop",
+        "pin_sha256": "a" * 64,
         "expected_pin": "a" * 64,
         "observed_pin": "b" * 64,
     }
     controller._on_offloader_pair_pin_mismatch(MagicMock(data=payload))
 
-    cached = controller._offloader_alerts[("host.local", 6055)]
+    cached = controller._offloader_alerts["a" * 64]
     assert cached["kind"] == "pin_mismatch"
     assert cached["receiver_hostname"] == "host.local"
     assert cached["receiver_port"] == 6055
+    assert cached["pin_sha256"] == "a" * 64
     assert cached["receiver_label"] == "my-laptop"
     assert cached["expected_pin"] == "a" * 64
     assert cached["observed_pin"] == "b" * 64
@@ -2543,15 +2545,17 @@ def test_on_offloader_queue_status_changed_caches_snapshot(tmp_path: Path) -> No
     payload = {
         "receiver_hostname": "192.168.1.10",
         "receiver_port": 6055,
+        "pin_sha256": "a" * 64,
         "idle": False,
         "running": True,
         "queue_depth": 3,
     }
     controller._on_offloader_queue_status_changed(MagicMock(data=payload))
 
-    cached = controller._peer_queue_status[("192.168.1.10", 6055)]
+    cached = controller._peer_queue_status["a" * 64]
     assert cached["receiver_hostname"] == "192.168.1.10"
     assert cached["receiver_port"] == 6055
+    assert cached["pin_sha256"] == "a" * 64
     assert cached["idle"] is False
     assert cached["running"] is True
     assert cached["queue_depth"] == 3
@@ -2560,9 +2564,11 @@ def test_on_offloader_queue_status_changed_caches_snapshot(tmp_path: Path) -> No
 def test_on_offloader_queue_status_changed_overwrites_prior(tmp_path: Path) -> None:
     """A second event for the same key replaces the prior snapshot."""
     controller = _make_controller(config_dir=tmp_path)
+    pin = "a" * 64
     first = {
         "receiver_hostname": "host",
         "receiver_port": 6055,
+        "pin_sha256": pin,
         "idle": True,
         "running": False,
         "queue_depth": 0,
@@ -2570,6 +2576,7 @@ def test_on_offloader_queue_status_changed_overwrites_prior(tmp_path: Path) -> N
     second = {
         "receiver_hostname": "host",
         "receiver_port": 6055,
+        "pin_sha256": pin,
         "idle": False,
         "running": True,
         "queue_depth": 5,
@@ -2577,7 +2584,7 @@ def test_on_offloader_queue_status_changed_overwrites_prior(tmp_path: Path) -> N
     controller._on_offloader_queue_status_changed(MagicMock(data=first))
     controller._on_offloader_queue_status_changed(MagicMock(data=second))
 
-    cached = controller._peer_queue_status[("host", 6055)]
+    cached = controller._peer_queue_status[pin]
     assert cached["queue_depth"] == 5
     assert cached["running"] is True
     assert len(controller._peer_queue_status) == 1
@@ -2586,16 +2593,18 @@ def test_on_offloader_queue_status_changed_overwrites_prior(tmp_path: Path) -> N
 def test_peer_queue_status_snapshot_returns_list(tmp_path: Path) -> None:
     """``peer_queue_status_snapshot`` returns a list of cached entries."""
     controller = _make_controller(config_dir=tmp_path)
-    controller._peer_queue_status[("a", 6055)] = {
+    controller._peer_queue_status["a" * 64] = {
         "receiver_hostname": "a",
         "receiver_port": 6055,
+        "pin_sha256": "a" * 64,
         "idle": True,
         "running": False,
         "queue_depth": 0,
     }
-    controller._peer_queue_status[("b", 6055)] = {
+    controller._peer_queue_status["b" * 64] = {
         "receiver_hostname": "b",
         "receiver_port": 6055,
+        "pin_sha256": "b" * 64,
         "idle": False,
         "running": True,
         "queue_depth": 2,

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -937,10 +937,12 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     # the row is gone from the pin-keyed dict (4a-o part 6).
     assert "a" * 64 not in offloader._pair_status_listeners
     # The captured task reference was cancelled by ``unpair``'s
-    # ``_cancel_pair_status_listener``; awaiting it surfaces the
-    # ``CancelledError`` from the cancel call.
-    with pytest.raises(asyncio.CancelledError):
-        await listener
+    # ``_cancel_pair_status_listener``; drain via ``gather`` so
+    # the cancellation propagates without surfacing as a test
+    # failure (same shape ``RemoteBuildController.stop()`` uses
+    # for its own cancel-and-drain).
+    await asyncio.gather(listener, return_exceptions=True)
+    assert listener.cancelled()
 
 
 @pytest.mark.asyncio
@@ -1644,8 +1646,11 @@ async def test_request_pair_repair_then_unpair_clean_state(
     )
     listener_v2 = offloader._pair_status_listeners[pin2]
     assert listener_v2 is not listener_v1
-    with pytest.raises(asyncio.CancelledError):
-        await listener_v1
+    # Drain the cancelled v1 task — same cancel-and-gather
+    # shape ``RemoteBuildController.stop()`` uses for its
+    # task-set drain.
+    await asyncio.gather(listener_v1, return_exceptions=True)
+    assert listener_v1.cancelled()
     # Re-pair under a new pin landed a new entry under pin2;
     # the sweep dropped the old entry under pin1.
     assert offloader._pairings[pin2].pin_sha256 == pin2
@@ -1653,8 +1658,8 @@ async def test_request_pair_repair_then_unpair_clean_state(
 
     # Unpair cancels listener_v2 + clears the dict.
     await offloader.unpair(pin_sha256=pin2)
-    with pytest.raises(asyncio.CancelledError):
-        await listener_v2
+    await asyncio.gather(listener_v2, return_exceptions=True)
+    assert listener_v2.cancelled()
     assert offloader._pairings == {}
     assert offloader._pair_status_listeners == {}
 
@@ -1751,16 +1756,18 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
         offloader_label="off-label",
     )
 
-    # Old listener got cancelled (cleared pin-drift exposure).
-    with pytest.raises(asyncio.CancelledError):
-        await old_listener
+    # Old listener got cancelled (cleared pin-drift exposure);
+    # drain via gather, same shape as production's
+    # ``RemoteBuildController.stop()``.
+    await asyncio.gather(old_listener, return_exceptions=True)
+    assert old_listener.cancelled()
     # New listener spawned with the fresh pairing under the new pin key.
     new_listener = offloader._pair_status_listeners.get(new_pin)
     assert new_listener is not None
     assert new_listener is not old_listener
     new_listener.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await new_listener
+    await asyncio.gather(new_listener, return_exceptions=True)
+    assert new_listener.cancelled()
     # The dict entry now holds the new pin.
     assert offloader._pairings[new_pin].pin_sha256 == new_pin
     assert summary.pin_sha256 == new_pin

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -923,7 +923,8 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     async def _park() -> None:
         await park.wait()
 
-    offloader._pair_status_listeners["a" * 64] = asyncio.create_task(_park())
+    listener = asyncio.create_task(_park())
+    offloader._pair_status_listeners["a" * 64] = listener
     # Settle one event-loop tick so the create_task is actually
     # scheduled before unpair tries to cancel it.
     await asyncio.sleep(0)
@@ -932,12 +933,14 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
 
     assert result == {"removed": True}
     assert "a" * 64 not in offloader._pairings
-    # Listener was cancelled; let the loop run so the cancellation
-    # propagates and we can drain it cleanly.
-    listener = offloader._pair_status_listeners.get(("rcv.local", 6055))
-    if listener is not None:
-        with pytest.raises(asyncio.CancelledError):
-            await listener
+    # ``unpair`` popped the listener entry from the registry —
+    # the row is gone from the pin-keyed dict (4a-o part 6).
+    assert "a" * 64 not in offloader._pair_status_listeners
+    # The captured task reference was cancelled by ``unpair``'s
+    # ``_cancel_pair_status_listener``; awaiting it surfaces the
+    # ``CancelledError`` from the cancel call.
+    with pytest.raises(asyncio.CancelledError):
+        await listener
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -747,7 +747,7 @@ async def test_controller_request_pair_persists_pending_row(
     # dict; the persisted file stays APPROVED-only so a malicious
     # receiver can't bloat the offloader's settings file.
     assert await _saved_pairings(offloader) == []
-    assert ("127.0.0.1", server.port) in offloader._pairings
+    assert expected_pin in offloader._pairings
 
 
 @pytest.mark.asyncio
@@ -915,7 +915,7 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
     # A no-op listener task standing in for the real long-poll
     # task; the test verifies cancel + cleanup, not the wire flow.
     park = asyncio.Event()
@@ -923,15 +923,15 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     async def _park() -> None:
         await park.wait()
 
-    offloader._pair_status_listeners[("rcv.local", 6055)] = asyncio.create_task(_park())
+    offloader._pair_status_listeners["a" * 64] = asyncio.create_task(_park())
     # Settle one event-loop tick so the create_task is actually
     # scheduled before unpair tries to cancel it.
     await asyncio.sleep(0)
 
-    result = await offloader.unpair(hostname="rcv.local", port=6055)
+    result = await offloader.unpair(pin_sha256="a" * 64)
 
     assert result == {"removed": True}
-    assert ("rcv.local", 6055) not in offloader._pairings
+    assert "a" * 64 not in offloader._pairings
     # Listener was cancelled; let the loop run so the cancellation
     # propagates and we can drain it cleanly.
     listener = offloader._pair_status_listeners.get(("rcv.local", 6055))
@@ -959,12 +959,12 @@ async def test_unpair_drops_persisted_row(
     )
     # Land the row in RAM + force-flush an initial save so the
     # unpair has something to drop on disk too.
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
     offloader._pairings_store.async_delay_save(offloader._serialize_pairings, delay=0.0)
     for cb in offloader._shutdown_callbacks:
         await cb()
 
-    result = await offloader.unpair(hostname="rcv.local", port=6055)
+    result = await offloader.unpair(pin_sha256="a" * 64)
 
     assert result == {"removed": True}
     # Flush the second debounced save (the unpair's removal).
@@ -983,7 +983,7 @@ async def test_unpair_unknown_returns_removed_false_idempotent(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
 
-    result = await offloader.unpair(hostname="ghost.local", port=6055)
+    result = await offloader.unpair(pin_sha256="a" * 64)
 
     assert result == {"removed": False}
 
@@ -1004,17 +1004,19 @@ async def test_pairings_snapshot_returns_ram_dict(
     pending = _stub_pairing(
         receiver_hostname="pending.local",
         receiver_port=6055,
+        pin_sha256="a" * 64,
         label="pending-receiver",
         status=PeerStatus.PENDING,
     )
     approved = _stub_pairing(
         receiver_hostname="approved.local",
         receiver_port=6055,
+        pin_sha256="b" * 64,
         label="approved-receiver",
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[("pending.local", 6055)] = pending
-    offloader._pairings[("approved.local", 6055)] = approved
+    offloader._pairings["a" * 64] = pending
+    offloader._pairings["b" * 64] = approved
 
     rows = offloader.pairings_snapshot()
 
@@ -1047,7 +1049,7 @@ async def test_start_seeds_pairings_dict_from_disk(
         static_x25519_pub=pubkey,
         status=PeerStatus.APPROVED,
     )
-    seeder._pairings[("seeded.local", 6055)] = seeded
+    seeder._pairings[pin] = seeded
     seeder._pairings_store.async_delay_save(seeder._serialize_pairings, delay=0.0)
     for cb in seeder._shutdown_callbacks:
         await cb()
@@ -1063,8 +1065,8 @@ async def test_start_seeds_pairings_dict_from_disk(
     fresh._db.devices = None  # short-circuit the post-load branches.
     await fresh.start()
 
-    assert ("seeded.local", 6055) in fresh._pairings
-    loaded = fresh._pairings[("seeded.local", 6055)]
+    assert pin in fresh._pairings
+    loaded = fresh._pairings[pin]
     assert loaded.pin_sha256 == pin
     assert loaded.static_x25519_pub == pubkey
     assert loaded.status is PeerStatus.APPROVED
@@ -1092,7 +1094,7 @@ async def test_apply_pair_status_result_approved_promotes_and_fires(
         static_x25519_pub=pubkey,
         status=PeerStatus.PENDING,
     )
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.APPROVED, pin_sha256=pin
     )
@@ -1102,7 +1104,7 @@ async def test_apply_pair_status_result_approved_promotes_and_fires(
     assert terminal is True
     # Row stays in the dict with promoted status — the unified
     # ``_pairings`` map carries both PENDING and APPROVED.
-    assert offloader._pairings[("rcv.local", 6055)].status is PeerStatus.APPROVED
+    assert offloader._pairings["a" * 64].status is PeerStatus.APPROVED
     saved = await _saved_pairings(offloader)
     assert len(saved) == 1
     assert saved[0].pin_sha256 == pin
@@ -1125,7 +1127,7 @@ async def test_apply_pair_status_result_approved_pin_drift_drops_and_fires_remov
         pin_sha256="a" * 64,
         label="lab-pc",
     )
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
     # Receiver returned APPROVED but its pubkey hash doesn't match
     # what we stored; treat as peer-revoked rather than silently
     # adopting the new identity.
@@ -1136,7 +1138,7 @@ async def test_apply_pair_status_result_approved_pin_drift_drops_and_fires_remov
     terminal = await offloader._apply_pair_status_result(pairing, result)
 
     assert terminal is True
-    assert ("rcv.local", 6055) not in offloader._pairings
+    assert "a" * 64 not in offloader._pairings
     assert await _saved_pairings(offloader) == []
     # Two events should have fired in order: the discriminator
     # (PIN_MISMATCH) carrying the diagnostic detail + label,
@@ -1152,6 +1154,7 @@ async def test_apply_pair_status_result_approved_pin_drift_drops_and_fires_remov
         "receiver_hostname": "rcv.local",
         "receiver_port": 6055,
         "receiver_label": "lab-pc",
+        "pin_sha256": "a" * 64,
         "expected_pin": "a" * 64,
         "observed_pin": "b" * 64,
     }
@@ -1172,7 +1175,7 @@ async def test_apply_pair_status_result_rejected_drops_and_fires_removed(
         receiver_port=6055,
         label="lab-pc",
     )
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.REJECTED, pin_sha256="a" * 64
     )
@@ -1180,7 +1183,7 @@ async def test_apply_pair_status_result_rejected_drops_and_fires_removed(
     terminal = await offloader._apply_pair_status_result(pairing, result)
 
     assert terminal is True
-    assert ("rcv.local", 6055) not in offloader._pairings
+    assert "a" * 64 not in offloader._pairings
     # Same fire-discriminator-first ordering as the pin-drift
     # branch: PEER_REVOKED carrying the row label, then
     # STATUS_CHANGED("removed") that drops the row.
@@ -1192,6 +1195,7 @@ async def test_apply_pair_status_result_rejected_drops_and_fires_removed(
         "receiver_hostname": "rcv.local",
         "receiver_port": 6055,
         "receiver_label": "lab-pc",
+        "pin_sha256": "a" * 64,
     }
     second_event_type, second_payload = fire_calls[1].args
     assert second_event_type is EventType.OFFLOADER_PAIR_STATUS_CHANGED
@@ -1219,7 +1223,7 @@ async def test_apply_pair_status_result_pin_drift_seeds_offloader_alert(
         pin_sha256="a" * 64,
         label="lab-pc",
     )
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.APPROVED, pin_sha256="b" * 64
     )
@@ -1256,7 +1260,7 @@ async def test_apply_pair_status_result_rejected_seeds_offloader_alert(
         receiver_port=6055,
         label="lab-pc",
     )
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.REJECTED, pin_sha256="a" * 64
     )
@@ -1281,8 +1285,8 @@ async def test_unpair_clears_offloader_alert_and_fires_dismissed(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings[("rcv.local", 6055)] = pairing
-    offloader._offloader_alerts[("rcv.local", 6055)] = {
+    offloader._pairings["a" * 64] = pairing
+    offloader._offloader_alerts["a" * 64] = {
         "kind": "peer_revoked",
         "receiver_hostname": "rcv.local",
         "receiver_port": 6055,
@@ -1290,7 +1294,7 @@ async def test_unpair_clears_offloader_alert_and_fires_dismissed(
         "fired_at": 1.0,
     }
 
-    result = await offloader.unpair(hostname="rcv.local", port=6055)
+    result = await offloader.unpair(pin_sha256="a" * 64)
 
     assert result == {"removed": True}
     assert offloader.offloader_alerts_snapshot() == []
@@ -1310,7 +1314,7 @@ async def test_apply_pair_status_result_unexpected_status_logs_and_continues(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.OK, pin_sha256="a" * 64
     )
@@ -1320,7 +1324,7 @@ async def test_apply_pair_status_result_unexpected_status_logs_and_continues(
     # Not terminal — the listener loop reconnects after a backoff.
     assert terminal is False
     # Pending entry untouched.
-    assert ("rcv.local", 6055) in offloader._pairings
+    assert "a" * 64 in offloader._pairings
     offloader._db.bus.fire.assert_not_called()
 
 
@@ -1354,7 +1358,7 @@ async def test_apply_pair_status_result_approved_after_unpair_does_not_resurrect
     # Simulate the unpair path: dict entry was already popped.
     # The pairing in the listener's closure is what remains
     # (captured at spawn time).
-    assert ("rcv.local", 6055) not in offloader._pairings
+    assert "a" * 64 not in offloader._pairings
 
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.APPROVED, pin_sha256=pin
@@ -1384,14 +1388,14 @@ async def test_unpair_cancels_listener_before_disk_transaction(
     async def _park() -> None:
         await park.wait()
 
-    key = ("rcv.local", 6055)
+    key = "a" * 64
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
     offloader._pairings[key] = pairing
     listener = asyncio.create_task(_park())
     offloader._pair_status_listeners[key] = listener
     await asyncio.sleep(0)
 
-    await offloader.unpair(hostname="rcv.local", port=6055)
+    await offloader.unpair(pin_sha256="a" * 64)
 
     with pytest.raises(asyncio.CancelledError):
         await listener
@@ -1413,9 +1417,9 @@ async def test_unpair_fires_offloader_pair_status_changed_removed(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings["a" * 64] = pairing
 
-    result = await offloader.unpair(hostname="rcv.local", port=6055)
+    result = await offloader.unpair(pin_sha256="a" * 64)
 
     assert result == {"removed": True}
     fire = offloader._db.bus.fire
@@ -1425,6 +1429,7 @@ async def test_unpair_fires_offloader_pair_status_changed_removed(
     assert payload == {
         "receiver_hostname": "rcv.local",
         "receiver_port": 6055,
+        "pin_sha256": "a" * 64,
         "status": "removed",
     }
 
@@ -1482,10 +1487,11 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
 
     # Pre-seed an alert as if a prior pair-status detection had
     # registered one against this receiver.
-    offloader._offloader_alerts[("rcv.local", 6055)] = {
+    offloader._offloader_alerts["a" * 64] = {
         "kind": "pin_mismatch",
         "receiver_hostname": "rcv.local",
         "receiver_port": 6055,
+        "pin_sha256": "a" * 64,
         "receiver_label": "lab-pc",
         "expected_pin": "a" * 64,
         "observed_pin": "b" * 64,
@@ -1508,7 +1514,7 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
     assert EventType.OFFLOADER_PAIR_ALERT_DISMISSED in fire_event_types
 
     # Cleanup: cancel the listener so the test exits clean.
-    listener = offloader._pair_status_listeners.get(("rcv.local", 6055))
+    listener = offloader._pair_status_listeners.get(pin)
     if listener is not None:
         listener.cancel()
         await asyncio.gather(listener, return_exceptions=True)
@@ -1525,7 +1531,7 @@ async def test_unpair_does_not_fire_event_when_nothing_to_remove(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
 
-    result = await offloader.unpair(hostname="ghost.local", port=6055)
+    result = await offloader.unpair(pin_sha256="a" * 64)
 
     assert result == {"removed": False}
     offloader._db.bus.fire.assert_not_called()
@@ -1609,7 +1615,7 @@ async def test_request_pair_repair_then_unpair_clean_state(
         receiver_label="rcv-1",
         offloader_label="off",
     )
-    listener_v1 = offloader._pair_status_listeners[("rcv.local", 6055)]
+    listener_v1 = offloader._pair_status_listeners[pin1]
 
     # Wait until ``listener_v1`` has actually reached its
     # ``await peer_link_await_pair_status`` parked state.
@@ -1633,14 +1639,17 @@ async def test_request_pair_repair_then_unpair_clean_state(
         receiver_label="rcv-2",
         offloader_label="off",
     )
-    listener_v2 = offloader._pair_status_listeners[("rcv.local", 6055)]
+    listener_v2 = offloader._pair_status_listeners[pin2]
     assert listener_v2 is not listener_v1
     with pytest.raises(asyncio.CancelledError):
         await listener_v1
-    assert offloader._pairings[("rcv.local", 6055)].pin_sha256 == pin2
+    # Re-pair under a new pin landed a new entry under pin2;
+    # the sweep dropped the old entry under pin1.
+    assert offloader._pairings[pin2].pin_sha256 == pin2
+    assert pin1 not in offloader._pairings
 
     # Unpair cancels listener_v2 + clears the dict.
-    await offloader.unpair(hostname="rcv.local", port=6055)
+    await offloader.unpair(pin_sha256=pin2)
     with pytest.raises(asyncio.CancelledError):
         await listener_v2
     assert offloader._pairings == {}
@@ -1659,7 +1668,7 @@ async def test_spawn_pair_status_listener_is_idempotent_on_running_task(
     async def _park() -> None:
         await park.wait()
 
-    key = ("rcv.local", 6055)
+    key = "a" * 64
     existing = asyncio.create_task(_park())
     offloader._pair_status_listeners[key] = existing
     await asyncio.sleep(0)  # schedule the task
@@ -1683,7 +1692,7 @@ async def test_cancel_pair_status_listener_noop_when_absent(
     offloader._db.bus = MagicMock()
 
     # No-op; doesn't raise.
-    offloader._cancel_pair_status_listener("ghost.local", 6055)
+    offloader._cancel_pair_status_listener("a" * 64)
 
 
 @pytest.mark.asyncio
@@ -1705,13 +1714,13 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
     async def _park() -> None:
         await park.wait()
 
-    key = ("rcv.local", 6055)
+    key_old = "a" * 64
     old_pairing = _stub_pairing(
         receiver_hostname="rcv.local", receiver_port=6055, pin_sha256="a" * 64
     )
-    offloader._pairings[key] = old_pairing
+    offloader._pairings[key_old] = old_pairing
     old_listener = asyncio.create_task(_park())
-    offloader._pair_status_listeners[key] = old_listener
+    offloader._pair_status_listeners[key_old] = old_listener
     await asyncio.sleep(0)
 
     # Stub the wire round-trip so request_pair completes without
@@ -1742,16 +1751,19 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
     # Old listener got cancelled (cleared pin-drift exposure).
     with pytest.raises(asyncio.CancelledError):
         await old_listener
-    # New listener spawned with the fresh pairing.
-    new_listener = offloader._pair_status_listeners.get(key)
+    # New listener spawned with the fresh pairing under the new pin key.
+    new_listener = offloader._pair_status_listeners.get(new_pin)
     assert new_listener is not None
     assert new_listener is not old_listener
     new_listener.cancel()
     with pytest.raises(asyncio.CancelledError):
         await new_listener
     # The dict entry now holds the new pin.
-    assert offloader._pairings[key].pin_sha256 == new_pin
+    assert offloader._pairings[new_pin].pin_sha256 == new_pin
     assert summary.pin_sha256 == new_pin
+    # Old (pin-keyed) entry is gone — re-pair under a new pin
+    # creates a fresh row, doesn't shadow the old one.
+    assert key_old not in offloader._pairings
 
 
 @pytest.mark.asyncio
@@ -1785,7 +1797,7 @@ async def test_request_pair_already_approved_persists_to_disk(
     # Cancel the offloader's listener so the second request_pair
     # below doesn't race with it; we're only testing the
     # already-approved → persist path.
-    offloader._cancel_pair_status_listener("127.0.0.1", server.port)
+    offloader._cancel_pair_status_listener(expected_pin)
 
     # Promote the receiver-side row to APPROVED so the next
     # request_pair gets the short-circuit path.
@@ -1808,7 +1820,7 @@ async def test_request_pair_already_approved_persists_to_disk(
     assert saved[0].pin_sha256 == expected_pin
     # The row stays in the unified dict with APPROVED status —
     # no separate PENDING entry, no double-counting on the wire.
-    assert offloader._pairings[("127.0.0.1", server.port)].status is PeerStatus.APPROVED
+    assert offloader._pairings[expected_pin].status is PeerStatus.APPROVED
 
 
 @pytest.mark.asyncio
@@ -2009,7 +2021,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
         pin_sha256=pin,
         static_x25519_pub=pubkey,
     )
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings[pin] = pairing
 
     calls = 0
 
@@ -2042,7 +2054,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
     assert calls == 2
     # Terminal branch ran: row stays in the dict but is now
     # APPROVED, and an approved event fired.
-    assert offloader._pairings[("rcv.local", 6055)].status is PeerStatus.APPROVED
+    assert offloader._pairings[pin].status is PeerStatus.APPROVED
 
 
 @pytest.mark.asyncio
@@ -2069,7 +2081,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
         pin_sha256=pin,
         static_x25519_pub=pubkey,
     )
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings[pin] = pairing
 
     calls = 0
 
@@ -2102,7 +2114,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
 
     # Two poll attempts (OK → backoff → REJECTED → terminal).
     assert calls == 2
-    assert ("rcv.local", 6055) not in offloader._pairings
+    assert pin not in offloader._pairings
 
 
 # ---------------------------------------------------------------------------
@@ -2188,6 +2200,7 @@ async def test_peer_link_client_fires_opened_after_handshake(
         identity_priv=initiator_priv,
         dashboard_id="alpha",
         pinned_static_x25519_pub=receiver_pub,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2223,6 +2236,7 @@ async def test_peer_link_client_fires_closed_on_cancel(
         identity_priv=initiator_priv,
         dashboard_id="alpha",
         pinned_static_x25519_pub=receiver_pub,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2276,6 +2290,7 @@ async def test_peer_link_client_orphans_on_superseded(
         identity_priv=initiator_priv,
         dashboard_id="alpha",
         pinned_static_x25519_pub=receiver_pub,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2288,6 +2303,7 @@ async def test_peer_link_client_orphans_on_superseded(
         identity_priv=initiator_priv,
         dashboard_id="alpha",
         pinned_static_x25519_pub=receiver_pub,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2355,6 +2371,7 @@ async def test_peer_link_client_reconnects_on_transport_error(
         identity_priv=initiator_priv,
         dashboard_id="alpha",
         pinned_static_x25519_pub=receiver_pub,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2407,6 +2424,7 @@ async def test_run_session_loops_send_ping_routes_through_channel(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=EventBus(),
     )
@@ -2458,6 +2476,7 @@ async def test_run_session_loops_returns_heartbeat_timeout_when_dead(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=EventBus(),
     )
@@ -2509,6 +2528,7 @@ async def test_peer_link_client_backoff_advances_when_session_never_opens(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2552,6 +2572,7 @@ def test_peer_link_client_exposes_receiver_coordinates() -> None:
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=EventBus(),
     )
@@ -2594,6 +2615,7 @@ async def test_peer_link_client_returns_transport_error_on_type_error(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2638,6 +2660,7 @@ async def test_peer_link_client_returns_transport_error_on_noise_failure(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2671,6 +2694,7 @@ async def test_peer_link_client_auth_rejected_when_dashboard_id_unknown(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="never-paired",
         pinned_static_x25519_pub=receiver_pub,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -2731,6 +2755,7 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
         identity_priv=initiator_priv,
         dashboard_id="alpha",
         pinned_static_x25519_pub=wrong_pub,
+        pin_sha256="a" * 64,
         receiver_label="my-laptop",
         bus=bus,
     )
@@ -2804,6 +2829,7 @@ async def test_run_session_loops_responds_to_peer_ping(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=EventBus(),
     )
@@ -2865,6 +2891,7 @@ async def test_run_session_loops_bumps_last_pong_on_pong(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=EventBus(),
     )
@@ -2918,6 +2945,7 @@ async def test_run_session_loops_returns_transport_error_on_malformed_frame(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=EventBus(),
     )
@@ -2960,6 +2988,7 @@ async def test_run_session_loops_ignores_unknown_msg_type(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=EventBus(),
     )
@@ -3021,6 +3050,7 @@ async def test_run_session_loops_on_dead_swallows_aiohttp_close_error(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=EventBus(),
     )
@@ -3078,13 +3108,13 @@ async def test_await_pair_status_flip_self_removes_listener_on_terminal_exit(
         static_x25519_pub=pubkey,
         status=PeerStatus.PENDING,
     )
-    offloader._pairings[("rcv.local", 6055)] = pairing
+    offloader._pairings[pin] = pairing
     offloader._spawn_pair_status_listener(pairing)
-    listener = offloader._pair_status_listeners[("rcv.local", 6055)]
+    listener = offloader._pair_status_listeners[pin]
 
     await listener
 
-    assert ("rcv.local", 6055) not in offloader._pair_status_listeners
+    assert pin not in offloader._pair_status_listeners
 
 
 @pytest.mark.asyncio
@@ -3115,12 +3145,12 @@ async def test_spawn_peer_link_client_idempotent_when_task_running(
 
     offloader._spawn_peer_link_client(pairing)
     await asyncio.sleep(0)
-    first_task = offloader._peer_link_clients[("rcv.local", 6055)]
+    first_task = offloader._peer_link_clients["a" * 64]
 
     offloader._spawn_peer_link_client(pairing)
     await asyncio.sleep(0)
 
-    assert offloader._peer_link_clients[("rcv.local", 6055)] is first_task
+    assert offloader._peer_link_clients["a" * 64] is first_task
     park.set()
     await cancel_and_drain(first_task)
 
@@ -3152,11 +3182,11 @@ async def test_cancel_peer_link_client_cancels_running_task(
     )
     offloader._spawn_peer_link_client(pairing)
     await asyncio.sleep(0)
-    task = offloader._peer_link_clients[("rcv.local", 6055)]
+    task = offloader._peer_link_clients["a" * 64]
 
-    offloader._cancel_peer_link_client("rcv.local", 6055)
+    offloader._cancel_peer_link_client("a" * 64)
 
-    assert ("rcv.local", 6055) not in offloader._peer_link_clients
+    assert "a" * 64 not in offloader._peer_link_clients
     with pytest.raises(asyncio.CancelledError):
         await task
 
@@ -3182,9 +3212,17 @@ async def test_stop_drains_peer_link_clients(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     _prime_offloader_identity_for_spawn(offloader)
-    for host, port in (("a.local", 6055), ("b.local", 6055)):
+    for host, port, pin in (
+        ("a.local", 6055, "a" * 64),
+        ("b.local", 6055, "b" * 64),
+    ):
         offloader._spawn_peer_link_client(
-            _stub_pairing(receiver_hostname=host, receiver_port=port, status=PeerStatus.APPROVED)
+            _stub_pairing(
+                receiver_hostname=host,
+                receiver_port=port,
+                pin_sha256=pin,
+                status=PeerStatus.APPROVED,
+            )
         )
     await asyncio.sleep(0)
     tasks = list(offloader._peer_link_clients.values())
@@ -3253,6 +3291,7 @@ async def test_run_session_loops_fires_queue_status_event_on_inbound_frame(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -3268,6 +3307,7 @@ async def test_run_session_loops_fires_queue_status_event_on_inbound_frame(
     assert payload == {
         "receiver_hostname": "receiver.local",
         "receiver_port": 6055,
+        "pin_sha256": "a" * 64,
         "idle": False,
         "running": True,
         "queue_depth": 3,
@@ -3333,6 +3373,7 @@ async def test_run_session_loops_drops_malformed_queue_status(
         identity_priv=secrets.token_bytes(32),
         dashboard_id="alpha",
         pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="a" * 64,
         receiver_label="test-receiver",
         bus=bus,
     )


### PR DESCRIPTION
# What does this implement/fix?

Phase 4a-o part 6 from
[#106](https://github.com/esphome/device-builder/issues/106) —
the refactor that re-keys offloader-side state from
`(receiver_hostname, receiver_port)` to `pin_sha256`. The pin
is the stable cryptographic identity (hash of the receiver's
static X25519 pubkey); network coords are routing hints stored
as fields on the value rather than as the primary key.

## Why

A receiver hostname rename used to require a multi-dict atomic
remap (pop+insert across four state structures, cancel +
respawn tasks, error-prone). Under pin-keying it becomes a
one-line mutation of the value's `receiver_hostname` field.
Symmetric to the receiver-side `_approved_peers` keyed on
`dashboard_id` — both ends index by stable cryptographic
identity with network coords as fields.

This PR is the prep for 4a-o part 7 (auto-rebind on mDNS
pin-match): with pin-keyed registries the rebind is a one-line
value mutation of `_pairings[pin].receiver_hostname` instead of
a multi-dict atomic remap.

## Scope

**State structures (RAM-only, all controller-side):**

- `_pairings: dict[str, StoredPairing]`
- `_pair_status_listeners: dict[str, asyncio.Task]`
- `_peer_link_clients: dict[str, asyncio.Task]`
- `_offloader_alerts: dict[str, OffloaderAlertSnapshotEntry]`
- `_peer_queue_status: dict[str, PeerQueueStatusSnapshotEntry]`

All five pivot to `pin_sha256` (lowercase-hex SHA-256 of the
receiver's X25519 pubkey) as the primary key.

**Wire shape changes (event payloads):**

`OffloaderPairStatusChangedData` /
`OffloaderPeerLinkOpenedData` / `OffloaderPeerLinkClosedData`
/ `OffloaderPairAlertDismissedData` /
`OffloaderPairPinMismatchData` /
`OffloaderPairPeerRevokedData` /
`OffloaderQueueStatusChangedData` all gain `pin_sha256: str`
so listeners (the controller's own and the frontend's once it
migrates) can look up the row by pin without a follow-up scan.
Receiver coords stay on the payload as display fields the
frontend can render without a second round-trip.

**Wire shape changes (snapshots):**

`OffloaderPinMismatchAlert` / `OffloaderPeerRevokedAlert` /
`PeerQueueStatusSnapshotEntry` rows in
`subscribe_events.initial_state.*` similarly gain `pin_sha256`.

**WS command shape change:**

`unpair` takes `pin_sha256: str` instead of
`hostname: str, port: int`. Frontend already carries
`pin_sha256` on every `PairingSummary`, so the user-clicks-Unpair
path threads that value directly. **Breaking** for the WS shape
— fine pre-release per the no-back-compat memory.

**Internal contract additions:**

- `_sweep_stale_pairings_at_endpoint(host, port,
  keep_pin_sha256=...)` — new helper called by `request_pair`
  to clean up rows under stale pins at the same `(host, port)`
  (receiver rotated identity, or a different receiver moved to
  that hostname). Walks both `_pairings` and
  `_offloader_alerts` so a pre-existing alert under the old
  pin gets dismissed when the user re-pairs under a new pin
  at the same coords.
- `_dismiss_offloader_alert` / `_cancel_pair_status_listener`
  / `_cancel_peer_link_client` now take `pin_sha256` instead
  of `(hostname, port)`.
- `_fire_offloader_pair_status_changed` /
  `_fire_offloader_pair_pin_mismatch` /
  `_fire_offloader_pair_peer_revoked` thread `pin_sha256`
  through to the event payload.
- `PeerLinkClient` constructor takes `pin_sha256` and fires it
  on every event (`OFFLOADER_PEER_LINK_OPENED` / `_CLOSED` /
  `OFFLOADER_PAIR_PIN_MISMATCH` /
  `OFFLOADER_QUEUE_STATUS_CHANGED`).

## On-disk format unchanged

The persisted shape was already a list serialised from the
dict (`OffloaderRemoteBuildSettings.pairings: list[StoredPairing]`),
so re-keying the in-RAM collection doesn't touch disk. Existing
on-disk pairings load cleanly under the new keying.

## Tests

Every existing test that seeded `_pairings[(host, port)]`
migrates to `_pairings[pin_sha256]`; every event-payload
assertion gains `pin_sha256`; every `unpair(hostname, port)`
call becomes `unpair(pin_sha256)`. 2484 tests pass; the touched
suites (controller / peer-link / event-payload contracts /
e2e) are all green.

## Frontend coordination

Frontend follow-up will:

- Pivot `_buildOffloadPairings` keying from
  `${hostname}:${port}` to `pin_sha256`.
- Update `unpairRemoteBuild` API client to take pin.
- Consume the new `pin_sha256` field on each event payload's
  TypedDict.

Default-`""` defensive deserialisation could keep the frontend
working against a backend running this PR's wire shape, but
the cleaner path is a lockstep frontend PR. Drafted PR
[#529](https://github.com/esphome/device-builder/pull/529)
(offloader-connected indicator) is gated on this PR landing
+ rebasing on top.

**Related issue or feature (if applicable):**

- part of #106 (4a-o part 6).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

(Tagged `breaking-change` because the `unpair` WS arg shape
and several event-payload shapes change. Pre-release, no
installed base; the breaking-change label is for the
release-notes section.)

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD>

Without the frontend mirror, the existing `${hostname}:${port}`
lookups against the new event payloads still work (host/port
stay on the payload), and `unpair` calls fail until the
frontend ships the new arg shape.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
