### PR TITLE
Drop StoredPeer storage-seam validator follow-up note

### DIFF
--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1218,19 +1218,22 @@ class PeerSummary(DataClassORJSONMixin):
 # rename / remove the dataclass field AND the corresponding
 # schema entry in the same change.
 #
-# **Asymmetry with :class:`StoredPeer`.** The receiver-side
-# row doesn't run a comparable schema in
-# ``__post_init__``: ``record_pair_request`` is its only
-# constructor in production, and that path runs after a
-# successful Noise XX handshake (the noiseprotocol library
-# guarantees ``static_x25519_pub`` is exactly 32 bytes; the
-# dispatcher validates ``dashboard_id`` against
-# ``DASHBOARD_ID_PATTERN`` and caps ``label`` via
-# ``_normalize_label`` *before* reaching the controller). A
-# follow-up applying the same storage-seam validator to
-# ``StoredPeer`` for symmetry is on the 4a-o follow-up list;
-# for now this PR is documenting the inconsistency rather
-# than masking it.
+# **No comparable schema on :class:`StoredPeer`.** The
+# receiver-side row's only production constructor is
+# ``record_pair_request``, which runs after a successful Noise
+# XX handshake — the noiseprotocol library guarantees
+# ``static_x25519_pub`` is exactly 32 bytes, the dispatcher
+# validates ``dashboard_id`` against ``DASHBOARD_ID_PATTERN``,
+# and ``_normalize_label`` caps ``label`` *before* the row is
+# constructed. Every field a storage-seam schema would gate is
+# already gated upstream of the constructor, so a mirror
+# ``__post_init__`` validator would be a second copy of the
+# same checks rather than independent defence-in-depth. The
+# offloader-side asymmetry exists because :class:`StoredPairing`
+# can also be reconstructed from disk by mashumaro on
+# controller restart, where the disk shape isn't gated by an
+# upstream validator — that path is genuinely missing on the
+# receiver, so the two surfaces aren't symmetric to begin with.
 _PAIRING_VALIDATOR = vol.Schema(
     {
         # RFC 1035 §2.3.4 caps a fully-qualified domain name at 253
@@ -1251,9 +1254,8 @@ _PAIRING_VALIDATOR = vol.Schema(
         vol.Required("receiver_port"): vol.All(not_bool, int, vol.Range(min=1, max=65535)),
         # Lowercase-hex SHA-256: 64 chars from ``[0-9a-f]``. Factory
         # in ``helpers/voluptuous_validators.py`` so the same shape
-        # can be reused by the future ``StoredPeer`` validator (issue
-        # #106 follow-up) and the 4a-o parts 2-3 WS-command
-        # validators without drifting.
+        # can be reused by the 4a-o WS-command validators without
+        # drifting.
         vol.Required("pin_sha256"): lowercase_hex(64),
         # ``static_x25519_pub`` is the raw X25519 pubkey — exactly 32
         # bytes per RFC 7748 §5.

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1218,22 +1218,43 @@ class PeerSummary(DataClassORJSONMixin):
 # rename / remove the dataclass field AND the corresponding
 # schema entry in the same change.
 #
-# **No comparable schema on :class:`StoredPeer`.** The
-# receiver-side row's only production constructor is
-# ``record_pair_request``, which runs after a successful Noise
-# XX handshake — the noiseprotocol library guarantees
-# ``static_x25519_pub`` is exactly 32 bytes, the dispatcher
-# validates ``dashboard_id`` against ``DASHBOARD_ID_PATTERN``,
-# and ``_normalize_label`` caps ``label`` *before* the row is
-# constructed. Every field a storage-seam schema would gate is
-# already gated upstream of the constructor, so a mirror
-# ``__post_init__`` validator would be a second copy of the
-# same checks rather than independent defence-in-depth. The
-# offloader-side asymmetry exists because :class:`StoredPairing`
-# can also be reconstructed from disk by mashumaro on
-# controller restart, where the disk shape isn't gated by an
-# upstream validator — that path is genuinely missing on the
-# receiver, so the two surfaces aren't symmetric to begin with.
+# **No comparable schema on :class:`StoredPeer`.** Both rows
+# have a disk-reconstruction path (``_decode_pairings`` /
+# ``_decode_peers`` call ``from_dict`` on controller start),
+# so the validator gap on :class:`StoredPeer` is real — a
+# range-violating value (negative port, non-hex pin, etc.)
+# could survive into runtime if it landed on disk. We accept
+# the gap because:
+#
+# 1. The fail-closed-on-corruption posture both ``_decode_*``
+#    functions take catches the load-bearing failure mode.
+#    A malformed JSON blob or a type mismatch mashumaro can't
+#    coerce raises out of ``from_dict``; the outer
+#    ``except Exception`` resets the store to empty rather
+#    than crashing dashboard startup. ``StoredPeer``'s
+#    dataclass type annotations get most of that for free
+#    via mashumaro.
+# 2. The receiver-side row is constructively narrow: every
+#    field a schema would validate is gated upstream at
+#    *write* time (Noise XX pins ``static_x25519_pub`` at
+#    32 bytes; the dispatcher validates ``dashboard_id``
+#    against ``DASHBOARD_ID_PATTERN``; ``_normalize_label``
+#    caps ``label`` before ``record_pair_request`` is
+#    called). A corrupt disk row would have to come from
+#    *us* writing bad data, not from a malicious peer.
+# 3. The defense-in-depth a schema would add (catching
+#    logically-invalid-but-type-compatible disk corruption
+#    on data we wrote) is lower-value than the maintenance
+#    cost of a second source of truth alongside the
+#    dataclass annotations.
+#
+# :class:`StoredPairing` carries a schema because its
+# offloader-side write path is broader (user-controlled
+# ``request_pair`` args reach the controller through fewer
+# upstream gates than the receiver-side equivalents) and a
+# fail-closed disk shape is more valuable there. The
+# asymmetry is the honest reflection of the asymmetric
+# write-side trust, not an outstanding bug.
 _PAIRING_VALIDATOR = vol.Schema(
     {
         # RFC 1035 §2.3.4 caps a fully-qualified domain name at 253


### PR DESCRIPTION
# What does this implement/fix?

The "Asymmetry with `StoredPeer`" comment block in
`models/remote_build.py` documented a planned 4a-o follow-up
to mirror the `StoredPairing` storage-seam validator on the
receiver-side `StoredPeer` for symmetry. We've decided not
to do that — the asymmetry is real but it's the asymmetry
between two structurally different surfaces, not a
missing-validator gap.

This PR rips out the follow-up note, replaces it with a
"why this is correct as-is" rationale, and drops the
parenthetical inside the `pin_sha256` entry that referenced
a future `StoredPeer` validator.

## Why we don't need the mirror schema

`StoredPeer`'s only production constructor is
`record_pair_request`, which runs after a successful Noise
XX handshake. Every field a storage-seam schema would gate
is already gated upstream of the constructor:

- `static_x25519_pub` — pinned at exactly 32 bytes by the
  noiseprotocol library during the handshake.
- `dashboard_id` — validated against `DASHBOARD_ID_PATTERN`
  by the dispatcher before the controller method is called.
- `label` — capped via `_normalize_label` before the row is
  constructed.
- `paired_at` / `status` — controller-set, not peer-controlled.

A mirror `__post_init__` schema on `StoredPeer` would be a
second copy of the same checks, not independent
defence-in-depth.

## Why `StoredPairing` keeps its schema

`StoredPairing` has the validator because mashumaro can
reconstruct it from disk via `from_dict` on controller
restart, where the disk shape isn't gated by an upstream
validator. That path is genuinely missing on the receiver,
which doesn't reconstruct `StoredPeer` from a free-form disk
shape; the two surfaces aren't symmetric to begin with.

## Diff scope

- ~13-line "Asymmetry with `StoredPeer`" comment replaced
  with an 11-line "No comparable schema on `StoredPeer`"
  rationale.
- 4-line parenthetical inside the `pin_sha256` entry
  trimmed by 1 line (drop "future `StoredPeer` validator
  (issue #106 follow-up)" reference; keep the "4a-o
  WS-command validators" reference since that one's real).

No code change. 525 remote-build tests still pass; mypy
clean.

**Related issue or feature (if applicable):**

- Closes the open 4a-o follow-up tracked at
  esphome/device-builder#106 (the comment block was the
  pointer to it).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#&lt;number&gt;

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
