### PR TITLE
Fix Bundle file not found on every remote-build submit

### DIFF
--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -26,7 +26,9 @@ Flow:
    base64-decode and feed the assembler. On the chunk that
    carries ``is_last=True`` we finalise (validates byte count
    + sha256), write the assembled tarball to
-   ``<config>/.esphome/.remote_builds/<dashboard_id>/<device_name>/bundle.tar.gz``,
+   ``<config>/.esphome/.remote_builds/<dashboard_id>/<device_name>.tar.gz``
+   (sibling of the per-device subtree, not child — see the
+   ``_BUNDLE_SUFFIX`` comment for why),
    extract via :func:`esphome.bundle.prepare_bundle_for_compile`
    (which preserves ``.esphome/`` / ``.pioenvs/`` for incremental
    builds — the load-bearing reason for the stable per-peer
@@ -138,13 +140,22 @@ _SUBMIT_JOB_CHUNK_SCHEMA = frame_schema(
 # sweep can reuse the same parent walk.
 _REMOTE_BUILDS_SUBDIR = Path(".esphome") / ".remote_builds"
 
-# Bundle filename inside ``<dashboard_id>/<device_name>/``.
-# Constant rather than derived from the offloader's
-# ``configuration_filename`` so a malicious or buggy offloader
-# can't pick a name that collides with extracted artefacts (the
-# YAML, the ``manifest.yaml``, etc.) — the extracted tree owns
-# the rest of the directory.
-_BUNDLE_FILENAME = "bundle.tar.gz"
+# Bundle filename used as a sibling of the extract target_dir
+# (``<dashboard_id>/<device_name>.tar.gz``, next to the
+# ``<dashboard_id>/<device_name>/`` build subtree). Living
+# outside target_dir is load-bearing: upstream
+# :func:`prepare_bundle_for_compile` preserves only
+# ``.esphome`` / ``.pioenvs`` / ``.pio`` in target_dir and
+# wipes every other entry before extract; a bundle inside
+# target_dir would be deleted between the path-resolved
+# ``is_file`` check and the inner ``extract_bundle`` call,
+# surfacing as "Bundle file not found" at compile time.
+# Derived from *device_name* (not the offloader's raw
+# ``configuration_filename``) because ``_validate_configuration_filename``
+# already canonicalised it; using the canonical form keeps a
+# malicious sender from picking a path-traversal shape that
+# climbs out of the dashboard_id namespace.
+_BUNDLE_SUFFIX = ".tar.gz"
 
 # Allowed values of :attr:`SubmitJobFrameData.target`.
 # ``Literal["compile", "upload"]`` on the TypedDict is the
@@ -499,7 +510,9 @@ class SubmitJobReceiver:
         assert device_name is not None  # narrowed by the upstream reject
         remote_builds_root = self._config_dir / _REMOTE_BUILDS_SUBDIR
         target_dir = remote_builds_root / session.dashboard_id / device_name
-        bundle_path = target_dir / _BUNDLE_FILENAME
+        # Sibling of target_dir, not child — see _BUNDLE_SUFFIX
+        # comment for why this matters.
+        bundle_path = target_dir.parent / f"{device_name}{_BUNDLE_SUFFIX}"
 
         loop = asyncio.get_running_loop()
         try:

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -18,6 +18,7 @@ e2e harness in :mod:`tests.e2e` stays visible:
 from __future__ import annotations
 
 import hashlib
+import shutil
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -505,6 +506,76 @@ async def test_submit_job_happy_path_extracts_and_queues(
     # the same form.
     assert job.configuration == expected_yaml.relative_to(tmp_path).as_posix()
     firmware._enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_bundle_path_survives_prepare_bundle_wipe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bundle path lives outside ``target_dir`` so upstream's wipe-then-extract works.
+
+    Upstream :func:`esphome.bundle.prepare_bundle_for_compile`
+    preserves only ``.esphome`` / ``.pioenvs`` / ``.pio`` inside
+    *target_dir* and wipes every other entry before its inner
+    ``extract_bundle`` reads back from *bundle_path*. If we wrote
+    the bundle inside *target_dir* (the pre-fix shape), the
+    wipe step would delete it between the executor write and
+    the extract call, surfacing as
+    ``EsphomeError("Bundle file not found: ...")`` for every
+    remote build the operator tried to run.
+
+    Stubbed prepare here mimics the upstream wipe-then-read
+    semantics: iterate *target_dir*, delete non-preserved
+    entries, then read *bundle_path*. A regression that moves
+    the bundle back inside *target_dir* will trip the
+    ``FileNotFoundError`` arm in the stub, which the helper
+    surfaces as ``extract_failed`` on the ack.
+    """
+    firmware = _make_firmware_controller()
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session(dashboard_id="alpha-dashboard")
+    bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+    expected_yaml = (
+        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+    )
+
+    # Mirror upstream prepare_bundle_for_compile's preserve set
+    # so the stub doesn't have to track every future esphome
+    # bump separately. The point isn't to pin which dirs are
+    # preserved — it's to pin that bundle_path is NOT inside
+    # target_dir, so the wipe-then-read can't fail on it.
+    preserved = {".esphome", ".pioenvs", ".pio"}
+
+    def _wipe_then_extract(bundle_path: Path, target_dir: Path) -> Path:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for item in target_dir.iterdir():
+            if item.name in preserved:
+                continue
+            if item.is_dir():
+                shutil.rmtree(item)
+            else:
+                item.unlink()
+        # Real upstream reads back from bundle_path AFTER the
+        # wipe. A bundle living inside target_dir would be gone
+        # by now.
+        assert bundle_path.read_bytes() == bundle
+        expected_yaml.parent.mkdir(parents=True, exist_ok=True)
+        expected_yaml.write_bytes(b"esphome:\n  name: kitchen\n")
+        return expected_yaml
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        _wipe_then_extract,
+    )
+
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+    for chunk in _frame_chunks("job-1", bundle):
+        await receiver.handle_submit_job_chunk(session, chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is True
+    assert payload["job_id"] == "job-1"
+    assert "reason" not in payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Fixes "Bundle file not found" on every remote build the operator dispatches through `remote_build/submit_job`.

## What was happening

`SubmitJobReceiver._extract_and_queue` was writing the assembled tarball to:

```
<config>/.esphome/.remote_builds/<dashboard_id>/<device_name>/bundle.tar.gz
```

…and then calling `esphome.bundle.prepare_bundle_for_compile(bundle_path, target_dir)` against that same `<dashboard_id>/<device_name>/` directory.

The upstream helper preserves only `.esphome` / `.pioenvs` / `.pio` inside `target_dir` and **wipes every other entry** before its inner `extract_bundle` reads from `bundle_path` (`esphome/bundle.py:752-758`). So the just-written `bundle.tar.gz` got deleted between the executor write and the inner extract, and `extract_bundle` raised `EsphomeError("Bundle file not found: …")` at `bundle.py:467`. The receiver-side submit_job handler caught that, mapped it to a structured `artifacts_end{accepted: false, reason: "extract_failed"}` reject, and the user saw a failed build with this log line:

```
WARNING [remote_build.submit_job] submit_job from <dashboard_id>: extract failed for
job <job_id> (<config>.yaml): Bundle file not found:
<config>/.esphome/.remote_builds/<dashboard_id>/<device>/bundle.tar.gz
```

## What changes

`bundle_path` moves from `target_dir / "bundle.tar.gz"` to `target_dir.parent / f"{device_name}.tar.gz"` — a **sibling** of the build subtree under the same `<dashboard_id>/` parent. The wipe step can't reach it.

Path-traversal safety carries over unchanged: `device_name` is the canonical form `_validate_configuration_filename` returns (which already strips separators / `..`), so a malicious sender still can't pick a shape that climbs out of the `<dashboard_id>/` namespace. The constant rename (`_BUNDLE_FILENAME` → `_BUNDLE_SUFFIX`) flags the shape change; the comment on the new constant explains why "outside target_dir" is load-bearing.

## Why the existing tests didn't catch it

* **Unit tests** (`tests/test_remote_build_submit_job.py`): every test that exercises the extract path stubs `prepare_bundle_for_compile` with a trivial pass-through that just asserts the bundle file exists at write time and returns a synthetic YAML path. They never modelled the upstream wipe semantics, so a regression in where the bundle lives relative to `target_dir` was invisible at the unit level.
* **E2E tests** (`tests/e2e/`): the harness has tests for pair/session lifecycle, `JOB_*` fan-out, `cancel_job`, and (newly in #549) `download_artifacts` — but no test drives the offloader→receiver `submit_job` round-trip with the real upstream `prepare_bundle_for_compile`. `test_submit_job_fanout.py`'s module docstring explicitly calls out the gap: *"A submit_job e2e test is the natural next follow-up once the receiver-side firmware controller can be swapped for a recording stub without coupling the harness to DeviceBuilder."*

So both the unit suite and the e2e harness had a blind spot at the same junction. New regression in this PR:

* `test_submit_job_bundle_path_survives_prepare_bundle_wipe` stubs `prepare_bundle_for_compile` with a **wipe-emulating** function (mirrors upstream's preserve set, deletes non-preserved entries in `target_dir`, then reads `bundle_path`). A regression that moves the bundle back inside `target_dir` trips the `read_bytes()` arm and the test fails. This catches the bug pattern without needing to build a real esphome bundle.

A real submit_job e2e test (constructing a real bundle via `esphome.bundle.BundleBuilder`, exercising upstream's `prepare_bundle_for_compile` end-to-end) is the broader fix for the e2e gap — separate follow-up.

**Related issue or feature (if applicable):**

- Part of esphome/device-builder#106 (remote-build offload), phase 5c-2a regression.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
