### PR TITLE
De-flake async_delay_save earlier-replaces-later on Windows CI

### DIFF
--- a/tests/test_helpers_storage.py
+++ b/tests/test_helpers_storage.py
@@ -141,15 +141,24 @@ async def test_async_delay_save_extends_deadline_on_later_call(
 async def test_async_delay_save_earlier_call_replaces_handle(
     store_path: Path, store: Store[bytes]
 ) -> None:
-    """A call requesting an earlier deadline cancels the existing handle."""
+    """A call requesting an earlier deadline cancels the existing handle.
+
+    The threshold sits well below the 'later' deadline so the
+    timing distinguishes 'replaced' from 'fired the later
+    handle'. Generous slack (1.5s) covers Windows-CI's slow
+    timer granularity + executor-hop + atomic-rename latency
+    on a noisy xdist worker — the previous 0.45s threshold
+    flaked at ~0.7s elapsed on the Windows runner even when
+    the earlier handle correctly replaced the later one.
+    """
     loop = asyncio.get_running_loop()
     started = loop.time()
-    store.async_delay_save(lambda: b"later", delay=0.50)
+    store.async_delay_save(lambda: b"later", delay=3.0)
     store.async_delay_save(lambda: b"earlier", delay=0.05)
 
-    await _drain_loop_until(store_path.exists, timeout=1.0)
+    await _drain_loop_until(store_path.exists, timeout=4.0)
     elapsed = loop.time() - started
-    assert elapsed < 0.45
+    assert elapsed < 1.5, f"earlier handle did not replace later: {elapsed:.3f}s"
     assert store_path.read_bytes() == b"earlier"
 
 


### PR DESCRIPTION
# What does this implement/fix?

`tests/test_helpers_storage.py::test_async_delay_save_earlier_call_replaces_handle`
flaked on Windows CI:

```
> assert elapsed < 0.45
E assert 0.6983758000001217 < 0.45
```

The test verifies that calling `async_delay_save` with an
earlier deadline cancels the existing handle and writes at
the earlier time. It discriminates "earlier handle replaced
later" from "the later handle fired" purely by wall-clock
elapsed time: the earlier 50ms delay lands well under the
threshold, the later 500ms delay does not. Previous shape:

| Knob | Value | Margin |
|---|---|---|
| earlier delay | 0.05s | — |
| later delay | 0.50s | — |
| threshold | < 0.45s | 0.40s above earlier's expected completion |
| drain timeout | 1.0s | — |

0.40s of margin is fine on Linux but flakes on Windows CI:
asyncio's timer resolution is coarser there, the
executor-hop adds latency, and atomic-rename through
`NamedTemporaryFile`+`shutil.move` is slow. Observed 698ms
elapsed on a Windows xdist worker even when the earlier
handle correctly replaced the later one — a false-positive
failure.

## Fix

Widen the discriminator so the margin covers worst-case
Windows latency:

| Knob | Old | New |
|---|---|---|
| later delay | 0.50s | **3.0s** |
| threshold | < 0.45s | **< 1.5s** |
| drain timeout | 1.0s | **4.0s** |

1.5s of slack covers the observed flake by ~2x. The test
still completes in <1s on the success path (the earlier
handle's 50ms timer + executor finishes well before the
threshold). Only failure paths pay the wider delay.

Also added a fail-message on the timing assertion so a
future regression surfaces the actual
elapsed-vs-threshold ratio rather than just `assert X < Y`.

Docstring updated to call out the Windows-slack reasoning
so a future maintainer doesn't tighten the margin back
without knowing about the CI failure mode.

## Why not mock the loop clock

`asyncio` doesn't ship a fake-clock primitive, and rolling
one for this single test would be a much larger diff than
the flake warrants. The bumped delays add ~0s to the
success path (the earlier handle still fires at 50ms) and
~3s to a regression-failure path; net cost on a
1024-test suite is negligible.

**Related issue or feature (if applicable):**

- Flaky test surfaced on Windows worker:
  `assert 0.6983758000001217 < 0.45`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
