### PR TITLE
Set default pytest per-test timeout to 10s

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,7 +282,16 @@ jobs:
         # ``instrumentation`` — same callgrind-based runner under
         # the hood, just renamed. The action prints a deprecation
         # warning when you ask for ``instrumentation`` explicitly.
+        #
+        # ``--timeout=600`` overrides the 10s per-test default set
+        # in ``pyproject.toml``. CodSpeed's callgrind instrumentation
+        # multiplies each benchmark's wallclock by 10-50x, so a
+        # microbenchmark that runs in 50ms outside the harness can
+        # legitimately take a few minutes here. 10 minutes covers
+        # worst-case (the catalog-load benchmark, which exercises
+        # every BoardCatalogEntry's nested dataclass deserialisation)
+        # with ~5x headroom over the observed 3-5 minute floor.
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd  # v4.15.1
         with:
           mode: simulation
-          run: pytest tests/benchmarks --codspeed --no-cov
+          run: pytest tests/benchmarks --codspeed --no-cov --timeout=600

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,18 @@ asyncio_mode = "auto"
 # ``ComponentCatalog.load`` (~2s on Linux CI) per run instead of
 # paying it on every xdist worker.
 addopts = "--dist=loadgroup"
+# Default per-test timeout (pytest-timeout plugin) so a local
+# ``pytest tests/...`` invocation doesn't wedge forever when an
+# event loop deadlocks, a subprocess hangs, or an asyncio.wait_for
+# is forgotten. Slowest tests in the suite today land under 3s
+# (catalog setup + a couple of peer-link reconnect probes), so 10s
+# gives ~3x headroom against any single test legitimately running
+# slow. CI passes ``--timeout=120`` explicitly (see
+# ``.github/workflows/test.yml``) for the looser cap that covers
+# noisy runners; the CLI flag wins over this default. Override
+# locally with ``--timeout=30`` or ``--timeout=0`` when iterating
+# on a known-slow test.
+timeout = 10
 
 [build-system]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
# What does this implement/fix?

Local `pytest tests/...` invocations don't pass
`--timeout` on the CLI today, so a wedged event loop, hung
subprocess, or forgotten `asyncio.wait_for` can hang the
run indefinitely. CI catches that via `--timeout=120` on
the pytest command + `timeout-minutes: 5` on the runner,
but local devs don't get the safety net.

This came up after a recent local pytest invocation got
killed mid-run with no diagnostic — the wedged test left
no traceback because the runner sat in a deadlocked
asyncio loop with no upper bound. Setting a per-test
default in `pyproject.toml` makes the failure mode loud:
`pytest-timeout` faults the offending test with a
traceback at the deadline rather than the user having to
Ctrl-C blindly.

## Fix

Add `timeout = 10` under `[tool.pytest.ini_options]`.
Slowest test in the suite today lands under 3s (catalog
setup, a couple of peer-link reconnect probes that
simulate transport errors with 2s sleeps), so 10s gives
~3x headroom over any single test that legitimately runs
slow.

## Why 10s and not 120s like CI

CI's 120s cap exists to cover noisy runners — Windows
agents, macOS agents under load, the codspeed benchmark
suite, etc. Local devs running on their own machine want
a much tighter signal: 10s means a hang surfaces in
~10s rather than 2 minutes. CI continues to pass
`--timeout=120` explicitly; the CLI flag wins over the
ini default so CI behaviour is unchanged.

Devs iterating on a known-slow test (catalog regeneration,
benchmark probe, anything that legitimately exceeds 10s)
override locally with `--timeout=30` or `--timeout=0` to
disable.

## Verification

Full suite under the new default:

```
2933 passed, 26 skipped, 1 warning in 8.36s
```

No test exceeds the cap. Slowest test body in the run
(`test_start_seeds_pairings_dict_from_disk`'s 5s teardown)
isn't covered by `timeout = 10` anyway — pytest-timeout
applies to the function body, not setup/teardown.

**Related issue or feature (if applicable):**

- Quality-of-life follow-up after recent local pytest
  hang investigations (no specific issue).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
