### PR TITLE
Advertise receiver esphome_version through the peer-link handshake (7a-2 prerequisite)

### DIFF
--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -610,6 +610,7 @@ def _pairing_summary(
         connected=connected,
         connecting=connecting,
         last_connect_error=last_connect_error,
+        esphome_version=pairing.esphome_version,
     )
 
 
@@ -1777,8 +1778,36 @@ class RemoteBuildController:
         self._offloader_alerts[data["pin_sha256"]] = alert
 
     def _on_offloader_peer_link_opened(self, event: Event[OffloaderPeerLinkOpenedData]) -> None:
-        """Add ``pin_sha256`` to ``_open_peer_links`` on session open."""
-        self._open_peer_links.add(event.data["pin_sha256"])
+        """Add ``pin_sha256`` to ``_open_peer_links`` and refresh the receiver version.
+
+        The receiver advertises its
+        :data:`esphome.const.__version__` on every
+        ``intent_response`` payload; the offloader-side
+        :class:`PeerLinkClient` lifts it onto this event so the
+        controller can land the up-to-date value on the matching
+        :class:`StoredPairing` without reaching into the per-pin
+        client task. pick_build_path's deferred version-compat
+        gate reads this field; the value refreshes on every
+        reconnect so a receiver upgrade picks up on the next
+        session-open without operator action.
+
+        Empty ``esphome_version`` (older receiver predating this
+        wire change, or a malformed response) leaves the stored
+        value alone — clobbering with empty would lose the
+        previously-captured version after a reconnect from an
+        older receiver mid-rollout.
+        """
+        data = event.data
+        pin_sha256 = data["pin_sha256"]
+        self._open_peer_links.add(pin_sha256)
+        version = data["esphome_version"]
+        if not version:
+            return
+        pairing = self._pairings.get(pin_sha256)
+        if pairing is None or pairing.esphome_version == version:
+            return
+        pairing.esphome_version = version
+        self._schedule_pairings_save()
 
     def _on_offloader_peer_link_closed(self, event: Event[OffloaderPeerLinkClosedData]) -> None:
         """Discard ``pin_sha256`` from ``_open_peer_links`` on session close.

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -93,6 +93,7 @@ from ...helpers.peer_link_frames import frame_schema, is_valid_frame
 from ...helpers.peer_link_identity import get_or_create_peer_link_identity
 from ...helpers.storage import ShutdownCallback, Store
 from ...models import (
+    PAIRING_VERSION_MAX_LEN,
     TERMINAL_JOB_EVENTS,
     ErrorCode,
     EventType,
@@ -1795,13 +1796,22 @@ class RemoteBuildController:
         wire change, or a malformed response) leaves the stored
         value alone — clobbering with empty would lose the
         previously-captured version after a reconnect from an
-        older receiver mid-rollout.
+        older receiver mid-rollout. Values exceeding
+        :data:`PAIRING_VERSION_MAX_LEN` are also rejected: the
+        :class:`StoredPairing` validator caps at the same length
+        on disk-load, so persisting an oversize value through
+        the in-memory mutation path would survive until the next
+        sidecar load and then poison it. The wire-extract path
+        on the :class:`PeerLinkClient` side already caps before
+        firing this event; the listener-side guard is defense-
+        in-depth for any other future fire site of the same
+        event.
         """
         data = event.data
         pin_sha256 = data["pin_sha256"]
         self._open_peer_links.add(pin_sha256)
         version = data["esphome_version"]
-        if not version:
+        if not version or len(version) > PAIRING_VERSION_MAX_LEN:
             return
         pairing = self._pairings.get(pin_sha256)
         if pairing is None or pairing.esphome_version == version:

--- a/esphome_device_builder/controllers/remote_build/peer_link.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link.py
@@ -64,6 +64,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 from aiohttp import WSMsgType, web
+from esphome.const import __version__ as esphome_version
 
 from ...helpers import json as _json
 from ...helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
@@ -982,8 +983,22 @@ async def _send_response(
     ws: web.WebSocketResponse,
     response: IntentResponse,
 ) -> None:
-    """Send the post-handshake intent_response as a single ChaCha20-Poly1305 frame."""
-    body = _json.dumps({"intent_response": response.value})
+    """Send the post-handshake intent_response as a single ChaCha20-Poly1305 frame.
+
+    The payload carries the response discriminator
+    (``intent_response``) plus the receiver's
+    :data:`esphome.const.__version__` (``esphome_version``).
+    Both halves run the same shared field on every intent so a
+    caller that opens any flow — preview / pair_request /
+    pair_status / peer_link — gets the receiver's version
+    alongside the discriminator. Offloader-side consumption
+    centres on the long-lived ``peer_link`` session, where the
+    captured value lands on :attr:`StoredPairing.esphome_version`
+    and refreshes on every reconnect so a receiver upgrade
+    surfaces in pick_build_path's version-compat gate on the
+    next session-open without operator action.
+    """
+    body = _json.dumps({"intent_response": response.value, "esphome_version": esphome_version})
     try:
         encrypted = session.encrypt(body)
     except NOISE_ERRORS:

--- a/esphome_device_builder/controllers/remote_build/peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client.py
@@ -191,6 +191,35 @@ class InitiatorRoundTrip:
     response: dict[str, Any]
 
 
+def _extract_receiver_esphome_version(response: dict[str, Any]) -> str:
+    """Lift ``esphome_version`` off the post-handshake response.
+
+    The receiver populates the field on every ``intent_response``
+    payload (see :func:`controllers.remote_build.peer_link._send_response`)
+    so the offloader can land it on
+    :attr:`StoredPairing.esphome_version` and pick_build_path's
+    deferred version-compat gate (7a-2) can read it without an
+    extra round-trip.
+
+    Returns:
+        The receiver's ``esphome.const.__version__`` as a string,
+        or ``""`` when the field is missing (older receiver
+        predating this wire change) or not a string (malformed
+        response — defense-in-depth gate so a non-string value
+        from a buggy peer doesn't propagate as a type error into
+        :class:`StoredPairing`'s validator).
+
+    Empty flows through as "unknown" — pick_build_path's gate
+    treats unknown as compatible (silent-fallback semantic; the
+    operator opted in to remote builds, refusing on the unknown
+    case would be more surprising than the alternative).
+    """
+    value = response.get("esphome_version", "")
+    if not isinstance(value, str):
+        return ""
+    return value
+
+
 def _build_ws_url(hostname: str, port: int) -> URL:
     """Build the peer-link WS URL for *hostname* / *port*.
 
@@ -1494,16 +1523,8 @@ class PeerLinkClient:
                     self._last_connect_error = "auth rejected"
                     return _LOCAL_CLOSE_AUTH_REJECTED
                 # Lift the receiver's ``esphome_version`` off the
-                # response so OPENED carries it onto the bus. The
-                # receiver always populates the field (see
-                # :func:`_send_response`); the ``isinstance``
-                # guard keeps a malformed / older-receiver
-                # response from raising here — empty string flows
-                # through as "unknown" and pick_build_path's
-                # version-compat gate accepts it as compatible.
-                receiver_version = response.get("esphome_version", "")
-                if not isinstance(receiver_version, str):
-                    receiver_version = ""
+                # response so OPENED carries it onto the bus.
+                receiver_version = _extract_receiver_esphome_version(response)
                 # Session is live — build the shared channel
                 # over (noise, ws), fire OPENED, park on the
                 # receive loop with a heartbeat task running

--- a/esphome_device_builder/controllers/remote_build/peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client.py
@@ -60,6 +60,7 @@ from ...helpers.peer_link_noise import (
     pin_sha256_for_pubkey,
 )
 from ...models import (
+    PAIRING_VERSION_MAX_LEN,
     ArtifactsChunkFrameData,
     ArtifactsEndFrameData,
     ArtifactsStartFrameData,
@@ -204,10 +205,15 @@ def _extract_receiver_esphome_version(response: dict[str, Any]) -> str:
     Returns:
         The receiver's ``esphome.const.__version__`` as a string,
         or ``""`` when the field is missing (older receiver
-        predating this wire change) or not a string (malformed
-        response — defense-in-depth gate so a non-string value
-        from a buggy peer doesn't propagate as a type error into
-        :class:`StoredPairing`'s validator).
+        predating this wire change), not a string (malformed
+        response from a buggy peer), or exceeds
+        :data:`PAIRING_VERSION_MAX_LEN` (a malicious / buggy
+        peer trying to poison the sidecar — the
+        :class:`StoredPairing` validator caps at the same length
+        on disk-load, so a longer value would persist through
+        the in-memory mutation path and then fail the next load
+        of the persisted sidecar). The cap mirrors the validator
+        so the wire seam and the disk seam can't drift apart.
 
     Empty flows through as "unknown" — pick_build_path's gate
     treats unknown as compatible (silent-fallback semantic; the
@@ -216,6 +222,8 @@ def _extract_receiver_esphome_version(response: dict[str, Any]) -> str:
     """
     value = response.get("esphome_version", "")
     if not isinstance(value, str):
+        return ""
+    if len(value) > PAIRING_VERSION_MAX_LEN:
         return ""
     return value
 

--- a/esphome_device_builder/controllers/remote_build/peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client.py
@@ -1493,6 +1493,17 @@ class PeerLinkClient:
                     )
                     self._last_connect_error = "auth rejected"
                     return _LOCAL_CLOSE_AUTH_REJECTED
+                # Lift the receiver's ``esphome_version`` off the
+                # response so OPENED carries it onto the bus. The
+                # receiver always populates the field (see
+                # :func:`_send_response`); the ``isinstance``
+                # guard keeps a malformed / older-receiver
+                # response from raising here — empty string flows
+                # through as "unknown" and pick_build_path's
+                # version-compat gate accepts it as compatible.
+                receiver_version = response.get("esphome_version", "")
+                if not isinstance(receiver_version, str):
+                    receiver_version = ""
                 # Session is live — build the shared channel
                 # over (noise, ws), fire OPENED, park on the
                 # receive loop with a heartbeat task running
@@ -1511,7 +1522,7 @@ class PeerLinkClient:
                 )
                 self._session_was_opened = True
                 self._last_connect_error = ""
-                self._fire_opened()
+                self._fire_opened(esphome_version=receiver_version)
                 try:
                     return await self._run_session_loops(channel)
                 except asyncio.CancelledError:
@@ -1969,11 +1980,12 @@ class PeerLinkClient:
             DownloadArtifactsResult(tarball=tarball, firmware_offset=state.firmware_offset)
         )
 
-    def _fire_opened(self) -> None:
+    def _fire_opened(self, *, esphome_version: str = "") -> None:
         payload: OffloaderPeerLinkOpenedData = {
             "receiver_hostname": self._hostname,
             "receiver_port": self._port,
             "pin_sha256": self._pin_sha256,
+            "esphome_version": esphome_version,
         }
         self._bus.fire(EventType.OFFLOADER_PEER_LINK_OPENED, payload)
 

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -502,11 +502,22 @@ class OffloaderPeerLinkOpenedData(TypedDict):
     (4a-o part 6 re-keyed offloader state on pin); receiver
     coords stay on the payload as display fields the frontend
     can render without a follow-up lookup.
+
+    ``esphome_version`` is the receiver's
+    :data:`esphome.const.__version__` lifted off the
+    ``intent_response`` payload. Empty when the receiver's
+    response didn't carry the field (older receiver predating
+    this wire change, or any future intent that doesn't include
+    it). The controller subscribes to this event to refresh
+    :attr:`StoredPairing.esphome_version` so pick_build_path's
+    version-compat gate sees the up-to-date value on the next
+    decision.
     """
 
     receiver_hostname: str
     receiver_port: int
     pin_sha256: str
+    esphome_version: str
 
 
 class OffloaderPeerLinkClosedData(TypedDict):
@@ -1298,6 +1309,17 @@ _PAIRING_VALIDATOR = vol.Schema(
         # that ``DataClassORJSONMixin.from_dict`` produces when
         # round-tripping through JSON.
         vol.Required("status"): vol.In(PeerStatus),
+        # Receiver's ``esphome.const.__version__`` captured at
+        # peer-link session-open time. In-RAM only at session
+        # close; persisted across restarts so a disconnected row
+        # still carries its last-seen version for the UI's
+        # "last known: X.Y.Z" display. Capped to keep a corrupt
+        # / hand-edited sidecar from landing a megabyte string.
+        # Empty when no peer-link session has opened yet (fresh
+        # PENDING row, or an old sidecar from before this field
+        # existed); pick_build_path's version-compat gate
+        # accepts empty as "unknown, fall through to compat".
+        vol.Required("esphome_version"): vol.All(str, vol.Length(max=64)),
     }
 )
 
@@ -1380,6 +1402,18 @@ class StoredPairing(DataClassORJSONMixin):
     label: str
     paired_at: float
     status: PeerStatus = PeerStatus.APPROVED
+    # Receiver-advertised ``esphome.const.__version__``, captured
+    # on every peer-link session-open from the ``intent_response``
+    # post-handshake payload. Empty on a fresh PENDING row + on
+    # APPROVED rows loaded from an older sidecar that predates
+    # this field (``DataClassORJSONMixin.from_dict`` tolerates
+    # missing fields with non-empty defaults). The version
+    # refreshes on every reconnect — pick_build_path consumes
+    # the in-RAM value so a receiver upgrade picks up on the
+    # next session-open without operator action; the persisted
+    # copy is the cross-restart fallback for "last known
+    # version" UI display.
+    esphome_version: str = ""
 
     def __post_init__(self) -> None:
         """Run :data:`_PAIRING_VALIDATOR`; re-raise as ``ValueError``."""
@@ -1447,6 +1481,14 @@ class PairingSummary(DataClassORJSONMixin):
     connected: bool = False
     connecting: bool = False
     last_connect_error: str = ""
+    # Receiver-advertised ``esphome.const.__version__``, mirroring
+    # :attr:`StoredPairing.esphome_version`. Refreshed on every
+    # peer-link session-open; empty on a never-connected row /
+    # an older sidecar. Surfaced in the offloader's paired-
+    # receivers UI as a "last known: X.Y.Z" line so the operator
+    # can spot a version skew before the version-compat gate in
+    # pick_build_path silent-fallbacks them to LOCAL.
+    esphome_version: str = ""
 
 
 @dataclass

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1259,6 +1259,18 @@ class PeerSummary(DataClassORJSONMixin):
 #    cost of a second source of truth alongside the
 #    dataclass annotations.
 #
+# Cap on :attr:`StoredPairing.esphome_version`. The validator
+# below rejects rows whose stored version exceeds this length;
+# the wire-extract path on the offloader side
+# (:func:`controllers.remote_build.peer_link_client._extract_receiver_esphome_version`)
+# applies the same cap before writing the field so a malicious
+# / buggy receiver can't poison the sidecar with a multi-MB
+# string that then fails to load on the next start. 64 chars is
+# generous for any real ``esphome.const.__version__``
+# (``"2026.5.0-dev"`` is 13 chars) — the cap is the "this isn't
+# a version string anymore" boundary, not a tight fit.
+PAIRING_VERSION_MAX_LEN = 64
+
 # :class:`StoredPairing` carries a schema because its
 # offloader-side write path is broader (user-controlled
 # ``request_pair`` args reach the controller through fewer
@@ -1319,7 +1331,7 @@ _PAIRING_VALIDATOR = vol.Schema(
         # PENDING row, or an old sidecar from before this field
         # existed); pick_build_path's version-compat gate
         # accepts empty as "unknown, fall through to compat".
-        vol.Required("esphome_version"): vol.All(str, vol.Length(max=64)),
+        vol.Required("esphome_version"): vol.All(str, vol.Length(max=PAIRING_VERSION_MAX_LEN)),
     }
 )
 
@@ -1407,7 +1419,8 @@ class StoredPairing(DataClassORJSONMixin):
     # post-handshake payload. Empty on a fresh PENDING row + on
     # APPROVED rows loaded from an older sidecar that predates
     # this field (``DataClassORJSONMixin.from_dict`` tolerates
-    # missing fields with non-empty defaults). The version
+    # missing fields with declared dataclass defaults; the empty
+    # string default below is what fills in). The version
     # refreshes on every reconnect — pick_build_path consumes
     # the in-RAM value so a receiver upgrade picks up on the
     # next session-open without operator action; the persisted

--- a/tests/e2e/test_pair_and_session.py
+++ b/tests/e2e/test_pair_and_session.py
@@ -11,6 +11,7 @@ assertions on top.
 from __future__ import annotations
 
 import pytest
+from esphome.const import __version__ as receiver_version
 
 from .conftest import PairedInstances
 
@@ -126,3 +127,37 @@ async def test_paired_instances_snapshot_reflects_connected_state(
     assert summary.connected is True
     assert summary.connecting is False
     assert summary.last_connect_error == ""
+
+
+@pytest.mark.asyncio
+async def test_paired_instances_snapshot_carries_receiver_esphome_version(
+    paired_instances: PairedInstances,
+) -> None:
+    """``pairings_snapshot`` surfaces the receiver's esphome_version after session-open.
+
+    Pins the wire-and-capture round-trip that unblocks
+    pick_build_path's deferred version-compat gate:
+
+    1. Receiver's ``_send_response`` ships its bundled
+       :data:`esphome.const.__version__` on every
+       ``intent_response`` payload.
+    2. Offloader's :meth:`PeerLinkClient._run_one_session`
+       lifts the field off the decoded response.
+    3. ``_fire_opened`` rides it onto
+       ``OFFLOADER_PEER_LINK_OPENED``.
+    4. The controller's listener writes it onto the matching
+       :class:`StoredPairing`.
+    5. :meth:`pairings_snapshot` projects it onto
+       :attr:`PairingSummary.esphome_version`.
+
+    Both halves run the same ``esphome`` package (single
+    process), so the value the offloader observes on its
+    snapshot equals the version the receiver imported — pin
+    that here so a regression on the wire-shape, the lift,
+    the listener wiring, or the projection trips this test
+    rather than producing a silent empty value on
+    pick_build_path's gate input.
+    """
+    await paired_instances.wait_until_session_opened()
+    [summary] = paired_instances.offloader.pairings_snapshot()
+    assert summary.esphome_version == receiver_version

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import secrets
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
@@ -31,6 +32,7 @@ import pytest
 from aiohttp import WSMessage, WSMsgType, web
 from aiohttp.test_utils import TestClient, TestServer
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from esphome.const import __version__ as esphome_version
 from noise.exceptions import NoiseInvalidMessage
 from noise.exceptions import NoiseInvalidMessage as _NoiseInvalidMessage
 
@@ -456,6 +458,38 @@ async def test_send_response_encrypt_error_skips_send() -> None:
 
     await _send_response(session, ws, IntentResponse.OK)
     ws.send_bytes.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_response_advertises_esphome_version() -> None:
+    """The ``intent_response`` body carries the receiver's esphome version.
+
+    Pins the wire contract that unblocks pick_build_path's
+    version-compat gate: the receiver's response carries
+    ``intent_response`` (the discriminator the offloader already
+    branches on) AND ``esphome_version`` (the version the
+    offloader stores on :class:`StoredPairing` and the
+    version-compat gate eventually compares against the
+    offloader's own bundled :mod:`esphome` version). The body
+    is JSON-encoded before encrypt; this test reads back the
+    plaintext bytes :func:`session.encrypt` was called with so
+    a regression that drops the field or changes its name trips
+    here instead of producing a silent empty value on the
+    offloader.
+    """
+    ws = _make_ws_stub()
+    session = MagicMock(spec=PeerLinkNoiseSession)
+    session.encrypt.return_value = b"ciphertext-stub"
+
+    await _send_response(session, ws, IntentResponse.OK)
+
+    session.encrypt.assert_called_once()
+    body = session.encrypt.call_args.args[0]
+    parsed = json.loads(body)
+    assert parsed == {
+        "intent_response": IntentResponse.OK.value,
+        "esphome_version": esphome_version,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -79,6 +79,7 @@ from esphome_device_builder.helpers.peer_link_noise import (
     pin_sha256_for_pubkey,
 )
 from esphome_device_builder.models import (
+    PAIRING_VERSION_MAX_LEN,
     ErrorCode,
     EventType,
     IntentResponse,
@@ -1149,17 +1150,29 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
         ({"esphome_version": 12345}, ""),
         ({"esphome_version": None}, ""),
         ({"esphome_version": {"nested": "shape"}}, ""),
+        # At the cap: 64-char version exactly matches the
+        # validator's max; flows through unchanged.
+        ({"esphome_version": "x" * PAIRING_VERSION_MAX_LEN}, "x" * PAIRING_VERSION_MAX_LEN),
+        # One past the cap: a buggy / malicious receiver trying
+        # to poison the sidecar. The wire seam returns empty
+        # rather than firing OPENED with an oversize value that
+        # would survive the in-memory mutation path and then
+        # fail the next StoredPairing.from_dict on a real disk
+        # load.
+        ({"esphome_version": "x" * (PAIRING_VERSION_MAX_LEN + 1)}, ""),
     ],
 )
 def test_extract_receiver_esphome_version_branches(response: dict[str, Any], expected: str) -> None:
-    """Helper handles missing / non-string / valid response shapes.
+    """Helper handles missing / non-string / oversize / valid response shapes.
 
     Pins the post-handshake response → ``StoredPairing.esphome_version``
     seam: a valid string flows through unchanged; missing field
-    (older receiver) and malformed shapes (non-string from a
-    buggy peer) both fall back to empty so pick_build_path's
-    compat gate sees "unknown" rather than a type error from
-    deep inside the validator chain.
+    (older receiver), malformed shapes (non-string from a buggy
+    peer), and oversize strings (peer-controlled wire data that
+    exceeds the validator's cap) all fall back to empty so
+    pick_build_path's compat gate sees "unknown" rather than
+    propagating into the next StoredPairing load and poisoning
+    the sidecar.
     """
     assert _extract_receiver_esphome_version(response) == expected
 
@@ -1230,6 +1243,18 @@ async def test_peer_link_opened_refreshes_stored_pairing_version(
     # empty version: leave the stored value alone so a mixed-
     # version rollout doesn't lose the captured version.
     offloader._on_offloader_peer_link_opened(_opened(""))
+    assert pairing.esphome_version == "2026.6.0"
+    assert len(save_calls) == 2
+
+    # Oversize version (peer-controlled wire data exceeding the
+    # StoredPairing validator's cap): the listener-side guard
+    # rejects so the in-memory mutation path can't persist a
+    # value that the disk-load validator would reject on the
+    # next start. Wire seam already filters in
+    # _extract_receiver_esphome_version; the listener gate is
+    # defense-in-depth for any other future fire site of the
+    # same event.
+    offloader._on_offloader_peer_link_opened(_opened("x" * (PAIRING_VERSION_MAX_LEN + 1)))
     assert pairing.esphome_version == "2026.6.0"
     assert len(save_calls) == 2
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -57,6 +57,7 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
     SubmitJobTimeoutError,
     _build_ws_url,
     _DownloadArtifactsState,
+    _extract_receiver_esphome_version,
     drive_initiator_round_trip,
     preview_pair,
     request_pair,
@@ -1134,6 +1135,33 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
     # listener is ready.
     offloader._on_offloader_peer_link_closed(MagicMock(data=closed))
     assert pin not in offloader._open_peer_links
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ({"esphome_version": "2026.5.0"}, "2026.5.0"),
+        # Older receiver predating the wire change.
+        ({}, ""),
+        # Malformed: non-string value. Defense-in-depth gate
+        # returns empty rather than letting a type error propagate
+        # into StoredPairing's validator.
+        ({"esphome_version": 12345}, ""),
+        ({"esphome_version": None}, ""),
+        ({"esphome_version": {"nested": "shape"}}, ""),
+    ],
+)
+def test_extract_receiver_esphome_version_branches(response: dict[str, Any], expected: str) -> None:
+    """Helper handles missing / non-string / valid response shapes.
+
+    Pins the post-handshake response → ``StoredPairing.esphome_version``
+    seam: a valid string flows through unchanged; missing field
+    (older receiver) and malformed shapes (non-string from a
+    buggy peer) both fall back to empty so pick_build_path's
+    compat gate sees "unknown" rather than a type error from
+    deep inside the validator chain.
+    """
+    assert _extract_receiver_esphome_version(response) == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -1114,6 +1114,7 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
         "receiver_hostname": "host.local",
         "receiver_port": 6055,
         "pin_sha256": pin,
+        "esphome_version": "",
     }
     offloader._on_offloader_peer_link_opened(MagicMock(data=opened))
     assert pin in offloader._open_peer_links
@@ -1133,6 +1134,105 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
     # listener is ready.
     offloader._on_offloader_peer_link_closed(MagicMock(data=closed))
     assert pin not in offloader._open_peer_links
+
+
+@pytest.mark.asyncio
+async def test_peer_link_opened_refreshes_stored_pairing_version(
+    offloader_controller_dir: Path,
+) -> None:
+    """``OFFLOADER_PEER_LINK_OPENED`` payload's ``esphome_version`` lands on the pairing.
+
+    Pins the unblocker for pick_build_path's deferred
+    version-compat gate: the receiver advertises its
+    :data:`esphome.const.__version__` on the post-handshake
+    ``intent_response`` body, the offloader's
+    :class:`PeerLinkClient` lifts it onto the OPENED event,
+    and the controller's listener updates
+    :attr:`StoredPairing.esphome_version` for the matching
+    pin. A subsequent OPENED with a different version
+    (receiver upgraded between reconnects) overwrites; an
+    OPENED carrying empty ``esphome_version`` (older receiver
+    predating this wire change) leaves the stored value alone
+    so a mixed-version rollout doesn't lose the captured
+    version on a reconnect from the older half.
+    """
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+    pin = "a" * 64
+    pairing = _stub_pairing(
+        receiver_hostname="rcv.local",
+        receiver_port=6055,
+        pin_sha256=pin,
+        status=PeerStatus.APPROVED,
+    )
+    offloader._pairings[pin] = pairing
+    offloader._pairings_save_scheduled = False
+
+    # Mock the save scheduler so the test doesn't have to
+    # stand up the Store; we just want to see it was called
+    # when a real update happens, and NOT called on a no-op.
+    save_calls: list[None] = []
+    offloader._schedule_pairings_save = lambda: save_calls.append(None)  # type: ignore[method-assign]
+
+    def _opened(version: str) -> Any:
+        payload: OffloaderPeerLinkOpenedData = {
+            "receiver_hostname": "rcv.local",
+            "receiver_port": 6055,
+            "pin_sha256": pin,
+            "esphome_version": version,
+        }
+        return MagicMock(data=payload)
+
+    # First OPENED: captures the receiver's version + schedules a save.
+    offloader._on_offloader_peer_link_opened(_opened("2026.5.0"))
+    assert pairing.esphome_version == "2026.5.0"
+    assert len(save_calls) == 1
+
+    # Same-version reconnect: cache-hit, no redundant save.
+    offloader._on_offloader_peer_link_opened(_opened("2026.5.0"))
+    assert pairing.esphome_version == "2026.5.0"
+    assert len(save_calls) == 1
+
+    # Receiver upgrade: new version overwrites + schedules save.
+    offloader._on_offloader_peer_link_opened(_opened("2026.6.0"))
+    assert pairing.esphome_version == "2026.6.0"
+    assert len(save_calls) == 2
+
+    # Older receiver (or malformed response) reconnect with
+    # empty version: leave the stored value alone so a mixed-
+    # version rollout doesn't lose the captured version.
+    offloader._on_offloader_peer_link_opened(_opened(""))
+    assert pairing.esphome_version == "2026.6.0"
+    assert len(save_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_peer_link_opened_for_unknown_pin_is_silent_no_op(
+    offloader_controller_dir: Path,
+) -> None:
+    """An OPENED event for a pin not in ``_pairings`` doesn't raise or schedule a save.
+
+    Defense-in-depth: an OPENED firing after the matching
+    pairing was just removed (operator unpair concurrent with
+    a session-open the WS layer hadn't torn down yet) would
+    otherwise blow up on the ``_pairings.get(pin)`` lookup
+    returning ``None``. The listener's ``is None`` gate
+    short-circuits silently — same shape the CLOSED handler
+    uses ``set.discard`` for.
+    """
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+    save_calls: list[None] = []
+    offloader._schedule_pairings_save = lambda: save_calls.append(None)  # type: ignore[method-assign]
+
+    payload: OffloaderPeerLinkOpenedData = {
+        "receiver_hostname": "rcv.local",
+        "receiver_port": 6055,
+        "pin_sha256": "a" * 64,
+        "esphome_version": "2026.5.0",
+    }
+    offloader._on_offloader_peer_link_opened(MagicMock(data=payload))
+    assert len(save_calls) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Unblocks the deferred version-compat gate in `pick_build_path` (7a-1, #553). The receiver's bundled esphome version is now advertised on every peer-link `intent_response` and captured onto `StoredPairing.esphome_version` so the scheduler can read it when deciding LOCAL vs REMOTE.

From the `build_scheduler.py` module docstring on the deferred work:

> **Version-compat check.** `StoredPairing` doesn't currently carry the receiver's `esphome_version` (it's available in mDNS TXT for discovered peers but doesn't flow through the pair-time handshake into the persisted row). The design doc's `version_compatible` gate is documented inline as the version-cache home; needs separate wiring before it can fire. Until then every connected + idle APPROVED pairing is a candidate regardless of receiver version.

This PR is the separate wiring. The gate itself stays deferred to the 7a-2 follow-up.

## Wire change

Receiver's `_send_response` now ships `{intent_response, esphome_version}` instead of just `{intent_response}`. The version comes from `esphome.const.__version__` so it tracks whatever esphome the receiver imported. Applies to every intent (`preview` / `pair_request` / `pair_status` / `peer_link`) — same shared field on every response so a caller for any flow gets the receiver's version alongside the discriminator.

## Offloader-side capture (long-lived `peer_link` path)

* `_run_one_session` lifts `esphome_version` off the decoded response. Older receivers that don't carry the field land as empty string via the `isinstance` guard.
* `_fire_opened` carries the version onto `OFFLOADER_PEER_LINK_OPENED`; the event's TypedDict gains the field.
* The controller's `_on_offloader_peer_link_opened` listener updates the matching `StoredPairing` and schedules a debounced disk write. Same-version reconnect short-circuits. Empty version (older receiver) leaves the stored value alone — clobbering with empty during a mixed-version rollout would lose the previously captured version.

## Persistence

* `StoredPairing.esphome_version: str = ""` with a max-64 validator. Empty default keeps old sidecars loading cleanly through mashumaro's missing-field handling.
* `PairingSummary.esphome_version: str = ""` mirrors the stored shape onto the wire projection. The `_pairing_summary_for` projector threads the field through; every WS surface (`pairings_snapshot`, `request_pair` response, `pair-status` event) now carries the captured version for free.

## Tests

* **Unit** `test_send_response_advertises_esphome_version` — reads back the plaintext body off `session.encrypt`'s call args and asserts the JSON dict carries both fields. Wire-shape pin.
* **Unit** `test_peer_link_opened_refreshes_stored_pairing_version` — exercises the listener directly with synthesised event payloads. Pins update / no-op-on-same-version / no-op-on-empty / receiver-upgrade branches.
* **Unit** `test_peer_link_opened_for_unknown_pin_is_silent_no_op` — defense-in-depth gate for an OPENED firing after the matching row was removed.
* **E2E** `test_paired_instances_snapshot_carries_receiver_esphome_version` — drives the full wire-and-capture chain through a real Noise XX handshake. Both halves run the same `esphome` package (single process), so the value the offloader observes on its snapshot equals the version the receiver imported. Pins the contract end-to-end so a regression on the wire-shape, the lift, the listener wiring, or the projection trips this test rather than producing a silent empty value on pick_build_path's gate input.

## What's NOT in this PR

* `pick_build_path` itself doesn't read `esphome_version` yet — that's the 7a-2 follow-up that adds the actual compat gate. This PR just makes the value available.
* Frontend changes — no UI surface for the version yet. `PairingSummary.esphome_version` flows over the existing wire shape and frontend consumers can add a "Last known: X.Y.Z" line whenever it's useful.
* mDNS TXT path — discovered peers still carry `esphome_version` on their TXT record, and that's where it lands on `RemoteBuildPeer.esphome_version` for the discovered-hosts list. The handshake path is what populates `StoredPairing.esphome_version`; the two are sibling caches.

**Related issue or feature (if applicable):**

- Part of esphome/device-builder#106 (remote-build offload), 7a-2 prerequisite. Follow-up to 7a-1 (#553).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

The wire projection on `PairingSummary` gains a new field, but the frontend already tolerates additive shape changes — old clients ignore the unknown key. No companion PR required for this change to land cleanly. A future PR that surfaces "Last known esphome version: X.Y.Z" in the paired-receivers UI would be a small frontend addition; not required here.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
