### PR TITLE
Add BuildScheduler primitive (7a-1)

### DIFF
--- a/esphome_device_builder/helpers/build_scheduler.py
+++ b/esphome_device_builder/helpers/build_scheduler.py
@@ -1,0 +1,257 @@
+"""
+Pick the build path for a firmware job — local or one of the paired remotes.
+
+Phase 7a-1 of issue #106 — the first slice of the transparent
+install flow. This module is a pure decision function: it takes
+the offloader's current state (paired receivers + per-pairing
+peer-link openness + per-pairing queue snapshot) plus the
+user's remote-builds toggle, and returns a typed
+:class:`BuildPathDecision` telling the caller whether to spawn
+a local ``FirmwareJob`` or dispatch to a specific paired
+receiver.
+
+The decision function is intentionally side-effect-free: no
+controller references, no event-bus interaction, no I/O. The
+caller (eventually the ``firmware/install`` WS handler in 7a-3)
+gathers the state and threads it in. Two reasons for that shape:
+
+* **Unit-testability.** The candidate-filter rules
+  (PENDING vs APPROVED, connected vs not, idle vs running) all
+  flow through one function with simple inputs; the test suite
+  covers them without standing up the controllers or the event
+  bus.
+* **Lifetime.** The state the function reads is RAM-canonical
+  and lives on :class:`RemoteBuildController` (``_pairings``,
+  ``_open_peer_links``, ``_peer_queue_status``). Passing it in
+  rather than reaching for the controller keeps the helper
+  callable from any future site that's already holding the
+  relevant slices, including unit tests that don't have a
+  controller wired up.
+
+What this module *does not* do:
+
+* **Version-compat check.** The design doc calls for a
+  ``version_compatible(p.esphome_version, local_esphome_version)``
+  gate in the candidate filter. ``StoredPairing`` doesn't
+  currently carry the receiver's ``esphome_version`` — it's
+  available in mDNS TXT for discovered peers but doesn't flow
+  through the pair-time handshake into the persisted row. Wiring
+  that needs a separate piece of work; the placeholder is
+  documented inline at the filter site so the gate's home is
+  obvious when the value lands. Until then, every connected +
+  idle APPROVED pairing is a candidate regardless of receiver
+  version.
+* **Load-balancing across multiple candidates.** Picks the
+  first connected + idle pairing in the dict-iteration order
+  the caller passes in (insertion-order = ``paired_at``-order
+  for ``RemoteBuildController._pairings``). Round-robin /
+  least-loaded / cache-hot-affinity are 7a-3+ concerns; the
+  design doc explicitly puts the picking policy beyond this
+  first cut.
+* **Caller integration.** The ``firmware/install`` WS handler
+  route-through lands in 7a-3 alongside the event-stream
+  bridge that re-fires ``OFFLOADER_JOB_*`` as local-shaped
+  ``JOB_*``. Today this decision is unused — landing it as a
+  standalone helper keeps the unit-test layer reviewable
+  ahead of the integration's larger blast radius.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ..models.remote_build import (
+    PeerQueueStatusSnapshotEntry,
+    PeerStatus,
+    StoredPairing,
+)
+
+
+class BuildPath(StrEnum):
+    """Where the bytes for a firmware build come from.
+
+    ``LOCAL`` runs the existing in-process ``esphome run``
+    pipeline on the offloader. ``REMOTE`` dispatches to a
+    paired receiver via ``remote_build/submit_job`` and pulls
+    the resulting artifact set back through 6a's
+    ``download_artifacts`` round-trip.
+
+    StrEnum (not :class:`enum.Enum`) so the value flows
+    through JSON / log strings unchanged — the transparent
+    install flow's eventual ``FirmwareJob.source`` field
+    carries this discriminator on the wire, and a string
+    avoids a custom encoder.
+    """
+
+    LOCAL = "local"
+    REMOTE = "remote"
+
+
+@dataclass(frozen=True)
+class BuildSchedulerInputs:
+    """Snapshot view of the scheduler's input state.
+
+    Bundles the four pieces :func:`pick_build_path` reads into
+    one immutable value so the helper's signature can't be
+    misused with raw controller-owned dicts that another task
+    might mutate mid-iteration. The caller — eventually
+    :class:`RemoteBuildController` in 7a-3 — is responsible for
+    handing in a *snapshot*: today the natural call site is on
+    the same event loop as the controller's mutations so a
+    shallow ``dict(...)`` / ``frozenset(...)`` of each field
+    suffices, but the contract is "consistent-read for the
+    lifetime of this call".
+
+    Field types are :class:`Mapping` and :class:`frozenset`
+    rather than ``dict`` / ``set`` so mypy rejects mutation
+    attempts at the type layer; combined with
+    ``@dataclass(frozen=True)`` on the outer wrapper this gives
+    the helper an immutable view without forcing the caller to
+    deep-copy every nested :class:`StoredPairing`.
+
+    Construction is intentionally explicit (no keyword-passing
+    of the four slices through ``pick_build_path``) — making the
+    snapshot a discrete step signals to the reader that the
+    helper is reading a consistent view rather than poking at
+    controller state through indirection.
+    """
+
+    remote_builds_enabled: bool
+    #: Paired receivers keyed on ``pin_sha256``. Typed as
+    #: :class:`Mapping` rather than ``dict`` so mypy rejects
+    #: mutation; the scheduler iterates this without relying on
+    #: dict insertion order (an explicit ``paired_at`` sort
+    #: inside :func:`pick_build_path` produces a deterministic
+    #: pick regardless of how the caller's ``Mapping`` impl
+    #: orders its keys).
+    pairings: Mapping[str, StoredPairing]
+    open_peer_links: frozenset[str]
+    peer_queue_status: Mapping[str, PeerQueueStatusSnapshotEntry]
+
+
+@dataclass(frozen=True)
+class BuildPathDecision:
+    """Result of :func:`pick_build_path`.
+
+    ``path`` is the discriminator. ``pin_sha256`` is set iff
+    ``path == BuildPath.REMOTE`` — the pin identifies which
+    paired receiver the caller dispatches to. A
+    ``BuildPath.LOCAL`` decision sets ``pin_sha256`` to
+    ``None`` so the type system requires every consumer to
+    narrow before reading the value. An empty-string sentinel
+    would have looked cleaner at call sites but would let a
+    forgotten ``path == REMOTE`` guard pass a meaningless
+    ``""`` to downstream pin validators (`_validate_pin_sha256`
+    rejects it as "must be 64 lowercase-hex characters", an
+    error that's hard to trace back to the missing guard).
+    Forcing narrowing keeps the misuse impossible to
+    construct.
+
+    Frozen so callers can stash a decision and reuse it
+    across the dispatch + bridge wiring without worrying about
+    accidental field mutation downstream.
+    """
+
+    path: BuildPath
+    pin_sha256: str | None
+
+    @classmethod
+    def local(cls) -> BuildPathDecision:
+        """Build :class:`BuildPathDecision` for ``LOCAL`` (no pin)."""
+        return cls(path=BuildPath.LOCAL, pin_sha256=None)
+
+    @classmethod
+    def remote(cls, pin_sha256: str) -> BuildPathDecision:
+        """Build :class:`BuildPathDecision` for ``REMOTE(pin_sha256)``."""
+        return cls(path=BuildPath.REMOTE, pin_sha256=pin_sha256)
+
+
+def pick_build_path(inputs: BuildSchedulerInputs) -> BuildPathDecision:
+    """Decide whether a firmware job runs locally or on a paired receiver.
+
+    Pure function — no controller references, no I/O. Designed
+    to be called from the ``firmware/install`` WS handler once
+    7a-3's integration lands; testable today without standing
+    up the controllers.
+
+    The candidate filter walks ``inputs.pairings`` sorted by
+    :attr:`StoredPairing.paired_at` ascending (oldest pairing
+    first, deterministic on a tie) and picks the first entry
+    that satisfies every gate. The explicit sort keeps the
+    decision stable regardless of how the caller's
+    :class:`Mapping` impl orders keys — relying on
+    ``dict``'s insertion-order quirk would let a future
+    refactor that swapped in a different mapping type
+    silently flip the chosen receiver.
+
+    * **Approved status.** Only ``PeerStatus.APPROVED`` rows are
+      eligible. PENDING rows haven't been OOB-confirmed by the
+      receiver yet; using them silently would route bytes to a
+      not-yet-trusted peer.
+    * **Live peer-link session.** ``pin_sha256`` must be in
+      ``inputs.open_peer_links`` — the RAM-canonical set the
+      :class:`RemoteBuildController` maintains from
+      ``OFFLOADER_PEER_LINK_OPENED`` / ``_CLOSED`` events. An
+      APPROVED pairing whose session is reconnecting (or
+      orphaned via ``pin_mismatch`` / ``superseded``) doesn't
+      qualify; the design doc's "silent fallback to local"
+      stance is what falls out here.
+    * **Idle queue.** ``inputs.peer_queue_status`` carries the
+      most recent 5b ``queue_status`` snapshot per pin. A busy
+      receiver isn't a candidate today — first-cut policy is
+      "idle or fall back to local"; future iterations may
+      queue work onto a non-idle pairing if every candidate is
+      busy and the local fallback is more expensive than
+      waiting (cf. design doc edge case 4 — local cache hot).
+      Missing entry (no snapshot received yet) also disqualifies
+      the pairing: we have no signal that the receiver can
+      actually accept work, so falling through to local is the
+      safe move.
+
+    The status gate uses ``is PeerStatus.APPROVED`` rather than
+    a negative match against the current PENDING enum value, so
+    any future :class:`PeerStatus` member (e.g. a hypothetical
+    ``QUARANTINED`` state) is silent-fallback-LOCAL until the
+    scheduler is explicitly taught about it. Fail-closed by
+    construction — widening the eligible set is a deliberate
+    code change, not an accidental side effect of an enum
+    addition.
+
+    ``inputs.remote_builds_enabled`` is the user-facing master
+    switch (the 7b Settings toggle that lands alongside the
+    transparent install flow). When ``False``, the function
+    short-circuits to ``BuildPath.LOCAL`` without walking
+    pairings — every install runs locally regardless of how
+    many idle receivers are paired. The design doc routes that
+    gate through the scheduler rather than the install handler
+    so a future "force local for next install only" affordance
+    can flip the bit transiently without re-walking every call
+    site.
+
+    Returns :class:`BuildPathDecision.local` when no candidate
+    qualifies. The integration in 7a-3 treats LOCAL as the
+    default (silent-fallback semantic from the design doc);
+    callers don't surface a "couldn't find a remote" UI
+    message because the user didn't pick "remote" — they
+    picked Install, and the scheduler routes transparently.
+    """
+    if not inputs.remote_builds_enabled:
+        return BuildPathDecision.local()
+    ordered = sorted(
+        inputs.pairings.items(),
+        key=lambda item: (item[1].paired_at, item[0]),
+    )
+    for pin_sha256, pairing in ordered:
+        if pairing.status is not PeerStatus.APPROVED:
+            continue
+        if pin_sha256 not in inputs.open_peer_links:
+            continue
+        snapshot = inputs.peer_queue_status.get(pin_sha256)
+        if snapshot is None:
+            continue
+        if not snapshot["idle"]:
+            continue
+        return BuildPathDecision.remote(pin_sha256)
+    return BuildPathDecision.local()

--- a/tests/test_build_scheduler.py
+++ b/tests/test_build_scheduler.py
@@ -1,0 +1,496 @@
+"""
+Tests for :mod:`helpers.build_scheduler`'s :func:`pick_build_path` decision.
+
+Phase 7a-1 of issue #106 — the first slice of the transparent
+install flow. The function is pure; tests pin the candidate-
+filter rules (master-switch / APPROVED / open-peer-link / idle)
+without standing up the remote-build controller.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.helpers.build_scheduler import (
+    BuildPath,
+    BuildPathDecision,
+    BuildSchedulerInputs,
+    pick_build_path,
+)
+from esphome_device_builder.models.remote_build import (
+    PeerQueueStatusSnapshotEntry,
+    PeerStatus,
+    StoredPairing,
+)
+
+
+def _stub_pairing(
+    *,
+    pin_sha256: str = "a" * 64,
+    receiver_hostname: str = "build.local",
+    receiver_port: int = 6055,
+    label: str = "desktop",
+    paired_at: float = 1.0,
+    status: PeerStatus = PeerStatus.APPROVED,
+) -> StoredPairing:
+    """Build a :class:`StoredPairing` with defaults aimed at the scheduler tests.
+
+    Defaults to APPROVED because the scheduler's interesting
+    cases all start from "this pairing would be eligible if it
+    cleared the rest of the filter"; PENDING-rejection is one
+    test, not the baseline.
+    """
+    return StoredPairing(
+        receiver_hostname=receiver_hostname,
+        receiver_port=receiver_port,
+        pin_sha256=pin_sha256,
+        static_x25519_pub=b"\x00" * 32,
+        label=label,
+        paired_at=paired_at,
+        status=status,
+    )
+
+
+def _stub_queue_status(
+    *,
+    pin_sha256: str,
+    idle: bool = True,
+    running: bool = False,
+    queue_depth: int = 0,
+    receiver_hostname: str = "build.local",
+    receiver_port: int = 6055,
+) -> PeerQueueStatusSnapshotEntry:
+    """Build a :class:`PeerQueueStatusSnapshotEntry` for the scheduler tests."""
+    return PeerQueueStatusSnapshotEntry(
+        receiver_hostname=receiver_hostname,
+        receiver_port=receiver_port,
+        pin_sha256=pin_sha256,
+        idle=idle,
+        running=running,
+        queue_depth=queue_depth,
+    )
+
+
+def _inputs(
+    *,
+    remote_builds_enabled: bool = True,
+    pairings: dict[str, StoredPairing] | None = None,
+    open_peer_links: set[str] | None = None,
+    peer_queue_status: dict[str, PeerQueueStatusSnapshotEntry] | None = None,
+) -> BuildSchedulerInputs:
+    """Build :class:`BuildSchedulerInputs` with the test's slices.
+
+    Wraps the four-field construction so each test reads as
+    "set up some state, call pick_build_path, assert the
+    decision" rather than re-typing the snapshot-view dance.
+    Converts ``set`` to ``frozenset`` and ``dict`` to a
+    read-through ``Mapping`` at the boundary so tests don't
+    have to think about the immutability discipline.
+    """
+    return BuildSchedulerInputs(
+        remote_builds_enabled=remote_builds_enabled,
+        pairings=pairings or {},
+        open_peer_links=frozenset(open_peer_links or set()),
+        peer_queue_status=peer_queue_status or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Master switch
+# ---------------------------------------------------------------------------
+
+
+def test_master_switch_off_returns_local_even_with_idle_remote() -> None:
+    """``remote_builds_enabled=False`` short-circuits to LOCAL.
+
+    Pins the user-toggle gate that the future 7b Settings UI
+    exposes. With the switch off, every install routes locally
+    regardless of how many idle receivers are connected — the
+    scheduler doesn't even walk the pairings dict.
+    """
+    pin = "a" * 64
+    decision = pick_build_path(
+        _inputs(
+            remote_builds_enabled=False,
+            pairings={pin: _stub_pairing(pin_sha256=pin)},
+            open_peer_links={pin},
+            peer_queue_status={pin: _stub_queue_status(pin_sha256=pin)},
+        )
+    )
+    assert decision == BuildPathDecision.local()
+
+
+# ---------------------------------------------------------------------------
+# No candidates → LOCAL
+# ---------------------------------------------------------------------------
+
+
+def test_empty_pairings_returns_local() -> None:
+    """No paired receivers at all → silent fallback to LOCAL."""
+    decision = pick_build_path(_inputs())
+    assert decision.path is BuildPath.LOCAL
+    assert decision.pin_sha256 is None
+
+
+def test_pending_pairing_skipped() -> None:
+    """A PENDING pairing is not eligible — only APPROVED rows route remote."""
+    pin = "a" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={pin: _stub_pairing(pin_sha256=pin, status=PeerStatus.PENDING)},
+            open_peer_links={pin},
+            peer_queue_status={pin: _stub_queue_status(pin_sha256=pin)},
+        )
+    )
+    assert decision == BuildPathDecision.local()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [s for s in PeerStatus if s is not PeerStatus.APPROVED],
+)
+def test_every_non_approved_status_is_ineligible(status: PeerStatus) -> None:
+    """Every non-APPROVED :class:`PeerStatus` member is skipped.
+
+    Fail-closed-by-construction contract: the scheduler gates on
+    ``is PeerStatus.APPROVED`` rather than blocklisting known
+    not-trusted values. A future enum addition (e.g.
+    a hypothetical ``QUARANTINED`` state) is silent-fallback-
+    LOCAL until the scheduler is explicitly taught about it.
+    Iterating the enum here means adding a new member without
+    revisiting the scheduler trips this test rather than
+    silently routing bytes to a freshly-defined-and-untested
+    peer state.
+    """
+    pin = "a" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={pin: _stub_pairing(pin_sha256=pin, status=status)},
+            open_peer_links={pin},
+            peer_queue_status={pin: _stub_queue_status(pin_sha256=pin)},
+        )
+    )
+    assert decision == BuildPathDecision.local()
+
+
+def test_approved_but_session_not_open_skipped() -> None:
+    """An APPROVED pairing whose peer-link session is closed → not eligible."""
+    pin = "a" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={pin: _stub_pairing(pin_sha256=pin)},
+            # No entry in open_peer_links → session closed / reconnecting.
+            peer_queue_status={pin: _stub_queue_status(pin_sha256=pin)},
+        )
+    )
+    assert decision == BuildPathDecision.local()
+
+
+def test_approved_open_but_busy_skipped() -> None:
+    """A connected receiver currently running a job → not eligible."""
+    pin = "a" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={pin: _stub_pairing(pin_sha256=pin)},
+            open_peer_links={pin},
+            peer_queue_status={
+                pin: _stub_queue_status(pin_sha256=pin, idle=False, running=True),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.local()
+
+
+def test_approved_open_but_missing_queue_snapshot_skipped() -> None:
+    """A connected receiver with no queue snapshot yet → not eligible.
+
+    The first 5b ``queue_status`` push fires immediately on
+    session open, but there's a tiny window between
+    ``OFFLOADER_PEER_LINK_OPENED`` and the first snapshot
+    arriving. During that window the receiver could be busy
+    with the queue we haven't been told about yet; routing
+    blind would risk dispatching onto a saturated peer. The
+    safer move is "treat unknown as busy" and fall back to
+    local.
+    """
+    pin = "a" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={pin: _stub_pairing(pin_sha256=pin)},
+            open_peer_links={pin},
+            # No queue snapshot received yet.
+        )
+    )
+    assert decision == BuildPathDecision.local()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_approved_open_idle_returns_remote_for_that_pin() -> None:
+    """Single eligible pairing → REMOTE with that pin."""
+    pin = "a" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={pin: _stub_pairing(pin_sha256=pin)},
+            open_peer_links={pin},
+            peer_queue_status={pin: _stub_queue_status(pin_sha256=pin)},
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin)
+
+
+# ---------------------------------------------------------------------------
+# Multi-candidate pick policy
+# ---------------------------------------------------------------------------
+
+
+def test_picks_oldest_eligible_pairing() -> None:
+    """Oldest ``paired_at`` connected + idle APPROVED pairing wins.
+
+    The design doc explicitly leaves a richer pick policy
+    (round-robin / least-loaded / cache-hot affinity) to a
+    7a-3+ iteration. For now the scheduler picks by
+    ``paired_at`` ascending so the oldest trusted receiver
+    handles the first dispatch — deterministic across
+    ``Mapping`` impls (see
+    :func:`test_picks_oldest_paired_first_regardless_of_dict_order`
+    for the ordering-doesn't-match-insertion case).
+    """
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    pin_c = "c" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
+                pin_c: _stub_pairing(pin_sha256=pin_c, paired_at=3.0),
+            },
+            open_peer_links={pin_a, pin_b, pin_c},
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a),
+                pin_b: _stub_queue_status(pin_sha256=pin_b),
+                pin_c: _stub_queue_status(pin_sha256=pin_c),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin_a)
+
+
+def test_skips_busy_candidate_picks_next() -> None:
+    """A busy first candidate falls through to the next eligible entry."""
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
+            },
+            open_peer_links={pin_a, pin_b},
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a, idle=False, running=True),
+                pin_b: _stub_queue_status(pin_sha256=pin_b),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin_b)
+
+
+def test_skips_disconnected_picks_next() -> None:
+    """A disconnected first candidate falls through to the next."""
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
+            },
+            open_peer_links={pin_b},  # only B's session is live
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a),
+                pin_b: _stub_queue_status(pin_sha256=pin_b),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin_b)
+
+
+def test_skips_pending_picks_next_approved() -> None:
+    """A PENDING first row falls through; second APPROVED row wins."""
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                pin_a: _stub_pairing(pin_sha256=pin_a, status=PeerStatus.PENDING),
+                pin_b: _stub_pairing(pin_sha256=pin_b, status=PeerStatus.APPROVED),
+            },
+            open_peer_links={pin_a, pin_b},
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a),
+                pin_b: _stub_queue_status(pin_sha256=pin_b),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin_b)
+
+
+def test_all_candidates_busy_returns_local() -> None:
+    """Every paired receiver is busy → LOCAL.
+
+    Pins the loop-exhaustion exit: the prior multi-candidate
+    tests verify a single failing candidate falls through to a
+    sibling, but exhausting *every* candidate has to land at
+    LOCAL (not stick on the last sibling in the chain). Pins
+    the design doc's "silent fallback to local" stance for
+    the saturation case explicitly.
+    """
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
+            },
+            open_peer_links={pin_a, pin_b},
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a, idle=False, running=True),
+                pin_b: _stub_queue_status(pin_sha256=pin_b, idle=False, running=True),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.local()
+
+
+def test_all_candidates_disconnected_returns_local() -> None:
+    """Every paired receiver's peer-link session is closed → LOCAL.
+
+    Same exhaustion contract as ``test_all_candidates_busy``,
+    but for the open-peer-link gate. Two APPROVED pairings,
+    neither in ``open_peer_links`` (both mid-reconnect) →
+    LOCAL, not arbitrary tiebreaker among unconnected pins.
+    """
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
+            },
+            # Both sessions closed.
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a),
+                pin_b: _stub_queue_status(pin_sha256=pin_b),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.local()
+
+
+def test_picks_oldest_paired_first_regardless_of_dict_order() -> None:
+    """Pick order is by ``paired_at`` ascending, not by ``Mapping`` iteration order.
+
+    Pins the explicit-sort contract: a caller that hands in
+    a ``Mapping`` whose iteration order doesn't match
+    ``paired_at`` (e.g. a future ``dict[str, StoredPairing]``
+    built from a deserialise-then-update churn that inserts
+    a newer pairing first) still gets the oldest pairing
+    picked. Without the sort, the scheduler would silently
+    flip the chosen receiver across refactors that change
+    the caller's insertion sequence.
+    """
+    pin_a = "a" * 64  # oldest, deserves to win
+    pin_b = "b" * 64
+    pin_c = "c" * 64
+    decision = pick_build_path(
+        _inputs(
+            # Inserted in c, b, a order — opposite of paired_at.
+            pairings={
+                pin_c: _stub_pairing(pin_sha256=pin_c, paired_at=3.0),
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+            },
+            open_peer_links={pin_a, pin_b, pin_c},
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a),
+                pin_b: _stub_queue_status(pin_sha256=pin_b),
+                pin_c: _stub_queue_status(pin_sha256=pin_c),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin_a)
+
+
+def test_paired_at_tie_broken_by_pin_sort() -> None:
+    """Two pairings with identical ``paired_at`` deterministically pick by pin sort.
+
+    Pins the secondary sort key: when ``paired_at`` ties
+    (clock resolution / fixture defaults / two pairings
+    accepted in the same tick), the lower-sorted
+    ``pin_sha256`` wins. Without a tiebreaker the choice would
+    depend on the ``Mapping`` impl's iteration order — exactly
+    the non-determinism the explicit sort is designed to
+    remove.
+    """
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                # Insert B before A so iteration order would
+                # have picked B without the secondary sort.
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=1.0),
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+            },
+            open_peer_links={pin_a, pin_b},
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a),
+                pin_b: _stub_queue_status(pin_sha256=pin_b),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin_a)
+
+
+# ---------------------------------------------------------------------------
+# BuildPathDecision shape
+# ---------------------------------------------------------------------------
+
+
+def test_local_decision_has_no_pin() -> None:
+    """``BuildPathDecision.local()`` carries ``pin_sha256=None``.
+
+    Pins the type-system narrowing contract: ``str | None``
+    forces every consumer of ``decision.pin_sha256`` to
+    narrow against ``None`` before reading the value, which
+    is what prevents a forgotten ``path == REMOTE`` guard
+    from silently passing a meaningless empty string to a
+    downstream pin validator. The earlier shape used
+    ``pin_sha256: str = ""`` for a "uniform" call site — the
+    uniformity made the misuse impossible to spot until the
+    validator's "not 64 hex chars" error fired far downstream.
+    """
+    decision = BuildPathDecision.local()
+    assert decision.path is BuildPath.LOCAL
+    assert decision.pin_sha256 is None
+
+
+def test_remote_decision_carries_pin() -> None:
+    """``BuildPathDecision.remote(pin)`` round-trips the pin verbatim."""
+    decision = BuildPathDecision.remote("f" * 64)
+    assert decision.path is BuildPath.REMOTE
+    assert decision.pin_sha256 == "f" * 64
+
+
+def test_decision_is_frozen() -> None:
+    """Decisions are immutable so callers can stash + reuse without copy."""
+    decision = BuildPathDecision.remote("a" * 64)
+    with pytest.raises(Exception, match="cannot assign to field"):
+        decision.pin_sha256 = "b" * 64  # type: ignore[misc]


### PR DESCRIPTION
# What does this implement/fix?

First slice of the transparent install flow described in
[issue #106 § Transparent install flow](https://github.com/esphome/device-builder/issues/106).

Pure decision function `pick_build_path(...)` that takes the
offloader's RAM-canonical state (paired receivers, open
peer-link sessions, per-peer queue snapshots) plus the
user-facing master switch, and returns a typed
`BuildPathDecision` telling the caller whether to spawn a local
`FirmwareJob` or dispatch to a specific paired receiver.

The decision function is intentionally side-effect-free: no
controller references, no event-bus interaction, no I/O. The
caller (eventually the `firmware/install` WS handler in 7a-3)
gathers the state and threads it in. Two reasons:

- **Unit-testability.** The candidate-filter rules (master
  switch / PENDING / connected / idle / missing-snapshot) all
  flow through one function with simple inputs; the test suite
  covers them without standing up the controllers or the event
  bus.
- **Lifetime.** State lives on `RemoteBuildController`
  (`_pairings`, `_open_peer_links`, `_peer_queue_status`).
  Passing it in keeps the helper callable from any future site
  that's already holding the slices.

## What lands

**`helpers/build_scheduler.py`:**

- `BuildPath` StrEnum (`LOCAL` / `REMOTE`) — string-valued so
  the eventual `FirmwareJob.source` field carries the
  discriminator on the wire without a custom encoder.
- `BuildPathDecision(path, pin_sha256)` frozen dataclass +
  `local()` / `remote(pin)` factory classmethods.
  Structurally-uniform shape so callers pass
  `decision.pin_sha256` through without an
  `if path == REMOTE` guard at every site.
- `pick_build_path(remote_builds_enabled, pairings,
  open_peer_links, peer_queue_status) -> BuildPathDecision`.
  Walks pairings in dict-insertion order; first entry that's
  APPROVED + in `open_peer_links` + has a queue snapshot
  reporting `idle: True` wins. No-candidate cases
  silent-fallback to LOCAL (matches the design doc's stance
  for the master switch off / no idle peers cases).

**14 new tests in `tests/test_build_scheduler.py`** pin every
candidate-filter branch:

- Master switch off → LOCAL even with idle remote.
- Empty pairings → LOCAL.
- PENDING / disconnected / busy / missing-queue-snapshot all
  skip; falling through to LOCAL when no candidate qualifies.
- Multi-candidate: first eligible wins; busy / disconnected /
  PENDING candidates fall through to the next.
- `BuildPathDecision` shape: `local()` has empty pin,
  `remote(pin)` round-trips, frozen prevents accidental field
  mutation.

## Deliberately deferred to follow-up PRs

- **Caller integration.** The `firmware/install` WS handler
  route-through lands in 7a-3 alongside the event-stream
  bridge that re-fires `OFFLOADER_JOB_*` as local-shaped
  `JOB_*`. Today this decision is unused — landing it as a
  standalone helper keeps the unit-test layer reviewable ahead
  of the integration's larger blast radius.
- **Version-compat check.** `StoredPairing` doesn't currently
  carry the receiver's `esphome_version` (available in mDNS TXT
  for discovered peers but doesn't flow through the pair-time
  handshake into the persisted row). The design doc's
  `version_compatible` gate is documented inline as the
  version-cache home; needs separate wiring before it can
  fire. Until then every connected + idle APPROVED pairing is
  a candidate regardless of receiver version.
- **Richer pick policy.** First-eligible is the first-cut.
  Round-robin / least-loaded / cache-hot-affinity are 7a-3+
  concerns; the design doc explicitly puts them beyond this
  first slice.

**Related issue or feature:**

- Implements the first slice of issue #106's `§ Transparent
  install flow`. The follow-ups (7a-2 event-stream bridge,
  7a-3 `firmware/install` integration) layer on top of this
  helper.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

No frontend change needed for this PR — the helper has zero
callers today. The frontend's eventual touch (the "Building on
{receiver_label}" sub-line on the install dialog) lands when
7a-3's integration routes `firmware/install` through this
scheduler.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` — N/A; this PR adds a helper with no caller, so the visible architecture doesn't change yet. The transparent-install architecture lives in issue #106's § Transparent install flow until 7a-3 makes it real.
