### PR TITLE
Phase 4a-o part 7: mDNS auto-rebind with probe-before-mutate

### DIFF
--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -60,7 +60,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Callable, Hashable, Iterator
+from collections.abc import Callable, Coroutine, Hashable, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass as _dataclass
 from enum import StrEnum
@@ -224,6 +224,23 @@ def _decode_txt_value(raw: bytes | None) -> str:
         return raw.decode("utf-8")
     except UnicodeDecodeError:
         return ""
+
+
+def _endpoints_equal(host_a: str, port_a: int, host_b: str, port_b: int) -> bool:
+    """Case- and trailing-dot-insensitive equality on ``(host, port)`` pairs.
+
+    Two paths in this controller compare an mDNS-resolved
+    endpoint against another stored endpoint (the dashboard's
+    own advertise via :meth:`_is_self_endpoint`, and a stored
+    pairing's coordinates via :meth:`_maybe_schedule_rebind_probe`).
+    Both want hostname comparison through
+    :func:`normalize_hostname` so trailing-dot / case
+    differences between the SRV target form and the stored form
+    don't show up as spurious mismatches; this helper centralises
+    the shape so the two call sites stay in lockstep on the
+    normalisation rules.
+    """
+    return port_a == port_b and normalize_hostname(host_a) == normalize_hostname(host_b)
 
 
 def _decode_txt_port(raw: bytes | None) -> int:
@@ -1610,9 +1627,7 @@ class RemoteBuildController:
         if info.load_from_cache(zeroconf):
             self._upsert_host(name, info)
             return
-        task = asyncio.create_task(self._resolve_and_apply(zeroconf, info, name))
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
+        self._track_task(self._resolve_and_apply(zeroconf, info, name))
 
     async def _resolve_and_apply(self, zeroconf: Any, info: AsyncServiceInfo, name: str) -> None:
         """Async resolve path for cache misses."""
@@ -1687,12 +1702,53 @@ class RemoteBuildController:
         if endpoint is None:
             return False
         own_host, own_port = endpoint
-        return port == own_port and normalize_hostname(hostname) == own_host
+        return _endpoints_equal(hostname, port, own_host, own_port)
 
     def _fire_host_removed(self, name: str) -> None:
         """Fire ``REMOTE_BUILD_HOST_REMOVED`` for *name*."""
         payload: RemoteBuildHostRemovedData = {"name": name}
         self._db.bus.fire(EventType.REMOTE_BUILD_HOST_REMOVED, payload)
+
+    def _track_task(
+        self, coro: Coroutine[Any, Any, None], *, name: str | None = None
+    ) -> asyncio.Task[None]:
+        """Schedule *coro* and hold a strong ref in :attr:`_tasks`.
+
+        Wraps the create / track / auto-discard dance fire-and-forget
+        background tasks owned by this controller need: the
+        garbage collector would otherwise reap a task whose only
+        reference is the local in the spawning frame. The
+        :meth:`set.discard` done-callback unwires the ref the
+        moment the task settles so :attr:`_tasks` doesn't grow
+        unbounded.
+
+        Distinct from :meth:`DeviceBuilder.create_background_task`
+        because the controller's :meth:`stop` gathers
+        :attr:`_tasks` separately (4a-o subsystem teardown
+        ordering); mixing the two sets would change shutdown
+        semantics.
+        """
+        task = asyncio.create_task(coro, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    def _schedule_pairings_save(self) -> None:
+        """Debounce-write the offloader pairings store.
+
+        Three sites flow through here: ``request_pair`` /
+        ``unpair`` / ``_apply_pair_status_result`` /
+        ``_probe_and_rebind_endpoint``. The
+        :data:`_PAIRINGS_SAVE_DELAY_SECONDS` window collapses
+        bursts (multi-step flows that mutate the dict more than
+        once before yielding) into a single disk write, and the
+        ``Store``'s atomic-tempfile semantics ensure the on-disk
+        shape is always either the pre-burst or the post-burst
+        snapshot, never a partial.
+        """
+        self._pairings_store.async_delay_save(
+            self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
+        )
 
     # ------------------------------------------------------------------
     # mDNS auto-rebind (4a-o part 7)
@@ -1719,9 +1775,8 @@ class RemoteBuildController:
         if pairing is None or pairing.status is not PeerStatus.APPROVED:
             return
         new_hostname = normalize_hostname(peer.hostname)
-        if (
-            normalize_hostname(pairing.receiver_hostname) == new_hostname
-            and pairing.receiver_port == new_port
+        if _endpoints_equal(
+            pairing.receiver_hostname, pairing.receiver_port, new_hostname, new_port
         ):
             return
         if self._offloader_peer_link_priv is None:
@@ -1730,14 +1785,12 @@ class RemoteBuildController:
         if self._rebind_probe_until.get(pin, 0.0) > now:
             return
         self._rebind_probe_until[pin] = now + _REBIND_PROBE_COOLDOWN_SECONDS
-        task = asyncio.create_task(
+        self._track_task(
             self._probe_and_rebind_endpoint(
                 pairing=pairing, new_hostname=new_hostname, new_port=new_port
             ),
             name=f"rebind-probe-{pin[:8]}",
         )
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
 
     async def _probe_and_rebind_endpoint(
         self, *, pairing: StoredPairing, new_hostname: str, new_port: int
@@ -1813,9 +1866,7 @@ class RemoteBuildController:
                 return
             current.receiver_hostname = new_hostname
             current.receiver_port = new_port
-            self._pairings_store.async_delay_save(
-                self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
-            )
+            self._schedule_pairings_save()
             # Cancel-then-spawn so the old task (parked on
             # ``aiohttp.ws_connect`` against the dead endpoint)
             # doesn't idle there until heartbeat-timeout.
@@ -2251,9 +2302,7 @@ class RemoteBuildController:
             # the debounced disk write; the controller's ``stop()``
             # flushes any still-pending save through the registered
             # shutdown callback.
-            self._pairings_store.async_delay_save(
-                self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
-            )
+            self._schedule_pairings_save()
             # APPROVED row → spawn the long-lived peer-link
             # client (5a-2). Receiver already authenticated us
             # via the pair_request; the client just opens a
@@ -2339,9 +2388,7 @@ class RemoteBuildController:
         # scheduling a save on every removal keeps the code path
         # uniform — the eventual write rebuilds the pairings list
         # from RAM regardless of what the dropped row's status was.
-        self._pairings_store.async_delay_save(
-            self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
-        )
+        self._schedule_pairings_save()
         # Fire the local bus event so other clients on the global
         # ``subscribe_events`` stream see the removal without
         # re-fetching the pairings snapshot. Mirrors the
@@ -2725,9 +2772,7 @@ class RemoteBuildController:
                     # previously-APPROVED row drifted-pin lands here
                     # in some future flow, the schedule_save still
                     # evicts it from disk — keep the path uniform.
-                    self._pairings_store.async_delay_save(
-                        self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
-                    )
+                    self._schedule_pairings_save()
                     # Capture the alert in RAM before firing so a
                     # late-subscribing client picks it up via the
                     # ``initial_state.offloader_alerts`` snapshot.
@@ -2766,9 +2811,7 @@ class RemoteBuildController:
             if existing is None:
                 return True
             existing.status = PeerStatus.APPROVED
-            self._pairings_store.async_delay_save(
-                self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
-            )
+            self._schedule_pairings_save()
             self._fire_offloader_pair_status_changed(host, port, key, "approved")
             # Spawn the long-lived peer-link client now that the
             # receiver has approved us. The client's
@@ -2778,9 +2821,7 @@ class RemoteBuildController:
             return True
         if result.status is IntentResponse.REJECTED:
             if self._pairings.pop(key, None) is not None:
-                self._pairings_store.async_delay_save(
-                    self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
-                )
+                self._schedule_pairings_save()
                 # Capture the alert in RAM before firing so a
                 # late-subscribing client picks it up via the
                 # ``initial_state.offloader_alerts`` snapshot.

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -226,6 +226,25 @@ def _decode_txt_value(raw: bytes | None) -> str:
         return ""
 
 
+def _decode_txt_int(raw: bytes | None) -> int:
+    """Decode a TXT value as an int, falling back to 0.
+
+    Defensive: a corrupted / non-numeric TXT entry shouldn't
+    raise into the browser callback (which would abort the
+    resolve task and silently lose the peer). 0 is the same
+    "not advertised" sentinel TXT-absent rows already produce,
+    so downstream sites that gate on a real port already cover
+    the malformed-payload case.
+    """
+    decoded = _decode_txt_value(raw)
+    if not decoded:
+        return 0
+    try:
+        return int(decoded)
+    except ValueError:
+        return 0
+
+
 def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPeer:
     """
     Build a :class:`RemoteBuildPeer` from a resolved ``AsyncServiceInfo``.
@@ -253,15 +272,7 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
     # receivers that haven't published them; the rebind path
     # silently skips those rows.
     pin_sha256 = _decode_txt_value(properties.get(b"pin_sha256"))
-    remote_build_port_raw = _decode_txt_value(properties.get(b"remote_build_port"))
-    try:
-        remote_build_port = int(remote_build_port_raw) if remote_build_port_raw else 0
-    except ValueError:
-        # Malformed TXT (non-numeric) lands as 0 — the rebind
-        # path already early-returns on 0, so a corrupted
-        # broadcast just silently skips rebind rather than
-        # raising into the browser callback.
-        remote_build_port = 0
+    remote_build_port = _decode_txt_int(properties.get(b"remote_build_port"))
     # ``info.name`` comes back as ``<instance>.<service_type>``; we
     # only want the leftmost label as the friendly name.
     instance = (info.name or name).split(".", 1)[0]

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -1750,6 +1750,36 @@ class RemoteBuildController:
             self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
         )
 
+    def _respawn_peer_link_at_new_endpoint(self, pairing: StoredPairing) -> None:
+        """Cancel + respawn the peer-link client and announce the new endpoint.
+
+        Called after a caller has mutated *pairing*'s
+        ``receiver_hostname`` / ``receiver_port`` in place to
+        new coordinates. Encapsulates the three-step rebind
+        epilogue:
+
+        * cancel the old peer-link client task (parked on
+          ``aiohttp.ws_connect`` against the now-dead endpoint;
+          would otherwise idle there until heartbeat-timeout),
+        * spawn a fresh client at the pairing's new coordinates,
+        * fire :attr:`EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND`
+          so subscribed frontends update display fields without
+          a snapshot read.
+
+        Used by :meth:`_probe_and_rebind_endpoint` today; the
+        eventual phase 8b "manually edit a paired sender's
+        hostname/port" surface lands on the same epilogue
+        (different validate-and-mutate prologue, identical
+        respawn-and-announce shape).
+        """
+        self._cancel_peer_link_client(pairing.pin_sha256)
+        self._spawn_peer_link_client(pairing)
+        self._fire_offloader_pair_endpoint_rebound(
+            pin_sha256=pairing.pin_sha256,
+            receiver_hostname=pairing.receiver_hostname,
+            receiver_port=pairing.receiver_port,
+        )
+
     # ------------------------------------------------------------------
     # mDNS auto-rebind (4a-o part 7)
     # ------------------------------------------------------------------
@@ -1867,16 +1897,7 @@ class RemoteBuildController:
             current.receiver_hostname = new_hostname
             current.receiver_port = new_port
             self._schedule_pairings_save()
-            # Cancel-then-spawn so the old task (parked on
-            # ``aiohttp.ws_connect`` against the dead endpoint)
-            # doesn't idle there until heartbeat-timeout.
-            self._cancel_peer_link_client(pin)
-            self._spawn_peer_link_client(current)
-            self._fire_offloader_pair_endpoint_rebound(
-                pin_sha256=pin,
-                receiver_hostname=new_hostname,
-                receiver_port=new_port,
-            )
+            self._respawn_peer_link_at_new_endpoint(current)
             self._rebind_probe_until.pop(pin, None)
             _LOGGER.info("rebound pairing %s to %s:%d", pin, new_hostname, new_port)
 

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -226,23 +226,30 @@ def _decode_txt_value(raw: bytes | None) -> str:
         return ""
 
 
-def _decode_txt_int(raw: bytes | None) -> int:
-    """Decode a TXT value as an int, falling back to 0.
+def _decode_txt_port(raw: bytes | None) -> int:
+    """Decode a TCP port from a TXT value; fall back to 0 on absent / malformed / out-of-range.
 
-    Defensive: a corrupted / non-numeric TXT entry shouldn't
-    raise into the browser callback (which would abort the
-    resolve task and silently lose the peer). 0 is the same
-    "not advertised" sentinel TXT-absent rows already produce,
-    so downstream sites that gate on a real port already cover
-    the malformed-payload case.
+    Defensive: a corrupted / non-numeric / out-of-range TXT
+    entry shouldn't raise into the browser callback (which
+    would abort the resolve task and silently lose the peer),
+    and shouldn't trigger spurious rebind probes for a port
+    we couldn't dial anyway. Negative integers and values
+    outside the IANA ``1..65535`` range collapse to the same
+    "not advertised" 0 sentinel TXT-absent rows already
+    produce, so downstream sites that gate on a real port
+    cover absence, malformation, and spoof attempts in one
+    check.
     """
     decoded = _decode_txt_value(raw)
     if not decoded:
         return 0
     try:
-        return int(decoded)
+        port = int(decoded)
     except ValueError:
         return 0
+    if not 1 <= port <= 65535:
+        return 0
+    return port
 
 
 def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPeer:
@@ -272,7 +279,7 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
     # receivers that haven't published them; the rebind path
     # silently skips those rows.
     pin_sha256 = _decode_txt_value(properties.get(b"pin_sha256"))
-    remote_build_port = _decode_txt_int(properties.get(b"remote_build_port"))
+    remote_build_port = _decode_txt_port(properties.get(b"remote_build_port"))
     # ``info.name`` comes back as ``<instance>.<service_type>``; we
     # only want the leftmost label as the friendly name.
     instance = (info.name or name).split(".", 1)[0]

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -60,8 +60,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Callable, Hashable
-from contextlib import ExitStack
+from collections.abc import Callable, Hashable, Iterator
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass as _dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -1764,7 +1764,7 @@ class RemoteBuildController:
         immediately. Failure paths leave the cooldown in place.
         """
         pin = pairing.pin_sha256
-        try:
+        with self._clear_cooldown_on_unexpected_exit(pin):
             assert self._offloader_peer_link_priv is not None  # narrowed by caller
             try:
                 observed_pin = await peer_link_preview_pair(
@@ -1820,12 +1820,22 @@ class RemoteBuildController:
             )
             self._rebind_probe_until.pop(pin, None)
             _LOGGER.info("rebound pairing %s to %s:%d", pin, new_hostname, new_port)
+
+    @contextmanager
+    def _clear_cooldown_on_unexpected_exit(self, pin: str) -> Iterator[None]:
+        """Pop *pin* from ``_rebind_probe_until`` iff the wrapped block raises.
+
+        Graceful failure paths inside the probe (unreachable
+        host, pin mismatch, mid-probe re-pair) preserve the
+        cooldown entry to throttle retries. Cancellation /
+        unexpected exceptions shouldn't lock the pin out of
+        future legitimate rebind attempts, so on any escaped
+        exception we drop the entry before the exception
+        propagates.
+        """
+        try:
+            yield
         except BaseException:
-            # Catch-all reraise: anything that escapes (cancellation,
-            # unexpected exception) shouldn't leave the cooldown
-            # entry stranded in a way that blocks future probes
-            # for the full window. Keep the entry only on
-            # graceful-failure paths above.
             self._rebind_probe_until.pop(pin, None)
             raise
 

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -82,6 +82,7 @@ from ...helpers.dashboard_identity import (
     rotate_certificate,
 )
 from ...helpers.event_bus import Event
+from ...helpers.hostname import normalize_hostname
 from ...helpers.json import dumps as json_dumps
 from ...helpers.json import loads as json_loads
 from ...helpers.peer_link_identity import get_or_create_peer_link_identity
@@ -94,6 +95,7 @@ from ...models import (
     IntentResponse,
     OffloaderAlertSnapshotEntry,
     OffloaderPairAlertDismissedData,
+    OffloaderPairEndpointReboundData,
     OffloaderPairPeerRevokedData,
     OffloaderPairPinMismatchData,
     OffloaderPairStatusChangedData,
@@ -242,6 +244,24 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
     properties = info.properties or {}
     server_version = _decode_txt_value(properties.get(b"server_version"))
     esphome_version = _decode_txt_value(properties.get(b"esphome_version"))
+    # ``pin_sha256`` and ``remote_build_port`` are emitted by the
+    # advertiser only when the peer-link listener is bound (see
+    # :class:`DashboardAdvertiser`). The offloader-side mDNS
+    # auto-rebind path (4a-o part 7) reads both: pin to match a
+    # broadcast against a stored pairing, port to dial the
+    # peer-link Noise WS on the new endpoint. ``""`` / ``0`` for
+    # receivers that haven't published them; the rebind path
+    # silently skips those rows.
+    pin_sha256 = _decode_txt_value(properties.get(b"pin_sha256"))
+    remote_build_port_raw = _decode_txt_value(properties.get(b"remote_build_port"))
+    try:
+        remote_build_port = int(remote_build_port_raw) if remote_build_port_raw else 0
+    except ValueError:
+        # Malformed TXT (non-numeric) lands as 0 — the rebind
+        # path already early-returns on 0, so a corrupted
+        # broadcast just silently skips rebind rather than
+        # raising into the browser callback.
+        remote_build_port = 0
     # ``info.name`` comes back as ``<instance>.<service_type>``; we
     # only want the leftmost label as the friendly name.
     instance = (info.name or name).split(".", 1)[0]
@@ -254,6 +274,8 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
         addresses=info.parsed_scoped_addresses(IPVersion.All) or [],
         server_version=server_version,
         esphome_version=esphome_version,
+        pin_sha256=pin_sha256,
+        remote_build_port=remote_build_port,
     )
 
 
@@ -635,6 +657,17 @@ _PAIR_STATUS_RECONNECT_BACKOFF_SECONDS = 2.0
 # ``async_delay_save`` cadence on its own ``Store`` callers.
 _PAIRINGS_SAVE_DELAY_SECONDS = 1.0
 
+# Sliding window enforced per-pin between mDNS rebind probes
+# (4a-o part 7). Doubles as the in-flight guard (set when
+# scheduling, cleared only on probe success) and the
+# retry-throttle (failure leaves the entry in place until the
+# window elapses, so a permanently-unreachable host doesn't
+# trigger one probe per mDNS Updated burst). 30 s is plenty
+# longer than the longest plausible probe round-trip
+# (Noise WS ``_DEFAULT_TIMEOUT_SECONDS`` ~ 10 s) so an in-flight
+# probe never expires its own slot.
+_REBIND_PROBE_COOLDOWN_SECONDS = 30.0
+
 # On-disk filename for the offloader-side pairings store. Sibling
 # of ``.device-builder.json`` in ``config_dir`` rather than a
 # sub-key of it: per-domain atomicity, no lock contention against
@@ -705,6 +738,19 @@ class RemoteBuildController:
         # Strong refs for fire-and-forget resolve tasks so the
         # garbage collector can't reap them mid-await.
         self._tasks: set[asyncio.Task[None]] = set()
+        # mDNS auto-rebind probe slot per pin (4a-o part 7),
+        # mapping ``pin_sha256`` to the monotonic timestamp at
+        # which another probe is allowed. Doubles as the
+        # in-flight guard (set on schedule) and the
+        # retry-throttle (failure leaves it in place until the
+        # cooldown elapses), so a probe storm from mDNS Updated
+        # bursts and a retry hammer from a permanently-unreachable
+        # host both collapse to one probe per
+        # :data:`_REBIND_PROBE_COOLDOWN_SECONDS`. Successful
+        # probes clear the entry — the row's stored coords now
+        # match the broadcast and future broadcasts skip on the
+        # equality check before they reach this map.
+        self._rebind_probe_until: dict[str, float] = {}
         # The mDNS service-instance name our own ``DashboardAdvertiser``
         # publishes; captured at start so we can filter our own
         # broadcast out of the discovered list. ``None`` when the
@@ -1593,6 +1639,16 @@ class RemoteBuildController:
             return
         self._peers[name] = peer
         self._db.bus.fire(EventType.REMOTE_BUILD_HOST_ADDED, peer.to_dict())
+        # mDNS auto-rebind (4a-o part 7). Same callback that fires
+        # the discovered-hosts event also drives the per-pairing
+        # rebind: if this broadcast carries a ``pin_sha256`` we
+        # have a stored pairing for AND its ``(host, port)``
+        # differs from what we have on disk, kick off a
+        # probe-then-rebind background task. The probe is what
+        # enforces "verify the new endpoint is actually our paired
+        # receiver, not an mDNS spoof, before mutating internal
+        # state."
+        self._maybe_schedule_rebind_probe(peer)
 
     def _is_self_endpoint(self, hostname: str, port: int) -> bool:
         """Return True when *(hostname, port)* matches our published advertise.
@@ -1600,11 +1656,10 @@ class RemoteBuildController:
         Reads the live ``service_target_endpoint`` off the
         :class:`DashboardAdvertiser` rather than a captured-at-start
         value so a post-start register / re-register isn't missed.
-        Hostname comparison is case-insensitive and trailing-dot
-        tolerant; the advertiser already normalises its end of
-        the comparison to lowercase + no trailing dot, and the
-        resolved peer hostname (off the SRV target) gets the
-        same treatment here.
+        Hostname comparison goes through
+        :func:`normalize_hostname` so the resolved peer hostname
+        and the advertiser's published target compare equal
+        regardless of trailing-dot / case.
         """
         advertiser = self._db._dashboard_advertiser
         if advertiser is None:
@@ -1613,12 +1668,170 @@ class RemoteBuildController:
         if endpoint is None:
             return False
         own_host, own_port = endpoint
-        return port == own_port and hostname.rstrip(".").lower() == own_host
+        return port == own_port and normalize_hostname(hostname) == own_host
 
     def _fire_host_removed(self, name: str) -> None:
         """Fire ``REMOTE_BUILD_HOST_REMOVED`` for *name*."""
         payload: RemoteBuildHostRemovedData = {"name": name}
         self._db.bus.fire(EventType.REMOTE_BUILD_HOST_REMOVED, payload)
+
+    # ------------------------------------------------------------------
+    # mDNS auto-rebind (4a-o part 7)
+    # ------------------------------------------------------------------
+
+    def _maybe_schedule_rebind_probe(self, peer: RemoteBuildPeer) -> None:
+        """Spawn a probe-and-rebind task if *peer* is a known pin at a new endpoint.
+
+        Called from :meth:`_upsert_host` on every resolved
+        broadcast. Cheap early-returns dominate (most discoveries
+        are unpaired peers or steady-state re-announces); only a
+        rare hostname / port change for an APPROVED pairing
+        spawns a probe task. The probe slot is rate-limited via
+        :attr:`_rebind_probe_until` so a burst of zeroconf
+        Updated callbacks or a permanently-unreachable host both
+        collapse to one probe per
+        :data:`_REBIND_PROBE_COOLDOWN_SECONDS`.
+        """
+        pin = peer.pin_sha256
+        new_port = peer.remote_build_port
+        if not pin or new_port == 0:
+            return
+        pairing = self._pairings.get(pin)
+        if pairing is None or pairing.status is not PeerStatus.APPROVED:
+            return
+        new_hostname = normalize_hostname(peer.hostname)
+        if (
+            normalize_hostname(pairing.receiver_hostname) == new_hostname
+            and pairing.receiver_port == new_port
+        ):
+            return
+        if self._offloader_peer_link_priv is None:
+            return
+        now = time.monotonic()
+        if self._rebind_probe_until.get(pin, 0.0) > now:
+            return
+        self._rebind_probe_until[pin] = now + _REBIND_PROBE_COOLDOWN_SECONDS
+        task = asyncio.create_task(
+            self._probe_and_rebind_endpoint(
+                pairing=pairing, new_hostname=new_hostname, new_port=new_port
+            ),
+            name=f"rebind-probe-{pin[:8]}",
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _probe_and_rebind_endpoint(
+        self, *, pairing: StoredPairing, new_hostname: str, new_port: int
+    ) -> None:
+        """Probe the candidate endpoint; rebind the pairing iff the pin still matches.
+
+        The probe is one ``intent="preview"`` Noise XX round-trip
+        via :func:`peer_link_preview_pair` and serves three roles
+        in a single network call:
+
+        * **Reachability check** — TCP connect + Noise handshake
+          completing means the new endpoint is up and answering
+          peer-link traffic. Any connect / timeout / Noise error
+          raises :class:`PeerLinkClientError`; we leave stored
+          state alone (and let the cooldown gate the next
+          attempt).
+        * **Identity verification** — Noise XX binds the
+          responder's static X25519 pubkey into the handshake
+          transcript. A mismatch against the stored pin means a
+          different keypair under the same advertised pin (mDNS
+          spoof, untracked identity rotation, fresh receiver
+          grabbing the old hostname); refuse to rebind.
+        * **Pairing-window-independent** — ``preview`` is the
+          one intent the receiver always honours, so a quiet
+          receiver doesn't deadlock the rebind path.
+
+        On match, mutate :class:`StoredPairing` in place,
+        schedule the debounced save, cancel + respawn the
+        peer-link client at the new coordinates, fire
+        :attr:`EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND`, and
+        clear the cooldown so a future move is probed
+        immediately. Failure paths leave the cooldown in place.
+        """
+        pin = pairing.pin_sha256
+        try:
+            assert self._offloader_peer_link_priv is not None  # narrowed by caller
+            try:
+                observed_pin = await peer_link_preview_pair(
+                    hostname=new_hostname,
+                    port=new_port,
+                    identity_priv=self._offloader_peer_link_priv,
+                )
+            except PeerLinkClientError:
+                _LOGGER.debug(
+                    "rebind probe %s -> %s:%d failed (unreachable / handshake error)",
+                    pin,
+                    new_hostname,
+                    new_port,
+                    exc_info=True,
+                )
+                return
+            if observed_pin != pin:
+                _LOGGER.warning(
+                    "rebind probe %s -> %s:%d observed pin %s; ignoring (spoof or rotation)",
+                    pin,
+                    new_hostname,
+                    new_port,
+                    observed_pin,
+                )
+                return
+            # Identity check on the dict entry, not just presence:
+            # ``unpair`` may have dropped the row, or a fresh
+            # ``request_pair`` against the same pin (re-pair under
+            # the same identity) replaces the entry with a new
+            # :class:`StoredPairing` object via
+            # :meth:`_upsert_pairing`. Either way the probe
+            # outcome is stale relative to what's now in the dict;
+            # mutating it would clobber the user's current state.
+            current = self._pairings.get(pin)
+            if current is not pairing:
+                return
+            if current.status is not PeerStatus.APPROVED:
+                return
+            current.receiver_hostname = new_hostname
+            current.receiver_port = new_port
+            self._pairings_store.async_delay_save(
+                self._serialize_pairings, delay=_PAIRINGS_SAVE_DELAY_SECONDS
+            )
+            # Cancel-then-spawn so the old task (parked on
+            # ``aiohttp.ws_connect`` against the dead endpoint)
+            # doesn't idle there until heartbeat-timeout.
+            self._cancel_peer_link_client(pin)
+            self._spawn_peer_link_client(current)
+            self._fire_offloader_pair_endpoint_rebound(
+                pin_sha256=pin,
+                receiver_hostname=new_hostname,
+                receiver_port=new_port,
+            )
+            self._rebind_probe_until.pop(pin, None)
+            _LOGGER.info("rebound pairing %s to %s:%d", pin, new_hostname, new_port)
+        except BaseException:
+            # Catch-all reraise: anything that escapes (cancellation,
+            # unexpected exception) shouldn't leave the cooldown
+            # entry stranded in a way that blocks future probes
+            # for the full window. Keep the entry only on
+            # graceful-failure paths above.
+            self._rebind_probe_until.pop(pin, None)
+            raise
+
+    def _fire_offloader_pair_endpoint_rebound(
+        self,
+        *,
+        pin_sha256: str,
+        receiver_hostname: str,
+        receiver_port: int,
+    ) -> None:
+        """Fire ``OFFLOADER_PAIR_ENDPOINT_REBOUND`` after a successful rebind."""
+        payload: OffloaderPairEndpointReboundData = {
+            "pin_sha256": pin_sha256,
+            "receiver_hostname": receiver_hostname,
+            "receiver_port": receiver_port,
+        }
+        self._db.bus.fire(EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND, payload)
 
     def hosts_snapshot(self) -> list[RemoteBuildPeer]:
         """Return the current mDNS-discovered hosts.

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -1550,6 +1550,7 @@ class RemoteBuildController:
         self._pairings.clear()
         self._peer_queue_status.clear()
         self._open_peer_links.clear()
+        self._rebind_probe_until.clear()
         self._peers.clear()
         # Receiver-side APPROVED peers clear silently too —
         # unlike :meth:`_clear_pending_peers_on_window_close`

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -140,6 +140,21 @@ class EventType(StrEnum):
     # offloader knows are the ``(hostname, port)`` it dialled.
     OFFLOADER_PAIR_STATUS_CHANGED = "offloader_pair_status_changed"
 
+    # Offloader-side mDNS auto-rebind. Payload: ``{pin_sha256,
+    # receiver_hostname, receiver_port}``. Fired when the
+    # offloader's mDNS browser observes a known paired receiver
+    # broadcasting from a different ``(hostname, port)`` than the
+    # ``StoredPairing`` records, and a probe-before-mutate Noise
+    # XX handshake against the new endpoint confirmed the
+    # responder's static pubkey matches the stored pin. The
+    # controller has already mutated ``StoredPairing`` in place,
+    # cancelled the old peer-link client, and respawned a fresh
+    # one against the new coordinates by the time this fires;
+    # frontends update the row's display fields off the new
+    # ``receiver_hostname`` / ``receiver_port`` without a
+    # re-fetch (4a-o part 7).
+    OFFLOADER_PAIR_ENDPOINT_REBOUND = "offloader_pair_endpoint_rebound"
+
     # Pairing window opened, extended, or closed. Payload:
     # ``{open: bool, expires_in_seconds: float | None}``. Fires
     # on every state transition: window open (open=true,

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1301,10 +1301,11 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     server_version: str = ""
     esphome_version: str = ""
     # Receiver's peer-link X25519 static pubkey hash (lowercase-
-    # hex SHA-256, same value :class:`StoredPairing.pin_sha256`
-    # stores) and peer-link Noise WS port, both pulled out of
-    # the ``_esphomebuilder._tcp.local.`` TXT record. Distinct
-    # from the dashboard's 3a TLS cert SPKI fingerprint; the
+    # hex SHA-256, the same value as
+    # :attr:`StoredPairing.pin_sha256`) and peer-link Noise WS
+    # port, both pulled out of the
+    # ``_esphomebuilder._tcp.local.`` TXT record. Distinct from
+    # the dashboard's 3a TLS cert SPKI fingerprint; the
     # peer-link identity is its own X25519 keypair (see
     # ``helpers/peer_link_identity.py``). The offloader uses
     # both to match a discovered broadcast against a stored
@@ -1312,7 +1313,7 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     # port for the auto-rebind probe (4a-o part 7). Empty
     # string / 0 for: receivers that haven't bound the
     # peer-link listener (default-off mode), and ``MANUAL``
-    # rows (which never go through the mDNS resolve path — the
+    # rows (which never go through the mDNS resolve path; the
     # user typed the hostname/port and the pair flow captures
     # the pin into ``StoredPairing`` rather than back onto this
     # row).

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1300,17 +1300,22 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     addresses: list[str] = field(default_factory=list)
     server_version: str = ""
     esphome_version: str = ""
-    # Receiver's SPKI fingerprint (lowercase-hex SHA-256) and
-    # peer-link Noise WS port, both pulled out of the
-    # ``_esphomebuilder._tcp.local.`` TXT record. The offloader
-    # uses both to match a discovered broadcast against a stored
-    # pairing's ``pin_sha256`` and dial the right peer-link port
-    # for the auto-rebind probe (4a-o part 7). Empty string / 0
-    # for: receivers that haven't bound the peer-link listener
-    # (default-off mode), and ``MANUAL`` rows (which never go
-    # through the mDNS resolve path — the user typed the
-    # hostname/port and the pair flow captures the pin into
-    # ``StoredPairing`` rather than back onto this row).
+    # Receiver's peer-link X25519 static pubkey hash (lowercase-
+    # hex SHA-256, same value :class:`StoredPairing.pin_sha256`
+    # stores) and peer-link Noise WS port, both pulled out of
+    # the ``_esphomebuilder._tcp.local.`` TXT record. Distinct
+    # from the dashboard's 3a TLS cert SPKI fingerprint; the
+    # peer-link identity is its own X25519 keypair (see
+    # ``helpers/peer_link_identity.py``). The offloader uses
+    # both to match a discovered broadcast against a stored
+    # pairing's ``pin_sha256`` and dial the right peer-link
+    # port for the auto-rebind probe (4a-o part 7). Empty
+    # string / 0 for: receivers that haven't bound the
+    # peer-link listener (default-off mode), and ``MANUAL``
+    # rows (which never go through the mDNS resolve path — the
+    # user typed the hostname/port and the pair flow captures
+    # the pin into ``StoredPairing`` rather than back onto this
+    # row).
     pin_sha256: str = ""
     remote_build_port: int = 0
 

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1302,14 +1302,15 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     esphome_version: str = ""
     # Receiver's SPKI fingerprint (lowercase-hex SHA-256) and
     # peer-link Noise WS port, both pulled out of the
-    # ``_esphomebuilder._tcp.local.`` TXT record. Empty / 0 when
-    # the receiver hasn't published them (default-off mode, or
-    # the listener hasn't bound yet); the offloader uses both to
-    # match a discovered broadcast against a stored pairing's
-    # ``pin_sha256`` and dial the right peer-link port for the
-    # auto-rebind probe (4a-o part 7). Manual-source rows leave
-    # both empty; phase 4 attempts the connection during pair
-    # and fills them in.
+    # ``_esphomebuilder._tcp.local.`` TXT record. The offloader
+    # uses both to match a discovered broadcast against a stored
+    # pairing's ``pin_sha256`` and dial the right peer-link port
+    # for the auto-rebind probe (4a-o part 7). Empty string / 0
+    # for: receivers that haven't bound the peer-link listener
+    # (default-off mode), and ``MANUAL`` rows (which never go
+    # through the mDNS resolve path — the user typed the
+    # hostname/port and the pair flow captures the pin into
+    # ``StoredPairing`` rather than back onto this row).
     pin_sha256: str = ""
     remote_build_port: int = 0
 

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -242,6 +242,32 @@ class OffloaderPairStatusChangedData(TypedDict):
     status: Literal["approved", "removed"]
 
 
+class OffloaderPairEndpointReboundData(TypedDict):
+    """
+    Payload for ``EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND``.
+
+    Fired by the offloader's mDNS auto-rebind path
+    (``RemoteBuildController._probe_and_rebind_endpoint``) after
+    a paired receiver's broadcast arrived from a different
+    ``(hostname, port)`` than the ``StoredPairing`` records and a
+    probe-before-mutate Noise XX handshake against the new
+    endpoint confirmed the responder's static pubkey hash still
+    matches the stored ``pin_sha256``.
+
+    Carries the row's stable ``pin_sha256`` plus the new
+    receiver coordinates so subscribers update display fields
+    without a follow-up snapshot read. The peer-link client task
+    has already been respawned against the new coordinates by
+    the time this event fires; the ``OFFLOADER_PEER_LINK_OPENED``
+    fired by the new client follows in the same loop tick after
+    the handshake completes.
+    """
+
+    pin_sha256: str
+    receiver_hostname: str
+    receiver_port: int
+
+
 class OffloaderPairPinMismatchData(TypedDict):
     """
     Payload for ``EventType.OFFLOADER_PAIR_PIN_MISMATCH``.
@@ -1274,6 +1300,18 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     addresses: list[str] = field(default_factory=list)
     server_version: str = ""
     esphome_version: str = ""
+    # Receiver's SPKI fingerprint (lowercase-hex SHA-256) and
+    # peer-link Noise WS port, both pulled out of the
+    # ``_esphomebuilder._tcp.local.`` TXT record. Empty / 0 when
+    # the receiver hasn't published them (default-off mode, or
+    # the listener hasn't bound yet); the offloader uses both to
+    # match a discovered broadcast against a stored pairing's
+    # ``pin_sha256`` and dial the right peer-link port for the
+    # auto-rebind probe (4a-o part 7). Manual-source rows leave
+    # both empty; phase 4 attempts the connection during pair
+    # and fills them in.
+    pin_sha256: str = ""
+    remote_build_port: int = 0
 
 
 @dataclass

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -721,13 +721,27 @@ def test_peer_from_service_info_parses_pin_and_remote_build_port() -> None:
     assert peer.remote_build_port == 6058
 
 
-def test_peer_from_service_info_tolerates_malformed_remote_build_port() -> None:
-    """A non-numeric ``remote_build_port`` lands as 0 (rebind path skips on 0).
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"not-a-number",  # non-numeric
+        b"-1",  # negative
+        b"0",  # zero
+        b"65536",  # one past the IANA range
+        b"99999999",  # absurdly large
+        b"",  # empty
+    ],
+)
+def test_peer_from_service_info_clamps_invalid_remote_build_port(raw: bytes) -> None:
+    """Non-numeric / out-of-range ``remote_build_port`` values land as 0.
 
-    Defensive: a corrupted broadcast shouldn't raise into the
-    browser callback (which would abort the resolve task and
-    silently lose the peer). Lands as 0 instead, and the rebind
-    early-return on ``remote_build_port == 0`` skips the row.
+    Defensive: a corrupted or spoofed broadcast shouldn't raise
+    into the browser callback (which would abort the resolve
+    task and silently lose the peer), and shouldn't trigger
+    spurious rebind probes for a port we couldn't dial anyway.
+    Negative integers, 0, and values above 65535 collapse to
+    the same ``0`` "not advertised" sentinel TXT-absent rows
+    already produce.
     """
     info = MagicMock()
     info.name = f"green.{SERVICE_TYPE}"
@@ -737,7 +751,7 @@ def test_peer_from_service_info_tolerates_malformed_remote_build_port() -> None:
         b"server_version": b"",
         b"esphome_version": b"",
         b"pin_sha256": (b"a" * 64),
-        b"remote_build_port": b"not-a-number",
+        b"remote_build_port": raw,
     }
     info.parsed_scoped_addresses = MagicMock(return_value=[])
 

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -409,8 +409,13 @@ async def test_rebind_probe_pin_mismatch_does_not_mutate(
     controller._cancel_peer_link_client.assert_not_called()
     controller._spawn_peer_link_client.assert_not_called()
     # No rebind event for a mismatch.
-    fire_calls = [c.args for c in controller._db.bus.fire.call_args_list]
-    assert (EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND, ...) not in fire_calls
+    # No rebind event for a mismatch — iterate the full call list
+    # because positional args alone don't make a stable equality
+    # match against an arbitrary payload dict.
+    assert not any(
+        call.args[0] is EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND
+        for call in controller._db.bus.fire.call_args_list
+    )
     # Cooldown stays in place: a permanent spoof source mustn't
     # trigger one probe per mDNS Updated burst.
     assert controller._rebind_probe_until[pin] == 9999.0

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -287,6 +287,460 @@ def test_upsert_host_drops_self_endpoint(tmp_path: Path) -> None:
     controller._db.bus.fire.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# mDNS auto-rebind (4a-o part 7)
+# ---------------------------------------------------------------------------
+
+
+def _make_paired_offloader_controller(
+    *,
+    config_dir: Path,
+    pairing: StoredPairing,
+) -> RemoteBuildController:
+    """Build a controller with the offloader-side identity loaded + one APPROVED pairing.
+
+    The rebind path early-returns when the offloader's
+    peer-link identity isn't loaded (start-order guard). Tests
+    that drive the rebind code synthesise the post-start state
+    by setting both the dashboard_id and the priv key directly.
+    """
+    controller = _make_controller(config_dir=config_dir)
+    controller._db.bus = MagicMock()
+    controller._offloader_dashboard_id = "offloader-id-aaaa"
+    controller._offloader_peer_link_priv = b"\x42" * 32
+    controller._pairings[pairing.pin_sha256] = pairing
+    return controller
+
+
+def _make_mdns_info(
+    *,
+    name: str,
+    hostname: str,
+    port: int,
+    pin_sha256: str,
+    remote_build_port: int,
+) -> MagicMock:
+    """Build an ``AsyncServiceInfo`` mock matching the resolved-mDNS shape.
+
+    Mirrors what ``_peer_from_service_info`` reads off zeroconf:
+    ``name`` / ``server`` / ``port`` plus a TXT properties dict
+    with ``server_version`` / ``esphome_version`` /
+    ``pin_sha256`` / ``remote_build_port``.
+    """
+    info = MagicMock()
+    info.name = name
+    info.server = hostname
+    info.port = port
+    info.properties = {
+        b"server_version": b"0.1.0",
+        b"esphome_version": b"2026.5.0-dev",
+        b"pin_sha256": pin_sha256.encode(),
+        b"remote_build_port": str(remote_build_port).encode(),
+    }
+    info.parsed_scoped_addresses = MagicMock(return_value=["10.0.0.42"])
+    return info
+
+
+@pytest.mark.asyncio
+async def test_rebind_probe_match_mutates_pairing_and_fires_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful probe rebinds the StoredPairing and fires OFFLOADER_PAIR_ENDPOINT_REBOUND.
+
+    Pins the happy-path: an APPROVED pairing for pin X observed
+    at the same hostname but a new ``remote_build_port``, the
+    probe returns the matching pin, the pairing is mutated in
+    place, the peer-link client is cancelled + respawned at the
+    new endpoint, and the rebind event fires with the new
+    coords.
+    """
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    cancel_calls: list[str] = []
+    spawn_calls: list[StoredPairing] = []
+    monkeypatch.setattr(controller, "_cancel_peer_link_client", cancel_calls.append)
+    monkeypatch.setattr(controller, "_spawn_peer_link_client", spawn_calls.append)
+    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value=pin))
+
+    await controller._probe_and_rebind_endpoint(
+        pairing=pairing, new_hostname="new.local", new_port=7000
+    )
+
+    assert pairing.receiver_hostname == "new.local"
+    assert pairing.receiver_port == 7000
+    assert cancel_calls == [pin]
+    assert spawn_calls == [pairing]
+    controller._db.bus.fire.assert_any_call(
+        EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND,
+        {"pin_sha256": pin, "receiver_hostname": "new.local", "receiver_port": 7000},
+    )
+    # Successful rebind clears the cooldown so a future move
+    # gets probed immediately rather than waiting out the window.
+    assert pin not in controller._rebind_probe_until
+
+
+@pytest.mark.asyncio
+async def test_rebind_probe_pin_mismatch_does_not_mutate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A probe whose observed pin differs from the stored pin leaves state alone.
+
+    Defends against an mDNS spoof where an attacker advertises
+    our pin at their endpoint: the probe's Noise XX handshake
+    captures the actual responder pubkey, hashes it, and a
+    mismatch bails the rebind.
+    """
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
+    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
+    # Prime the cooldown to assert it's preserved on mismatch.
+    controller._rebind_probe_until[pin] = 9999.0
+    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value="b" * 64))
+
+    await controller._probe_and_rebind_endpoint(
+        pairing=pairing, new_hostname="spoofed.local", new_port=7000
+    )
+
+    assert pairing.receiver_hostname == "old.local"
+    assert pairing.receiver_port == 6058
+    controller._cancel_peer_link_client.assert_not_called()
+    controller._spawn_peer_link_client.assert_not_called()
+    # No rebind event for a mismatch.
+    fire_calls = [c.args for c in controller._db.bus.fire.call_args_list]
+    assert (EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND, ...) not in fire_calls
+    # Cooldown stays in place: a permanent spoof source mustn't
+    # trigger one probe per mDNS Updated burst.
+    assert controller._rebind_probe_until[pin] == 9999.0
+
+
+@pytest.mark.asyncio
+async def test_rebind_probe_unreachable_does_not_mutate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A probe that raises PeerLinkClientError leaves state alone and keeps the cooldown.
+
+    The probe is the reachability check (TCP connect + Noise
+    handshake completing means the new endpoint is up). A
+    transport / handshake error means we couldn't verify the
+    new endpoint at all; the rebind doesn't happen, and the
+    cooldown stays in place so a permanently-unreachable host
+    doesn't trigger a probe per mDNS event.
+    """
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    controller._rebind_probe_until[pin] = 9999.0
+    monkeypatch.setattr(
+        rb,
+        "peer_link_preview_pair",
+        AsyncMock(side_effect=rb.PeerLinkClientError("connect refused")),
+    )
+
+    await controller._probe_and_rebind_endpoint(
+        pairing=pairing, new_hostname="unreachable.local", new_port=7000
+    )
+
+    assert pairing.receiver_hostname == "old.local"
+    assert pairing.receiver_port == 6058
+    # Cooldown preserved — gates retry on next mDNS event.
+    assert controller._rebind_probe_until[pin] == 9999.0
+
+
+@pytest.mark.asyncio
+async def test_rebind_probe_skips_when_pairing_replaced_mid_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A re-pair under the same pin while the probe is in flight wins; probe doesn't clobber.
+
+    Race: ``unpair`` + ``request_pair`` for the same pin
+    replaces the dict entry with a fresh ``StoredPairing``
+    object via ``_upsert_pairing``. The in-flight probe captured
+    the OLD pairing reference; on completion it must refuse to
+    mutate the NEW pairing's hostname/port.
+    """
+    pin = "a" * 64
+    old = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=old)
+    # Simulate the in-flight re-pair: replace the dict entry
+    # with a fresh object before the probe applies its result.
+    fresh = _valid_stored_pairing(receiver_hostname="user-typed.local", receiver_port=6060)
+    controller._pairings[pin] = fresh
+    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
+    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
+    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value=pin))
+
+    await controller._probe_and_rebind_endpoint(
+        pairing=old, new_hostname="rebind-target.local", new_port=7000
+    )
+
+    # Fresh pairing is untouched: identity check on the dict
+    # entry refuses to mutate a different object.
+    assert fresh.receiver_hostname == "user-typed.local"
+    assert fresh.receiver_port == 6060
+    controller._cancel_peer_link_client.assert_not_called()
+    controller._spawn_peer_link_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rebind_probe_skips_when_pairing_status_flips_mid_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pairing that flips out of APPROVED mid-probe doesn't get rebound.
+
+    Defensive: status is the row's lifecycle gate. If something
+    (a stale pair-status listener result, a manual mutation in
+    a test, a future code path) flips the captured pairing back
+    to PENDING after the probe completes, the rebind shouldn't
+    install a new endpoint on a row that no longer matches the
+    APPROVED contract.
+    """
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
+    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
+
+    async def _flip_status_then_match(**_: Any) -> str:
+        # Same identity, but the row's status flipped between
+        # schedule and apply.
+        pairing.status = PeerStatus.PENDING
+        return pin
+
+    monkeypatch.setattr(rb, "peer_link_preview_pair", _flip_status_then_match)
+
+    await controller._probe_and_rebind_endpoint(
+        pairing=pairing, new_hostname="new.local", new_port=7000
+    )
+
+    assert pairing.receiver_hostname == "old.local"
+    assert pairing.receiver_port == 6058
+    controller._cancel_peer_link_client.assert_not_called()
+    controller._spawn_peer_link_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rebind_probe_unexpected_exception_clears_cooldown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unexpected exception (or cancellation) clears the cooldown and reraises.
+
+    Pins the BaseException-reraise path: graceful failures
+    (PeerLinkClientError, pin mismatch) preserve the cooldown
+    to throttle retries; unexpected escapes shouldn't lock the
+    pin out of future legitimate rebind attempts.
+    """
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    controller._rebind_probe_until[pin] = 9999.0
+    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(side_effect=RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await controller._probe_and_rebind_endpoint(
+            pairing=pairing, new_hostname="new.local", new_port=7000
+        )
+
+    assert pin not in controller._rebind_probe_until
+
+
+@pytest.mark.asyncio
+async def test_rebind_probe_skips_when_pairing_unpaired_mid_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user ``unpair`` while the probe is in flight wins; probe doesn't resurrect the row."""
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    # Simulate the in-flight unpair: drop the dict entry
+    # before the probe's mutate step.
+    controller._pairings.pop(pin)
+    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
+    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
+    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value=pin))
+
+    await controller._probe_and_rebind_endpoint(
+        pairing=pairing, new_hostname="new.local", new_port=7000
+    )
+
+    assert pin not in controller._pairings
+    controller._cancel_peer_link_client.assert_not_called()
+    controller._spawn_peer_link_client.assert_not_called()
+
+
+def test_maybe_schedule_rebind_probe_skips_when_endpoint_matches(
+    tmp_path: Path,
+) -> None:
+    """Steady-state mDNS Updated for an unchanged endpoint never spawns a probe."""
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="paired.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+
+    peer = RemoteBuildPeer(
+        name="paired",
+        hostname="paired.local.",  # trailing dot, common from zeroconf
+        port=6052,  # SRV port (dashboard HTTP); irrelevant to rebind
+        source=RemoteBuildPeerSource.MDNS,
+        pin_sha256=pin,
+        remote_build_port=6058,
+    )
+    controller._maybe_schedule_rebind_probe(peer)
+
+    assert pin not in controller._rebind_probe_until
+    assert controller._tasks == set()
+
+
+def test_maybe_schedule_rebind_probe_skips_when_no_pin_in_txt(tmp_path: Path) -> None:
+    """A receiver that hasn't bound the listener yet (no TXT pin) never triggers a probe."""
+    pairing = _valid_stored_pairing()
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+
+    peer = RemoteBuildPeer(
+        name="no-listener",
+        hostname="no-listener.local.",
+        port=6052,
+        source=RemoteBuildPeerSource.MDNS,
+        # No pin_sha256, no remote_build_port — receiver has the
+        # peer-link listener disabled (default-off mode).
+    )
+    controller._maybe_schedule_rebind_probe(peer)
+
+    assert controller._tasks == set()
+
+
+def test_maybe_schedule_rebind_probe_skips_pending(tmp_path: Path) -> None:
+    """A PENDING pairing isn't auto-rebound; pair-status listener owns its own connect."""
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(
+        receiver_hostname="old.local", receiver_port=6058, status=PeerStatus.PENDING
+    )
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+
+    peer = RemoteBuildPeer(
+        name="moved",
+        hostname="new.local.",
+        port=6052,
+        source=RemoteBuildPeerSource.MDNS,
+        pin_sha256=pin,
+        remote_build_port=7000,
+    )
+    controller._maybe_schedule_rebind_probe(peer)
+
+    assert controller._tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_maybe_schedule_rebind_probe_dedupes_within_cooldown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second mDNS Updated within the cooldown window doesn't spawn a duplicate probe.
+
+    Pins the in-flight + retry-throttle role of
+    ``_rebind_probe_until``: the first event sets the entry to
+    ``now + COOLDOWN``; subsequent events within that window
+    early-return rather than racing.
+    """
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    # Hang the probe so the first task stays in flight while the
+    # second schedule attempt runs against the live cooldown.
+    blocked = asyncio.Event()
+
+    async def _hanging_preview(**_: Any) -> str:
+        await blocked.wait()
+        return pin
+
+    monkeypatch.setattr(rb, "peer_link_preview_pair", _hanging_preview)
+    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
+    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
+
+    peer = RemoteBuildPeer(
+        name="moved",
+        hostname="new.local.",
+        port=6052,
+        source=RemoteBuildPeerSource.MDNS,
+        pin_sha256=pin,
+        remote_build_port=7000,
+    )
+    controller._maybe_schedule_rebind_probe(peer)
+    assert len(controller._tasks) == 1
+    controller._maybe_schedule_rebind_probe(peer)
+    assert len(controller._tasks) == 1
+
+    # Drain the hanging probe so the test exits cleanly.
+    blocked.set()
+    await asyncio.gather(*controller._tasks, return_exceptions=True)
+
+
+def test_maybe_schedule_rebind_probe_skips_without_priv(tmp_path: Path) -> None:
+    """No probe scheduled when the offloader's peer-link identity hasn't loaded yet."""
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    controller._offloader_peer_link_priv = None
+
+    peer = RemoteBuildPeer(
+        name="moved",
+        hostname="new.local.",
+        port=6052,
+        source=RemoteBuildPeerSource.MDNS,
+        pin_sha256=pin,
+        remote_build_port=7000,
+    )
+    controller._maybe_schedule_rebind_probe(peer)
+
+    assert controller._tasks == set()
+    assert pin not in controller._rebind_probe_until
+
+
+def test_peer_from_service_info_parses_pin_and_remote_build_port() -> None:
+    """TXT ``pin_sha256`` and ``remote_build_port`` flow through to ``RemoteBuildPeer``."""
+    info = MagicMock()
+    info.name = f"green.{SERVICE_TYPE}"
+    info.server = "green.local."
+    info.port = 6052
+    info.properties = {
+        b"server_version": b"0.1.0",
+        b"esphome_version": b"2026.5.0-dev",
+        b"pin_sha256": (b"a" * 64),
+        b"remote_build_port": b"6058",
+    }
+    info.parsed_scoped_addresses = MagicMock(return_value=["10.0.0.42"])
+
+    peer = _peer_from_service_info(f"green.{SERVICE_TYPE}", info)
+
+    assert peer.pin_sha256 == "a" * 64
+    assert peer.remote_build_port == 6058
+
+
+def test_peer_from_service_info_tolerates_malformed_remote_build_port() -> None:
+    """A non-numeric ``remote_build_port`` lands as 0 (rebind path skips on 0).
+
+    Defensive: a corrupted broadcast shouldn't raise into the
+    browser callback (which would abort the resolve task and
+    silently lose the peer). Lands as 0 instead, and the rebind
+    early-return on ``remote_build_port == 0`` skips the row.
+    """
+    info = MagicMock()
+    info.name = f"green.{SERVICE_TYPE}"
+    info.server = "green.local."
+    info.port = 6052
+    info.properties = {
+        b"server_version": b"",
+        b"esphome_version": b"",
+        b"pin_sha256": (b"a" * 64),
+        b"remote_build_port": b"not-a-number",
+    }
+    info.parsed_scoped_addresses = MagicMock(return_value=[])
+
+    peer = _peer_from_service_info(f"green.{SERVICE_TYPE}", info)
+
+    assert peer.remote_build_port == 0
+
+
 def test_on_service_state_change_removed_drops_peer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -312,35 +312,6 @@ def _make_paired_offloader_controller(
     return controller
 
 
-def _make_mdns_info(
-    *,
-    name: str,
-    hostname: str,
-    port: int,
-    pin_sha256: str,
-    remote_build_port: int,
-) -> MagicMock:
-    """Build an ``AsyncServiceInfo`` mock matching the resolved-mDNS shape.
-
-    Mirrors what ``_peer_from_service_info`` reads off zeroconf:
-    ``name`` / ``server`` / ``port`` plus a TXT properties dict
-    with ``server_version`` / ``esphome_version`` /
-    ``pin_sha256`` / ``remote_build_port``.
-    """
-    info = MagicMock()
-    info.name = name
-    info.server = hostname
-    info.port = port
-    info.properties = {
-        b"server_version": b"0.1.0",
-        b"esphome_version": b"2026.5.0-dev",
-        b"pin_sha256": pin_sha256.encode(),
-        b"remote_build_port": str(remote_build_port).encode(),
-    }
-    info.parsed_scoped_addresses = MagicMock(return_value=["10.0.0.42"])
-    return info
-
-
 @pytest.mark.asyncio
 async def test_rebind_probe_match_mutates_pairing_and_fires_event(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -408,8 +379,7 @@ async def test_rebind_probe_pin_mismatch_does_not_mutate(
     assert pairing.receiver_port == 6058
     controller._cancel_peer_link_client.assert_not_called()
     controller._spawn_peer_link_client.assert_not_called()
-    # No rebind event for a mismatch.
-    # No rebind event for a mismatch — iterate the full call list
+    # No rebind event for a mismatch. Walk the full call list
     # because positional args alone don't make a stable equality
     # match against an arbitrary payload dict.
     assert not any(

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -312,6 +312,47 @@ def _make_paired_offloader_controller(
     return controller
 
 
+def _patch_probe_internals(
+    monkeypatch: pytest.MonkeyPatch,
+    controller: RemoteBuildController,
+    *,
+    preview_return: str | None = None,
+    preview_side_effect: BaseException | None = None,
+    seed_cooldown_for: str | None = None,
+    cooldown_until: float = 9999.0,
+) -> tuple[MagicMock, MagicMock]:
+    """Stub the probe's three external calls and seed an optional cooldown.
+
+    Every probe test mocks the same three surfaces:
+    ``_cancel_peer_link_client`` (assert called or not),
+    ``_spawn_peer_link_client`` (same), and
+    ``peer_link_preview_pair`` (return the observed pin or
+    raise). Tests that pin "the cooldown is preserved on
+    failure" also seed ``_rebind_probe_until[pin]`` before
+    driving the probe; *seed_cooldown_for* / *cooldown_until*
+    handle that seed in the same call.
+
+    Returns ``(cancel_mock, spawn_mock)`` so the caller can do
+    ``cancel.assert_called_once_with(pin)`` on the success
+    path or ``cancel.assert_not_called()`` on every failure
+    path. Pass exactly one of *preview_return* /
+    *preview_side_effect*.
+    """
+    cancel = MagicMock()
+    spawn = MagicMock()
+    monkeypatch.setattr(controller, "_cancel_peer_link_client", cancel)
+    monkeypatch.setattr(controller, "_spawn_peer_link_client", spawn)
+    if preview_side_effect is not None:
+        monkeypatch.setattr(
+            rb, "peer_link_preview_pair", AsyncMock(side_effect=preview_side_effect)
+        )
+    elif preview_return is not None:
+        monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value=preview_return))
+    if seed_cooldown_for is not None:
+        controller._rebind_probe_until[seed_cooldown_for] = cooldown_until
+    return cancel, spawn
+
+
 @pytest.mark.asyncio
 async def test_rebind_probe_match_mutates_pairing_and_fires_event(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -328,11 +369,7 @@ async def test_rebind_probe_match_mutates_pairing_and_fires_event(
     pin = "a" * 64
     pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
     controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
-    cancel_calls: list[str] = []
-    spawn_calls: list[StoredPairing] = []
-    monkeypatch.setattr(controller, "_cancel_peer_link_client", cancel_calls.append)
-    monkeypatch.setattr(controller, "_spawn_peer_link_client", spawn_calls.append)
-    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value=pin))
+    cancel, spawn = _patch_probe_internals(monkeypatch, controller, preview_return=pin)
 
     await controller._probe_and_rebind_endpoint(
         pairing=pairing, new_hostname="new.local", new_port=7000
@@ -340,8 +377,8 @@ async def test_rebind_probe_match_mutates_pairing_and_fires_event(
 
     assert pairing.receiver_hostname == "new.local"
     assert pairing.receiver_port == 7000
-    assert cancel_calls == [pin]
-    assert spawn_calls == [pairing]
+    cancel.assert_called_once_with(pin)
+    spawn.assert_called_once_with(pairing)
     controller._db.bus.fire.assert_any_call(
         EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND,
         {"pin_sha256": pin, "receiver_hostname": "new.local", "receiver_port": 7000},
@@ -365,11 +402,12 @@ async def test_rebind_probe_pin_mismatch_does_not_mutate(
     pin = "a" * 64
     pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
     controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
-    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
-    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
-    # Prime the cooldown to assert it's preserved on mismatch.
-    controller._rebind_probe_until[pin] = 9999.0
-    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value="b" * 64))
+    cancel, spawn = _patch_probe_internals(
+        monkeypatch,
+        controller,
+        preview_return="b" * 64,
+        seed_cooldown_for=pin,
+    )
 
     await controller._probe_and_rebind_endpoint(
         pairing=pairing, new_hostname="spoofed.local", new_port=7000
@@ -377,8 +415,8 @@ async def test_rebind_probe_pin_mismatch_does_not_mutate(
 
     assert pairing.receiver_hostname == "old.local"
     assert pairing.receiver_port == 6058
-    controller._cancel_peer_link_client.assert_not_called()
-    controller._spawn_peer_link_client.assert_not_called()
+    cancel.assert_not_called()
+    spawn.assert_not_called()
     # No rebind event for a mismatch. Walk the full call list
     # because positional args alone don't make a stable equality
     # match against an arbitrary payload dict.
@@ -407,11 +445,11 @@ async def test_rebind_probe_unreachable_does_not_mutate(
     pin = "a" * 64
     pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
     controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
-    controller._rebind_probe_until[pin] = 9999.0
-    monkeypatch.setattr(
-        rb,
-        "peer_link_preview_pair",
-        AsyncMock(side_effect=rb.PeerLinkClientError("connect refused")),
+    _patch_probe_internals(
+        monkeypatch,
+        controller,
+        preview_side_effect=rb.PeerLinkClientError("connect refused"),
+        seed_cooldown_for=pin,
     )
 
     await controller._probe_and_rebind_endpoint(
@@ -420,7 +458,7 @@ async def test_rebind_probe_unreachable_does_not_mutate(
 
     assert pairing.receiver_hostname == "old.local"
     assert pairing.receiver_port == 6058
-    # Cooldown preserved — gates retry on next mDNS event.
+    # Cooldown preserved: gates retry on next mDNS event.
     assert controller._rebind_probe_until[pin] == 9999.0
 
 
@@ -443,9 +481,7 @@ async def test_rebind_probe_skips_when_pairing_replaced_mid_probe(
     # with a fresh object before the probe applies its result.
     fresh = _valid_stored_pairing(receiver_hostname="user-typed.local", receiver_port=6060)
     controller._pairings[pin] = fresh
-    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
-    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
-    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value=pin))
+    cancel, spawn = _patch_probe_internals(monkeypatch, controller, preview_return=pin)
 
     await controller._probe_and_rebind_endpoint(
         pairing=old, new_hostname="rebind-target.local", new_port=7000
@@ -455,8 +491,8 @@ async def test_rebind_probe_skips_when_pairing_replaced_mid_probe(
     # entry refuses to mutate a different object.
     assert fresh.receiver_hostname == "user-typed.local"
     assert fresh.receiver_port == 6060
-    controller._cancel_peer_link_client.assert_not_called()
-    controller._spawn_peer_link_client.assert_not_called()
+    cancel.assert_not_called()
+    spawn.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -475,8 +511,6 @@ async def test_rebind_probe_skips_when_pairing_status_flips_mid_probe(
     pin = "a" * 64
     pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
     controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
-    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
-    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
 
     async def _flip_status_then_match(**_: Any) -> str:
         # Same identity, but the row's status flipped between
@@ -484,7 +518,9 @@ async def test_rebind_probe_skips_when_pairing_status_flips_mid_probe(
         pairing.status = PeerStatus.PENDING
         return pin
 
-    monkeypatch.setattr(rb, "peer_link_preview_pair", _flip_status_then_match)
+    cancel, spawn = _patch_probe_internals(
+        monkeypatch, controller, preview_side_effect=_flip_status_then_match
+    )
 
     await controller._probe_and_rebind_endpoint(
         pairing=pairing, new_hostname="new.local", new_port=7000
@@ -492,8 +528,8 @@ async def test_rebind_probe_skips_when_pairing_status_flips_mid_probe(
 
     assert pairing.receiver_hostname == "old.local"
     assert pairing.receiver_port == 6058
-    controller._cancel_peer_link_client.assert_not_called()
-    controller._spawn_peer_link_client.assert_not_called()
+    cancel.assert_not_called()
+    spawn.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -510,8 +546,12 @@ async def test_rebind_probe_unexpected_exception_clears_cooldown(
     pin = "a" * 64
     pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
     controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
-    controller._rebind_probe_until[pin] = 9999.0
-    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(side_effect=RuntimeError("boom")))
+    _patch_probe_internals(
+        monkeypatch,
+        controller,
+        preview_side_effect=RuntimeError("boom"),
+        seed_cooldown_for=pin,
+    )
 
     with pytest.raises(RuntimeError, match="boom"):
         await controller._probe_and_rebind_endpoint(
@@ -532,17 +572,15 @@ async def test_rebind_probe_skips_when_pairing_unpaired_mid_probe(
     # Simulate the in-flight unpair: drop the dict entry
     # before the probe's mutate step.
     controller._pairings.pop(pin)
-    monkeypatch.setattr(controller, "_cancel_peer_link_client", MagicMock())
-    monkeypatch.setattr(controller, "_spawn_peer_link_client", MagicMock())
-    monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value=pin))
+    cancel, spawn = _patch_probe_internals(monkeypatch, controller, preview_return=pin)
 
     await controller._probe_and_rebind_endpoint(
         pairing=pairing, new_hostname="new.local", new_port=7000
     )
 
     assert pin not in controller._pairings
-    controller._cancel_peer_link_client.assert_not_called()
-    controller._spawn_peer_link_client.assert_not_called()
+    cancel.assert_not_called()
+    spawn.assert_not_called()
 
 
 def test_maybe_schedule_rebind_probe_skips_when_endpoint_matches(


### PR DESCRIPTION
# What does this implement/fix?

Closes phase 4a-o part 7 of the remote-build offload feature
(#106): the offloader auto-rebinds a paired receiver when the
receiver's mDNS broadcast surfaces from a different
`(hostname, port)` than the stored pairing records, so a DHCP
rotation / host rename / network move / container restart on
a fresh address heals on its own instead of stranding the
pairing until the user re-pairs.

The rebind path is **probe-before-mutate**. The mDNS broadcast
already carries the receiver's `pin_sha256` and
`remote_build_port` in TXT, so a broadcast whose pin matches a
stored pairing is the same receiver at a new endpoint. But a
naive rebind off the broadcast alone would let an mDNS spoofer
silently redirect future bundles. Instead, before mutating any
state, the offloader runs one `intent="preview"` Noise XX
handshake against the candidate endpoint. The single
round-trip serves three roles:

* **Reachability** — TCP connect + Noise handshake completing
  means the new endpoint is up and answering peer-link
  traffic. Connect / timeout / Noise error all raise
  `PeerLinkClientError`; we leave stored state alone.
* **Identity** — Noise XX captures the responder's static
  X25519 pubkey from msg2; mismatch against the stored pin
  means a different keypair under the same advertised pin
  (mDNS spoof / untracked rotation / fresh receiver grabbing
  the old hostname). Refuse to rebind.
* **Pairing-window-independent** — `preview` is the one
  intent the receiver always honours, so a quiet receiver
  doesn't deadlock the rebind path.

## Wire-shape changes

* `RemoteBuildPeer` gains `pin_sha256: str = ""` and
  `remote_build_port: int = 0`, parsed from TXT.
* New `OFFLOADER_PAIR_ENDPOINT_REBOUND` event with
  `OffloaderPairEndpointReboundData` (`{pin_sha256,
  receiver_hostname, receiver_port}`). Fires after a
  successful rebind so subscribed frontends update display
  fields without a refetch. (Frontend mirror PR will follow.)

## Controller plumbing

* `_maybe_schedule_rebind_probe` (sync gate, called from
  `_upsert_host`) cheap-early-returns on the dominant cases
  and only spawns a probe task when there's a real candidate.
* `_probe_and_rebind_endpoint` runs the probe; on match it
  mutates the captured `StoredPairing` in place, schedules the
  debounced save, cancels and respawns the long-lived
  peer-link client at the new endpoint, fires the rebind
  event, and clears the cooldown.
* `_rebind_probe_until: dict[str, float]` doubles as the
  in-flight guard and the retry throttle: set to
  `now + 30s` on schedule, cleared only on success. Failure
  paths leave it in place so a probe storm from mDNS Updated
  bursts and a retry hammer from a permanently-unreachable
  host both collapse to one probe per cooldown window.
  `BaseException` reraise clears the entry so cancellation /
  unexpected exceptions don't strand the slot.
* Identity check on the dict entry (`current is pairing`)
  refuses to clobber a fresh row that `unpair` +
  `request_pair` installed mid-probe.
* Hostname comparisons go through the existing
  `helpers.hostname.normalize_hostname` so trailing-dot /
  case-insensitive equality holds against
  `StoredPairing.receiver_hostname` regardless of which form
  the SRV target arrives in.

## Tests

12 new tests covering: probe match → mutate + event + clear
cooldown; pin mismatch → no mutate, cooldown preserved;
unreachable → no mutate, cooldown preserved; mid-probe
`unpair` / `request_pair` / status-flip races → no mutate;
unexpected-exception reraise clears cooldown; gate skips on
no-TXT-pin / PENDING / endpoint-match / no-identity-loaded;
cooldown dedup within window; `_peer_from_service_info` parses
the new TXT fields and tolerates a malformed
`remote_build_port` (lands as 0; rebind path early-returns).

**Related issue or feature (if applicable):**

- fixes #106 (remote build offload, phase 4a-o part 7)

## Frontend coordination

Backend-only PR. New `OFFLOADER_PAIR_ENDPOINT_REBOUND` event
carries `pin_sha256` + new `receiver_hostname` /
`receiver_port`; the existing frontend handler for
`OFFLOADER_PAIR_STATUS_CHANGED` doesn't see this event, so the
display fields on a rebound row will only update on the next
`subscribe_events` reconnect until the frontend mirror PR
adds the handler. The two new `RemoteBuildPeer` TXT fields
(`pin_sha256`, `remote_build_port`) ride through the
discovered-hosts list with backward-compat defaults; existing
frontend code ignores them.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
