### PR TITLE
Extract _start_discovery from RemoteBuildController.start

### DIFF
--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -1241,22 +1241,19 @@ class RemoteBuildController:
         for pairing in self._pairings.values():
             if pairing.status is PeerStatus.APPROVED:
                 self._spawn_peer_link_client(pairing)
-        # Bus-listener registration runs unconditionally — the
-        # zeroconf / device-controller gates below skip
-        # discovery-side work (the mDNS browser, advertiser
-        # name capture) when those subsystems aren't up, but
-        # the lifecycle listeners maintained here only need
-        # ``self._db.bus`` (always present) and feed
+        # Bus-listener registration runs unconditionally; the
+        # discovery-side bring-up (mDNS browser, advertiser name
+        # capture) is split into ``_start_discovery`` below and
+        # runs *last* so its zeroconf-availability gate can't
+        # shadow the listener registration. The listeners only
+        # need ``self._db.bus`` (always present) and feed
         # ``_open_peer_links`` / ``_offloader_alerts`` /
-        # ``_peer_queue_status`` / ``_offloader_remote_jobs``
-        # — none of which are zeroconf-driven. The earlier
-        # arrangement put listener registration after the
-        # zeroconf early-return; in test harnesses (and
-        # production paths where zeroconf failed to start) the
-        # listeners never wired and ``pairings_snapshot()``
-        # silently reported every paired session as
-        # ``connected=False`` because OFFLOADER_PEER_LINK_OPENED
-        # had nowhere to land.
+        # ``_peer_queue_status`` / ``_offloader_remote_jobs`` —
+        # none of which are zeroconf-driven, so this ordering
+        # invariant is what keeps ``pairings_snapshot()``'s
+        # ``connected`` projection working in test harnesses
+        # (and any production path where zeroconf failed to
+        # start).
         #
         # Subscribe to firmware-queue lifecycle events so every
         # transition broadcasts a fresh ``queue_status`` snapshot
@@ -1348,12 +1345,27 @@ class RemoteBuildController:
                 self._on_offloader_peer_link_closed,
             )
         )
+        self._start_discovery()
+
+    def _start_discovery(self) -> None:
+        """
+        Bring up the mDNS service browser for peer discovery.
+
+        Captures the dashboard's own service-instance name (so
+        our own advertise doesn't show up in ``list_hosts``) and
+        constructs the :class:`AsyncServiceBrowser` against the
+        shared zeroconf. Skips silently if either the devices
+        controller or its zeroconf isn't available (peer
+        discovery is opt-in fail-soft); on browser-construction
+        failure logs the exception and leaves :attr:`_browser`
+        as ``None``.
+        """
         if self._db.devices is None:
-            _LOGGER.debug("RemoteBuildController.start called before devices controller")
+            _LOGGER.debug("remote-build discovery skipped: devices controller unavailable")
             return
         zeroconf = self._db.devices.zeroconf
         if zeroconf is None:
-            _LOGGER.debug("zeroconf unavailable; remote-build discovery disabled")
+            _LOGGER.debug("remote-build discovery skipped: zeroconf unavailable")
             return
         # Capture own service-instance name so our own advertise
         # doesn't show up in ``list_hosts``. Reads through the
@@ -1364,11 +1376,10 @@ class RemoteBuildController:
         advertiser = self._db._dashboard_advertiser
         if advertiser is not None:
             self._own_instance_name = advertiser.service_instance_name
-        # Wrap browser construction so a zeroconf-side failure (e.g.
-        # the underlying socket got torn down between
-        # ``DeviceStateMonitor.start`` and now, or the cache is in an
-        # unexpected state) doesn't abort dashboard startup. Peer
-        # discovery is fail-soft; same contract as the advertise.
+        # Wrap browser construction so a zeroconf-side failure
+        # (e.g. the underlying socket got torn down between
+        # ``DeviceStateMonitor.start`` and now, or the cache is in
+        # an unexpected state) doesn't abort dashboard startup.
         try:
             self._browser = AsyncServiceBrowser(
                 zeroconf.zeroconf,


### PR DESCRIPTION
# What does this implement/fix?

Follow-up cleanup from #545. `RemoteBuildController.start()` was doing two unrelated things back-to-back: (1) registering bus-listeners that feed the controller's RAM dicts (`_open_peer_links`, `_offloader_alerts`, `_peer_queue_status`, `_offloader_remote_jobs`) and (2) standing up the zeroconf-driven mDNS browser for peer discovery. The two have completely different dependencies — the listeners only need `self._db.bus` (always present), the discovery side needs `self._db.devices.zeroconf` (optional, fail-soft).

#545 fixed the ordering so the listener block ran above the discovery block; the structural fact that they were both inline in `start()` meant the load-bearing ordering was held in place by a comment rather than by topology. Extract the discovery-side bring-up into its own private method so the invariant is enforced by the file layout and a future ordering bug can't accidentally shadow the listener registration behind a discovery early-return.

## What changed

* **`RemoteBuildController._start_discovery()` (new)** — holds the three discovery-side concerns: the `_db.devices is None` and `zeroconf is None` early-returns, the own-instance-name capture from the dashboard advertiser, and the `AsyncServiceBrowser` construction (still wrapped in the same fail-soft `try/except`). All three returns are silent debug-level — peer discovery is opt-in fail-soft per the same contract `DashboardAdvertiser` follows. The exception case logs at exception level so the operator has a way to notice silently-disabled discovery.
* **`RemoteBuildController.start()`** — the discovery block is replaced by a single `self._start_discovery()` call as the very last line, after every bus-listener registration. The narrative comment in `start()` was rewritten from "the gates below skip discovery work" to "the discovery-side bring-up is split into `_start_discovery` below and runs *last* so its zeroconf-availability gate can't shadow the listener registration." Topology now enforces what the comment used to assert.

No behaviour change. `start()` still runs discovery startup at the same point in its lifecycle; the only structural change is that the gates and browser construction live behind a named seam.

## Tests

`.venv/bin/pytest tests/` passes (2725 / 4 skipped). No new tests — the e2e harness's existing `test_paired_instances_snapshot_reflects_connected_state` (added in #545) is the regression guard for the listener-vs-discovery ordering invariant; with this refactor that test continues to pass because the listener block still runs first and the discovery block still gracefully skips when `zeroconf is None` (the harness default).

**Related issue or feature (if applicable):**

- Follow-up to #545's listener-registration ordering fix; the structural cleanup that fix called out in its PR body.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
