### PR TITLE
Filter own dashboard from mDNS host list by (host, port)

### DIFF
--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -1568,10 +1568,47 @@ class RemoteBuildController:
         construction; adding a field to :class:`RemoteBuildPeer`
         flows through both surfaces in lockstep without a manual
         bookkeeping update here.
+
+        Drops resolved entries whose ``(server, port)`` matches our
+        own published advertise so this dashboard never offers
+        itself as a pair candidate. The early
+        ``service_instance_name`` filter in
+        :meth:`_on_service_state_change` covers the common case
+        before resolve, but a rename-on-conflict zeroconf bounce
+        between our own register and our own browse callback can
+        leave the captured instance name out of date — the
+        endpoint comparison is the live cross-check that survives
+        that drift. Matching on both ``server`` and ``port`` (not
+        just ``server``) preserves the ability to run two
+        dashboards on the same host on different ports as
+        distinct peer candidates.
         """
         peer = _peer_from_service_info(name, info)
+        if self._is_self_endpoint(peer.hostname, peer.port):
+            return
         self._peers[name] = peer
         self._db.bus.fire(EventType.REMOTE_BUILD_HOST_ADDED, peer.to_dict())
+
+    def _is_self_endpoint(self, hostname: str, port: int) -> bool:
+        """Return True when *(hostname, port)* matches our published advertise.
+
+        Reads the live ``service_target_endpoint`` off the
+        :class:`DashboardAdvertiser` rather than a captured-at-start
+        value so a post-start register / re-register isn't missed.
+        Hostname comparison is case-insensitive and trailing-dot
+        tolerant; the advertiser already normalises its end of
+        the comparison to lowercase + no trailing dot, and the
+        resolved peer hostname (off the SRV target) gets the
+        same treatment here.
+        """
+        advertiser = self._db._dashboard_advertiser
+        if advertiser is None:
+            return False
+        endpoint = advertiser.service_target_endpoint
+        if endpoint is None:
+            return False
+        own_host, own_port = endpoint
+        return port == own_port and hostname.rstrip(".").lower() == own_host
 
     def _fire_host_removed(self, name: str) -> None:
         """Fire ``REMOTE_BUILD_HOST_REMOVED`` for *name*."""

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -338,6 +338,35 @@ class DashboardAdvertiser:
         """
         return self._info.name if self._info is not None else None
 
+    @property
+    def service_target_endpoint(self) -> tuple[str, int] | None:
+        """
+        The published ``(server, port)`` SRV target, or ``None``.
+
+        ``server`` is the SRV record's target (the FQDN peers
+        will connect to, normalised to lowercase with the trailing
+        dot stripped); ``port`` is the dashboard's HTTP listen
+        port. Returned as a tuple so peer-discovery code can do
+        a single equality check against the resolved endpoint
+        of every browsed service to filter our own broadcast on
+        the (host, port) axis rather than the service-instance
+        name axis (which can drift if zeroconf rename-on-conflict
+        kicks in between our own register and our own browse
+        callback).
+
+        Two dashboards on the same host with different ports are
+        legitimate distinct peers; matching on both axes preserves
+        that ability. ``None`` when the advertiser hasn't
+        registered yet, same shape as :attr:`service_instance_name`.
+        """
+        if self._info is None:
+            return None
+        server = self._info.server
+        port = self._info.port
+        if server is None or port is None:
+            return None
+        return (server.rstrip(".").lower(), port)
+
     def build_service_info(self, addresses: list[str] | None = None) -> ServiceInfo:
         """
         Construct the ``ServiceInfo`` that will be published on register.

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -433,6 +433,39 @@ def test_service_target_endpoint_returns_none_before_register() -> None:
 
 
 @pytest.mark.asyncio
+async def test_service_target_endpoint_returns_none_when_info_lacks_server_or_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ServiceInfo`` whose ``server`` / ``port`` is ``None`` doesn't crash the accessor.
+
+    The :class:`ServiceInfo` type stubs admit ``str | None`` /
+    ``int | None`` for those fields even though zeroconf always
+    populates them after ``register()``. Defensive guard on the
+    accessor; pin the contract so a future zeroconf version that
+    returns ``None`` for either field doesn't ``AttributeError``
+    inside peer-discovery hot paths.
+    """
+    monkeypatch.setattr(dashboard_advertise, "_local_addresses", lambda: ["192.168.1.10"])
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    try:
+        assert advertiser._info is not None
+        # Wipe ``server`` and re-check; same for ``port``.
+        advertiser._info.server = None
+        assert advertiser.service_target_endpoint is None
+        advertiser._info.server = "green.local."
+        advertiser._info.port = None
+        assert advertiser.service_target_endpoint is None
+    finally:
+        # Restore real server / port so ``unregister`` can match
+        # zeroconf's registered ServiceInfo.
+        advertiser._info.server = "green.local."
+        advertiser._info.port = advertiser._port
+        await advertiser.unregister()
+
+
+@pytest.mark.asyncio
 async def test_service_target_endpoint_returns_lowercased_no_trailing_dot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -426,6 +426,35 @@ async def test_service_instance_name_returns_published_name_after_register(
     assert advertiser.service_instance_name is None
 
 
+def test_service_target_endpoint_returns_none_before_register() -> None:
+    """``service_target_endpoint`` is ``None`` until ``register()`` succeeds."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    assert advertiser.service_target_endpoint is None
+
+
+@pytest.mark.asyncio
+async def test_service_target_endpoint_returns_lowercased_no_trailing_dot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Post-``register``, the endpoint tuple is lowercased and trailing-dot stripped.
+
+    Peer-discovery code compares the resolved peer's
+    ``(server, port)`` against this tuple; both ends are
+    normalised the same way so the equality check just works.
+    """
+    monkeypatch.setattr(dashboard_advertise, "_local_addresses", lambda: ["192.168.1.10"])
+    advertiser = _make_advertiser(name="Green", hostname="Green.Local")
+    zc = _make_zeroconf_mock()
+    await advertiser.register(zc)
+    try:
+        endpoint = advertiser.service_target_endpoint
+        assert endpoint == ("green.local", advertiser._port)
+    finally:
+        await advertiser.unregister()
+    assert advertiser.service_target_endpoint is None
+
+
 def test_build_service_info_falls_back_when_hostname_is_blank(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -215,6 +215,78 @@ def test_on_service_state_change_filters_own_advertise(tmp_path: Path) -> None:
     assert controller._peers == {}
 
 
+def test_is_self_endpoint_matches_advertised_host_and_port(tmp_path: Path) -> None:
+    """A ``(host, port)`` matching the advertiser's published endpoint reports True.
+
+    Hostname comparison is case-insensitive and trailing-dot
+    tolerant on both sides; port match is exact. Pins the
+    contract :meth:`_upsert_host` relies on to drop our own
+    broadcast even when ``_own_instance_name`` capture missed
+    (rename-on-conflict bounce, HA-addon delayed register).
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    advertiser = MagicMock()
+    advertiser.service_target_endpoint = ("mac.example.org", 6052)
+    controller._db._dashboard_advertiser = advertiser
+
+    assert controller._is_self_endpoint("Mac.example.org.", 6052) is True
+    assert controller._is_self_endpoint("MAC.EXAMPLE.ORG", 6052) is True
+    # Same host on a different port is a legitimate distinct
+    # peer (two dashboards on the same machine on different
+    # ports); preserve that capability.
+    assert controller._is_self_endpoint("mac.example.org", 6053) is False
+    # Different host on the same port is also legitimate.
+    assert controller._is_self_endpoint("other.local", 6052) is False
+
+
+def test_is_self_endpoint_returns_false_when_advertiser_absent(tmp_path: Path) -> None:
+    """An unregistered / missing advertiser leaves the filter open.
+
+    Mirror of the early ``_own_instance_name`` capture path:
+    HA addon and zeroconf-down branches leave the dashboard
+    without a published advertise, so there's no self-broadcast
+    to filter and this guard must always return False.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+
+    controller._db._dashboard_advertiser = None
+    assert controller._is_self_endpoint("any.host.", 6052) is False
+
+    advertiser = MagicMock()
+    advertiser.service_target_endpoint = None
+    controller._db._dashboard_advertiser = advertiser
+    assert controller._is_self_endpoint("any.host.", 6052) is False
+
+
+def test_upsert_host_drops_self_endpoint(tmp_path: Path) -> None:
+    """``_upsert_host`` skips the self-endpoint even when the instance-name guard missed.
+
+    Simulates the rename-on-conflict zeroconf bounce: the early
+    instance-name filter doesn't catch the broadcast (different
+    name from what the controller captured), but the
+    ``(server, port)`` cross-check inside ``_upsert_host``
+    still drops the row and never fires
+    ``REMOTE_BUILD_HOST_ADDED``.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    advertiser = MagicMock()
+    advertiser.service_target_endpoint = ("mac.example.org", 6052)
+    controller._db._dashboard_advertiser = advertiser
+
+    info = MagicMock()
+    info.name = f"renamed.{SERVICE_TYPE}"
+    info.server = "Mac.example.org."
+    info.port = 6052
+    info.properties = {b"server_version": b"0.1.0", b"esphome_version": b"2026.5.0-dev"}
+    info.parsed_scoped_addresses = MagicMock(return_value=["10.0.0.42"])
+
+    controller._upsert_host(f"renamed.{SERVICE_TYPE}", info)
+
+    assert controller._peers == {}
+    controller._db.bus.fire.assert_not_called()
+
+
 def test_on_service_state_change_removed_drops_peer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The host running the dashboard was being offered as a pair
candidate in the offloader UI's discovered-hosts list (e.g.
`host.example.org.:6052` showing up alongside genuine
remote dashboards). The existing self-filter compares the
full mDNS service-instance name the browser callback
delivers against `DashboardAdvertiser.service_instance_name`
captured once at controller start. That works in the steady
state, but a zeroconf rename-on-conflict bounce between our
own register and our own browse callback
(`allow_name_change=True` is load-bearing for
two-dashboards-on-one-host scenarios) leaves the captured
instance name out of date and the broadcast slips through.

Fix: add an endpoint cross-check inside `_upsert_host` that
reads the live published `(server, port)` off the advertiser
at filter time and drops resolved entries whose server
(case-insensitive, trailing-dot stripped) and port both
match. Two dashboards on the same host on different ports
stay legitimate distinct peer candidates; only the exact
`(host, port)` self-match is filtered.

The advertiser exposes the new check via a new
`service_target_endpoint` property mirroring the existing
`service_instance_name` shape (`None` until `register()`
succeeds), so the controller doesn't reach into private
state.

Test coverage:

* `_is_self_endpoint` matches the advertised host / port with
  case-insensitive + trailing-dot tolerant comparison.
* Same host / different port stays unfiltered (preserves the
  two-dashboards-on-one-host capability).
* Different host / same port stays unfiltered.
* Missing / unregistered advertiser returns False (HA addon
  default-off, zeroconf-down branches).
* `_upsert_host` skips a self endpoint even when the early
  instance-name guard missed (the rename-on-conflict path).
* `service_target_endpoint` returns the lowercased,
  trailing-dot-stripped tuple after `register()`.

**Related issue or feature (if applicable):**

- fixes #106 (remote build offload, mDNS discovery
  self-filter)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
