### PR TITLE
Add e2e coverage for cancel_job round-trip (5d)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -48,7 +48,13 @@ from esphome_device_builder.controllers.remote_build.peer_link import (
     make_peer_link_handler,
 )
 from esphome_device_builder.helpers.event_bus import EventBus
-from esphome_device_builder.models import EventType
+from esphome_device_builder.models import (
+    EventType,
+    FirmwareJob,
+    JobLifecycleData,
+    JobStatus,
+    JobType,
+)
 
 from ..conftest import _CapturedEvents, capture_events, make_remote_build_controller
 
@@ -277,3 +283,68 @@ async def paired_instances(
         await offloader.stop()
         await receiver.stop()
         await server.close()
+
+
+def make_remote_peer_job(
+    *,
+    remote_peer: str,
+    remote_job_id: str = "off-job-1",
+    job_id: str = "rcv-job-1",
+    error: str | None = None,
+) -> FirmwareJob:
+    """Build a synthetic :class:`FirmwareJob` carrying the remote-peer correlation.
+
+    Shared harness helper for fan-out / cancel / submit-job e2e
+    tests. The wire path only inspects ``job_id`` (cache key),
+    ``remote_peer`` (session lookup), ``remote_job_id`` (echoed
+    on the wire frame), and ``error`` (used on failed /
+    cancelled). Other fields take their dataclass defaults; we
+    deliberately don't run the firmware queue here since the
+    point is exercising the receiver-bus → wire → offloader-bus
+    chain on a synthetic event, not the queue's own state
+    transitions.
+    """
+    return FirmwareJob(
+        job_id=job_id,
+        configuration=".esphome/.remote_builds/foo/kitchen/kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.QUEUED,
+        remote_peer=remote_peer,
+        remote_job_id=remote_job_id,
+        error=error,
+    )
+
+
+async def make_and_seed_remote_peer_job(
+    instances: PairedInstances,
+    *,
+    error: str | None = None,
+) -> FirmwareJob:
+    """Build a synthetic remote-peer job and seed ``JOB_QUEUED`` so the fan-out caches it.
+
+    Combines :func:`make_remote_peer_job` (build a
+    :class:`FirmwareJob` whose ``remote_peer`` matches the
+    harness's offloader) with the ``JOB_QUEUED`` seed step that
+    populates :attr:`JobFanout._remote_jobs` so subsequent
+    lifecycle / output / cancel events fan out instead of
+    dropping on the floor. Every test that drives a
+    correlated :class:`JobFanout` lookup needs both, in this
+    order, against the same harness offloader id; the helper
+    collapses the two-line prelude into one call.
+
+    :class:`JobFanout._on_lifecycle` is a sync bus listener that
+    looks up the correlation in :attr:`JobFanout._remote_jobs`,
+    populated only by ``JOB_QUEUED`` (the fan-out deliberately
+    skips the queued frame itself; see
+    ``test_submit_job_fanout.py``'s module docstring on why a
+    redundant ``job_state_changed{queued}`` would race the
+    submit ack).
+    """
+    job = make_remote_peer_job(remote_peer=instances.offloader_dashboard_id, error=error)
+    instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))
+    # Listener runs synchronously inside ``fire``; nothing to
+    # await. Yielding once lets any background-task scheduling
+    # the listener's send-frame work would have done settle
+    # before the test fires the next event.
+    await asyncio.sleep(0)
+    return job

--- a/tests/e2e/test_cancel_job.py
+++ b/tests/e2e/test_cancel_job.py
@@ -1,0 +1,199 @@
+"""
+End-to-end: offloader-driven cancel routes to receiver-side firmware.cancel.
+
+Exercises the 5d ``cancel_job`` reverse-direction wire path. The
+unit tests in ``test_remote_build_peer_link_client.py`` cover the
+offloader-side ``PeerLinkClient.cancel_job`` send in isolation;
+the unit tests in ``test_remote_build_controller.py`` cover the
+receiver-side ``handle_cancel_job`` handler with a synthetic
+frame; this PR's tests pin the wire round-trip across both halves
+so a wire-shape mismatch on either side surfaces here rather than
+slipping past two unit suites that pass on the same drift.
+
+The chain:
+
+  offloader-side ``RemoteBuildController.cancel_job`` WS handler
+                       →  ``PeerLinkClient.cancel_job``
+                       →  peer-link ``cancel_job`` frame
+                          (real Noise AEAD)
+                       →  receiver-side ``_run_session_loops``
+                          receive loop
+                       →  ``handle_cancel_job`` resolves
+                          ``(remote_peer, remote_job_id)`` →
+                          ``firmware_job_id`` via
+                          ``JobFanout.resolve_firmware_job_id``
+                       →  ``firmware.cancel(job_id=...)``
+
+The receiver-side firmware controller is an :class:`AsyncMock`
+on ``db.firmware`` — we don't need a real firmware queue to
+verify the cancel landed at the right primitive, and a real
+queue would couple this test to the firmware controller's own
+state machine. The point of the e2e variant is the wire shape +
+the JobFanout correlation; the firmware-cancel side-effect is
+already covered by ``test_firmware_controller.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.models import (
+    EventType,
+    JobLifecycleData,
+)
+
+from ..conftest import capture_events
+from .conftest import PairedInstances
+from .test_submit_job_fanout import _make_and_seed_remote_peer_job
+
+
+@pytest.mark.asyncio
+async def test_offloader_cancel_job_routes_to_receiver_firmware_cancel(
+    paired_instances: PairedInstances,
+) -> None:
+    """``cancel_job`` over the wire lands at ``firmware.cancel`` on the receiver.
+
+    Pins the 5d round-trip:
+
+    1. Receiver fires ``JOB_QUEUED`` so the :class:`JobFanout`
+       cache learns the ``(remote_peer, remote_job_id)`` →
+       ``firmware_job_id`` correlation.
+    2. Offloader's ``cancel_job`` WS handler fires the wire
+       frame via :meth:`PeerLinkClient.cancel_job`.
+    3. Receiver's :meth:`handle_cancel_job` resolves the
+       offloader's ``job_id`` back to the receiver-local
+       firmware id via :meth:`JobFanout.resolve_firmware_job_id`,
+       then routes to :meth:`FirmwareController.cancel` — the
+       same primitive a local operator-driven cancel uses.
+
+    The firmware controller stays stubbed; we assert the cancel
+    landed with the right kwargs rather than driving the real
+    queue.
+    """
+    await paired_instances.wait_until_session_opened()
+    cancel_mock = AsyncMock()
+    paired_instances.receiver._db.firmware = MagicMock()
+    paired_instances.receiver._db.firmware.cancel = cancel_mock
+    job = await _make_and_seed_remote_peer_job(paired_instances)
+
+    result = await paired_instances.offloader.cancel_job(
+        pin_sha256=paired_instances.pin_sha256,
+        job_id=job.remote_job_id,
+    )
+
+    assert result == {"sent": True}
+    # Wait for the wire round-trip; the cancel frame is sent
+    # fire-and-forget on the offloader side, decrypt + dispatch
+    # happens on the receiver's receive loop on its own task.
+    # Poll the mock's call list rather than a bus event because
+    # the receiver-side ``firmware.cancel`` is the assertion
+    # surface for this test, not a derived event.
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while not cancel_mock.await_count and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    cancel_mock.assert_awaited_once_with(job_id=job.job_id)
+
+
+@pytest.mark.asyncio
+async def test_offloader_cancel_job_full_round_trip_to_state_changed(
+    paired_instances: PairedInstances,
+) -> None:
+    """Cancel → simulated ``JOB_CANCELLED`` → ``OFFLOADER_JOB_STATE_CHANGED{cancelled}``.
+
+    Extends the firmware-cancel test with the lifecycle
+    confirmation leg: once :meth:`FirmwareController.cancel`
+    completes, the firmware queue would fire :attr:`JOB_CANCELLED`,
+    :class:`JobFanout` would fan that out as a
+    ``job_state_changed{status: "cancelled"}`` frame, and the
+    offloader's existing :attr:`OFFLOADER_JOB_STATE_CHANGED`
+    plumbing would surface the terminal state on its own bus.
+
+    Stub firmware doesn't fire :attr:`JOB_CANCELLED` itself, so
+    the test simulates that side-effect by firing the bus event
+    manually after the cancel mock is awaited. The wire round-
+    trip downstream of :attr:`JOB_CANCELLED` is identical to
+    the lifecycle path covered in
+    ``test_submit_job_fanout.py``; rerunning it here pins that
+    cancel funnels through the same fan-out as any other
+    terminal transition (no special cancel-only event type).
+    """
+    await paired_instances.wait_until_session_opened()
+    cancel_mock = AsyncMock()
+    paired_instances.receiver._db.firmware = MagicMock()
+    paired_instances.receiver._db.firmware.cancel = cancel_mock
+    job = await _make_and_seed_remote_peer_job(paired_instances)
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+
+    await paired_instances.offloader.cancel_job(
+        pin_sha256=paired_instances.pin_sha256,
+        job_id=job.remote_job_id,
+    )
+
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while not cancel_mock.await_count and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    cancel_mock.assert_awaited_once_with(job_id=job.job_id)
+
+    # Simulate the firmware queue's JOB_CANCELLED that the
+    # stub didn't fire on its own.
+    paired_instances.receiver_bus.fire(EventType.JOB_CANCELLED, JobLifecycleData(job=job))
+
+    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
+    payload = state_changes[-1]
+    assert payload["job_id"] == job.remote_job_id
+    assert payload["status"] == "cancelled"
+    assert payload["pin_sha256"] == paired_instances.pin_sha256
+
+
+@pytest.mark.asyncio
+async def test_offloader_cancel_job_unknown_correlation_drops_silently(
+    paired_instances: PairedInstances,
+) -> None:
+    """A cancel for an unknown ``job_id`` is silently dropped on the receiver.
+
+    Pins the best-effort contract from
+    :meth:`handle_cancel_job`'s docstring: a
+    ``(remote_peer, remote_job_id)`` correlation that's missing
+    from the :class:`JobFanout` cache (typical race: receiver
+    already evicted the entry on terminal transition before the
+    offloader's cancel arrived) gets a debug-level skip — no
+    exception propagates, ``firmware.cancel`` is never called,
+    no terminate-frame is sent.
+
+    The offloader's WS handler still returns ``sent=true``: the
+    frame made it onto the wire. Whether the receiver acted on
+    it is the receiver's call, and the offloader's UI relies on
+    the next observed ``job_state_changed`` (or its absence) for
+    the actual state.
+    """
+    await paired_instances.wait_until_session_opened()
+    cancel_mock = AsyncMock()
+    paired_instances.receiver._db.firmware = MagicMock()
+    paired_instances.receiver._db.firmware.cancel = cancel_mock
+    # Deliberately skip the JOB_QUEUED seed so JobFanout's cache
+    # has no correlation for the offloader's job_id below.
+
+    result = await paired_instances.offloader.cancel_job(
+        pin_sha256=paired_instances.pin_sha256,
+        job_id="off-job-never-seen",
+    )
+
+    assert result == {"sent": True}
+    # Yield the loop a few times to let any incorrectly-routed
+    # cancel land before asserting it didn't.
+    for _ in range(10):
+        await asyncio.sleep(0.01)
+    cancel_mock.assert_not_awaited()
+
+
+# WS-layer error-mapping (CommandError(NOT_FOUND) /
+# CommandError(PRECONDITION_FAILED) / CommandError(INVALID_ARGS))
+# is pinned by unit tests on the same handler in
+# ``test_remote_build_controller.py``; the e2e variant adds value
+# only on the wire round-trip cases above, where the contract
+# spans both halves of the pair.

--- a/tests/e2e/test_cancel_job.py
+++ b/tests/e2e/test_cancel_job.py
@@ -48,8 +48,7 @@ from esphome_device_builder.models import (
 )
 
 from ..conftest import capture_events
-from .conftest import PairedInstances
-from .test_submit_job_fanout import _make_and_seed_remote_peer_job
+from .conftest import PairedInstances, make_and_seed_remote_peer_job
 
 
 @dataclass(frozen=True)
@@ -119,7 +118,7 @@ async def test_offloader_cancel_job_routes_to_receiver_firmware_cancel(
     queue.
     """
     await paired_instances.wait_until_session_opened()
-    job = await _make_and_seed_remote_peer_job(paired_instances)
+    job = await make_and_seed_remote_peer_job(paired_instances)
 
     result = await paired_instances.offloader.cancel_job(
         pin_sha256=paired_instances.pin_sha256,
@@ -156,7 +155,7 @@ async def test_offloader_cancel_job_full_round_trip_to_state_changed(
     terminal transition (no special cancel-only event type).
     """
     await paired_instances.wait_until_session_opened()
-    job = await _make_and_seed_remote_peer_job(paired_instances)
+    job = await make_and_seed_remote_peer_job(paired_instances)
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
@@ -201,24 +200,42 @@ async def test_offloader_cancel_job_unknown_correlation_drops_silently(
     it is the receiver's call, and the offloader's UI relies on
     the next observed ``job_state_changed`` (or its absence) for
     the actual state.
+
+    Negative-path sync uses a known-good cancel as a barrier
+    rather than an arbitrary sleep. The unknown cancel goes out
+    first, then a known cancel for a seeded job follows; frames
+    are processed serially on the receiver's session loop, so
+    when the known cancel lands at :meth:`firmware.cancel` the
+    unknown one has already been processed and (correctly)
+    dropped. The final ``assert_awaited_once_with(job_id=
+    known.job_id)`` then pins both halves: only one cancel
+    reached the firmware controller, and it was the known one.
     """
     await paired_instances.wait_until_session_opened()
-    # Deliberately skip the JOB_QUEUED seed so JobFanout's cache
-    # has no correlation for the offloader's job_id below.
+    # Seed exactly one known job. The unknown cancel below
+    # targets a different ``job_id`` so JobFanout's cache has
+    # no correlation for it.
+    known_job = await make_and_seed_remote_peer_job(paired_instances)
 
-    result = await paired_instances.offloader.cancel_job(
+    unknown_result = await paired_instances.offloader.cancel_job(
         pin_sha256=paired_instances.pin_sha256,
         job_id="off-job-never-seen",
     )
+    assert unknown_result == {"sent": True}
 
-    assert result == {"sent": True}
-    # The receiver's handler logs-and-skips on the unknown
-    # correlation; no Event will ever fire. Wait briefly with
-    # ``asyncio.wait_for`` for the negative path — a timeout here
-    # is the success signal.
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=0.2)
-    receiver_firmware_cancel.mock.assert_not_awaited()
+    known_result = await paired_instances.offloader.cancel_job(
+        pin_sha256=paired_instances.pin_sha256,
+        job_id=known_job.remote_job_id,
+    )
+    assert known_result == {"sent": True}
+
+    # Sync on the known cancel landing. By the time this fires,
+    # the receiver's serial frame loop has already processed the
+    # earlier unknown cancel — so the assertion below catches a
+    # late incorrect cancel deterministically rather than racing
+    # an arbitrary timeout.
+    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=2.0)
+    receiver_firmware_cancel.mock.assert_awaited_once_with(job_id=known_job.job_id)
 
 
 # WS-layer error-mapping (CommandError(NOT_FOUND) /

--- a/tests/e2e/test_cancel_job.py
+++ b/tests/e2e/test_cancel_job.py
@@ -36,6 +36,8 @@ already covered by ``test_firmware_controller.py``.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -50,9 +52,52 @@ from .conftest import PairedInstances
 from .test_submit_job_fanout import _make_and_seed_remote_peer_job
 
 
+@dataclass(frozen=True)
+class _FirmwareCancelStub:
+    """AsyncMock-wired ``db.firmware.cancel`` plus an :class:`asyncio.Event`.
+
+    The ``called`` event is set inside the mock's ``side_effect`` the
+    moment ``cancel`` is awaited on the receiver, so test bodies sync
+    on the wire round-trip via ``asyncio.wait_for(stub.called.wait(),
+    ...)`` rather than polling :attr:`AsyncMock.await_count` on a
+    sleep loop. Mirrors the ``capture_events`` /
+    ``_CapturedEvents.received`` pattern used elsewhere in the
+    harness.
+    """
+
+    mock: AsyncMock
+    called: asyncio.Event
+
+
+@pytest.fixture
+def receiver_firmware_cancel(paired_instances: PairedInstances) -> _FirmwareCancelStub:
+    """Stub ``db.firmware.cancel`` on the receiver and surface a wait primitive.
+
+    Every cancel test in this module stubs the same surface
+    (receiver-side firmware controller's ``cancel`` method) so
+    the wire round-trip's terminal step can be asserted without
+    standing up a real firmware queue. The fixture wires the
+    mock's ``side_effect`` to set an :class:`asyncio.Event` so
+    test bodies can ``await asyncio.wait_for(stub.called.wait(),
+    timeout=...)`` for deterministic synchronisation, then call
+    ``stub.mock.assert_awaited_once_with(...)`` /
+    ``stub.mock.assert_not_awaited()``.
+    """
+    called = asyncio.Event()
+
+    def _record_call(**kwargs: Any) -> None:
+        called.set()
+
+    cancel = AsyncMock(side_effect=_record_call)
+    paired_instances.receiver._db.firmware = MagicMock()
+    paired_instances.receiver._db.firmware.cancel = cancel
+    return _FirmwareCancelStub(mock=cancel, called=called)
+
+
 @pytest.mark.asyncio
 async def test_offloader_cancel_job_routes_to_receiver_firmware_cancel(
     paired_instances: PairedInstances,
+    receiver_firmware_cancel: _FirmwareCancelStub,
 ) -> None:
     """``cancel_job`` over the wire lands at ``firmware.cancel`` on the receiver.
 
@@ -74,9 +119,6 @@ async def test_offloader_cancel_job_routes_to_receiver_firmware_cancel(
     queue.
     """
     await paired_instances.wait_until_session_opened()
-    cancel_mock = AsyncMock()
-    paired_instances.receiver._db.firmware = MagicMock()
-    paired_instances.receiver._db.firmware.cancel = cancel_mock
     job = await _make_and_seed_remote_peer_job(paired_instances)
 
     result = await paired_instances.offloader.cancel_job(
@@ -85,21 +127,14 @@ async def test_offloader_cancel_job_routes_to_receiver_firmware_cancel(
     )
 
     assert result == {"sent": True}
-    # Wait for the wire round-trip; the cancel frame is sent
-    # fire-and-forget on the offloader side, decrypt + dispatch
-    # happens on the receiver's receive loop on its own task.
-    # Poll the mock's call list rather than a bus event because
-    # the receiver-side ``firmware.cancel`` is the assertion
-    # surface for this test, not a derived event.
-    deadline = asyncio.get_running_loop().time() + 2.0
-    while not cancel_mock.await_count and asyncio.get_running_loop().time() < deadline:
-        await asyncio.sleep(0.01)
-    cancel_mock.assert_awaited_once_with(job_id=job.job_id)
+    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=2.0)
+    receiver_firmware_cancel.mock.assert_awaited_once_with(job_id=job.job_id)
 
 
 @pytest.mark.asyncio
 async def test_offloader_cancel_job_full_round_trip_to_state_changed(
     paired_instances: PairedInstances,
+    receiver_firmware_cancel: _FirmwareCancelStub,
 ) -> None:
     """Cancel → simulated ``JOB_CANCELLED`` → ``OFFLOADER_JOB_STATE_CHANGED{cancelled}``.
 
@@ -121,9 +156,6 @@ async def test_offloader_cancel_job_full_round_trip_to_state_changed(
     terminal transition (no special cancel-only event type).
     """
     await paired_instances.wait_until_session_opened()
-    cancel_mock = AsyncMock()
-    paired_instances.receiver._db.firmware = MagicMock()
-    paired_instances.receiver._db.firmware.cancel = cancel_mock
     job = await _make_and_seed_remote_peer_job(paired_instances)
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
@@ -134,10 +166,8 @@ async def test_offloader_cancel_job_full_round_trip_to_state_changed(
         job_id=job.remote_job_id,
     )
 
-    deadline = asyncio.get_running_loop().time() + 2.0
-    while not cancel_mock.await_count and asyncio.get_running_loop().time() < deadline:
-        await asyncio.sleep(0.01)
-    cancel_mock.assert_awaited_once_with(job_id=job.job_id)
+    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=2.0)
+    receiver_firmware_cancel.mock.assert_awaited_once_with(job_id=job.job_id)
 
     # Simulate the firmware queue's JOB_CANCELLED that the
     # stub didn't fire on its own.
@@ -153,6 +183,7 @@ async def test_offloader_cancel_job_full_round_trip_to_state_changed(
 @pytest.mark.asyncio
 async def test_offloader_cancel_job_unknown_correlation_drops_silently(
     paired_instances: PairedInstances,
+    receiver_firmware_cancel: _FirmwareCancelStub,
 ) -> None:
     """A cancel for an unknown ``job_id`` is silently dropped on the receiver.
 
@@ -172,9 +203,6 @@ async def test_offloader_cancel_job_unknown_correlation_drops_silently(
     the actual state.
     """
     await paired_instances.wait_until_session_opened()
-    cancel_mock = AsyncMock()
-    paired_instances.receiver._db.firmware = MagicMock()
-    paired_instances.receiver._db.firmware.cancel = cancel_mock
     # Deliberately skip the JOB_QUEUED seed so JobFanout's cache
     # has no correlation for the offloader's job_id below.
 
@@ -184,11 +212,13 @@ async def test_offloader_cancel_job_unknown_correlation_drops_silently(
     )
 
     assert result == {"sent": True}
-    # Yield the loop a few times to let any incorrectly-routed
-    # cancel land before asserting it didn't.
-    for _ in range(10):
-        await asyncio.sleep(0.01)
-    cancel_mock.assert_not_awaited()
+    # The receiver's handler logs-and-skips on the unknown
+    # correlation; no Event will ever fire. Wait briefly with
+    # ``asyncio.wait_for`` for the negative path — a timeout here
+    # is the success signal.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=0.2)
+    receiver_firmware_cancel.mock.assert_not_awaited()
 
 
 # WS-layer error-mapping (CommandError(NOT_FOUND) /

--- a/tests/e2e/test_submit_job_fanout.py
+++ b/tests/e2e/test_submit_job_fanout.py
@@ -45,77 +45,12 @@ import pytest
 
 from esphome_device_builder.models import (
     EventType,
-    FirmwareJob,
     JobLifecycleData,
     JobOutputData,
-    JobStatus,
-    JobType,
 )
 
 from ..conftest import capture_events
-from .conftest import PairedInstances
-
-
-def _make_remote_peer_job(
-    *,
-    remote_peer: str,
-    remote_job_id: str = "off-job-1",
-    job_id: str = "rcv-job-1",
-    error: str | None = None,
-) -> FirmwareJob:
-    """Build a synthetic :class:`FirmwareJob` carrying the remote-peer correlation.
-
-    The fan-out logic only inspects ``job_id`` (cache key),
-    ``remote_peer`` (session lookup), ``remote_job_id`` (echoed
-    on the wire frame), and ``error`` (used on failed /
-    cancelled). Other fields take their dataclass defaults; we
-    deliberately don't run the firmware queue here since the
-    point is exercising the receiver-bus → wire → offloader-bus
-    chain on a synthetic event, not the queue's own state
-    transitions.
-    """
-    return FirmwareJob(
-        job_id=job_id,
-        configuration=".esphome/.remote_builds/foo/kitchen/kitchen.yaml",
-        job_type=JobType.COMPILE,
-        status=JobStatus.QUEUED,
-        remote_peer=remote_peer,
-        remote_job_id=remote_job_id,
-        error=error,
-    )
-
-
-async def _make_and_seed_remote_peer_job(
-    instances: PairedInstances,
-    *,
-    error: str | None = None,
-) -> FirmwareJob:
-    """Build a synthetic remote-peer job and seed ``JOB_QUEUED`` so the fan-out caches it.
-
-    Combines :func:`_make_remote_peer_job` (build a
-    :class:`FirmwareJob` whose ``remote_peer`` matches the
-    harness's offloader) with the ``JOB_QUEUED`` seed step that
-    populates :attr:`JobFanout._remote_jobs` so subsequent
-    lifecycle / output events fan out instead of dropping on
-    the floor. Every fan-out test in this module needs both,
-    in this order, against the same harness offloader id; the
-    helper collapses the two-line prelude into one call.
-
-    :class:`JobFanout._on_lifecycle` is a sync bus listener that
-    looks up the correlation in :attr:`JobFanout._remote_jobs`,
-    populated only by ``JOB_QUEUED`` (the fan-out deliberately
-    skips the queued frame itself; see the module docstring on
-    why a redundant ``job_state_changed{queued}`` would race the
-    submit ack).
-    """
-    job = _make_remote_peer_job(remote_peer=instances.offloader_dashboard_id, error=error)
-    instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))
-    # Listener runs synchronously inside ``fire``; nothing to
-    # await. Yielding once lets any background-task scheduling
-    # the listener's send-frame work would have done settle
-    # before the test fires the next event.
-    await asyncio.sleep(0)
-    return job
+from .conftest import PairedInstances, make_and_seed_remote_peer_job
 
 
 @pytest.mark.asyncio
@@ -150,7 +85,7 @@ async def test_remote_peer_job_lifecycle_fans_out_to_offloader_bus(
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
-    job = await _make_and_seed_remote_peer_job(paired_instances)
+    job = await make_and_seed_remote_peer_job(paired_instances)
 
     # Drive the lifecycle event the fan-out actually fires for.
     paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
@@ -186,7 +121,7 @@ async def test_remote_peer_terminal_failure_carries_error_message(
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
-    job = await _make_and_seed_remote_peer_job(
+    job = await make_and_seed_remote_peer_job(
         paired_instances, error="esphome compile failed: undefined reference"
     )
 
@@ -219,7 +154,7 @@ async def test_remote_peer_job_output_fans_out_to_offloader_bus(
     """
     await paired_instances.wait_until_session_opened()
     outputs = capture_events(paired_instances.offloader_bus, EventType.OFFLOADER_JOB_OUTPUT)
-    job = await _make_and_seed_remote_peer_job(paired_instances)
+    job = await make_and_seed_remote_peer_job(paired_instances)
 
     paired_instances.receiver_bus.fire(
         EventType.JOB_OUTPUT,
@@ -247,7 +182,7 @@ async def test_remote_peer_lifecycle_drops_when_session_already_closed(
     ``OFFLOADER_JOB_STATE_CHANGED`` fires on the offloader's bus.
     """
     await paired_instances.wait_until_session_opened()
-    job = await _make_and_seed_remote_peer_job(paired_instances)
+    job = await make_and_seed_remote_peer_job(paired_instances)
 
     # Tear the session down before firing the lifecycle event.
     await paired_instances.offloader.stop()


### PR DESCRIPTION
# What does this implement/fix?

PR #543 extended the e2e harness to cover the 5c-2b `JOB_*`
fan-out path, but didn't include the 5d `cancel_job` reverse-
direction wire round-trip from #542. This adds three e2e
tests driving the chain end-to-end:

```
offloader-side cancel_job WS handler
  -> PeerLinkClient.cancel_job
  -> peer-link cancel_job frame (real Noise AEAD)
  -> receiver-side _run_session_loops receive loop
  -> handle_cancel_job resolves (remote_peer, remote_job_id)
     -> firmware_job_id via JobFanout.resolve_firmware_job_id
  -> firmware.cancel(job_id=...)
```

## Test cases

1. **`test_offloader_cancel_job_routes_to_receiver_firmware_cancel`** —
   happy path wire round-trip ending at `firmware.cancel` being
   awaited with the receiver-local `firmware_job_id` (not the
   offloader's `remote_job_id`; `JobFanout`'s resolve step is
   the translation seam between the two id spaces).

2. **`test_offloader_cancel_job_full_round_trip_to_state_changed`** —
   adds the lifecycle confirmation leg. Stub firmware doesn't
   fire `JOB_CANCELLED` on its own, so the test simulates it
   manually after the cancel mock is awaited. Asserts the
   offloader sees `OFFLOADER_JOB_STATE_CHANGED{status=cancelled}`
   on its bus. Pins that cancel funnels through the same
   fan-out as any other terminal transition (no special
   cancel-only event type).

3. **`test_offloader_cancel_job_unknown_correlation_drops_silently`** —
   pins the best-effort drop contract from
   `handle_cancel_job`'s docstring: a cancel for an unknown
   `(remote_peer, remote_job_id)` gets a debug skip on the
   receiver, never calls `firmware.cancel`, and the offloader's
   WS handler still returns `sent=true`.

## What's NOT in this PR

WS-layer error-mapping (`NOT_FOUND` / `PRECONDITION_FAILED` /
`INVALID_ARGS`) is already pinned by unit tests on the same
handler in `test_remote_build_controller.py`. The e2e variant
adds value only on the wire round-trip cases above, where the
contract spans both halves of the pair.

**Related issue or feature (if applicable):**

- fixes — covers the gap noted between #542 (cancel feature)
  and #543 (e2e harness extension).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
