### PR TITLE
Refactor: move remote_build into a controllers/remote_build/ package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,7 +573,7 @@ When changing the sync script or catalog handling, watch for these:
 | Path | What |
 |---|---|
 | `esphome_device_builder/device_builder.py` | Singleton owning controllers + event bus |
-| `esphome_device_builder/controllers/*.py` | One file per API surface (devices, firmware, components, boards, ...) |
+| `esphome_device_builder/controllers/*.py` | One file per API surface (components, boards, labels, ...). Larger surfaces (devices, firmware, remote_build) are packages — same shape, with a `controller.py` for the main class plus per-concern submodules and an `__init__.py` re-exporting the controller. |
 | `esphome_device_builder/models/*.py` | Data classes (mashumaro) — pure shape, no logic |
 | `esphome_device_builder/api/ws.py` | WebSocket dispatch |
 | `esphome_device_builder/definitions/components.json` | Generated; do not hand-edit |

--- a/esphome_device_builder/controllers/remote_build/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/__init__.py
@@ -1,0 +1,37 @@
+"""
+Remote-build feature controller package — public surface.
+
+Re-exports :class:`RemoteBuildController` so existing
+``from .controllers.remote_build import RemoteBuildController``
+imports keep resolving after the package split. Submodules:
+
+- ``controller`` — :class:`RemoteBuildController` itself: pair
+  flow, peer-link session registry, queue_status fan-out wiring,
+  offloader-side alerts, mDNS host discovery, all WS commands
+  under the ``remote_build/`` namespace.
+- ``peer_link`` — receiver-side Noise XX handler
+  (:func:`make_peer_link_handler`, :class:`PeerLinkSession`,
+  :class:`PeerLinkChannel`, the receive loop, heartbeat).
+- ``peer_link_client`` — offloader-side initiator
+  (:class:`PeerLinkClient`, :func:`drive_initiator_round_trip`,
+  :func:`preview_pair` / :func:`request_pair` /
+  :func:`await_pair_status`).
+- ``submit_job`` — receiver-side ``submit_job`` accept path
+  (5c-2a): :class:`SubmitJobReceiver`, bundle assembly →
+  ``prepare_bundle_for_compile`` → ``FirmwareJob`` queue.
+- ``job_fanout`` — receiver-side fan-out (5c-2b) of firmware
+  ``JOB_*`` events to ``job_state_changed`` / ``job_output``
+  peer-link frames.
+
+External callers reaching into specific submodules use the
+submodule path directly (e.g.
+``from .controllers.remote_build.peer_link import PEER_LINK_PATH``);
+this ``__init__`` only re-exports the controller class to
+match the :mod:`controllers.firmware` shape.
+"""
+
+from __future__ import annotations
+
+from .controller import RemoteBuildController
+
+__all__ = ["RemoteBuildController"]

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -71,21 +71,21 @@ from yarl import URL
 from zeroconf import IPVersion, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
-from ..constants import __version__ as server_version
-from ..helpers.api import CommandError, api_command
-from ..helpers.dashboard_advertise import SERVICE_TYPE
-from ..helpers.dashboard_identity import (
+from ...constants import __version__ as server_version
+from ...helpers.api import CommandError, api_command
+from ...helpers.dashboard_advertise import SERVICE_TYPE
+from ...helpers.dashboard_identity import (
     DASHBOARD_ID_MAX_CHARS,
     DASHBOARD_ID_PATTERN,
     get_or_create_identity,
     rotate_certificate,
 )
-from ..helpers.event_bus import Event
-from ..helpers.json import dumps as json_dumps
-from ..helpers.json import loads as json_loads
-from ..helpers.peer_link_identity import get_or_create_peer_link_identity
-from ..helpers.storage import ShutdownCallback, Store
-from ..models import (
+from ...helpers.event_bus import Event
+from ...helpers.json import dumps as json_dumps
+from ...helpers.json import loads as json_loads
+from ...helpers.peer_link_identity import get_or_create_peer_link_identity
+from ...helpers.storage import ShutdownCallback, Store
+from ...models import (
     TERMINAL_JOB_EVENTS,
     ErrorCode,
     EventType,
@@ -123,32 +123,32 @@ from ..models import (
     StoredPairing,
     StoredPeer,
 )
-from .config import (
+from ..config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
 )
-from .remote_build_job_fanout import JobFanout
-from .remote_build_peer_link import PeerLinkSession, TerminateReason
-from .remote_build_peer_link_client import (
+from .job_fanout import JobFanout
+from .peer_link import PeerLinkSession, TerminateReason
+from .peer_link_client import (
     PairStatusResult,
     PeerLinkClient,
     PeerLinkClientError,
 )
-from .remote_build_peer_link_client import (
+from .peer_link_client import (
     await_pair_status as peer_link_await_pair_status,
 )
-from .remote_build_peer_link_client import (
+from .peer_link_client import (
     preview_pair as peer_link_preview_pair,
 )
-from .remote_build_peer_link_client import (
+from .peer_link_client import (
     request_pair as peer_link_request_pair,
 )
-from .remote_build_submit_job import SubmitJobReceiver
+from .submit_job import SubmitJobReceiver
 
 if TYPE_CHECKING:
-    from ..device_builder import DeviceBuilder
-    from ..helpers.dashboard_identity import DashboardIdentity
-    from ..helpers.peer_link_identity import PeerLinkIdentity
+    from ...device_builder import DeviceBuilder
+    from ...helpers.dashboard_identity import DashboardIdentity
+    from ...helpers.peer_link_identity import PeerLinkIdentity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome_device_builder/controllers/remote_build/job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build/job_fanout.py
@@ -44,8 +44,8 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
-from ..helpers.event_bus import Event
-from ..models import (
+from ...helpers.event_bus import Event
+from ...models import (
     TERMINAL_JOB_EVENTS,
     EventType,
     JobLifecycleData,
@@ -55,8 +55,8 @@ from ..models import (
 )
 
 if TYPE_CHECKING:
-    from .remote_build import RemoteBuildController
-    from .remote_build_peer_link import PeerLinkSession
+    from .controller import RemoteBuildController
+    from .peer_link import PeerLinkSession
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome_device_builder/controllers/remote_build/peer_link.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link.py
@@ -65,16 +65,16 @@ from typing import TYPE_CHECKING, Any, cast
 import aiohttp
 from aiohttp import WSMsgType, web
 
-from ..helpers import json as _json
-from ..helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
-from ..helpers.peer_link_identity import get_or_create_peer_link_identity
-from ..helpers.peer_link_noise import (
+from ...helpers import json as _json
+from ...helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
+from ...helpers.peer_link_identity import get_or_create_peer_link_identity
+from ...helpers.peer_link_noise import (
     NOISE_ERRORS,
     HandshakeNotCompleteError,
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
-from ..models import (
+from ...models import (
     IntentResponse,
     PeerLinkIntent,
     SubmitJobChunkFrameData,
@@ -125,7 +125,7 @@ class _DispatchInput:
 
 
 if TYPE_CHECKING:
-    from .remote_build import RemoteBuildController
+    from .controller import RemoteBuildController
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome_device_builder/controllers/remote_build/peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client.py
@@ -40,14 +40,14 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 from yarl import URL
 
-from ..helpers import json as _json
-from ..helpers.peer_link_noise import (
+from ...helpers import json as _json
+from ...helpers.peer_link_noise import (
     NOISE_ERRORS,
     HandshakeNotCompleteError,
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
-from ..models import (
+from ...models import (
     EventType,
     IntentResponse,
     OffloaderPairPinMismatchData,
@@ -56,7 +56,7 @@ from ..models import (
     OffloaderQueueStatusChangedData,
     PeerLinkIntent,
 )
-from .remote_build_peer_link import (
+from .peer_link import (
     APP_FRAME_MAX_BYTES,
     PEER_LINK_PATH,
     AppMessageType,
@@ -66,7 +66,7 @@ from .remote_build_peer_link import (
 )
 
 if TYPE_CHECKING:
-    from ..helpers.event_bus import EventBus
+    from ...helpers.event_bus import EventBus
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -61,13 +61,13 @@ from typing import TYPE_CHECKING, Any, cast
 
 from esphome.bundle import EsphomeError, prepare_bundle_for_compile
 
-from ..helpers.peer_link_bundle import (
+from ...helpers.peer_link_bundle import (
     BundleAssembler,
     BundleAssemblerError,
     BundleAssemblerErrorCode,
     decode_chunk,
 )
-from ..models import (
+from ...models import (
     JobType,
     SubmitJobAckFrameData,
     SubmitJobChunkFrameData,
@@ -75,8 +75,8 @@ from ..models import (
 )
 
 if TYPE_CHECKING:
-    from .firmware import FirmwareController
-    from .remote_build_peer_link import PeerLinkSession
+    from ..firmware import FirmwareController
+    from .peer_link import PeerLinkSession
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -628,7 +628,7 @@ class SubmitJobReceiver:
         # module via :class:`SubmitJobReceiver`-shaped duck
         # typing in its receive loop, but only the
         # ``TerminateReason`` enum reads back the other way.
-        from .remote_build_peer_link import TerminateReason  # noqa: PLC0415
+        from .peer_link import TerminateReason  # noqa: PLC0415
 
         if drop_inflight:
             self._inflight.pop(session.dashboard_id, None)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -42,7 +42,7 @@ from .controllers.firmware import FirmwareController
 from .controllers.labels import LabelsController
 from .controllers.onboarding import OnboardingController
 from .controllers.remote_build import RemoteBuildController
-from .controllers.remote_build_peer_link import PEER_LINK_PATH, make_peer_link_handler
+from .controllers.remote_build.peer_link import PEER_LINK_PATH, make_peer_link_handler
 from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.auth import auth_middleware
 from .helpers.dashboard_advertise import DashboardAdvertiser

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -43,7 +43,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestServer
 
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
-from esphome_device_builder.controllers.remote_build_peer_link import (
+from esphome_device_builder.controllers.remote_build.peer_link import (
     PEER_LINK_PATH,
     make_peer_link_handler,
 )

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -22,9 +22,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from zeroconf import ServiceStateChange
 
-from esphome_device_builder.controllers import remote_build as rb
-from esphome_device_builder.controllers.remote_build import (
-    RemoteBuildController,
+from esphome_device_builder.controllers.remote_build import RemoteBuildController
+from esphome_device_builder.controllers.remote_build import controller as rb
+from esphome_device_builder.controllers.remote_build.controller import (
     _decode_pairings,
     _decode_txt_value,
     _encode_pairings,
@@ -266,7 +266,7 @@ def test_on_service_state_change_uses_cache_when_available(
     fake_info = _fake_service_info(name="desktop")
     fake_info.load_from_cache = MagicMock(return_value=True)
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.AsyncServiceInfo",
+        "esphome_device_builder.controllers.remote_build.controller.AsyncServiceInfo",
         MagicMock(return_value=fake_info),
     )
     zeroconf = MagicMock()
@@ -394,7 +394,7 @@ async def test_start_swallows_browser_construction_errors(
     not crash dashboard startup.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        "esphome_device_builder.controllers.remote_build.controller.AsyncServiceBrowser",
         MagicMock(side_effect=RuntimeError("zeroconf socket gone")),
     )
     controller = _make_controller(config_dir=tmp_path)
@@ -417,7 +417,7 @@ async def test_start_captures_own_instance_name(
     fake_browser = MagicMock()
     fake_browser.async_cancel = AsyncMock()
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        "esphome_device_builder.controllers.remote_build.controller.AsyncServiceBrowser",
         MagicMock(return_value=fake_browser),
     )
     controller = _make_controller(config_dir=tmp_path)
@@ -440,7 +440,7 @@ async def test_start_skips_self_capture_when_advertiser_unregistered(
     fake_browser = MagicMock()
     fake_browser.async_cancel = AsyncMock()
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        "esphome_device_builder.controllers.remote_build.controller.AsyncServiceBrowser",
         MagicMock(return_value=fake_browser),
     )
     controller = _make_controller(config_dir=tmp_path)
@@ -465,7 +465,7 @@ async def test_start_skips_self_capture_when_no_advertiser(
     fake_browser = MagicMock()
     fake_browser.async_cancel = AsyncMock()
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        "esphome_device_builder.controllers.remote_build.controller.AsyncServiceBrowser",
         MagicMock(return_value=fake_browser),
     )
     controller = _make_controller(config_dir=tmp_path)
@@ -485,7 +485,7 @@ async def test_stop_swallows_browser_cancel_errors(
     fake_browser = MagicMock()
     fake_browser.async_cancel = AsyncMock(side_effect=RuntimeError("boom"))
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.AsyncServiceBrowser",
+        "esphome_device_builder.controllers.remote_build.controller.AsyncServiceBrowser",
         MagicMock(return_value=fake_browser),
     )
     controller = _make_controller(config_dir=tmp_path)
@@ -507,7 +507,7 @@ async def test_on_service_state_change_spawns_resolve_task_on_cache_miss(
     fake_info.load_from_cache = MagicMock(return_value=False)
     fake_info.async_request = AsyncMock(return_value=True)
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.AsyncServiceInfo",
+        "esphome_device_builder.controllers.remote_build.controller.AsyncServiceInfo",
         MagicMock(return_value=fake_info),
     )
     zeroconf = MagicMock()
@@ -2620,7 +2620,7 @@ def test_get_submit_job_receiver_raises_before_start(tmp_path: Path) -> None:
     """Accessing ``get_submit_job_receiver`` before ``start()`` raises ``RuntimeError``.
 
     Pins the bring-up ordering invariant: the wire dispatch in
-    :func:`controllers.remote_build_peer_link._receive_loop`
+    :func:`controllers.remote_build.peer_link._receive_loop`
     reaches the receiver via this accessor, and the peer-link
     listener only binds after :meth:`start` has installed it.
     The explicit failure surfaces a future bring-up regression

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.remote_build_job_fanout import JobFanout
+from esphome_device_builder.controllers.remote_build.job_fanout import JobFanout
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import (
     EventType,
@@ -265,7 +265,7 @@ async def test_queued_with_missing_remote_job_id_logs_and_skips_cache(
     job = _make_remote_job(remote_job_id="")
     debug_calls: list[str] = []
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_job_fanout._LOGGER.debug",
+        "esphome_device_builder.controllers.remote_build.job_fanout._LOGGER.debug",
         lambda fmt, *args, **kwargs: debug_calls.append(fmt % args if args else fmt),
     )
 

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -34,11 +34,11 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from noise.exceptions import NoiseInvalidMessage
 from noise.exceptions import NoiseInvalidMessage as _NoiseInvalidMessage
 
-from esphome_device_builder.controllers import (
-    remote_build_peer_link as _peer_link_module,
-)
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
-from esphome_device_builder.controllers.remote_build_peer_link import (
+from esphome_device_builder.controllers.remote_build import (
+    peer_link as _peer_link_module,
+)
+from esphome_device_builder.controllers.remote_build.peer_link import (
     _PEER_LABEL_MAX_CHARS,
     APP_FRAME_MAX_BYTES,
     PEER_LINK_PATH,
@@ -59,7 +59,7 @@ from esphome_device_builder.controllers.remote_build_peer_link import (
     _send_response,
     make_peer_link_handler,
 )
-from esphome_device_builder.controllers.remote_build_submit_job import (
+from esphome_device_builder.controllers.remote_build.submit_job import (
     SubmitJobReceiver,
 )
 from esphome_device_builder.helpers import json as _json
@@ -371,7 +371,7 @@ async def test_read_handshake_message_timeout_returns_none(
 ) -> None:
     """A peer that opens TCP but never sends msg1 falls through the timeout branch."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
+        "esphome_device_builder.controllers.remote_build.peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
         0.01,
     )
     session = PeerLinkNoiseSession.responder(secrets.token_bytes(32))
@@ -461,7 +461,7 @@ async def test_drive_session_msg1_timeout_returns_quietly(
 ) -> None:
     """A peer that never sends msg1 closes the WS without dispatching anything."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
+        "esphome_device_builder.controllers.remote_build.peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
         0.01,
     )
     controller = MagicMock(spec=RemoteBuildController)
@@ -491,7 +491,7 @@ async def test_handler_logs_unexpected_exception(
         raise RuntimeError("synthetic")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_peer_link._drive_peer_link_session",
+        "esphome_device_builder.controllers.remote_build.peer_link._drive_peer_link_session",
         _boom,
     )
 
@@ -501,12 +501,12 @@ async def test_handler_logs_unexpected_exception(
     ws_response = AsyncMock(spec=web.WebSocketResponse)
     ws_response.closed = False
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_peer_link.web.WebSocketResponse",
+        "esphome_device_builder.controllers.remote_build.peer_link.web.WebSocketResponse",
         lambda: ws_response,
     )
 
     with caplog.at_level(
-        "ERROR", logger="esphome_device_builder.controllers.remote_build_peer_link"
+        "ERROR", logger="esphome_device_builder.controllers.remote_build.peer_link"
     ):
         await handler(request)
     assert any("peer-link session error" in record.message for record in caplog.records)
@@ -587,7 +587,7 @@ async def test_drive_session_unknown_intent_msg3_read_failure(
 ) -> None:
     """Unknown intent + peer disconnects before msg3 closes without a response frame."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
+        "esphome_device_builder.controllers.remote_build.peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
         0.01,
     )
     controller = MagicMock(spec=RemoteBuildController)
@@ -636,7 +636,7 @@ async def test_drive_session_happy_path_msg3_read_failure(
 ) -> None:
     """Known intent + msg2 sends + msg3 read times out → driver bails before dispatch."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
+        "esphome_device_builder.controllers.remote_build.peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
         0.01,
     )
     controller = MagicMock(spec=RemoteBuildController)
@@ -680,7 +680,7 @@ async def test_drive_session_handshake_not_complete_logs_and_returns(
 
     real_session = PeerLinkNoiseSession.responder(responder_priv)
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_peer_link.PeerLinkNoiseSession.responder",
+        "esphome_device_builder.controllers.remote_build.peer_link.PeerLinkNoiseSession.responder",
         lambda priv: real_session,
     )
 
@@ -710,7 +710,7 @@ async def test_drive_session_handshake_not_complete_logs_and_returns(
         )
         with caplog.at_level(
             "WARNING",
-            logger="esphome_device_builder.controllers.remote_build_peer_link",
+            logger="esphome_device_builder.controllers.remote_build.peer_link",
         ):
             await _drive_peer_link_session(controller, ws, "10.0.0.1", responder_priv)
 
@@ -1332,7 +1332,7 @@ async def test_e2e_submit_job_dispatches_to_receiver(
     """A ``submit_job`` header + chunks over the wire dispatches to the receiver.
 
     Drives the receive-loop branches in
-    :func:`controllers.remote_build_peer_link._receive_loop`
+    :func:`controllers.remote_build.peer_link._receive_loop`
     that route ``SUBMIT_JOB`` / ``SUBMIT_JOB_CHUNK`` to the
     :class:`SubmitJobReceiver`. Stubs
     :func:`prepare_bundle_for_compile` because the real
@@ -1364,7 +1364,7 @@ async def test_e2e_submit_job_dispatches_to_receiver(
         return extracted_path
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
         _stub_prepare,
     )
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -32,15 +32,17 @@ from aiohttp.test_utils import TestServer
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from noise.exceptions import NoiseInvalidMessage
 
-from esphome_device_builder.controllers import remote_build as rb
-from esphome_device_builder.controllers import remote_build_peer_link_client
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
-from esphome_device_builder.controllers.remote_build_peer_link import (
+from esphome_device_builder.controllers.remote_build import controller as rb
+from esphome_device_builder.controllers.remote_build import (
+    peer_link_client as remote_build_peer_link_client,
+)
+from esphome_device_builder.controllers.remote_build.peer_link import (
     PEER_LINK_PATH,
     PeerLinkChannel,
     make_peer_link_handler,
 )
-from esphome_device_builder.controllers.remote_build_peer_link_client import (
+from esphome_device_builder.controllers.remote_build.peer_link_client import (
     PairStatusResult,
     PeerLinkClient,
     PeerLinkClientError,
@@ -851,7 +853,7 @@ async def test_controller_request_pair_unexpected_status_raises_internal_error(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link_request_pair",
+        "esphome_device_builder.controllers.remote_build.controller.peer_link_request_pair",
         _fake_request_pair,
     )
 
@@ -1547,7 +1549,7 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link_request_pair",
+        "esphome_device_builder.controllers.remote_build.controller.peer_link_request_pair",
         _fake_request_pair,
     )
     fake_identity = MagicMock()
@@ -1555,7 +1557,7 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
     fake_dashboard = MagicMock()
     fake_dashboard.dashboard_id = "dashboard-stub"
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build._load_offloader_identities",
+        "esphome_device_builder.controllers.remote_build.controller._load_offloader_identities",
         lambda _config_dir: (fake_identity, fake_dashboard),
     )
     # Park the spawned listener on an unfulfilled wait so the
@@ -1569,7 +1571,7 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
         raise AssertionError("park event should never be set in this test")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link_await_pair_status",
+        "esphome_device_builder.controllers.remote_build.controller.peer_link_await_pair_status",
         _fake_await_pair_status,
     )
 
@@ -1656,7 +1658,7 @@ async def test_request_pair_repair_then_unpair_clean_state(
         return fake_results.pop(0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link_request_pair",
+        "esphome_device_builder.controllers.remote_build.controller.peer_link_request_pair",
         _fake_request_pair,
     )
 
@@ -1683,7 +1685,7 @@ async def test_request_pair_repair_then_unpair_clean_state(
         raise AssertionError("park event should never be set in this test")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link_await_pair_status",
+        "esphome_device_builder.controllers.remote_build.controller.peer_link_await_pair_status",
         _fake_await_pair_status,
     )
     fake_identity = MagicMock()
@@ -1691,7 +1693,7 @@ async def test_request_pair_repair_then_unpair_clean_state(
     fake_dashboard = MagicMock()
     fake_dashboard.dashboard_id = "dashboard-stub"
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build._load_offloader_identities",
+        "esphome_device_builder.controllers.remote_build.controller._load_offloader_identities",
         lambda _config_dir: (fake_identity, fake_dashboard),
     )
 
@@ -1827,7 +1829,7 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link_request_pair",
+        "esphome_device_builder.controllers.remote_build.controller.peer_link_request_pair",
         _fake_request_pair,
     )
 
@@ -2101,7 +2103,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
     on the first call and returns APPROVED on the second.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build._PAIR_STATUS_RECONNECT_BACKOFF_SECONDS",
+        "esphome_device_builder.controllers.remote_build.controller._PAIR_STATUS_RECONNECT_BACKOFF_SECONDS",
         0.0,
     )
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -2128,7 +2130,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link_await_pair_status",
+        "esphome_device_builder.controllers.remote_build.controller.peer_link_await_pair_status",
         _fake_poll,
     )
     # Stub identity load so it doesn't try to read real key files.
@@ -2137,7 +2139,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
     fake_dashboard = MagicMock()
     fake_dashboard.dashboard_id = "alpha"
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build._load_offloader_identities",
+        "esphome_device_builder.controllers.remote_build.controller._load_offloader_identities",
         lambda _config_dir: (fake_identity, fake_dashboard),
     )
 
@@ -2161,7 +2163,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
     tight-loop against it.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build._PAIR_STATUS_RECONNECT_BACKOFF_SECONDS",
+        "esphome_device_builder.controllers.remote_build.controller._PAIR_STATUS_RECONNECT_BACKOFF_SECONDS",
         0.0,
     )
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -2191,7 +2193,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link_await_pair_status",
+        "esphome_device_builder.controllers.remote_build.controller.peer_link_await_pair_status",
         _fake_poll,
     )
     fake_identity = MagicMock()
@@ -2199,7 +2201,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
     fake_dashboard = MagicMock()
     fake_dashboard.dashboard_id = "alpha"
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build._load_offloader_identities",
+        "esphome_device_builder.controllers.remote_build.controller._load_offloader_identities",
         lambda _config_dir: (fake_identity, fake_dashboard),
     )
 

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -25,7 +25,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from esphome.bundle import EsphomeError
 
-from esphome_device_builder.controllers.remote_build_submit_job import (
+from esphome_device_builder.controllers.remote_build.submit_job import (
     SubmitJobReceiver,
     _validate_configuration_filename,
 )
@@ -480,7 +480,7 @@ async def test_submit_job_happy_path_extracts_and_queues(
         return expected_yaml
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
         _stub_prepare,
     )
 
@@ -553,7 +553,7 @@ async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
     session = _make_session(dashboard_id="../../escape")
     bundle = b"hello"
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
         lambda _bundle, _target: tmp_path / "kitchen.yaml",
     )
 
@@ -579,7 +579,7 @@ async def test_submit_job_enqueue_failure_rejects(
     bundle = b"hello"
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
         lambda _bundle, target: target / "kitchen.yaml",
     )
 
@@ -607,7 +607,7 @@ async def test_submit_job_extract_failure_rejects_without_terminate(
         raise EsphomeError("bundle invalid: missing manifest")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build_submit_job.prepare_bundle_for_compile",
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
         _failing_prepare,
     )
 


### PR DESCRIPTION
# What does this implement/fix?

Pure refactor: move the five `controllers/remote_build*.py` modules into a `controllers/remote_build/` package, mirroring the existing `controllers/firmware/` and `controllers/devices/` shapes.

**Why:** the sibling sprawl (six top-level `remote_build_*` files plus `remote_build.py` itself at ~2k lines) is a sign the package boundary wants to be promoted. Splitting *now*, before 5c-3 / 5d / 6 add more files, keeps each future PR small instead of fighting an ever-larger flat namespace.

**Mechanical changes:**

- `controllers/remote_build.py` → `controllers/remote_build/controller.py`
- `controllers/remote_build_peer_link.py` → `controllers/remote_build/peer_link.py`
- `controllers/remote_build_peer_link_client.py` → `controllers/remote_build/peer_link_client.py`
- `controllers/remote_build_submit_job.py` → `controllers/remote_build/submit_job.py`
- `controllers/remote_build_job_fanout.py` → `controllers/remote_build/job_fanout.py`
- New `controllers/remote_build/__init__.py` re-exports `RemoteBuildController` (matching `controllers/firmware/__init__.py`'s shape — minimal re-export; submodule contents accessed via the submodule path).
- Internal relative imports rewritten: sibling `remote_build_*` references collapse to short names (`from .peer_link import ...`); `..helpers` / `..models` / `..api` / `..device_builder` go up one more level (`..` → `...`); cross-controller imports (`firmware`, `config`, etc.) stay one level out (`.firmware` → `..firmware`).
- External callers updated: `device_builder.py`'s peer-link-handler import + every test file that referenced an old module path or string-form monkeypatch target. `RemoteBuildController` import path on production callers is unchanged (the `__init__.py` keeps `from .controllers.remote_build import RemoteBuildController` working).
- `CLAUDE.md` "Useful entry points" table updated to flag the package-when-it-grows pattern.

**Verification:**

- All 2545 tests pass (no test changes beyond import-path updates).
- Mypy clean (76 source files).
- Ruff clean.
- File renames preserve git history (`git log --follow` works on the new paths).

**Related issue or feature (if applicable):**

- esphome/device-builder#106 — reorg ahead of 5c-3 / 5d / 6.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

(Pure module reorg — no architectural surface change beyond CLAUDE.md's entry-point table. The "Long-lived peer-link sessions" / "Remote build" sections in `docs/ARCHITECTURE.md` reference module *concepts* rather than file paths and stay accurate.)
