### PR TITLE
Extend e2e harness to exercise receiver-side JOB_* fan-out

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,6 +202,16 @@ def make_remote_build_controller(
     (e.g. the e2e harness's two-instance setup), otherwise
     ``MagicMock`` auto-attribute resolution gives the controller
     a no-op ``bus.fire`` — the convention single-side tests use.
+
+    ``db.create_background_task`` is wired to
+    :func:`asyncio.create_task` rather than left as a MagicMock so
+    coroutines passed through it actually run. Single-side tests
+    that don't drive any background-scheduled work won't notice;
+    the e2e harness needs the wiring because the receiver-side
+    fan-out (5c-2b ``JobFanout._dispatch``) hands its
+    ``send_app_frame`` calls through this path, and a no-op
+    background-task hook would silently drop every fan-out frame
+    without ever raising on the unawaited coroutine.
     """
     db = MagicMock()
     db.devices = MagicMock()
@@ -209,6 +219,7 @@ def make_remote_build_controller(
     db._dashboard_advertiser = None
     db.settings = MagicMock()
     db.settings.config_dir = config_dir
+    db.create_background_task = asyncio.create_task
     if bus is not None:
         db.bus = bus
     return RemoteBuildController(db)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -75,6 +75,17 @@ class PairedInstances:
     receiver_bus: EventBus
     offloader_bus: EventBus
     offloader_dashboard_id: str
+    # Lowercase-hex SHA-256 of the receiver's Noise static
+    # X25519 public key, observed by the offloader during the
+    # live Noise XX handshake (see
+    # :func:`helpers.peer_link_noise.pin_sha256_for_pubkey`).
+    # Tests that drive post-pairing application messages
+    # (5b/5c/5d) look the offloader-side peer-link client up
+    # via ``_lookup_open_peer_link_client(pin_sha256)``;
+    # capturing the pin here means the harness's pre-paired
+    # state is immediately addressable from test bodies
+    # without each one re-walking the pair flow.
+    pin_sha256: str
     # Pre-subscribed at fixture-construct time, before either
     # ``start()`` runs. Tests assert against these captured
     # lists rather than re-subscribing after the fixture yields
@@ -248,6 +259,7 @@ async def paired_instances(
         receiver_bus=receiver_bus,
         offloader_bus=offloader_bus,
         offloader_dashboard_id=pending_dashboard_id,
+        pin_sha256=pin_sha256,
         offloader_opened=offloader_opened,
         offloader_closed=offloader_closed,
         receiver_opened=receiver_opened,

--- a/tests/e2e/test_submit_job_fanout.py
+++ b/tests/e2e/test_submit_job_fanout.py
@@ -1,0 +1,267 @@
+"""
+End-to-end: receiver-side ``JOB_*`` events fan out to the offloader bus.
+
+Exercises the 5c-2b wire-round-trip path that the unit tests
+in ``tests/test_remote_build_job_fanout.py`` only cover up to
+``send_app_frame``-was-called. The harness here drives a real
+peer-link session, so every assertion below proves the chain
+that production runs end-to-end:
+
+  receiver-side bus  →  JobFanout listener (5c-2b)
+                     →  peer-link ``job_state_changed`` /
+                        ``job_output`` frame (real Noise AEAD)
+                     →  offloader-side ``_run_session_loops``
+                        receive loop
+                     →  ``_dispatch_job_state_changed`` /
+                        ``_dispatch_job_output``
+                     →  offloader-side bus
+                        (``OFFLOADER_JOB_STATE_CHANGED`` /
+                        ``OFFLOADER_JOB_OUTPUT``)
+
+The receiver-side firmware controller stays a ``MagicMock`` (the
+harness's default) — we don't need a real build pipeline to fire
+synthetic ``JOB_*`` events on the controller's bus, and a real
+build would balloon the wall-clock to multi-minute. The point of
+the e2e variant is the wire shape, not the queue plumbing.
+
+The ``submit_job`` accept path itself (header → chunks → ack) is
+covered by the receiver-side unit tests
+(``test_remote_build_submit_job.py``) and the offloader-side
+unit tests (``test_remote_build_peer_link_client.py`` 5c-3
+section); the value-add of an end-to-end submit_job test is
+catching wire-shape mismatches between the two halves, which
+``test_pair_and_session.py`` already pins for the handshake +
+session lifecycle. A submit_job e2e test is the natural next
+follow-up once the receiver-side firmware controller can be
+swapped for a recording stub without coupling the harness to
+``DeviceBuilder``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from esphome_device_builder.models import (
+    EventType,
+    FirmwareJob,
+    JobLifecycleData,
+    JobOutputData,
+    JobStatus,
+    JobType,
+)
+
+from ..conftest import capture_events
+from .conftest import PairedInstances
+
+
+def _make_remote_peer_job(
+    *,
+    remote_peer: str,
+    remote_job_id: str = "off-job-1",
+    job_id: str = "rcv-job-1",
+    error: str | None = None,
+) -> FirmwareJob:
+    """Build a synthetic :class:`FirmwareJob` carrying the remote-peer correlation.
+
+    The fan-out logic only inspects ``job_id`` (cache key),
+    ``remote_peer`` (session lookup), ``remote_job_id`` (echoed
+    on the wire frame), and ``error`` (used on failed /
+    cancelled). Other fields take their dataclass defaults; we
+    deliberately don't run the firmware queue here since the
+    point is exercising the receiver-bus → wire → offloader-bus
+    chain on a synthetic event, not the queue's own state
+    transitions.
+    """
+    return FirmwareJob(
+        job_id=job_id,
+        configuration=".esphome/.remote_builds/foo/kitchen/kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.QUEUED,
+        remote_peer=remote_peer,
+        remote_job_id=remote_job_id,
+        error=error,
+    )
+
+
+async def _make_and_seed_remote_peer_job(
+    instances: PairedInstances,
+    *,
+    error: str | None = None,
+) -> FirmwareJob:
+    """Build a synthetic remote-peer job and seed ``JOB_QUEUED`` so the fan-out caches it.
+
+    Combines :func:`_make_remote_peer_job` (build a
+    :class:`FirmwareJob` whose ``remote_peer`` matches the
+    harness's offloader) with the ``JOB_QUEUED`` seed step that
+    populates :attr:`JobFanout._remote_jobs` so subsequent
+    lifecycle / output events fan out instead of dropping on
+    the floor. Every fan-out test in this module needs both,
+    in this order, against the same harness offloader id; the
+    helper collapses the two-line prelude into one call.
+
+    :class:`JobFanout._on_lifecycle` is a sync bus listener that
+    looks up the correlation in :attr:`JobFanout._remote_jobs`,
+    populated only by ``JOB_QUEUED`` (the fan-out deliberately
+    skips the queued frame itself; see the module docstring on
+    why a redundant ``job_state_changed{queued}`` would race the
+    submit ack).
+    """
+    job = _make_remote_peer_job(remote_peer=instances.offloader_dashboard_id, error=error)
+    instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))
+    # Listener runs synchronously inside ``fire``; nothing to
+    # await. Yielding once lets any background-task scheduling
+    # the listener's send-frame work would have done settle
+    # before the test fires the next event.
+    await asyncio.sleep(0)
+    return job
+
+
+@pytest.mark.asyncio
+async def test_remote_peer_job_lifecycle_fans_out_to_offloader_bus(
+    paired_instances: PairedInstances,
+) -> None:
+    """``JOB_STARTED`` on the receiver bus → ``OFFLOADER_JOB_STATE_CHANGED`` on the offloader bus.
+
+    Pins the 5c-2b fan-out's wire-round-trip contract:
+
+    1. Receiver fires :attr:`EventType.JOB_QUEUED` so the
+       :class:`JobFanout` cache learns this job's
+       ``(remote_peer, remote_job_id)`` correlation.
+    2. Receiver fires :attr:`EventType.JOB_STARTED`; the
+       fan-out looks up the session for ``remote_peer`` in
+       :attr:`RemoteBuildController._peer_link_sessions`,
+       sends a typed :class:`JobStateChangedFrameData` over the
+       live peer-link channel.
+    3. Offloader's receive loop deserialises the frame, validates
+       shape, fires :attr:`EventType.OFFLOADER_JOB_STATE_CHANGED`
+       on its own bus carrying the offloader's ``remote_job_id``
+       (so the offloader's submit-side caller can match against
+       its own job tag, not the receiver's local id).
+
+    The receiver-side ``error`` field rides through to
+    ``error_message`` only on terminal failure / cancel paths;
+    a ``running`` transition carries an empty
+    ``error_message`` regardless of whatever's on the
+    :class:`FirmwareJob`.
+    """
+    await paired_instances.wait_until_session_opened()
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+    job = await _make_and_seed_remote_peer_job(paired_instances)
+
+    # Drive the lifecycle event the fan-out actually fires for.
+    paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
+
+    # Wait for the wire round-trip — frame send is scheduled as
+    # a background task, frame decrypt + dispatch happens on the
+    # offloader's receive loop on its own task. The capture
+    # ``Event`` flips when the OFFLOADER_JOB_STATE_CHANGED fires.
+    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
+    assert len(state_changes) == 1
+    payload = state_changes[-1]
+    assert payload["job_id"] == "off-job-1"  # offloader's tag echoed back
+    assert payload["status"] == "running"
+    assert payload["error_message"] == ""
+    assert payload["pin_sha256"] == paired_instances.pin_sha256
+    assert payload["receiver_hostname"] == "127.0.0.1"
+    assert payload["receiver_port"] == paired_instances.receiver_server.port
+
+
+@pytest.mark.asyncio
+async def test_remote_peer_terminal_failure_carries_error_message(
+    paired_instances: PairedInstances,
+) -> None:
+    """``JOB_FAILED`` rides the receiver's ``FirmwareJob.error`` into ``error_message``.
+
+    Distinct from the ``running`` test because failure is the
+    one path the offloader needs a human-readable hint for —
+    the firmware-tasks panel surfaces ``error_message`` as the
+    failed-row tooltip without round-tripping the full job
+    output.
+    """
+    await paired_instances.wait_until_session_opened()
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+    job = await _make_and_seed_remote_peer_job(
+        paired_instances, error="esphome compile failed: undefined reference"
+    )
+
+    paired_instances.receiver_bus.fire(EventType.JOB_FAILED, JobLifecycleData(job=job))
+
+    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
+    payload = state_changes[-1]
+    assert payload["status"] == "failed"
+    assert payload["error_message"] == "esphome compile failed: undefined reference"
+
+
+@pytest.mark.asyncio
+async def test_remote_peer_job_output_fans_out_to_offloader_bus(
+    paired_instances: PairedInstances,
+) -> None:
+    """``JOB_OUTPUT`` on the receiver bus → ``OFFLOADER_JOB_OUTPUT`` on the offloader bus.
+
+    Same wire chain as the lifecycle test, different frame
+    type. ``JobFanout`` caches the correlation on
+    ``JOB_QUEUED`` (the seed step) and reads it on every
+    ``JOB_OUTPUT`` to look up the submitting session — this is
+    the high-rate path during an active build (one event per
+    line of compiler / linker output) so the cache hit is what
+    keeps the fan-out off the hot path.
+
+    Pins the ``stream`` field rides through verbatim — the
+    receiver classifies stdout vs. stderr; the offloader's
+    ansi-log renderer needs both classes to colour them
+    differently.
+    """
+    await paired_instances.wait_until_session_opened()
+    outputs = capture_events(paired_instances.offloader_bus, EventType.OFFLOADER_JOB_OUTPUT)
+    job = await _make_and_seed_remote_peer_job(paired_instances)
+
+    paired_instances.receiver_bus.fire(
+        EventType.JOB_OUTPUT,
+        JobOutputData(job_id=job.job_id, line="Compiling kitchen.cpp...\n"),
+    )
+
+    await asyncio.wait_for(outputs.received.wait(), timeout=2.0)
+    payload = outputs[-1]
+    assert payload["job_id"] == "off-job-1"  # offloader's tag, not the receiver's
+    assert payload["line"] == "Compiling kitchen.cpp...\n"
+    assert payload["stream"] == "stdout"
+    assert payload["pin_sha256"] == paired_instances.pin_sha256
+
+
+@pytest.mark.asyncio
+async def test_remote_peer_lifecycle_drops_when_session_already_closed(
+    paired_instances: PairedInstances,
+) -> None:
+    """A lifecycle event fired after session close is silently dropped.
+
+    Pins the best-effort contract from the ``JobFanout`` module
+    docstring: a session that's gone away (registry empty for
+    that ``remote_peer``) gets a debug-level skip — no exception
+    propagates, no half-formed frame leaves the wire, no
+    ``OFFLOADER_JOB_STATE_CHANGED`` fires on the offloader's bus.
+    """
+    await paired_instances.wait_until_session_opened()
+    job = await _make_and_seed_remote_peer_job(paired_instances)
+
+    # Tear the session down before firing the lifecycle event.
+    await paired_instances.offloader.stop()
+    await paired_instances.wait_until_session_closed()
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+
+    paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
+
+    # Give any incorrectly-scheduled background task a tick to
+    # run before asserting nothing fired. The fan-out's
+    # ``send_app_frame`` lookup against the empty registry
+    # short-circuits before any task gets created, but yielding
+    # once is the standard pattern for "no event should fire."
+    await asyncio.sleep(0)
+    assert len(state_changes) == 0


### PR DESCRIPTION
# What does this implement/fix?

Extends the `paired_instances` end-to-end harness to cover the 5c-2b receiver-side `JOB_*` fan-out path that lands on the offloader-side bus. The unit tests in `tests/test_remote_build_job_fanout.py` cover the receiver-side handler up to "`send_app_frame` was called"; the unit tests in `tests/test_remote_build_peer_link_client.py` cover the offloader-side dispatch in isolation; this PR's tests pin the wire round-trip across both halves so a wire-shape regression on either side surfaces here rather than slipping past two unit suites that pass on the same drift.

The four new tests drive the chain end-to-end:

```
receiver-side bus  →  JobFanout listener (5c-2b)
                   →  peer-link `job_state_changed` /
                      `job_output` frame (real Noise AEAD)
                   →  offloader-side `_run_session_loops`
                      receive loop
                   →  `_dispatch_job_state_changed` /
                      `_dispatch_job_output`
                   →  offloader-side bus
                      (`OFFLOADER_JOB_STATE_CHANGED` /
                      `OFFLOADER_JOB_OUTPUT`)
```

## What changed

* **`tests/conftest.py`** — `make_remote_build_controller` now wires `db.create_background_task` to `asyncio.create_task` instead of leaving it as a `MagicMock`. The previous shape silently dropped every coroutine passed through it: a no-op `MagicMock(create_background_task)` returns another `MagicMock` without scheduling anything, so the receiver-side `JobFanout._dispatch` would emit "coroutine was never awaited" warnings and the wire frame would never leave the receiver. Single-side tests that don't drive any background-scheduled work are unaffected; the e2e harness needs the wiring to exercise the production path.
* **`tests/e2e/conftest.py`** — `PairedInstances` now exposes `pin_sha256`, the receiver's SPKI fingerprint as captured during the live Noise XX handshake. Tests that drive post-pairing application messages (5b/5c/5d) look the offloader-side peer-link client up via `_lookup_open_peer_link_client(pin_sha256)`; capturing the pin on the harness object means each test body doesn't have to re-walk the pair flow to recover it.
* **`tests/e2e/test_submit_job_fanout.py` (new)** — four tests:
    * `test_remote_peer_job_lifecycle_fans_out_to_offloader_bus` — fires `JOB_QUEUED` (seeds the fan-out's correlation cache) then `JOB_STARTED` on the receiver bus; asserts a single `OFFLOADER_JOB_STATE_CHANGED` lands on the offloader bus carrying the offloader's `remote_job_id` (echoed back, not the receiver's local id), `status="running"`, empty `error_message`, the receiver's `pin_sha256` / `hostname` / `port` for cross-receiver disambiguation.
    * `test_remote_peer_terminal_failure_carries_error_message` — same chain on `JOB_FAILED`, with the receiver-side `FirmwareJob.error` riding through to the offloader-side `error_message`. Pins the failure-tooltip-without-output contract.
    * `test_remote_peer_job_output_fans_out_to_offloader_bus` — `JOB_OUTPUT` → `OFFLOADER_JOB_OUTPUT`. Asserts the `stream` field rides through verbatim (the offloader's ansi-log renderer needs stdout vs stderr classification to colour them differently) and the `line` body is unchanged.
    * `test_remote_peer_lifecycle_drops_when_session_already_closed` — pins the best-effort contract from `JobFanout`'s module docstring: a session that's gone away (offloader stopped, registry empty for that `remote_peer`) gets a debug-level skip; no exception propagates, no half-formed frame leaves the wire, no `OFFLOADER_JOB_STATE_CHANGED` fires.

## Testing scope

The receiver-side firmware controller stays a `MagicMock` (the harness's default). We don't need a real build pipeline to fire synthetic `JOB_*` events on the controller's bus, and a real build would balloon the wall-clock to multi-minute. The point of the e2e variant is the wire shape, not the queue plumbing — the receiver-side accept path (header → chunks → ack) is covered by `test_remote_build_submit_job.py`'s receiver-side unit tests and the offloader-side `submit_job` send path is covered by `test_remote_build_peer_link_client.py`'s 5c-3 section, both with dict-mocking shortcuts. A submit_job e2e test is a natural follow-up once the receiver-side firmware controller can be swapped for a recording stub without coupling the harness to `DeviceBuilder`; this PR opts for the more focused "wire shape across both halves" test instead.

`.venv/bin/pytest tests/` passes (2704 / 4 skipped). `.venv/bin/pytest tests/e2e/` passes the 6 e2e tests (2 pre-existing pair/session, 4 new fan-out).

**Related issue or feature (if applicable):**

- Issue #106 phase 5c follow-up; the harness extension lands behind 5c-2b's fan-out so the wire round-trip has explicit test coverage instead of leaving "trust the two unit suites agree" as the only signal.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
