### PR TITLE
Use contextlib.ExitStack for controller bus-listener bookkeeping

### DIFF
--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -61,6 +61,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Callable, Hashable
+from contextlib import ExitStack
 from dataclasses import dataclass as _dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -966,21 +967,25 @@ class RemoteBuildController:
             shutdown_register=self._shutdown_callbacks.append,
             name="receiver_peers",
         )
-        # Bus-listener unsubscribers held for the lifetime of the
-        # controller. Populated in :meth:`start` and walked in
-        # :meth:`stop` so the listeners don't outlive the
-        # controller. Currently covers the receiver-side
-        # firmware-queue lifecycle listeners (``JOB_QUEUED`` /
-        # ``JOB_STARTED`` / terminal events) that drive the
-        # ``queue_status`` peer-link broadcast and the
-        # offloader-side ``OFFLOADER_QUEUE_STATUS_CHANGED``
-        # listener that updates ``_peer_queue_status``. New
-        # controller-scoped bus subscriptions should append their
+        # Lifecycle bag of bus-listener unsubscribers held for
+        # the lifetime of the controller. Populated in
+        # :meth:`start` via ``self._listeners.callback(...)`` and
+        # closed in :meth:`stop`. Currently covers the
+        # receiver-side firmware-queue lifecycle listeners
+        # (``JOB_QUEUED`` / ``JOB_STARTED`` / terminal events) that
+        # drive the ``queue_status`` peer-link broadcast and the
+        # offloader-side ``OFFLOADER_QUEUE_STATUS_CHANGED`` /
+        # ``OFFLOADER_PAIR_PIN_MISMATCH`` /
+        # ``OFFLOADER_PEER_LINK_OPENED`` /
+        # ``OFFLOADER_PEER_LINK_CLOSED`` listeners. New
+        # controller-scoped bus subscriptions should register their
         # closer here so :meth:`stop` doesn't need a parallel
-        # collection. Empty at cold-start; the per-instance
-        # attribute exists so ``stop`` can run unconditionally
-        # without an ``hasattr`` dance.
-        self._unsub_bus_listeners: list[Callable[[], None]] = []
+        # collection. ``contextlib.ExitStack`` is the stdlib
+        # pattern for accumulating cleanup callables — each
+        # ``EventBus.add_listener`` return is a sync ``Callable[[],
+        # None]`` and ``ExitStack.callback`` is what stdlib provides
+        # for that exact shape.
+        self._listeners = ExitStack()
 
     async def start(self) -> None:
         """
@@ -1102,24 +1107,24 @@ class RemoteBuildController:
         # trigger a broadcast — they're per-line streaming events
         # that fire at high rates during a build, and the
         # ``queue_status`` shape doesn't change across them.
-        self._unsub_bus_listeners = [
-            self._db.bus.add_listener(event_type, self._on_firmware_queue_transition)
-            for event_type in (
-                EventType.JOB_QUEUED,
-                EventType.JOB_STARTED,
-                *TERMINAL_JOB_EVENTS,
+        for event_type in (
+            EventType.JOB_QUEUED,
+            EventType.JOB_STARTED,
+            *TERMINAL_JOB_EVENTS,
+        ):
+            self._listeners.callback(
+                self._db.bus.add_listener(event_type, self._on_firmware_queue_transition)
             )
-        ]
         # Offloader-side: subscribe to the inbound queue-status
         # bus event the :class:`PeerLinkClient` receive loop
         # fires after parsing a ``queue_status`` frame. The
         # listener mirrors the wire-shape primitives into
         # ``_peer_queue_status`` so a late ``subscribe_events``
         # snapshot reflects every paired peer's most recent
-        # state. Same teardown shape as the JOB_* listeners
-        # above — append the unsub closer to the same list so
-        # :meth:`stop` walks one collection.
-        self._unsub_bus_listeners.append(
+        # state. Registered into the same ``_listeners`` stack
+        # as the JOB_* listeners above so :meth:`stop` walks one
+        # collection.
+        self._listeners.callback(
             self._db.bus.add_listener(
                 EventType.OFFLOADER_QUEUE_STATUS_CHANGED,
                 self._on_offloader_queue_status_changed,
@@ -1138,7 +1143,7 @@ class RemoteBuildController:
         # so a same-tick fire from the pair-status listener
         # ends with the listener overwriting a value the
         # caller already wrote (no behaviour change there).
-        self._unsub_bus_listeners.append(
+        self._listeners.callback(
             self._db.bus.add_listener(
                 EventType.OFFLOADER_PAIR_PIN_MISMATCH,
                 self._on_offloader_pair_pin_mismatch,
@@ -1151,13 +1156,13 @@ class RemoteBuildController:
         # multi-event listener so each callback is straight-line
         # (add vs. discard) without an event-type branch on the
         # hot path.
-        self._unsub_bus_listeners.append(
+        self._listeners.callback(
             self._db.bus.add_listener(
                 EventType.OFFLOADER_PEER_LINK_OPENED,
                 self._on_offloader_peer_link_opened,
             )
         )
-        self._unsub_bus_listeners.append(
+        self._listeners.callback(
             self._db.bus.add_listener(
                 EventType.OFFLOADER_PEER_LINK_CLOSED,
                 self._on_offloader_peer_link_closed,
@@ -1396,7 +1401,7 @@ class RemoteBuildController:
             raise RuntimeError(msg)
         return self._submit_job_receiver
 
-    async def stop(self) -> None:  # noqa: PLR0912 — drains many resources
+    async def stop(self) -> None:
         """Cancel the browser and drain in-flight resolve tasks."""
         if self._browser is not None:
             try:
@@ -1405,16 +1410,16 @@ class RemoteBuildController:
                 _LOGGER.debug("remote-build browser cancel failed", exc_info=True)
             self._browser = None
         # Detach every bus listener registered in :meth:`start`.
-        # Each closer is the unsubscribe handle returned by
-        # ``EventBus.add_listener``; calling it removes the
-        # listener from the bus's per-event set so later fires
+        # ``ExitStack.close`` walks the registered callbacks in
+        # LIFO order and calls each — every captured callback is
+        # the unsubscribe handle returned by
+        # ``EventBus.add_listener``, so calling it removes the
+        # listener from the bus's per-event set and later fires
         # don't re-enter the controller's callbacks after it's
-        # gone. Covers both the receiver-side firmware-queue
-        # lifecycle listeners and the offloader-side
-        # ``OFFLOADER_QUEUE_STATUS_CHANGED`` listener.
-        for unsub in self._unsub_bus_listeners:
-            unsub()
-        self._unsub_bus_listeners.clear()
+        # gone. Covers the receiver-side firmware-queue lifecycle
+        # listeners and every offloader-side bus listener
+        # registered above.
+        self._listeners.close()
         # 5c-2b job fan-out maintains its own listener set
         # (firmware-controller's bus, scoped to ``JOB_*`` event
         # types). Detach via the helper so the controller's

--- a/esphome_device_builder/controllers/remote_build/job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build/job_fanout.py
@@ -41,7 +41,7 @@ problem to surface (or 5d's cancel path to mop up).
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from contextlib import ExitStack
 from typing import TYPE_CHECKING, Literal
 
 from ...helpers.event_bus import Event
@@ -95,10 +95,12 @@ class JobFanout:
 
     def __init__(self, controller: RemoteBuildController) -> None:
         self._controller = controller
-        # Captured ``EventBus.add_listener`` returns; each is a
-        # callable that drops the listener when invoked.
-        # Populated by :meth:`start`, walked by :meth:`stop`.
-        self._unsubscribers: list[Callable[[], None]] = []
+        # Lifecycle bag of bus-listener unsubs. Each
+        # ``EventBus.add_listener`` return is a sync callable
+        # that drops the listener; ``ExitStack.callback`` is
+        # the stdlib pattern for accumulating those across
+        # ``start`` and walking them on ``stop``.
+        self._listeners = ExitStack()
         # Receiver-side ``FirmwareJob.job_id`` →
         # ``(remote_peer, remote_job_id)`` for every in-flight
         # remote-peer job. Populated on JOB_QUEUED (the first
@@ -127,16 +129,14 @@ class JobFanout:
         # module docstring on the deliberate skip — the
         # ``submit_job_ack`` already signals queued, and a frame
         # firing here would race the ack).
-        self._unsubscribers.append(bus.add_listener(EventType.JOB_QUEUED, self._on_queued))
+        self._listeners.callback(bus.add_listener(EventType.JOB_QUEUED, self._on_queued))
         for event_type in _LIFECYCLE_EVENT_TO_STATUS:
-            self._unsubscribers.append(bus.add_listener(event_type, self._on_lifecycle))
-        self._unsubscribers.append(bus.add_listener(EventType.JOB_OUTPUT, self._on_output))
+            self._listeners.callback(bus.add_listener(event_type, self._on_lifecycle))
+        self._listeners.callback(bus.add_listener(EventType.JOB_OUTPUT, self._on_output))
 
     def stop(self) -> None:
         """Drop every listener registered by :meth:`start` and clear the cache."""
-        for unsub in self._unsubscribers:
-            unsub()
-        self._unsubscribers.clear()
+        self._listeners.close()
         self._remote_jobs.clear()
 
     def _on_queued(self, event: Event[JobLifecycleData]) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Followup to the remote_build package refactor (#534). While auditing the moved code for duplication I noticed two near-identical bus-listener bookkeeping shapes:

- `RemoteBuildController._unsub_bus_listeners: list[Callable[[], None]]` — populated in `start`, walked + cleared in `stop`.
- `JobFanout._unsubscribers: list[Callable[[], None]]` — same shape.

Both are the lifecycle counterpart to the existing `EventBus.listening()` scoped-context manager: long-lived subscriptions whose lifetime is bounded by a controller's `start`/`stop` rather than a `with` block. `contextlib.ExitStack` is the stdlib helper for exactly that pattern — `add_listener` returns a sync `Callable[[], None]`, `ExitStack.callback(fn)` registers it, `ExitStack.close()` walks them all in LIFO order. Replace the hand-rolled list+walk in both call sites with `ExitStack`.

**Considered and rejected:** a custom `ListenerSet` helper alongside `EventBus.listening()`. `ExitStack` already covers the lifecycle case at zero new surface area, so keep the public helper inventory stdlib-only.

**Mechanical changes:**

- `RemoteBuildController.__init__` swaps the typed empty list for `ExitStack()`; `start` switches every `_unsub_bus_listeners.append(...)` (5 sites) plus the seed list-comprehension to `self._listeners.callback(...)`; `stop` swaps the for-loop + clear for `self._listeners.close()`. The collapse drops the branch count enough that the `# noqa: PLR0912` on `stop` is no longer needed (ruff caught it as `RUF100`).
- `JobFanout.__init__` / `start` / `stop` get the same treatment. `from collections.abc import Callable` is no longer needed in `job_fanout.py` and is dropped; in `controller.py` `Callable` is still used by `_modify_settings` so the import stays.

**Verification:**

- All 2612 tests pass (the three pre-existing failures in `tests/test_device_yaml.py` are unrelated — same failures on `origin/main`).
- Mypy clean (76 source files).
- Ruff clean (after the `RUF100` autofix).
- No frontend impact — pure controller-internal bookkeeping change, no WS surface change, no model shape change.

**Related issue or feature (if applicable):**

- esphome/device-builder#106 — followup to #534's refactor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

(No new tests — the existing `tests/test_remote_build_controller.py` and `tests/test_remote_build_job_fanout.py` already exercise the start/stop teardown path; both pass unchanged. No architectural surface change — this is a stdlib-helper substitution under the existing public API.)
