### PR TITLE
Uppercase variant when calling upstream has_native_wifi

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -370,10 +370,24 @@ def _infer_native_wifi(board: BoardCatalogEntry) -> bool:
     # ``Esp32Variant`` are ``StrEnum``) and bare-string inputs from
     # tests that mock the catalog entry without going through the
     # enum constructors.
+    #
+    # Variant is uppercased because the upstream
+    # ``esphome.components.wifi.has_native_wifi`` dispatcher
+    # compares against ``NO_WIFI_VARIANTS`` literal-equality and
+    # that list is built from ``const.VARIANT_*`` (uppercase,
+    # ``"ESP32H2"`` / ``"ESP32P4"``) — the dashboard's
+    # ``Esp32Variant`` StrEnum carries the lowercase form
+    # (``"esp32h2"``), so passing it through verbatim falsely
+    # tells the dispatcher H2 / P4 have Wi-Fi and the wizard
+    # emits ``wifi:`` / ``api:`` / ``ota:`` blocks the
+    # downstream compile then rejects. Our pre-#16300 fallback
+    # at ``_fallback_has_native_wifi`` already normalises to
+    # lowercase on both sides; the upstream path needs the
+    # symmetric uppercase normalisation here.
     return _has_native_wifi(
         platform=str(esphome_cfg.platform) if esphome_cfg.platform else "",
         board=esphome_cfg.board,
-        variant=str(esphome_cfg.variant) if esphome_cfg.variant else None,
+        variant=str(esphome_cfg.variant).upper() if esphome_cfg.variant else None,
     )
 
 

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1049,8 +1049,13 @@ def test_infer_native_wifi_routes_through_module_alias(
     assert device_yaml._infer_native_wifi(esp32_board) is False
     assert device_yaml._infer_native_wifi(rp2040_board) is False
 
+    # Variant is uppercased because the upstream
+    # ``has_native_wifi`` dispatcher compares against the
+    # uppercase ``NO_WIFI_VARIANTS`` literal. See the comment
+    # in ``_infer_native_wifi`` for the case-normalisation
+    # rationale.
     assert calls == [
-        {"platform": "esp32", "board": "", "variant": "esp32c3"},
+        {"platform": "esp32", "board": "", "variant": "ESP32C3"},
         {"platform": "rp2040", "board": "rpipicow", "variant": None},
     ]
 


### PR DESCRIPTION
# What does this implement/fix?

The upstream `esphome.components.wifi.has_native_wifi`
dispatcher landed in esphome/esphome@d143df3c49 on
2026-05-07 and immediately became the active path for the
dashboard's `_has_native_wifi` alias on dev. Upstream
compares `variant` against `NO_WIFI_VARIANTS` by literal
equality, and `NO_WIFI_VARIANTS` is built from
`const.VARIANT_*` which are uppercase (`"ESP32H2"`,
`"ESP32P4"`).

The dashboard's `Esp32Variant` StrEnum carries the
lowercase form (`"esp32h2"`); `_infer_native_wifi` was
passing `str(variant)` through verbatim. Lowercase didn't
match the uppercase entries upstream, so `has_native_wifi`
falsely returned `True` for H2 / P4 and the wizard emitted
`wifi:` / `api:` / `ota:` blocks that the downstream
compile then rejected.

Surfaces on dev as three test failures in
`tests/test_device_yaml.py`:

- `test_generate_yaml_omits_wifi_for_esp32h2_without_explicit_connectivity`
- `test_generate_yaml_omits_api_and_ota_for_no_wifi_board`
- `test_generate_yaml_no_wifi_board_emits_network_todo_comment`

Example failing CI run:
https://github.com/esphome/device-builder/actions/runs/25645010447/job/75272154972?pr=559

## Fix

Uppercase the variant at the call site so the dispatcher
sees a value that matches its lookup table. Mirrors the
symmetric lowercase normalisation our pre-#16300
`_fallback_has_native_wifi` has always done on both sides
(`variant.lower() in _ESP32_NO_WIFI_VARIANTS`, with the
set built from `.lower()`).

The test pin in
`test_infer_native_wifi_routes_through_module_alias` is
updated to expect the uppercased value the routing now
sends.

## Followup upstream

Plan to file an esphome PR teaching `has_native_wifi` to
normalise variant case itself, so future external callers
(this is the only one documented today, but the docstring
explicitly calls out the device-builder consumer) don't
have to remember the convention. Once that lands here we
can drop the local `.upper()` and the comment.

**Related issue or feature (if applicable):**

- Fixes dev-only failures introduced by
  esphome/esphome@d143df3c49 ([wifi/rp2040] Add stable
  wifi-capability helpers for device-builder).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
