### PR TITLE
Add e2e coverage for submit_job round-trip with a real bundle

### DIFF
--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -6,12 +6,12 @@ Closes the gap that let the "Bundle file not found" regression
 :func:`esphome.bundle.prepare_bundle_for_compile`'s wipe step)
 ship despite the unit suite passing. The unit tests in
 ``tests/test_remote_build_submit_job.py`` stub
-:func:`prepare_bundle_for_compile` with a trivial pass-through,
-so the upstream wipe-then-extract semantics never ran against
-the production bundle layout; the e2e harness here drives the
-real upstream function against a real bundle written by the
-real receive loop, so a regression in that seam surfaces on the
-ack instead of in production.
+:func:`esphome.bundle.prepare_bundle_for_compile` with a
+trivial pass-through, so the upstream wipe-then-extract
+semantics never ran against the production bundle layout; the
+e2e harness here drives the real upstream function against a
+real bundle written by the real receive loop, so a regression
+in that seam surfaces on the ack instead of in production.
 
 The chain:
 
@@ -199,7 +199,10 @@ async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
     assert job.remote_peer == paired_instances.offloader_dashboard_id
     assert job.remote_job_id == "off-job-1"
     assert job.job_type is JobType.COMPILE
-    paired_instances.receiver._db.firmware._enqueue.assert_awaited_once()
+    # Pin that the awaited _enqueue saw the same FirmwareJob
+    # _create_job built — assert_awaited_once() alone would
+    # accept a second enqueue of any object.
+    paired_instances.receiver._db.firmware._enqueue.assert_awaited_once_with(job)
 
     receiver_config_dir = paired_instances.receiver._db.settings.config_dir
     extracted_yaml = (
@@ -272,7 +275,14 @@ async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
     # JobFanout's correlation cache; JOB_STARTED triggers the
     # fan-out frame.
     paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))
-    await asyncio.sleep(0)
+    # JobFanout._on_queued is a sync bus listener — it runs
+    # inline inside fire() and populates the correlation cache
+    # before fire() returns. Pin that observable invariant here
+    # so a regression that makes _on_queued async (or schedules
+    # the cache update via a background task) trips this
+    # assertion instead of producing flaky CI behaviour at the
+    # JOB_STARTED fan-out check below.
+    assert job.job_id in paired_instances.receiver._job_fanout._remote_jobs
     paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
 
     await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -1,0 +1,282 @@
+"""
+End-to-end: ``submit_job`` round-trip across the live peer-link with a real bundle.
+
+Closes the gap that let the "Bundle file not found" regression
+(receiver-side bundle path collision with
+:func:`esphome.bundle.prepare_bundle_for_compile`'s wipe step)
+ship despite the unit suite passing. The unit tests in
+``tests/test_remote_build_submit_job.py`` stub
+:func:`prepare_bundle_for_compile` with a trivial pass-through,
+so the upstream wipe-then-extract semantics never ran against
+the production bundle layout; the e2e harness here drives the
+real upstream function against a real bundle written by the
+real receive loop, so a regression in that seam surfaces on the
+ack instead of in production.
+
+The chain:
+
+  offloader-side :meth:`PeerLinkClient.submit_job`
+                       →  ``submit_job`` header
+                          (real Noise AEAD)
+                       →  ``submit_job_chunk`` frames
+                          (chunked + base64-enveloped by
+                          :func:`chunk_bundle`)
+                       →  receiver-side ``_run_session_loops``
+                          receive loop
+                       →  :meth:`SubmitJobReceiver.handle_submit_job`
+                          + :meth:`handle_submit_job_chunk`
+                          run the real :class:`BundleAssembler`,
+                          verify SHA-256, write the assembled
+                          tarball to disk
+                       →  real
+                          :func:`esphome.bundle.prepare_bundle_for_compile`
+                          wipes target_dir's non-preserved
+                          entries, extracts the bundle, returns
+                          the absolute YAML path
+                       →  ``firmware._create_job`` + ``_enqueue``
+                          land the :class:`FirmwareJob` with
+                          ``remote_peer=offloader_dashboard_id``
+                       →  ``submit_job_ack{accepted: true}`` rides
+                          back to the offloader
+
+The offloader's ``remote_build/submit_job`` WS command
+additionally spawns the ``esphome bundle`` CLI subprocess to
+build *bundle_bytes* from a YAML on disk; we bypass that step
+and call :meth:`PeerLinkClient.submit_job` with a pre-built
+in-test bundle so the test stays focused on the receiver-side
+gap. The subprocess invocation is upstream esphome's contract,
+covered separately by tests on :func:`build_yaml_bundle`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import tarfile
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.models import (
+    EventType,
+    FirmwareJob,
+    JobLifecycleData,
+    JobStatus,
+    JobType,
+)
+
+from ..conftest import capture_events
+from .conftest import PairedInstances
+
+
+def _build_real_bundle(*, configuration_filename: str = "kitchen.yaml") -> bytes:
+    """Build a minimal-but-valid esphome bundle the upstream extractor accepts.
+
+    Upstream :func:`esphome.bundle.extract_bundle` needs:
+
+    * A ``manifest.json`` member with
+      ``{"manifest_version": 1, "config_filename": "..."}``.
+    * The referenced ``config_filename`` member, with non-empty
+      content.
+
+    Nothing else — :func:`_validate_tar_members` rejects symlinks
+    / absolute paths / path traversal / oversized archives, all
+    of which we naturally avoid by emitting two regular file
+    members at the top level.
+
+    Deliberately not going through :class:`BundleBuilder`: that
+    class drives ``BundleBuilder.discover_files`` off real
+    ``CORE.config_dir`` + ``CORE.config_path`` state, which
+    would couple this test to a real config-dir layout when all
+    we want is the wire-format contract. The minimal bundle
+    here exercises the same upstream extract code as a
+    BundleBuilder-emitted one for the path that the receiver-
+    side gap lives in.
+    """
+    manifest = {
+        "manifest_version": 1,
+        "config_filename": configuration_filename,
+    }
+    yaml_body = b"esphome:\n  name: kitchen\n"
+    members: list[tuple[str, bytes]] = [
+        ("manifest.json", json.dumps(manifest).encode("utf-8")),
+        (configuration_filename, yaml_body),
+    ]
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, data in members:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[FirmwareJob]:
+    """Make the receiver's ``db.firmware`` record submitted jobs and report success.
+
+    Mirrors :func:`tests.test_remote_build_submit_job._make_firmware_controller`'s
+    shape: ``_create_job`` builds a :class:`FirmwareJob` carrying every
+    field the receiver-side dispatch passes through, ``_enqueue`` resolves
+    accepted=True so the ``submit_job_ack`` lands on the success branch.
+    Returns the list ``_create_job`` appends to so the test body can
+    assert on the queued job's fields after the round-trip.
+    """
+    created_jobs: list[FirmwareJob] = []
+
+    def _create_job(
+        configuration: str,
+        job_type: JobType,
+        *,
+        remote_peer: str = "",
+        remote_job_id: str = "",
+        **_: Any,
+    ) -> FirmwareJob:
+        job = FirmwareJob(
+            job_id=f"rcv-{len(created_jobs)}",
+            configuration=configuration,
+            job_type=job_type,
+            status=JobStatus.QUEUED,
+            remote_peer=remote_peer,
+            remote_job_id=remote_job_id,
+        )
+        created_jobs.append(job)
+        return job
+
+    firmware = instances.receiver._db.firmware
+    firmware._create_job = MagicMock(side_effect=_create_job)
+    firmware._enqueue = AsyncMock(side_effect=lambda job: job)
+    return created_jobs
+
+
+@pytest.mark.asyncio
+async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
+    paired_instances: PairedInstances,
+) -> None:
+    """``submit_job`` from the offloader lands a queued :class:`FirmwareJob` on the receiver.
+
+    Pins the full wire-and-extract round-trip end-to-end. The
+    happy-path assertions cover both the wire contract and the
+    on-disk contract that the unit tests + the existing e2e
+    harness skipped:
+
+    * ``submit_job_ack{accepted: true, job_id}`` flows back over
+      the same Noise channel.
+    * Receiver's ``_create_job`` was called with the canonical
+      relative YAML path the dispatch resolved, the offloader's
+      ``dashboard_id`` on ``remote_peer``, and the offloader-
+      supplied ``job_id`` on ``remote_job_id``.
+    * Receiver's ``_enqueue`` was awaited (the queue side
+      observes the job).
+    * The extracted YAML actually exists on disk at
+      ``<receiver_config_dir>/.esphome/.remote_builds/<dashboard_id>/<device_name>/<configuration>.yaml``,
+      with the body the offloader-side bundle carried. This is
+      the load-bearing assertion the bundle-path fix unblocks:
+      a regression that puts the bundle back inside target_dir
+      would land here as "Bundle file not found" on the
+      upstream extract and the ack would carry ``accepted=False``,
+      not ``True``.
+    """
+    await paired_instances.wait_until_session_opened()
+    created_jobs = _wire_receiver_firmware_recorder(paired_instances)
+
+    bundle_bytes = _build_real_bundle()
+    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    ack = await handle.client.submit_job(
+        job_id="off-job-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=bundle_bytes,
+    )
+
+    assert ack["accepted"] is True
+    assert ack["job_id"] == "off-job-1"
+    assert "reason" not in ack
+
+    assert len(created_jobs) == 1
+    job = created_jobs[0]
+    assert job.remote_peer == paired_instances.offloader_dashboard_id
+    assert job.remote_job_id == "off-job-1"
+    assert job.job_type is JobType.COMPILE
+    paired_instances.receiver._db.firmware._enqueue.assert_awaited_once()
+
+    receiver_config_dir = paired_instances.receiver._db.settings.config_dir
+    extracted_yaml = (
+        receiver_config_dir
+        / ".esphome"
+        / ".remote_builds"
+        / paired_instances.offloader_dashboard_id
+        / "kitchen"
+        / "kitchen.yaml"
+    )
+    assert extracted_yaml.is_file(), (
+        f"extracted YAML missing at {extracted_yaml} — upstream "
+        "prepare_bundle_for_compile didn't write it (possibly the "
+        "bundle-path-inside-target_dir regression)"
+    )
+    assert extracted_yaml.read_bytes() == b"esphome:\n  name: kitchen\n"
+    # FirmwareJob.configuration is the receiver-relative POSIX path
+    # (same shape upstream emits for local jobs); pin it so a
+    # cross-platform regression on path separator handling surfaces
+    # here rather than later in the queue's working-dir logic.
+    assert job.configuration == extracted_yaml.relative_to(receiver_config_dir).as_posix()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
+    paired_instances: PairedInstances,
+) -> None:
+    """``submit_job`` → ``JOB_STARTED`` on receiver → ``OFFLOADER_JOB_STATE_CHANGED`` on offloader.
+
+    Extends the happy-path round-trip with the fan-out leg:
+    once the receiver has queued the :class:`FirmwareJob`, the
+    firmware controller's lifecycle events drive
+    :class:`JobFanout` to push ``job_state_changed`` frames
+    over the same peer-link session. Pins that the receiver-
+    side ``JobFanout._remote_jobs`` correlation cache was
+    populated by the ``JOB_QUEUED`` the queue fires after
+    ``_enqueue`` lands (the real receiver-side flow; in this
+    test we fire ``JOB_QUEUED`` + ``JOB_STARTED`` manually
+    because ``_enqueue`` is stubbed to resolve immediately
+    without driving the queue's own state machine).
+
+    The existing ``test_submit_job_fanout.py`` covers
+    ``JOB_STARTED`` → fan-out in isolation by seeding the
+    correlation directly via ``make_and_seed_remote_peer_job``.
+    Stitching the fan-out leg onto the real submit_job round-
+    trip closes the gap end-to-end so a future regression in
+    either half (submit_job extract OR JobFanout dispatch) can
+    surface on this test.
+    """
+    await paired_instances.wait_until_session_opened()
+    created_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+
+    ack = await paired_instances.offloader._peer_link_clients[
+        paired_instances.pin_sha256
+    ].client.submit_job(
+        job_id="off-job-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=_build_real_bundle(),
+    )
+    assert ack["accepted"] is True
+    assert len(created_jobs) == 1
+    job = created_jobs[0]
+
+    # Fire the lifecycle events the real firmware queue would
+    # have fired after _enqueue. JOB_QUEUED populates
+    # JobFanout's correlation cache; JOB_STARTED triggers the
+    # fan-out frame.
+    paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))
+    await asyncio.sleep(0)
+    paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
+
+    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
+    payload = state_changes[-1]
+    assert payload["job_id"] == "off-job-1"  # offloader's tag echoed back
+    assert payload["status"] == "running"
+    assert payload["pin_sha256"] == paired_instances.pin_sha256


### PR DESCRIPTION
# What does this implement/fix?

Closes the unit-vs-e2e gap that let PR #552's "Bundle file not found" regression ship — the seam where the `submit_job` receive loop writes the assembled tarball and hands it to upstream `esphome.bundle.prepare_bundle_for_compile` for extract.

## Why the prior coverage missed it

* The unit tests in `tests/test_remote_build_submit_job.py` stubbed `prepare_bundle_for_compile` with a trivial pass-through (`assert exists + write yaml + return`), so the upstream wipe-then-extract semantics never ran against the production bundle layout. PR #552 added a wipe-emulating stub there as a focused regression test.
* The e2e harness already covered pair/session lifecycle (`test_pair_and_session`), `JOB_*` fan-out (`test_submit_job_fanout` — uses synthetic `JOB_*` events fired directly on the receiver bus, bypassing `submit_job`), `cancel_job` (`test_cancel_job`), and `download_artifacts` (#549). But **no test drove the offloader→receiver `submit_job` round-trip with the real upstream `prepare_bundle_for_compile`**. The `test_submit_job_fanout` module docstring even called out the gap explicitly:

  > A submit_job e2e test is the natural next follow-up once the receiver-side firmware controller can be swapped for a recording stub without coupling the harness to DeviceBuilder.

This PR is that follow-up.

## What's covered

Two new tests in `tests/e2e/test_submit_job.py`:

1. **`test_submit_job_round_trip_extracts_real_bundle_and_queues_job`** — happy-path round-trip. Builds a minimal-but-valid esphome bundle in-test (`manifest.json` + `kitchen.yaml` in a gzipped tar — same shape upstream's `extract_bundle` accepts), drives `PeerLinkClient.submit_job` across the live peer-link Noise WS, and asserts:

   * `submit_job_ack{accepted: true, job_id}` flows back over the same Noise channel.
   * Receiver's `_create_job` was called with the canonical relative YAML path the dispatch resolved, the offloader's `dashboard_id` on `remote_peer`, and the offloader-supplied `job_id` on `remote_job_id`.
   * Receiver's `_enqueue` was awaited.
   * **The extracted YAML actually exists on disk** at `<receiver_config_dir>/.esphome/.remote_builds/<dashboard_id>/<device_name>/<configuration>.yaml`, with the exact body the offloader-side bundle carried.

   The on-disk assertion is the load-bearing one. A regression that puts the bundle back inside `target_dir` would surface here as the upstream wipe step deleting the bundle before `extract_bundle` can read it; `accepted` would flip to `false` and the test fails before the disk check fires.

2. **`test_submit_job_round_trip_then_fanout_to_offloader_bus`** — stitches the fan-out leg onto the same round-trip. Once the receiver queues the `FirmwareJob`, `JOB_QUEUED` + `JOB_STARTED` on the receiver bus drive `JobFanout` to push `job_state_changed` back through the same session, landing as `OFFLOADER_JOB_STATE_CHANGED` on the offloader bus. The existing `test_submit_job_fanout.py` covered the fan-out half in isolation by seeding the correlation directly via `make_and_seed_remote_peer_job`; this test pins both halves end-to-end so a regression in either surfaces here.

## What's not covered

The offloader-side WS command's `esphome bundle` CLI subprocess is deliberately bypassed — that path is upstream esphome's contract, covered by tests on `build_yaml_bundle`. The bundle is built in-test and handed straight to `PeerLinkClient.submit_job` so the e2e stays focused on the receiver-side gap.

**Related issue or feature (if applicable):**

- Part of esphome/device-builder#106 (remote-build offload). Follows up on #552 which fixed the runtime bug; this PR adds the coverage that would have caught it before merge.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
