### PR TITLE
Add receiver-side TTL cleanup sweep for cold remote-build subtrees (6c)

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -17,7 +17,7 @@ import importlib
 import logging
 import os
 import sys
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from operator import attrgetter
@@ -456,6 +456,31 @@ class FirmwareController:
     async def get_job(self, *, job_id: str, **kwargs: Any) -> FirmwareJob | None:
         """Get a specific job with full output."""
         return self._jobs.get(job_id)
+
+    def active_remote_peer_jobs(self) -> Iterator[FirmwareJob]:
+        """Yield every QUEUED / RUNNING job that arrived via the peer-link.
+
+        Synchronous, no-copy generator over :attr:`_jobs` for the
+        peer-link tier's lookups (the 6c cleanup sweep keys off
+        this to skip in-flight subtrees; future schedulers /
+        diagnostics surfaces should call this rather than
+        reaching into ``_jobs`` directly). The single-underscore
+        prefix on ``_jobs`` marks it as private to the firmware
+        controller; this public accessor is the load-bearing
+        seam so a future refactor (lock-wrapped jobs map,
+        QUEUED + RUNNING split into two dicts, indexed view)
+        doesn't silently break callers.
+
+        ``remote_peer`` filters to peer-link-originated jobs
+        only — :class:`FirmwareJob.remote_peer` is empty for
+        locally-submitted jobs (see :mod:`models.firmware`).
+        """
+        for job in self._jobs.values():
+            if job.status not in _ACTIVE_JOB_STATUSES:
+                continue
+            if not job.remote_peer:
+                continue
+            yield job
 
     @api_command("firmware/follow_job")
     async def follow_job(

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -104,7 +104,6 @@ from ...models import (
     EventType,
     IdentityView,
     IntentResponse,
-    JobStatus,
     OffloaderAlertSnapshotEntry,
     OffloaderJobStateChangedData,
     OffloaderPairAlertDismissedData,
@@ -2444,6 +2443,13 @@ class RemoteBuildController:
         sweep, unexpected exception) are logged and the loop
         continues with the next sleep — cleanup is best-effort
         hygiene, a single bad cycle shouldn't lose the loop.
+
+        Sleeps before the first cycle on purpose: receivers
+        deploy with no accumulated subtrees (6c lands ahead of
+        any production user), and the TTL is 24h, so nothing
+        is eligible for reclamation for the first 24+ hours
+        anyway. Firing on startup would just churn an empty
+        directory.
         """
         config_dir = self._db.settings.config_dir
         loop = asyncio.get_running_loop()
@@ -2459,12 +2465,14 @@ class RemoteBuildController:
                 if firmware is None:
                     continue
                 settings = await loop.run_in_executor(None, load_remote_build_settings, config_dir)
+                # ``active_remote_peer_jobs`` is the public seam
+                # on the firmware controller (status-and-remote_peer
+                # filtered); reaching directly into ``_jobs`` here
+                # would couple us to its private shape.
                 in_flight_keys = frozenset(
                     rbp
-                    for job in firmware._jobs.values()
-                    if job.status in (JobStatus.QUEUED, JobStatus.RUNNING)
-                    and job.remote_peer
-                    and (rbp := parse_from_configuration(job.configuration)) is not None
+                    for job in firmware.active_remote_peer_jobs()
+                    if (rbp := parse_from_configuration(job.configuration)) is not None
                 )
                 deleted = await loop.run_in_executor(
                     None,

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -67,6 +67,7 @@ from collections.abc import Callable, Coroutine, Hashable, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass as _dataclass
 from enum import StrEnum
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import uuid4
@@ -91,14 +92,19 @@ from ...helpers.json import dumps as json_dumps
 from ...helpers.json import loads as json_loads
 from ...helpers.peer_link_frames import frame_schema, is_valid_frame
 from ...helpers.peer_link_identity import get_or_create_peer_link_identity
+from ...helpers.remote_build_cleanup import sweep_remote_builds
+from ...helpers.remote_build_layout import parse_from_configuration
 from ...helpers.storage import ShutdownCallback, Store
 from ...models import (
+    MAX_CLEANUP_TTL_SECONDS,
+    MIN_CLEANUP_TTL_SECONDS,
     PAIRING_VERSION_MAX_LEN,
     TERMINAL_JOB_EVENTS,
     ErrorCode,
     EventType,
     IdentityView,
     IntentResponse,
+    JobStatus,
     OffloaderAlertSnapshotEntry,
     OffloaderJobStateChangedData,
     OffloaderPairAlertDismissedData,
@@ -1111,6 +1117,15 @@ _PAIR_STATUS_RECONNECT_BACKOFF_SECONDS = 2.0
 # ``async_delay_save`` cadence on its own ``Store`` callers.
 _PAIRINGS_SAVE_DELAY_SECONDS = 1.0
 
+# 6c cleanup-sweep cadence. The sweep itself is cheap (one
+# stat per subtree + an rmtree for the cold ones); the cadence
+# just determines how long an expired subtree lingers before
+# reclamation. Hourly keeps the worst-case lag bounded without
+# burning CPU on a tight loop; the TTL itself is the
+# operator-tunable knob (default 24h, see
+# :data:`DEFAULT_CLEANUP_TTL_SECONDS`).
+_CLEANUP_SWEEP_INTERVAL_SECONDS = 60 * 60
+
 # Sliding window enforced per-pin between mDNS rebind probes
 # (4a-o part 7). Doubles as the in-flight guard (set when
 # scheduling, cleared only on probe success) and the
@@ -1561,6 +1576,18 @@ class RemoteBuildController:
             # controller-bound: detached in :meth:`stop`.
             self._job_fanout = JobFanout(self)
             self._job_fanout.start()
+            # 6c: periodic TTL sweep over the remote-build
+            # subtree. Lives alongside the other receiver-side
+            # primitives since it reads ``firmware._jobs`` to
+            # skip in-flight subtrees — gating on the same
+            # ``self._db.firmware is not None`` block keeps the
+            # cleanup task scoped to receivers that can
+            # actually compile. ``_track_task`` reaps it through
+            # the existing :meth:`stop` cancel-and-gather.
+            self._track_task(
+                self._run_cleanup_loop(),
+                name=f"{type(self).__name__}._run_cleanup_loop",
+            )
         # Load APPROVED pairings into RAM. ``StoredPairing.status``
         # defaults to ``APPROVED`` so older sidecars without the
         # field round-trip cleanly; freshly-saved files carry the
@@ -2401,6 +2428,50 @@ class RemoteBuildController:
         task.add_done_callback(self._tasks.discard)
         return task
 
+    async def _run_cleanup_loop(self) -> None:
+        """Sweep cold remote-build subtrees on a periodic tick (6c).
+
+        Reads the operator-configured TTL off
+        :attr:`RemoteBuildSettings.cleanup_ttl_seconds`,
+        collects in-flight job keys via the layout helper, and
+        hands the disk walk to the executor every
+        :data:`_CLEANUP_SWEEP_INTERVAL_SECONDS`. Cancel via
+        :meth:`stop` fires :class:`asyncio.CancelledError`
+        through the sleep so the loop settles cleanly (the
+        exception is a :class:`BaseException` subclass, so the
+        per-cycle ``except Exception`` below doesn't swallow
+        it). Per-cycle failures (permission error inside the
+        sweep, unexpected exception) are logged and the loop
+        continues with the next sleep — cleanup is best-effort
+        hygiene, a single bad cycle shouldn't lose the loop.
+        """
+        config_dir = self._db.settings.config_dir
+        loop = asyncio.get_running_loop()
+        while True:
+            await asyncio.sleep(_CLEANUP_SWEEP_INTERVAL_SECONDS)
+            try:
+                settings = await loop.run_in_executor(None, load_remote_build_settings, config_dir)
+                in_flight_keys = frozenset(
+                    rbp
+                    for job in self._db.firmware._jobs.values()
+                    if job.status in (JobStatus.QUEUED, JobStatus.RUNNING)
+                    and job.remote_peer
+                    and (rbp := parse_from_configuration(job.configuration)) is not None
+                )
+                deleted = await loop.run_in_executor(
+                    None,
+                    partial(
+                        sweep_remote_builds,
+                        config_dir,
+                        ttl_seconds=settings.cleanup_ttl_seconds,
+                        in_flight_keys=in_flight_keys,
+                    ),
+                )
+                if deleted:
+                    _LOGGER.info("remote-build cleanup: swept %d cold subtree(s)", deleted)
+            except Exception:
+                _LOGGER.exception("remote-build cleanup sweep failed")
+
     def _schedule_pairings_save(self) -> None:
         """Debounce-write the offloader pairings store.
 
@@ -2713,6 +2784,7 @@ class RemoteBuildController:
         """
         return RemoteBuildSettingsView(
             enabled=settings.enabled,
+            cleanup_ttl_seconds=settings.cleanup_ttl_seconds,
             peers=self._peer_summaries(),
         )
 
@@ -2795,7 +2867,13 @@ class RemoteBuildController:
         return self._to_view(settings)
 
     @api_command("remote_build/set_settings")
-    async def set_settings(self, *, enabled: bool, **kwargs: Any) -> RemoteBuildSettingsView:
+    async def set_settings(
+        self,
+        *,
+        enabled: bool,
+        cleanup_ttl_seconds: int | None = None,
+        **kwargs: Any,
+    ) -> RemoteBuildSettingsView:
         """
         Persist the receiver-side ``enabled`` master switch.
 
@@ -2809,6 +2887,16 @@ class RemoteBuildController:
         the opposite of what the user intended on a security-
         sensitive toggle.
 
+        Optionally accepts ``cleanup_ttl_seconds`` to update the
+        6c TTL sweep's cold-subtree threshold. Validated against
+        :data:`MIN_CLEANUP_TTL_SECONDS` /
+        :data:`MAX_CLEANUP_TTL_SECONDS` so a fat-fingered value
+        can't push the sweep to "delete everything every tick"
+        or "never reclaim disk". Omitting it (or sending
+        ``None``) preserves the current setting; the field is
+        optional on the wire so clients that only flip the
+        master switch don't have to re-supply the TTL.
+
         Live-rebinds the peer-link Noise WS listener after the
         write lands: a flip to ``True`` runs the same bind path
         :meth:`DeviceBuilder._maybe_start_remote_build_site` does
@@ -2821,9 +2909,27 @@ class RemoteBuildController:
         if not isinstance(enabled, bool):
             msg = "remote_build/set_settings: 'enabled' must be a boolean"
             raise CommandError(ErrorCode.INVALID_ARGS, msg)
+        if cleanup_ttl_seconds is not None:
+            # ``not_bool`` check first: Python's bool subclasses
+            # int, so ``isinstance(True, int)`` is true. A wire
+            # value of ``True`` would otherwise pass the int
+            # check and bind to ``cleanup_ttl_seconds=1`` (well
+            # below MIN), surfacing a confusing OUT_OF_RANGE
+            # rather than the "wrong type" the operator hit.
+            if isinstance(cleanup_ttl_seconds, bool) or not isinstance(cleanup_ttl_seconds, int):
+                msg = "remote_build/set_settings: 'cleanup_ttl_seconds' must be an integer"
+                raise CommandError(ErrorCode.INVALID_ARGS, msg)
+            if not MIN_CLEANUP_TTL_SECONDS <= cleanup_ttl_seconds <= MAX_CLEANUP_TTL_SECONDS:
+                msg = (
+                    f"remote_build/set_settings: 'cleanup_ttl_seconds' must be between "
+                    f"{MIN_CLEANUP_TTL_SECONDS} and {MAX_CLEANUP_TTL_SECONDS}"
+                )
+                raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
         def _set(settings: RemoteBuildSettings) -> None:
             settings.enabled = enabled
+            if cleanup_ttl_seconds is not None:
+                settings.cleanup_ttl_seconds = cleanup_ttl_seconds
 
         view = await self._modify_settings(_set)
         await self._db.apply_remote_build_enabled()

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -2450,10 +2450,18 @@ class RemoteBuildController:
         while True:
             await asyncio.sleep(_CLEANUP_SWEEP_INTERVAL_SECONDS)
             try:
+                # The spawn site in ``start`` already gates on
+                # ``self._db.firmware is not None``; re-checking
+                # here narrows the type for mypy and survives a
+                # future controller reshape that decouples spawn
+                # from start.
+                firmware = self._db.firmware
+                if firmware is None:
+                    continue
                 settings = await loop.run_in_executor(None, load_remote_build_settings, config_dir)
                 in_flight_keys = frozenset(
                     rbp
-                    for job in self._db.firmware._jobs.values()
+                    for job in firmware._jobs.values()
                     if job.status in (JobStatus.QUEUED, JobStatus.RUNNING)
                     and job.remote_peer
                     and (rbp := parse_from_configuration(job.configuration)) is not None

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -27,8 +27,9 @@ Flow:
    carries ``is_last=True`` we finalise (validates byte count
    + sha256), write the assembled tarball to
    ``<config>/.esphome/.remote_builds/<dashboard_id>/<device_name>.tar.gz``
-   (sibling of the per-device subtree, not child — see the
-   ``_BUNDLE_SUFFIX`` comment for why),
+   (sibling of the per-device subtree, not child — see
+   :class:`helpers.remote_build_layout.RemoteBuildPath` for the
+   canonical layout),
    extract via :func:`esphome.bundle.prepare_bundle_for_compile`
    (which preserves ``.esphome/`` / ``.pioenvs/`` for incremental
    builds — the load-bearing reason for the stable per-peer
@@ -70,6 +71,7 @@ from ...helpers.peer_link_bundle import (
     decode_chunk,
 )
 from ...helpers.peer_link_frames import frame_schema, is_valid_frame
+from ...helpers.remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
 from ...models import (
     JobType,
     SubmitJobAckFrameData,
@@ -132,30 +134,12 @@ _SUBMIT_JOB_CHUNK_SCHEMA = frame_schema(
     }
 )
 
-# Subdirectory under ``<config_dir>/.esphome/`` where remote-peer
-# bundles land. Hidden by the leading dot so a casual ``ls`` of
-# the user's main config tree doesn't show it next to their own
-# YAMLs; living under ``.esphome/`` keeps it adjacent to other
-# build artefacts (StorageJSON, build dirs) so phase-6's TTL
-# sweep can reuse the same parent walk.
-_REMOTE_BUILDS_SUBDIR = Path(".esphome") / ".remote_builds"
-
-# Bundle filename used as a sibling of the extract target_dir
-# (``<dashboard_id>/<device_name>.tar.gz``, next to the
-# ``<dashboard_id>/<device_name>/`` build subtree). Living
-# outside target_dir is load-bearing: upstream
-# :func:`prepare_bundle_for_compile` preserves only
-# ``.esphome`` / ``.pioenvs`` / ``.pio`` in target_dir and
-# wipes every other entry before extract; a bundle inside
-# target_dir would be deleted between the path-resolved
-# ``is_file`` check and the inner ``extract_bundle`` call,
-# surfacing as "Bundle file not found" at compile time.
-# Derived from *device_name* (not the offloader's raw
-# ``configuration_filename``) because ``_validate_configuration_filename``
-# already canonicalised it; using the canonical form keeps a
-# malicious sender from picking a path-traversal shape that
-# climbs out of the dashboard_id namespace.
-_BUNDLE_SUFFIX = ".tar.gz"
+# Layout for the per-dashboard / per-device subtree + sibling
+# bundle tarball lives in :mod:`helpers.remote_build_layout` so
+# the writer here, the 6c TTL sweep, and the controller's
+# in-flight-key derivation all flow through one source of
+# truth. See that module's :class:`RemoteBuildPath` for the
+# canonical key shape.
 
 # Allowed values of :attr:`SubmitJobFrameData.target`.
 # ``Literal["compile", "upload"]`` on the TypedDict is the
@@ -508,11 +492,18 @@ class SubmitJobReceiver:
         # only for filenames that already passed the gate.
         device_name = _validate_configuration_filename(pending.configuration_filename)
         assert device_name is not None  # narrowed by the upstream reject
-        remote_builds_root = self._config_dir / _REMOTE_BUILDS_SUBDIR
-        target_dir = remote_builds_root / session.dashboard_id / device_name
-        # Sibling of target_dir, not child — see _BUNDLE_SUFFIX
-        # comment for why this matters.
-        bundle_path = target_dir.parent / f"{device_name}{_BUNDLE_SUFFIX}"
+        # Subtree (extract target) + bundle (sibling tarball)
+        # flow through the layout helper so the writer here and
+        # the 6c sweeper read one source of truth for the
+        # on-disk shape. Sibling-not-child is load-bearing:
+        # upstream prepare_bundle_for_compile wipes target_dir
+        # before extract_bundle reads from bundle_path, so a
+        # bundle inside target_dir would be deleted mid-flow
+        # (PR #552).
+        key = RemoteBuildPath(dashboard_id=session.dashboard_id, device_name=device_name)
+        target_dir = key.subtree(self._config_dir)
+        bundle_path = key.bundle(self._config_dir)
+        remote_builds_root = self._config_dir / REMOTE_BUILDS_SUBDIR
 
         loop = asyncio.get_running_loop()
         try:

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -86,7 +86,16 @@ def sweep_remote_builds(
 
     deleted = 0
     for dashboard_dir in _safe_iterdir(root):
-        if not dashboard_dir.is_dir():
+        # Symlinks at any level are skipped outright. ``is_dir()``
+        # follows symlinks by default, so a symlink to a directory
+        # would pass the next check; ``rmtree`` on that symlink
+        # would then refuse (top-level symlink) and emit a warning.
+        # Refusing the symlink up-front keeps the sweep silent on
+        # foreign filesystem shapes and provides defense-in-depth
+        # against an operator (or attacker with write access to
+        # the remote-builds root) placing a symlink that points
+        # outside the canonical subtree.
+        if dashboard_dir.is_symlink() or not dashboard_dir.is_dir():
             _LOGGER.debug(
                 "remote-build cleanup: skipping non-directory under %s: %s",
                 root,
@@ -94,6 +103,9 @@ def sweep_remote_builds(
             )
             continue
         for entry in _safe_iterdir(dashboard_dir):
+            if entry.is_symlink():
+                _LOGGER.debug("remote-build cleanup: skipping symlink %s", entry)
+                continue
             if entry.is_dir():
                 key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=entry.name)
                 if key in in_flight_keys:
@@ -195,8 +207,20 @@ def _reclaim_orphan_bundle(
     submit.
     """
     device_name = bundle.name[: -len(BUNDLE_SUFFIX)]
+    # Empty device_name (a bare ``.tar.gz`` entry — pathological,
+    # shouldn't happen via the writer) lookups the dashboard_dir
+    # itself, which always exists, so this naturally falls
+    # through the "sibling exists" gate below and skips. Just
+    # short-circuit explicitly to avoid the spurious
+    # ``RemoteBuildPath(..., device_name="")`` allocation.
+    if not device_name:
+        return
     sibling_subtree = dashboard_dir / device_name
-    if sibling_subtree.exists():
+    # ``exists`` follows symlinks; ``is_symlink`` catches the
+    # case where the sibling is a symlink (broken or not) — we
+    # don't want to treat a symlink as "subtree present" because
+    # it could resolve outside the canonical layout.
+    if sibling_subtree.exists() or sibling_subtree.is_symlink():
         return
     key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=device_name)
     if key in in_flight_keys:

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -81,7 +81,15 @@ def sweep_remote_builds(
         now = time.time()
     cutoff = now - ttl_seconds
     root = config_dir / REMOTE_BUILDS_SUBDIR
-    if not root.is_dir():
+    # Skip if the root itself is a symlink — ``is_dir()`` would
+    # follow it and the sweep would walk into whatever directory
+    # the symlink targets, potentially deleting subtrees outside
+    # the canonical layout. The canonical writer (submit_job)
+    # creates this root as a real directory; a symlink here is
+    # operator-or-attacker-placed and outside trust scope.
+    # Defense-in-depth matching the symlink skips at the
+    # dashboard_dir and entry levels below.
+    if root.is_symlink() or not root.is_dir():
         return 0
 
     deleted = 0

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -216,10 +216,17 @@ def _reclaim_orphan_bundle(
     if not device_name:
         return
     sibling_subtree = dashboard_dir / device_name
-    # ``exists`` follows symlinks; ``is_symlink`` catches the
-    # case where the sibling is a symlink (broken or not) — we
-    # don't want to treat a symlink as "subtree present" because
-    # it could resolve outside the canonical layout.
+    # Treat anything at the sibling position — real dir, real
+    # file, broken symlink, live symlink to anywhere — as a
+    # signal that this bundle is NOT an orphan we should
+    # reclaim. ``exists`` covers real entries (following live
+    # symlinks); the explicit ``is_symlink`` arm covers broken
+    # symlinks too (``exists`` returns False for those). The
+    # safe stance is "leak the tarball" rather than "make a
+    # delete decision based on a symlink we don't control":
+    # the canonical writer never creates symlinks under the
+    # remote-builds root, so anything at this position is
+    # operator-or-attacker-placed and outside our trust scope.
     if sibling_subtree.exists() or sibling_subtree.is_symlink():
         return
     key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=device_name)

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -1,0 +1,175 @@
+"""
+Receiver-side TTL cleanup sweep for the remote-build subtree.
+
+Phase 6c of issue #106. Disk-side counterpart to the periodic
+loop in :class:`RemoteBuildController`: walks every
+``<dashboard_id>/<device_name>/`` subtree under the remote-builds
+root, deletes the ones whose modification time is older than
+the operator-configured TTL AND aren't tracked by an in-flight
+:class:`FirmwareJob`. The path layout lives in a single source
+of truth in :mod:`helpers.remote_build_layout`; this module is
+just the walk + delete logic.
+
+Why directory mtime tracks "last submitted-to": upstream
+:func:`esphome.bundle.prepare_bundle_for_compile` wipes the
+subtree contents and re-extracts on every submission, so the
+subtree's own ``st_mtime`` bumps each time. Compile output
+writing inside the subtree (PIO build cache under ``.pioenvs/``)
+also bumps the parent's mtime through the same syscall path, so
+a running compile keeps its subtree warm before the next submit
+even lands. The in-flight gate is still load-bearing for the
+QUEUED case (waiting in the receiver's queue before
+``JOB_STARTED`` fires) and for the brief gap between a job
+completing and the next submission.
+
+Empty ``<dashboard_id>/`` parents are pruned after the subtree
+sweep so an offloader that's been removed entirely doesn't
+leave a permanent empty directory behind.
+
+Best-effort: per-subtree exceptions (permission denied, races
+against a concurrent submit) get logged and the walk continues.
+A single bad subtree doesn't kill the sweep for everything else.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import time
+from pathlib import Path
+
+from .remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def sweep_remote_builds(
+    config_dir: Path,
+    *,
+    ttl_seconds: float,
+    in_flight_keys: frozenset[RemoteBuildPath],
+    now: float | None = None,
+) -> int:
+    """Delete cold remote-build subtrees under *config_dir*.
+
+    Synchronous; designed to run inside an executor (the
+    filesystem walk + ``shutil.rmtree`` are blocking syscalls).
+
+    Args:
+        config_dir: The receiver's ``CORE.config_dir`` — the
+            sweep operates on
+            ``config_dir / REMOTE_BUILDS_SUBDIR``.
+        ttl_seconds: Delete every subtree whose ``st_mtime`` is
+            older than ``now - ttl_seconds``. Values <= 0 are
+            treated as "delete everything not in-flight"; the
+            settings layer caps inputs so a zero TTL only
+            reaches here on an operator override.
+        in_flight_keys: :class:`RemoteBuildPath` keys whose
+            subtrees the receiver is currently compiling or has
+            queued; the controller derives this from its
+            firmware queue via
+            :func:`helpers.remote_build_layout.parse_from_configuration`.
+        now: Optional override for "current time"; tests pin a
+            specific value so the mtime comparison is
+            deterministic.
+
+    Returns:
+        Number of subtrees deleted. Useful for the caller's log
+        line so operators can see the cleanup running.
+    """
+    if now is None:
+        now = time.time()
+    cutoff = now - ttl_seconds
+    root = config_dir / REMOTE_BUILDS_SUBDIR
+    if not root.is_dir():
+        return 0
+
+    deleted = 0
+    for dashboard_dir in _safe_iterdir(root):
+        if not dashboard_dir.is_dir():
+            _LOGGER.debug(
+                "remote-build cleanup: skipping non-directory under %s: %s",
+                root,
+                dashboard_dir,
+            )
+            continue
+        for entry in _safe_iterdir(dashboard_dir):
+            if not entry.is_dir():
+                # Bare sibling tarballs are paired with their
+                # subtree below; an orphan tarball (subtree
+                # already deleted but the .tar.gz survived a
+                # previous half-failed sweep) gets reclaimed
+                # when its sibling-named subtree next appears
+                # OR by an offloader re-submitting the same
+                # device_name (which overwrites it).
+                continue
+            key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=entry.name)
+            if key in in_flight_keys:
+                _LOGGER.debug("remote-build cleanup: skipping in-flight %s", key)
+                continue
+            if not _is_cold(entry, cutoff):
+                continue
+            if _delete_subtree_and_sibling(key, config_dir):
+                deleted += 1
+        # An offloader that was paired once and never came back
+        # leaves an otherwise-permanent empty dashboard_id dir;
+        # prune here so the filesystem stays tidy without a
+        # separate housekeeping pass.
+        _prune_empty_dir(dashboard_dir)
+    return deleted
+
+
+def _safe_iterdir(directory: Path) -> list[Path]:
+    """Return entries under *directory*, or empty on error."""
+    try:
+        return list(directory.iterdir())
+    except OSError as exc:
+        _LOGGER.debug("remote-build cleanup: iterdir(%s) failed: %s", directory, exc)
+        return []
+
+
+def _is_cold(subtree: Path, cutoff: float) -> bool:
+    """Return ``True`` when *subtree*'s mtime is older than *cutoff*.
+
+    On stat failure (concurrent rmtree race, broken symlink,
+    permission denied) log + treat as "not cold" so the sweep
+    doesn't try to delete a subtree it can't measure.
+    """
+    try:
+        return subtree.stat().st_mtime < cutoff
+    except OSError as exc:
+        _LOGGER.debug("remote-build cleanup: stat(%s) failed: %s", subtree, exc)
+        return False
+
+
+def _delete_subtree_and_sibling(key: RemoteBuildPath, config_dir: Path) -> bool:
+    """Delete *key*'s subtree + its sibling bundle tarball.
+
+    Returns ``True`` when the subtree was deleted (regardless
+    of whether the sibling tarball delete succeeded — the
+    subtree is the load-bearing reclamation; the tarball is a
+    tiny cache file). Both deletes are guarded against
+    :class:`OSError` so a single bad subtree doesn't poison the
+    rest of the sweep.
+    """
+    subtree = key.subtree(config_dir)
+    bundle = key.bundle(config_dir)
+    try:
+        shutil.rmtree(subtree)
+    except OSError as exc:
+        _LOGGER.warning("remote-build cleanup: rmtree(%s) failed: %s", subtree, exc)
+        return False
+    try:
+        bundle.unlink(missing_ok=True)
+    except OSError as exc:
+        _LOGGER.warning("remote-build cleanup: unlink(%s) failed: %s", bundle, exc)
+    _LOGGER.info("remote-build cleanup: removed cold subtree %s", subtree)
+    return True
+
+
+def _prune_empty_dir(directory: Path) -> None:
+    """Remove *directory* if empty; debug-log + continue otherwise."""
+    try:
+        directory.rmdir()
+    except OSError as exc:
+        _LOGGER.debug("remote-build cleanup: rmdir(%s) skipped: %s", directory, exc)

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -38,7 +38,7 @@ import shutil
 import time
 from pathlib import Path
 
-from .remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
+from .remote_build_layout import BUNDLE_SUFFIX, REMOTE_BUILDS_SUBDIR, RemoteBuildPath
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -94,23 +94,28 @@ def sweep_remote_builds(
             )
             continue
         for entry in _safe_iterdir(dashboard_dir):
-            if not entry.is_dir():
-                # Bare sibling tarballs are paired with their
-                # subtree below; an orphan tarball (subtree
-                # already deleted but the .tar.gz survived a
-                # previous half-failed sweep) gets reclaimed
-                # when its sibling-named subtree next appears
-                # OR by an offloader re-submitting the same
-                # device_name (which overwrites it).
-                continue
-            key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=entry.name)
-            if key in in_flight_keys:
-                _LOGGER.debug("remote-build cleanup: skipping in-flight %s", key)
-                continue
-            if not _is_cold(entry, cutoff):
-                continue
-            if _delete_subtree_and_sibling(key, config_dir):
-                deleted += 1
+            if entry.is_dir():
+                key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=entry.name)
+                if key in in_flight_keys:
+                    _LOGGER.debug("remote-build cleanup: skipping in-flight %s", key)
+                    continue
+                if not _is_cold(entry, cutoff):
+                    continue
+                if _delete_subtree_and_sibling(key, config_dir):
+                    deleted += 1
+            elif entry.is_file() and entry.name.endswith(BUNDLE_SUFFIX):
+                # Orphan bundle path: a ``.tar.gz`` whose sibling
+                # subtree is missing. Happens when the previous
+                # sweep's ``rmtree`` succeeded but the ``unlink``
+                # failed (logged as warning, sweep continued),
+                # when an operator hand-deleted the subtree, or
+                # any other transient failure that left only the
+                # tarball behind. Without this branch the orphan
+                # would accumulate forever — the subtree-path
+                # above never visits it because that branch
+                # requires ``is_dir()``. Pair with the same
+                # in-flight + cold gates the subtree path uses.
+                _reclaim_orphan_bundle(entry, dashboard_dir, in_flight_keys, cutoff)
         # An offloader that was paired once and never came back
         # leaves an otherwise-permanent empty dashboard_id dir;
         # prune here so the filesystem stays tidy without a
@@ -165,6 +170,46 @@ def _delete_subtree_and_sibling(key: RemoteBuildPath, config_dir: Path) -> bool:
         _LOGGER.warning("remote-build cleanup: unlink(%s) failed: %s", bundle, exc)
     _LOGGER.info("remote-build cleanup: removed cold subtree %s", subtree)
     return True
+
+
+def _reclaim_orphan_bundle(
+    bundle: Path,
+    dashboard_dir: Path,
+    in_flight_keys: frozenset[RemoteBuildPath],
+    cutoff: float,
+) -> None:
+    """Unlink *bundle* when its sibling subtree is missing + it's cold + not in-flight.
+
+    The "sibling subtree missing" gate is load-bearing: when
+    both exist the subtree-path branch above already handles
+    the bundle delete via :func:`_delete_subtree_and_sibling`,
+    so firing here would double-unlink. Restricting this branch
+    to true orphans keeps the two paths disjoint.
+
+    The in-flight gate covers the racy edge where a
+    ``submit_job`` mid-flow has written the bundle but hasn't
+    laid down the subtree yet; the sweep shouldn't reclaim the
+    bundle out from under the in-flight extract. The cold gate
+    avoids reclaiming a bundle whose subtree was just deleted
+    out-of-band and is about to be re-extracted on the next
+    submit.
+    """
+    device_name = bundle.name[: -len(BUNDLE_SUFFIX)]
+    sibling_subtree = dashboard_dir / device_name
+    if sibling_subtree.exists():
+        return
+    key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=device_name)
+    if key in in_flight_keys:
+        _LOGGER.debug("remote-build cleanup: skipping in-flight orphan bundle %s", bundle)
+        return
+    if not _is_cold(bundle, cutoff):
+        return
+    try:
+        bundle.unlink()
+    except OSError as exc:
+        _LOGGER.warning("remote-build cleanup: unlink orphan bundle(%s) failed: %s", bundle, exc)
+        return
+    _LOGGER.info("remote-build cleanup: removed orphan bundle %s", bundle)
 
 
 def _prune_empty_dir(directory: Path) -> None:

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -70,6 +70,14 @@ BUNDLE_SUFFIX = ".tar.gz"
 # stores ``.esphome/.remote_builds/...``).
 _REMOTE_BUILDS_PARTS: tuple[str, ...] = tuple(REMOTE_BUILDS_SUBDIR.as_posix().split("/"))
 
+# Number of path segments AFTER ``_REMOTE_BUILDS_PARTS`` that a
+# valid configuration carries: ``dashboard_id`` (1) +
+# ``device_name`` (2) + at least one entry inside the device
+# subtree (3 — the YAML filename the writer extracts). Anything
+# shorter is malformed; the parse returns ``None`` so callers
+# can skip it.
+_TAIL_SEGMENT_COUNT = 3
+
 
 @dataclass(frozen=True)
 class RemoteBuildPath:
@@ -131,12 +139,15 @@ def parse_from_configuration(configuration: str) -> RemoteBuildPath | None:
     """
     parts = PurePosixPath(configuration).parts
     expected = _REMOTE_BUILDS_PARTS
-    # Require root segments + dashboard_id + device_name + at
-    # least one entry under the device subtree (the YAML name).
-    # A 4-segment path (e.g. ``.esphome/.remote_builds/alpha/kitchen.yaml``)
-    # is the writer never producing the device subtree it
-    # should have; treat as malformed.
-    if len(parts) < len(expected) + 3:
+    # Layout: <expected...>/<dashboard_id>/<device_name>/<yaml>.
+    # That's three tail segments after the root prefix:
+    # dashboard_id (1), device_name (2), and at least one
+    # entry inside the device subtree (3 — the YAML filename
+    # the writer extracts). A 4-segment path like
+    # ``.esphome/.remote_builds/alpha/kitchen.yaml`` is the
+    # writer never producing the device subtree it should
+    # have; treat as malformed and return ``None``.
+    if len(parts) < len(expected) + _TAIL_SEGMENT_COUNT:
         return None
     if parts[: len(expected)] != tuple(expected):
         return None

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -1,0 +1,146 @@
+"""
+Single source of truth for the receiver-side remote-build on-disk layout.
+
+Every remote-build subtree the receiver writes lives at
+
+    ``<config_dir>/.esphome/.remote_builds/<dashboard_id>/<device_name>/``
+
+with its bundle tarball as a sibling at
+
+    ``<config_dir>/.esphome/.remote_builds/<dashboard_id>/<device_name>.tar.gz``
+
+Three sites need to know this shape:
+
+* :mod:`controllers.remote_build.submit_job` writes it
+  (constructing ``target_dir`` and ``bundle_path`` per submission).
+* :mod:`helpers.remote_build_cleanup` walks it
+  (iterating ``<dashboard_id>/<device_name>/`` subtrees for the
+  6c TTL sweep).
+* :class:`controllers.remote_build.RemoteBuildController`'s
+  cleanup loop parses :attr:`FirmwareJob.configuration` back
+  into ``(dashboard_id, device_name)`` to skip in-flight
+  subtrees from the sweep.
+
+Without a shared module each site encodes the shape its own
+way — three implicit ``Path`` constructions plus a fragile
+``PurePosixPath(...).parts[...]`` reverse-parse. Drift between
+them silently breaks the sweep (deletes a subtree that's still
+in-flight) or the writer (writes to a path the sweep doesn't
+recognise). Consolidating here means the shape lives in
+exactly one file: change it here once, every consumer follows.
+
+:class:`RemoteBuildPath` is the canonical key. The forward
+methods (:meth:`subtree`, :meth:`bundle`) take a
+``config_dir`` and return absolute paths; the reverse
+factory (:func:`parse_from_configuration`) takes the
+relative POSIX path :attr:`FirmwareJob.configuration` carries
+and rebuilds the key. Anything that doesn't match the layout
+shape (a locally-submitted job, a hand-edited configuration,
+a future call site that bends the path) round-trips through
+``None`` so callers can short-circuit cleanly without an
+``if len(parts) >= ...`` chain at every call site.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+# Subdirectory under ``<config_dir>/.esphome/`` where remote-peer
+# build artefacts land. Hidden by the leading dot so a casual
+# ``ls`` of the user's main config tree doesn't show it next to
+# their own YAMLs; living under ``.esphome/`` keeps it adjacent
+# to other build artefacts (StorageJSON, build dirs).
+REMOTE_BUILDS_SUBDIR = Path(".esphome") / ".remote_builds"
+
+# Suffix the bundle tarball lives at, as a sibling of the
+# extracted build subtree (PR #552 moved the bundle outside the
+# extract target so upstream
+# :func:`esphome.bundle.prepare_bundle_for_compile`'s wipe step
+# doesn't delete it).
+BUNDLE_SUFFIX = ".tar.gz"
+
+
+# POSIX-form path segments of ``REMOTE_BUILDS_SUBDIR``. Computed
+# once at module load so the reverse-parse path doesn't pay a
+# ``Path(...).parts`` rebuild on every :attr:`FirmwareJob.configuration`
+# lookup. Locked to the POSIX shape because
+# :attr:`FirmwareJob.configuration` is serialised as a forward-
+# slash path on every platform (a Windows receiver still
+# stores ``.esphome/.remote_builds/...``).
+_REMOTE_BUILDS_PARTS: tuple[str, ...] = REMOTE_BUILDS_SUBDIR.as_posix().split("/")
+
+
+@dataclass(frozen=True)
+class RemoteBuildPath:
+    """Canonical ``(dashboard_id, device_name)`` key for a remote-build subtree.
+
+    Frozen + hashable so the cleanup sweep can build a
+    :class:`frozenset` of in-flight keys and pass it across
+    the executor boundary without worrying about mutation.
+    """
+
+    dashboard_id: str
+    device_name: str
+
+    def subtree(self, config_dir: Path) -> Path:
+        """Return the absolute build-subtree directory under *config_dir*.
+
+        Used by the writer (:class:`SubmitJobReceiver`) to lay
+        down the extract target and by the sweeper to point
+        :func:`shutil.rmtree` at the right path when reclaiming
+        a cold entry.
+        """
+        return config_dir / REMOTE_BUILDS_SUBDIR / self.dashboard_id / self.device_name
+
+    def bundle(self, config_dir: Path) -> Path:
+        """Return the absolute bundle tarball sibling under *config_dir*.
+
+        The bundle lives one level up from
+        :meth:`subtree` (sibling of the subtree directory, not
+        inside it) so upstream
+        :func:`esphome.bundle.prepare_bundle_for_compile`'s wipe
+        step can't delete it mid-extract; see PR #552.
+        """
+        return (
+            config_dir
+            / REMOTE_BUILDS_SUBDIR
+            / self.dashboard_id
+            / f"{self.device_name}{BUNDLE_SUFFIX}"
+        )
+
+
+def parse_from_configuration(configuration: str) -> RemoteBuildPath | None:
+    """Recover the :class:`RemoteBuildPath` key from *configuration*, or ``None``.
+
+    Reverse of :meth:`RemoteBuildPath.subtree` for the case
+    where the caller has a :attr:`FirmwareJob.configuration`
+    relative-POSIX path and wants to know which subtree it
+    belongs to. Returns ``None`` for any path that doesn't
+    match the canonical layout — typically a locally-submitted
+    job whose configuration sits at the top level of
+    ``<config_dir>`` rather than under the remote-builds root.
+    Callers that read this return value should treat ``None``
+    as "not a remote-build job" and skip whatever scan they're
+    running.
+
+    The layout's path segments are checked positionally
+    against :data:`_REMOTE_BUILDS_PARTS` so a future rename of
+    the subdirectory ripples here automatically without a
+    cross-file find-and-replace.
+    """
+    parts = PurePosixPath(configuration).parts
+    expected = _REMOTE_BUILDS_PARTS
+    # Require root segments + dashboard_id + device_name + at
+    # least one entry under the device subtree (the YAML name).
+    # A 4-segment path (e.g. ``.esphome/.remote_builds/alpha/kitchen.yaml``)
+    # is the writer never producing the device subtree it
+    # should have; treat as malformed.
+    if len(parts) < len(expected) + 3:
+        return None
+    if parts[: len(expected)] != tuple(expected):
+        return None
+    return RemoteBuildPath(
+        dashboard_id=parts[len(expected)],
+        device_name=parts[len(expected) + 1],
+    )

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -68,7 +68,7 @@ BUNDLE_SUFFIX = ".tar.gz"
 # :attr:`FirmwareJob.configuration` is serialised as a forward-
 # slash path on every platform (a Windows receiver still
 # stores ``.esphome/.remote_builds/...``).
-_REMOTE_BUILDS_PARTS: tuple[str, ...] = REMOTE_BUILDS_SUBDIR.as_posix().split("/")
+_REMOTE_BUILDS_PARTS: tuple[str, ...] = tuple(REMOTE_BUILDS_SUBDIR.as_posix().split("/"))
 
 
 @dataclass(frozen=True)

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1504,15 +1504,29 @@ class PairingSummary(DataClassORJSONMixin):
     esphome_version: str = ""
 
 
+# Default + bounds for :attr:`RemoteBuildSettings.cleanup_ttl_seconds`.
+# 24h matches 6c's "subtree is cold if it hasn't been
+# submitted-to for a day" intuition. Bounds: 1h floor keeps the
+# operator from setting "delete everything every sweep tick" by
+# accident; 30d ceiling keeps the cap somewhere finite for the
+# input validator (the disk-walk doesn't care about the upper
+# bound, but a typed cap surfaces silly inputs at the WS layer
+# rather than landing them on disk).
+DEFAULT_CLEANUP_TTL_SECONDS = 24 * 60 * 60
+MIN_CLEANUP_TTL_SECONDS = 60 * 60
+MAX_CLEANUP_TTL_SECONDS = 30 * 24 * 60 * 60
+
+
 @dataclass
 class RemoteBuildSettings(DataClassORJSONMixin):
     """
     Receiver-side settings for the remote-build feature (storage shape).
 
     Stored in ``.device-builder.json`` under the ``_remote_build``
-    top-level key. Carries only the master ``enabled`` toggle
-    today. APPROVED :class:`StoredPeer` rows live in their own
-    per-file :class:`~helpers.storage.Store` at
+    top-level key. Carries the master ``enabled`` toggle and the
+    6c TTL sweep's ``cleanup_ttl_seconds`` knob. APPROVED
+    :class:`StoredPeer` rows live in their own per-file
+    :class:`~helpers.storage.Store` at
     ``<config_dir>/.receiver_peers.json`` (mirrors the offloader-
     side :class:`OffloaderRemoteBuildSettings` shape) so reads
     short-circuit through RAM and don't race a write in flight.
@@ -1522,9 +1536,21 @@ class RemoteBuildSettings(DataClassORJSONMixin):
     started typing hostnames straight into ``request_pair``, and
     the ``tokens`` list (hash-only bearer tokens) went with the
     dormant bearer machinery in phase 4a-r2.
+
+    ``cleanup_ttl_seconds`` is the operator-tunable threshold
+    the 6c background sweep uses to decide a remote-build
+    subtree is cold enough to delete. Defaults to 24h
+    (:data:`DEFAULT_CLEANUP_TTL_SECONDS`); the WS validator
+    caps the input between :data:`MIN_CLEANUP_TTL_SECONDS` and
+    :data:`MAX_CLEANUP_TTL_SECONDS` so a fat-fingered or
+    malicious write can't push the sweep to "delete everything
+    every tick" or "never reclaim disk". Missing on an older
+    sidecar deserialises to the default via the dataclass
+    field default.
     """
 
     enabled: bool = False
+    cleanup_ttl_seconds: int = DEFAULT_CLEANUP_TTL_SECONDS
 
 
 @dataclass
@@ -1545,6 +1571,7 @@ class RemoteBuildSettingsView(DataClassORJSONMixin):
     """
 
     enabled: bool = False
+    cleanup_ttl_seconds: int = DEFAULT_CLEANUP_TTL_SECONDS
     peers: list[PeerSummary] = field(default_factory=list)
 
 

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1552,6 +1552,46 @@ class RemoteBuildSettings(DataClassORJSONMixin):
     enabled: bool = False
     cleanup_ttl_seconds: int = DEFAULT_CLEANUP_TTL_SECONDS
 
+    def __post_init__(self) -> None:
+        """Coerce + clamp ``cleanup_ttl_seconds`` on load.
+
+        The WS validator on :meth:`RemoteBuildController.set_settings`
+        gates writes that come through the WS surface, but the
+        on-disk decode path (``from_dict`` →
+        ``RemoteBuildSettings(...)``) doesn't apply the same
+        ``not_bool`` / range check. A hand-edited or corrupt
+        sidecar with ``cleanup_ttl_seconds: true`` would
+        deserialise as ``1`` (bool is an int subclass), and
+        the sweep would treat anything older than 1s as cold —
+        near-immediate cache deletion. Other wrong types (string,
+        float, None) would propagate to the sweep's ``now -
+        ttl_seconds`` arithmetic and raise ``TypeError``, which
+        the controller's cleanup loop catches but logs every
+        cycle.
+
+        Both failure modes resolve to the safe default: coerce
+        non-int / bool values back to
+        :data:`DEFAULT_CLEANUP_TTL_SECONDS` and clamp the
+        result to [:data:`MIN_CLEANUP_TTL_SECONDS`,
+        :data:`MAX_CLEANUP_TTL_SECONDS`]. The ``enabled``
+        toggle is left alone — a bad cleanup TTL shouldn't
+        flip the master switch.
+
+        Doesn't reject the row (no ``ValueError``) so the
+        load path stays robust against partially-corrupt
+        sidecars; the operator's last good ``enabled`` value
+        survives even if the TTL field is broken.
+        """
+        if isinstance(self.cleanup_ttl_seconds, bool) or not isinstance(
+            self.cleanup_ttl_seconds, int
+        ):
+            self.cleanup_ttl_seconds = DEFAULT_CLEANUP_TTL_SECONDS
+            return
+        if self.cleanup_ttl_seconds < MIN_CLEANUP_TTL_SECONDS:
+            self.cleanup_ttl_seconds = MIN_CLEANUP_TTL_SECONDS
+        elif self.cleanup_ttl_seconds > MAX_CLEANUP_TTL_SECONDS:
+            self.cleanup_ttl_seconds = MAX_CLEANUP_TTL_SECONDS
+
 
 @dataclass
 class RemoteBuildSettingsView(DataClassORJSONMixin):

--- a/tests/controllers/firmware/test_get_jobs.py
+++ b/tests/controllers/firmware/test_get_jobs.py
@@ -233,3 +233,63 @@ async def test_get_job_does_not_mutate_state(
 
     assert await controller.get_jobs() == before
     controller._persist_jobs.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# active_remote_peer_jobs
+# ---------------------------------------------------------------------------
+
+
+def test_active_remote_peer_jobs_yields_only_in_flight_remote_jobs(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Only QUEUED / RUNNING jobs with non-empty ``remote_peer`` are yielded.
+
+    The 6c cleanup sweep keys off this iterator to skip
+    in-flight subtrees; other potential callers (future
+    schedulers, diagnostics surfaces) need the same shape.
+    Pin every filter branch so a future refactor that
+    inverts a condition trips here instead of in production.
+    """
+    local_queued = _job("local-queued", status=JobStatus.QUEUED)
+    remote_queued = FirmwareJob(
+        job_id="remote-queued",
+        configuration=".esphome/.remote_builds/alpha/kitchen/kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.QUEUED,
+        remote_peer="alpha",
+    )
+    remote_running = FirmwareJob(
+        job_id="remote-running",
+        configuration=".esphome/.remote_builds/alpha/bedroom/bedroom.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.RUNNING,
+        remote_peer="alpha",
+    )
+    remote_completed = FirmwareJob(
+        job_id="remote-completed",
+        configuration=".esphome/.remote_builds/alpha/bath/bath.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.COMPLETED,
+        remote_peer="alpha",
+    )
+    controller = firmware_controller_factory(
+        local_queued, remote_queued, remote_running, remote_completed, with_settings=False
+    )
+
+    yielded = list(controller.active_remote_peer_jobs())
+
+    assert {job.job_id for job in yielded} == {"remote-queued", "remote-running"}
+
+
+def test_active_remote_peer_jobs_empty_when_no_remote_jobs(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """All-local jobs → empty iterator; the cleanup sweep gets an empty in-flight set."""
+    controller = firmware_controller_factory(
+        _job("local-1", status=JobStatus.QUEUED),
+        _job("local-2", status=JobStatus.RUNNING),
+        with_settings=False,
+    )
+
+    assert list(controller.active_remote_peer_jobs()) == []

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -57,7 +57,14 @@ from esphome_device_builder.controllers.config import (
     set_device_metadata,
 )
 from esphome_device_builder.helpers.api import CommandError
-from esphome_device_builder.models import ErrorCode, Label, RemoteBuildSettings
+from esphome_device_builder.models import (
+    DEFAULT_CLEANUP_TTL_SECONDS,
+    MAX_CLEANUP_TTL_SECONDS,
+    MIN_CLEANUP_TTL_SECONDS,
+    ErrorCode,
+    Label,
+    RemoteBuildSettings,
+)
 from esphome_device_builder.models.preferences import (
     DashboardView,
     Theme,
@@ -419,6 +426,71 @@ def test_save_remote_build_settings_round_trip(tmp_path: Path) -> None:
     settings = RemoteBuildSettings(enabled=True)
     save_remote_build_settings(tmp_path, settings)
     assert load_remote_build_settings(tmp_path) == settings
+
+
+@pytest.mark.parametrize(
+    "ttl_in",
+    [
+        True,  # bool (int subclass): decodes as 1, would trigger immediate sweep.
+        "86400",  # string: comparison in sweep would raise TypeError.
+        None,
+        86400.5,  # float
+    ],
+)
+def test_remote_build_settings_post_init_coerces_bad_ttl_to_default(
+    ttl_in: object,
+) -> None:
+    """Non-int / bool ``cleanup_ttl_seconds`` falls back to default at construction.
+
+    The WS validator on ``set_settings`` rejects these, but the
+    on-disk decode path (``from_dict`` →
+    ``RemoteBuildSettings(...)``) doesn't apply the same gate.
+    A hand-edited or corrupt sidecar with
+    ``cleanup_ttl_seconds: true`` would deserialise as 1 (bool
+    is an int subclass) and trigger near-immediate cache
+    deletion. ``__post_init__`` coerces back to
+    :data:`DEFAULT_CLEANUP_TTL_SECONDS` so the sweep stays
+    safe regardless of what mashumaro produced.
+
+    Doesn't reject the row (no ``ValueError``) — the load path
+    stays robust against partially-corrupt sidecars; the
+    operator's last-good ``enabled`` value survives even if
+    the TTL field is broken.
+    """
+    settings = RemoteBuildSettings(
+        enabled=True,
+        cleanup_ttl_seconds=ttl_in,  # type: ignore[arg-type]
+    )
+    assert settings.cleanup_ttl_seconds == DEFAULT_CLEANUP_TTL_SECONDS
+    assert settings.enabled is True  # bad TTL doesn't flip the master switch
+
+
+@pytest.mark.parametrize(
+    ("ttl_in", "expected"),
+    [
+        (0, MIN_CLEANUP_TTL_SECONDS),
+        (60, MIN_CLEANUP_TTL_SECONDS),  # below MIN
+        (MAX_CLEANUP_TTL_SECONDS + 1, MAX_CLEANUP_TTL_SECONDS),
+        (-3600, MIN_CLEANUP_TTL_SECONDS),
+    ],
+)
+def test_remote_build_settings_post_init_clamps_out_of_range_ttl(
+    ttl_in: int, expected: int
+) -> None:
+    """An out-of-range int is clamped to the nearest MIN / MAX bound.
+
+    Hand-edited sidecars setting silly values (0, negative,
+    decades in seconds) don't push the sweep into pathological
+    behaviour; they land at the nearest sane bound.
+    """
+    settings = RemoteBuildSettings(cleanup_ttl_seconds=ttl_in)
+    assert settings.cleanup_ttl_seconds == expected
+
+
+def test_remote_build_settings_post_init_preserves_valid_ttl() -> None:
+    """An in-range int passes through unchanged."""
+    settings = RemoteBuildSettings(cleanup_ttl_seconds=7200)
+    assert settings.cleanup_ttl_seconds == 7200
 
 
 def test_remote_build_settings_transaction_falls_back_on_bad_data(

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -230,6 +230,38 @@ def test_sweep_does_not_unlink_bundle_when_subtree_still_exists(tmp_path: Path) 
     assert not key.bundle(tmp_path).exists()
 
 
+def test_sweep_skips_when_root_itself_is_symlink(tmp_path: Path) -> None:
+    """A symlink at the remote-builds root is skipped, not traversed.
+
+    Defense-in-depth: ``root.is_dir()`` follows symlinks; a
+    symlink at ``<config_dir>/.esphome/.remote_builds`` would
+    otherwise pass the check and the sweep would walk into
+    whatever directory the symlink targets, potentially
+    reclaiming subtrees outside the canonical layout. The
+    explicit ``is_symlink`` skip catches this.
+    """
+    now = 1_000_000.0
+    real_root = tmp_path / "elsewhere"
+    real_root.mkdir()
+    # Plant a populated subtree at the symlink TARGET to make
+    # sure the sweep wouldn't accidentally clean it up.
+    (real_root / "alpha").mkdir()
+    (real_root / "alpha" / "kitchen").mkdir()
+    (real_root / "alpha" / "kitchen" / "important.txt").write_text("hands off")
+    age_seconds = 3600
+    target_mtime = now - age_seconds
+    os.utime(real_root / "alpha" / "kitchen", (target_mtime, target_mtime))
+
+    # Make the remote-builds root a symlink pointing at the
+    # populated real_root.
+    (tmp_path / ".esphome").mkdir()
+    (tmp_path / ".esphome" / ".remote_builds").symlink_to(real_root)
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 0
+    assert (real_root / "alpha" / "kitchen" / "important.txt").is_file()
+
+
 def test_sweep_skips_symlink_at_dashboard_level(tmp_path: Path) -> None:
     """A symlink at the ``<dashboard_id>/`` level is left untouched.
 

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -141,6 +141,90 @@ def test_sweep_ignores_stray_files_under_root(tmp_path: Path) -> None:
     assert stray.is_file()
 
 
+def test_sweep_reclaims_cold_orphan_bundle(tmp_path: Path) -> None:
+    """An orphan .tar.gz (subtree missing) gets unlinked when cold + not in-flight.
+
+    Models the post-failure state where a previous sweep's
+    ``rmtree`` succeeded but the bundle ``unlink`` failed (or
+    where an operator hand-deleted the subtree but left the
+    tarball, or any other transient failure that left only the
+    bundle behind). Without this branch the orphan would
+    accumulate forever — the subtree-path of the sweep
+    requires ``is_dir()`` and never visits the bundle.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    bundle = key.bundle(tmp_path)
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    bundle.write_bytes(b"orphan bundle bytes")
+    age_seconds = 3600
+    os.utime(bundle, (now - age_seconds, now - age_seconds))
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert not bundle.exists()
+
+
+def test_sweep_keeps_fresh_orphan_bundle(tmp_path: Path) -> None:
+    """A within-TTL orphan bundle survives the sweep."""
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    bundle = key.bundle(tmp_path)
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    bundle.write_bytes(b"fresh orphan")
+    os.utime(bundle, (now - 60, now - 60))
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert bundle.is_file()
+
+
+def test_sweep_skips_in_flight_orphan_bundle(tmp_path: Path) -> None:
+    """An orphan bundle whose key is in-flight is left alone.
+
+    Covers the racy edge: a ``submit_job`` mid-flow has written
+    the bundle but hasn't laid down the subtree yet; reclaiming
+    the bundle here would yank the input out from under the
+    in-flight extract.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    bundle = key.bundle(tmp_path)
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    bundle.write_bytes(b"in-flight bundle")
+    os.utime(bundle, (now - 3600, now - 3600))
+
+    sweep_remote_builds(
+        tmp_path,
+        ttl_seconds=600,
+        in_flight_keys=frozenset({key}),
+        now=now,
+    )
+    assert bundle.is_file()
+
+
+def test_sweep_does_not_unlink_bundle_when_subtree_still_exists(tmp_path: Path) -> None:
+    """A paired (subtree+bundle) pair flows through the subtree branch only.
+
+    Defends against the orphan branch firing in the
+    paired-cold case: that would double-unlink (subtree-path's
+    ``_delete_subtree_and_sibling`` deletes the bundle, and
+    then the orphan branch would try to unlink an
+    already-deleted file). The sibling-subtree-exists gate
+    inside the orphan path keeps the two branches disjoint.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)
+
+    # Pre-condition: both subtree and bundle present.
+    assert key.subtree(tmp_path).is_dir()
+    assert key.bundle(tmp_path).is_file()
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 1
+    assert not key.subtree(tmp_path).exists()
+    assert not key.bundle(tmp_path).exists()
+
+
 def test_sweep_continues_after_subtree_rmtree_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -1,0 +1,177 @@
+"""
+Tests for the receiver-side TTL cleanup sweep (issue #106 phase 6c).
+
+Drives the helper directly against real on-disk subtrees + bundle
+tarballs constructed under :class:`tmp_path`; the controller's
+periodic loop is a thin executor-hop around this function so the
+disk-side branches all surface here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.remote_build_cleanup import sweep_remote_builds
+from esphome_device_builder.helpers.remote_build_layout import (
+    REMOTE_BUILDS_SUBDIR,
+    RemoteBuildPath,
+)
+
+
+def _populate(config_dir: Path, key: RemoteBuildPath, *, age_seconds: float, now: float) -> None:
+    """Create a subtree + sibling bundle under *config_dir* aged by *age_seconds*.
+
+    Stamps mtime to ``now - age_seconds`` on the subtree so the
+    sweep's ``st_mtime`` check has a deterministic value to
+    compare against ``now - ttl``. Bundle stays at its natural
+    write time; the sweep keys on the subtree, not the bundle.
+    """
+    subtree = key.subtree(config_dir)
+    subtree.mkdir(parents=True, exist_ok=True)
+    (subtree / "kitchen.yaml").write_bytes(b"esphome:\n  name: kitchen\n")
+    key.bundle(config_dir).write_bytes(b"fake bundle bytes")
+    target_mtime = now - age_seconds
+    os.utime(subtree, (target_mtime, target_mtime))
+
+
+def test_sweep_returns_zero_on_missing_remote_builds_root(tmp_path: Path) -> None:
+    """A fresh receiver with no submissions yet → no-op + zero deletes."""
+    assert sweep_remote_builds(tmp_path, ttl_seconds=10, in_flight_keys=frozenset()) == 0
+
+
+def test_sweep_deletes_subtree_and_bundle_when_cold(tmp_path: Path) -> None:
+    """Cold subtree → deleted + sibling bundle gone."""
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 1
+    assert not key.subtree(tmp_path).exists()
+    assert not key.bundle(tmp_path).exists()
+
+
+def test_sweep_keeps_fresh_subtree(tmp_path: Path) -> None:
+    """A subtree within the TTL window stays untouched."""
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=60, now=now)
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 0
+    assert key.subtree(tmp_path).is_dir()
+    assert key.bundle(tmp_path).is_file()
+
+
+def test_sweep_skips_in_flight_even_when_cold(tmp_path: Path) -> None:
+    """A cold subtree still in-flight stays — defense-in-depth gate."""
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)
+
+    deleted = sweep_remote_builds(
+        tmp_path,
+        ttl_seconds=600,
+        in_flight_keys=frozenset({key}),
+        now=now,
+    )
+    assert deleted == 0
+    assert key.subtree(tmp_path).is_dir()
+
+
+def test_sweep_prunes_empty_dashboard_parent(tmp_path: Path) -> None:
+    """After the last device under a dashboard_id is swept, prune the parent."""
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    parent = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    assert not parent.exists()
+
+
+def test_sweep_keeps_dashboard_parent_when_sibling_still_warm(tmp_path: Path) -> None:
+    """A dashboard with one cold + one warm device keeps the parent."""
+    now = 1_000_000.0
+    cold = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    warm = RemoteBuildPath(dashboard_id="alpha", device_name="bedroom")
+    _populate(tmp_path, cold, age_seconds=3600, now=now)
+    _populate(tmp_path, warm, age_seconds=60, now=now)
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 1
+    assert not cold.subtree(tmp_path).exists()
+    assert warm.subtree(tmp_path).is_dir()
+    assert (tmp_path / REMOTE_BUILDS_SUBDIR / "alpha").is_dir()
+
+
+def test_sweep_handles_multiple_dashboards(tmp_path: Path) -> None:
+    """Sweep walks every dashboard_id parent independently."""
+    now = 1_000_000.0
+    alpha_kitchen = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    beta_kitchen = RemoteBuildPath(dashboard_id="beta", device_name="kitchen")
+    _populate(tmp_path, alpha_kitchen, age_seconds=3600, now=now)
+    _populate(tmp_path, beta_kitchen, age_seconds=60, now=now)
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 1
+    assert not alpha_kitchen.subtree(tmp_path).exists()
+    assert beta_kitchen.subtree(tmp_path).is_dir()
+
+
+def test_sweep_ignores_stray_files_under_root(tmp_path: Path) -> None:
+    """A stray non-directory under the remote-builds root is left alone.
+
+    Operator hand-edit, foreign file. The sweep walks
+    directories; bare files at the dashboard-level or under
+    a dashboard are skipped (the iterdir loop's ``is_dir``
+    guard handles them).
+    """
+    now = 1_000_000.0
+    root = tmp_path / REMOTE_BUILDS_SUBDIR
+    root.mkdir(parents=True)
+    stray = root / "readme.txt"
+    stray.write_text("hands off")
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 0
+    assert stray.is_file()
+
+
+def test_sweep_continues_after_subtree_rmtree_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing rmtree on one subtree doesn't abort the rest of the sweep.
+
+    Permission errors / races against a concurrent submit /
+    broken symlinks in the tree all happen in production; the
+    sweep is best-effort hygiene, a single bad subtree
+    shouldn't poison the rest. Monkeypatches ``shutil.rmtree``
+    to fail on the first call and succeed on the second; the
+    second cold subtree should still get reclaimed.
+    """
+    now = 1_000_000.0
+    first = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    second = RemoteBuildPath(dashboard_id="alpha", device_name="bedroom")
+    _populate(tmp_path, first, age_seconds=3600, now=now)
+    _populate(tmp_path, second, age_seconds=3600, now=now)
+
+    real_rmtree = __import__("shutil").rmtree
+    calls: list[Path] = []
+
+    def _flaky(path: str | Path, *args: object, **kwargs: object) -> None:
+        calls.append(Path(path))
+        if len(calls) == 1:
+            raise PermissionError("simulated denied")
+        real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr("esphome_device_builder.helpers.remote_build_cleanup.shutil.rmtree", _flaky)
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    # One success out of two attempts; the failed subtree still
+    # exists, the successful one is gone.
+    assert deleted == 1
+    assert len(calls) == 2

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -11,10 +11,15 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.helpers.remote_build_cleanup import sweep_remote_builds
+from esphome_device_builder.helpers.remote_build_cleanup import (
+    _is_cold,
+    _safe_iterdir,
+    sweep_remote_builds,
+)
 from esphome_device_builder.helpers.remote_build_layout import (
     REMOTE_BUILDS_SUBDIR,
     RemoteBuildPath,
@@ -290,6 +295,91 @@ def test_sweep_leaves_bare_dot_tar_gz_alone(tmp_path: Path) -> None:
 
     sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert weird.is_file()
+
+
+def test_safe_iterdir_returns_empty_on_oserror() -> None:
+    """``_safe_iterdir`` swallows OSError and returns an empty list.
+
+    The sweep's outer + inner loops both pass this helper's
+    return value to ``for ... in ...``; a propagated OSError
+    here would unwind the whole sweep and the controller's
+    cleanup loop would log the per-cycle exception. Pin the
+    log-and-fallthrough contract directly.
+    """
+    fake_dir = MagicMock(spec=Path)
+    fake_dir.iterdir.side_effect = PermissionError("simulated denied")
+    assert _safe_iterdir(fake_dir) == []
+
+
+def test_is_cold_returns_false_on_stat_error() -> None:
+    """``_is_cold`` treats a stat failure as "not cold" — skip rather than guess.
+
+    Pins the defensive arm: a stat that raises (broken symlink
+    resolution mid-walk, race against rmtree, permission flip)
+    returns ``False`` so the sweep doesn't try to delete a
+    subtree it can't measure.
+    """
+    fake_subtree = MagicMock(spec=Path)
+    fake_subtree.stat.side_effect = PermissionError("simulated stat denied")
+    assert _is_cold(fake_subtree, cutoff=0) is False
+
+
+def test_sweep_logs_sibling_unlink_failure_but_still_counts_delete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sibling-bundle unlink raising doesn't unwind the subtree delete.
+
+    Pins the docstring contract: the subtree is the load-bearing
+    reclamation; the bundle is a tiny cache file. A failed
+    bundle unlink logs at warning but the sweep returns the
+    subtree as "deleted" so the operator-facing count reflects
+    actual disk reclaimed.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)
+    real_unlink = Path.unlink
+
+    def _flaky_unlink(self: Path, *args: object, **kwargs: object) -> object:
+        if self == key.bundle(tmp_path):
+            raise PermissionError("simulated denied")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _flaky_unlink)
+
+    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 1
+    assert not key.subtree(tmp_path).exists()
+    # Bundle unlink failed → bundle still on disk; the next
+    # sweep will retry it via the orphan-bundle branch.
+    assert key.bundle(tmp_path).is_file()
+
+
+def test_sweep_logs_orphan_unlink_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An orphan bundle whose unlink raises is logged + the sweep continues.
+
+    Pins ``_reclaim_orphan_bundle``'s defensive arm: a
+    PermissionError on the unlink doesn't unwind the sweep.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    bundle = key.bundle(tmp_path)
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    bundle.write_bytes(b"orphan")
+    os.utime(bundle, (now - 3600, now - 3600))
+
+    real_unlink = Path.unlink
+
+    def _flaky_unlink(self: Path, *args: object, **kwargs: object) -> object:
+        if self == bundle:
+            raise PermissionError("simulated denied")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _flaky_unlink)
+
+    # Should not raise.
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert bundle.is_file()
 
 
 def test_sweep_continues_after_subtree_rmtree_failure(

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -246,10 +246,13 @@ def test_sweep_skips_symlink_at_dashboard_level(tmp_path: Path) -> None:
     link.symlink_to(real_dir)
 
     sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
-    # The symlink itself may or may not be removed by the
-    # ``rmdir`` parent-prune (rmdir refuses non-empty); the
-    # important assertion is that the target's contents are
-    # intact.
+    # The symlink stays in place because the dashboard-level
+    # ``is_symlink()`` skip in ``sweep_remote_builds`` does
+    # ``continue`` before reaching ``_prune_empty_dir``; the
+    # load-bearing assertion is that the target's contents are
+    # intact (the sweep didn't walk through the symlink and
+    # delete anything on the other side).
+    assert link.is_symlink()
     assert (real_dir / "important.txt").is_file()
 
 

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -225,6 +225,70 @@ def test_sweep_does_not_unlink_bundle_when_subtree_still_exists(tmp_path: Path) 
     assert not key.bundle(tmp_path).exists()
 
 
+def test_sweep_skips_symlink_at_dashboard_level(tmp_path: Path) -> None:
+    """A symlink at the ``<dashboard_id>/`` level is left untouched.
+
+    Defense-in-depth: a symlink that resolves to a directory
+    elsewhere on the FS would otherwise pass the ``is_dir()``
+    gate and reach ``rmtree``, which refuses top-level symlinks
+    but emits a warning. The explicit ``is_symlink`` skip
+    catches it earlier so the warning never fires AND a
+    malicious operator-placed symlink pointing outside the
+    canonical layout can't even be considered.
+    """
+    now = 1_000_000.0
+    root = tmp_path / REMOTE_BUILDS_SUBDIR
+    root.mkdir(parents=True)
+    real_dir = tmp_path / "untouchable"
+    real_dir.mkdir()
+    (real_dir / "important.txt").write_text("hands off")
+    link = root / "alpha"
+    link.symlink_to(real_dir)
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    # The symlink itself may or may not be removed by the
+    # ``rmdir`` parent-prune (rmdir refuses non-empty); the
+    # important assertion is that the target's contents are
+    # intact.
+    assert (real_dir / "important.txt").is_file()
+
+
+def test_sweep_skips_symlink_at_subtree_level(tmp_path: Path) -> None:
+    """A symlink under ``<dashboard_id>/`` is skipped, not deleted-through."""
+    now = 1_000_000.0
+    dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    dashboard_dir.mkdir(parents=True)
+    real_dir = tmp_path / "untouchable"
+    real_dir.mkdir()
+    (real_dir / "important.txt").write_text("hands off")
+    link = dashboard_dir / "kitchen"
+    link.symlink_to(real_dir)
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert (real_dir / "important.txt").is_file()
+
+
+def test_sweep_leaves_bare_dot_tar_gz_alone(tmp_path: Path) -> None:
+    """A pathological bare ``.tar.gz`` entry doesn't trip the orphan branch.
+
+    ``device_name = bundle.name[: -len(BUNDLE_SUFFIX)]`` would
+    be empty for a file literally named ``.tar.gz``; the
+    explicit empty-name short-circuit in
+    ``_reclaim_orphan_bundle`` avoids spurious work and the
+    dashboard_dir-as-sibling false positive that would otherwise
+    follow.
+    """
+    now = 1_000_000.0
+    dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    dashboard_dir.mkdir(parents=True)
+    weird = dashboard_dir / ".tar.gz"
+    weird.write_bytes(b"weirdo")
+    os.utime(weird, (now - 3600, now - 3600))
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert weird.is_file()
+
+
 def test_sweep_continues_after_subtree_rmtree_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 import secrets as _secrets
 from pathlib import Path
 from typing import Any
@@ -44,11 +45,13 @@ from esphome_device_builder.controllers.remote_build.controller import (
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.dashboard_advertise import SERVICE_TYPE
 from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.helpers.remote_build_layout import RemoteBuildPath
 from esphome_device_builder.models import (
     ErrorCode,
     EventType,
     IdentityView,
     IntentResponse,
+    JobStatus,
     OffloaderRemoteBuildSettings,
     PairingSummary,
     PeerStatus,
@@ -1222,6 +1225,62 @@ async def test_set_settings_rejects_non_bool(tmp_path: Path) -> None:
     # No write happened — disk still at default.
     settings = await controller.get_settings()
     assert settings.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_set_settings_round_trips_cleanup_ttl(tmp_path: Path) -> None:
+    """``cleanup_ttl_seconds`` persists alongside ``enabled``."""
+    controller = _make_controller(config_dir=tmp_path)
+    written = await controller.set_settings(enabled=True, cleanup_ttl_seconds=7200)
+    assert written.cleanup_ttl_seconds == 7200
+    read = await controller.get_settings()
+    assert read.cleanup_ttl_seconds == 7200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        True,  # bool is an int subclass but not what the operator meant
+        "86400",  # string
+        86400.0,  # float
+    ],
+)
+async def test_set_settings_rejects_non_int_cleanup_ttl(tmp_path: Path, bad_value: object) -> None:
+    """Non-integer ``cleanup_ttl_seconds`` raises ``INVALID_ARGS``.
+
+    The ``not_bool``-style isinstance gate prevents ``True``
+    slipping through as ``int`` (Python's ``isinstance(True,
+    int)`` is True) and surfacing a confusing OUT_OF_RANGE
+    rather than the "wrong type" the operator hit.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.set_settings(
+            enabled=True,
+            cleanup_ttl_seconds=bad_value,  # type: ignore[arg-type]
+        )
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "out_of_range",
+    [
+        0,
+        60,  # below MIN_CLEANUP_TTL_SECONDS (1h)
+        30 * 24 * 60 * 60 + 1,  # one past MAX_CLEANUP_TTL_SECONDS (30d)
+        -1,
+    ],
+)
+async def test_set_settings_rejects_out_of_range_cleanup_ttl(
+    tmp_path: Path, out_of_range: int
+) -> None:
+    """Out-of-range ``cleanup_ttl_seconds`` raises ``INVALID_ARGS``."""
+    controller = _make_controller(config_dir=tmp_path)
+    with pytest.raises(CommandError) as exc:
+        await controller.set_settings(enabled=True, cleanup_ttl_seconds=out_of_range)
+    assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
 # ---------------------------------------------------------------------------
@@ -3518,3 +3577,169 @@ def test_get_artifacts_download_sender_returns_installed_sender(tmp_path: Path) 
     controller._artifacts_download_sender = installed
 
     assert controller.get_artifacts_download_sender() is installed
+
+
+@pytest.mark.asyncio
+async def test_run_cleanup_loop_reclaims_cold_subtree_and_skips_in_flight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One cycle of ``_run_cleanup_loop`` deletes a cold subtree + leaves in-flight.
+
+    Pins the controller-side body of the cleanup loop end-to-end:
+    settings load → in-flight key derivation off ``firmware._jobs``
+    → executor hand-off to :func:`sweep_remote_builds` → log on
+    non-zero deletes. Drives a single iteration by patching
+    ``asyncio.sleep`` to raise :class:`asyncio.CancelledError`
+    on the second call (after the sweep cycle completes), which
+    propagates out of the loop and back to the test body.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    # Wire a real firmware mock with two jobs: one in-flight,
+    # one terminal. The cleanup loop should keep the in-flight
+    # one's subtree.
+    in_flight_job = MagicMock()
+    in_flight_job.status = JobStatus.RUNNING
+    in_flight_job.remote_peer = "alpha"
+    in_flight_job.configuration = ".esphome/.remote_builds/alpha/in_flight/kitchen.yaml"
+    terminal_job = MagicMock()
+    terminal_job.status = JobStatus.COMPLETED
+    terminal_job.remote_peer = "alpha"
+    terminal_job.configuration = ".esphome/.remote_builds/alpha/terminal/kitchen.yaml"
+    firmware = MagicMock()
+    firmware._jobs = {"a": in_flight_job, "b": terminal_job}
+    controller._db.firmware = firmware
+
+    # Lay down two subtrees, both past TTL. Only the
+    # non-in-flight one should be reclaimed.
+    now = 1_000_000.0
+    in_flight = RemoteBuildPath(dashboard_id="alpha", device_name="in_flight")
+    cold = RemoteBuildPath(dashboard_id="alpha", device_name="cold")
+    for key in (in_flight, cold):
+        sub = key.subtree(tmp_path)
+        sub.mkdir(parents=True)
+        (sub / "kitchen.yaml").write_bytes(b"esphome:\n  name: kitchen\n")
+        os.utime(sub, (now - 86401, now - 86401))
+
+    # Drive one iteration: first sleep returns; second raises
+    # to unwind the loop.
+    sleep_calls = 0
+
+    async def _short_sleep(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            raise asyncio.CancelledError
+        # First call: fall through immediately so the cycle
+        # body runs without waiting an hour.
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.controller.asyncio.sleep",
+        _short_sleep,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await controller._run_cleanup_loop()
+
+    # In-flight subtree survives the cycle; the cold one's gone.
+    assert in_flight.subtree(tmp_path).is_dir()
+    assert not cold.subtree(tmp_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_run_cleanup_loop_logs_per_cycle_exception_and_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-cycle exception is caught + logged; the loop survives to the next sleep.
+
+    Pins the ``except Exception`` arm in the cleanup loop:
+    cleanup is best-effort hygiene, a single bad cycle (sweep
+    raising unexpectedly, settings load failing) shouldn't kill
+    the loop and leave the receiver accumulating cold subtrees
+    forever. Drives the loop through two cycles: the first
+    raises mid-sweep, the second proceeds normally.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.firmware = MagicMock()
+    controller._db.firmware._jobs = {}
+
+    sweep_calls = 0
+
+    def _flaky_sweep(*_args: object, **_kwargs: object) -> int:
+        nonlocal sweep_calls
+        sweep_calls += 1
+        if sweep_calls == 1:
+            raise RuntimeError("simulated cycle failure")
+        return 0
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.controller.sweep_remote_builds",
+        _flaky_sweep,
+    )
+
+    sleep_calls = 0
+
+    async def _short_sleep(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 3:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.controller.asyncio.sleep",
+        _short_sleep,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await controller._run_cleanup_loop()
+
+    # Two cycles ran (despite the first raising) — proves the
+    # loop body recovers from per-cycle exceptions.
+    assert sweep_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_run_cleanup_loop_short_circuits_when_firmware_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A nil ``_db.firmware`` short-circuits the cycle without raising.
+
+    The spawn site already gates on
+    ``self._db.firmware is not None``, but the re-check in the
+    loop body narrows the type for mypy AND survives a future
+    controller reshape that decouples spawn from start. Test
+    the re-check arm directly with firmware set to None on
+    an already-spawned loop.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.firmware = None
+
+    sweep_calls = 0
+
+    def _record_sweep(*_args: object, **_kwargs: object) -> int:
+        nonlocal sweep_calls
+        sweep_calls += 1
+        return 0
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.controller.sweep_remote_builds",
+        _record_sweep,
+    )
+
+    sleep_calls = 0
+
+    async def _short_sleep(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.controller.asyncio.sleep",
+        _short_sleep,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await controller._run_cleanup_loop()
+
+    # Sweep never ran because the firmware-None gate kicked in.
+    assert sweep_calls == 0

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -51,7 +51,6 @@ from esphome_device_builder.models import (
     EventType,
     IdentityView,
     IntentResponse,
-    JobStatus,
     OffloaderRemoteBuildSettings,
     PairingSummary,
     PeerStatus,
@@ -3586,27 +3585,25 @@ async def test_run_cleanup_loop_reclaims_cold_subtree_and_skips_in_flight(
     """One cycle of ``_run_cleanup_loop`` deletes a cold subtree + leaves in-flight.
 
     Pins the controller-side body of the cleanup loop end-to-end:
-    settings load → in-flight key derivation off ``firmware._jobs``
-    → executor hand-off to :func:`sweep_remote_builds` → log on
-    non-zero deletes. Drives a single iteration by patching
+    settings load → in-flight key derivation via
+    :meth:`FirmwareController.active_remote_peer_jobs` → executor
+    hand-off to :func:`sweep_remote_builds` → log on non-zero
+    deletes. Drives a single iteration by patching
     ``asyncio.sleep`` to raise :class:`asyncio.CancelledError`
     on the second call (after the sweep cycle completes), which
     propagates out of the loop and back to the test body.
     """
     controller = _make_controller(config_dir=tmp_path)
-    # Wire a real firmware mock with two jobs: one in-flight,
-    # one terminal. The cleanup loop should keep the in-flight
-    # one's subtree.
+    # Wire the firmware mock to return one in-flight remote-peer
+    # job through the public ``active_remote_peer_jobs`` seam.
+    # The cleanup loop derives in-flight keys from that
+    # generator; a terminal / non-remote job that the firmware
+    # controller wouldn't yield from this method is implicitly
+    # tested by absence from the iterator.
     in_flight_job = MagicMock()
-    in_flight_job.status = JobStatus.RUNNING
-    in_flight_job.remote_peer = "alpha"
     in_flight_job.configuration = ".esphome/.remote_builds/alpha/in_flight/kitchen.yaml"
-    terminal_job = MagicMock()
-    terminal_job.status = JobStatus.COMPLETED
-    terminal_job.remote_peer = "alpha"
-    terminal_job.configuration = ".esphome/.remote_builds/alpha/terminal/kitchen.yaml"
     firmware = MagicMock()
-    firmware._jobs = {"a": in_flight_job, "b": terminal_job}
+    firmware.active_remote_peer_jobs = MagicMock(return_value=iter([in_flight_job]))
     controller._db.firmware = firmware
 
     # Lay down two subtrees, both past TTL. Only the
@@ -3659,8 +3656,9 @@ async def test_run_cleanup_loop_logs_per_cycle_exception_and_continues(
     raises mid-sweep, the second proceeds normally.
     """
     controller = _make_controller(config_dir=tmp_path)
-    controller._db.firmware = MagicMock()
-    controller._db.firmware._jobs = {}
+    firmware = MagicMock()
+    firmware.active_remote_peer_jobs = MagicMock(return_value=iter([]))
+    controller._db.firmware = firmware
 
     sweep_calls = 0
 

--- a/tests/test_remote_build_layout.py
+++ b/tests/test_remote_build_layout.py
@@ -1,0 +1,125 @@
+"""Tests for the layout helper that locks the on-disk shape.
+
+:mod:`helpers.remote_build_layout` is the single source of truth
+for the receiver-side remote-build path layout. Round-trip
+coverage: every test that exercises a forward construction also
+exercises the reverse parse on the same key, so a regression in
+either direction trips here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.remote_build_layout import (
+    BUNDLE_SUFFIX,
+    REMOTE_BUILDS_SUBDIR,
+    RemoteBuildPath,
+    parse_from_configuration,
+)
+
+
+def test_subtree_builds_dashboard_device_path(tmp_path: Path) -> None:
+    """Subtree path is ``<config>/.esphome/.remote_builds/<dashboard>/<device>/``."""
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    assert key.subtree(tmp_path) == (tmp_path / ".esphome" / ".remote_builds" / "alpha" / "kitchen")
+
+
+def test_bundle_sits_as_sibling_of_subtree(tmp_path: Path) -> None:
+    """Bundle is ``<config>/.esphome/.remote_builds/<dashboard>/<device>.tar.gz``.
+
+    Sibling-not-child is load-bearing: upstream
+    :func:`prepare_bundle_for_compile` wipes target_dir before
+    extract_bundle reads from bundle_path, so a bundle inside
+    target_dir would be deleted mid-flow (PR #552 fix).
+    """
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    bundle = key.bundle(tmp_path)
+    assert bundle == (tmp_path / ".esphome" / ".remote_builds" / "alpha" / "kitchen.tar.gz")
+    assert bundle.parent == key.subtree(tmp_path).parent
+    # Use ``str.endswith`` rather than ``.suffix`` so the
+    # ``.tar.gz`` compound extension matches; ``.suffix`` only
+    # returns the trailing segment (``.gz``).
+    assert bundle.name.endswith(BUNDLE_SUFFIX)
+
+
+def test_remote_builds_subdir_is_dot_prefixed() -> None:
+    """Pin the on-disk root location.
+
+    Hidden under ``.esphome/.remote_builds`` so a casual ``ls``
+    of the user's config doesn't show it. Pinning the literal
+    value here means a future rename ripples through every
+    consumer instead of silently breaking the parse helper.
+    """
+    assert Path(".esphome") / ".remote_builds" == REMOTE_BUILDS_SUBDIR
+
+
+def test_parse_recovers_key_from_canonical_configuration_path() -> None:
+    """A canonical configuration path round-trips through the layout helper.
+
+    :attr:`FirmwareJob.configuration` carries the relative POSIX
+    path the writer emits; the reverse-parse recovers the
+    ``(dashboard_id, device_name)`` key for the cleanup sweep's
+    in-flight gate without each call site re-implementing the
+    `parts[...]` chain.
+    """
+    parsed = parse_from_configuration(".esphome/.remote_builds/alpha/kitchen/kitchen.yaml")
+    assert parsed == RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+
+
+def test_parse_handles_deep_nested_yaml_under_subtree() -> None:
+    """A configuration deeper than the canonical 5 segments still parses.
+
+    The bundle layout only constrains the first four segments
+    (``.esphome / .remote_builds / <dashboard_id> / <device_name>``);
+    the YAML name inside the subtree is free-form. A nested
+    YAML (theoretical, not the writer's current shape but
+    allowed by the contract) should still resolve.
+    """
+    parsed = parse_from_configuration(".esphome/.remote_builds/alpha/kitchen/subdir/kitchen.yaml")
+    assert parsed == RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+
+
+@pytest.mark.parametrize(
+    "configuration",
+    [
+        # Locally-submitted job at the config-dir root.
+        "kitchen.yaml",
+        # Under a non-remote-builds subdirectory.
+        "subdir/kitchen.yaml",
+        # Missing the ``.remote_builds`` segment.
+        ".esphome/build/alpha/kitchen/kitchen.yaml",
+        # Only the dashboard_id segment, no device_name.
+        ".esphome/.remote_builds/alpha/kitchen.yaml",
+        # Exactly four segments — no YAML name after device_name.
+        ".esphome/.remote_builds/alpha/kitchen",
+        # Empty string.
+        "",
+    ],
+)
+def test_parse_returns_none_on_non_remote_build_paths(configuration: str) -> None:
+    """Configurations that don't match the layout return ``None``.
+
+    Callers that read this value treat ``None`` as "not a
+    remote-build job" and skip whatever scan they're running.
+    Locally-submitted jobs are the common case; the rest are
+    defense-in-depth against hand-edited or malformed paths.
+    """
+    assert parse_from_configuration(configuration) is None
+
+
+def test_remote_build_path_is_hashable() -> None:
+    """``RemoteBuildPath`` lives in a :class:`frozenset` for the in-flight gate.
+
+    The 6c sweep passes a frozenset of in-flight keys across
+    the executor boundary; the dataclass is ``frozen=True`` so
+    hashing + immutability hold without manual ``__hash__`` /
+    ``__eq__`` impls.
+    """
+    a = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    b = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    keys = frozenset({a, b})
+    assert keys == frozenset({a})
+    assert hash(a) == hash(b)


### PR DESCRIPTION
# What does this implement/fix?

Phase 6c of issue #106. Receiver-side TTL cleanup sweep for cold remote-build subtrees.

Background sweep over every `<config>/.esphome/.remote_builds/<dashboard_id>/<device_name>/` subtree the receiver writes; deletes subtrees whose mtime exceeds the operator-configured TTL (default 24h, bounded 1h-30d via the WS validator) AND aren't currently queued or running on the firmware controller. Without this, per-peer per-device subtrees accumulate forever for offloaders that pair once and never come back — the `.pioenvs` / `.esphome` / `.pio` caches inside each subtree are tens of MiB per device, so even a small fleet chews through receiver disk over months.

## Scope: only remote-build subtrees, NOT local build dirs

**This sweep only reclaims `<config>/.esphome/.remote_builds/<dashboard_id>/<device_name>/` subtrees** — the per-peer-per-device caches the receiver writes when another dashboard submits a remote-build job. **Local build dirs at `<config>/.esphome/build/<device_name>/` are intentionally NOT touched.** No `FirmwareJob` queue entries are deleted either; on-disk artefacts only.

The asymmetry is by design:

- **Remote-build subtrees** are a transient build cache. The submitting offloader has its own canonical `.esphome/build/<device>/` tree on its filesystem; the receiver's cache exists only to keep PlatformIO's incremental-compile cache warm between submissions from that offloader. If the offloader stops sending (unpaired, retired, simply doesn't rebuild that device anymore), the receiver's cache is wasted disk.
- **Local build subtrees** belong to the user's own devices. They might rebuild on a quiet schedule (weekly, monthly), and the local `.esphome/build/<device>/` tree IS where PIO's incremental cache lives for the primary devices the operator manages. Sweeping that aggressively would force cold rebuilds (multi-minute → hours per device) — a regression, not hygiene.

A future "stop holding state for devices I no longer build locally" surface (closer to the existing `devices/delete` flow than to a TTL sweep) would be a separate concern.

## Single source of truth for the on-disk shape

`helpers/remote_build_layout.py` (new) is the only place that encodes the receiver-side path layout. Forward construction (`RemoteBuildPath.subtree(config_dir)` / `RemoteBuildPath.bundle(config_dir)`) and reverse parse (`parse_from_configuration(job.configuration) -> RemoteBuildPath | None`) both flow through one dataclass. `submit_job.py`, the cleanup sweeper, and the controller's cleanup loop all import from there.

Before this PR the layout was implicit at three sites:
- `submit_job.py` built paths via `Path` operators
- the prospective sweeper walked `iterdir` over the same shape
- the controller's in-flight-key derivation indexed `PurePosixPath(...).parts[...]` to recover `(dashboard_id, device_name)` from `FirmwareJob.configuration`

Drift between them would have silently broken the sweep (deleting a subtree that's still in-flight) or the writer (writing to a path the sweep doesn't recognise). Consolidating means the shape lives in exactly one file: change it here once, every consumer follows.

## Pieces

- **`helpers/remote_build_layout.py`** — `REMOTE_BUILDS_SUBDIR` / `BUNDLE_SUFFIX` constants + `RemoteBuildPath` frozen dataclass (hashable for the sweep's `frozenset` of in-flight keys) + `parse_from_configuration` reverse-factory.
- **`helpers/remote_build_cleanup.py`** — `sweep_remote_builds` synchronous sweep designed to run inside an executor. Walks subtrees, `rmtree`s the cold ones + their sibling `.tar.gz` bundles, prunes empty `<dashboard_id>/` parents, best-effort against per-subtree exceptions (permission denied / race against a concurrent submit / broken symlinks).
- **`models/remote_build.py`** — `cleanup_ttl_seconds: int` field on `RemoteBuildSettings` (and matching view) with `DEFAULT_CLEANUP_TTL_SECONDS=86400`, `MIN_CLEANUP_TTL_SECONDS=3600`, `MAX_CLEANUP_TTL_SECONDS=2592000` cap constants the WS validator references.
- **`controllers/remote_build/controller.py`** — `set_settings` gains an optional `cleanup_ttl_seconds` kwarg (validated against MIN/MAX with `not_bool` to prevent `True` slipping through as int); `_run_cleanup_loop` async task spawns through the existing `_track_task` helper on `start()` so the `_tasks` cancel-and-gather in `stop()` reaps it on shutdown.
- **`controllers/remote_build/submit_job.py`** — now uses `RemoteBuildPath.subtree` / `.bundle` for the writer paths instead of inline Path operators.

## Why directory mtime tracks "last submitted-to"

Upstream `esphome.bundle.prepare_bundle_for_compile` wipes the subtree contents and re-extracts on every submission, so the subtree's own `st_mtime` bumps each time. Compile output writing under the subtree (PIO build cache in `.pioenvs/`) also bumps the parent's mtime through the same syscall path, so a running compile keeps its subtree warm before the next submit even lands. The in-flight gate is still load-bearing for the QUEUED case (waiting in the queue before `JOB_STARTED` fires) and for the brief gap between a job completing and the next submission.

## Tests

- `test_remote_build_layout.py` — `RemoteBuildPath` construction, sibling-not-child bundle invariant, round-trip with `parse_from_configuration`, and the parse's `None`-on-malformed branches (locally-submitted job, non-remote-builds subdir, missing segment, 4-segment-too-short, empty string).
- `test_remote_build_cleanup.py` — sweep's full decision tree: empty root no-op, cold delete, fresh keep, in-flight skip, empty-parent prune, multi-dashboard walk, stray-file ignore, `rmtree`-failure isolation.

2890 tests pass.

## What's not in this PR

- Frontend exposure of the TTL knob — `cleanup_ttl_seconds` rides on `RemoteBuildSettingsView` for consumption when the receiver-side Settings UI grows the input. The wire shape is additive (existing clients ignore the unknown key).

**Related issue or feature (if applicable):**

- esphome/device-builder#106 phase 6c.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

`RemoteBuildSettingsView.cleanup_ttl_seconds` is additive on the wire; existing clients ignore the unknown key. A future frontend PR can surface the input on the receiver-side Settings UI without a coordinated lockstep with this one.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

