### PR TITLE
Source-route firmware runner on JobSource.REMOTE for compile (7a-2b)

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -68,7 +68,7 @@ from .remote_runner import run_remote_compile_job
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
-    from ...helpers.event_bus import Event
+    from ...helpers.event_bus import Event, EventBus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -149,6 +149,19 @@ class FirmwareController:
         # when the subprocess exits so we can mark the job CANCELLED
         # rather than the default FAILED-on-non-zero-exit.
         self._cancel_requested: set[str] = set()
+
+    @property
+    def bus(self) -> EventBus:
+        """The event bus this controller fires lifecycle / output events on.
+
+        Shorthand for ``self._db.bus`` so collaborators
+        (notably ``remote_runner``) don't reach across two
+        underscore-prefixed attributes to get at the canonical
+        offloader-side bus. Read-only — the bus reference is
+        installed by :class:`DeviceBuilder` at construction
+        and doesn't move.
+        """
+        return self._db.bus
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -149,6 +149,14 @@ class FirmwareController:
         # when the subprocess exits so we can mark the job CANCELLED
         # rather than the default FAILED-on-non-zero-exit.
         self._cancel_requested: set[str] = set()
+        # Per-job ``asyncio.Event`` that the cancel handler signals
+        # so an in-flight runner can wake instantly instead of
+        # polling. Only the remote-source runner registers an event
+        # today (the local subprocess path's cancel landing is
+        # driven by SIGTERM on the spawned process). The remote
+        # runner adds an entry before parking on the terminal wait
+        # and clears it on exit.
+        self._cancel_events: dict[str, asyncio.Event] = {}
 
     @property
     def bus(self) -> EventBus:
@@ -696,6 +704,13 @@ class FirmwareController:
                 msg = "Running job is not the active subprocess (state out of sync)"
                 raise RuntimeError(msg)
             self._cancel_requested.add(job_id)
+            # Wake any runner parked on its cancel event (the
+            # source-routed remote runner registers one; the
+            # local subprocess path doesn't need one because
+            # SIGTERM is the wake signal).
+            cancel_event = self._cancel_events.get(job_id)
+            if cancel_event is not None:
+                cancel_event.set()
             await self._terminate_current_process()
             return
 

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -43,6 +43,7 @@ from ...models import (
     JobLifecycleData,
     JobOutputData,
     JobProgressData,
+    JobSource,
     JobStatus,
     JobType,
     StreamEvent,
@@ -67,6 +68,7 @@ from .helpers import (
     _validate_port,
     _verify_esphome_importable,
 )
+from .remote_runner import run_remote_compile_job
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -833,6 +835,17 @@ class FirmwareController:
         await self._persist_jobs()
 
         try:
+            # Source-routed branch: REMOTE-source jobs dispatch via
+            # peer-link to a paired receiver instead of running a
+            # local subprocess. The receiver's ``OFFLOADER_JOB_*``
+            # fan-out events drive the same lifecycle / output /
+            # progress fires every local subscriber already
+            # consumes — follow_job and the firmware-tasks UI don't
+            # need to know whether the bytes are local or remote.
+            if job.source is JobSource.REMOTE:
+                await self._execute_remote_job(job)
+                return
+
             # Pre-flight: verify chip type for serial uploads
             if job.job_type in (JobType.UPLOAD, JobType.INSTALL):
                 await self._verify_chip(job)
@@ -1028,6 +1041,37 @@ class FirmwareController:
                 _trim_job_output(job)
                 self._prune_history()
             await self._persist_jobs()
+
+    async def _execute_remote_job(self, job: FirmwareJob) -> None:
+        """
+        Run a ``JobSource.REMOTE`` job by dispatching through peer-link.
+
+        Reads ``source_pin_sha256`` off *job*, looks up the live
+        :class:`PeerLinkClient` through the remote-build
+        controller, bundles the YAML via the ``esphome bundle``
+        subprocess, dispatches ``submit_job``, then translates
+        receiver-side ``OFFLOADER_JOB_OUTPUT`` /
+        ``OFFLOADER_JOB_STATE_CHANGED`` events into the same
+        local ``JOB_OUTPUT`` / ``JOB_PROGRESS`` /
+        ``JOB_<terminal>`` fires the local subprocess path emits.
+        ``follow_job`` and the firmware-tasks UI consume one
+        event stream regardless of which CPU compiled the bytes.
+
+        Scope is COMPILE-only — UPLOAD / INSTALL go through
+        7a-3 which adds a download-artifacts step on top to
+        pull the bytes back over peer-link before the local
+        flash phase. Anything else here lands as ``FAILED``
+        with an explanatory error.
+
+        Terminal states are mapped through the same helpers the
+        local path uses (``_mark_job_terminal`` /
+        ``_finalize_cancelled``), so the outer
+        ``_execute_job``'s ``finally`` runs the shared
+        ``_trim_job_output`` / ``_prune_history`` / persist
+        sequence regardless of which branch produced the
+        terminal status.
+        """
+        await run_remote_compile_job(self, job)
 
     @asynccontextmanager
     async def _tracked_subprocess(

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -41,8 +41,6 @@ from ...models import (
     EventType,
     FirmwareJob,
     JobLifecycleData,
-    JobOutputData,
-    JobProgressData,
     JobSource,
     JobStatus,
     JobType,
@@ -51,19 +49,17 @@ from ...models import (
 from ..config import _load_metadata, metadata_transaction
 from .constants import (
     _ERROR_PATTERNS,
-    _INFLIGHT_TRIM_KEEP,
     _JOBS_KEY,
     _MAX_AUX_TERMINAL_JOBS,
-    _MAX_OUTPUT_LINES_INFLIGHT,
     _MAX_PRIMARY_TERMINAL_JOBS,
     _PRIMARY_JOB_TYPES,
 )
 from .helpers import (
     _find_esphome_cmd,
+    _ingest_output_line,
     _is_no_module_named_esphome,
     _mark_job_terminal,
     _names_touched_by_job,
-    _parse_progress,
     _trim_job_output,
     _validate_port,
     _verify_esphome_importable,
@@ -898,23 +894,6 @@ class FirmwareController:
                         has_error_in_output = True
                         return
 
-            def _check_progress(text: str) -> None:
-                progress = _parse_progress(text)
-                if progress is None:
-                    return
-                # Monotonic clamp — output sometimes flips between
-                # phases (compile reports "100%", then flash starts at
-                # "0%"). For a single coarse bar we want the highest
-                # so far so the frontend doesn't appear to regress.
-                current = job.progress or 0
-                if progress > current:
-                    job.progress = progress
-                    progress_payload: JobProgressData = {
-                        "job_id": job.job_id,
-                        "progress": progress,
-                    }
-                    self._db.bus.fire(EventType.JOB_PROGRESS, progress_payload)
-
             async with self._tracked_subprocess(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
@@ -949,28 +928,22 @@ class FirmwareController:
                 # whether to append a new line or overwrite the last
                 # one.
                 async for line in iter_lines_with_progress(proc.stdout):
-                    job.output.append(line)
-                    # Bound mid-run memory growth. Without this, a
-                    # build that streams gigabytes of stderr (chatty
-                    # external_components fetch loop, esptool stuck on
-                    # a repeating error) holds every line in memory
-                    # until the subprocess exits — only the post-
-                    # completion ``_trim_job_output`` in the
-                    # ``finally`` block ever ran. Trim down to a
-                    # smaller keep size than the trigger so the next
-                    # ``cap - keep`` appends don't each pay an O(cap)
-                    # slice copy. Concretely with the current
-                    # constants: cap=4000, keep=2000, so 2000 lines
-                    # fit between trims.
-                    if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
-                        _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
-                    output_payload: JobOutputData = {
-                        "job_id": job.job_id,
-                        "line": line,
-                    }
-                    self._db.bus.fire(EventType.JOB_OUTPUT, output_payload)
+                    # Shared with the source-routed remote runner
+                    # (``remote_runner._on_output``). The helper
+                    # buffers + trims + fires ``JOB_OUTPUT`` and
+                    # advances ``JOB_PROGRESS`` on a parseable
+                    # percentage — same per-line bookkeeping
+                    # whether the build's bytes come from this
+                    # CPU or a paired receiver. ``_check_error``
+                    # stays inline because it mutates the
+                    # nonlocal ``has_error_in_output`` /
+                    # ``saw_no_esphome_module`` flags the
+                    # post-exit handler reads; remote builds
+                    # surface a structured ``failed`` status from
+                    # the receiver instead, so the stderr scrape
+                    # only matters here.
+                    _ingest_output_line(job, self._db.bus, line)
                     _check_error(line)
-                    _check_progress(line)
 
                 exit_code = await proc.wait()
                 job.exit_code = exit_code

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -16,22 +16,31 @@ import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ...helpers.api import CommandError
 from ...helpers.subprocess import run_subprocess_capture
 from ...models import (
     TERMINAL_JOB_STATUSES,
     ErrorCode,
+    EventType,
     FirmwareJob,
+    JobOutputData,
+    JobProgressData,
     JobStatus,
     JobType,
 )
 from .constants import (
+    _INFLIGHT_TRIM_KEEP,
+    _MAX_OUTPUT_LINES_INFLIGHT,
     _MAX_OUTPUT_LINES_RETAINED,
     _NO_ESPHOME_MODULE_MARKER,
     _OUTPUT_TRIM_NOTICE_PREFIX,
     _PROGRESS_PATTERNS,
 )
+
+if TYPE_CHECKING:
+    from ...helpers.event_bus import EventBus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -288,3 +297,44 @@ async def _verify_esphome_importable(cmd: list[str]) -> tuple[bool, str]:
     if result.returncode != 0 or "No module named" in output or "ModuleNotFoundError" in output:
         return False, output or f"exit {result.returncode}"
     return True, output
+
+
+def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
+    """
+    Append *line* to ``job.output`` and fire local follower events.
+
+    Shared bookkeeping for "one line of build output arrived" —
+    consumed by both the local subprocess streaming loop in
+    :meth:`FirmwareController._execute_job` and the remote-source
+    listener in :mod:`controllers.firmware.remote_runner`.
+
+    Steps:
+
+    1. Buffer the line on ``job.output``.
+    2. Trim down to ``_INFLIGHT_TRIM_KEEP`` if the in-flight
+       cap is hit, so a chatty build doesn't grow ``output``
+       without bound between terminal-event trims.
+    3. Fan it out as ``JOB_OUTPUT`` so live followers see it.
+    4. Parse a coarse 0-100 progress percentage; if it
+       advances the previous value, update the job and fire
+       ``JOB_PROGRESS``. Monotonic-clamp behaviour matches the
+       local subprocess path (esptool's "100%" followed by
+       PlatformIO's "0%" would otherwise look like a
+       regression to the progress-bar renderer).
+
+    Does **not** handle error-pattern detection — that's a
+    local-only concern (the remote path gets a structured
+    ``failed`` status from the receiver instead of having to
+    scrape stderr).
+    """
+    job.output.append(line)
+    if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
+        _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
+    out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
+    bus.fire(EventType.JOB_OUTPUT, out_payload)
+    progress = _parse_progress(line)
+    if progress is None or progress <= (job.progress or 0):
+        return
+    job.progress = progress
+    prog_payload: JobProgressData = {"job_id": job.job_id, "progress": progress}
+    bus.fire(EventType.JOB_PROGRESS, prog_payload)

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError
 from ...helpers.config_bundle import BundleBuildError, build_yaml_bundle
@@ -41,6 +41,7 @@ from ...models import (
     JobType,
     OffloaderJobOutputData,
     OffloaderJobStateChangedData,
+    OffloaderPeerLinkClosedData,
 )
 from ..remote_build.peer_link_client import (
     PeerLinkNoSessionError,
@@ -92,11 +93,18 @@ async def run_remote_compile_job(
         )
         return
 
-    bus = controller._db.bus
+    bus = controller.bus
     pin = job.source_pin_sha256
     target_job_id = job.job_id
     loop = asyncio.get_running_loop()
     terminal: asyncio.Future[OffloaderJobStateChangedData] = loop.create_future()
+    # Set when the peer-link session backing this job's
+    # receiver closes. Distinct from ``terminal`` because the
+    # receiver hasn't given us a structured terminal status —
+    # we have to synthesise the lost-session failure on the
+    # offloader side. ``_await_terminal`` waits on whichever
+    # fires first.
+    session_lost: asyncio.Future[OffloaderPeerLinkClosedData] = loop.create_future()
 
     def _on_output(event: Event[OffloaderJobOutputData]) -> None:
         data = event.data
@@ -111,15 +119,23 @@ async def run_remote_compile_job(
         if data["status"] in _TERMINAL_WIRE_STATUSES and not terminal.done():
             terminal.set_result(data)
 
+    def _on_session_closed(event: Event[OffloaderPeerLinkClosedData]) -> None:
+        data = event.data
+        if data["pin_sha256"] != pin or session_lost.done():
+            return
+        session_lost.set_result(data)
+
     with (
         bus.listening([EventType.OFFLOADER_JOB_OUTPUT], _on_output),
         bus.listening([EventType.OFFLOADER_JOB_STATE_CHANGED], _on_state),
+        bus.listening([EventType.OFFLOADER_PEER_LINK_CLOSED], _on_session_closed),
     ):
         try:
             await _dispatch_and_drive(
                 controller=controller,
                 job=job,
                 terminal=terminal,
+                session_lost=session_lost,
             )
         except asyncio.CancelledError:
             # Runner-task shutdown (controller stop). Mirror the
@@ -136,6 +152,7 @@ async def _dispatch_and_drive(
     controller: FirmwareController,
     job: FirmwareJob,
     terminal: asyncio.Future[OffloaderJobStateChangedData],
+    session_lost: asyncio.Future[OffloaderPeerLinkClosedData],
 ) -> None:
     """Build the bundle, submit, then wait for the receiver's terminal frame.
 
@@ -210,7 +227,12 @@ async def _dispatch_and_drive(
         )
         return
 
-    await _await_terminal(controller=controller, job=job, terminal=terminal)
+    await _await_terminal(
+        controller=controller,
+        job=job,
+        terminal=terminal,
+        session_lost=session_lost,
+    )
 
 
 async def _await_terminal(
@@ -218,6 +240,7 @@ async def _await_terminal(
     controller: FirmwareController,
     job: FirmwareJob,
     terminal: asyncio.Future[OffloaderJobStateChangedData],
+    session_lost: asyncio.Future[OffloaderPeerLinkClosedData],
 ) -> None:
     """Wait for the receiver's terminal state, translating local cancel to the wire.
 
@@ -228,15 +251,41 @@ async def _await_terminal(
     ``job_state_changed{status: cancelled}`` is the
     confirmation — we wait for it on the same future the
     happy path uses.
+
+    Also watches *session_lost*: if the peer-link session
+    backing this receiver closes while we're waiting,
+    finalise locally rather than wait forever for a frame
+    that will never arrive (the receiver may have crashed,
+    or the network may have dropped between accept and
+    completion). The runner cooperates with whichever of
+    *terminal* / *session_lost* / a local cancel arrives
+    first.
     """
     cancel_sent = False
-    bus = controller._db.bus
+    bus = controller.bus
+    # ``asyncio.wait`` is invariant on its element type; the two
+    # futures carry different TypedDict payloads, so widen to
+    # ``Any`` at the call so mypy doesn't complain about the
+    # mixed bag. The branches below each narrow back at the
+    # ``.result()`` call site.
+    waiters: list[asyncio.Future[Any]] = [terminal, session_lost]
     while not terminal.done():
+        if session_lost.done():
+            closed = session_lost.result()
+            reason = closed["reason"]
+            detail = closed["error_detail"]
+            text = f"{reason}: {detail}" if detail else reason
+            _fail_locally(
+                controller,
+                job,
+                error=f"remote build: peer-link session lost ({text})",
+            )
+            return
         if job.job_id in controller._cancel_requested and not cancel_sent:
             cancel_sent = True
             if not await _send_cancel_or_finalise(controller, job):
                 return
-        await asyncio.wait([terminal], timeout=0.5)
+        await asyncio.wait(waiters, timeout=0.5)
 
     data = terminal.result()
     if job.job_id in controller._cancel_requested:
@@ -294,24 +343,20 @@ async def _send_cancel_or_finalise(
         client = remote_build._lookup_open_peer_link_client(
             job.source_pin_sha256, label="firmware_remote_cancel"
         )
-    except CommandError as exc:
+        await client.cancel_job(job_id=job.job_id)
+    except (CommandError, PeerLinkNoSessionError) as exc:
+        # ``CommandError`` from the lookup means the receiver
+        # is unpaired / mid-reconnect; ``PeerLinkNoSessionError``
+        # from the send means the session dropped between the
+        # lookup and the wire write. Both translate the user's
+        # Stop click into a local CANCELLED finalise — without
+        # this fallback the cancel sits forever waiting for a
+        # confirmation frame that will never arrive.
+        detail = exc.message if isinstance(exc, CommandError) else str(exc)
         _LOGGER.info(
             "remote cancel for job %s: peer-link unavailable (%s); finalising locally",
             job.job_id,
-            exc.message,
-        )
-        controller._finalize_cancelled(job)
-        return False
-    try:
-        await client.cancel_job(job_id=job.job_id)
-    except PeerLinkNoSessionError as exc:
-        # Session dropped between lookup and send. Finalise
-        # locally so the user's Stop click doesn't hang on a
-        # frame that will never arrive.
-        _LOGGER.info(
-            "remote cancel for job %s: session gone (%s); finalising locally",
-            job.job_id,
-            exc,
+            detail,
         )
         controller._finalize_cancelled(job)
         return False
@@ -326,15 +371,28 @@ def _fail_locally(
 ) -> None:
     """Mark *job* FAILED with *error* and fire ``JOB_FAILED`` on the local bus.
 
-    Centralises the three-line "remote path can't proceed,
-    finalise as failed" sequence so every early-exit failure
-    branch above stays one line at the call site. The text
-    rides into ``job.error`` so a frontend that already
-    renders ``error`` for local failures shows the remote
-    failure with no special-case code.
+    Centralises the "remote path can't proceed, finalise
+    terminally" sequence so every early-exit failure branch
+    above stays one line at the call site. The text rides
+    into ``job.error`` so a frontend that already renders
+    ``error`` for local failures shows the remote failure
+    with no special-case code.
+
+    Cancel intent wins: if the user already flipped
+    ``_cancel_requested`` for this job (Stop click landed
+    during bundle build / lookup / dispatch / session-lost
+    detection — anywhere before the receiver could emit a
+    terminal frame), finalise as CANCELLED instead. Mirrors
+    the local subprocess path's contract — a Stop that
+    happened to race a failure should not show up as a red
+    error badge.
     """
+    if job.job_id in controller._cancel_requested:
+        controller._finalize_cancelled(job)
+        _LOGGER.info("Remote job %s cancelled (failure path: %s)", job.job_id, error)
+        return
     job.error = error
     _mark_job_terminal(job, JobStatus.FAILED)
     payload: JobLifecycleData = {"job": job}
-    controller._db.bus.fire(EventType.JOB_FAILED, payload)
+    controller.bus.fire(EventType.JOB_FAILED, payload)
     _LOGGER.warning("Remote job %s failed: %s", job.job_id, error)

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -1,0 +1,329 @@
+"""
+Source-routed runner branch for ``JobSource.REMOTE`` firmware jobs.
+
+Lives in its own module so ``controller.py`` stays focused on the
+local subprocess pipeline + WS surface. The branch is invoked
+from :meth:`FirmwareController._execute_job` when the job's
+``source`` field is ``REMOTE``, after ``JOB_STARTED`` has fired
+and before chip-verify; it returns once the receiver has emitted
+a terminal ``OFFLOADER_JOB_STATE_CHANGED`` (or a translatable
+failure path has been finalised locally).
+
+The receiver doesn't know about the offloader-side
+:class:`FirmwareJob` — it tracks its own row keyed by its own
+``job_id``, and echoes the offloader's id back on every
+fan-out frame so the offloader can correlate. We use
+``job.job_id`` (the offloader-side id) as the match key on
+inbound :class:`OffloaderJobOutputData` /
+:class:`OffloaderJobStateChangedData` events.
+
+Listener attach happens **before** ``submit_job`` is sent so an
+immediate ``running`` / ``output`` frame from the receiver
+can't outrace our subscription. The listener bucket is
+process-wide; a stray frame from a different in-flight remote
+job lands in a different match-id / pin combination and is
+filtered out at the callback boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from ...helpers.config_bundle import BundleBuildError, build_yaml_bundle
+from ...models import (
+    EventType,
+    FirmwareJob,
+    JobLifecycleData,
+    JobOutputData,
+    JobProgressData,
+    JobStatus,
+    JobType,
+    OffloaderJobOutputData,
+    OffloaderJobStateChangedData,
+)
+from ..remote_build.peer_link_client import (
+    PeerLinkNoSessionError,
+    SubmitJobSessionLostError,
+    SubmitJobTimeoutError,
+)
+from .constants import _INFLIGHT_TRIM_KEEP, _MAX_OUTPUT_LINES_INFLIGHT
+from .helpers import _mark_job_terminal, _parse_progress, _trim_job_output
+
+if TYPE_CHECKING:
+    from ...helpers.event_bus import Event
+    from .controller import FirmwareController
+
+_LOGGER = logging.getLogger(__name__)
+
+# Terminal receiver-side statuses on
+# :class:`OffloaderJobStateChangedData`. Mirror of
+# :data:`TERMINAL_JOB_STATUSES` but on the wire literal rather
+# than the local enum — receiver-side fan-out emits the lower-
+# case string per :class:`JobStateChangedFrameData`'s
+# ``Literal`` union.
+_TERMINAL_WIRE_STATUSES: frozenset[str] = frozenset({"completed", "failed", "cancelled"})
+
+
+async def run_remote_compile_job(
+    controller: FirmwareController,
+    job: FirmwareJob,
+) -> None:
+    """Run a REMOTE-source compile job and finalise *job* on the offloader bus.
+
+    Caller (``FirmwareController._execute_job``) has already
+    set ``status = RUNNING`` and fired ``JOB_STARTED``; this
+    function is responsible for the entire run-and-finalise
+    middle and leaves the outer ``finally`` block to clear
+    ``_current_job`` / persist.
+    """
+    if job.job_type is not JobType.COMPILE:
+        _fail_locally(
+            controller,
+            job,
+            error=(
+                f"remote source only supports COMPILE jobs in this phase (got {job.job_type.value})"
+            ),
+        )
+        return
+
+    if not job.source_pin_sha256:
+        _fail_locally(
+            controller,
+            job,
+            error="remote source missing source_pin_sha256",
+        )
+        return
+
+    bus = controller._db.bus
+    pin = job.source_pin_sha256
+    target_job_id = job.job_id
+    loop = asyncio.get_running_loop()
+    terminal: asyncio.Future[OffloaderJobStateChangedData] = loop.create_future()
+
+    def _on_output(event: Event[OffloaderJobOutputData]) -> None:
+        data = event.data
+        if data["pin_sha256"] != pin or data["job_id"] != target_job_id:
+            return
+        line = data["line"]
+        job.output.append(line)
+        if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
+            _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
+        out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
+        bus.fire(EventType.JOB_OUTPUT, out_payload)
+        progress = _parse_progress(line)
+        if progress is None:
+            return
+        current = job.progress or 0
+        if progress > current:
+            job.progress = progress
+            prog_payload: JobProgressData = {
+                "job_id": job.job_id,
+                "progress": progress,
+            }
+            bus.fire(EventType.JOB_PROGRESS, prog_payload)
+
+    def _on_state(event: Event[OffloaderJobStateChangedData]) -> None:
+        data = event.data
+        if data["pin_sha256"] != pin or data["job_id"] != target_job_id:
+            return
+        if data["status"] in _TERMINAL_WIRE_STATUSES and not terminal.done():
+            terminal.set_result(data)
+
+    with (
+        bus.listening([EventType.OFFLOADER_JOB_OUTPUT], _on_output),
+        bus.listening([EventType.OFFLOADER_JOB_STATE_CHANGED], _on_state),
+    ):
+        await _dispatch_and_drive(
+            controller=controller,
+            job=job,
+            terminal=terminal,
+        )
+
+
+async def _dispatch_and_drive(
+    *,
+    controller: FirmwareController,
+    job: FirmwareJob,
+    terminal: asyncio.Future[OffloaderJobStateChangedData],
+) -> None:
+    """Build the bundle, submit, then wait for the receiver's terminal frame.
+
+    Split out from :func:`run_remote_compile_job` so the
+    listener attach / detach lives in one ``with`` block at the
+    outer call site — every early-return failure path here
+    still releases the bus subscriptions.
+    """
+    loop = asyncio.get_running_loop()
+    yaml_path = await loop.run_in_executor(
+        None, controller._db.settings.rel_path, job.configuration
+    )
+
+    try:
+        bundle_bytes = await build_yaml_bundle(yaml_path)
+    except FileNotFoundError:
+        _fail_locally(
+            controller,
+            job,
+            error=f"remote build: configuration not found: {job.configuration}",
+        )
+        return
+    except BundleBuildError as exc:
+        _fail_locally(
+            controller,
+            job,
+            error=f"remote build: bundle failed: {exc.output or exc}",
+        )
+        return
+
+    remote_build = controller._db.remote_build
+    if remote_build is None:
+        _fail_locally(
+            controller,
+            job,
+            error="remote build: controller not initialised",
+        )
+        return
+    try:
+        client = remote_build._lookup_open_peer_link_client(
+            job.source_pin_sha256, label="firmware_remote"
+        )
+    except Exception as exc:  # CommandError shape — receiver gone / unpaired
+        _fail_locally(
+            controller,
+            job,
+            error=f"remote build: receiver not reachable: {exc}",
+        )
+        return
+
+    try:
+        ack = await client.submit_job(
+            job_id=job.job_id,
+            configuration_filename=job.configuration,
+            target="compile",
+            bundle_bytes=bundle_bytes,
+        )
+    except (PeerLinkNoSessionError, SubmitJobTimeoutError, SubmitJobSessionLostError) as exc:
+        _fail_locally(
+            controller,
+            job,
+            error=f"remote build: dispatch failed: {exc}",
+        )
+        return
+
+    if not ack["accepted"]:
+        reason = ack.get("reason", "no reason given")
+        _fail_locally(
+            controller,
+            job,
+            error=f"remote build: receiver rejected job: {reason}",
+        )
+        return
+
+    await _await_terminal(controller=controller, job=job, terminal=terminal)
+
+
+async def _await_terminal(
+    *,
+    controller: FirmwareController,
+    job: FirmwareJob,
+    terminal: asyncio.Future[OffloaderJobStateChangedData],
+) -> None:
+    """Wait for the receiver's terminal state, translating local cancel to the wire.
+
+    Polls a short ``asyncio.wait`` window so a
+    :attr:`FirmwareController._cancel_requested` flip lands
+    on the wire promptly without dedicating a separate task
+    to watch it. The receiver's resulting
+    ``job_state_changed{status: cancelled}`` is the
+    confirmation — we wait for it on the same future the
+    happy path uses.
+    """
+    cancel_sent = False
+    bus = controller._db.bus
+    while not terminal.done():
+        if job.job_id in controller._cancel_requested and not cancel_sent:
+            cancel_sent = True
+            remote_build = controller._db.remote_build
+            if remote_build is None:
+                # Receiver controller torn down mid-run — finalise as
+                # cancelled rather than spinning forever on a future
+                # that nothing will set.
+                controller._finalize_cancelled(job)
+                return
+            try:
+                client = remote_build._lookup_open_peer_link_client(
+                    job.source_pin_sha256, label="firmware_remote_cancel"
+                )
+                await client.cancel_job(job_id=job.job_id)
+            except PeerLinkNoSessionError as exc:
+                # Session dropped before cancel could land — finalise
+                # locally so the user's Stop click doesn't hang
+                # waiting for a frame that will never arrive.
+                _LOGGER.info(
+                    "remote cancel for job %s: session gone (%s); finalising locally",
+                    job.job_id,
+                    exc,
+                )
+                controller._finalize_cancelled(job)
+                return
+            except Exception as exc:
+                _LOGGER.warning(
+                    "remote cancel for job %s failed (%s); finalising locally",
+                    job.job_id,
+                    exc,
+                )
+                controller._finalize_cancelled(job)
+                return
+        await asyncio.wait([terminal], timeout=0.5)
+
+    data = terminal.result()
+    if job.job_id in controller._cancel_requested:
+        # User cancel beat the receiver's terminal frame to the
+        # loop (receiver completed / failed while our cancel was
+        # in flight). Mirror the local subprocess path: user
+        # intent wins, finalise as CANCELLED regardless of the
+        # status we received.
+        controller._finalize_cancelled(job)
+        return
+    status = data["status"]
+    if status == "completed":
+        _mark_job_terminal(job, JobStatus.COMPLETED)
+        payload: JobLifecycleData = {"job": job}
+        bus.fire(EventType.JOB_COMPLETED, payload)
+    elif status == "cancelled":
+        controller._finalize_cancelled(job)
+    else:
+        # ``failed`` — the only other element in
+        # :data:`_TERMINAL_WIRE_STATUSES`. Receiver-supplied
+        # error text rides into ``job.error``; an empty
+        # ``error_message`` (older receiver, internal bug)
+        # falls back to a generic string so subscribers always
+        # see a non-empty reason.
+        job.error = data["error_message"] or "remote build failed"
+        _mark_job_terminal(job, JobStatus.FAILED)
+        failed_payload: JobLifecycleData = {"job": job}
+        bus.fire(EventType.JOB_FAILED, failed_payload)
+
+
+def _fail_locally(
+    controller: FirmwareController,
+    job: FirmwareJob,
+    *,
+    error: str,
+) -> None:
+    """Mark *job* FAILED with *error* and fire ``JOB_FAILED`` on the local bus.
+
+    Centralises the three-line "remote path can't proceed,
+    finalise as failed" sequence so every early-exit failure
+    branch above stays one line at the call site. The text
+    rides into ``job.error`` so a frontend that already
+    renders ``error`` for local failures shows the remote
+    failure with no special-case code.
+    """
+    job.error = error
+    _mark_job_terminal(job, JobStatus.FAILED)
+    payload: JobLifecycleData = {"job": job}
+    controller._db.bus.fire(EventType.JOB_FAILED, payload)
+    _LOGGER.warning("Remote job %s failed: %s", job.job_id, error)

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -113,6 +113,16 @@ async def run_remote_compile_job(
     # and wakes on whichever fires first.
     cancel_event = asyncio.Event()
     controller._cancel_events[job.job_id] = cancel_event
+    # A cancel that landed during ``_execute_job``'s pre-runner
+    # phase (``_current_job = job`` is set before the persist
+    # await, so the cancel handler accepts the request and
+    # writes to ``_cancel_requested`` — but the runner hasn't
+    # yet installed its event, so the handler's
+    # ``_cancel_events.get(job_id)`` returns ``None`` and the
+    # ``set()`` is skipped). Replay the late wake here so the
+    # runner doesn't park on an event that will never fire.
+    if job.job_id in controller._cancel_requested:
+        cancel_event.set()
 
     def _is_ours(data: OffloaderJobOutputData | OffloaderJobStateChangedData) -> bool:
         """Return True if *data* belongs to this runner's (pin, job_id) pair."""

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -105,6 +105,14 @@ async def run_remote_compile_job(
     # offloader side. ``_await_terminal`` waits on whichever
     # fires first.
     session_lost: asyncio.Future[OffloaderPeerLinkClosedData] = loop.create_future()
+    # Set by ``FirmwareController.cancel`` when the user clicks
+    # Stop. Registering it on the controller lets the cancel
+    # handler signal the parked runner instantly instead of
+    # waiting for a polling cadence — the runner parks on
+    # ``asyncio.wait({terminal, session_lost, cancel_event_task})``
+    # and wakes on whichever fires first.
+    cancel_event = asyncio.Event()
+    controller._cancel_events[job.job_id] = cancel_event
 
     def _is_ours(data: OffloaderJobOutputData | OffloaderJobStateChangedData) -> bool:
         """Return True if *data* belongs to this runner's (pin, job_id) pair."""
@@ -132,26 +140,33 @@ async def run_remote_compile_job(
             return
         session_lost.set_result(data)
 
-    with (
-        bus.listening([EventType.OFFLOADER_JOB_OUTPUT], _on_output),
-        bus.listening([EventType.OFFLOADER_JOB_STATE_CHANGED], _on_state),
-        bus.listening([EventType.OFFLOADER_PEER_LINK_CLOSED], _on_session_closed),
-    ):
-        try:
-            await _dispatch_and_drive(
-                controller=controller,
-                job=job,
-                terminal=terminal,
-                session_lost=session_lost,
-            )
-        except asyncio.CancelledError:
-            # Runner-task shutdown (controller stop). Mirror the
-            # local subprocess path's contract: finalise the job
-            # as CANCELLED so subscribers see a terminal event,
-            # then re-raise to let the outer runner unwind.
-            controller._finalize_cancelled(job)
-            _LOGGER.info("Remote job %s cancelled (runner shutdown)", job.job_id)
-            raise
+    try:
+        with (
+            bus.listening([EventType.OFFLOADER_JOB_OUTPUT], _on_output),
+            bus.listening([EventType.OFFLOADER_JOB_STATE_CHANGED], _on_state),
+            bus.listening([EventType.OFFLOADER_PEER_LINK_CLOSED], _on_session_closed),
+        ):
+            try:
+                await _dispatch_and_drive(
+                    controller=controller,
+                    job=job,
+                    terminal=terminal,
+                    session_lost=session_lost,
+                    cancel_event=cancel_event,
+                )
+            except asyncio.CancelledError:
+                # Runner-task shutdown (controller stop). Mirror the
+                # local subprocess path's contract: finalise the job
+                # as CANCELLED so subscribers see a terminal event,
+                # then re-raise to let the outer runner unwind.
+                controller._finalize_cancelled(job)
+                _LOGGER.info("Remote job %s cancelled (runner shutdown)", job.job_id)
+                raise
+    finally:
+        # Clean up the registration so a future job reusing the
+        # id (theoretical — uuid4 collision aside) doesn't
+        # signal a stale event.
+        controller._cancel_events.pop(job.job_id, None)
 
 
 async def _dispatch_and_drive(
@@ -160,6 +175,7 @@ async def _dispatch_and_drive(
     job: FirmwareJob,
     terminal: asyncio.Future[OffloaderJobStateChangedData],
     session_lost: asyncio.Future[OffloaderPeerLinkClosedData],
+    cancel_event: asyncio.Event,
 ) -> None:
     """Build the bundle, submit, then wait for the receiver's terminal frame.
 
@@ -239,6 +255,7 @@ async def _dispatch_and_drive(
         job=job,
         terminal=terminal,
         session_lost=session_lost,
+        cancel_event=cancel_event,
     )
 
 
@@ -248,51 +265,60 @@ async def _await_terminal(
     job: FirmwareJob,
     terminal: asyncio.Future[OffloaderJobStateChangedData],
     session_lost: asyncio.Future[OffloaderPeerLinkClosedData],
+    cancel_event: asyncio.Event,
 ) -> None:
-    """Wait for the receiver's terminal state, translating local cancel to the wire.
+    """
+    Wait for the receiver's terminal state, translating local cancel to the wire.
 
-    Polls a short ``asyncio.wait`` window so a
-    :attr:`FirmwareController._cancel_requested` flip lands
-    on the wire promptly without dedicating a separate task
-    to watch it. The receiver's resulting
-    ``job_state_changed{status: cancelled}`` is the
-    confirmation — we wait for it on the same future the
-    happy path uses.
+    Parks on ``asyncio.wait({terminal, session_lost,
+    cancel_event.wait()}, return_when=FIRST_COMPLETED)`` —
+    event-driven, no polling cadence. The cancel handler
+    (``FirmwareController.cancel``) signals *cancel_event*
+    when the user clicks Stop, so the runner wakes
+    instantly instead of waiting up to half a second for a
+    poll iteration. ``session_lost`` is the synthetic
+    failure path the offloader uses when the peer-link
+    session closes before the receiver can emit a terminal
+    frame; without it the wait would deadlock on a dead
+    receiver.
 
-    Also watches *session_lost*: if the peer-link session
-    backing this receiver closes while we're waiting,
-    finalise locally rather than wait forever for a frame
-    that will never arrive (the receiver may have crashed,
-    or the network may have dropped between accept and
-    completion). The runner cooperates with whichever of
-    *terminal* / *session_lost* / a local cancel arrives
-    first.
+    The runner cooperates with whichever of *terminal* /
+    *session_lost* / *cancel_event* fires first; the
+    branches below decide the final job status.
     """
     cancel_sent = False
     bus = controller.bus
-    # ``asyncio.wait`` is invariant on its element type; the two
-    # futures carry different TypedDict payloads, so widen to
-    # ``Any`` at the call so mypy doesn't complain about the
-    # mixed bag. The branches below each narrow back at the
-    # ``.result()`` call site.
-    waiters: list[asyncio.Future[Any]] = [terminal, session_lost]
-    while not terminal.done():
-        if session_lost.done():
-            closed = session_lost.result()
-            reason = closed["reason"]
-            detail = closed["error_detail"]
-            text = f"{reason}: {detail}" if detail else reason
-            _fail_locally(
-                controller,
-                job,
-                error=f"remote build: peer-link session lost ({text})",
-            )
-            return
-        if job.job_id in controller._cancel_requested and not cancel_sent:
-            cancel_sent = True
-            if not await _send_cancel_or_finalise(controller, job):
+    # ``asyncio.wait`` is invariant on its element type; the
+    # heterogeneous awaitables (two TypedDict futures + one
+    # Event-wait coroutine wrapped as a Task) are widened to
+    # ``Any`` at the call so mypy doesn't reject the mix.
+    cancel_wait = asyncio.get_running_loop().create_task(cancel_event.wait())
+    waiters: list[asyncio.Future[Any]] = [terminal, session_lost, cancel_wait]
+    try:
+        while not terminal.done():
+            if session_lost.done():
+                closed = session_lost.result()
+                reason = closed["reason"]
+                detail = closed["error_detail"]
+                text = f"{reason}: {detail}" if detail else reason
+                _fail_locally(
+                    controller,
+                    job,
+                    error=f"remote build: peer-link session lost ({text})",
+                )
                 return
-        await asyncio.wait(waiters, timeout=0.5)
+            if cancel_event.is_set() and not cancel_sent:
+                cancel_sent = True
+                if not await _send_cancel_or_finalise(controller, job):
+                    return
+                # After dispatching the wire cancel we only care
+                # about ``terminal`` / ``session_lost`` — the
+                # cancel-event signal has already done its job.
+                waiters = [terminal, session_lost]
+            await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        if not cancel_wait.done():
+            cancel_wait.cancel()
 
     data = terminal.result()
     if job.job_id in controller._cancel_requested:

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -31,13 +31,12 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from ...helpers.api import CommandError
 from ...helpers.config_bundle import BundleBuildError, build_yaml_bundle
 from ...models import (
     EventType,
     FirmwareJob,
     JobLifecycleData,
-    JobOutputData,
-    JobProgressData,
     JobStatus,
     JobType,
     OffloaderJobOutputData,
@@ -48,8 +47,7 @@ from ..remote_build.peer_link_client import (
     SubmitJobSessionLostError,
     SubmitJobTimeoutError,
 )
-from .constants import _INFLIGHT_TRIM_KEEP, _MAX_OUTPUT_LINES_INFLIGHT
-from .helpers import _mark_job_terminal, _parse_progress, _trim_job_output
+from .helpers import _ingest_output_line, _mark_job_terminal
 
 if TYPE_CHECKING:
     from ...helpers.event_bus import Event
@@ -82,9 +80,7 @@ async def run_remote_compile_job(
         _fail_locally(
             controller,
             job,
-            error=(
-                f"remote source only supports COMPILE jobs in this phase (got {job.job_type.value})"
-            ),
+            error=f"remote source supports only COMPILE (got {job.job_type.value})",
         )
         return
 
@@ -106,23 +102,7 @@ async def run_remote_compile_job(
         data = event.data
         if data["pin_sha256"] != pin or data["job_id"] != target_job_id:
             return
-        line = data["line"]
-        job.output.append(line)
-        if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
-            _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
-        out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
-        bus.fire(EventType.JOB_OUTPUT, out_payload)
-        progress = _parse_progress(line)
-        if progress is None:
-            return
-        current = job.progress or 0
-        if progress > current:
-            job.progress = progress
-            prog_payload: JobProgressData = {
-                "job_id": job.job_id,
-                "progress": progress,
-            }
-            bus.fire(EventType.JOB_PROGRESS, prog_payload)
+        _ingest_output_line(job, bus, data["line"])
 
     def _on_state(event: Event[OffloaderJobStateChangedData]) -> None:
         data = event.data
@@ -135,11 +115,20 @@ async def run_remote_compile_job(
         bus.listening([EventType.OFFLOADER_JOB_OUTPUT], _on_output),
         bus.listening([EventType.OFFLOADER_JOB_STATE_CHANGED], _on_state),
     ):
-        await _dispatch_and_drive(
-            controller=controller,
-            job=job,
-            terminal=terminal,
-        )
+        try:
+            await _dispatch_and_drive(
+                controller=controller,
+                job=job,
+                terminal=terminal,
+            )
+        except asyncio.CancelledError:
+            # Runner-task shutdown (controller stop). Mirror the
+            # local subprocess path's contract: finalise the job
+            # as CANCELLED so subscribers see a terminal event,
+            # then re-raise to let the outer runner unwind.
+            controller._finalize_cancelled(job)
+            _LOGGER.info("Remote job %s cancelled (runner shutdown)", job.job_id)
+            raise
 
 
 async def _dispatch_and_drive(
@@ -189,11 +178,11 @@ async def _dispatch_and_drive(
         client = remote_build._lookup_open_peer_link_client(
             job.source_pin_sha256, label="firmware_remote"
         )
-    except Exception as exc:  # CommandError shape — receiver gone / unpaired
+    except CommandError as exc:
         _fail_locally(
             controller,
             job,
-            error=f"remote build: receiver not reachable: {exc}",
+            error=f"remote build: receiver not reachable: {exc.message}",
         )
         return
 
@@ -245,36 +234,7 @@ async def _await_terminal(
     while not terminal.done():
         if job.job_id in controller._cancel_requested and not cancel_sent:
             cancel_sent = True
-            remote_build = controller._db.remote_build
-            if remote_build is None:
-                # Receiver controller torn down mid-run — finalise as
-                # cancelled rather than spinning forever on a future
-                # that nothing will set.
-                controller._finalize_cancelled(job)
-                return
-            try:
-                client = remote_build._lookup_open_peer_link_client(
-                    job.source_pin_sha256, label="firmware_remote_cancel"
-                )
-                await client.cancel_job(job_id=job.job_id)
-            except PeerLinkNoSessionError as exc:
-                # Session dropped before cancel could land — finalise
-                # locally so the user's Stop click doesn't hang
-                # waiting for a frame that will never arrive.
-                _LOGGER.info(
-                    "remote cancel for job %s: session gone (%s); finalising locally",
-                    job.job_id,
-                    exc,
-                )
-                controller._finalize_cancelled(job)
-                return
-            except Exception as exc:
-                _LOGGER.warning(
-                    "remote cancel for job %s failed (%s); finalising locally",
-                    job.job_id,
-                    exc,
-                )
-                controller._finalize_cancelled(job)
+            if not await _send_cancel_or_finalise(controller, job):
                 return
         await asyncio.wait([terminal], timeout=0.5)
 
@@ -305,6 +265,57 @@ async def _await_terminal(
         _mark_job_terminal(job, JobStatus.FAILED)
         failed_payload: JobLifecycleData = {"job": job}
         bus.fire(EventType.JOB_FAILED, failed_payload)
+
+
+async def _send_cancel_or_finalise(
+    controller: FirmwareController,
+    job: FirmwareJob,
+) -> bool:
+    """
+    Translate a pending local cancel into a wire ``cancel_job``.
+
+    Returns ``True`` if the cancel frame is on the wire and the
+    caller should keep waiting for the receiver's cancelled
+    terminal frame; ``False`` if the local side already
+    finalised the job (because there's no live session to
+    cancel against, or the controller was torn down). Splits
+    out from :func:`_await_terminal`'s loop so the lookup-vs-
+    send error paths each get their own ``except`` clause
+    without nesting.
+    """
+    remote_build = controller._db.remote_build
+    if remote_build is None:
+        # Receiver controller torn down mid-run — finalise as
+        # cancelled rather than spinning forever on a future
+        # that nothing will set.
+        controller._finalize_cancelled(job)
+        return False
+    try:
+        client = remote_build._lookup_open_peer_link_client(
+            job.source_pin_sha256, label="firmware_remote_cancel"
+        )
+    except CommandError as exc:
+        _LOGGER.info(
+            "remote cancel for job %s: peer-link unavailable (%s); finalising locally",
+            job.job_id,
+            exc.message,
+        )
+        controller._finalize_cancelled(job)
+        return False
+    try:
+        await client.cancel_job(job_id=job.job_id)
+    except PeerLinkNoSessionError as exc:
+        # Session dropped between lookup and send. Finalise
+        # locally so the user's Stop click doesn't hang on a
+        # frame that will never arrive.
+        _LOGGER.info(
+            "remote cancel for job %s: session gone (%s); finalising locally",
+            job.job_id,
+            exc,
+        )
+        controller._finalize_cancelled(job)
+        return False
+    return True
 
 
 def _fail_locally(

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -106,20 +106,27 @@ async def run_remote_compile_job(
     # fires first.
     session_lost: asyncio.Future[OffloaderPeerLinkClosedData] = loop.create_future()
 
+    def _is_ours(data: OffloaderJobOutputData | OffloaderJobStateChangedData) -> bool:
+        """Return True if *data* belongs to this runner's (pin, job_id) pair."""
+        return data["pin_sha256"] == pin and data["job_id"] == target_job_id
+
     def _on_output(event: Event[OffloaderJobOutputData]) -> None:
-        data = event.data
-        if data["pin_sha256"] != pin or data["job_id"] != target_job_id:
+        if not _is_ours(event.data):
             return
-        _ingest_output_line(job, bus, data["line"])
+        _ingest_output_line(job, bus, event.data["line"])
 
     def _on_state(event: Event[OffloaderJobStateChangedData]) -> None:
         data = event.data
-        if data["pin_sha256"] != pin or data["job_id"] != target_job_id:
+        if not _is_ours(data):
             return
         if data["status"] in _TERMINAL_WIRE_STATUSES and not terminal.done():
             terminal.set_result(data)
 
     def _on_session_closed(event: Event[OffloaderPeerLinkClosedData]) -> None:
+        # Pin-only filter — session-close events don't carry a
+        # job_id (the close brings down every in-flight job on
+        # the link). ``_is_ours`` keys on job_id too, so this
+        # one stays inline.
         data = event.data
         if data["pin_sha256"] != pin or session_lost.done():
             return

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -170,6 +170,7 @@ def firmware_controller_factory(
             controller._current_job = None
             controller._current_process = None
             controller._cancel_requested = set()
+            controller._cancel_events = {}
             controller._terminate_current_process = AsyncMock()
 
         return controller

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -76,6 +76,7 @@ def _wire_real_queue(controller: FirmwareController) -> None:
     controller._current_job = None
     controller._current_process = None
     controller._cancel_requested = set()
+    controller._cancel_events = {}
 
 
 def _fake_esphome(controller: FirmwareController, script: str) -> None:

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -40,6 +40,9 @@ from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware import (
     controller as controller_module,
 )
+from esphome_device_builder.controllers.firmware import (
+    helpers as helpers_module,
+)
 from esphome_device_builder.controllers.firmware.constants import (
     _INFLIGHT_TRIM_KEEP,
     _MAX_OUTPUT_LINES_INFLIGHT,
@@ -706,7 +709,15 @@ async def test_compile_inflight_output_trims_when_cap_exceeded(
         else:
             real_trim(job, keep=keep)
 
+    # Patch both surfaces: the post-exit ``finally``-block call
+    # resolves through ``controller_module`` (the streaming-loop
+    # imports it directly), while the mid-run trim now lands via
+    # the shared ``_ingest_output_line`` helper in ``helpers.py``
+    # — which calls ``_trim_job_output`` from its own module
+    # scope. Without patching both, the mid-run branch escapes
+    # the spy and the regression check goes silent.
     monkeypatch.setattr(controller_module, "_trim_job_output", _spy_trim)
+    monkeypatch.setattr(helpers_module, "_trim_job_output", _spy_trim)
 
     excess = 200
     total = _MAX_OUTPUT_LINES_INFLIGHT + excess

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1,0 +1,475 @@
+"""
+Tests for the source-routed firmware runner branch.
+
+Exercises ``FirmwareController._execute_remote_job`` (7a-2b)
+end-to-end against a real :class:`EventBus`. The test scaffolding
+substitutes the bundle build + peer-link client surfaces with
+:class:`AsyncMock` shims so the runner's wire-event translation
+can be driven deterministically: a test fires a stub
+``OFFLOADER_JOB_OUTPUT`` or ``OFFLOADER_JOB_STATE_CHANGED`` and
+asserts the matching local ``JOB_*`` translation lands on the
+same bus.
+
+The receiver's correlation-id contract (echoes the offloader's
+``job_id`` back on every fan-out frame) is built into the
+fixtures — every fake event the test fires carries the
+offloader-side ``job.job_id``, so the runner's filter accepts
+it and exercises the translation path. A mismatched id on a
+stray frame from another in-flight remote job is covered by a
+separate test that asserts the runner ignores it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.firmware import remote_runner
+from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.models import (
+    EventType,
+    FirmwareJob,
+    JobSource,
+    JobStatus,
+    JobType,
+)
+
+if TYPE_CHECKING:
+    from .conftest import FirmwareControllerFactory
+
+
+_PIN = "a" * 64
+
+
+def _make_remote_job(*, job_id: str = "remote-1") -> FirmwareJob:
+    return FirmwareJob(
+        job_id=job_id,
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        source=JobSource.REMOTE,
+        source_pin_sha256=_PIN,
+        source_label="desktop",
+    )
+
+
+def _wire_remote_build(
+    controller: Any,
+    *,
+    client: Any | None = None,
+    lookup_error: Exception | None = None,
+) -> Any:
+    """Attach a stub ``_db.remote_build`` with a configurable lookup.
+
+    Returns the stub remote-build object so the test can assert on
+    its mock attributes. Either *client* is returned by every
+    lookup call, or *lookup_error* is raised — the runner's
+    receiver-unreachable branch consumes the latter.
+    """
+    remote_build = MagicMock()
+    if lookup_error is not None:
+        remote_build._lookup_open_peer_link_client.side_effect = lookup_error
+    else:
+        remote_build._lookup_open_peer_link_client.return_value = client or _make_client()
+    controller._db.remote_build = remote_build
+    return remote_build
+
+
+def _make_client(
+    *,
+    accepted: bool = True,
+    reason: str | None = None,
+    submit_error: Exception | None = None,
+    cancel_return: bool = True,
+) -> Any:
+    """Build a stub :class:`PeerLinkClient` mock.
+
+    Default shape: ``submit_job`` resolves to an ``accepted`` ack;
+    ``cancel_job`` resolves to ``True``. Overrides let a test
+    swap either side independently — the runner's failure
+    branches each lean on a different one of these.
+    """
+    client = MagicMock()
+    if submit_error is not None:
+        client.submit_job = AsyncMock(side_effect=submit_error)
+    else:
+        ack: dict[str, Any] = {"job_id": "remote-1", "accepted": accepted}
+        if reason is not None:
+            ack["reason"] = reason
+        client.submit_job = AsyncMock(return_value=ack)
+    client.cancel_job = AsyncMock(return_value=cancel_return)
+    return client
+
+
+@pytest.fixture
+def patch_bundle(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Replace ``build_yaml_bundle`` with an awaitable returning bytes.
+
+    Every remote runner test goes through bundle build before
+    the peer-link submit. Patching at module scope keeps each
+    test's setup focused on the runner-under-test rather than
+    spawning a real ``esphome bundle`` subprocess (which would
+    need an actual esphome install + a real YAML).
+    """
+    mock = AsyncMock(return_value=b"FAKEBUNDLE")
+    monkeypatch.setattr(remote_runner, "build_yaml_bundle", mock)
+    return mock
+
+
+def _capture_local_events(
+    controller: Any,
+) -> dict[EventType, list[dict[str, Any]]]:
+    """Subscribe a real ``EventBus`` to the local ``JOB_*`` events.
+
+    Returns a captured-events dict the assertion side can index
+    by event type. The fixture installs the bus on
+    ``controller._db.bus`` so the runner's fires land here.
+    """
+    bus = EventBus()
+    captured: dict[EventType, list[dict[str, Any]]] = {
+        EventType.JOB_OUTPUT: [],
+        EventType.JOB_PROGRESS: [],
+        EventType.JOB_COMPLETED: [],
+        EventType.JOB_FAILED: [],
+        EventType.JOB_CANCELLED: [],
+    }
+
+    def _make_listener(key: EventType) -> Any:
+        def _listen(event: Any) -> None:
+            captured[key].append(event.data)
+
+        return _listen
+
+    for et in captured:
+        bus.add_listener(et, _make_listener(et))
+    controller._db.bus = bus
+    return captured
+
+
+def _fire_state(
+    controller: Any,
+    *,
+    job_id: str,
+    status: str,
+    pin: str = _PIN,
+    error_message: str = "",
+) -> None:
+    controller._db.bus.fire(
+        EventType.OFFLOADER_JOB_STATE_CHANGED,
+        {
+            "receiver_hostname": "rx",
+            "receiver_port": 6053,
+            "pin_sha256": pin,
+            "job_id": job_id,
+            "status": status,
+            "error_message": error_message,
+        },
+    )
+
+
+def _fire_output(
+    controller: Any,
+    *,
+    job_id: str,
+    line: str,
+    pin: str = _PIN,
+    stream: str = "stdout",
+) -> None:
+    controller._db.bus.fire(
+        EventType.OFFLOADER_JOB_OUTPUT,
+        {
+            "receiver_hostname": "rx",
+            "receiver_port": 6053,
+            "pin_sha256": pin,
+            "job_id": job_id,
+            "stream": stream,
+            "line": line,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: receiver completes, runner translates terminal frame
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_translates_output_and_completes(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """Receiver fan-out events translate into local ``JOB_*`` fires.
+
+    The full happy path: bundle build returns bytes, ``submit_job``
+    accepts, two ``OFFLOADER_JOB_OUTPUT`` frames land + get
+    re-fired as ``JOB_OUTPUT`` on the same bus, then a
+    ``OFFLOADER_JOB_STATE_CHANGED{completed}`` terminal frame
+    causes the runner to mark the job ``COMPLETED`` and fire
+    ``JOB_COMPLETED``. Local subscribers see one event stream
+    regardless of which CPU compiled the bytes.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    # Yield until the runner is parked waiting on the terminal future.
+    # Two ticks: one to let the bundle build await resolve, one to let
+    # the submit_job await resolve, then we can fire wire events.
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    _fire_output(controller, job_id=job.job_id, line="Reading configuration\n")
+    _fire_output(controller, job_id=job.job_id, line="Compile finished\n")
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.COMPLETED
+    assert [d["line"] for d in captured[EventType.JOB_OUTPUT]] == [
+        "Reading configuration\n",
+        "Compile finished\n",
+    ]
+    assert len(captured[EventType.JOB_COMPLETED]) == 1
+    assert captured[EventType.JOB_COMPLETED][0]["job"] is job
+    assert captured[EventType.JOB_FAILED] == []
+    client.submit_job.assert_awaited_once_with(
+        job_id=job.job_id,
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=b"FAKEBUNDLE",
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_progress_translates_to_local_progress_event(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """A wire output line carrying a percentage fires a local ``JOB_PROGRESS``.
+
+    Progress detection runs on the offloader side — receiver
+    output is raw text per :class:`OffloaderJobOutputData`, no
+    structured progress field on the wire. The local
+    ``_parse_progress`` extracts the percentage and the runner
+    fires ``JOB_PROGRESS`` so the firmware-tasks progress bar
+    advances on remote builds the same way it does on local
+    ones.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    _fire_output(controller, job_id=job.job_id, line="[ 47%] Compiling .pio/build/foo.o\n")
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert captured[EventType.JOB_PROGRESS]
+    assert captured[EventType.JOB_PROGRESS][0]["progress"] == 47
+    assert job.progress == 47
+
+
+# ---------------------------------------------------------------------------
+# Stray events on the same bus must not affect this runner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_ignores_events_for_other_jobs(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """A wire frame for a different ``job_id`` doesn't leak into this runner.
+
+    The bus is process-wide; multiple in-flight remote jobs
+    share it. Each runner instance filters frames by both
+    ``pin_sha256`` and ``job_id`` so output for job A can't
+    bleed into job B's ``output`` buffer or trigger job B's
+    terminal.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job(job_id="ours")
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    # Stray traffic from a sibling job — must not appear in our captures
+    # and must not terminate our runner.
+    _fire_output(controller, job_id="someone-else", line="other job output\n")
+    _fire_state(controller, job_id="someone-else", status="completed")
+    await asyncio.sleep(0)
+    assert captured[EventType.JOB_OUTPUT] == []
+    assert captured[EventType.JOB_COMPLETED] == []
+    assert not runner.done()
+
+    # Now the real terminal arrives and the runner finishes.
+    _fire_state(controller, job_id="ours", status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+    assert job.status == JobStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Failure / rejection / unreachable paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_failed_status_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """A receiver ``failed`` terminal lands as local ``JOB_FAILED`` with the error text."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+    _fire_state(
+        controller,
+        job_id=job.job_id,
+        status="failed",
+        error_message="syntax error in YAML",
+    )
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error == "syntax error in YAML"
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_rejected_ack_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """``submit_job`` rejection (``accepted=False``) finalises locally with the reason."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client(accepted=False, reason="receiver queue full")
+    _wire_remote_build(controller, client=client)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "receiver queue full" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_receiver_unreachable_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """A missing peer-link client finalises the job as FAILED with the lookup error."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller, lookup_error=RuntimeError("session not connected"))
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "session not connected" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_non_compile_job_type_fails_locally(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """REMOTE with a non-COMPILE ``job_type`` is rejected at the runner's top.
+
+    7a-2b's scope is COMPILE only — UPLOAD / INSTALL land in
+    7a-3. Anything else here must surface a clear FAILED with
+    an explanatory ``error`` instead of running through the
+    submit path with the wrong target.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    _capture_local_events(controller)
+    _wire_remote_build(controller)
+    job = FirmwareJob(
+        job_id="x",
+        configuration="kitchen.yaml",
+        job_type=JobType.INSTALL,
+        source=JobSource.REMOTE,
+        source_pin_sha256=_PIN,
+    )
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "COMPILE" in job.error
+
+
+# ---------------------------------------------------------------------------
+# Cancel translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """Adding the job to ``_cancel_requested`` triggers a wire ``cancel_job`` send.
+
+    User Stop click flows through the existing
+    ``firmware/cancel`` handler, which adds the job id to
+    ``_cancel_requested``. The runner's poll loop notices and
+    invokes :meth:`PeerLinkClient.cancel_job` against the
+    receiver. The receiver's resulting cancelled terminal
+    frame finalises the local job as CANCELLED.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    controller._cancel_requested.add(job.job_id)
+    # The poll cadence is 0.5s; wait at most one tick + headroom.
+    await asyncio.sleep(0.6)
+    client.cancel_job.assert_awaited_once_with(job_id=job.job_id)
+
+    _fire_state(controller, job_id=job.job_id, status="cancelled")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert job.job_id not in controller._cancel_requested
+    assert len(captured[EventType.JOB_CANCELLED]) == 1

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -29,8 +29,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import remote_runner
+from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import (
+    ErrorCode,
     EventType,
     FirmwareJob,
     JobSource,
@@ -390,7 +392,10 @@ async def test_remote_compile_receiver_unreachable_fires_job_failed(
     """A missing peer-link client finalises the job as FAILED with the lookup error."""
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    _wire_remote_build(controller, lookup_error=RuntimeError("session not connected"))
+    _wire_remote_build(
+        controller,
+        lookup_error=CommandError(ErrorCode.PRECONDITION_FAILED, "session not connected"),
+    )
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
@@ -472,4 +477,47 @@ async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
 
     assert job.status == JobStatus.CANCELLED
     assert job.job_id not in controller._cancel_requested
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_cancel_beats_receiver_completed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    User cancel + receiver-completed race finalises as CANCELLED.
+
+    If a Stop click is registered (``_cancel_requested`` flips)
+    while the receiver is mid-build, the runner sends a wire
+    ``cancel_job`` — but the receiver may have already finished
+    and emit ``completed`` before the cancel lands. The local
+    contract (matching the local subprocess path) is that user
+    intent wins: the job is CANCELLED, not COMPLETED. Without
+    this branch the user would click Stop and still see a
+    successful install offered for the receiver's bytes — but
+    they explicitly asked to abort.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    # Register the cancel, then fire ``completed`` (instead of
+    # ``cancelled``) — the receiver finished before our cancel
+    # frame could arrive on its side.
+    controller._cancel_requested.add(job.job_id)
+    await asyncio.sleep(0.6)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert captured[EventType.JOB_COMPLETED] == []
     assert len(captured[EventType.JOB_CANCELLED]) == 1

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -268,14 +268,16 @@ async def _wait_for_wire_cancel(client: Any, *, timeout: float = 1.0) -> None:
     """
     Yield until the runner has translated a local cancel into a wire ``cancel_job``.
 
-    The runner's cancel handling is a 0.5s-cadence poll loop
-    (``await asyncio.wait(waiters, timeout=0.5)``), so the
-    wake-up latency between ``_cancel_requested.add(...)`` and
-    the ``cancel_job`` wire send is bounded by half a second.
-    Polling on :attr:`AsyncMock.await_count` with a 50 ms
-    granularity returns the instant the runner makes the
-    call, rather than always paying the full 0.6s of a
-    hard-coded sleep.
+    The runner parks on
+    ``asyncio.wait({terminal, session_lost, cancel_wait},
+    return_when=FIRST_COMPLETED)`` — fully event-driven, no
+    poll cadence — so as soon as
+    ``FirmwareController.cancel`` (or the test's
+    ``_request_remote_cancel`` mirror) signals the cancel
+    event, the runner wakes and dispatches
+    ``client.cancel_job``. Polling on
+    :attr:`AsyncMock.await_count` with a 50 ms granularity
+    returns the instant that wire send lands.
 
     Raises :class:`AssertionError` on timeout for the same
     reason :func:`_wait_until_dispatched` does — a regression

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1056,6 +1056,62 @@ async def test_remote_compile_ignores_session_closed_for_other_pin(
 
 
 @pytest.mark.asyncio
+async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    A cancel landed before the runner registered its event still fires the wire cancel.
+
+    The race the event-driven design opened up: between
+    ``_execute_job`` setting ``_current_job = job`` and the
+    runner registering its ``cancel_event`` on the
+    controller, the WS cancel handler may run. It would
+    happily ``_cancel_requested.add(job_id)`` and then find
+    no event in ``_cancel_events`` (the runner hasn't
+    arrived yet) — so the ``set()`` is skipped and the
+    runner parks on a future that will never wake. Without
+    the late-bind replay at registration time, the runner
+    hangs until either the receiver completes or the
+    peer-link heartbeat surfaces ``session_lost``.
+
+    The fix: at registration, the runner checks
+    ``_cancel_requested`` and self-fires the event if the
+    cancel already arrived. This test pins that path by
+    flipping ``_cancel_requested`` before the runner
+    starts, then asserting the runner still translates the
+    cancel onto the wire (instead of hanging on its newly-
+    created event).
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    job = _make_remote_job()
+
+    # Cancel landed BEFORE the runner registers its event —
+    # ``_cancel_requested`` carries the flag, but no entry
+    # exists in ``_cancel_events`` yet (the runner hasn't
+    # been called).
+    controller._cancel_requested.add(job.job_id)
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    # The runner's bundle build + submit will still complete
+    # (the cancel-aware ``_fail_locally`` short-circuit only
+    # kicks in when one of those branches raises). The
+    # registration's self-fire is what keeps the happy
+    # dispatch path from hanging on the cancel event.
+    await _wait_for_wire_cancel(client)
+    client.cancel_job.assert_awaited_once_with(job_id=job.job_id)
+
+    _fire_state(controller, job_id=job.job_id, status="cancelled")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
 async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -22,7 +22,6 @@ separate test that asserts the runner ignores it.
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -235,7 +234,6 @@ def _fire_session_closed(
 @pytest.mark.asyncio
 async def test_remote_compile_translates_output_and_completes(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """Receiver fan-out events translate into local ``JOB_*`` fires.
@@ -252,7 +250,6 @@ async def test_remote_compile_translates_output_and_completes(
     captured = _capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -286,7 +283,6 @@ async def test_remote_compile_translates_output_and_completes(
 @pytest.mark.asyncio
 async def test_remote_compile_progress_translates_to_local_progress_event(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """A wire output line carrying a percentage fires a local ``JOB_PROGRESS``.
@@ -302,7 +298,6 @@ async def test_remote_compile_progress_translates_to_local_progress_event(
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     _wire_remote_build(controller)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -326,7 +321,6 @@ async def test_remote_compile_progress_translates_to_local_progress_event(
 @pytest.mark.asyncio
 async def test_remote_compile_ignores_events_for_other_jobs(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """A wire frame for a different ``job_id`` doesn't leak into this runner.
@@ -340,7 +334,6 @@ async def test_remote_compile_ignores_events_for_other_jobs(
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     _wire_remote_build(controller)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job(job_id="ours")
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -370,14 +363,12 @@ async def test_remote_compile_ignores_events_for_other_jobs(
 @pytest.mark.asyncio
 async def test_remote_compile_failed_status_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """A receiver ``failed`` terminal lands as local ``JOB_FAILED`` with the error text."""
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     _wire_remote_build(controller)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -399,7 +390,6 @@ async def test_remote_compile_failed_status_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_rejected_ack_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """``submit_job`` rejection (``accepted=False``) finalises locally with the reason."""
@@ -407,7 +397,6 @@ async def test_remote_compile_rejected_ack_fires_job_failed(
     captured = _capture_local_events(controller)
     client = _make_client(accepted=False, reason="receiver queue full")
     _wire_remote_build(controller, client=client)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     await remote_runner.run_remote_compile_job(controller, job)
@@ -420,7 +409,6 @@ async def test_remote_compile_rejected_ack_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_receiver_unreachable_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """A missing peer-link client finalises the job as FAILED with the lookup error."""
@@ -430,7 +418,6 @@ async def test_remote_compile_receiver_unreachable_fires_job_failed(
         controller,
         lookup_error=CommandError(ErrorCode.PRECONDITION_FAILED, "session not connected"),
     )
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     await remote_runner.run_remote_compile_job(controller, job)
@@ -443,7 +430,6 @@ async def test_remote_compile_receiver_unreachable_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_non_compile_job_type_fails_locally(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """REMOTE with a non-COMPILE ``job_type`` is rejected at the runner's top.
@@ -478,7 +464,6 @@ async def test_remote_compile_non_compile_job_type_fails_locally(
 @pytest.mark.asyncio
 async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """Adding the job to ``_cancel_requested`` triggers a wire ``cancel_job`` send.
@@ -494,7 +479,6 @@ async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
     captured = _capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -517,7 +501,6 @@ async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
 @pytest.mark.asyncio
 async def test_remote_compile_cancel_beats_receiver_completed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """
@@ -537,7 +520,6 @@ async def test_remote_compile_cancel_beats_receiver_completed(
     captured = _capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -560,7 +542,6 @@ async def test_remote_compile_cancel_beats_receiver_completed(
 @pytest.mark.asyncio
 async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """
@@ -576,7 +557,6 @@ async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     _wire_remote_build(controller)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -593,7 +573,6 @@ async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
 @pytest.mark.asyncio
 async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
@@ -635,7 +614,6 @@ async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
 @pytest.mark.asyncio
 async def test_remote_compile_bundle_file_missing_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``FileNotFoundError`` from the bundle subprocess surfaces in ``job.error``."""
@@ -657,7 +635,6 @@ async def test_remote_compile_bundle_file_missing_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_bundle_build_error_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``BundleBuildError.output`` surfaces in ``job.error`` for the user."""
@@ -685,7 +662,6 @@ async def test_remote_compile_bundle_build_error_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_missing_source_pin_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """A REMOTE job with empty ``source_pin_sha256`` fails before any wire work."""
@@ -710,7 +686,6 @@ async def test_remote_compile_missing_source_pin_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_no_remote_build_controller_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """A REMOTE job dispatched before the remote-build controller is initialised fails cleanly."""
@@ -720,7 +695,6 @@ async def test_remote_compile_no_remote_build_controller_fires_job_failed(
     # ``DeviceBuilder.__init__`` but ``None`` is the typed
     # default the runner has to handle.
     controller._db.remote_build = None
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     await remote_runner.run_remote_compile_job(controller, job)
@@ -733,7 +707,6 @@ async def test_remote_compile_no_remote_build_controller_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_submit_no_session_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """``submit_job`` raising :class:`PeerLinkNoSessionError` surfaces in ``job.error``."""
@@ -741,7 +714,6 @@ async def test_remote_compile_submit_no_session_fires_job_failed(
     captured = _capture_local_events(controller)
     client = _make_client(submit_error=PeerLinkNoSessionError("session not open"))
     _wire_remote_build(controller, client=client)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     await remote_runner.run_remote_compile_job(controller, job)
@@ -759,7 +731,6 @@ async def test_remote_compile_submit_no_session_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """
@@ -775,7 +746,6 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     captured = _capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -801,7 +771,6 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
 @pytest.mark.asyncio
 async def test_remote_compile_cancel_translation_handles_missing_session(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """
@@ -824,7 +793,6 @@ async def test_remote_compile_cancel_translation_handles_missing_session(
         CommandError(ErrorCode.PRECONDITION_FAILED, "session not connected (mid-reconnect)"),
     ]
     controller._db.remote_build = remote_build
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -841,7 +809,6 @@ async def test_remote_compile_cancel_translation_handles_missing_session(
 @pytest.mark.asyncio
 async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """``cancel_job`` raising ``PeerLinkNoSessionError`` finalises CANCELLED locally."""
@@ -849,7 +816,6 @@ async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
     captured = _capture_local_events(controller)
     client = _make_client(cancel_error=PeerLinkNoSessionError("session gone"))
     _wire_remote_build(controller, client=client)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -870,7 +836,6 @@ async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
 @pytest.mark.asyncio
 async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """
@@ -885,7 +850,6 @@ async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     _wire_remote_build(controller)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
@@ -908,7 +872,6 @@ async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
 @pytest.mark.asyncio
 async def test_execute_job_routes_remote_source_through_remote_runner(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """
@@ -928,7 +891,6 @@ async def test_execute_job_routes_remote_source_through_remote_runner(
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     _wire_remote_build(controller)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job()
 
     runner = asyncio.create_task(controller._execute_job(job))
@@ -949,7 +911,6 @@ async def test_execute_job_routes_remote_source_through_remote_runner(
 @pytest.mark.asyncio
 async def test_submit_job_ack_echoes_caller_job_id(
     firmware_controller_factory: FirmwareControllerFactory,
-    tmp_path: Path,
     patch_bundle: AsyncMock,
 ) -> None:
     """
@@ -968,7 +929,6 @@ async def test_submit_job_ack_echoes_caller_job_id(
     _capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
     job = _make_remote_job(job_id="unique-echo-1234")
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -29,7 +29,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import remote_runner
+from esphome_device_builder.controllers.remote_build.peer_link_client import (
+    PeerLinkNoSessionError,
+)
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.config_bundle import BundleBuildError
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import (
     ErrorCode,
@@ -86,10 +90,14 @@ def _make_client(
     reason: str | None = None,
     submit_error: Exception | None = None,
     cancel_return: bool = True,
+    cancel_error: Exception | None = None,
 ) -> Any:
     """Build a stub :class:`PeerLinkClient` mock.
 
-    Default shape: ``submit_job`` resolves to an ``accepted`` ack;
+    Default shape: ``submit_job`` resolves to an ``accepted`` ack
+    whose ``job_id`` echoes the caller's id (matches the real
+    :class:`PeerLinkClient` contract — the receiver fans the
+    same id back on the ack so the offloader can correlate);
     ``cancel_job`` resolves to ``True``. Overrides let a test
     swap either side independently — the runner's failure
     branches each lean on a different one of these.
@@ -98,11 +106,18 @@ def _make_client(
     if submit_error is not None:
         client.submit_job = AsyncMock(side_effect=submit_error)
     else:
-        ack: dict[str, Any] = {"job_id": "remote-1", "accepted": accepted}
-        if reason is not None:
-            ack["reason"] = reason
-        client.submit_job = AsyncMock(return_value=ack)
-    client.cancel_job = AsyncMock(return_value=cancel_return)
+
+        async def _echo_ack(**kwargs: Any) -> dict[str, Any]:
+            ack: dict[str, Any] = {"job_id": kwargs["job_id"], "accepted": accepted}
+            if reason is not None:
+                ack["reason"] = reason
+            return ack
+
+        client.submit_job = AsyncMock(side_effect=_echo_ack)
+    if cancel_error is not None:
+        client.cancel_job = AsyncMock(side_effect=cancel_error)
+    else:
+        client.cancel_job = AsyncMock(return_value=cancel_return)
     return client
 
 
@@ -189,6 +204,25 @@ def _fire_output(
             "job_id": job_id,
             "stream": stream,
             "line": line,
+        },
+    )
+
+
+def _fire_session_closed(
+    controller: Any,
+    *,
+    pin: str = _PIN,
+    reason: str = "transport_error",
+    error_detail: str = "",
+) -> None:
+    controller._db.bus.fire(
+        EventType.OFFLOADER_PEER_LINK_CLOSED,
+        {
+            "receiver_hostname": "rx",
+            "receiver_port": 6053,
+            "pin_sha256": pin,
+            "reason": reason,
+            "error_detail": error_detail,
         },
     )
 
@@ -521,3 +555,427 @@ async def test_remote_compile_cancel_beats_receiver_completed(
     assert job.status == JobStatus.CANCELLED
     assert captured[EventType.JOB_COMPLETED] == []
     assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    A receiver-reported ``cancelled`` without a local cancel still lands as CANCELLED.
+
+    Distinct from the user-Stop path: an operator using the
+    receiver-side admin UI can cancel an in-flight job on
+    their end. The fan-out fires ``cancelled`` to us with no
+    corresponding entry in ``_cancel_requested``; the runner
+    must still finalise the job through ``_finalize_cancelled``
+    rather than misroute it as ``FAILED``.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+    _fire_state(controller, job_id=job.job_id, status="cancelled")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert captured[EventType.JOB_FAILED] == []
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A Stop click while ``build_yaml_bundle`` runs lands CANCELLED, not FAILED.
+
+    Mirrors the local subprocess path's "cancel intent wins"
+    contract: if the user explicitly aborted before the dispatch
+    even reached the peer-link, the resulting failure path must
+    not surface as a red FAILED badge. ``_fail_locally`` checks
+    ``_cancel_requested`` and routes through
+    ``_finalize_cancelled`` instead.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    job = _make_remote_job()
+
+    # Cancel was already requested by the time we get to bundle
+    # build — and the bundle build itself fails (configuration
+    # not on disk). Combined, the runner's failure path should
+    # route through the cancel-aware branch.
+    controller._cancel_requested.add(job.job_id)
+    monkeypatch.setattr(
+        remote_runner, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError)
+    )
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.CANCELLED
+    assert captured[EventType.JOB_FAILED] == []
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Bundle build failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_bundle_file_missing_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``FileNotFoundError`` from the bundle subprocess surfaces in ``job.error``."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    monkeypatch.setattr(
+        remote_runner, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError)
+    )
+    job = _make_remote_job()
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "kitchen.yaml" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_bundle_build_error_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``BundleBuildError.output`` surfaces in ``job.error`` for the user."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    bundle_error = BundleBuildError(
+        "bundle subprocess failed", output="ERROR: syntax in kitchen.yaml"
+    )
+    monkeypatch.setattr(remote_runner, "build_yaml_bundle", AsyncMock(side_effect=bundle_error))
+    job = _make_remote_job()
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "syntax in kitchen.yaml" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dispatch / pre-flight failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_missing_source_pin_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """A REMOTE job with empty ``source_pin_sha256`` fails before any wire work."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    job = FirmwareJob(
+        job_id="x",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        source=JobSource.REMOTE,
+        # source_pin_sha256 deliberately empty
+    )
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "source_pin_sha256" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_no_remote_build_controller_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """A REMOTE job dispatched before the remote-build controller is initialised fails cleanly."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    # No remote_build attached — production sets this in
+    # ``DeviceBuilder.__init__`` but ``None`` is the typed
+    # default the runner has to handle.
+    controller._db.remote_build = None
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "not initialised" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_submit_no_session_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """``submit_job`` raising :class:`PeerLinkNoSessionError` surfaces in ``job.error``."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client(submit_error=PeerLinkNoSessionError("session not open"))
+    _wire_remote_build(controller, client=client)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    await remote_runner.run_remote_compile_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "session not open" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Peer-link session loss while waiting on terminal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_session_lost_mid_build_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    A peer-link close after submit + before terminal finalises the job FAILED.
+
+    Without this branch the runner would wait on the terminal
+    future forever — the receiver is gone, no ``job_state_changed``
+    will ever land. The ``OFFLOADER_PEER_LINK_CLOSED`` listener
+    feeds a sibling future the wait loop consults so the job
+    fails fast rather than wedging the firmware queue.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    _fire_session_closed(
+        controller,
+        reason="transport_error",
+        error_detail="ConnectionResetError: [Errno 54] Connection reset by peer",
+    )
+    # Cancel poll cadence is 0.5s; allow the wake-up.
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None
+    assert "peer-link session lost" in job.error
+    assert "transport_error" in job.error
+    assert "ConnectionResetError" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_cancel_translation_handles_missing_session(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    Cancel arriving after the session dropped finalises locally without a wire send.
+
+    Stop-during-an-already-broken-link path: the second lookup
+    for ``firmware_remote_cancel`` raises ``CommandError`` (no
+    session), so the runner finalises as CANCELLED without
+    spinning waiting for a frame.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    # First lookup (for submit) succeeds; second lookup (for
+    # cancel) raises. Both flow through the same MagicMock so
+    # the side_effect list-pattern covers the sequence.
+    initial_client = _make_client()
+    remote_build = MagicMock()
+    remote_build._lookup_open_peer_link_client.side_effect = [
+        initial_client,
+        CommandError(ErrorCode.PRECONDITION_FAILED, "session not connected (mid-reconnect)"),
+    ]
+    controller._db.remote_build = remote_build
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+    controller._cancel_requested.add(job.job_id)
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert job.job_id not in controller._cancel_requested
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """``cancel_job`` raising ``PeerLinkNoSessionError`` finalises CANCELLED locally."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client(cancel_error=PeerLinkNoSessionError("session gone"))
+    _wire_remote_build(controller, client=client)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+    controller._cancel_requested.add(job.job_id)
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Runner-task shutdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    Cancelling the runner task (controller shutdown) finalises CANCELLED + re-raises.
+
+    Mirrors the local subprocess path's
+    ``asyncio.CancelledError`` branch: the cancelled coroutine
+    fires ``JOB_CANCELLED`` so subscribers see a terminal
+    event, then propagates the cancellation so the firmware
+    queue runner can unwind.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    runner.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await runner
+
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Branch wiring inside ``FirmwareController._execute_job``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_job_routes_remote_source_through_remote_runner(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    ``_execute_job`` early-returns to ``_execute_remote_job`` for REMOTE source.
+
+    Pins the controller-level wiring rather than the runner
+    itself: a future refactor that drops the
+    ``if job.source is JobSource.REMOTE`` guard would silently
+    push REMOTE jobs through the local subprocess pipeline,
+    where they'd try to ``esphome compile`` a configuration
+    that may not even be on disk in the offloader's
+    ``config_dir``. Going through ``_execute_job`` (rather
+    than calling ``run_remote_compile_job`` directly) covers
+    that branch + the ``_execute_remote_job`` delegator
+    method.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(controller._execute_job(job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.COMPLETED
+    assert len(captured[EventType.JOB_COMPLETED]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Wire ack ``job_id`` echo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_job_ack_echoes_caller_job_id(
+    firmware_controller_factory: FirmwareControllerFactory,
+    tmp_path: Path,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    Stub ``submit_job`` ack echoes the caller's ``job_id``.
+
+    Pins the fixture's :func:`_make_client` behaviour against
+    the real :class:`PeerLinkClient` contract — the receiver
+    correlates by echoing the offloader's id on the ack, and a
+    fixture that hard-coded the value (instead of echoing)
+    would silently diverge from production. If a future runner
+    change adds an ``assert ack["job_id"] == job.job_id``, this
+    test catches the stub drift instead of the divergence
+    showing up as an unrelated runner-test failure.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n")
+    job = _make_remote_job(job_id="unique-echo-1234")
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    ack_call = client.submit_job.await_args
+    assert ack_call.kwargs["job_id"] == "unique-echo-1234"

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -939,3 +939,95 @@ async def test_submit_job_ack_echoes_caller_job_id(
 
     ack_call = client.submit_job.await_args
     assert ack_call.kwargs["job_id"] == "unique-echo-1234"
+
+
+# ---------------------------------------------------------------------------
+# Defensive filter coverage — stray cross-pin / teardown races
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_ignores_session_closed_for_other_pin(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    A ``OFFLOADER_PEER_LINK_CLOSED`` for an unrelated peer doesn't kill our job.
+
+    The peer-link-closed listener is shared across every
+    in-flight remote job on the bus. A close for a different
+    receiver's session must not finalise this job — only the
+    receiver matching ``job.source_pin_sha256`` should
+    trigger the lost-session failure path. Without the pin
+    filter, two paired offloaders building concurrently would
+    take each other's jobs down on every reconnect.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+    # Different pin — the listener must filter this out.
+    _fire_session_closed(controller, pin="b" * 64, reason="transport_error")
+    await asyncio.sleep(0)
+    assert not runner.done()
+    assert captured[EventType.JOB_FAILED] == []
+
+    # Now the real terminal lands and the runner finishes
+    # cleanly — proving the stray close didn't poison the
+    # wait loop.
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+    assert job.status == JobStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_cancel_after_remote_build_torn_down_finalises_locally(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    Cancel after ``_db.remote_build`` reset to ``None`` finalises CANCELLED locally.
+
+    Teardown race: ``DeviceBuilder`` clears its
+    ``remote_build`` controller during shutdown, but a
+    remote-runner task may still be parked on
+    ``_await_terminal`` for an unfinished job. If the user
+    (or shutdown logic) then flips ``_cancel_requested``,
+    the runner must not call into ``None._lookup_open_peer_link_client``.
+    The defensive ``remote_build is None`` branch short-
+    circuits to ``_finalize_cancelled`` so subscribers see a
+    clean CANCELLED event.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    remote_build = _wire_remote_build(controller)
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    # Wait until the runner is past ``submit_job`` and parked
+    # in the terminal wait. Polling for ``cancel_job`` would
+    # be wrong here (cancel hasn't fired yet); instead pin on
+    # the runner having called the initial lookup, which is
+    # the last sync event before ``_await_terminal`` parks.
+    while remote_build._lookup_open_peer_link_client.call_count == 0:
+        await asyncio.sleep(0)
+    # Couple more turns to let the submit ack resolve and the
+    # ``asyncio.wait`` get scheduled.
+    for _ in range(2):
+        await asyncio.sleep(0)
+
+    # Simulate the receiver-controller teardown race: clear
+    # ``remote_build`` mid-flight, then register the cancel.
+    controller._db.remote_build = None
+    controller._cancel_requested.add(job.job_id)
+
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+    assert job.job_id not in controller._cancel_requested

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1056,6 +1056,58 @@ async def test_remote_compile_ignores_session_closed_for_other_pin(
 
 
 @pytest.mark.asyncio
+async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """
+    The ``firmware/cancel`` WS handler signals the runner's cancel event.
+
+    Pins the wiring on the controller side: the cancel
+    handler must look up
+    ``self._cancel_events[job_id]`` and call ``set()`` so a
+    runner parked on
+    ``asyncio.wait({..., cancel_wait})`` wakes immediately.
+    Without that signal the runner would deadlock until the
+    receiver pushed a terminal frame (or, before the
+    event-driven refactor, until the next 0.5 s poll tick).
+    Drives through ``controller.cancel(job_id=...)`` —
+    rather than the ``_request_remote_cancel`` test helper —
+    so the regression test is honest about the production
+    code path.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    job = _make_remote_job()
+
+    # The WS cancel handler refuses non-existent jobs and the
+    # ``_current_job`` mismatch is a hard error — wire both so
+    # the handler's ``RUNNING`` branch runs.
+    controller._jobs[job.job_id] = job
+    job.status = JobStatus.RUNNING
+    controller._current_job = job
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    await _wait_until_dispatched(client)
+
+    # Drive through the real handler — the cancel-event
+    # signal is its only job for the REMOTE path (the
+    # ``_terminate_current_process`` call is a no-op because
+    # ``_current_process`` is None).
+    await controller.cancel(job_id=job.job_id)
+    await _wait_for_wire_cancel(client)
+    client.cancel_job.assert_awaited_once_with(job_id=job.job_id)
+
+    _fire_state(controller, job_id=job.job_id, status="cancelled")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
 async def test_remote_compile_cancel_after_remote_build_torn_down_finalises_locally(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -66,21 +66,26 @@ def _wire_remote_build(
     *,
     client: Any | None = None,
     lookup_error: Exception | None = None,
-) -> Any:
+) -> tuple[Any, Any]:
     """Attach a stub ``_db.remote_build`` with a configurable lookup.
 
-    Returns the stub remote-build object so the test can assert on
-    its mock attributes. Either *client* is returned by every
-    lookup call, or *lookup_error* is raised — the runner's
-    receiver-unreachable branch consumes the latter.
+    Returns ``(remote_build, client)`` so the caller can both
+    assert on the remote-build mock and reference the client
+    for runner-state sync (``_wait_until_dispatched`` /
+    ``_wait_for_wire_cancel`` poll on the client's mock
+    counters). When *lookup_error* is passed the returned
+    client is ``None`` — there's nothing to dispatch to and
+    no submit-side sync to wait for.
     """
     remote_build = MagicMock()
     if lookup_error is not None:
         remote_build._lookup_open_peer_link_client.side_effect = lookup_error
-    else:
-        remote_build._lookup_open_peer_link_client.return_value = client or _make_client()
+        controller._db.remote_build = remote_build
+        return remote_build, None
+    client = client or _make_client()
+    remote_build._lookup_open_peer_link_client.return_value = client
     controller._db.remote_build = remote_build
-    return remote_build
+    return remote_build, client
 
 
 def _make_client(
@@ -207,6 +212,85 @@ def _fire_output(
     )
 
 
+def _request_remote_cancel(controller: Any, job: FirmwareJob) -> None:
+    """
+    Drive the cancel from a test the way ``FirmwareController.cancel`` does.
+
+    The runner used to poll ``_cancel_requested`` every 0.5s
+    so a test that flipped the set on its own would wake the
+    runner inside one poll iteration. The event-driven shape
+    means the runner parks on ``cancel_event`` instead — so a
+    bare ``_cancel_requested.add`` is no longer enough. Tests
+    use this helper to flip both, mirroring the production
+    cancel handler at :meth:`FirmwareController.cancel`. Going
+    through the helper (rather than calling ``controller.cancel``
+    directly) keeps the test focused on the runner under test
+    without bringing in the cancel handler's QUEUED-job and
+    ``_terminate_current_process`` branches that don't apply
+    on the remote path.
+    """
+    controller._cancel_requested.add(job.job_id)
+    event = controller._cancel_events.get(job.job_id)
+    if event is not None:
+        event.set()
+
+
+async def _wait_until_dispatched(client: Any, *, timeout: float = 1.0) -> None:
+    """
+    Yield until the runner has finished its dispatch phase.
+
+    Polls on :attr:`AsyncMock.await_count` for ``submit_job``
+    — the count increments only after the mock's awaited
+    coroutine has resolved, so this returns the instant the
+    runner moves past ``await client.submit_job(...)`` and
+    into ``_await_terminal``'s wait loop. Replaces fixed
+    ``for _ in range(N): await asyncio.sleep(0)`` constructs
+    that broke when residual coroutines from a prior test
+    left the loop in a different state than the runner
+    expected (the park-point depends on how many awaits the
+    runner has yielded through, and the number drifts across
+    refactors).
+
+    Raises :class:`AssertionError` on timeout so a runner
+    regression that never reaches the submit shows up as a
+    clear test failure rather than a hung pytest run.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while client.submit_job.await_count == 0:
+        if loop.time() >= deadline:
+            msg = f"submit_job not awaited within {timeout}s"
+            raise AssertionError(msg)
+        await asyncio.sleep(0)
+
+
+async def _wait_for_wire_cancel(client: Any, *, timeout: float = 1.0) -> None:
+    """
+    Yield until the runner has translated a local cancel into a wire ``cancel_job``.
+
+    The runner's cancel handling is a 0.5s-cadence poll loop
+    (``await asyncio.wait(waiters, timeout=0.5)``), so the
+    wake-up latency between ``_cancel_requested.add(...)`` and
+    the ``cancel_job`` wire send is bounded by half a second.
+    Polling on :attr:`AsyncMock.await_count` with a 50 ms
+    granularity returns the instant the runner makes the
+    call, rather than always paying the full 0.6s of a
+    hard-coded sleep.
+
+    Raises :class:`AssertionError` on timeout for the same
+    reason :func:`_wait_until_dispatched` does — a regression
+    that never sends the wire cancel should be a clean fail,
+    not a hang.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while client.cancel_job.await_count == 0:
+        if loop.time() >= deadline:
+            msg = f"cancel_job not awaited within {timeout}s"
+            raise AssertionError(msg)
+        await asyncio.sleep(0.05)
+
+
 def _fire_session_closed(
     controller: Any,
     *,
@@ -256,8 +340,7 @@ async def test_remote_compile_translates_output_and_completes(
     # Yield until the runner is parked waiting on the terminal future.
     # Two ticks: one to let the bundle build await resolve, one to let
     # the submit_job await resolve, then we can fire wire events.
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
     _fire_output(controller, job_id=job.job_id, line="Reading configuration\n")
     _fire_output(controller, job_id=job.job_id, line="Compile finished\n")
@@ -297,12 +380,11 @@ async def test_remote_compile_progress_translates_to_local_progress_event(
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    _wire_remote_build(controller)
+    _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
     _fire_output(controller, job_id=job.job_id, line="[ 47%] Compiling .pio/build/foo.o\n")
     _fire_state(controller, job_id=job.job_id, status="completed")
@@ -333,12 +415,11 @@ async def test_remote_compile_ignores_events_for_other_jobs(
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    _wire_remote_build(controller)
+    _, client = _wire_remote_build(controller)
     job = _make_remote_job(job_id="ours")
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
     # Stray traffic from a sibling job — must not appear in our captures
     # and must not terminate our runner.
@@ -368,12 +449,11 @@ async def test_remote_compile_failed_status_fires_job_failed(
     """A receiver ``failed`` terminal lands as local ``JOB_FAILED`` with the error text."""
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    _wire_remote_build(controller)
+    _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
     _fire_state(
         controller,
         job_id=job.job_id,
@@ -482,12 +562,11 @@ async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
-    controller._cancel_requested.add(job.job_id)
+    _request_remote_cancel(controller, job)
     # The poll cadence is 0.5s; wait at most one tick + headroom.
-    await asyncio.sleep(0.6)
+    await _wait_for_wire_cancel(client)
     client.cancel_job.assert_awaited_once_with(job_id=job.job_id)
 
     _fire_state(controller, job_id=job.job_id, status="cancelled")
@@ -523,14 +602,13 @@ async def test_remote_compile_cancel_beats_receiver_completed(
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
     # Register the cancel, then fire ``completed`` (instead of
     # ``cancelled``) — the receiver finished before our cancel
     # frame could arrive on its side.
-    controller._cancel_requested.add(job.job_id)
-    await asyncio.sleep(0.6)
+    _request_remote_cancel(controller, job)
+    await _wait_for_wire_cancel(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=2.0)
 
@@ -556,12 +634,11 @@ async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    _wire_remote_build(controller)
+    _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="cancelled")
     await asyncio.wait_for(runner, timeout=2.0)
 
@@ -594,7 +671,7 @@ async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
     # build — and the bundle build itself fails (configuration
     # not on disk). Combined, the runner's failure path should
     # route through the cancel-aware branch.
-    controller._cancel_requested.add(job.job_id)
+    _request_remote_cancel(controller, job)
     monkeypatch.setattr(
         remote_runner, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError)
     )
@@ -749,8 +826,7 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
     _fire_session_closed(
         controller,
@@ -796,9 +872,8 @@ async def test_remote_compile_cancel_translation_handles_missing_session(
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
-    controller._cancel_requested.add(job.job_id)
+    await _wait_until_dispatched(initial_client)
+    _request_remote_cancel(controller, job)
     await asyncio.wait_for(runner, timeout=2.0)
 
     assert job.status == JobStatus.CANCELLED
@@ -819,9 +894,8 @@ async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
-    controller._cancel_requested.add(job.job_id)
+    await _wait_until_dispatched(client)
+    _request_remote_cancel(controller, job)
     await asyncio.wait_for(runner, timeout=2.0)
 
     assert job.status == JobStatus.CANCELLED
@@ -849,12 +923,11 @@ async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    _wire_remote_build(controller)
+    _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
     runner.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -890,12 +963,11 @@ async def test_execute_job_routes_remote_source_through_remote_runner(
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    _wire_remote_build(controller)
+    _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
     runner = asyncio.create_task(controller._execute_job(job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=2.0)
 
@@ -932,8 +1004,7 @@ async def test_submit_job_ack_echoes_caller_job_id(
     job = _make_remote_job(job_id="unique-echo-1234")
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=2.0)
 
@@ -964,12 +1035,11 @@ async def test_remote_compile_ignores_session_closed_for_other_pin(
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    _wire_remote_build(controller)
+    _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    for _ in range(4):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
     # Different pin — the listener must filter this out.
     _fire_session_closed(controller, pin="b" * 64, reason="transport_error")
@@ -1005,26 +1075,16 @@ async def test_remote_compile_cancel_after_remote_build_torn_down_finalises_loca
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
-    remote_build = _wire_remote_build(controller)
+    _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
-    # Wait until the runner is past ``submit_job`` and parked
-    # in the terminal wait. Polling for ``cancel_job`` would
-    # be wrong here (cancel hasn't fired yet); instead pin on
-    # the runner having called the initial lookup, which is
-    # the last sync event before ``_await_terminal`` parks.
-    while remote_build._lookup_open_peer_link_client.call_count == 0:
-        await asyncio.sleep(0)
-    # Couple more turns to let the submit ack resolve and the
-    # ``asyncio.wait`` get scheduled.
-    for _ in range(2):
-        await asyncio.sleep(0)
+    await _wait_until_dispatched(client)
 
     # Simulate the receiver-controller teardown race: clear
     # ``remote_build`` mid-flight, then register the cancel.
     controller._db.remote_build = None
-    controller._cancel_requested.add(job.job_id)
+    _request_remote_cancel(controller, job)
 
     await asyncio.wait_for(runner, timeout=2.0)
 

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -87,6 +87,7 @@ def _wire_real_queue(controller: FirmwareController) -> None:
     controller._current_job = None
     controller._current_process = None
     controller._cancel_requested = set()
+    controller._cancel_events = {}
 
 
 def _seed_yaml(tmp_path: Path, name: str = "kitchen.yaml") -> None:


### PR DESCRIPTION
# What does this implement/fix?

Phase 7a-2b of issue #106 (transparent install). Branches `FirmwareController._execute_job` on the `FirmwareJob.source` field added in 7a-2a (#556) so a `JobSource.REMOTE` compile job actually dispatches to a paired receiver instead of sitting RUNNING with no work happening.

## Pieces

- **`controllers/firmware/controller.py`** — adds the early branch in `_execute_job` after `JOB_STARTED` fires and persist completes, before chip-verify: `if job.source is JobSource.REMOTE: await self._execute_remote_job(job); return`. Outer `finally` still runs the shared `_current_job = None` / `_persist_jobs()` cleanup so the local + remote paths share lifecycle bookkeeping.
- **`controllers/firmware/remote_runner.py`** (new) — `run_remote_compile_job`:
  - Builds the YAML bundle via the existing `helpers.config_bundle.build_yaml_bundle` (the same `esphome bundle` subprocess wrapper `remote_build/submit_job` uses).
  - Looks up the live `PeerLinkClient` via `RemoteBuildController._lookup_open_peer_link_client(job.source_pin_sha256)`. A missing pairing / closed session / unspawned client fails the job locally with the lookup's error text.
  - Subscribes to `OFFLOADER_JOB_OUTPUT` / `OFFLOADER_JOB_STATE_CHANGED` **before** dispatching `submit_job` so an immediate `running` / `output` frame can't outrace the subscription. Listener attach + detach lives in one `with bus.listening(...)` block so every early-return failure path releases the subscriptions.
  - Filters inbound frames by both `pin_sha256` and `job_id` so stray frames from another in-flight remote job land in a different runner.
  - Dispatches `client.submit_job(job_id=job.job_id, target="compile", bundle_bytes=...)`. The receiver echoes the offloader's `job_id` back on every fan-out frame per 5c contract, so the runner's filter matches without any side-channel correlation cache.
  - Translates inbound output / state-changed events into local `JOB_OUTPUT` / `JOB_PROGRESS` / `JOB_<terminal>` fires. `follow_job` and the firmware-tasks UI consume one event stream regardless of which CPU compiled the bytes.
  - Translates a local `firmware/cancel` flip (`_cancel_requested`) into a wire `cancel_job` send; the receiver's resulting `job_state_changed{status: cancelled}` finalises the local job through the existing `_finalize_cancelled` helper. Matches the local subprocess path's contract: if the user clicked Stop, the job is CANCELLED regardless of which terminal status the receiver eventually fired.

Receiver-supplied `error_message` rides into `job.error` on `failed`; the existing frontend `error` rendering shows it without any special-case code.

## Scope

COMPILE-only this slice. UPLOAD / INSTALL land in 7a-3, which layers `download_artifacts` + the local flash step on top of the same dispatch path. A REMOTE job with a non-COMPILE `job_type` lands as FAILED with an explanatory error.

## Tests

8 new tests in `tests/controllers/firmware/test_remote_runner.py` driving the runner against a real `EventBus` with `AsyncMock` shims for the bundle build + peer-link client surfaces:

- Happy path: bundle build → submit_job accepts → output frames re-fire as `JOB_OUTPUT` → terminal `completed` fires `JOB_COMPLETED`.
- Progress translation: a wire output line matching `_PROGRESS_PATTERNS` fires a local `JOB_PROGRESS`.
- Stray-event filtering: frames for a different `job_id` don't leak in or terminate this runner.
- Receiver `failed` translates with the supplied `error_message`.
- `submit_job` rejection (`accepted=False`) finalises locally with the rejection reason.
- Receiver unreachable (lookup error) finalises locally with the lookup's error text.
- Non-COMPILE `job_type` for a REMOTE job is rejected at the runner's top.
- Local cancel flips `_cancel_requested` → runner sends `client.cancel_job(...)` → receiver's cancelled frame finalises as CANCELLED.

340 tests in the firmware suite pass; full repo run shows only the three pre-existing ESP32-H2 no-wifi YAML-generation failures on main (unrelated).

**Related issue or feature (if applicable):**

- esphome/device-builder#106 phase 7a-2b (transparent install — runner branch).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

This slice is internal-only: no new WS commands, no wire-shape changes, no new frontend-visible fields beyond `source` / `source_label` already shipped in #556. The install-dialog "Building on {receiver_label}" sub-line lands with 7a-3 when install routes through `pick_build_path`.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
