### PR TITLE
Add FirmwareJob.source / source_label fields (7a-2a)

### DIFF
--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -40,6 +40,21 @@ class JobType(StrEnum):
     RENAME = "rename"
 
 
+class JobSource(StrEnum):
+    """
+    Where a :class:`FirmwareJob`'s bytes come from.
+
+    ``LOCAL`` is a build this dashboard's CPU ran. ``REMOTE``
+    is a build a paired receiver ran and this dashboard
+    fetched the artifacts from. Distinct from
+    :class:`JobType` ("what operation: compile / upload /
+    install"); ``source`` answers "who did the compile."
+    """
+
+    LOCAL = "local"
+    REMOTE = "remote"
+
+
 # Terminal job states — a job in any of these isn't running and
 # isn't waiting to run.
 TERMINAL_JOB_STATUSES: frozenset[JobStatus] = frozenset(
@@ -99,6 +114,37 @@ class FirmwareJob(DataClassORJSONMixin):
     # offloader matches against its own submit-tagged id, not
     # the receiver's local one.
     remote_job_id: str = ""
+    # Where the build's bytes come from. The offloader-side
+    # firmware-queue runner branches on this to choose its
+    # pipeline (local subprocess vs peer-link dispatch).
+    # Defaults to LOCAL so on-disk jobs from before this field
+    # existed deserialise correctly. Distinct from
+    # ``remote_peer`` / ``remote_job_id`` — those are
+    # receiver-side, set when a receiver picks up an
+    # offloader's ``submit_job``; ``source`` / ``source_pin_sha256``
+    # / ``source_label`` are the offloader-side fields for the
+    # same delegation seen from the dispatching dashboard.
+    source: JobSource = JobSource.LOCAL
+    # Machine-readable handle on the receiver that compiled
+    # this job, when ``source == REMOTE``. Matches
+    # :attr:`StoredPairing.pin_sha256` — the stable
+    # cryptographic identity, NOT the user-mutable display
+    # label. Load-bearing for restart recovery: the runner
+    # picks up an in-progress REMOTE job after a dashboard
+    # restart and needs to know which receiver to query /
+    # cancel / download from, and
+    # ``RemoteBuildController._open_peer_links`` is RAM-only
+    # so the mapping can't be reconstructed otherwise.
+    source_pin_sha256: str = ""
+    # Display label for the paired receiver that compiled this
+    # job, when ``source == REMOTE``. Empty for ``LOCAL`` jobs.
+    # Snapshot of :attr:`StoredPairing.label` at job-creation
+    # time — doesn't track later renames of the pairing label
+    # (the timeline the user saw when they clicked Install is
+    # what they expect to see in the log). Lookups go through
+    # ``source_pin_sha256``; ``source_label`` is purely for
+    # rendering.
+    source_label: str = ""
 
     def reset(self) -> None:
         """
@@ -128,8 +174,10 @@ class FirmwareJob(DataClassORJSONMixin):
           target).
         - **Preserves identity** — ``configuration`` /
           ``job_type`` / ``port`` / ``new_name`` / ``created_at``
-          / ``job_id`` describe the job rather than the run, so
-          they stay intact.
+          / ``job_id`` / ``source`` / ``source_pin_sha256`` /
+          ``source_label`` / ``remote_peer`` / ``remote_job_id``
+          describe the job rather than the run, so they stay
+          intact.
         """
         self.output = [*self.output, _RECOVERY_NOTICE]
         self.progress = None

--- a/tests/models/test_firmware_job.py
+++ b/tests/models/test_firmware_job.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from esphome_device_builder.models.firmware import FirmwareJob, JobStatus, JobType
+import pytest
+
+from esphome_device_builder.models.firmware import (
+    FirmwareJob,
+    JobSource,
+    JobStatus,
+    JobType,
+)
 
 
 def _make_job(**overrides: Any) -> FirmwareJob:
@@ -118,3 +125,124 @@ def test_reset_preserves_job_identity() -> None:
     assert job.new_name == "livingroom"
     assert job.port == "/dev/ttyUSB0"
     assert job.created_at == "2025-12-31T23:59:59+00:00"
+
+
+def test_reset_preserves_dispatch_origin_fields() -> None:
+    """
+    All dispatch-origin fields survive ``reset()``.
+
+    A crash-and-rebuild that lost ``source`` / ``source_label``
+    would re-render the rebuild as a LOCAL job; losing
+    ``source_pin_sha256`` would strand the runner from its
+    receiver (no way back to ``download_artifacts`` /
+    ``cancel_job``); losing receiver-side ``remote_peer`` /
+    ``remote_job_id`` would strand the receiver's rebuild from
+    the offloader's correlation cache. All silent — the build
+    still completes, just attributed to the wrong dashboard.
+    """
+    job = _make_job(
+        status=JobStatus.RUNNING,
+        source=JobSource.REMOTE,
+        source_pin_sha256="a" * 64,
+        source_label="desktop",
+        remote_peer="alpha-dashboard-id",
+        remote_job_id="offloader-job-7",
+    )
+
+    job.reset()
+
+    assert job.source is JobSource.REMOTE
+    assert job.source_pin_sha256 == "a" * 64
+    assert job.source_label == "desktop"
+    assert job.remote_peer == "alpha-dashboard-id"
+    assert job.remote_job_id == "offloader-job-7"
+
+
+# ---------------------------------------------------------------------------
+# JobSource / source / source_label
+# ---------------------------------------------------------------------------
+
+
+def test_source_defaults_to_local() -> None:
+    """
+    A freshly-constructed :class:`FirmwareJob` is ``LOCAL`` with no label.
+
+    The default matches every job-row written before this
+    field existed — older sidecars deserialise as "this
+    dashboard's CPU compiled it", which is what they actually
+    represent.
+    """
+    job = _make_job()
+    assert job.source is JobSource.LOCAL
+    assert job.source_label == ""
+
+
+def test_remote_source_round_trips_through_serialisation() -> None:
+    """
+    A REMOTE-source job survives a mashumaro serialise / deserialise cycle.
+
+    Pins the persistence contract: a dashboard restart can't
+    reattribute a REMOTE job to local or lose the receiver
+    handle the runner needs to route
+    ``download_artifacts`` / ``cancel_job`` against on the
+    rebuild.
+    """
+    job = _make_job(
+        source=JobSource.REMOTE,
+        source_pin_sha256="a" * 64,
+        source_label="desktop",
+    )
+
+    raw = job.to_json()
+    restored = FirmwareJob.from_json(raw)
+
+    assert restored.source is JobSource.REMOTE
+    assert restored.source_pin_sha256 == "a" * 64
+    assert restored.source_label == "desktop"
+
+
+def test_older_sidecar_without_source_field_loads_as_local() -> None:
+    """
+    A job-row serialised without the new fields deserialises to LOCAL defaults.
+
+    A field-missing crash on the persistence-load path would
+    strand every prior job from the firmware-tasks list on the
+    next dashboard start.
+    """
+    # Hand-crafted minimal job shape with no source /
+    # source_pin_sha256 / source_label keys — mirrors what an
+    # older firmware-jobs sidecar would have on disk.
+    raw = (
+        '{"job_id": "old-job-1", '
+        '"configuration": "kitchen.yaml", '
+        '"job_type": "compile", '
+        '"status": "completed", '
+        '"created_at": "2025-12-31T23:59:59+00:00"}'
+    )
+
+    restored = FirmwareJob.from_json(raw)
+
+    assert restored.job_id == "old-job-1"
+    assert restored.source is JobSource.LOCAL
+    assert restored.source_pin_sha256 == ""
+    assert restored.source_label == ""
+
+
+def test_malformed_source_value_rejected_on_load() -> None:
+    """
+    A sidecar carrying an unknown ``source`` string fails to deserialise.
+
+    Surfaces a corrupt-write / version-skew at the
+    persistence-load boundary rather than letting an unknown
+    value ride through into code that branches on
+    ``is JobSource.REMOTE``.
+    """
+    raw = (
+        '{"job_id": "j-1", '
+        '"configuration": "kitchen.yaml", '
+        '"job_type": "compile", '
+        '"source": "intergalactic"}'
+    )
+
+    with pytest.raises(ValueError):
+        FirmwareJob.from_json(raw)


### PR DESCRIPTION
# What does this implement/fix?

First slice of the transparent install flow described in
[issue #106 § Transparent install flow](https://github.com/esphome/device-builder/issues/106).
Makes the local-vs-remote-build distinction a **first-class
field** on `FirmwareJob`: the firmware queue's runner branches
on `source` to choose its pipeline (local subprocess vs
peer-link `submit_job` dispatch), and the install dialog reads
`source_label` to decide whether to render the
"Building on {receiver_label}" sub-line.

**No synthetic-job wrapper. No event-stream bridge.** One
`FirmwareJob` per build, the same `JOB_*` lifecycle events fire
either way, `source` is the only place LOCAL and REMOTE diverge
from a caller's perspective. The original design doc proposed a
synthetic-FirmwareJob + bridge construction to avoid changing
the install dialog's subscriber; that was extra ceremony for a
problem that doesn't exist (frontend ships lockstep with
backend, so adding a small consumer in the dialog when this PR
lands is one coordinated change). Arch.md catches up in a
separate docs PR.

## What lands

**New `JobSource` StrEnum** in `models/firmware.py`:

- `LOCAL` — this dashboard's CPU compiled the artifacts
  (today's default; matches every job-row written before this
  PR).
- `REMOTE` — a paired receiver compiled the artifacts and
  this dashboard fetched them via `download_artifacts`.

**New fields on `FirmwareJob`:**

- `source: JobSource = JobSource.LOCAL` — the discriminator.
- `source_pin_sha256: str = ""` — **machine-readable handle**
  on the receiver that compiled this job, when
  `source == REMOTE`. Matches `StoredPairing.pin_sha256`.
  Load-bearing for restart recovery: a crash-recovered REMOTE
  job needs to know which receiver to route
  `download_artifacts` / `cancel_job` against, and the RAM-only
  `_open_peer_links` cache doesn't survive the restart. Same
  shape as 5c-2's receiver-side `remote_peer` (machine id, not
  display label) and for the same reason.
- `source_label: str = ""` — display string for the
  receiver-label when `source == REMOTE`. Mirrors
  `StoredPairing.label` at job-creation time; doesn't track
  later renames of the pairing label (snapshot semantics). The
  machine-readable handle lookups go through is
  `source_pin_sha256`; `source_label` is purely for rendering.

All three default to the LOCAL shape so an offloader upgrading
across this landing sees its prior on-disk job-rows
deserialise correctly.

**Distinct from `remote_peer` / `remote_job_id`** — those are
*receiver*-side fields filled by 5c-2. The new fields are the
*offloader*-side for the same delegation seen from the
dispatching dashboard. Both pairs end up set on opposite-side
FirmwareJob rows for a single transparent dispatch.

**`FirmwareJob.reset()`'s "preserves identity" list extended**
to include `source` / `source_pin_sha256` / `source_label` /
`remote_peer` / `remote_job_id`. The `remote_*` omission was
already a latent bug for 5c-2 receivers (a crashed
receiver-side job losing `remote_peer` would strand the
rebuild from the offloader's correlation cache). Pinned with
a new test.

## Test additions

- `test_source_defaults_to_local` — default value.
- `test_remote_source_round_trips_through_serialisation` —
  persistence contract: all three new fields keep their values
  across a dashboard restart.
- `test_older_sidecar_without_source_field_loads_as_local` —
  upgrade-from-pre-7a-2a path: hand-crafted minimal JSON
  without the new keys deserialises with default values
  rather than crashing.
- `test_malformed_source_value_rejected_on_load` — corrupt
  `source: "intergalactic"` raises on construction; doesn't
  silently land in code that branches on
  `is JobSource.REMOTE`.
- `test_reset_preserves_dispatch_origin_fields` — all five
  dispatch-origin fields survive `FirmwareJob.reset()`.

ruff + mypy clean. 9 tests in `tests/models/test_firmware_job.py`.

## What this PR does NOT do

- **No caller integration.** The runner's source-routing
  branch lands in 7a-2b (rename of the previous "event-stream
  bridge" slice; the synthetic framing is gone in the new
  plan) alongside `firmware/install` integration in 7a-3.
  Today nothing reads the new field; landing it standalone
  keeps the model / persistence layer reviewable ahead of
  the runner's larger blast radius.
- **No frontend consumer.** The install dialog's
  "Building on {receiver_label}" sub-line lands when 7a-3
  wires `firmware/install` through the scheduler; the
  frontend `FirmwareJob` mirror gets the new fields then.
  Lockstep deployment means this is one coordinated PR
  rather than two waves of compatibility work.

**Related issue or feature:**

- Implements 7a-2a of issue #106's `§ Transparent install flow`.
  The 7a-2b (runner source-routing), 7a-3 (`firmware/install`
  integration), and 7a-4 (cancel translation) slices layer on
  top of this model change.
- Follow-up arch.md PR drops the synthetic-job / event-stream-
  bridge framing for the first-class shape this PR introduces.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` — follow-up docs PR drops the synthetic-job framing this PR replaces.
