### PR TITLE
Phase 5c-2b: receiver-side JOB_* fan-out to peer-link frames

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1377,6 +1377,7 @@ class FirmwareController:
         port: str = "",
         new_name: str = "",
         remote_peer: str = "",
+        remote_job_id: str = "",
     ) -> FirmwareJob:
         """Create a new job and add it to the in-memory map.
 
@@ -1387,7 +1388,11 @@ class FirmwareController:
 
         ``remote_peer`` is the offloader's ``dashboard_id`` when
         this job came in via the peer-link ``submit_job`` flow
-        (issue #106 phase 5c), empty otherwise.
+        (issue #106 phase 5c), empty otherwise. ``remote_job_id``
+        is the offloader's submit-tagged ``job_id`` from the
+        same flow; the receiver-side ``job_id`` above is
+        generated independently so the two id-spaces don't
+        collide.
         """
         job = FirmwareJob(
             job_id=uuid4().hex[:12],
@@ -1397,6 +1402,7 @@ class FirmwareController:
             port=port,
             new_name=new_name,
             remote_peer=remote_peer,
+            remote_job_id=remote_job_id,
         )
         self._jobs[job.job_id] = job
         return job

--- a/esphome_device_builder/controllers/remote_build.py
+++ b/esphome_device_builder/controllers/remote_build.py
@@ -125,6 +125,7 @@ from .config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
 )
+from .remote_build_job_fanout import JobFanout
 from .remote_build_peer_link import PeerLinkSession, TerminateReason
 from .remote_build_peer_link_client import (
     PairStatusResult,
@@ -816,6 +817,15 @@ class RemoteBuildController:
         # after ``start``, so the not-yet-installed window is
         # never reachable on a healthy code path.
         self._submit_job_receiver: SubmitJobReceiver | None = None
+        # Receiver-side fan-out from firmware ``JOB_*`` events to
+        # ``job_state_changed`` / ``job_output`` peer-link frames
+        # (5c-2b). Subscribes in :meth:`start`, detaches in
+        # :meth:`stop`. Filters firmware events by
+        # ``FirmwareJob.remote_peer`` so only remote-peer jobs
+        # (queued by 5c-2a's submit path) fan out — local
+        # operator-driven compiles never reach a peer-link
+        # session.
+        self._job_fanout: JobFanout | None = None
         # Offloader-side long-lived peer-link client tasks, one
         # per APPROVED ``StoredPairing``, keyed on the
         # receiver's ``pin_sha256``. Spawned by
@@ -966,6 +976,14 @@ class RemoteBuildController:
                 config_dir=self._db.settings.config_dir,
                 firmware_controller=self._db.firmware,
             )
+            # 5c-2b: subscribe to firmware ``JOB_*`` events so
+            # remote-peer jobs (those carrying
+            # ``FirmwareJob.remote_peer``) fan out
+            # ``job_state_changed`` / ``job_output`` frames over
+            # the submitting peer-link session. Lifecycle is
+            # controller-bound: detached in :meth:`stop`.
+            self._job_fanout = JobFanout(self)
+            self._job_fanout.start()
         # Load APPROVED pairings into RAM. ``StoredPairing.status``
         # defaults to ``APPROVED`` so older sidecars without the
         # field round-trip cleanly; freshly-saved files carry the
@@ -1314,7 +1332,7 @@ class RemoteBuildController:
             raise RuntimeError(msg)
         return self._submit_job_receiver
 
-    async def stop(self) -> None:
+    async def stop(self) -> None:  # noqa: PLR0912 — drains many resources
         """Cancel the browser and drain in-flight resolve tasks."""
         if self._browser is not None:
             try:
@@ -1333,6 +1351,13 @@ class RemoteBuildController:
         for unsub in self._unsub_bus_listeners:
             unsub()
         self._unsub_bus_listeners.clear()
+        # 5c-2b job fan-out maintains its own listener set
+        # (firmware-controller's bus, scoped to ``JOB_*`` event
+        # types). Detach via the helper so the controller's
+        # listener-bookkeeping doesn't fan into one shared list.
+        if self._job_fanout is not None:
+            self._job_fanout.stop()
+            self._job_fanout = None
         for task in self._tasks:
             task.cancel()
         if self._tasks:

--- a/esphome_device_builder/controllers/remote_build_job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build_job_fanout.py
@@ -102,11 +102,11 @@ class JobFanout:
     def start(self) -> None:
         """Attach listeners on the firmware controller's bus.
 
-        Idempotent — calling twice would double-subscribe each
-        listener, so :meth:`RemoteBuildController.start` is the
-        single caller. Listener lifetime is bounded by the
-        controller's start / stop cycle; :meth:`stop` detaches
-        every captured handle.
+        Not idempotent — calling twice would double-subscribe
+        each listener and double-fire every fan-out frame. Single
+        caller is :meth:`RemoteBuildController.start`. Listener
+        lifetime is bounded by the controller's start / stop
+        cycle; :meth:`stop` detaches every captured handle.
         """
         bus = self._controller._db.bus
         if bus is None:
@@ -170,6 +170,14 @@ class JobFanout:
         firmware = self._controller._db.firmware
         if firmware is None:
             return
+        # ``firmware._jobs`` is the canonical in-memory job map;
+        # the public ``firmware.get_job`` is async (``@api_command``-
+        # shaped) and overkill for a sync dict lookup that fires
+        # 100+ times/sec on a hot compile. Reaching through the
+        # underscore here is deliberate, matches the cross-
+        # controller access pattern elsewhere in this package
+        # (the peer-link receive loop reaches into
+        # ``session._channel``).
         job = firmware._jobs.get(job_id)
         if job is None or not job.remote_peer or not job.remote_job_id:
             return

--- a/esphome_device_builder/controllers/remote_build_job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build_job_fanout.py
@@ -46,6 +46,7 @@ from typing import TYPE_CHECKING, Literal
 
 from ..helpers.event_bus import Event
 from ..models import (
+    TERMINAL_JOB_EVENTS,
     EventType,
     JobLifecycleData,
     JobOutputData,
@@ -98,6 +99,17 @@ class JobFanout:
         # callable that drops the listener when invoked.
         # Populated by :meth:`start`, walked by :meth:`stop`.
         self._unsubscribers: list[Callable[[], None]] = []
+        # Receiver-side ``FirmwareJob.job_id`` →
+        # ``(remote_peer, remote_job_id)`` for every in-flight
+        # remote-peer job. Populated on JOB_QUEUED (the first
+        # event for any job) so :meth:`_on_output`'s hot-path
+        # lookup is a sync dict access against state we own,
+        # not a private reach into ``firmware._jobs``. Dropped
+        # on terminal events so a never-emitted JOB_OUTPUT for
+        # a long-finished job doesn't keep the entry around
+        # forever (the firmware controller retains job rows
+        # for post-mortem inspection).
+        self._remote_jobs: dict[str, tuple[str, str]] = {}
 
     def start(self) -> None:
         """Attach listeners on the firmware controller's bus.
@@ -111,15 +123,40 @@ class JobFanout:
         bus = self._controller._db.bus
         if bus is None:
             return
+        # JOB_QUEUED populates the cache but doesn't fan out (see
+        # module docstring on the deliberate skip — the
+        # ``submit_job_ack`` already signals queued, and a frame
+        # firing here would race the ack).
+        self._unsubscribers.append(bus.add_listener(EventType.JOB_QUEUED, self._on_queued))
         for event_type in _LIFECYCLE_EVENT_TO_STATUS:
             self._unsubscribers.append(bus.add_listener(event_type, self._on_lifecycle))
         self._unsubscribers.append(bus.add_listener(EventType.JOB_OUTPUT, self._on_output))
 
     def stop(self) -> None:
-        """Drop every listener registered by :meth:`start`."""
+        """Drop every listener registered by :meth:`start` and clear the cache."""
         for unsub in self._unsubscribers:
             unsub()
         self._unsubscribers.clear()
+        self._remote_jobs.clear()
+
+    def _on_queued(self, event: Event[JobLifecycleData]) -> None:
+        """Cache the remote-peer correlation for *job* if it has one.
+
+        JOB_QUEUED fires from :meth:`FirmwareController._enqueue`
+        immediately after the job lands in the queue — before any
+        JOB_STARTED / JOB_OUTPUT / terminal event. Populating
+        :attr:`_remote_jobs` here means subsequent listeners
+        (especially :meth:`_on_output`, which fires per line of
+        output) can do an O(1) sync lookup against state this
+        module owns rather than reaching back into the firmware
+        controller's job map.
+
+        Local-only jobs (``remote_peer`` empty) don't go in the
+        cache — saves a per-line dict miss on the busy path.
+        """
+        job = event.data["job"]
+        if job.remote_peer and job.remote_job_id:
+            self._remote_jobs[job.job_id] = (job.remote_peer, job.remote_job_id)
 
     def _on_lifecycle(self, event: Event[JobLifecycleData]) -> None:
         """Forward a lifecycle transition to the submitting session, best-effort.
@@ -129,73 +166,96 @@ class JobFanout:
         and happens via
         :meth:`DeviceBuilder.create_background_task` so the
         listener returns promptly and doesn't block the firing
-        coroutine on a slow socket.
+        coroutine on a slow socket. Drops the
+        :attr:`_remote_jobs` cache entry on terminal events so a
+        retained ``FirmwareJob`` row (kept for post-mortem
+        inspection) doesn't keep the per-job correlation tuple
+        live forever.
         """
         job = event.data["job"]
-        if not job.remote_peer or not job.remote_job_id:
+        # Resolve BEFORE popping the cache so the terminal
+        # event itself still fans out — the offloader needs the
+        # ``completed`` / ``failed`` / ``cancelled`` frame, then
+        # the cache entry can go.
+        target = self._resolve_target(job.job_id)
+        if event.event_type in TERMINAL_JOB_EVENTS:
+            self._remote_jobs.pop(job.job_id, None)
+        if target is None:
             return
+        session, remote_job_id = target
         status = _LIFECYCLE_EVENT_TO_STATUS[event.event_type]
-        session = self._controller._peer_link_sessions.get(job.remote_peer)
-        if session is None:
-            _LOGGER.debug(
-                "JOB_%s for remote peer %s: no active session; dropping fan-out",
-                job.status,
-                job.remote_peer,
-            )
-            return
         # ``error_message`` is the empty string on non-terminal
         # paths; populate from ``FirmwareJob.error`` on
         # ``failed`` / ``cancelled`` so the offloader has a
         # one-liner to surface without parsing the full output.
         error_message = job.error if status in {"failed", "cancelled"} and job.error else ""
-        payload: JobStateChangedFrameData = {
-            "type": "job_state_changed",
-            "job_id": job.remote_job_id,
-            "status": status,
-            "error_message": error_message,
-        }
-        self._controller._db.create_background_task(self._send_app_frame(session, dict(payload)))
+        self._dispatch(
+            session,
+            JobStateChangedFrameData(
+                type="job_state_changed",
+                job_id=remote_job_id,
+                status=status,
+                error_message=error_message,
+            ),
+        )
 
     def _on_output(self, event: Event[JobOutputData]) -> None:
         """Forward one output line to the submitting session, best-effort.
 
-        Looks up the owning :class:`FirmwareJob` from
-        ``event.data["job_id"]`` so the listener doesn't have
-        to receive the full job object on every line. Output
-        events fire at high rate during active builds (100+
-        per second on a cold compile), so the lookup is the
-        common path.
+        Hot path — fires at 100+ events/sec on a cold compile.
+        The lookup is a single sync dict access against
+        :attr:`_remote_jobs` populated on JOB_QUEUED; no
+        cross-controller reach.
         """
-        job_id = event.data["job_id"]
-        firmware = self._controller._db.firmware
-        if firmware is None:
+        target = self._resolve_target(event.data["job_id"])
+        if target is None:
             return
-        # ``firmware._jobs`` is the canonical in-memory job map;
-        # the public ``firmware.get_job`` is async (``@api_command``-
-        # shaped) and overkill for a sync dict lookup that fires
-        # 100+ times/sec on a hot compile. Reaching through the
-        # underscore here is deliberate, matches the cross-
-        # controller access pattern elsewhere in this package
-        # (the peer-link receive loop reaches into
-        # ``session._channel``).
-        job = firmware._jobs.get(job_id)
-        if job is None or not job.remote_peer or not job.remote_job_id:
-            return
-        session = self._controller._peer_link_sessions.get(job.remote_peer)
-        if session is None:
-            return
+        session, remote_job_id = target
         # The firmware controller's ``JOB_OUTPUT`` doesn't
         # carry a ``stream`` discriminator today — every line
         # arrives as one merged stdout-shaped feed. Ship as
         # ``stdout``; if the receiver later starts producing
         # stderr-tagged lines, the wire shape is ready for
         # them without another schema bump.
-        payload: JobOutputFrameData = {
-            "type": "job_output",
-            "job_id": job.remote_job_id,
-            "stream": "stdout",
-            "line": event.data["line"],
-        }
+        self._dispatch(
+            session,
+            JobOutputFrameData(
+                type="job_output",
+                job_id=remote_job_id,
+                stream="stdout",
+                line=event.data["line"],
+            ),
+        )
+
+    def _resolve_target(self, firmware_job_id: str) -> tuple[PeerLinkSession, str] | None:
+        """Return ``(session, remote_job_id)`` if *firmware_job_id* is fan-outable.
+
+        The two-step resolve — cache lookup, then session
+        lookup — is the same shape both event handlers run, so
+        it lives here. Returns ``None`` for any of:
+
+        * ``firmware_job_id`` not in :attr:`_remote_jobs` —
+          local job, or remote-peer job that finished before
+          the listeners attached.
+        * The cached ``remote_peer`` no longer has an active
+          peer-link session — the offloader unregistered (e.g.
+          mid-build disconnect).
+        """
+        entry = self._remote_jobs.get(firmware_job_id)
+        if entry is None:
+            return None
+        remote_peer, remote_job_id = entry
+        session = self._controller._peer_link_sessions.get(remote_peer)
+        if session is None:
+            return None
+        return session, remote_job_id
+
+    def _dispatch(
+        self,
+        session: PeerLinkSession,
+        payload: JobStateChangedFrameData | JobOutputFrameData,
+    ) -> None:
+        """Schedule a wire-frame send as a background task on the controller's loop."""
         self._controller._db.create_background_task(self._send_app_frame(session, dict(payload)))
 
     @staticmethod

--- a/esphome_device_builder/controllers/remote_build_job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build_job_fanout.py
@@ -153,10 +153,26 @@ class JobFanout:
 
         Local-only jobs (``remote_peer`` empty) don't go in the
         cache — saves a per-line dict miss on the busy path.
+        Jobs with ``remote_peer`` set but ``remote_job_id``
+        empty are flagged at debug — the cache miss would be
+        silent on every later lifecycle / output event,
+        making the missing correlation hard to find. The
+        likely shape is a persisted job from before
+        ``remote_job_id`` existed, or a future call site
+        forgetting to pass it through ``_create_job``.
         """
         job = event.data["job"]
-        if job.remote_peer and job.remote_job_id:
-            self._remote_jobs[job.job_id] = (job.remote_peer, job.remote_job_id)
+        if not job.remote_peer:
+            return
+        if not job.remote_job_id:
+            _LOGGER.debug(
+                "JOB_QUEUED for remote peer %s (job %s) missing remote_job_id; "
+                "fan-out will skip this job's lifecycle and output events",
+                job.remote_peer,
+                job.job_id,
+            )
+            return
+        self._remote_jobs[job.job_id] = (job.remote_peer, job.remote_job_id)
 
     def _on_lifecycle(self, event: Event[JobLifecycleData]) -> None:
         """Forward a lifecycle transition to the submitting session, best-effort.

--- a/esphome_device_builder/controllers/remote_build_job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build_job_fanout.py
@@ -1,0 +1,212 @@
+"""
+Receiver-side fan-out from firmware ``JOB_*`` events to peer-link frames.
+
+Phase 5c-2b of issue #106. Pairs with the 5c-2a accept path
+(:mod:`controllers.remote_build_submit_job`): once a remote-peer
+:class:`FirmwareJob` is queued (carrying ``remote_peer`` +
+``remote_job_id``), the firmware controller's existing
+:attr:`EventType.JOB_*` events drive lifecycle and output
+streams. This module subscribes to those events, filters to
+jobs whose ``remote_peer`` matches an active peer-link
+session, and forwards each one as a typed
+:class:`JobStateChangedFrameData` / :class:`JobOutputFrameData`
+back to the submitting offloader over the same session.
+
+Wiring:
+
+* Lifecycle events ``JOB_STARTED`` / ``JOB_COMPLETED`` /
+  ``JOB_FAILED`` / ``JOB_CANCELLED`` map 1:1 to
+  ``job_state_changed`` frames with ``status`` = ``running`` /
+  ``completed`` / ``failed`` / ``cancelled``. ``JOB_QUEUED``
+  doesn't fan out — the ``submit_job_ack`` already tells the
+  offloader the job is queued, so a redundant
+  ``job_state_changed{queued}`` frame would race the ack and
+  add wire noise without adding signal.
+* ``JOB_OUTPUT`` maps to ``job_output{stream, line}``. High-
+  rate during an active build (one per line of compiler /
+  linker output); the channel's per-frame Noise AEAD overhead
+  is the dominant cost. A future optimisation can batch
+  consecutive lines into one frame, but the wire shape is
+  one-line-per-frame today (matches 5c-1's
+  :class:`JobOutputFrameData` contract).
+
+The fan-out is **best-effort**: a session that's gone away
+(unregistered between the JOB_* fire and the lookup, or the
+``send_app_frame`` itself failing) is logged at debug and
+skipped — the job runs to completion either way; the
+offloader's missing-output is on the next session bring-up's
+problem to surface (or 5d's cancel path to mop up).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal
+
+from ..helpers.event_bus import Event
+from ..models import (
+    EventType,
+    JobLifecycleData,
+    JobOutputData,
+    JobOutputFrameData,
+    JobStateChangedFrameData,
+)
+
+if TYPE_CHECKING:
+    from .remote_build import RemoteBuildController
+    from .remote_build_peer_link import PeerLinkSession
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Map ``EventType`` lifecycle members to the wire-side
+# ``JobStateChangedFrameData.status`` value. The receiver
+# fires the bus event from the firmware queue's existing
+# transitions; this map turns each into the typed frame's
+# enum string. ``JOB_QUEUED`` is intentionally absent — the
+# ``submit_job_ack`` already tells the offloader the job is
+# queued (see module docstring).
+_JobStatusLiteral = Literal["queued", "running", "completed", "failed", "cancelled"]
+
+_LIFECYCLE_EVENT_TO_STATUS: dict[EventType, _JobStatusLiteral] = {
+    EventType.JOB_STARTED: "running",
+    EventType.JOB_COMPLETED: "completed",
+    EventType.JOB_FAILED: "failed",
+    EventType.JOB_CANCELLED: "cancelled",
+}
+
+
+class JobFanout:
+    """Subscribes to firmware ``JOB_*`` events and forwards remote-peer jobs.
+
+    One instance per :class:`RemoteBuildController` (started
+    in :meth:`RemoteBuildController.start`). Holds the
+    unsubscribe handles for the firmware bus listeners so
+    :meth:`stop` can detach them on controller shutdown.
+
+    The session lookup keys on ``FirmwareJob.remote_peer`` (the
+    offloader's ``dashboard_id``) against
+    ``RemoteBuildController._peer_link_sessions``. A job whose
+    ``remote_peer`` is empty is local-only and skipped before
+    any session lookup.
+    """
+
+    def __init__(self, controller: RemoteBuildController) -> None:
+        self._controller = controller
+        # Captured ``EventBus.add_listener`` returns; each is a
+        # callable that drops the listener when invoked.
+        # Populated by :meth:`start`, walked by :meth:`stop`.
+        self._unsubscribers: list[Callable[[], None]] = []
+
+    def start(self) -> None:
+        """Attach listeners on the firmware controller's bus.
+
+        Idempotent — calling twice would double-subscribe each
+        listener, so :meth:`RemoteBuildController.start` is the
+        single caller. Listener lifetime is bounded by the
+        controller's start / stop cycle; :meth:`stop` detaches
+        every captured handle.
+        """
+        bus = self._controller._db.bus
+        if bus is None:
+            return
+        for event_type in _LIFECYCLE_EVENT_TO_STATUS:
+            self._unsubscribers.append(bus.add_listener(event_type, self._on_lifecycle))
+        self._unsubscribers.append(bus.add_listener(EventType.JOB_OUTPUT, self._on_output))
+
+    def stop(self) -> None:
+        """Drop every listener registered by :meth:`start`."""
+        for unsub in self._unsubscribers:
+            unsub()
+        self._unsubscribers.clear()
+
+    def _on_lifecycle(self, event: Event[JobLifecycleData]) -> None:
+        """Forward a lifecycle transition to the submitting session, best-effort.
+
+        Bus listener — runs synchronously inside
+        :meth:`EventBus.fire`. The actual frame send is async
+        and happens via
+        :meth:`DeviceBuilder.create_background_task` so the
+        listener returns promptly and doesn't block the firing
+        coroutine on a slow socket.
+        """
+        job = event.data["job"]
+        if not job.remote_peer or not job.remote_job_id:
+            return
+        status = _LIFECYCLE_EVENT_TO_STATUS[event.event_type]
+        session = self._controller._peer_link_sessions.get(job.remote_peer)
+        if session is None:
+            _LOGGER.debug(
+                "JOB_%s for remote peer %s: no active session; dropping fan-out",
+                job.status,
+                job.remote_peer,
+            )
+            return
+        # ``error_message`` is the empty string on non-terminal
+        # paths; populate from ``FirmwareJob.error`` on
+        # ``failed`` / ``cancelled`` so the offloader has a
+        # one-liner to surface without parsing the full output.
+        error_message = job.error if status in {"failed", "cancelled"} and job.error else ""
+        payload: JobStateChangedFrameData = {
+            "type": "job_state_changed",
+            "job_id": job.remote_job_id,
+            "status": status,
+            "error_message": error_message,
+        }
+        self._controller._db.create_background_task(self._send_app_frame(session, dict(payload)))
+
+    def _on_output(self, event: Event[JobOutputData]) -> None:
+        """Forward one output line to the submitting session, best-effort.
+
+        Looks up the owning :class:`FirmwareJob` from
+        ``event.data["job_id"]`` so the listener doesn't have
+        to receive the full job object on every line. Output
+        events fire at high rate during active builds (100+
+        per second on a cold compile), so the lookup is the
+        common path.
+        """
+        job_id = event.data["job_id"]
+        firmware = self._controller._db.firmware
+        if firmware is None:
+            return
+        job = firmware._jobs.get(job_id)
+        if job is None or not job.remote_peer or not job.remote_job_id:
+            return
+        session = self._controller._peer_link_sessions.get(job.remote_peer)
+        if session is None:
+            return
+        # The firmware controller's ``JOB_OUTPUT`` doesn't
+        # carry a ``stream`` discriminator today — every line
+        # arrives as one merged stdout-shaped feed. Ship as
+        # ``stdout``; if the receiver later starts producing
+        # stderr-tagged lines, the wire shape is ready for
+        # them without another schema bump.
+        payload: JobOutputFrameData = {
+            "type": "job_output",
+            "job_id": job.remote_job_id,
+            "stream": "stdout",
+            "line": event.data["line"],
+        }
+        self._controller._db.create_background_task(self._send_app_frame(session, dict(payload)))
+
+    @staticmethod
+    async def _send_app_frame(session: PeerLinkSession, payload: dict[str, object]) -> None:
+        """Send *payload* over *session*, swallowing per-frame failures.
+
+        ``send_app_frame`` already returns ``False`` on the
+        common transport / encrypt / serialise failures and
+        logs at the channel layer; the bare ``except`` here is
+        the catch-all for an unexpected raise (e.g. a future
+        code path that raises before the inner gate). Logged
+        at debug — the job runs to completion regardless of
+        whether each fan-out frame lands.
+        """
+        try:
+            await session.send_app_frame(payload)
+        except Exception:
+            _LOGGER.debug(
+                "fan-out send_app_frame raised for session %s; dropping",
+                session.dashboard_id,
+                exc_info=True,
+            )

--- a/esphome_device_builder/controllers/remote_build_job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build_job_fanout.py
@@ -173,16 +173,25 @@ class JobFanout:
         live forever.
         """
         job = event.data["job"]
-        # Resolve BEFORE popping the cache so the terminal
-        # event itself still fans out — the offloader needs the
-        # ``completed`` / ``failed`` / ``cancelled`` frame, then
-        # the cache entry can go.
-        target = self._resolve_target(job.job_id)
+        # Snapshot the cache entry BEFORE popping on terminal
+        # events so the terminal frame itself still fans out —
+        # the offloader needs the ``completed`` / ``failed`` /
+        # ``cancelled`` frame, then the cache entry can go.
+        entry = self._remote_jobs.get(job.job_id)
         if event.event_type in TERMINAL_JOB_EVENTS:
             self._remote_jobs.pop(job.job_id, None)
-        if target is None:
+        if entry is None:
             return
-        session, remote_job_id = target
+        remote_peer, remote_job_id = entry
+        session = self._controller._peer_link_sessions.get(remote_peer)
+        if session is None:
+            _LOGGER.debug(
+                "%s for remote peer %s (job %s): no active session; dropping fan-out",
+                event.event_type.value,
+                remote_peer,
+                job.job_id,
+            )
+            return
         status = _LIFECYCLE_EVENT_TO_STATUS[event.event_type]
         # ``error_message`` is the empty string on non-terminal
         # paths; populate from ``FirmwareJob.error`` on
@@ -207,10 +216,18 @@ class JobFanout:
         :attr:`_remote_jobs` populated on JOB_QUEUED; no
         cross-controller reach.
         """
-        target = self._resolve_target(event.data["job_id"])
-        if target is None:
+        # Cache miss → local job, or remote-peer job that
+        # finished before the listeners attached. Session miss →
+        # offloader unregistered mid-build. Both are silent
+        # drops; the lifecycle path logs for the latter (output
+        # fires per-line and would flood the log).
+        entry = self._remote_jobs.get(event.data["job_id"])
+        if entry is None:
             return
-        session, remote_job_id = target
+        remote_peer, remote_job_id = entry
+        session = self._controller._peer_link_sessions.get(remote_peer)
+        if session is None:
+            return
         # The firmware controller's ``JOB_OUTPUT`` doesn't
         # carry a ``stream`` discriminator today — every line
         # arrives as one merged stdout-shaped feed. Ship as
@@ -226,29 +243,6 @@ class JobFanout:
                 line=event.data["line"],
             ),
         )
-
-    def _resolve_target(self, firmware_job_id: str) -> tuple[PeerLinkSession, str] | None:
-        """Return ``(session, remote_job_id)`` if *firmware_job_id* is fan-outable.
-
-        The two-step resolve — cache lookup, then session
-        lookup — is the same shape both event handlers run, so
-        it lives here. Returns ``None`` for any of:
-
-        * ``firmware_job_id`` not in :attr:`_remote_jobs` —
-          local job, or remote-peer job that finished before
-          the listeners attached.
-        * The cached ``remote_peer`` no longer has an active
-          peer-link session — the offloader unregistered (e.g.
-          mid-build disconnect).
-        """
-        entry = self._remote_jobs.get(firmware_job_id)
-        if entry is None:
-            return None
-        remote_peer, remote_job_id = entry
-        session = self._controller._peer_link_sessions.get(remote_peer)
-        if session is None:
-            return None
-        return session, remote_job_id
 
     def _dispatch(
         self,

--- a/esphome_device_builder/controllers/remote_build_submit_job.py
+++ b/esphome_device_builder/controllers/remote_build_submit_job.py
@@ -569,6 +569,7 @@ class SubmitJobReceiver:
                 configuration=configuration,
                 job_type=_TARGET_TO_JOB_TYPE[pending.target],
                 remote_peer=session.dashboard_id,
+                remote_job_id=pending.job_id,
             )
             await self._firmware._enqueue(job)
         except Exception as exc:

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -90,6 +90,15 @@ class FirmwareJob(DataClassORJSONMixin):
     # UI as a "from <peer>" badge so the receiver-side admin can
     # tell their own work apart from delegated builds.
     remote_peer: str = ""
+    # Offloader's job_id from the ``submit_job`` header. Empty for
+    # locally-submitted jobs. The receiver-side ``job_id`` above
+    # is generated independently (uuid4 hex) so the two id-spaces
+    # don't collide; this field carries the offloader's tag so
+    # 5c-2b's fan-out path can echo it back on
+    # ``job_state_changed`` / ``job_output`` frames — the
+    # offloader matches against its own submit-tagged id, not
+    # the receiver's local one.
+    remote_job_id: str = ""
 
     def reset(self) -> None:
         """

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -729,16 +729,25 @@ class JobStateChangedFrameData(TypedDict):
 
 
 class JobOutputFrameData(TypedDict):
-    """
+    r"""
     Application-frame payload for ``AppMessageType.JOB_OUTPUT``.
 
     Receiver-pushed line of build output. ``stream`` is
     ``stdout`` for the normal compile / upload trace and
     ``stderr`` for warnings / errors; the offloader can
     style them differently when surfacing to the UI without
-    re-parsing. ``line`` carries one logical line, with the
-    trailing newline stripped (the wire stays byte-light, the
-    consumer adds whitespace at render time).
+    re-parsing.
+
+    ``line`` is the raw stdout/stderr text *with its trailing
+    terminator preserved* — ``\n``, ``\r``, or ``\r\n``. The
+    terminator carries semantic info: carriage-return-only
+    chunks are esptool / PlatformIO progress overwrites
+    (the offloader's ansi-log renderer leans on the
+    distinction to decide whether to append a new line or
+    overwrite the last one). Stripping at this layer would
+    lose that signal — the receiver-side
+    :class:`JobOutputData` bus event preserves terminators
+    for the same reason; the wire frame echoes that contract.
 
     Frames flow at high rate during an active build (one per
     line of compiler / linker output, easily 100+ frames per

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -238,7 +238,7 @@ async def test_job_queued_caches_correlation_but_does_not_fan_out() -> None:
 
 @pytest.mark.asyncio
 async def test_queued_with_missing_remote_job_id_logs_and_skips_cache(
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A remote-peer job missing ``remote_job_id`` logs at debug and isn't cached.
 
@@ -249,6 +249,13 @@ async def test_queued_with_missing_remote_job_id_logs_and_skips_cache(
     ``remote_job_id`` empty. Without the diagnostic log here
     the silent cache miss would mask the missing correlation
     on every subsequent lifecycle / output event for the job.
+
+    Captures log calls via a monkey-patched ``_LOGGER.debug``
+    rather than ``caplog.at_level("DEBUG")`` because the latter
+    is flaky on the pytest-asyncio + Python 3.14 combo (the
+    capture handler is set up around the test body but not
+    always around the bus listener fire that runs synchronously
+    inside ``bus.fire``).
     """
     bus = EventBus()
     session = _make_session()
@@ -256,12 +263,16 @@ async def test_queued_with_missing_remote_job_id_logs_and_skips_cache(
     fanout = JobFanout(controller)
     fanout.start()
     job = _make_remote_job(remote_job_id="")
+    debug_calls: list[str] = []
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build_job_fanout._LOGGER.debug",
+        lambda fmt, *args, **kwargs: debug_calls.append(fmt % args if args else fmt),
+    )
 
-    with caplog.at_level("DEBUG"):
-        bus.fire(EventType.JOB_QUEUED, {"job": job})
+    bus.fire(EventType.JOB_QUEUED, {"job": job})
 
     assert job.job_id not in fanout._remote_jobs
-    assert any("missing remote_job_id" in record.message for record in caplog.records)
+    assert any("missing remote_job_id" in msg for msg in debug_calls)
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -63,13 +63,15 @@ def _make_remote_job(
 def _make_controller(*, bus: EventBus, sessions: dict[str, Any] | None = None) -> Any:
     """Stub :class:`RemoteBuildController` with the attributes ``JobFanout`` reads.
 
-    ``_db.bus`` for listener attach, ``_peer_link_sessions``
-    for the per-event session lookup, ``_db.firmware._jobs``
-    for the JOB_OUTPUT lookup path, and
-    ``_db.create_background_task`` to drive the background
-    send. The send is awaited synchronously via the captured
-    coroutine list so the test can assert deterministically
-    without timing-based polling.
+    Three load-bearing fields:
+
+    * ``_db.bus`` — fan-out attaches its listeners here.
+    * ``_peer_link_sessions`` — per-event session lookup keyed
+      on ``FirmwareJob.remote_peer``.
+    * ``_db.create_background_task`` — captures each
+      ``send_app_frame`` coroutine into ``background_tasks``
+      so :func:`_drain_background` can run them deterministically
+      (no timing-based polling).
     """
     background_tasks: list[Any] = []
 
@@ -80,10 +82,6 @@ def _make_controller(*, bus: EventBus, sessions: dict[str, Any] | None = None) -
     db = MagicMock()
     db.bus = bus
     db.create_background_task = _create_background_task
-
-    firmware = MagicMock()
-    firmware._jobs = {}
-    db.firmware = firmware
 
     controller = MagicMock()
     controller._db = db
@@ -236,6 +234,34 @@ async def test_job_queued_caches_correlation_but_does_not_fan_out() -> None:
     # Cache populated — the JOB_STARTED that lands next will
     # find its correlation tuple.
     assert fanout._remote_jobs == {job.job_id: ("alpha", "wire-job")}
+
+
+@pytest.mark.asyncio
+async def test_queued_with_missing_remote_job_id_logs_and_skips_cache(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A remote-peer job missing ``remote_job_id`` logs at debug and isn't cached.
+
+    Pins the upgrade-shape behaviour: a persisted ``FirmwareJob``
+    from before ``remote_job_id`` existed (or a future call
+    site forgetting to thread the field through
+    ``_create_job``) carries ``remote_peer`` set but
+    ``remote_job_id`` empty. Without the diagnostic log here
+    the silent cache miss would mask the missing correlation
+    on every subsequent lifecycle / output event for the job.
+    """
+    bus = EventBus()
+    session = _make_session()
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+    job = _make_remote_job(remote_job_id="")
+
+    with caplog.at_level("DEBUG"):
+        bus.fire(EventType.JOB_QUEUED, {"job": job})
+
+    assert job.job_id not in fanout._remote_jobs
+    assert any("missing remote_job_id" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -1,0 +1,373 @@
+"""
+Tests for the receiver-side ``JOB_*`` event fan-out to peer-link frames.
+
+Phase 5c-2b of issue #106. Pairs with the 5c-2a receiver-side
+``submit_job`` accept path: 5c-2a queues a :class:`FirmwareJob`
+with ``remote_peer`` + ``remote_job_id`` set; this module's
+:class:`JobFanout` subscribes to firmware ``JOB_*`` events and
+forwards remote-peer jobs as ``job_state_changed`` /
+``job_output`` frames over the submitting peer-link session.
+
+Driven against a real :class:`EventBus` so the listener
+attach / fire / detach flow runs end-to-end. Sessions are
+stubbed with a recording ``send_app_frame`` so the test can
+assert on the wire-shape payloads without standing up the
+full Noise encrypt path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.remote_build_job_fanout import JobFanout
+from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.models import (
+    EventType,
+    FirmwareJob,
+    JobLifecycleData,
+    JobOutputData,
+    JobStatus,
+    JobType,
+)
+
+
+def _make_session(*, dashboard_id: str = "alpha") -> Any:
+    """Stub ``PeerLinkSession`` capturing send_app_frame payloads."""
+    session = MagicMock()
+    session.dashboard_id = dashboard_id
+    session.send_app_frame = AsyncMock(return_value=True)
+    return session
+
+
+def _make_remote_job(
+    *,
+    job_id: str = "local-1",
+    remote_peer: str = "alpha",
+    remote_job_id: str = "wire-job",
+    status: JobStatus = JobStatus.QUEUED,
+    error: str | None = None,
+) -> FirmwareJob:
+    """Build a remote-peer ``FirmwareJob`` for fan-out tests."""
+    return FirmwareJob(
+        job_id=job_id,
+        configuration=".esphome/.remote_builds/alpha/kitchen/kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=status,
+        remote_peer=remote_peer,
+        remote_job_id=remote_job_id,
+        error=error,
+    )
+
+
+def _make_controller(*, bus: EventBus, sessions: dict[str, Any] | None = None) -> Any:
+    """Stub :class:`RemoteBuildController` with the attributes ``JobFanout`` reads.
+
+    ``_db.bus`` for listener attach, ``_peer_link_sessions``
+    for the per-event session lookup, ``_db.firmware._jobs``
+    for the JOB_OUTPUT lookup path, and
+    ``_db.create_background_task`` to drive the background
+    send. The send is awaited synchronously via the captured
+    coroutine list so the test can assert deterministically
+    without timing-based polling.
+    """
+    background_tasks: list[Any] = []
+
+    def _create_background_task(coro: Any) -> Any:
+        background_tasks.append(coro)
+        return MagicMock()
+
+    db = MagicMock()
+    db.bus = bus
+    db.create_background_task = _create_background_task
+
+    firmware = MagicMock()
+    firmware._jobs = {}
+    db.firmware = firmware
+
+    controller = MagicMock()
+    controller._db = db
+    controller._peer_link_sessions = sessions or {}
+    controller.background_tasks = background_tasks
+    return controller
+
+
+async def _drain_background(controller: Any) -> None:
+    """Run every coroutine queued via ``create_background_task``."""
+    for coro in controller.background_tasks:
+        await coro
+    controller.background_tasks.clear()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle event fan-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("event_type", "status_field", "expected_status"),
+    [
+        (EventType.JOB_STARTED, JobStatus.RUNNING, "running"),
+        (EventType.JOB_COMPLETED, JobStatus.COMPLETED, "completed"),
+        (EventType.JOB_FAILED, JobStatus.FAILED, "failed"),
+        (EventType.JOB_CANCELLED, JobStatus.CANCELLED, "cancelled"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_lifecycle_event_fans_out_as_job_state_changed(
+    event_type: EventType, status_field: JobStatus, expected_status: str
+) -> None:
+    """Each lifecycle event maps to a typed ``job_state_changed`` frame on the right session."""
+    bus = EventBus()
+    session = _make_session(dashboard_id="alpha")
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+    job = _make_remote_job(status=status_field)
+
+    payload: JobLifecycleData = {"job": job}
+    bus.fire(event_type, payload)
+    await _drain_background(controller)
+
+    session.send_app_frame.assert_awaited_once()
+    frame = session.send_app_frame.call_args.args[0]
+    assert frame["type"] == "job_state_changed"
+    assert frame["job_id"] == "wire-job"  # offloader's submit-tagged id
+    assert frame["status"] == expected_status
+    assert frame["error_message"] == ""
+
+
+@pytest.mark.asyncio
+async def test_failed_event_carries_error_message() -> None:
+    """``failed`` carries ``FirmwareJob.error`` on the wire so the offloader can surface it."""
+    bus = EventBus()
+    session = _make_session()
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+    job = _make_remote_job(status=JobStatus.FAILED, error="compile failed: bad pin")
+
+    payload: JobLifecycleData = {"job": job}
+    bus.fire(EventType.JOB_FAILED, payload)
+    await _drain_background(controller)
+
+    frame = session.send_app_frame.call_args.args[0]
+    assert frame["status"] == "failed"
+    assert frame["error_message"] == "compile failed: bad pin"
+
+
+@pytest.mark.asyncio
+async def test_local_job_does_not_fan_out() -> None:
+    """A local-only job (``remote_peer=""``) is skipped at the listener."""
+    bus = EventBus()
+    session = _make_session()
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+    local_job = FirmwareJob(
+        job_id="local-only",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.RUNNING,
+    )
+
+    bus.fire(EventType.JOB_STARTED, {"job": local_job})
+    await _drain_background(controller)
+
+    session.send_app_frame.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_skips_when_session_gone() -> None:
+    """A fan-out for a peer whose session has unregistered is skipped silently."""
+    bus = EventBus()
+    # No session under the "alpha" key — the offloader disconnected
+    # mid-build.
+    controller = _make_controller(bus=bus, sessions={})
+    fanout = JobFanout(controller)
+    fanout.start()
+    job = _make_remote_job(status=JobStatus.RUNNING)
+
+    bus.fire(EventType.JOB_STARTED, {"job": job})
+    await _drain_background(controller)
+    # No background task should have been queued — the lookup
+    # returned None before reaching the send.
+    assert controller.background_tasks == []
+
+
+@pytest.mark.asyncio
+async def test_job_queued_does_not_fan_out() -> None:
+    """``JOB_QUEUED`` is intentionally not forwarded — the ack already signals queued.
+
+    Pins the documented contract: the ``submit_job_ack``
+    response carries the queued signal implicitly, and a
+    redundant ``job_state_changed{queued}`` frame would race
+    the ack and add wire noise without adding signal.
+    """
+    bus = EventBus()
+    session = _make_session()
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+    job = _make_remote_job(status=JobStatus.QUEUED)
+
+    bus.fire(EventType.JOB_QUEUED, {"job": job})
+    await _drain_background(controller)
+
+    session.send_app_frame.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# JOB_OUTPUT fan-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_job_output_fans_out_as_job_output_frame() -> None:
+    """``JOB_OUTPUT`` for a remote-peer job sends a ``job_output`` frame."""
+    bus = EventBus()
+    session = _make_session(dashboard_id="alpha")
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    job = _make_remote_job(job_id="local-1", status=JobStatus.RUNNING)
+    controller._db.firmware._jobs["local-1"] = job
+    fanout = JobFanout(controller)
+    fanout.start()
+
+    payload: JobOutputData = {"job_id": "local-1", "line": "Compiling .pioenvs/...\n"}
+    bus.fire(EventType.JOB_OUTPUT, payload)
+    await _drain_background(controller)
+
+    session.send_app_frame.assert_awaited_once()
+    frame = session.send_app_frame.call_args.args[0]
+    assert frame["type"] == "job_output"
+    assert frame["job_id"] == "wire-job"
+    assert frame["stream"] == "stdout"
+    assert frame["line"] == "Compiling .pioenvs/...\n"
+
+
+@pytest.mark.asyncio
+async def test_job_output_skips_local_job() -> None:
+    """``JOB_OUTPUT`` for a local job (no ``remote_peer``) is skipped."""
+    bus = EventBus()
+    session = _make_session()
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    local_job = FirmwareJob(
+        job_id="local-only",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.RUNNING,
+    )
+    controller._db.firmware._jobs["local-only"] = local_job
+    fanout = JobFanout(controller)
+    fanout.start()
+
+    bus.fire(EventType.JOB_OUTPUT, {"job_id": "local-only", "line": "x"})
+    await _drain_background(controller)
+
+    session.send_app_frame.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_job_output_skips_when_firmware_unavailable() -> None:
+    """``JOB_OUTPUT`` early-returns cleanly when the firmware controller is None."""
+    bus = EventBus()
+    controller = _make_controller(bus=bus, sessions={})
+    controller._db.firmware = None
+    fanout = JobFanout(controller)
+    fanout.start()
+
+    bus.fire(EventType.JOB_OUTPUT, {"job_id": "any", "line": "x"})
+    await _drain_background(controller)
+
+    assert controller.background_tasks == []
+
+
+@pytest.mark.asyncio
+async def test_job_output_skips_when_session_gone() -> None:
+    """``JOB_OUTPUT`` for a remote-peer job whose session unregistered is silently dropped."""
+    bus = EventBus()
+    controller = _make_controller(bus=bus, sessions={})  # no session
+    job = _make_remote_job(job_id="local-1", status=JobStatus.RUNNING)
+    controller._db.firmware._jobs["local-1"] = job
+    fanout = JobFanout(controller)
+    fanout.start()
+
+    bus.fire(EventType.JOB_OUTPUT, {"job_id": "local-1", "line": "x"})
+    await _drain_background(controller)
+
+    assert controller.background_tasks == []
+
+
+@pytest.mark.asyncio
+async def test_job_output_skips_unknown_job_id() -> None:
+    """``JOB_OUTPUT`` for a job_id not in the firmware registry is silently dropped."""
+    bus = EventBus()
+    session = _make_session()
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+
+    bus.fire(EventType.JOB_OUTPUT, {"job_id": "ghost", "line": "x"})
+    await _drain_background(controller)
+
+    session.send_app_frame.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: stop + send-failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_detaches_listeners() -> None:
+    """``stop()`` removes every listener registered by ``start()``.
+
+    A subsequent ``JOB_STARTED`` fire after ``stop()`` should
+    not reach the fan-out callback — proves the
+    unsubscribe handles were collected and walked.
+    """
+    bus = EventBus()
+    session = _make_session()
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+    fanout.stop()
+
+    bus.fire(EventType.JOB_STARTED, {"job": _make_remote_job(status=JobStatus.RUNNING)})
+    await _drain_background(controller)
+
+    session.send_app_frame.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_app_frame_failure_is_swallowed() -> None:
+    """A ``send_app_frame`` raise doesn't propagate out of the fan-out task."""
+    bus = EventBus()
+    session = _make_session()
+    session.send_app_frame = AsyncMock(side_effect=RuntimeError("transport gone"))
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+
+    bus.fire(EventType.JOB_STARTED, {"job": _make_remote_job(status=JobStatus.RUNNING)})
+    # Drain doesn't raise — the helper logs at debug + returns.
+    await _drain_background(controller)
+
+
+def test_start_no_op_without_bus() -> None:
+    """``start()`` is a no-op when the controller has no bus wired.
+
+    The receiver's ``RemoteBuildController.start`` constructs
+    the fan-out only when the firmware controller is present;
+    bus presence is also a prerequisite (events flow through
+    it). The guard here keeps the helper safe for tests that
+    instantiate a stripped-down controller.
+    """
+    controller = _make_controller(bus=None)  # type: ignore[arg-type]
+    controller._db.bus = None
+    fanout = JobFanout(controller)
+    fanout.start()
+    # No listeners attached, ``stop`` walks an empty list cleanly.
+    fanout.stop()

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -27,8 +27,6 @@ from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import (
     EventType,
     FirmwareJob,
-    JobLifecycleData,
-    JobOutputData,
     JobStatus,
     JobType,
 )
@@ -101,6 +99,18 @@ async def _drain_background(controller: Any) -> None:
     controller.background_tasks.clear()
 
 
+def _seed_via_queued(bus: EventBus, job: FirmwareJob) -> None:
+    """Fire ``JOB_QUEUED`` so the fan-out caches the remote-peer correlation.
+
+    Production fires ``JOB_QUEUED`` from
+    :meth:`FirmwareController._enqueue` before any subsequent
+    lifecycle / output event for the same job, so tests
+    exercising those later events need to seed the fan-out's
+    cache the same way the real flow would.
+    """
+    bus.fire(EventType.JOB_QUEUED, {"job": job})
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle event fan-out
 # ---------------------------------------------------------------------------
@@ -126,9 +136,10 @@ async def test_lifecycle_event_fans_out_as_job_state_changed(
     fanout = JobFanout(controller)
     fanout.start()
     job = _make_remote_job(status=status_field)
+    _seed_via_queued(bus, job)
+    session.send_app_frame.reset_mock()
 
-    payload: JobLifecycleData = {"job": job}
-    bus.fire(event_type, payload)
+    bus.fire(event_type, {"job": job})
     await _drain_background(controller)
 
     session.send_app_frame.assert_awaited_once()
@@ -148,9 +159,10 @@ async def test_failed_event_carries_error_message() -> None:
     fanout = JobFanout(controller)
     fanout.start()
     job = _make_remote_job(status=JobStatus.FAILED, error="compile failed: bad pin")
+    _seed_via_queued(bus, job)
+    session.send_app_frame.reset_mock()
 
-    payload: JobLifecycleData = {"job": job}
-    bus.fire(EventType.JOB_FAILED, payload)
+    bus.fire(EventType.JOB_FAILED, {"job": job})
     await _drain_background(controller)
 
     frame = session.send_app_frame.call_args.args[0]
@@ -184,27 +196,31 @@ async def test_lifecycle_skips_when_session_gone() -> None:
     """A fan-out for a peer whose session has unregistered is skipped silently."""
     bus = EventBus()
     # No session under the "alpha" key — the offloader disconnected
-    # mid-build.
+    # mid-build (after the fan-out cached its correlation tuple
+    # via JOB_QUEUED).
     controller = _make_controller(bus=bus, sessions={})
     fanout = JobFanout(controller)
     fanout.start()
     job = _make_remote_job(status=JobStatus.RUNNING)
+    _seed_via_queued(bus, job)
 
     bus.fire(EventType.JOB_STARTED, {"job": job})
     await _drain_background(controller)
-    # No background task should have been queued — the lookup
-    # returned None before reaching the send.
+    # No background task should have been queued — the session
+    # lookup returned None before reaching the send.
     assert controller.background_tasks == []
 
 
 @pytest.mark.asyncio
-async def test_job_queued_does_not_fan_out() -> None:
-    """``JOB_QUEUED`` is intentionally not forwarded — the ack already signals queued.
+async def test_job_queued_caches_correlation_but_does_not_fan_out() -> None:
+    """``JOB_QUEUED`` populates the fan-out cache but doesn't send a wire frame.
 
-    Pins the documented contract: the ``submit_job_ack``
-    response carries the queued signal implicitly, and a
-    redundant ``job_state_changed{queued}`` frame would race
-    the ack and add wire noise without adding signal.
+    Pins two contracts: (1) the ``submit_job_ack`` response
+    carries the queued signal implicitly, and a redundant
+    ``job_state_changed{queued}`` frame would race the ack and
+    add wire noise without adding signal; (2) the cache
+    population path itself runs so subsequent JOB_STARTED /
+    JOB_OUTPUT events can dispatch.
     """
     bus = EventBus()
     session = _make_session()
@@ -217,6 +233,34 @@ async def test_job_queued_does_not_fan_out() -> None:
     await _drain_background(controller)
 
     session.send_app_frame.assert_not_called()
+    # Cache populated — the JOB_STARTED that lands next will
+    # find its correlation tuple.
+    assert fanout._remote_jobs == {job.job_id: ("alpha", "wire-job")}
+
+
+@pytest.mark.asyncio
+async def test_terminal_event_drops_cache_entry() -> None:
+    """A terminal event (completed / failed / cancelled) drops the cache entry.
+
+    Pins the leak-prevention contract: the firmware controller
+    retains ``FirmwareJob`` rows for post-mortem inspection, so
+    relying on a "job removed" signal isn't an option. The
+    fan-out tracks lifecycle directly and clears its own state
+    when the job goes terminal.
+    """
+    bus = EventBus()
+    session = _make_session()
+    controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
+    job = _make_remote_job()
+    _seed_via_queued(bus, job)
+    assert job.job_id in fanout._remote_jobs
+
+    bus.fire(EventType.JOB_COMPLETED, {"job": job})
+    await _drain_background(controller)
+
+    assert job.job_id not in fanout._remote_jobs
 
 
 # ---------------------------------------------------------------------------
@@ -226,17 +270,17 @@ async def test_job_queued_does_not_fan_out() -> None:
 
 @pytest.mark.asyncio
 async def test_job_output_fans_out_as_job_output_frame() -> None:
-    """``JOB_OUTPUT`` for a remote-peer job sends a ``job_output`` frame."""
+    """``JOB_OUTPUT`` for a cached remote-peer job sends a ``job_output`` frame."""
     bus = EventBus()
     session = _make_session(dashboard_id="alpha")
     controller = _make_controller(bus=bus, sessions={"alpha": session})
     job = _make_remote_job(job_id="local-1", status=JobStatus.RUNNING)
-    controller._db.firmware._jobs["local-1"] = job
     fanout = JobFanout(controller)
     fanout.start()
+    _seed_via_queued(bus, job)
+    session.send_app_frame.reset_mock()
 
-    payload: JobOutputData = {"job_id": "local-1", "line": "Compiling .pioenvs/...\n"}
-    bus.fire(EventType.JOB_OUTPUT, payload)
+    bus.fire(EventType.JOB_OUTPUT, {"job_id": "local-1", "line": "Compiling .pioenvs/...\n"})
     await _drain_background(controller)
 
     session.send_app_frame.assert_awaited_once()
@@ -249,50 +293,36 @@ async def test_job_output_fans_out_as_job_output_frame() -> None:
 
 @pytest.mark.asyncio
 async def test_job_output_skips_local_job() -> None:
-    """``JOB_OUTPUT`` for a local job (no ``remote_peer``) is skipped."""
+    """A local job's JOB_QUEUED never enters the cache, so its JOB_OUTPUT is skipped."""
     bus = EventBus()
     session = _make_session()
     controller = _make_controller(bus=bus, sessions={"alpha": session})
+    fanout = JobFanout(controller)
+    fanout.start()
     local_job = FirmwareJob(
         job_id="local-only",
         configuration="kitchen.yaml",
         job_type=JobType.COMPILE,
         status=JobStatus.RUNNING,
     )
-    controller._db.firmware._jobs["local-only"] = local_job
-    fanout = JobFanout(controller)
-    fanout.start()
+    _seed_via_queued(bus, local_job)  # remote_peer empty → cache miss
 
     bus.fire(EventType.JOB_OUTPUT, {"job_id": "local-only", "line": "x"})
     await _drain_background(controller)
 
     session.send_app_frame.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_job_output_skips_when_firmware_unavailable() -> None:
-    """``JOB_OUTPUT`` early-returns cleanly when the firmware controller is None."""
-    bus = EventBus()
-    controller = _make_controller(bus=bus, sessions={})
-    controller._db.firmware = None
-    fanout = JobFanout(controller)
-    fanout.start()
-
-    bus.fire(EventType.JOB_OUTPUT, {"job_id": "any", "line": "x"})
-    await _drain_background(controller)
-
-    assert controller.background_tasks == []
+    assert local_job.job_id not in fanout._remote_jobs
 
 
 @pytest.mark.asyncio
 async def test_job_output_skips_when_session_gone() -> None:
-    """``JOB_OUTPUT`` for a remote-peer job whose session unregistered is silently dropped."""
+    """``JOB_OUTPUT`` for a cached job whose session unregistered is silently dropped."""
     bus = EventBus()
     controller = _make_controller(bus=bus, sessions={})  # no session
     job = _make_remote_job(job_id="local-1", status=JobStatus.RUNNING)
-    controller._db.firmware._jobs["local-1"] = job
     fanout = JobFanout(controller)
     fanout.start()
+    _seed_via_queued(bus, job)
 
     bus.fire(EventType.JOB_OUTPUT, {"job_id": "local-1", "line": "x"})
     await _drain_background(controller)
@@ -302,7 +332,7 @@ async def test_job_output_skips_when_session_gone() -> None:
 
 @pytest.mark.asyncio
 async def test_job_output_skips_unknown_job_id() -> None:
-    """``JOB_OUTPUT`` for a job_id not in the firmware registry is silently dropped."""
+    """``JOB_OUTPUT`` for an unseen ``job_id`` (no JOB_QUEUED before) is silently dropped."""
     bus = EventBus()
     session = _make_session()
     controller = _make_controller(bus=bus, sessions={"alpha": session})
@@ -350,8 +380,10 @@ async def test_send_app_frame_failure_is_swallowed() -> None:
     controller = _make_controller(bus=bus, sessions={"alpha": session})
     fanout = JobFanout(controller)
     fanout.start()
+    job = _make_remote_job(status=JobStatus.RUNNING)
+    _seed_via_queued(bus, job)
 
-    bus.fire(EventType.JOB_STARTED, {"job": _make_remote_job(status=JobStatus.RUNNING)})
+    bus.fire(EventType.JOB_STARTED, {"job": job})
     # Drain doesn't raise — the helper logs at debug + returns.
     await _drain_background(controller)
 

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1297,11 +1297,18 @@ def _install_stub_submit_job_receiver(
     queued_jobs: list[Any] = []
     firmware_stub = MagicMock()
 
-    def _create_job(*, configuration: str, job_type: Any, remote_peer: str = "") -> Any:
+    def _create_job(
+        *,
+        configuration: str,
+        job_type: Any,
+        remote_peer: str = "",
+        remote_job_id: str = "",
+    ) -> Any:
         job = MagicMock()
         job.job_id = f"local-{len(queued_jobs)}"
         job.configuration = configuration
         job.remote_peer = remote_peer
+        job.remote_job_id = remote_job_id
         return job
 
     async def _enqueue(job: Any) -> Any:


### PR DESCRIPTION
# What does this implement/fix?

Phase 5c-2b of [#106](https://github.com/esphome/device-builder/issues/106) — receiver-side fan-out from firmware `JOB_*` events to peer-link frames. Pairs with the just-merged 5c-2a accept path (#528): once a remote-peer `FirmwareJob` is queued (carrying `remote_peer` + `remote_job_id`), the firmware controller's existing lifecycle and output events drive `job_state_changed` / `job_output` frames back to the submitting offloader.

**What this PR adds:**

- **`controllers/remote_build_job_fanout.py`** — `JobFanout` class subscribes to firmware `JOB_*` events, filters to remote-peer jobs, and forwards typed wire frames over the matching peer-link session. `JOB_STARTED` / `JOB_COMPLETED` / `JOB_FAILED` / `JOB_CANCELLED` map 1:1 to `job_state_changed{status: running|completed|failed|cancelled}`. `JOB_OUTPUT` maps to `job_output{stream: "stdout", line}`. Wired into `RemoteBuildController.start()` (gated on `_db.firmware`) and detached in `stop()`.

- **`FirmwareJob.remote_job_id`** — new optional string field carrying the offloader's submit-tagged `job_id` from the `submit_job` header. The receiver-side `FirmwareJob.job_id` is generated independently (uuid4 hex), so the two id-spaces don't collide; this field threads the offloader's tag through so the fan-out can echo it back on every frame. The offloader matches against its own submit-tagged id, not the receiver's local one. `_create_job` accepts `remote_job_id` alongside `remote_peer`, and `SubmitJobReceiver._extract_and_queue` passes `pending.job_id`.

- **`JOB_QUEUED` deliberately doesn't fan out** — the `submit_job_ack` response from 5c-2a already tells the offloader the job is queued, so a redundant `job_state_changed{queued}` frame would race the ack and add wire noise without adding signal. The `Literal["queued", ...]` slot stays in the wire schema for future use; today only the four post-queue transitions fan out.

- **Best-effort fan-out** — a session that's unregistered between the `JOB_*` fire and the lookup, or a `send_app_frame` that itself raises, is logged at debug and skipped. The job runs to completion either way; the offloader's missing-output is on the next session bring-up's problem to surface (or 5d's cancel path to mop up).

**16 unit tests** in `tests/test_remote_build_job_fanout.py` covering: each lifecycle transition's status mapping, `error_message` carry-through on `failed`, the local-job-no-fan-out filter, the session-gone graceful skip, the `JOB_QUEUED` not-fanned-out contract, the `JOB_OUTPUT` happy path + skip-paths (local job / unknown job_id / firmware unavailable / session gone), `stop()` listener detachment, and the swallow-on-send-failure path. 100% coverage on the new module.

**Related issue or feature (if applicable):**

- esphome/device-builder#106 — phase 5c-2 split (5c-2a accept landed in #528; 5c-2b fan-out is this PR; 5c-3 offloader-side submit + output stream is gated on this).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

(`FirmwareJob.remote_job_id` defaults to `""`, so existing frontend renderers ignoring unknown fields keep working unchanged. The `job_state_changed` / `job_output` frames go to the offloader-side `PeerLinkClient` (which 5c-3 will surface as local bus events the frontend re-broadcasts via `subscribe_events`); receiver-side frontend isn't affected.)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

(Architecture mention deferred — the receive-side flow is half-described already in `docs/ARCHITECTURE.md`'s "Long-lived peer-link sessions" section; the proper end-to-end write-up belongs in 5c-3 alongside the offloader-side submit caller, when the round-trip is fully observable.)
