### PR TITLE
Route firmware/install through pick_build_path + REMOTE upload chain (7a-3)

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -74,6 +74,28 @@ _NO_ESPHOME_MODULE_MARKER = "No module named 'esphome'"
 #     progress bar is a single coarse 0-100 indicator.
 #   * ESPHome OTA upload:            ``Uploading: [====] 100% Done...``
 #     Anchored to the ``Uploading:`` prefix.
+# Force ANSI colour through even when stdout isn't a TTY. The local
+# subprocess path and the source-routed remote runner's local upload
+# step (7a-3) share this — both spawn an ``esphome`` subprocess whose
+# output the dashboard pipes verbatim to the firmware-tasks UI, so a
+# divergence between the two would produce visually-different streams
+# for jobs subscribers can't tell apart by source. Pulling the dict
+# into a shared constant pins the parity at one source-of-truth.
+#
+# * ``PLATFORMIO_FORCE_ANSI`` covers PlatformIO's own output.
+# * ``FORCE_COLOR`` / ``CLICOLOR_FORCE`` cover everything that uses
+#   click (esphome itself, esptool, etc.).
+# * ``PYTHONUNBUFFERED`` keeps Python subprocesses flushing progress
+#   lines (especially ``\r``-terminated ones) instead of buffering
+#   them until a ``\n`` arrives.
+ESPHOME_SUBPROCESS_ENV: dict[str, str] = {
+    "PLATFORMIO_FORCE_ANSI": "true",
+    "FORCE_COLOR": "1",
+    "CLICOLOR_FORCE": "1",
+    "PYTHONUNBUFFERED": "1",
+}
+
+
 _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*\[\s*(\d{1,3})\s*%\s*\]"),
     re.compile(r"\(\s*(\d{1,3})\s*%\s*\)"),

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -54,6 +54,7 @@ from .constants import (
     _MAX_AUX_TERMINAL_JOBS,
     _MAX_PRIMARY_TERMINAL_JOBS,
     _PRIMARY_JOB_TYPES,
+    ESPHOME_SUBPROCESS_ENV,
 )
 from .helpers import (
     _find_esphome_cmd,
@@ -66,7 +67,7 @@ from .helpers import (
     _validate_port,
     _verify_esphome_importable,
 )
-from .remote_runner import run_remote_compile_job
+from .remote_runner import run_remote_job
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -944,20 +945,12 @@ class FirmwareController:
             cmd = self._build_command(job.job_type, config_path, job.port, cache_args, job.new_name)
             _LOGGER.debug("Running: %s", " ".join(cmd))
 
-            # Force ANSI color output even though stdout isn't a TTY.
-            # `PLATFORMIO_FORCE_ANSI` covers PlatformIO's own output;
-            # `FORCE_COLOR` / `CLICOLOR_FORCE` cover everything that
-            # uses click for output (esphome itself, esptool, etc.);
-            # `PYTHONUNBUFFERED` keeps Python subprocesses flushing
-            # progress lines (especially `\r`-terminated ones) instead
-            # of buffering them until a `\n` arrives.
-            env = {
-                **os.environ,
-                "PLATFORMIO_FORCE_ANSI": "true",
-                "FORCE_COLOR": "1",
-                "CLICOLOR_FORCE": "1",
-                "PYTHONUNBUFFERED": "1",
-            }
+            # Force ANSI colour through even when stdout isn't a TTY.
+            # Shared with the source-routed remote runner's local
+            # upload step (7a-3) so output streams look identical
+            # regardless of which CPU produced the bytes — see
+            # :data:`ESPHOME_SUBPROCESS_ENV` for the rationale.
+            env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
             has_error_in_output = False
             # Captured at append time because the in-flight trim can
             # elide the offending line before the post-exit handler
@@ -1128,7 +1121,7 @@ class FirmwareController:
         sequence regardless of which branch produced the
         terminal status.
         """
-        await run_remote_compile_job(self, job)
+        await run_remote_job(self, job)
 
     @asynccontextmanager
     async def _tracked_subprocess(

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -31,6 +31,7 @@ from esphome.components.libretiny.const import (
 from esphome.storage_json import StorageJSON, ext_storage_path
 
 from ...helpers.api import CommandError, api_command
+from ...helpers.build_scheduler import BuildPath, pick_build_path
 from ...helpers.event_bus import StreamControls, stream_events
 from ...helpers.process import terminate_subtree_with_grace
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
@@ -58,6 +59,7 @@ from .helpers import (
     _find_esphome_cmd,
     _ingest_output_line,
     _is_no_module_named_esphome,
+    _is_serial_port,
     _mark_job_terminal,
     _names_touched_by_job,
     _trim_job_output,
@@ -340,10 +342,31 @@ class FirmwareController:
         explicit IP / hostname for "install to a specific address"
         — the address cache is bypassed when the user names the
         target directly.
+
+        Routes through :func:`helpers.build_scheduler.pick_build_path`
+        before queuing: when a paired receiver is APPROVED +
+        peer-link-connected + idle, the resulting job carries
+        ``source=REMOTE`` + ``source_pin_sha256=<pin>`` +
+        ``source_label=<receiver_label>`` so the source-routed
+        runner (7a-2b) dispatches the compile to that receiver
+        and stages the resulting artifacts back for the local
+        flash step. Otherwise the job stays ``source=LOCAL``
+        and runs through the existing in-process subprocess
+        pipeline. Silent fallback by design — the user doesn't
+        choose a build location; the scheduler routes
+        transparently.
         """
         _validate_port(port)
         await self._validate_configuration_boundary(configuration)
-        job = self._create_job(configuration, JobType.INSTALL, port=port)
+        source, pin_sha256, label = self._resolve_install_source(configuration, port)
+        job = self._create_job(
+            configuration,
+            JobType.INSTALL,
+            port=port,
+            source=source,
+            source_pin_sha256=pin_sha256,
+            source_label=label,
+        )
         return await self._enqueue(job)
 
     @api_command("firmware/rename")
@@ -443,7 +466,15 @@ class FirmwareController:
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:
-                job = self._create_job(config, JobType.INSTALL, port=port)
+                source, pin_sha256, label = self._resolve_install_source(config, port)
+                job = self._create_job(
+                    config,
+                    JobType.INSTALL,
+                    port=port,
+                    source=source,
+                    source_pin_sha256=pin_sha256,
+                    source_label=label,
+                )
                 await self._enqueue(job)
             except CommandError as exc:
                 _LOGGER.info("Skipping %s in install_bulk: %s", config, exc.message)
@@ -1448,6 +1479,9 @@ class FirmwareController:
         new_name: str = "",
         remote_peer: str = "",
         remote_job_id: str = "",
+        source: JobSource = JobSource.LOCAL,
+        source_pin_sha256: str = "",
+        source_label: str = "",
     ) -> FirmwareJob:
         """Create a new job and add it to the in-memory map.
 
@@ -1463,6 +1497,15 @@ class FirmwareController:
         same flow; the receiver-side ``job_id`` above is
         generated independently so the two id-spaces don't
         collide.
+
+        ``source`` / ``source_pin_sha256`` / ``source_label`` are
+        the offloader-side dispatch-origin fields (7a-2a):
+        ``LOCAL`` for jobs the offloader compiles itself, ``REMOTE``
+        for jobs the offloader dispatches to a paired receiver via
+        the source-routed runner (7a-2b). ``source_pin_sha256``
+        identifies the receiver; ``source_label`` is the display
+        name. Defaults make every existing call site continue to
+        produce LOCAL jobs.
         """
         job = FirmwareJob(
             job_id=uuid4().hex[:12],
@@ -1473,9 +1516,68 @@ class FirmwareController:
             new_name=new_name,
             remote_peer=remote_peer,
             remote_job_id=remote_job_id,
+            source=source,
+            source_pin_sha256=source_pin_sha256,
+            source_label=source_label,
         )
         self._jobs[job.job_id] = job
         return job
+
+    def _resolve_install_source(self, configuration: str, port: str) -> tuple[JobSource, str, str]:
+        """
+        Pick LOCAL or REMOTE for an install of *configuration*.
+
+        Calls :func:`helpers.build_scheduler.pick_build_path` with
+        a snapshot from the remote-build controller. Returns
+        ``(source, pin_sha256, label)`` — for LOCAL decisions
+        ``pin_sha256`` and ``label`` are empty strings.
+
+        Pure sync helper so the install handlers can call it
+        without an additional executor hop; the snapshot read
+        is RAM-only and the scheduler is a pure function.
+        Returns LOCAL whenever the remote-build controller
+        hasn't been wired up — :class:`DeviceBuilder`
+        initialises ``self.remote_build`` to ``None`` in
+        ``__init__`` and only sets the controller during
+        ``start()``, so a firmware-queue restart-recovery
+        path that fires before remote-build start would
+        otherwise reach into ``None``.
+
+        Serial *port* values also force LOCAL: the runner's
+        REMOTE flash step spawns ``esphome upload --file
+        <staged_firmware.bin>`` against the staged bytes,
+        which upstream wires through to a single FlashImage
+        at offset ``0x0`` (see
+        :func:`esphome.__main__.upload_using_esptool`). That
+        single-image shape works for OTA / web-server pushes
+        (where one binary is the entire upload) but corrupts
+        an ESP32 wired flash, which needs bootloader /
+        partitions / OTA-data at their own offsets stitched
+        from ``idedata.extra.flash_images``. Until the runner
+        can stage the full multi-image set in a way the
+        non-``--file`` path resolves cleanly, serial REMOTE
+        installs stay LOCAL.
+        """
+        if _is_serial_port(port):
+            return JobSource.LOCAL, "", ""
+        remote_build = self._db.remote_build
+        if remote_build is None:
+            return JobSource.LOCAL, "", ""
+        decision = pick_build_path(remote_build.build_scheduler_snapshot())
+        if decision.path is not BuildPath.REMOTE or decision.pin_sha256 is None:
+            return JobSource.LOCAL, "", ""
+        pairing = remote_build.get_pairing(decision.pin_sha256)
+        if pairing is None:
+            # Scheduler picked a pin that's no longer paired (race
+            # against an ``unpair`` on the same loop tick); silent
+            # fallback to local. The scheduler's filters already
+            # reject non-APPROVED rows so this is a near-impossible
+            # window, but the typed return keeps the install handler
+            # from feeding an empty ``source_pin_sha256`` to the
+            # runner, which would land on the runner's missing-pin
+            # FAILED branch.
+            return JobSource.LOCAL, "", ""
+        return JobSource.REMOTE, pairing.pin_sha256, pairing.label
 
     async def _enqueue(self, job: FirmwareJob) -> FirmwareJob:
         """

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1099,19 +1099,34 @@ class FirmwareController:
         Reads ``source_pin_sha256`` off *job*, looks up the live
         :class:`PeerLinkClient` through the remote-build
         controller, bundles the YAML via the ``esphome bundle``
-        subprocess, dispatches ``submit_job``, then translates
-        receiver-side ``OFFLOADER_JOB_OUTPUT`` /
+        subprocess, dispatches ``submit_job(target="compile")``,
+        then translates receiver-side ``OFFLOADER_JOB_OUTPUT`` /
         ``OFFLOADER_JOB_STATE_CHANGED`` events into the same
         local ``JOB_OUTPUT`` / ``JOB_PROGRESS`` /
         ``JOB_<terminal>`` fires the local subprocess path emits.
         ``follow_job`` and the firmware-tasks UI consume one
         event stream regardless of which CPU compiled the bytes.
 
-        Scope is COMPILE-only — UPLOAD / INSTALL go through
-        7a-3 which adds a download-artifacts step on top to
-        pull the bytes back over peer-link before the local
-        flash phase. Anything else here lands as ``FAILED``
-        with an explanatory error.
+        Dispatches by ``job.job_type``:
+
+        * :attr:`JobType.COMPILE` — wait for the receiver's
+          terminal frame, finalise based on the wire status.
+        * :attr:`JobType.UPLOAD` / :attr:`JobType.INSTALL` —
+          same compile dispatch (per § Transparent install
+          flow's load-bearing "receiver only ever compiles"
+          policy), but on receiver-completed pull the
+          artifacts back via ``download_artifacts`` and run a
+          local ``esphome upload --file <staged>`` subprocess
+          to flash the device. The local flash step shares the
+          ``_tracked_subprocess`` plumbing the LOCAL path uses
+          so cancel SIGTERM lands on the upload chain the same
+          way.
+
+        Other job types (``CLEAN`` / ``RENAME`` /
+        ``RESET_BUILD_ENV``) are rejected at the runner's top
+        because the receiver-side ``submit_job`` contract is
+        compile-only — these don't have a corresponding wire
+        flow.
 
         Terminal states are mapped through the same helpers the
         local path uses (``_mark_job_terminal`` /

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -188,6 +188,35 @@ def _parse_progress(line: str) -> int | None:
     return None
 
 
+def _is_serial_port(port: str) -> bool:
+    """
+    Return True if *port* looks like a serial-device path.
+
+    Shared between :func:`_validate_port`'s accept rules and
+    the remote-install gate that forces serial targets to the
+    LOCAL path. ``esphome.__main__.get_port_type`` is the
+    upstream equivalent, but it lives in ``__main__`` — not a
+    stable public surface to import from. Owning our own
+    classifier keeps the dashboard pinned to its own rules
+    rather than tracking an unversioned upstream private.
+
+    Tracked at esphome/device-builder#562 — once we land an
+    upstream PR that re-exports ``get_port_type`` /
+    ``PortType`` from a non-``__main__`` module and bump the
+    esphome dependency floor past it, this helper collapses
+    to a thin re-export of the upstream call.
+
+    Adding a new serial-path marker updates both
+    :func:`_validate_port` (the WS validator) and the
+    remote-install gate together — keep them in lockstep.
+    """
+    return (
+        port.startswith("/")
+        or port.startswith("COM")
+        or any(marker in port for marker in ("ttyUSB", "ttyACM", "cu.", "tty."))
+    )
+
+
 def _validate_port(port: str) -> None:
     """Sanity-check the user-supplied ``--device`` value.
 
@@ -225,11 +254,7 @@ def _validate_port(port: str) -> None:
     if not port or port == "OTA":
         return
     # Serial paths.
-    if (
-        port.startswith("/")
-        or port.startswith("COM")
-        or any(marker in port for marker in ("ttyUSB", "ttyACM", "cu.", "tty."))
-    ):
+    if _is_serial_port(port):
         return
     # IP-shaped input must parse as a valid IP. Doing this check
     # *before* the hostname check rejects truncated / malformed

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -54,10 +55,11 @@ from ..remote_build.peer_link_client import (
     SubmitJobSessionLostError,
     SubmitJobTimeoutError,
 )
+from .constants import ESPHOME_SUBPROCESS_ENV
 from .helpers import _ingest_output_line, _mark_job_terminal
 
 if TYPE_CHECKING:
-    from ...helpers.event_bus import Event
+    from ...helpers.event_bus import Event, EventBus
     from ..remote_build.peer_link_client import PeerLinkClient
     from .controller import FirmwareController
 
@@ -72,7 +74,7 @@ _LOGGER = logging.getLogger(__name__)
 _TERMINAL_WIRE_STATUSES: frozenset[str] = frozenset({"completed", "failed", "cancelled"})
 
 
-async def run_remote_compile_job(
+async def run_remote_job(
     controller: FirmwareController,
     job: FirmwareJob,
 ) -> None:
@@ -219,7 +221,7 @@ async def _dispatch_and_drive(  # noqa: PLR0911
 ) -> None:
     """Build the bundle, submit, then wait for the receiver's terminal frame.
 
-    Split out from :func:`run_remote_compile_job` so the
+    Split out from :func:`run_remote_job` so the
     listener attach / detach lives in one ``with`` block at the
     outer call site — every early-return failure path here
     still releases the bus subscriptions.
@@ -307,7 +309,13 @@ async def _dispatch_and_drive(  # noqa: PLR0911
     # the whole job; for UPLOAD / INSTALL we still owe the
     # local flash step using the receiver's bytes.
     if job.job_type is JobType.COMPILE:
-        _finalise_compile(controller, job)
+        # Stamp ``exit_code=0`` because the remote compile
+        # didn't run a local subprocess. The legacy
+        # ``follow_job`` framing coerces ``None`` to a
+        # failure code (``1``), so a missing stamp would
+        # land a successful compile as a failure on the wire.
+        job.exit_code = 0
+        _finalize_success(controller, job)
         return
     await _fetch_and_run_local_upload(controller=controller, job=job, client=client)
 
@@ -347,7 +355,6 @@ async def _await_terminal(
     state has been finalised here.
     """
     cancel_sent = False
-    bus = controller.bus
     # ``asyncio.wait`` is invariant on its element type; the
     # heterogeneous awaitables (two TypedDict futures + one
     # Event-wait coroutine wrapped as a Task) are widened to
@@ -398,10 +405,11 @@ async def _await_terminal(
         # an empty ``error_message`` (older receiver, internal
         # bug) falls back to a generic string so subscribers
         # always see a non-empty reason.
-        job.error = data["error_message"] or "remote build failed"
-        _mark_job_terminal(job, JobStatus.FAILED)
-        failed_payload: JobLifecycleData = {"job": job}
-        bus.fire(EventType.JOB_FAILED, failed_payload)
+        _fail_locally(
+            controller,
+            job,
+            error=data["error_message"] or "remote build failed",
+        )
         return None
     # ``completed`` — the only status the caller must act on.
     # Don't finalise here; the caller owes a local flash step
@@ -478,13 +486,29 @@ async def _fetch_and_run_local_upload(
         )
         return
 
+    # Honour a cancel that arrived between the receiver's
+    # completed frame and us getting here — no point staging
+    # bytes or spawning a flash subprocess for a job the user
+    # already aborted. ``_fail_locally`` is cancel-aware and
+    # routes through ``_finalize_cancelled`` in this case.
+    if job.job_id in controller._cancel_requested:
+        controller._finalize_cancelled(job)
+        return
+
     bus = controller.bus
     loop = asyncio.get_running_loop()
     yaml_path = await loop.run_in_executor(
         None, controller._db.settings.rel_path, job.configuration
     )
 
-    with tempfile.TemporaryDirectory(prefix="esphome-remote-firmware-") as tmpdir:
+    # ``tempfile.TemporaryDirectory`` ctor calls
+    # :func:`os.mkdir` synchronously — blockbuster catches
+    # that on CI. Use :func:`tempfile.mkdtemp` via an executor
+    # and clean up by hand in the ``finally`` so the blocking
+    # syscalls (``os.mkdir`` / ``shutil.rmtree``) never run on
+    # the event loop.
+    tmpdir = await loop.run_in_executor(None, tempfile.mkdtemp, "", "esphome-remote-firmware-")
+    try:
         firmware_path = Path(tmpdir) / "firmware.bin"
         await loop.run_in_executor(None, firmware_path.write_bytes, firmware_bytes)
 
@@ -502,13 +526,7 @@ async def _fetch_and_run_local_upload(
         ]
         _LOGGER.debug("Remote upload subprocess: %s", " ".join(cmd))
 
-        env = {
-            **os.environ,
-            "PLATFORMIO_FORCE_ANSI": "true",
-            "FORCE_COLOR": "1",
-            "CLICOLOR_FORCE": "1",
-            "PYTHONUNBUFFERED": "1",
-        }
+        env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
         exit_code = await _run_upload_subprocess(
             controller=controller,
             job=job,
@@ -516,6 +534,8 @@ async def _fetch_and_run_local_upload(
             cmd=cmd,
             env=env,
         )
+    finally:
+        await loop.run_in_executor(None, shutil.rmtree, tmpdir, True)
 
     if exit_code is None:
         # ``_run_upload_subprocess`` already finalised the
@@ -523,21 +543,20 @@ async def _fetch_and_run_local_upload(
         return
 
     if exit_code == 0:
-        _mark_job_terminal(job, JobStatus.COMPLETED)
-        completed_payload: JobLifecycleData = {"job": job}
-        bus.fire(EventType.JOB_COMPLETED, completed_payload)
+        _finalize_success(controller, job)
     else:
-        job.error = f"remote build: local upload failed (exit {exit_code})"
-        _mark_job_terminal(job, JobStatus.FAILED)
-        failed_payload: JobLifecycleData = {"job": job}
-        bus.fire(EventType.JOB_FAILED, failed_payload)
+        _fail_locally(
+            controller,
+            job,
+            error=f"remote build: local upload failed (exit {exit_code})",
+        )
 
 
 async def _run_upload_subprocess(
     *,
     controller: FirmwareController,
     job: FirmwareJob,
-    bus: Any,
+    bus: EventBus,
     cmd: list[str],
     env: dict[str, str],
 ) -> int | None:
@@ -588,13 +607,24 @@ async def _run_upload_subprocess(
     return exit_code
 
 
-def _finalise_compile(controller: FirmwareController, job: FirmwareJob) -> None:
-    """Fire ``JOB_COMPLETED`` for a COMPILE job whose receiver returned success.
+def _finalize_success(controller: FirmwareController, job: FirmwareJob) -> None:
+    """Mark *job* COMPLETED and fire ``JOB_COMPLETED`` on the local bus.
 
-    Split out so :func:`_dispatch_and_drive`'s post-terminal
-    branch reads as ``COMPILE finalise vs UPLOAD/INSTALL
-    local-flash`` rather than open-coding the
-    ``_mark_job_terminal`` + ``bus.fire`` dance inline.
+    Shared between every REMOTE success path:
+
+    * The COMPILE-only branch on receiver-completed — there's
+      no subprocess that produced an exit code, so callers
+      stamp ``job.exit_code = 0`` before invoking this helper.
+    * The UPLOAD / INSTALL branch after the local
+      ``esphome upload`` subprocess returns ``0`` — the
+      subprocess wrapper already stamped ``job.exit_code``
+      with the real exit, so this helper just runs the
+      finalize + fire pair.
+
+    The legacy ``follow_job`` framing coerces a ``None``
+    ``exit_code`` to a failure code (``1``); leaving the
+    stamp on the caller forces the COMPILE path to make the
+    "remote compile produced zero exit" choice explicit.
     """
     _mark_job_terminal(job, JobStatus.COMPLETED)
     payload: JobLifecycleData = {"job": job}

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -29,10 +29,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError
 from ...helpers.config_bundle import BundleBuildError, build_yaml_bundle
+from ...helpers.subprocess import iter_lines_with_progress
 from ...models import (
     EventType,
     FirmwareJob,
@@ -43,7 +47,9 @@ from ...models import (
     OffloaderJobStateChangedData,
     OffloaderPeerLinkClosedData,
 )
+from ..remote_build.artifacts_tarball import UnpackArtifactsError, extract_firmware_bin
 from ..remote_build.peer_link_client import (
+    DownloadArtifactsError,
     PeerLinkNoSessionError,
     SubmitJobSessionLostError,
     SubmitJobTimeoutError,
@@ -52,6 +58,7 @@ from .helpers import _ingest_output_line, _mark_job_terminal
 
 if TYPE_CHECKING:
     from ...helpers.event_bus import Event
+    from ..remote_build.peer_link_client import PeerLinkClient
     from .controller import FirmwareController
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,19 +76,42 @@ async def run_remote_compile_job(
     controller: FirmwareController,
     job: FirmwareJob,
 ) -> None:
-    """Run a REMOTE-source compile job and finalise *job* on the offloader bus.
+    """
+    Run a REMOTE-source firmware job and finalise *job* on the offloader bus.
 
     Caller (``FirmwareController._execute_job``) has already
     set ``status = RUNNING`` and fired ``JOB_STARTED``; this
     function is responsible for the entire run-and-finalise
     middle and leaves the outer ``finally`` block to clear
     ``_current_job`` / persist.
+
+    Dispatches by ``job.job_type``:
+
+    * :attr:`JobType.COMPILE` — submit_job(target="compile"),
+      wait for the receiver's terminal frame, finalise based
+      on the wire status.
+    * :attr:`JobType.UPLOAD` / :attr:`JobType.INSTALL` — same
+      compile dispatch (per § Transparent install flow's
+      load-bearing "receiver only ever compiles" policy), but
+      on receiver-completed pull the artifacts back via
+      ``download_artifacts`` and run a local
+      ``esphome upload --file <staged_firmware.bin>``
+      subprocess to flash the device. INSTALL and UPLOAD
+      share this shape — the difference between the two on
+      the local subprocess path is "compile-then-upload" vs
+      "upload existing artifact", and here the receiver
+      already did the compile half.
+
+    Other job types (``CLEAN`` / ``RENAME`` / ``RESET_BUILD_ENV``)
+    are rejected at the top because the receiver-side
+    ``submit_job`` contract is compile-only and these don't
+    have a corresponding wire flow.
     """
-    if job.job_type is not JobType.COMPILE:
+    if job.job_type not in (JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL):
         _fail_locally(
             controller,
             job,
-            error=f"remote source supports only COMPILE (got {job.job_type.value})",
+            error=f"remote source supports COMPILE/UPLOAD/INSTALL only (got {job.job_type.value})",
         )
         return
 
@@ -179,7 +209,7 @@ async def run_remote_compile_job(
         controller._cancel_events.pop(job.job_id, None)
 
 
-async def _dispatch_and_drive(
+async def _dispatch_and_drive(  # noqa: PLR0911
     *,
     controller: FirmwareController,
     job: FirmwareJob,
@@ -260,13 +290,26 @@ async def _dispatch_and_drive(
         )
         return
 
-    await _await_terminal(
+    wire_status = await _await_terminal(
         controller=controller,
         job=job,
         terminal=terminal,
         session_lost=session_lost,
         cancel_event=cancel_event,
     )
+    if wire_status != "completed":
+        # ``_await_terminal`` already finalised the job (cancel
+        # / failed / session-lost / explicit-cancelled). Nothing
+        # left to do.
+        return
+
+    # Receiver compiled successfully. For COMPILE jobs that's
+    # the whole job; for UPLOAD / INSTALL we still owe the
+    # local flash step using the receiver's bytes.
+    if job.job_type is JobType.COMPILE:
+        _finalise_compile(controller, job)
+        return
+    await _fetch_and_run_local_upload(controller=controller, job=job, client=client)
 
 
 async def _await_terminal(
@@ -276,7 +319,7 @@ async def _await_terminal(
     terminal: asyncio.Future[OffloaderJobStateChangedData],
     session_lost: asyncio.Future[OffloaderPeerLinkClosedData],
     cancel_event: asyncio.Event,
-) -> None:
+) -> str | None:
     """
     Wait for the receiver's terminal state, translating local cancel to the wire.
 
@@ -292,9 +335,16 @@ async def _await_terminal(
     frame; without it the wait would deadlock on a dead
     receiver.
 
-    The runner cooperates with whichever of *terminal* /
-    *session_lost* / *cancel_event* fires first; the
-    branches below decide the final job status.
+    Returns the receiver-side wire status string (``"completed"``
+    / ``"failed"`` / ``"cancelled"``) when the receiver's frame
+    arrived AND the local side hasn't already finalised the
+    job for some other reason. Returns ``None`` when the local
+    side already wrote a terminal status (cancel, session loss,
+    failed, receiver-side cancelled) — the caller has nothing
+    left to do. Specifically: ``"completed"`` is the *only*
+    return value the caller must act on (it owes the local
+    flash step for UPLOAD / INSTALL); every other terminal
+    state has been finalised here.
     """
     cancel_sent = False
     bus = controller.bus
@@ -316,11 +366,11 @@ async def _await_terminal(
                     job,
                     error=f"remote build: peer-link session lost ({text})",
                 )
-                return
+                return None
             if cancel_event.is_set() and not cancel_sent:
                 cancel_sent = True
                 if not await _send_cancel_or_finalise(controller, job):
-                    return
+                    return None
                 # After dispatching the wire cancel we only care
                 # about ``terminal`` / ``session_lost`` — the
                 # cancel-event signal has already done its job.
@@ -338,25 +388,217 @@ async def _await_terminal(
         # intent wins, finalise as CANCELLED regardless of the
         # status we received.
         controller._finalize_cancelled(job)
-        return
+        return None
     status = data["status"]
-    if status == "completed":
-        _mark_job_terminal(job, JobStatus.COMPLETED)
-        payload: JobLifecycleData = {"job": job}
-        bus.fire(EventType.JOB_COMPLETED, payload)
-    elif status == "cancelled":
+    if status == "cancelled":
         controller._finalize_cancelled(job)
-    else:
-        # ``failed`` — the only other element in
-        # :data:`_TERMINAL_WIRE_STATUSES`. Receiver-supplied
-        # error text rides into ``job.error``; an empty
-        # ``error_message`` (older receiver, internal bug)
-        # falls back to a generic string so subscribers always
-        # see a non-empty reason.
+        return None
+    if status == "failed":
+        # Receiver-supplied error text rides into ``job.error``;
+        # an empty ``error_message`` (older receiver, internal
+        # bug) falls back to a generic string so subscribers
+        # always see a non-empty reason.
         job.error = data["error_message"] or "remote build failed"
         _mark_job_terminal(job, JobStatus.FAILED)
         failed_payload: JobLifecycleData = {"job": job}
         bus.fire(EventType.JOB_FAILED, failed_payload)
+        return None
+    # ``completed`` — the only status the caller must act on.
+    # Don't finalise here; the caller owes a local flash step
+    # for UPLOAD / INSTALL.
+    return status
+
+
+async def _fetch_and_run_local_upload(
+    *,
+    controller: FirmwareController,
+    job: FirmwareJob,
+    client: PeerLinkClient,
+) -> None:
+    """
+    Pull the receiver's compile artifacts and flash the device locally.
+
+    Called once the receiver returned ``completed`` for an
+    ``UPLOAD`` / ``INSTALL`` job. The transparent install
+    contract says the offloader owns the flash step — only
+    the *compile* hops to the receiver. So:
+
+    1. Fetch the artifact tarball via
+       :meth:`PeerLinkClient.download_artifacts`.
+    2. Extract ``firmware.bin`` to a per-run tmpdir (the
+       only piece the OTA / web_server flash paths need; the
+       multi-image set required for ESP32 wired flash isn't
+       supported in 7a-3 — serial REMOTE installs were
+       rejected at the install handler).
+    3. Spawn ``esphome upload --device <port> --file
+       <staged>`` through :meth:`FirmwareController._tracked_subprocess`
+       so the cancel handler's SIGTERM lands on the subprocess
+       if the user clicks Stop mid-upload.
+    4. Stream stdout through :func:`helpers._ingest_output_line`
+       — same per-line bookkeeping (buffer / trim / fire
+       ``JOB_OUTPUT`` + ``JOB_PROGRESS``) every local
+       subscriber already consumes.
+    5. Finalise based on exit code + cancel state, same shape
+       the local subprocess path uses.
+
+    Wire / unpack failures and a non-zero upload exit fail
+    the job locally with ``JOB_FAILED`` (or ``JOB_CANCELLED``
+    via the cancel-aware ``_fail_locally`` when the user
+    raced a Stop).
+    """
+    try:
+        packed = await client.download_artifacts(job_id=job.job_id)
+    except (
+        PeerLinkNoSessionError,
+        SubmitJobSessionLostError,
+        DownloadArtifactsError,
+    ) as exc:
+        _fail_locally(
+            controller,
+            job,
+            error=f"remote build: download_artifacts failed: {exc}",
+        )
+        return
+
+    # Extract firmware.bin from the receiver's gzipped tarball.
+    # The receiver-side packer guarantees ``firmware.bin`` is
+    # always present (see ``ArtifactsDownloadSender``); a
+    # missing entry means the wire shape drifted, so surface
+    # as a clean error rather than letting the upload step
+    # silently flash whatever was at the tmpdir path.
+    try:
+        firmware_bytes = await asyncio.get_running_loop().run_in_executor(
+            None, extract_firmware_bin, packed.tarball
+        )
+    except UnpackArtifactsError as exc:
+        _fail_locally(
+            controller,
+            job,
+            error=f"remote build: tarball: {exc}",
+        )
+        return
+
+    bus = controller.bus
+    loop = asyncio.get_running_loop()
+    yaml_path = await loop.run_in_executor(
+        None, controller._db.settings.rel_path, job.configuration
+    )
+
+    with tempfile.TemporaryDirectory(prefix="esphome-remote-firmware-") as tmpdir:
+        firmware_path = Path(tmpdir) / "firmware.bin"
+        await loop.run_in_executor(None, firmware_path.write_bytes, firmware_bytes)
+
+        cache_args = controller._build_cache_args(job)
+        cmd = [
+            *controller._esphome_cmd,
+            "--dashboard",
+            *cache_args,
+            "upload",
+            str(yaml_path),
+            "--device",
+            job.port,
+            "--file",
+            str(firmware_path),
+        ]
+        _LOGGER.debug("Remote upload subprocess: %s", " ".join(cmd))
+
+        env = {
+            **os.environ,
+            "PLATFORMIO_FORCE_ANSI": "true",
+            "FORCE_COLOR": "1",
+            "CLICOLOR_FORCE": "1",
+            "PYTHONUNBUFFERED": "1",
+        }
+        exit_code = await _run_upload_subprocess(
+            controller=controller,
+            job=job,
+            bus=bus,
+            cmd=cmd,
+            env=env,
+        )
+
+    if exit_code is None:
+        # ``_run_upload_subprocess`` already finalised the
+        # job (cancel during the subprocess run).
+        return
+
+    if exit_code == 0:
+        _mark_job_terminal(job, JobStatus.COMPLETED)
+        completed_payload: JobLifecycleData = {"job": job}
+        bus.fire(EventType.JOB_COMPLETED, completed_payload)
+    else:
+        job.error = f"remote build: local upload failed (exit {exit_code})"
+        _mark_job_terminal(job, JobStatus.FAILED)
+        failed_payload: JobLifecycleData = {"job": job}
+        bus.fire(EventType.JOB_FAILED, failed_payload)
+
+
+async def _run_upload_subprocess(
+    *,
+    controller: FirmwareController,
+    job: FirmwareJob,
+    bus: Any,
+    cmd: list[str],
+    env: dict[str, str],
+) -> int | None:
+    """
+    Spawn the local ``esphome upload`` and stream its output.
+
+    Returns the subprocess exit code, or ``None`` when the
+    runner already finalised the job locally (e.g. a Stop
+    click landed and ``_finalize_cancelled`` ran). The caller
+    treats ``None`` as "nothing more to do" and skips its own
+    terminal-status mapping.
+
+    Mirrors the local subprocess path's per-line bookkeeping
+    (``_ingest_output_line``) so the firmware-tasks UI sees
+    one event stream regardless of which CPU produced the
+    bytes. ``_tracked_subprocess`` registers the spawn with
+    ``controller._current_process`` so a concurrent
+    ``firmware/cancel`` lands SIGTERM on the upload chain
+    just like it does for the local-only path.
+    """
+    async with controller._tracked_subprocess(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        env=env,
+        # Same process-group rationale as the local subprocess
+        # path: SIGTERM has to walk the whole esphome →
+        # platformio → esptool tree.
+        start_new_session=True,
+    ) as proc:
+        # Honour a cancel that landed between the
+        # ``download_artifacts`` await and the spawn — without
+        # this check, the subprocess gets started for a job
+        # the user already aborted.
+        if job.job_id in controller._cancel_requested:
+            await controller._terminate_current_process()
+
+        assert proc.stdout is not None  # type narrowing
+        async for line in iter_lines_with_progress(proc.stdout):
+            _ingest_output_line(job, bus, line)
+
+        exit_code = await proc.wait()
+
+    if job.job_id in controller._cancel_requested:
+        controller._finalize_cancelled(job)
+        return None
+    job.exit_code = exit_code
+    return exit_code
+
+
+def _finalise_compile(controller: FirmwareController, job: FirmwareJob) -> None:
+    """Fire ``JOB_COMPLETED`` for a COMPILE job whose receiver returned success.
+
+    Split out so :func:`_dispatch_and_drive`'s post-terminal
+    branch reads as ``COMPILE finalise vs UPLOAD/INSTALL
+    local-flash`` rather than open-coding the
+    ``_mark_job_terminal`` + ``bus.fire`` dance inline.
+    """
+    _mark_job_terminal(job, JobStatus.COMPLETED)
+    payload: JobLifecycleData = {"job": job}
+    controller.bus.fire(EventType.JOB_COMPLETED, payload)
 
 
 async def _send_cancel_or_finalise(

--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -63,16 +63,12 @@ collision is structurally impossible.
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
-import tarfile
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from ...helpers.build_artifacts import load_build_artifacts
 from ...helpers.peer_link_bundle import (
     BUNDLE_CHUNK_SIZE_BYTES,
-    FIRMWARE_MAX_TOTAL_BYTES,
     chunk_bundle,
     compute_bundle_sha256,
     encode_chunk,
@@ -85,6 +81,7 @@ from ...models import (
     DownloadArtifactsFrameData,
     JobStatus,
 )
+from .artifacts_tarball import PackedArtifacts, pack_build_artifacts
 
 if TYPE_CHECKING:
     from ..firmware import FirmwareController
@@ -218,7 +215,7 @@ class ArtifactsDownloadSender:
             loop = asyncio.get_running_loop()
             try:
                 packed = await loop.run_in_executor(
-                    None, _pack_build_artifacts, firmware_job.configuration
+                    None, pack_build_artifacts, firmware_job.configuration
                 )
             except FileNotFoundError:
                 _LOGGER.debug(
@@ -269,7 +266,7 @@ class ArtifactsDownloadSender:
         await session.send_app_frame(cast(dict[str, Any], end))
 
     async def _send_stream(
-        self, session: PeerLinkSession, job_id: str, packed: _PackedArtifacts
+        self, session: PeerLinkSession, job_id: str, packed: PackedArtifacts
     ) -> None:
         """Stream *packed*'s tarball as start → chunks → end{accepted: true}.
 
@@ -311,135 +308,3 @@ class ArtifactsDownloadSender:
             "accepted": True,
         }
         await session.send_app_frame(cast(dict[str, Any], end))
-
-
-@dataclass(frozen=True)
-class _PackedArtifacts:
-    """Output of :func:`_pack_build_artifacts` — tarball bytes + start-frame fields.
-
-    ``firmware_offset`` rides alongside the tarball so the
-    sender can populate :attr:`ArtifactsStartFrameData.firmware_offset`
-    without re-running
-    :func:`helpers.build_artifacts.load_build_artifacts`.
-    Same string form ``idedata.extra.flash_images`` uses
-    (lowercase hex, ``0x`` prefix) — keeps the wire shape
-    uniform across the firmware partition and the extras.
-    """
-
-    tarball: bytes
-    firmware_offset: str
-
-
-def _pack_build_artifacts(configuration: str) -> _PackedArtifacts:
-    """Pack the build's flash artifacts for *configuration* into a gzipped tarball.
-
-    Synchronous; meant to run inside an executor. Calls
-    :func:`helpers.build_artifacts.load_build_artifacts` to
-    discover the flash-image set + idedata bytes, then
-    packs every image (flattened to its basename) + the
-    ``idedata.json`` manifest into a single gzipped tarball.
-
-    Returned tarball layout:
-
-    .. code-block:: text
-
-        idedata.json
-        firmware.bin
-        bootloader.bin       (ESP32 / native IDF only)
-        partitions.bin       (ESP32 / native IDF only)
-        ota_data_initial.bin (ESP32 / native IDF only)
-
-    Files are flattened (no subdirectory structure) because
-    the offloader-side install path only needs the bytes +
-    the offsets from ``idedata.extra.flash_images`` (plus
-    ``firmware.bin``'s offset, which the receiver puts on
-    :attr:`ArtifactsStartFrameData.firmware_offset` because
-    upstream tracks the firmware partition separately from
-    the ``extra`` block). The flash-image entries in
-    ``idedata.json`` reference each file by its absolute
-    build-dir path on the receiver; the offloader's extractor
-    rewrites those to the basenames it just unpacked.
-
-    Raises :class:`FileNotFoundError` from
-    :func:`load_build_artifacts` when the StorageJSON sidecar
-    or any required artifact is missing. Raises
-    :class:`RuntimeError` on duplicate-basename collision
-    (defensive — upstream esphome doesn't emit this shape
-    today, but we fail loudly rather than ship a silently-
-    truncated set) or when the artifact set exceeds
-    :data:`FIRMWARE_MAX_TOTAL_BYTES`. Two cap checks fire:
-    the uncompressed walking sum (cheap, lets us short-circuit
-    before reading huge files), and a final compressed-size
-    check on the rendered tarball (the offloader's
-    :class:`BundleAssembler` caps on
-    ``ArtifactsStartFrameData.total_bytes``, the wire-side
-    length, so the receiver-side ceiling needs to match).
-    Compression usually shrinks the payload, so the
-    uncompressed gate fires first in practice; the
-    post-render check exists for the incompressible-data +
-    tar-header-overhead corner where ``len(tarball)`` could
-    technically exceed the uncompressed total. The caller
-    (:meth:`ArtifactsDownloadSender.handle_download_artifacts`)
-    catches both and surfaces a structured reject reason.
-    """
-    artifacts = load_build_artifacts(configuration)
-    buf = io.BytesIO()
-    total_uncompressed = len(artifacts.idedata_bytes)
-    if total_uncompressed > FIRMWARE_MAX_TOTAL_BYTES:
-        msg = (
-            f"idedata.json for {configuration} ({total_uncompressed} bytes) "
-            f"already exceeds FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
-        )
-        raise RuntimeError(msg)
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        # ``idedata.json`` first so the offloader can peek at
-        # the manifest before chunking the binaries.
-        info = tarfile.TarInfo(name="idedata.json")
-        info.size = len(artifacts.idedata_bytes)
-        tar.addfile(info, io.BytesIO(artifacts.idedata_bytes))
-
-        seen_names: set[str] = set()
-        for image in artifacts.flash_images:
-            name = image.path.name
-            if name in seen_names:
-                msg = f"duplicate flash image basename {name!r} in idedata"
-                raise RuntimeError(msg)
-            seen_names.add(name)
-            image_bytes = image.path.read_bytes()
-            total_uncompressed += len(image_bytes)
-            if total_uncompressed > FIRMWARE_MAX_TOTAL_BYTES:
-                msg = (
-                    f"build artifacts for {configuration} would exceed "
-                    f"FIRMWARE_MAX_TOTAL_BYTES uncompressed "
-                    f"({total_uncompressed} > {FIRMWARE_MAX_TOTAL_BYTES})"
-                )
-                raise RuntimeError(msg)
-            info = tarfile.TarInfo(name=name)
-            info.size = len(image_bytes)
-            tar.addfile(info, io.BytesIO(image_bytes))
-
-    # ``flash_images[0]`` is firmware.bin (load_build_artifacts
-    # invariant) — its offset is the value the offloader needs
-    # for the start frame, since idedata.json's manifest
-    # doesn't include the firmware partition itself.
-    tarball = buf.getvalue()
-    # Final post-render cap on the wire-side length. The
-    # uncompressed-walking gate above already short-circuits
-    # the common case, but tar adds 512-byte headers per
-    # member and gzip can grow incompressible data by a few
-    # percent — for an artifact set that lands right at the
-    # limit, ``len(tarball)`` could in principle exceed the
-    # uncompressed total even though the body fits. The
-    # offloader's ``BundleAssembler`` caps on
-    # ``ArtifactsStartFrameData.total_bytes`` (the
-    # post-render length), so without this match the receiver
-    # could deterministically ship a stream the offloader
-    # rejects.
-    if len(tarball) > FIRMWARE_MAX_TOTAL_BYTES:
-        msg = (
-            f"build artifacts tarball for {configuration} would exceed "
-            f"FIRMWARE_MAX_TOTAL_BYTES on the wire "
-            f"({len(tarball)} > {FIRMWARE_MAX_TOTAL_BYTES})"
-        )
-        raise RuntimeError(msg)
-    return _PackedArtifacts(tarball=tarball, firmware_offset=artifacts.flash_images[0].offset)

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -245,24 +245,31 @@ def extract_firmware_bin(tarball_bytes: bytes) -> bytes:
     returns to a Web Serial / esptool consumer.
 
     Raises :class:`UnpackArtifactsError` on any structural
-    problem so the runner finalises with a clean error
-    message rather than a tarfile traceback.
+    problem (missing entry, non-file member, malformed
+    tarball) or when ``firmware.bin``'s declared size exceeds
+    :data:`FIRMWARE_MAX_TOTAL_BYTES`. The size gate is a
+    decompression-bomb guard: gzip can compress huge
+    zero-filled / sparse data to a tiny on-the-wire payload,
+    so reading without a header-side bound would let a hostile
+    peer expand a few-KiB tarball into multi-GiB memory.
     """
     try:
         with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
-            for member in tar:
-                if member.name == "firmware.bin":
-                    payload = tar.extractfile(member)
-                    if payload is None:
-                        msg = "firmware.bin in tarball is not a regular file"
-                        raise UnpackArtifactsError(msg)
-                    bytes_payload: bytes = payload.read()
-                    return bytes_payload
+            try:
+                member = tar.getmember("firmware.bin")
+            except KeyError as exc:
+                msg = "firmware.bin missing from receiver's tarball"
+                raise UnpackArtifactsError(msg) from exc
+            _check_member_size(member, total_so_far=0)
+            payload = tar.extractfile(member)
+            if payload is None:
+                msg = "firmware.bin in tarball is not a regular file"
+                raise UnpackArtifactsError(msg)
+            bytes_payload: bytes = payload.read()
+            return bytes_payload
     except tarfile.TarError as exc:
         msg = f"malformed tarball: {exc}"
         raise UnpackArtifactsError(msg) from exc
-    msg = "firmware.bin missing from receiver's tarball"
-    raise UnpackArtifactsError(msg)
 
 
 def read_artifacts_tarball(tarball: bytes) -> tuple[dict[str, Any], dict[str, bytes]]:
@@ -272,14 +279,21 @@ def read_artifacts_tarball(tarball: bytes) -> tuple[dict[str, Any], dict[str, by
     ``idedata`` is the parsed ``idedata.json`` object;
     ``files-by-basename`` excludes ``idedata.json``. Raises
     :class:`UnpackArtifactsError` on any structural problem
-    in the tarball.
+    in the tarball, or when the cumulative decompressed
+    payload would exceed :data:`FIRMWARE_MAX_TOTAL_BYTES`
+    (decompression-bomb guard — see
+    :func:`extract_firmware_bin` for the same rationale on the
+    per-member size check).
     """
     idedata: dict[str, Any] | None = None
     image_bytes_by_name: dict[str, bytes] = {}
+    total_bytes = 0
     try:
         with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
             for member in tar:
+                _check_member_size(member, total_so_far=total_bytes)
                 payload = _read_tarball_member(tar, member)
+                total_bytes += len(payload)
                 if member.name == "idedata.json":
                     idedata = _parse_idedata(payload)
                 else:
@@ -291,6 +305,35 @@ def read_artifacts_tarball(tarball: bytes) -> tuple[dict[str, Any], dict[str, by
         msg = "artifacts tarball missing idedata.json"
         raise UnpackArtifactsError(msg)
     return idedata, image_bytes_by_name
+
+
+def _check_member_size(member: tarfile.TarInfo, *, total_so_far: int) -> None:
+    """
+    Reject a tarball member whose decompressed size would blow the cap.
+
+    Combines a per-member check (``member.size`` exceeds the
+    cap on its own) with a cumulative check
+    (``member.size + total_so_far`` would push the running
+    total past the cap). The receiver-side packer
+    (:func:`pack_build_artifacts`) enforces the same ceiling
+    on the way out, so a well-formed tarball never trips
+    this gate; a peer-controlled / malformed stream that
+    declares a multi-GiB member in the tar header bails
+    here before :meth:`tarfile.TarFile.extractfile` reads
+    a single byte.
+    """
+    if member.size > FIRMWARE_MAX_TOTAL_BYTES:
+        msg = (
+            f"tarball member {member.name!r} declares size {member.size} "
+            f"exceeding FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
+        )
+        raise UnpackArtifactsError(msg)
+    if total_so_far + member.size > FIRMWARE_MAX_TOTAL_BYTES:
+        msg = (
+            f"tarball cumulative size {total_so_far + member.size} "
+            f"exceeds FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
+        )
+        raise UnpackArtifactsError(msg)
 
 
 def _read_tarball_member(tar: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -260,11 +260,26 @@ def extract_firmware_bin(tarball_bytes: bytes) -> bytes:
             except KeyError as exc:
                 msg = "firmware.bin missing from receiver's tarball"
                 raise UnpackArtifactsError(msg) from exc
-            _check_member_size(member, total_so_far=0)
-            payload = tar.extractfile(member)
-            if payload is None:
-                msg = "firmware.bin in tarball is not a regular file"
+            # ``isfile()`` rejects symlinks / hardlinks /
+            # device nodes / FIFOs / directories — anything
+            # that isn't a plain file entry. Load-bearing
+            # against a hostile peer: ``tarfile.extractfile()``
+            # follows symlinks + hardlinks transparently and
+            # returns a readable stream for them, so reading
+            # ``firmware.bin`` without this gate would
+            # silently flash whatever the link target resolved
+            # to on the receiver's filesystem. Matches
+            # :func:`_read_tarball_member`'s gate on the
+            # general-purpose unpack path.
+            if not member.isfile():
+                msg = f"firmware.bin in tarball is not a regular file ({member.type!r})"
                 raise UnpackArtifactsError(msg)
+            _check_member_size(member, total_so_far=0)
+            # ``isfile() == True`` is the stdlib contract for
+            # ``extractfile()`` returning a readable stream;
+            # the cast is safe because we've already gated on
+            # ``isfile()`` above.
+            payload = cast(io.BufferedReader, tar.extractfile(member))
             bytes_payload: bytes = payload.read()
             return bytes_payload
     except tarfile.TarError as exc:

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -1,0 +1,418 @@
+"""
+Pack / unpack the receiver's build-artifact tarball.
+
+The remote-build feature ships compiled firmware between two
+dashboards by serialising the receiver's flash-artifact set
+(``firmware.bin`` plus the platform's auxiliary images +
+``idedata.json``) into a single gzipped tarball. This module
+owns the pack + unpack helpers — pure data transforms with no
+WS / wire-flow knowledge — so the two end-to-end surfaces that
+consume the format (the receiver-side
+:class:`ArtifactsDownloadSender` streamer and the offloader-side
+``download_artifacts`` WS unpacker / source-routed runner) call
+into one place instead of re-implementing the format twice.
+
+Tarball layout (flat — no subdirectories):
+
+.. code-block:: text
+
+    idedata.json
+    firmware.bin
+    bootloader.bin       (ESP32 / native IDF only)
+    partitions.bin       (ESP32 / native IDF only)
+    ota_data_initial.bin (ESP32 / native IDF only)
+
+The offsets for each image live inside ``idedata.json``'s
+``extra.flash_images`` array (and on the receiver-resolved
+``firmware_offset`` for ``firmware.bin`` itself, which upstream
+tracks separately from the ``extra`` block). The receiver's
+absolute build-dir paths in the manifest are rewritten to
+basenames on the offloader side — see
+:func:`_rewrite_idedata_paths`.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from ...helpers.build_artifacts import load_build_artifacts
+from ...helpers.json import loads as json_loads
+from ...helpers.peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
+
+if TYPE_CHECKING:
+    from .peer_link_client import DownloadArtifactsResult
+
+
+# ---------------------------------------------------------------------------
+# Pack (receiver side)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PackedArtifacts:
+    """Output of :func:`pack_build_artifacts` — tarball bytes + start-frame fields.
+
+    ``firmware_offset`` rides alongside the tarball so the
+    sender can populate
+    :attr:`ArtifactsStartFrameData.firmware_offset` without
+    re-running
+    :func:`helpers.build_artifacts.load_build_artifacts`.
+    Same string form ``idedata.extra.flash_images`` uses
+    (lowercase hex, ``0x`` prefix) — keeps the wire shape
+    uniform across the firmware partition and the extras.
+    """
+
+    tarball: bytes
+    firmware_offset: str
+
+
+def pack_build_artifacts(configuration: str) -> PackedArtifacts:
+    """Pack the build's flash artifacts for *configuration* into a gzipped tarball.
+
+    Synchronous; meant to run inside an executor. Calls
+    :func:`helpers.build_artifacts.load_build_artifacts` to
+    discover the flash-image set + idedata bytes, then packs
+    every image (flattened to its basename) +
+    ``idedata.json`` into a single gzipped tarball.
+
+    Tarball layout matches the module docstring; flat files
+    only. The offloader-side install path needs the bytes +
+    the offsets from ``idedata.extra.flash_images`` (plus
+    ``firmware.bin``'s offset on the start frame because
+    upstream tracks the firmware partition separately).
+
+    Raises :class:`FileNotFoundError` from
+    :func:`load_build_artifacts` when the StorageJSON sidecar
+    or any required artifact is missing. Raises
+    :class:`RuntimeError` on duplicate-basename collision
+    (defensive — upstream esphome doesn't emit this shape
+    today, but we fail loudly rather than ship a silently-
+    truncated set) or when the artifact set exceeds
+    :data:`FIRMWARE_MAX_TOTAL_BYTES`. Two cap checks fire:
+    the uncompressed walking sum (cheap, lets us short-
+    circuit before reading huge files), and a final
+    compressed-size check on the rendered tarball (the
+    offloader's :class:`BundleAssembler` caps on
+    ``ArtifactsStartFrameData.total_bytes``, the wire-side
+    length, so the receiver-side ceiling needs to match).
+    Compression usually shrinks the payload, so the
+    uncompressed gate fires first in practice; the
+    post-render check exists for the incompressible-data +
+    tar-header-overhead corner where ``len(tarball)`` could
+    technically exceed the uncompressed total. The caller
+    (:meth:`ArtifactsDownloadSender.handle_download_artifacts`)
+    catches both and surfaces a structured reject reason.
+    """
+    artifacts = load_build_artifacts(configuration)
+    buf = io.BytesIO()
+    total_uncompressed = len(artifacts.idedata_bytes)
+    if total_uncompressed > FIRMWARE_MAX_TOTAL_BYTES:
+        msg = (
+            f"idedata.json for {configuration} ({total_uncompressed} bytes) "
+            f"already exceeds FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
+        )
+        raise RuntimeError(msg)
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        # ``idedata.json`` first so the offloader can peek at
+        # the manifest before chunking the binaries.
+        info = tarfile.TarInfo(name="idedata.json")
+        info.size = len(artifacts.idedata_bytes)
+        tar.addfile(info, io.BytesIO(artifacts.idedata_bytes))
+
+        seen_names: set[str] = set()
+        for image in artifacts.flash_images:
+            name = image.path.name
+            if name in seen_names:
+                msg = f"duplicate flash image basename {name!r} in idedata"
+                raise RuntimeError(msg)
+            seen_names.add(name)
+            image_bytes = image.path.read_bytes()
+            total_uncompressed += len(image_bytes)
+            if total_uncompressed > FIRMWARE_MAX_TOTAL_BYTES:
+                msg = (
+                    f"build artifacts for {configuration} would exceed "
+                    f"FIRMWARE_MAX_TOTAL_BYTES uncompressed "
+                    f"({total_uncompressed} > {FIRMWARE_MAX_TOTAL_BYTES})"
+                )
+                raise RuntimeError(msg)
+            info = tarfile.TarInfo(name=name)
+            info.size = len(image_bytes)
+            tar.addfile(info, io.BytesIO(image_bytes))
+
+    # ``flash_images[0]`` is firmware.bin (load_build_artifacts
+    # invariant) — its offset is the value the offloader needs
+    # for the start frame, since idedata.json's manifest
+    # doesn't include the firmware partition itself.
+    tarball = buf.getvalue()
+    # Final post-render cap on the wire-side length. The
+    # uncompressed-walking gate above already short-circuits
+    # the common case, but tar adds 512-byte headers per
+    # member and gzip can grow incompressible data by a few
+    # percent — for an artifact set that lands right at the
+    # limit, ``len(tarball)`` could in principle exceed the
+    # uncompressed total even though the body fits. The
+    # offloader's ``BundleAssembler`` caps on
+    # ``ArtifactsStartFrameData.total_bytes`` (the
+    # post-render length), so without this match the receiver
+    # could deterministically ship a stream the offloader
+    # rejects.
+    if len(tarball) > FIRMWARE_MAX_TOTAL_BYTES:
+        msg = (
+            f"build artifacts tarball for {configuration} would exceed "
+            f"FIRMWARE_MAX_TOTAL_BYTES on the wire "
+            f"({len(tarball)} > {FIRMWARE_MAX_TOTAL_BYTES})"
+        )
+        raise RuntimeError(msg)
+    return PackedArtifacts(tarball=tarball, firmware_offset=artifacts.flash_images[0].offset)
+
+
+# ---------------------------------------------------------------------------
+# Unpack (offloader side)
+# ---------------------------------------------------------------------------
+
+
+class UnpackArtifactsError(RuntimeError):
+    """Raised on a malformed receiver tarball.
+
+    The receiver-side packer (:func:`pack_build_artifacts`) is
+    the only thing that should be writing this stream, so a
+    structural failure here means an in-flight bug or a
+    misbehaving peer — surfaced as ``INVALID_ARGS`` at the WS
+    layer rather than ``INTERNAL_ERROR`` so the user sees a
+    clear "the receiver sent a tarball we can't parse"
+    message rather than a generic backend-stack-trace toast.
+    """
+
+
+def unpack_artifacts_response(packed: DownloadArtifactsResult, job_id: str) -> dict[str, Any]:
+    """
+    Unpack the receiver's artifact tarball into the WS response shape.
+
+    Synchronous; meant to run in an executor (``tarfile.open``
+    + per-image ``read()`` are blocking syscalls). Reads
+    ``idedata.json`` to recover the upstream-canonical
+    flash-image manifest, then walks the tarball's remaining
+    members to build the ``images`` list. The ``firmware.bin``
+    partition's offset comes from *packed*'s
+    ``firmware_offset`` field — the receiver populated it
+    from ``StorageJSON.target_platform`` via
+    :func:`helpers.build_artifacts._firmware_offset_for_platform`.
+    The remaining offsets ride inside
+    ``idedata.extra.flash_images``. Rewrites every
+    ``extra.flash_images[].path`` from the receiver's
+    absolute build-dir paths to bare basenames (the only
+    thing the offloader's install path can resolve against
+    the in-tarball entries).
+
+    Raises :class:`UnpackArtifactsError` on:
+
+    * Missing ``idedata.json``.
+    * ``idedata.json`` not parseable as JSON, or not a dict.
+    * A flash image declared in ``idedata.extra.flash_images``
+      whose tarball member is missing.
+    * Missing ``firmware.bin`` in the tarball.
+    * A directory entry in the tarball (the receiver-side
+      packer is flat by design; a directory means the wire
+      format drifted).
+    """
+    idedata, image_bytes_by_name = read_artifacts_tarball(packed.tarball)
+    images = _build_images_response(packed.firmware_offset, idedata, image_bytes_by_name)
+    rewritten_idedata = _rewrite_idedata_paths(idedata)
+    total_bytes = sum(int(image["size"]) for image in images)
+    return {
+        "job_id": job_id,
+        "idedata": rewritten_idedata,
+        "images": images,
+        "total_bytes": total_bytes,
+    }
+
+
+def extract_firmware_bin(tarball_bytes: bytes) -> bytes:
+    """
+    Pull ``firmware.bin`` out of the receiver's gzipped tarball.
+
+    Synchronous; meant to run in an executor — the
+    :func:`tarfile.open` + member read are blocking
+    syscalls. Used by the source-routed runner's UPLOAD /
+    INSTALL branch: the runner only needs the firmware
+    image to feed into ``esphome upload --file``, not the
+    full idedata + multi-image set the WS unpacker
+    returns to a Web Serial / esptool consumer.
+
+    Raises :class:`UnpackArtifactsError` on any structural
+    problem so the runner finalises with a clean error
+    message rather than a tarfile traceback.
+    """
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
+            for member in tar:
+                if member.name == "firmware.bin":
+                    payload = tar.extractfile(member)
+                    if payload is None:
+                        msg = "firmware.bin in tarball is not a regular file"
+                        raise UnpackArtifactsError(msg)
+                    bytes_payload: bytes = payload.read()
+                    return bytes_payload
+    except tarfile.TarError as exc:
+        msg = f"malformed tarball: {exc}"
+        raise UnpackArtifactsError(msg) from exc
+    msg = "firmware.bin missing from receiver's tarball"
+    raise UnpackArtifactsError(msg)
+
+
+def read_artifacts_tarball(tarball: bytes) -> tuple[dict[str, Any], dict[str, bytes]]:
+    """
+    Read every member of *tarball* into ``(idedata, files-by-basename)``.
+
+    ``idedata`` is the parsed ``idedata.json`` object;
+    ``files-by-basename`` excludes ``idedata.json``. Raises
+    :class:`UnpackArtifactsError` on any structural problem
+    in the tarball.
+    """
+    idedata: dict[str, Any] | None = None
+    image_bytes_by_name: dict[str, bytes] = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
+            for member in tar:
+                payload = _read_tarball_member(tar, member)
+                if member.name == "idedata.json":
+                    idedata = _parse_idedata(payload)
+                else:
+                    image_bytes_by_name[member.name] = payload
+    except tarfile.TarError as exc:
+        msg = f"artifacts tarball is malformed: {exc}"
+        raise UnpackArtifactsError(msg) from exc
+    if idedata is None:
+        msg = "artifacts tarball missing idedata.json"
+        raise UnpackArtifactsError(msg)
+    return idedata, image_bytes_by_name
+
+
+def _read_tarball_member(tar: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
+    """Read *member*'s bytes.
+
+    Raises :class:`UnpackArtifactsError` on directory entries
+    or any other non-regular tarball member type. Stdlib
+    ``tarfile`` guarantees ``extractfile()`` returns a
+    readable stream iff ``isfile()`` returns ``True`` —
+    ``extractfile`` only returns ``None`` for link / device /
+    FIFO members, every one of which ``isfile()`` already
+    rejects.
+    """
+    if not member.isfile():
+        msg = f"unexpected non-file tarball entry: {member.name!r}"
+        raise UnpackArtifactsError(msg)
+    return cast(io.BufferedReader, tar.extractfile(member)).read()
+
+
+def _parse_idedata(payload: bytes) -> dict[str, Any]:
+    """Parse *payload* as ``idedata.json``; raise on non-dict / invalid JSON."""
+    try:
+        parsed = json_loads(payload)
+    except ValueError as exc:
+        msg = f"idedata.json is not valid JSON: {exc}"
+        raise UnpackArtifactsError(msg) from exc
+    if not isinstance(parsed, dict):
+        msg = "idedata.json is not a JSON object"
+        raise UnpackArtifactsError(msg)
+    return parsed
+
+
+def _build_images_response(
+    firmware_offset: str,
+    idedata: dict[str, Any],
+    image_bytes_by_name: dict[str, bytes],
+) -> list[dict[str, Any]]:
+    """
+    Pop bytes from *image_bytes_by_name* in canonical order; base64-encode.
+
+    Order is ``firmware.bin`` first, then every entry from
+    ``idedata.extra.flash_images`` in their declared order
+    (matches :attr:`BuildArtifacts.flash_images` on the
+    receiver side). Mutates *image_bytes_by_name*: every
+    image referenced by the manifest is popped; on return
+    the dict should be empty, and any leftover entry means
+    the tarball carried a file the manifest didn't account
+    for.
+    """
+    images: list[dict[str, Any]] = []
+    firmware_bytes = image_bytes_by_name.pop("firmware.bin", None)
+    if firmware_bytes is None:
+        msg = "artifacts tarball missing firmware.bin"
+        raise UnpackArtifactsError(msg)
+    images.append(_image_entry("firmware.bin", firmware_offset, firmware_bytes))
+    # Guard the chained ``.get`` — a non-dict ``extra`` field
+    # (``null`` / list / scalar) on a corrupt-but-parseable
+    # idedata would otherwise blow up on the second ``.get``
+    # with ``AttributeError`` and bypass the
+    # :class:`UnpackArtifactsError` mapping. Mirror the
+    # :func:`helpers.build_artifacts.load_build_artifacts`
+    # stance: treat non-dict as "no extras."
+    extra = idedata.get("extra")
+    extras_list = extra.get("flash_images") or [] if isinstance(extra, dict) else []
+    for entry in extras_list:
+        basename, offset = _flash_image_basename_offset(entry)
+        image_bytes = image_bytes_by_name.pop(basename, None)
+        if image_bytes is None:
+            msg = f"artifacts tarball missing flash image {basename!r}"
+            raise UnpackArtifactsError(msg)
+        images.append(_image_entry(basename, offset, image_bytes))
+    if image_bytes_by_name:
+        msg = (
+            f"artifacts tarball contains unexpected files not referenced by idedata: "
+            f"{sorted(image_bytes_by_name)}"
+        )
+        raise UnpackArtifactsError(msg)
+    return images
+
+
+def _image_entry(name: str, offset: str, payload: bytes) -> dict[str, Any]:
+    """Build one ``images`` list entry: ``{name, offset, size, data_b64}``."""
+    return {
+        "name": name,
+        "offset": offset,
+        "size": len(payload),
+        "data_b64": base64.b64encode(payload).decode("ascii"),
+    }
+
+
+def _flash_image_basename_offset(entry: object) -> tuple[str, str]:
+    """Validate one ``idedata.extra.flash_images`` entry and return ``(basename, offset)``."""
+    if not isinstance(entry, dict):
+        msg = "idedata.extra.flash_images entry is not an object"
+        raise UnpackArtifactsError(msg)
+    path_str = entry.get("path")
+    offset = entry.get("offset")
+    if not isinstance(path_str, str) or not isinstance(offset, str):
+        msg = "idedata.extra.flash_images entry missing path/offset"
+        raise UnpackArtifactsError(msg)
+    return Path(path_str).name, offset
+
+
+def _rewrite_idedata_paths(idedata: dict[str, Any]) -> dict[str, Any]:
+    """
+    Return *idedata* with ``extra.flash_images[].path`` replaced by basenames.
+
+    The receiver writes absolute build-dir paths into
+    ``idedata.json`` at compile time; those paths are
+    meaningless on the offloader. The offloader-side
+    consumers look up bytes by basename in the unpacked
+    ``images`` list, so the wire-rendered idedata mirrors
+    that with basenames in the same field. Returns a
+    shallow-copied dict; the caller's input isn't mutated.
+    """
+    extra = idedata.get("extra")
+    if not isinstance(extra, dict):
+        return idedata
+    flash_images = extra.get("flash_images") or []
+    rewritten = [
+        {**entry, "path": Path(entry["path"]).name}
+        for entry in flash_images
+        if isinstance(entry, dict) and isinstance(entry.get("path"), str)
+    ]
+    return {**idedata, "extra": {**extra, "flash_images": rewritten}}

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -3583,13 +3583,29 @@ class RemoteBuildController:
         (``Mapping[str, StoredPairing]`` + ``frozenset[str]`` +
         ``Mapping[str, PeerQueueStatusSnapshotEntry]``) forces
         the caller into read-only iteration: a concurrent
-        mutation on the controller's underlying dicts during a
-        long-running install (a fresh pairing landing on a
-        different event-loop tick) doesn't poison the snapshot
-        the scheduler is walking. Shallow copies are enough
-        because :class:`StoredPairing` is a frozen dataclass —
-        any future mutation of an existing row goes through a
-        replace, not an in-place edit.
+        mutation on the controller's underlying *mapping*
+        membership during a long-running install (a fresh
+        pairing landing on a different event-loop tick)
+        doesn't poison the snapshot the scheduler is walking.
+
+        The shallow copy doesn't extend to the
+        :class:`StoredPairing` rows themselves —
+        ``StoredPairing`` is a mutable ``@dataclass`` and is
+        edited in place elsewhere
+        (e.g. ``_apply_pair_status_result`` updates
+        ``esphome_version`` on an existing row;
+        ``_commit_endpoint_rebind`` rewrites the hostname /
+        port pair). The scheduler today is the only consumer,
+        runs sync on the same event-loop tick as the install
+        handler, and reads the four scalar fields
+        (``status`` / ``paired_at`` / ``pin_sha256`` /
+        ``esphome_version``) that aren't being mutated by any
+        in-flight call. If a future consumer needs a deep
+        snapshot stable across awaits, the right shape is
+        ``BuildSchedulerInputs.pairings: Mapping[str,
+        PairingSummary]`` (frozen-by-projection at construction
+        time) — flagged here so the surface choice is a
+        deliberate move, not a silent assumption.
 
         ``remote_builds_enabled`` is hardcoded to ``True`` for
         7a-3 — the master "remote builds enabled" toggle in

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -58,10 +58,7 @@ own browsers (``_esphomelib._tcp.local.`` for devices,
 from __future__ import annotations
 
 import asyncio
-import base64
-import io
 import logging
-import tarfile
 import time
 from collections.abc import Callable, Coroutine, Hashable, Iterator
 from contextlib import ExitStack, contextmanager
@@ -79,6 +76,7 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
 from ...constants import __version__ as server_version
 from ...helpers.api import CommandError, api_command
+from ...helpers.build_scheduler import BuildSchedulerInputs
 from ...helpers.dashboard_advertise import SERVICE_TYPE
 from ...helpers.dashboard_identity import (
     DASHBOARD_ID_MAX_CHARS,
@@ -144,11 +142,11 @@ from ..config import (
     remote_build_settings_transaction,
 )
 from .artifacts_download import ArtifactsDownloadSender
+from .artifacts_tarball import UnpackArtifactsError, unpack_artifacts_response
 from .job_fanout import JobFanout
 from .peer_link import PeerLinkSession, TerminateReason
 from .peer_link_client import (
     DownloadArtifactsError,
-    DownloadArtifactsResult,
     PairStatusResult,
     PeerLinkClient,
     PeerLinkClientError,
@@ -642,20 +640,6 @@ _DOWNLOAD_ARTIFACTS_REASON_TO_ERROR_CODE: dict[str, ErrorCode] = {
 }
 
 
-class _UnpackArtifactsError(RuntimeError):
-    """Raised by :func:`_unpack_artifacts_response` on a malformed tarball.
-
-    The receiver-side packer
-    (:func:`controllers.remote_build.artifacts_download._pack_build_artifacts`)
-    is the only thing that should be writing this stream, so a
-    structural failure here means an in-flight bug or a
-    misbehaving peer — surfaced as ``INVALID_ARGS`` rather than
-    ``INTERNAL_ERROR`` so the user sees a clear "the receiver
-    sent a tarball we can't parse" message rather than a
-    generic backend-stack-trace toast.
-    """
-
-
 def _download_artifacts_error_to_command_error(exc: DownloadArtifactsError) -> CommandError:
     """Map the receiver's structured reject reason to a typed :class:`CommandError`.
 
@@ -673,209 +657,6 @@ def _download_artifacts_error_to_command_error(exc: DownloadArtifactsError) -> C
     """
     code = _DOWNLOAD_ARTIFACTS_REASON_TO_ERROR_CODE.get(exc.reason, ErrorCode.UNAVAILABLE)
     return CommandError(code, str(exc))
-
-
-def _unpack_artifacts_response(packed: DownloadArtifactsResult, job_id: str) -> dict[str, Any]:
-    """Unpack the receiver's artifact tarball into the WS response shape.
-
-    Synchronous; meant to run in an executor (``tarfile.open``
-    + per-image ``read()`` are blocking syscalls). Mirrors the
-    layout the receiver-side packer
-    (:func:`controllers.remote_build.artifacts_download._pack_build_artifacts`)
-    writes:
-
-    .. code-block:: text
-
-        idedata.json
-        firmware.bin
-        bootloader.bin       (ESP32 / native IDF only)
-        partitions.bin       (ESP32 / native IDF only)
-        ota_data_initial.bin (ESP32 / native IDF only)
-
-    Reads ``idedata.json`` to recover the upstream-canonical
-    flash-image manifest, then walks the tarball's remaining
-    members to build the ``images`` list. The
-    ``firmware.bin`` partition's offset comes from
-    *packed*'s ``firmware_offset`` field — the receiver
-    populated it from ``StorageJSON.target_platform`` via
-    :func:`helpers.build_artifacts._firmware_offset_for_platform`.
-    The remaining offsets ride inside
-    ``idedata.extra.flash_images``. Rewrites every
-    ``extra.flash_images[].path`` from the receiver's absolute
-    build-dir paths to bare basenames (the only thing the
-    offloader's install path can resolve against the
-    in-tarball entries).
-
-    Raises :class:`_UnpackArtifactsError` on:
-
-    * Missing ``idedata.json``.
-    * ``idedata.json`` not parseable as JSON, or not a dict.
-    * A flash image declared in ``idedata.extra.flash_images``
-      whose tarball member is missing.
-    * Missing ``firmware.bin`` in the tarball.
-    * A directory entry in the tarball (the receiver-side
-      packer is flat by design; a directory means the wire
-      format drifted).
-    """
-    idedata, image_bytes_by_name = _read_artifacts_tarball(packed.tarball)
-    images = _build_images_response(packed.firmware_offset, idedata, image_bytes_by_name)
-    rewritten_idedata = _rewrite_idedata_paths(idedata)
-    total_bytes = sum(int(image["size"]) for image in images)
-    return {
-        "job_id": job_id,
-        "idedata": rewritten_idedata,
-        "images": images,
-        "total_bytes": total_bytes,
-    }
-
-
-def _read_artifacts_tarball(tarball: bytes) -> tuple[dict[str, Any], dict[str, bytes]]:
-    """Read every member of *tarball* into ``(idedata, files-by-basename)``.
-
-    ``idedata`` is the parsed ``idedata.json`` object;
-    ``files-by-basename`` excludes ``idedata.json``. Raises
-    :class:`_UnpackArtifactsError` on any structural problem
-    in the tarball.
-    """
-    idedata: dict[str, Any] | None = None
-    image_bytes_by_name: dict[str, bytes] = {}
-    try:
-        with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
-            for member in tar:
-                payload = _read_tarball_member(tar, member)
-                if member.name == "idedata.json":
-                    idedata = _parse_idedata(payload)
-                else:
-                    image_bytes_by_name[member.name] = payload
-    except tarfile.TarError as exc:
-        msg = f"artifacts tarball is malformed: {exc}"
-        raise _UnpackArtifactsError(msg) from exc
-    if idedata is None:
-        msg = "artifacts tarball missing idedata.json"
-        raise _UnpackArtifactsError(msg)
-    return idedata, image_bytes_by_name
-
-
-def _read_tarball_member(tar: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
-    """Read *member*'s bytes.
-
-    Raises :class:`_UnpackArtifactsError` on directory entries
-    or any other non-regular tarball member type. Stdlib
-    ``tarfile`` guarantees ``extractfile()`` returns a readable
-    stream iff ``isfile()`` returns ``True`` — ``extractfile``
-    only returns ``None`` for link / device / FIFO members,
-    every one of which ``isfile()`` already rejects.
-    """
-    if not member.isfile():
-        msg = f"unexpected non-file tarball entry: {member.name!r}"
-        raise _UnpackArtifactsError(msg)
-    return cast(io.BufferedReader, tar.extractfile(member)).read()
-
-
-def _parse_idedata(payload: bytes) -> dict[str, Any]:
-    """Parse *payload* as ``idedata.json``; raise on non-dict / invalid JSON."""
-    try:
-        parsed = json_loads(payload)
-    except ValueError as exc:
-        msg = f"idedata.json is not valid JSON: {exc}"
-        raise _UnpackArtifactsError(msg) from exc
-    if not isinstance(parsed, dict):
-        msg = "idedata.json is not a JSON object"
-        raise _UnpackArtifactsError(msg)
-    return parsed
-
-
-def _build_images_response(
-    firmware_offset: str,
-    idedata: dict[str, Any],
-    image_bytes_by_name: dict[str, bytes],
-) -> list[dict[str, Any]]:
-    """Pop bytes from *image_bytes_by_name* in the canonical order, base64-encoding as we go.
-
-    Order is ``firmware.bin`` first, then every entry from
-    ``idedata.extra.flash_images`` in their declared order
-    (matches :attr:`BuildArtifacts.flash_images` on the
-    receiver side). Mutates *image_bytes_by_name*: every
-    image referenced by the manifest is popped; on return
-    the dict should be empty, and any leftover entry means
-    the tarball carried a file the manifest didn't account
-    for.
-    """
-    images: list[dict[str, Any]] = []
-    firmware_bytes = image_bytes_by_name.pop("firmware.bin", None)
-    if firmware_bytes is None:
-        msg = "artifacts tarball missing firmware.bin"
-        raise _UnpackArtifactsError(msg)
-    images.append(_image_entry("firmware.bin", firmware_offset, firmware_bytes))
-    # Guard the chained ``.get`` — a non-dict ``extra`` field
-    # (``null`` / list / scalar) on a corrupt-but-parseable
-    # idedata would otherwise blow up on the second ``.get``
-    # with ``AttributeError`` and bypass the
-    # :class:`_UnpackArtifactsError` mapping. Mirror the
-    # :func:`helpers.build_artifacts.load_build_artifacts`
-    # stance: treat non-dict as "no extras."
-    extra = idedata.get("extra")
-    extras_list = extra.get("flash_images") or [] if isinstance(extra, dict) else []
-    for entry in extras_list:
-        basename, offset = _flash_image_basename_offset(entry)
-        image_bytes = image_bytes_by_name.pop(basename, None)
-        if image_bytes is None:
-            msg = f"artifacts tarball missing flash image {basename!r}"
-            raise _UnpackArtifactsError(msg)
-        images.append(_image_entry(basename, offset, image_bytes))
-    if image_bytes_by_name:
-        msg = (
-            f"artifacts tarball contains unexpected files not referenced by idedata: "
-            f"{sorted(image_bytes_by_name)}"
-        )
-        raise _UnpackArtifactsError(msg)
-    return images
-
-
-def _image_entry(name: str, offset: str, payload: bytes) -> dict[str, Any]:
-    """Build one ``images`` list entry: ``{name, offset, size, data_b64}``."""
-    return {
-        "name": name,
-        "offset": offset,
-        "size": len(payload),
-        "data_b64": base64.b64encode(payload).decode("ascii"),
-    }
-
-
-def _flash_image_basename_offset(entry: object) -> tuple[str, str]:
-    """Validate one ``idedata.extra.flash_images`` entry and return ``(basename, offset)``."""
-    if not isinstance(entry, dict):
-        msg = "idedata.extra.flash_images entry is not an object"
-        raise _UnpackArtifactsError(msg)
-    path_str = entry.get("path")
-    offset = entry.get("offset")
-    if not isinstance(path_str, str) or not isinstance(offset, str):
-        msg = "idedata.extra.flash_images entry missing path/offset"
-        raise _UnpackArtifactsError(msg)
-    return Path(path_str).name, offset
-
-
-def _rewrite_idedata_paths(idedata: dict[str, Any]) -> dict[str, Any]:
-    """Return *idedata* with ``extra.flash_images[].path`` replaced by basenames.
-
-    The receiver writes absolute build-dir paths into
-    ``idedata.json`` at compile time; those paths are
-    meaningless on the offloader. The offloader-side
-    consumers look up bytes by basename in the unpacked
-    ``images`` list, so the wire-rendered idedata mirrors
-    that with basenames in the same field. Returns a
-    shallow-copied dict; the caller's input isn't mutated.
-    """
-    extra = idedata.get("extra")
-    if not isinstance(extra, dict):
-        return idedata
-    flash_images = extra.get("flash_images") or []
-    rewritten = [
-        {**entry, "path": Path(entry["path"]).name}
-        for entry in flash_images
-        if isinstance(entry, dict) and isinstance(entry.get("path"), str)
-    ]
-    return {**idedata, "extra": {**extra, "flash_images": rewritten}}
 
 
 def _validate_pin_sha256(raw: object) -> str:
@@ -3720,9 +3501,9 @@ class RemoteBuildController:
             raise _download_artifacts_error_to_command_error(exc) from exc
         try:
             return await asyncio.get_running_loop().run_in_executor(
-                None, _unpack_artifacts_response, packed, job_id
+                None, unpack_artifacts_response, packed, job_id
             )
-        except _UnpackArtifactsError as exc:
+        except UnpackArtifactsError as exc:
             raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
 
     @api_command("remote_build/cancel_job")
@@ -3770,6 +3551,59 @@ class RemoteBuildController:
         except PeerLinkNoSessionError as exc:
             raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
         return {"sent": sent}
+
+    def get_pairing(self, pin_sha256: str) -> StoredPairing | None:
+        """
+        Return the :class:`StoredPairing` for *pin_sha256*, or ``None``.
+
+        Pure synchronous read of the unified ``_pairings`` dict.
+        Used by the firmware controller's install-source resolver
+        after :func:`helpers.build_scheduler.pick_build_path` has
+        chosen a receiver — the resolver needs the pairing's
+        ``label`` to stamp on the new :class:`FirmwareJob`'s
+        ``source_label`` so the install dialog's "Building on
+        {receiver_label}" sub-line has a name to render.
+        """
+        return self._pairings.get(pin_sha256)
+
+    def build_scheduler_snapshot(self) -> BuildSchedulerInputs:
+        """
+        Bundle the scheduler's input state into an immutable snapshot.
+
+        Pure synchronous read of three RAM-canonical dicts plus
+        a master toggle: ``_pairings`` (every paired receiver,
+        PENDING + APPROVED), ``_open_peer_links`` (pin_sha256 set
+        of currently-live peer-link sessions), and
+        ``_peer_queue_status`` (most recent ``queue_status``
+        snapshot per pin). Construction is sync + side-effect-
+        free so the ``firmware/install`` WS handler can call it
+        without an executor hop on the hot install path.
+
+        The :class:`BuildSchedulerInputs` typing
+        (``Mapping[str, StoredPairing]`` + ``frozenset[str]`` +
+        ``Mapping[str, PeerQueueStatusSnapshotEntry]``) forces
+        the caller into read-only iteration: a concurrent
+        mutation on the controller's underlying dicts during a
+        long-running install (a fresh pairing landing on a
+        different event-loop tick) doesn't poison the snapshot
+        the scheduler is walking. Shallow copies are enough
+        because :class:`StoredPairing` is a frozen dataclass —
+        any future mutation of an existing row goes through a
+        replace, not an in-place edit.
+
+        ``remote_builds_enabled`` is hardcoded to ``True`` for
+        7a-3 — the master "remote builds enabled" toggle in
+        :class:`OffloaderRemoteBuildSettings` lands with the
+        7b Settings UI; until then the implicit gate is
+        whether any APPROVED + connected + idle pairing
+        exists.
+        """
+        return BuildSchedulerInputs(
+            remote_builds_enabled=True,
+            pairings=dict(self._pairings),
+            open_peer_links=frozenset(self._open_peer_links),
+            peer_queue_status=dict(self._peer_queue_status),
+        )
 
     def pairings_snapshot(self) -> list[PairingSummary]:
         """Return the in-memory pairings snapshot (PENDING + APPROVED).

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -149,7 +149,14 @@ def firmware_controller_factory(
             controller._persist_jobs = AsyncMock()
 
         bus: EventBus | MagicMock = EventBus() if with_real_bus else MagicMock()
-        db_attrs: dict[str, Any] = {"bus": bus}
+        # ``remote_build`` defaults to ``None`` so the firmware
+        # controller's ``_resolve_install_source`` helper sees the
+        # same shape it does in production before
+        # ``DeviceBuilder.start()`` has constructed the
+        # ``RemoteBuildController`` — without the seed an attribute
+        # lookup would raise ``AttributeError`` and mask the
+        # silent-fallback-LOCAL semantic.
+        db_attrs: dict[str, Any] = {"bus": bus, "remote_build": None}
         if with_settings:
             settings = DashboardSettings()
             settings.config_dir = tmp_path

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -408,6 +408,58 @@ async def test_install_falls_back_to_local_when_remote_build_controller_absent(
 
 
 @pytest.mark.asyncio
+async def test_install_falls_back_to_local_when_scheduler_picked_pin_disappeared(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """
+    Scheduler picks a pin → ``get_pairing`` returns ``None`` → falls back to LOCAL.
+
+    Defensive against a TOCTOU window: the scheduler walks
+    one snapshot, then ``_resolve_install_source`` looks up
+    the chosen pin's label from a fresh ``get_pairing`` call.
+    If an ``unpair`` ran on the same loop tick between the
+    two reads, the second read returns ``None`` and we
+    silently fall back to LOCAL — feeding an empty
+    ``source_pin_sha256`` to the runner would otherwise land
+    on its missing-pin FAILED branch.
+
+    Near-impossible in practice but the typed-return surface
+    is the gate, so pin it.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    # Scheduler picks ``_PIN`` (snapshot says it's APPROVED +
+    # connected + idle), but ``get_pairing(_PIN)`` returns
+    # ``None`` — the unpair landed between the two reads.
+    pairing = _make_pairing()
+    remote_build = MagicMock()
+    remote_build.build_scheduler_snapshot.return_value = BuildSchedulerInputs(
+        remote_builds_enabled=True,
+        pairings={_PIN: pairing},
+        open_peer_links=frozenset({_PIN}),
+        peer_queue_status={
+            _PIN: PeerQueueStatusSnapshotEntry(
+                receiver_hostname="build.local",
+                receiver_port=6055,
+                pin_sha256=_PIN,
+                idle=True,
+                running=False,
+                queue_depth=0,
+            ),
+        },
+    )
+    # ``get_pairing`` returns None — the unpair happened
+    # after the snapshot was taken.
+    remote_build.get_pairing.return_value = None
+    controller._db.remote_build = remote_build
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.install(configuration="kitchen.yaml")
+
+    assert job.source is JobSource.LOCAL
+    assert job.source_pin_sha256 == ""
+
+
+@pytest.mark.asyncio
 async def test_install_bulk_routes_each_config_through_the_scheduler(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -405,3 +405,70 @@ async def test_install_falls_back_to_local_when_remote_build_controller_absent(
     job = await controller.install(configuration="kitchen.yaml")
 
     assert job.source is JobSource.LOCAL
+
+
+@pytest.mark.asyncio
+async def test_install_bulk_routes_each_config_through_the_scheduler(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """
+    ``install_bulk`` resolves the install source per-config.
+
+    Every entry in the bulk call goes through
+    ``_resolve_install_source``, so a bulk request lands all
+    eligible jobs as REMOTE when a paired receiver is healthy
+    + idle (and stays LOCAL when none is available). Pins the
+    per-config shape so a future refactor that hoists the
+    scheduler call to call-time-once-and-share doesn't
+    silently drop the per-job ``source_label`` stamp.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing(label="desktop")
+    _stub_remote_build(
+        controller,
+        pairings=[pairing],
+        open_pins=frozenset({_PIN}),
+        idle_pins=frozenset({_PIN}),
+    )
+    (tmp_path / "kitchen.yaml").write_text("")
+    (tmp_path / "garage.yaml").write_text("")
+    (tmp_path / "office.yaml").write_text("")
+
+    jobs = await controller.install_bulk(
+        configurations=["kitchen.yaml", "garage.yaml", "office.yaml"]
+    )
+
+    assert [j.source for j in jobs] == [JobSource.REMOTE] * 3
+    assert all(j.source_pin_sha256 == _PIN for j in jobs)
+    assert all(j.source_label == "desktop" for j in jobs)
+
+
+@pytest.mark.asyncio
+async def test_install_bulk_with_serial_port_forces_every_config_local(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """
+    A serial-port bulk install routes every config to LOCAL.
+
+    Per-port gate is checked first; the scheduler isn't even
+    consulted when the port is serial. Pins the gate's order
+    so a future refactor that lifts the port check out of the
+    resolver doesn't silently send wired-flash jobs to a
+    remote receiver.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing()
+    _stub_remote_build(
+        controller,
+        pairings=[pairing],
+        open_pins=frozenset({_PIN}),
+        idle_pins=frozenset({_PIN}),
+    )
+    (tmp_path / "kitchen.yaml").write_text("")
+    (tmp_path / "garage.yaml").write_text("")
+
+    jobs = await controller.install_bulk(
+        configurations=["kitchen.yaml", "garage.yaml"], port="/dev/ttyUSB0"
+    )
+
+    assert [j.source for j in jobs] == [JobSource.LOCAL, JobSource.LOCAL]

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -22,11 +22,23 @@ the right defaults and order. This file pins:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from esphome_device_builder.helpers.api import CommandError
-from esphome_device_builder.models import ErrorCode, EventType, JobStatus, JobType
+from esphome_device_builder.helpers.build_scheduler import BuildSchedulerInputs
+from esphome_device_builder.models import (
+    ErrorCode,
+    EventType,
+    JobSource,
+    JobStatus,
+    JobType,
+    PeerQueueStatusSnapshotEntry,
+    PeerStatus,
+    StoredPairing,
+)
 from tests.controllers.firmware.conftest import (
     CaptureEnqueueOrderFactory,
     EnqueueStep,
@@ -200,3 +212,196 @@ async def test_install_registers_job_in_jobs_map(
     job = await controller.install(configuration="kitchen.yaml")
 
     assert await controller.get_job(job_id=job.job_id) is job
+
+
+# ---------------------------------------------------------------------------
+# Scheduler integration (7a-3) — install routes through pick_build_path
+# ---------------------------------------------------------------------------
+
+
+_PIN = "a" * 64
+
+
+def _make_pairing(label: str = "desktop") -> StoredPairing:
+    """Build a passing :class:`StoredPairing` for the scheduler tests."""
+    return StoredPairing(
+        receiver_hostname="build.local",
+        receiver_port=6055,
+        pin_sha256=_PIN,
+        static_x25519_pub=b"\x01" * 32,
+        label=label,
+        paired_at=1.0,
+        status=PeerStatus.APPROVED,
+    )
+
+
+def _stub_remote_build(
+    controller: Any,
+    *,
+    pairings: list[StoredPairing] | None = None,
+    open_pins: frozenset[str] = frozenset(),
+    idle_pins: frozenset[str] = frozenset(),
+) -> None:
+    """Wire a stub ``_db.remote_build`` with a scripted scheduler snapshot.
+
+    The scheduler walks ``pairings`` and gates each entry on
+    membership in ``open_pins`` + an idle entry in the queue
+    snapshot — so tests parametrise the three slices
+    independently and assert the resulting LOCAL / REMOTE
+    routing.
+    """
+    rows = pairings or []
+    pairings_map = {p.pin_sha256: p for p in rows}
+    queue_status = {
+        pin: PeerQueueStatusSnapshotEntry(
+            receiver_hostname="build.local",
+            receiver_port=6055,
+            pin_sha256=pin,
+            idle=True,
+            running=False,
+            queue_depth=0,
+        )
+        for pin in idle_pins
+    }
+    remote_build = MagicMock()
+    remote_build.build_scheduler_snapshot.return_value = BuildSchedulerInputs(
+        remote_builds_enabled=True,
+        pairings=pairings_map,
+        open_peer_links=open_pins,
+        peer_queue_status=queue_status,
+    )
+    remote_build.get_pairing.side_effect = pairings_map.get
+    controller._db.remote_build = remote_build
+
+
+@pytest.mark.asyncio
+async def test_install_routes_to_local_when_no_paired_receivers(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """No paired receivers → ``install`` falls through to LOCAL.
+
+    The scheduler only picks REMOTE when at least one
+    APPROVED + connected + idle pairing is available. A fresh
+    dashboard with no pairings stays on the local subprocess
+    pipeline — the existing behaviour, with no user-visible
+    change.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _stub_remote_build(controller, pairings=[])
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.install(configuration="kitchen.yaml")
+
+    assert job.source is JobSource.LOCAL
+    assert job.source_pin_sha256 == ""
+    assert job.source_label == ""
+
+
+@pytest.mark.asyncio
+async def test_install_routes_to_remote_when_pairing_is_idle_and_connected(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """
+    An APPROVED + connected + idle pairing routes the install to REMOTE.
+
+    Pins the transparent install flow's user-visible
+    behaviour: Install with a paired build server up routes
+    transparently to that server; the user doesn't choose,
+    the scheduler decides. ``source_pin_sha256`` carries the
+    machine handle the runner uses to look up the
+    PeerLinkClient; ``source_label`` is the display string
+    the install dialog renders as "Building on
+    {receiver_label}".
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing(label="desktop")
+    _stub_remote_build(
+        controller,
+        pairings=[pairing],
+        open_pins=frozenset({_PIN}),
+        idle_pins=frozenset({_PIN}),
+    )
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.install(configuration="kitchen.yaml")
+
+    assert job.source is JobSource.REMOTE
+    assert job.source_pin_sha256 == _PIN
+    assert job.source_label == "desktop"
+
+
+@pytest.mark.asyncio
+async def test_install_falls_back_to_local_when_receiver_is_busy(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """A paired receiver that isn't idle falls back to LOCAL (silent fallback).
+
+    The scheduler's first-cut policy is "idle or local"; a
+    busy receiver doesn't queue work today. The install
+    handler honours that silently — the user doesn't see a
+    "remote build server busy" message, the install just
+    runs locally.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing()
+    # APPROVED + connected, but ``idle_pins`` is empty so the
+    # snapshot has no queue entry → scheduler skips.
+    _stub_remote_build(controller, pairings=[pairing], open_pins=frozenset({_PIN}))
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.install(configuration="kitchen.yaml")
+
+    assert job.source is JobSource.LOCAL
+
+
+@pytest.mark.asyncio
+async def test_install_forces_local_for_serial_port(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """
+    Serial ``port`` forces LOCAL regardless of the scheduler.
+
+    The runner's REMOTE flash step uses ``esphome upload
+    --file`` which routes through
+    ``upload_using_esptool`` as a single ``FlashImage`` at
+    offset ``0x0``. That works for OTA / web_server pushes
+    but corrupts an ESP32 wired flash (needs bootloader /
+    partitions / OTA-data at their own offsets stitched
+    from ``idedata.extra.flash_images``). Until the runner
+    can stage the full multi-image set, serial REMOTE
+    installs stay LOCAL.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing()
+    _stub_remote_build(
+        controller,
+        pairings=[pairing],
+        open_pins=frozenset({_PIN}),
+        idle_pins=frozenset({_PIN}),
+    )
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.install(configuration="kitchen.yaml", port="/dev/ttyUSB0")
+
+    assert job.source is JobSource.LOCAL
+
+
+@pytest.mark.asyncio
+async def test_install_falls_back_to_local_when_remote_build_controller_absent(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """
+    ``_db.remote_build is None`` falls through to LOCAL without raising.
+
+    Production sets ``DeviceBuilder.remote_build`` during
+    ``start()``; a firmware-queue restart-recovery path that
+    fires before remote-build start would otherwise reach
+    into ``None``. The resolver's None check is the gate.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.remote_build = None
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.install(configuration="kitchen.yaml")
+
+    assert job.source is JobSource.LOCAL

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -22,13 +22,19 @@ separate test that asserts the runner ignores it.
 from __future__ import annotations
 
 import asyncio
+import sys
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from esphome_device_builder.controllers.firmware import remote_runner
+from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
+    UnpackArtifactsError,
+)
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
+    DownloadArtifactsError,
+    DownloadArtifactsResult,
     PeerLinkNoSessionError,
 )
 from esphome_device_builder.helpers.api import CommandError
@@ -510,16 +516,17 @@ async def test_remote_compile_receiver_unreachable_fires_job_failed(
 
 
 @pytest.mark.asyncio
-async def test_remote_compile_non_compile_job_type_fails_locally(
+async def test_remote_compile_unsupported_job_type_fails_locally(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
 ) -> None:
-    """REMOTE with a non-COMPILE ``job_type`` is rejected at the runner's top.
+    """REMOTE with a non-COMPILE/UPLOAD/INSTALL ``job_type`` is rejected at the runner's top.
 
-    7a-2b's scope is COMPILE only — UPLOAD / INSTALL land in
-    7a-3. Anything else here must surface a clear FAILED with
-    an explanatory ``error`` instead of running through the
-    submit path with the wrong target.
+    The receiver's ``submit_job`` contract is compile-only;
+    job types that don't have a corresponding wire flow
+    (``CLEAN``, ``RENAME``, ``RESET_BUILD_ENV``) must surface
+    a clear FAILED with an explanatory ``error`` rather than
+    running through the submit path with the wrong target.
     """
     controller = firmware_controller_factory(with_terminate=True)
     _capture_local_events(controller)
@@ -527,7 +534,7 @@ async def test_remote_compile_non_compile_job_type_fails_locally(
     job = FirmwareJob(
         job_id="x",
         configuration="kitchen.yaml",
-        job_type=JobType.INSTALL,
+        job_type=JobType.CLEAN,
         source=JobSource.REMOTE,
         source_pin_sha256=_PIN,
     )
@@ -1201,3 +1208,300 @@ async def test_remote_compile_cancel_after_remote_build_torn_down_finalises_loca
     assert job.status == JobStatus.CANCELLED
     assert len(captured[EventType.JOB_CANCELLED]) == 1
     assert job.job_id not in controller._cancel_requested
+
+
+# ---------------------------------------------------------------------------
+# UPLOAD / INSTALL — local flash step after receiver compile
+# ---------------------------------------------------------------------------
+
+
+def _make_remote_install_job(*, job_id: str = "remote-1", port: str = "OTA") -> FirmwareJob:
+    return FirmwareJob(
+        job_id=job_id,
+        configuration="kitchen.yaml",
+        job_type=JobType.INSTALL,
+        port=port,
+        source=JobSource.REMOTE,
+        source_pin_sha256=_PIN,
+        source_label="desktop",
+    )
+
+
+def _wire_upload_subprocess(
+    controller: Any,
+    *,
+    exit_code: int = 0,
+    stdout: str = "Uploading 100%...\n",
+) -> None:
+    """Point the controller's runner at a python-one-liner ``esphome upload``.
+
+    The runner builds the cmd as ``[*controller._esphome_cmd,
+    '--dashboard', ..., 'upload', <yaml>, '--device', <port>,
+    '--file', <staged_firmware>]``. Pointing
+    ``_esphome_cmd`` at ``python -c <script>`` lets the test
+    drive a deterministic subprocess (controlled stdout +
+    exit code) without an actual esphome install on PATH.
+
+    ``_build_cache_args`` is stubbed to return ``[]`` so the
+    runner doesn't reach into the (absent in unit tests)
+    devices controller's address cache. The runner's
+    ``_tracked_subprocess`` is the real method — it
+    registers the spawn with ``_current_process`` so the
+    cancel-during-upload tests can SIGTERM the chain.
+    """
+    quoted_stdout = repr(stdout)
+    script = (
+        f"import sys; sys.stdout.write({quoted_stdout}); sys.stdout.flush(); sys.exit({exit_code})"
+    )
+    controller._esphome_cmd = [sys.executable, "-c", script]
+    controller._build_cache_args = lambda _job: []
+
+
+def _make_packed_artifacts(tarball: bytes = b"FAKE-TARBALL") -> DownloadArtifactsResult:
+    return DownloadArtifactsResult(tarball=tarball, firmware_offset="0x10000")
+
+
+@pytest.fixture
+def patch_extract_firmware(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Replace :func:`extract_firmware_bin` with a stub that returns canned bytes.
+
+    The real implementation parses a gzipped tarball; tests
+    don't care about the parse, only about the bytes that
+    end up at the staged path. Patching the symbol on
+    ``remote_runner`` (where the import landed) is the
+    standard "intercept at the call site" pattern.
+    """
+    stub = MagicMock(return_value=b"STAGED-FIRMWARE-BYTES")
+    monkeypatch.setattr(remote_runner, "extract_firmware_bin", stub)
+    return stub
+
+
+@pytest.mark.asyncio
+async def test_remote_install_completes_after_local_upload_succeeds(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+    patch_extract_firmware: MagicMock,
+    tmp_path: Any,
+) -> None:
+    """
+    Happy path: receiver compile → download_artifacts → local upload → COMPLETED.
+
+    Pins the end-to-end shape of the transparent-install
+    REMOTE branch: dispatch is ``submit_job(target=compile)``,
+    receiver returns completed, runner pulls the tarball back
+    via ``download_artifacts``, stages ``firmware.bin`` to a
+    tmpdir, and spawns the local ``esphome upload`` subprocess
+    against the staged file. A zero exit code closes the job
+    as ``COMPLETED`` and fires the local terminal event.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
+    _wire_remote_build(controller, client=client)
+    _wire_upload_subprocess(controller, exit_code=0)
+    job = _make_remote_install_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=5.0)
+
+    assert job.status == JobStatus.COMPLETED
+    assert job.exit_code == 0
+    assert len(captured[EventType.JOB_COMPLETED]) == 1
+    client.download_artifacts.assert_awaited_once_with(job_id=job.job_id)
+    # ``firmware.bin`` was staged + ``esphome upload`` saw it.
+    patch_extract_firmware.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_remote_install_local_upload_failure_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+    patch_extract_firmware: MagicMock,
+) -> None:
+    """A non-zero ``esphome upload`` exit lands as JOB_FAILED with exit-code in error."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
+    _wire_remote_build(controller, client=client)
+    _wire_upload_subprocess(controller, exit_code=7)
+    job = _make_remote_install_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=5.0)
+
+    assert job.status == JobStatus.FAILED
+    assert job.exit_code == 7
+    assert job.error is not None and "exit 7" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_install_download_artifacts_failure_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """``download_artifacts`` failing surfaces in ``job.error`` with the receiver's reason."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(
+        side_effect=DownloadArtifactsError("build dir wiped", reason="build_dir_missing")
+    )
+    _wire_remote_build(controller, client=client)
+    job = _make_remote_install_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "build dir wiped" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_install_malformed_tarball_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Tarball missing ``firmware.bin`` surfaces as JOB_FAILED with extract error.
+
+    Defensive — the receiver-side packer enforces the
+    layout, so a malformed tarball means an in-flight bug
+    or a misbehaving peer.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
+    _wire_remote_build(controller, client=client)
+    monkeypatch.setattr(
+        remote_runner,
+        "extract_firmware_bin",
+        MagicMock(side_effect=UnpackArtifactsError("firmware.bin missing")),
+    )
+    job = _make_remote_install_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "firmware.bin missing" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+    patch_extract_firmware: MagicMock,
+) -> None:
+    """
+    User Stop during the ``esphome upload`` subprocess finalises as CANCELLED.
+
+    The runner's ``_tracked_subprocess`` registers the
+    upload spawn with ``controller._current_process``, and
+    ``FirmwareController.cancel``'s
+    ``_terminate_current_process`` lands SIGTERM on the
+    spawned tree. The subprocess exits non-zero (terminated
+    by signal); the runner's post-spawn cancel-check
+    routes through ``_finalize_cancelled`` rather than the
+    FAILED branch the non-zero exit would normally trigger.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
+    _wire_remote_build(controller, client=client)
+    # A subprocess that runs long enough for us to cancel it.
+    _wire_upload_subprocess(
+        controller,
+        exit_code=0,
+        stdout=(
+            "import sys, time; sys.stdout.write('starting upload\\n'); "
+            "sys.stdout.flush(); time.sleep(30)"
+        ),
+    )
+    # Replace the script with one that actually sleeps, so the
+    # subprocess is parked when we cancel.
+    controller._esphome_cmd = [
+        sys.executable,
+        "-c",
+        "import sys, time; sys.stdout.write('starting upload\\n'); "
+        "sys.stdout.flush(); time.sleep(30)",
+    ]
+
+    async def _terminate() -> None:
+        assert controller._current_process is not None  # type narrowing
+        controller._current_process.terminate()
+
+    controller._terminate_current_process = _terminate  # type: ignore[method-assign]
+    job = _make_remote_install_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+
+    # Wait until the subprocess is up.
+    while controller._current_process is None:
+        await asyncio.sleep(0.01)
+
+    _request_remote_cancel(controller, job)
+    await controller._terminate_current_process()
+    await asyncio.wait_for(runner, timeout=5.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_upload_runs_the_same_local_flash_chain_as_install(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+    patch_extract_firmware: MagicMock,
+) -> None:
+    """
+    ``JobType.UPLOAD`` with REMOTE source follows the same artifact-fetch + flash chain.
+
+    INSTALL and UPLOAD share the runner's UPLOAD/INSTALL
+    branch — the difference between the two on the local
+    subprocess path (compile-then-flash vs flash-only)
+    doesn't matter here because the receiver did the
+    compile already. Pinning this prevents a future
+    branch that special-cases on ``job_type`` from
+    silently breaking the UPLOAD path.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
+    _wire_remote_build(controller, client=client)
+    _wire_upload_subprocess(controller, exit_code=0)
+    job = FirmwareJob(
+        job_id="upload-1",
+        configuration="kitchen.yaml",
+        job_type=JobType.UPLOAD,
+        port="192.168.1.50",
+        source=JobSource.REMOTE,
+        source_pin_sha256=_PIN,
+    )
+
+    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=5.0)
+
+    assert job.status == JobStatus.COMPLETED
+    assert len(captured[EventType.JOB_COMPLETED]) == 1
+    client.download_artifacts.assert_awaited_once()

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -344,7 +344,7 @@ async def test_remote_compile_translates_output_and_completes(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     # Yield until the runner is parked waiting on the terminal future.
     # Two ticks: one to let the bundle build await resolve, one to let
     # the submit_job await resolve, then we can fire wire events.
@@ -391,7 +391,7 @@ async def test_remote_compile_progress_translates_to_local_progress_event(
     _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     _fire_output(controller, job_id=job.job_id, line="[ 47%] Compiling .pio/build/foo.o\n")
@@ -426,7 +426,7 @@ async def test_remote_compile_ignores_events_for_other_jobs(
     _, client = _wire_remote_build(controller)
     job = _make_remote_job(job_id="ours")
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     # Stray traffic from a sibling job — must not appear in our captures
@@ -460,7 +460,7 @@ async def test_remote_compile_failed_status_fires_job_failed(
     _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(
         controller,
@@ -487,7 +487,7 @@ async def test_remote_compile_rejected_ack_fires_job_failed(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job()
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None and "receiver queue full" in job.error
@@ -508,7 +508,7 @@ async def test_remote_compile_receiver_unreachable_fires_job_failed(
     )
     job = _make_remote_job()
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None and "session not connected" in job.error
@@ -539,7 +539,7 @@ async def test_remote_compile_unsupported_job_type_fails_locally(
         source_pin_sha256=_PIN,
     )
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None and "COMPILE" in job.error
@@ -570,7 +570,7 @@ async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     _request_remote_cancel(controller, job)
@@ -610,7 +610,7 @@ async def test_remote_compile_cancel_beats_receiver_completed(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     # Register the cancel, then fire ``completed`` (instead of
@@ -646,7 +646,7 @@ async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
     _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="cancelled")
     await asyncio.wait_for(runner, timeout=2.0)
@@ -685,7 +685,7 @@ async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
         remote_runner, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError)
     )
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.CANCELLED
     assert captured[EventType.JOB_FAILED] == []
@@ -711,7 +711,7 @@ async def test_remote_compile_bundle_file_missing_fires_job_failed(
     )
     job = _make_remote_job()
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None and "kitchen.yaml" in job.error
@@ -733,7 +733,7 @@ async def test_remote_compile_bundle_build_error_fires_job_failed(
     monkeypatch.setattr(remote_runner, "build_yaml_bundle", AsyncMock(side_effect=bundle_error))
     job = _make_remote_job()
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None and "syntax in kitchen.yaml" in job.error
@@ -762,7 +762,7 @@ async def test_remote_compile_missing_source_pin_fires_job_failed(
         # source_pin_sha256 deliberately empty
     )
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None and "source_pin_sha256" in job.error
@@ -783,7 +783,7 @@ async def test_remote_compile_no_remote_build_controller_fires_job_failed(
     controller._db.remote_build = None
     job = _make_remote_job()
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None and "not initialised" in job.error
@@ -802,7 +802,7 @@ async def test_remote_compile_submit_no_session_fires_job_failed(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job()
 
-    await remote_runner.run_remote_compile_job(controller, job)
+    await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None and "session not open" in job.error
@@ -834,7 +834,7 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     _fire_session_closed(
@@ -880,7 +880,7 @@ async def test_remote_compile_cancel_translation_handles_missing_session(
     controller._db.remote_build = remote_build
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(initial_client)
     _request_remote_cancel(controller, job)
     await asyncio.wait_for(runner, timeout=2.0)
@@ -902,7 +902,7 @@ async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _request_remote_cancel(controller, job)
     await asyncio.wait_for(runner, timeout=2.0)
@@ -935,7 +935,7 @@ async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
     _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     runner.cancel()
@@ -966,7 +966,7 @@ async def test_execute_job_routes_remote_source_through_remote_runner(
     where they'd try to ``esphome compile`` a configuration
     that may not even be on disk in the offloader's
     ``config_dir``. Going through ``_execute_job`` (rather
-    than calling ``run_remote_compile_job`` directly) covers
+    than calling ``run_remote_job`` directly) covers
     that branch + the ``_execute_remote_job`` delegator
     method.
     """
@@ -1012,7 +1012,7 @@ async def test_submit_job_ack_echoes_caller_job_id(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job(job_id="unique-echo-1234")
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=2.0)
@@ -1047,7 +1047,7 @@ async def test_remote_compile_ignores_session_closed_for_other_pin(
     _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     # Different pin — the listener must filter this out.
@@ -1104,7 +1104,7 @@ async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
     # been called).
     controller._cancel_requested.add(job.job_id)
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     # The runner's bundle build + submit will still complete
     # (the cancel-aware ``_fail_locally`` short-circuit only
     # kicks in when one of those branches raises). The
@@ -1154,7 +1154,7 @@ async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
     job.status = JobStatus.RUNNING
     controller._current_job = job
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     # Drive through the real handler — the cancel-event
@@ -1195,7 +1195,7 @@ async def test_remote_compile_cancel_after_remote_build_torn_down_finalises_loca
     _, client = _wire_remote_build(controller)
     job = _make_remote_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     # Simulate the receiver-controller teardown race: clear
@@ -1302,7 +1302,7 @@ async def test_remote_install_completes_after_local_upload_succeeds(
     _wire_upload_subprocess(controller, exit_code=0)
     job = _make_remote_install_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=5.0)
@@ -1330,7 +1330,7 @@ async def test_remote_install_local_upload_failure_fires_job_failed(
     _wire_upload_subprocess(controller, exit_code=7)
     job = _make_remote_install_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=5.0)
@@ -1356,7 +1356,7 @@ async def test_remote_install_download_artifacts_failure_fires_job_failed(
     _wire_remote_build(controller, client=client)
     job = _make_remote_install_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=2.0)
@@ -1391,7 +1391,7 @@ async def test_remote_install_malformed_tarball_fires_job_failed(
     )
     job = _make_remote_install_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=2.0)
@@ -1449,7 +1449,7 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     controller._terminate_current_process = _terminate  # type: ignore[method-assign]
     job = _make_remote_install_job()
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
 
@@ -1497,7 +1497,7 @@ async def test_remote_upload_runs_the_same_local_flash_chain_as_install(
         source_pin_sha256=_PIN,
     )
 
-    runner = asyncio.create_task(remote_runner.run_remote_compile_job(controller, job))
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
     await asyncio.wait_for(runner, timeout=5.0)

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1461,6 +1462,75 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     await controller._terminate_current_process()
     await asyncio.wait_for(runner, timeout=5.0)
 
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_terminates(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_extract_firmware: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Cancel landing during the staging executor hops fires ``_terminate_current_process`` post-spawn.
+
+    The runner has two cancel-check sites for this path:
+
+    1. **Pre-spawn early check** in
+       ``_fetch_and_run_local_upload`` — covered by
+       ``test_fetch_and_run_local_upload_cancel_pre_spawn_skips_subprocess``.
+    2. **Post-spawn in-context-manager check** in
+       ``_run_upload_subprocess`` — fires when the cancel
+       flag was *not* set at the pre-check moment but *is*
+       set by the time the spawn returns. The window is the
+       executor hops for ``mkdtemp`` + ``firmware_path.write_bytes``
+       between the two checks.
+
+    This test races a cancel into that window by patching
+    ``firmware_path.write_bytes`` (via ``Path.write_bytes``)
+    to flip ``_cancel_requested`` as a side effect — so by
+    the time the spawn returns, the in-context check sees
+    the flag and fires ``_terminate_current_process``.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
+    job = _make_remote_install_job()
+
+    terminate_calls: list[None] = []
+
+    async def _terminate() -> None:
+        terminate_calls.append(None)
+
+    controller._terminate_current_process = _terminate  # type: ignore[method-assign]
+    # Subprocess emits one line + exits 0 — the
+    # cancel-aware finalise routes through CANCELLED
+    # regardless of the exit.
+    _wire_upload_subprocess(controller, exit_code=0, stdout="ok\n")
+
+    # Patch ``Path.write_bytes`` so the executor hop that
+    # writes the staged firmware file flips
+    # ``_cancel_requested`` as a side effect. That puts the
+    # cancel into the gap between the pre-spawn check and
+    # the in-context-manager check.
+    original_write_bytes = Path.write_bytes
+
+    def _write_bytes_then_cancel(self: Path, data: bytes) -> int:
+        result = original_write_bytes(self, data)
+        controller._cancel_requested.add(job.job_id)
+        return result
+
+    monkeypatch.setattr(Path, "write_bytes", _write_bytes_then_cancel)
+
+    await remote_runner._fetch_and_run_local_upload(controller=controller, job=job, client=client)
+
+    # The post-spawn check inside ``_run_upload_subprocess``
+    # called ``_terminate_current_process``.
+    assert terminate_calls, (
+        "expected _terminate_current_process to fire from the in-context-manager cancel check"
+    )
     assert job.status == JobStatus.CANCELLED
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1466,6 +1466,52 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_run_local_upload_cancel_pre_spawn_skips_subprocess(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_extract_firmware: MagicMock,
+) -> None:
+    """
+    Cancel landing between extract + spawn skips the subprocess.
+
+    The wire round-trip (``download_artifacts``) and the
+    in-executor tarball extract have already happened by the
+    time the check fires — those couldn't be cancelled
+    cleanly anyway. The check guards the staging + spawn
+    phase: a cancel that arrived between the executor hop
+    and the spawn finalises the job locally without writing
+    the tmpdir or starting ``esphome upload``.
+
+    Unit-tested directly because the outer runner routes
+    most cancel races through ``_await_terminal``'s in-loop
+    check — this defensive gate is only reachable via the
+    helper's own entry. Pinning it here keeps the branch
+    alive against a future refactor that introduces an
+    ``await`` between ``_await_terminal`` and this helper.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
+
+    # Track spawn attempts: ``_tracked_subprocess`` is an
+    # async context manager on the controller; a successful
+    # cancel-pre-spawn skip means it's never invoked.
+    controller._tracked_subprocess = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("subprocess should not have spawned")
+    )
+
+    job = _make_remote_install_job()
+    controller._cancel_requested.add(job.job_id)
+
+    await remote_runner._fetch_and_run_local_upload(controller=controller, job=job, client=client)
+
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+    client.download_artifacts.assert_awaited_once()
+    patch_extract_firmware.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_remote_upload_runs_the_same_local_flash_chain_as_install(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,

--- a/tests/controllers/firmware/test_rename_lock.py
+++ b/tests/controllers/firmware/test_rename_lock.py
@@ -175,6 +175,11 @@ async def test_install_bulk_skips_locked_configs_and_queues_the_rest(
                 (),
                 {"rel_path": lambda self, *parts: None},
             )(),
+            # ``install`` resolves its source via the scheduler,
+            # which reads ``_db.remote_build`` — match production's
+            # pre-start shape (``None`` until the controller is
+            # constructed) so the resolver falls through to LOCAL.
+            "remote_build": None,
         },
     )()
     controller._persist_jobs = AsyncMock()

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -12,8 +12,8 @@ harness stays visible:
   (``artifacts_start`` → chunks →
   ``artifacts_end{accepted: true}``).
 * Tarball pack/unpack contract — the receiver's
-  ``_pack_build_artifacts`` and the offloader's
-  ``_unpack_artifacts_response`` are wire-format mirrors;
+  ``pack_build_artifacts`` and the offloader's
+  ``unpack_artifacts_response`` are wire-format mirrors;
   pin the round-trip + the basename rewrite of
   ``idedata.extra.flash_images[].path``.
 """
@@ -31,12 +31,12 @@ import pytest
 
 from esphome_device_builder.controllers.remote_build.artifacts_download import (
     ArtifactsDownloadSender,
-    _pack_build_artifacts,
-    _PackedArtifacts,
 )
-from esphome_device_builder.controllers.remote_build.controller import (
-    _unpack_artifacts_response,
-    _UnpackArtifactsError,
+from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
+    PackedArtifacts,
+    UnpackArtifactsError,
+    pack_build_artifacts,
+    unpack_artifacts_response,
 )
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
     DownloadArtifactsResult,
@@ -185,7 +185,7 @@ async def test_download_artifacts_build_dir_missing_rejected(
         raise FileNotFoundError("build dir gone")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download._pack_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_download.pack_build_artifacts",
         _raise_missing,
     )
     sender = _make_sender()
@@ -209,7 +209,7 @@ async def test_download_artifacts_pack_failed_rejected(
         raise RuntimeError("size cap")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download._pack_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_download.pack_build_artifacts",
         _raise,
     )
     sender = _make_sender()
@@ -230,11 +230,11 @@ async def test_download_artifacts_happy_path_streams_start_chunk_end(
     """Happy path sends ``artifacts_start`` → chunk(s) → ``artifacts_end{accepted: true}``."""
     tarball = b"x" * 200
 
-    def _fake_pack(_configuration: str) -> _PackedArtifacts:
-        return _PackedArtifacts(tarball=tarball, firmware_offset="0x10000")
+    def _fake_pack(_configuration: str) -> PackedArtifacts:
+        return PackedArtifacts(tarball=tarball, firmware_offset="0x10000")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download._pack_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_download.pack_build_artifacts",
         _fake_pack,
     )
     sender = _make_sender()
@@ -268,7 +268,7 @@ async def test_download_artifacts_clears_inflight_on_reject(
         raise RuntimeError("boom")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download._pack_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_download.pack_build_artifacts",
         _raise,
     )
     sender = _make_sender()
@@ -320,11 +320,11 @@ def test_pack_build_artifacts_layout(tmp_path: Path, monkeypatch: pytest.MonkeyP
         extra_offsets=[("bootloader.bin", "0x1000"), ("partitions.bin", "0x8000")],
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download.load_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
         lambda _config: artifacts,
     )
 
-    packed = _pack_build_artifacts("kitchen.yaml")
+    packed = pack_build_artifacts("kitchen.yaml")
 
     assert packed.firmware_offset == "0x10000"
     with tarfile.open(fileobj=io.BytesIO(packed.tarball), mode="r:gz") as tar:
@@ -343,12 +343,12 @@ def test_pack_build_artifacts_rejects_oversized_idedata(
         idedata_bytes=b"x" * (FIRMWARE_MAX_TOTAL_BYTES + 1),
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download.load_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
         lambda _config: artifacts,
     )
 
     with pytest.raises(RuntimeError, match=r"already exceeds FIRMWARE_MAX_TOTAL_BYTES"):
-        _pack_build_artifacts("kitchen.yaml")
+        pack_build_artifacts("kitchen.yaml")
 
 
 def test_pack_build_artifacts_rejects_oversized_compressed(
@@ -372,7 +372,7 @@ def test_pack_build_artifacts_rejects_oversized_compressed(
         idedata_bytes=b"{}",  # 2 bytes
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download.load_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
         lambda _config: artifacts,
     )
     # Cap=10 lets uncompressed total (2 bytes idedata + 0
@@ -380,13 +380,13 @@ def test_pack_build_artifacts_rejects_oversized_compressed(
     # rendered tarball — gzip envelope (~20B) + two tar
     # headers (1024B compressed to ~30B) — easily exceeds.
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download."
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball."
         "FIRMWARE_MAX_TOTAL_BYTES",
         10,
     )
 
     with pytest.raises(RuntimeError, match=r"on the wire"):
-        _pack_build_artifacts("kitchen.yaml")
+        pack_build_artifacts("kitchen.yaml")
 
 
 def test_pack_build_artifacts_rejects_oversized_cumulative(
@@ -400,12 +400,12 @@ def test_pack_build_artifacts_rejects_oversized_cumulative(
         idedata_bytes=b"{}",
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download.load_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
         lambda _config: artifacts,
     )
 
     with pytest.raises(RuntimeError, match=r"would exceed FIRMWARE_MAX_TOTAL_BYTES"):
-        _pack_build_artifacts("kitchen.yaml")
+        pack_build_artifacts("kitchen.yaml")
 
 
 def test_artifacts_download_sender_discard_session_clears_inflight() -> None:
@@ -439,12 +439,12 @@ def test_pack_build_artifacts_rejects_duplicate_basename(
         idedata_bytes=b"{}",
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download.load_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
         lambda _config: artifacts,
     )
 
     with pytest.raises(RuntimeError, match="duplicate flash image basename"):
-        _pack_build_artifacts("kitchen.yaml")
+        pack_build_artifacts("kitchen.yaml")
 
 
 def test_unpack_artifacts_response_round_trip(
@@ -456,12 +456,12 @@ def test_unpack_artifacts_response_round_trip(
         extra_offsets=[("bootloader.bin", "0x1000"), ("ota_data_initial.bin", "0xe000")],
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_download.load_build_artifacts",
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
         lambda _config: artifacts,
     )
 
-    packed = _pack_build_artifacts("kitchen.yaml")
-    response = _unpack_artifacts_response(
+    packed = pack_build_artifacts("kitchen.yaml")
+    response = unpack_artifacts_response(
         DownloadArtifactsResult(tarball=packed.tarball, firmware_offset="0x10000"),
         job_id="remote-1",
     )
@@ -479,22 +479,22 @@ def test_unpack_artifacts_response_round_trip(
 
 
 def test_unpack_artifacts_response_missing_idedata_raises() -> None:
-    """A tarball without ``idedata.json`` raises :class:`_UnpackArtifactsError`."""
+    """A tarball without ``idedata.json`` raises :class:`UnpackArtifactsError`."""
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         info = tarfile.TarInfo(name="firmware.bin")
         info.size = 4
         tar.addfile(info, io.BytesIO(b"FIRM"))
 
-    with pytest.raises(_UnpackArtifactsError, match=r"missing idedata\.json"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match=r"missing idedata\.json"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x0"),
             job_id="j",
         )
 
 
 def test_unpack_artifacts_response_missing_firmware_raises() -> None:
-    """A tarball without ``firmware.bin`` raises :class:`_UnpackArtifactsError`."""
+    """A tarball without ``firmware.bin`` raises :class:`UnpackArtifactsError`."""
     idedata_bytes = json.dumps({"extra": {"flash_images": []}}).encode("utf-8")
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
@@ -502,8 +502,8 @@ def test_unpack_artifacts_response_missing_firmware_raises() -> None:
         info.size = len(idedata_bytes)
         tar.addfile(info, io.BytesIO(idedata_bytes))
 
-    with pytest.raises(_UnpackArtifactsError, match=r"missing firmware\.bin"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match=r"missing firmware\.bin"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x0"),
             job_id="j",
         )
@@ -524,30 +524,30 @@ def test_unpack_artifacts_response_unreferenced_file_raises() -> None:
         stray_info.size = 1
         tar.addfile(stray_info, io.BytesIO(b"X"))
 
-    with pytest.raises(_UnpackArtifactsError, match="unexpected files not referenced"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match="unexpected files not referenced"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x0"),
             job_id="j",
         )
 
 
 def test_unpack_artifacts_response_invalid_idedata_json_raises() -> None:
-    """Malformed JSON in idedata.json raises :class:`_UnpackArtifactsError`."""
+    """Malformed JSON in idedata.json raises :class:`UnpackArtifactsError`."""
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         info = tarfile.TarInfo(name="idedata.json")
         info.size = 4
         tar.addfile(info, io.BytesIO(b"{bad"))
 
-    with pytest.raises(_UnpackArtifactsError, match="not valid JSON"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match="not valid JSON"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x0"),
             job_id="j",
         )
 
 
 def test_unpack_artifacts_response_non_dict_idedata_raises() -> None:
-    """idedata.json that parses to a non-object raises :class:`_UnpackArtifactsError`."""
+    """idedata.json that parses to a non-object raises :class:`UnpackArtifactsError`."""
     payload = b'["not", "an", "object"]'  # valid JSON, parses to list
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
@@ -555,15 +555,15 @@ def test_unpack_artifacts_response_non_dict_idedata_raises() -> None:
         info.size = len(payload)
         tar.addfile(info, io.BytesIO(payload))
 
-    with pytest.raises(_UnpackArtifactsError, match="not a JSON object"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match="not a JSON object"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x0"),
             job_id="j",
         )
 
 
 def test_unpack_artifacts_response_directory_entry_raises() -> None:
-    """A directory entry in the tarball (wire-format drift) raises ``_UnpackArtifactsError``."""
+    """A directory entry in the tarball (wire-format drift) raises ``UnpackArtifactsError``."""
     idedata_bytes = json.dumps({"extra": {"flash_images": []}}).encode("utf-8")
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
@@ -577,8 +577,8 @@ def test_unpack_artifacts_response_directory_entry_raises() -> None:
         dir_info.type = tarfile.DIRTYPE
         tar.addfile(dir_info)
 
-    with pytest.raises(_UnpackArtifactsError, match="non-file tarball entry"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match="non-file tarball entry"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x0"),
             job_id="j",
         )
@@ -600,15 +600,15 @@ def test_unpack_artifacts_response_missing_flash_image_from_extras_raises() -> N
         # No bootloader.bin in the tarball even though idedata
         # declares it.
 
-    with pytest.raises(_UnpackArtifactsError, match=r"missing flash image 'bootloader\.bin'"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match=r"missing flash image 'bootloader\.bin'"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x10000"),
             job_id="j",
         )
 
 
 def test_unpack_artifacts_response_non_dict_flash_image_entry_raises() -> None:
-    """A non-dict ``extra.flash_images`` entry raises :class:`_UnpackArtifactsError`."""
+    """A non-dict ``extra.flash_images`` entry raises :class:`UnpackArtifactsError`."""
     idedata_bytes = json.dumps(
         {"extra": {"flash_images": ["not-a-dict"]}}  # malformed entry
     ).encode("utf-8")
@@ -621,8 +621,8 @@ def test_unpack_artifacts_response_non_dict_flash_image_entry_raises() -> None:
         firmware_info.size = 4
         tar.addfile(firmware_info, io.BytesIO(b"FIRM"))
 
-    with pytest.raises(_UnpackArtifactsError, match="entry is not an object"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match="entry is not an object"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x10000"),
             job_id="j",
         )
@@ -642,8 +642,8 @@ def test_unpack_artifacts_response_flash_image_entry_missing_fields_raises() -> 
         firmware_info.size = 4
         tar.addfile(firmware_info, io.BytesIO(b"FIRM"))
 
-    with pytest.raises(_UnpackArtifactsError, match="missing path/offset"):
-        _unpack_artifacts_response(
+    with pytest.raises(UnpackArtifactsError, match="missing path/offset"):
+        unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x10000"),
             job_id="j",
         )
@@ -661,7 +661,7 @@ def test_unpack_artifacts_response_handles_non_dict_extra() -> None:
         firmware_info.size = 4
         tar.addfile(firmware_info, io.BytesIO(b"FIRM"))
 
-    response = _unpack_artifacts_response(
+    response = unpack_artifacts_response(
         DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x10000"),
         job_id="j",
     )

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -35,7 +35,9 @@ from esphome_device_builder.controllers.remote_build.artifacts_download import (
 from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     PackedArtifacts,
     UnpackArtifactsError,
+    extract_firmware_bin,
     pack_build_artifacts,
+    read_artifacts_tarball,
     unpack_artifacts_response,
 )
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
@@ -706,3 +708,131 @@ def test_load_build_artifacts_rejects_non_dict_idedata(
 
     with pytest.raises(ValueError, match="not a JSON object"):
         load_build_artifacts("kitchen.yaml")
+
+
+# ---------------------------------------------------------------------------
+# extract_firmware_bin — runner-side single-image extractor (7a-3)
+# ---------------------------------------------------------------------------
+
+
+def _build_minimal_tarball(members: dict[str, bytes]) -> bytes:
+    """Build a gzipped tarball with *members* (basename → bytes)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+def test_extract_firmware_bin_returns_firmware_bytes() -> None:
+    """The happy path: a tarball with ``firmware.bin`` returns its payload."""
+    expected = b"\xe9\x08\x02\x20RUNTIME-FIRMWARE-BYTES"
+    tarball = _build_minimal_tarball(
+        {"idedata.json": b"{}", "firmware.bin": expected, "extra.bin": b"x"},
+    )
+
+    assert extract_firmware_bin(tarball) == expected
+
+
+def test_extract_firmware_bin_raises_when_firmware_missing() -> None:
+    """No ``firmware.bin`` in the tarball → ``UnpackArtifactsError``."""
+    tarball = _build_minimal_tarball(
+        {"idedata.json": b"{}", "bootloader.bin": b"boot"},
+    )
+
+    with pytest.raises(UnpackArtifactsError, match=r"firmware\.bin missing"):
+        extract_firmware_bin(tarball)
+
+
+def test_extract_firmware_bin_raises_when_firmware_is_a_directory() -> None:
+    """
+    A directory entry named ``firmware.bin`` surfaces as ``UnpackArtifactsError``.
+
+    Defensive — the receiver-side packer never writes a
+    directory, so this is a wire-shape-drift / hostile-peer
+    case. ``tar.extractfile()`` returns ``None`` for non-file
+    members, and we surface a typed error rather than reading
+    bytes from ``None``.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name="firmware.bin")
+        info.type = tarfile.DIRTYPE
+        tar.addfile(info)
+    tarball = buf.getvalue()
+
+    with pytest.raises(UnpackArtifactsError, match="not a regular file"):
+        extract_firmware_bin(tarball)
+
+
+def test_extract_firmware_bin_raises_on_malformed_tarball() -> None:
+    """A non-gzipped / non-tar payload surfaces as ``UnpackArtifactsError``."""
+    with pytest.raises(UnpackArtifactsError, match="malformed tarball"):
+        extract_firmware_bin(b"this is not a gzipped tarball")
+
+
+def test_extract_firmware_bin_rejects_oversized_member() -> None:
+    """
+    A tarball declaring a firmware.bin larger than the cap fails fast.
+
+    Decompression-bomb defence: gzip can shrink huge zero-
+    filled / sparse data to a tiny on-the-wire payload. The
+    header-size gate trips before ``extractfile`` reads a
+    single byte.
+    """
+    # Build a tarball whose header declares a huge size but
+    # whose actual payload is tiny — mimic the
+    # "decompression-bomb" shape: a TarInfo with an inflated
+    # ``size`` field followed by the matching payload.
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        oversized_payload = b"\x00" * (FIRMWARE_MAX_TOTAL_BYTES + 1)
+        info = tarfile.TarInfo(name="firmware.bin")
+        info.size = len(oversized_payload)
+        tar.addfile(info, io.BytesIO(oversized_payload))
+    tarball = buf.getvalue()
+
+    with pytest.raises(UnpackArtifactsError, match="exceeding FIRMWARE_MAX_TOTAL_BYTES"):
+        extract_firmware_bin(tarball)
+
+
+# ---------------------------------------------------------------------------
+# read_artifacts_tarball — cumulative size cap (decompression-bomb defence)
+# ---------------------------------------------------------------------------
+
+
+def test_read_artifacts_tarball_rejects_cumulative_size_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Cumulative sum across members trips the cap even if every individual member fits.
+
+    The packer enforces the same per-call ceiling on the way
+    out, so a well-formed tarball never exceeds the cap. A
+    peer-controlled / malformed stream that declares N
+    just-under-cap members would still blow up the offloader
+    without this gate.
+    """
+    # Patch the cap to a tiny value so the test stays cheap.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball."
+        "FIRMWARE_MAX_TOTAL_BYTES",
+        128,
+    )
+    members = {
+        "idedata.json": b'{"extra": {}}',
+        "firmware.bin": b"x" * 64,
+        "bootloader.bin": b"x" * 64,
+    }
+    tarball = _build_minimal_tarball(members)
+
+    with pytest.raises(UnpackArtifactsError, match="cumulative size"):
+        read_artifacts_tarball(tarball)
+
+
+def test_read_artifacts_tarball_surfaces_malformed_tarball_as_unpack_error() -> None:
+    """A corrupt gzip / tar header → ``UnpackArtifactsError`` (not a tarfile traceback)."""
+    with pytest.raises(UnpackArtifactsError, match="is malformed"):
+        read_artifacts_tarball(b"definitely not a tarball")

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -752,14 +752,37 @@ def test_extract_firmware_bin_raises_when_firmware_is_a_directory() -> None:
 
     Defensive — the receiver-side packer never writes a
     directory, so this is a wire-shape-drift / hostile-peer
-    case. ``tar.extractfile()`` returns ``None`` for non-file
-    members, and we surface a typed error rather than reading
-    bytes from ``None``.
+    case. ``isfile()`` rejects non-regular members before we
+    read any bytes.
     """
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         info = tarfile.TarInfo(name="firmware.bin")
         info.type = tarfile.DIRTYPE
+        tar.addfile(info)
+    tarball = buf.getvalue()
+
+    with pytest.raises(UnpackArtifactsError, match="not a regular file"):
+        extract_firmware_bin(tarball)
+
+
+def test_extract_firmware_bin_raises_when_firmware_is_a_symlink() -> None:
+    """
+    A symlink entry named ``firmware.bin`` surfaces as ``UnpackArtifactsError``.
+
+    Defence against a hostile peer: ``tarfile.extractfile()``
+    follows symlinks transparently and returns a readable
+    stream pointing at whatever the link target resolves to
+    on the receiver's filesystem. An ``is None`` guard alone
+    would let the bytes through; the explicit
+    ``member.isfile()`` check rejects every non-regular type
+    before the read.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name="firmware.bin")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../../etc/passwd"
         tar.addfile(info)
     tarball = buf.getvalue()
 

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -43,6 +43,7 @@ from esphome_device_builder.controllers.remote_build.controller import (
     _validate_port,
 )
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.build_scheduler import BuildSchedulerInputs
 from esphome_device_builder.helpers.dashboard_advertise import SERVICE_TYPE
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.helpers.remote_build_layout import RemoteBuildPath
@@ -53,6 +54,7 @@ from esphome_device_builder.models import (
     IntentResponse,
     OffloaderRemoteBuildSettings,
     PairingSummary,
+    PeerQueueStatusSnapshotEntry,
     PeerStatus,
     RemoteBuildPeer,
     RemoteBuildPeerSource,
@@ -3741,3 +3743,86 @@ async def test_run_cleanup_loop_short_circuits_when_firmware_missing(
 
     # Sweep never ran because the firmware-None gate kicked in.
     assert sweep_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# build_scheduler_snapshot + get_pairing
+# ---------------------------------------------------------------------------
+
+
+def test_build_scheduler_snapshot_returns_immutable_view(tmp_path: Path) -> None:
+    """
+    The snapshot exposes pairings / open links / queue status as a frozen view.
+
+    The scheduler reads these without holding the controller's
+    event loop, and the helper :func:`pick_build_path` walks
+    them in a single tick. Immutable typing on the
+    :class:`BuildSchedulerInputs` fields means a future
+    refactor that hands the snapshot to a task can't mutate
+    the controller's RAM state through the indirection.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    pairing = _valid_stored_pairing()
+    controller._pairings[pairing.pin_sha256] = pairing
+    controller._open_peer_links.add(pairing.pin_sha256)
+    controller._peer_queue_status[pairing.pin_sha256] = PeerQueueStatusSnapshotEntry(
+        receiver_hostname=pairing.receiver_hostname,
+        receiver_port=pairing.receiver_port,
+        pin_sha256=pairing.pin_sha256,
+        idle=True,
+        running=False,
+        queue_depth=0,
+    )
+
+    snapshot = controller.build_scheduler_snapshot()
+
+    assert isinstance(snapshot, BuildSchedulerInputs)
+    assert snapshot.remote_builds_enabled is True
+    assert snapshot.pairings[pairing.pin_sha256] is pairing
+    assert pairing.pin_sha256 in snapshot.open_peer_links
+    assert snapshot.peer_queue_status[pairing.pin_sha256]["idle"] is True
+
+
+def test_build_scheduler_snapshot_decouples_from_live_state(tmp_path: Path) -> None:
+    """
+    Mutating the controller after the snapshot doesn't change the snapshot.
+
+    Shallow copies of the three dicts + a frozenset means a
+    follow-up mutation on the controller (a fresh pair, a
+    queue-status update) is invisible to a scheduler call
+    that's still walking the snapshot. The
+    :class:`BuildSchedulerInputs` typing already gates
+    mutation through the view; this test pins the underlying
+    copy behaviour so the typing's promise is honoured.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    initial = _valid_stored_pairing(label="initial")
+    controller._pairings[initial.pin_sha256] = initial
+
+    snapshot = controller.build_scheduler_snapshot()
+
+    # Mutations after the snapshot don't bleed through.
+    controller._pairings.clear()
+    controller._open_peer_links.add("some-other-pin")
+    controller._peer_queue_status["pin-2"] = PeerQueueStatusSnapshotEntry(
+        receiver_hostname="other.local",
+        receiver_port=6055,
+        pin_sha256="pin-2",
+        idle=False,
+        running=True,
+        queue_depth=0,
+    )
+
+    assert initial.pin_sha256 in snapshot.pairings
+    assert snapshot.open_peer_links == frozenset()
+    assert snapshot.peer_queue_status == {}
+
+
+def test_get_pairing_returns_matching_row(tmp_path: Path) -> None:
+    """``get_pairing(pin)`` returns the stored row; missing pins return ``None``."""
+    controller = _make_controller(config_dir=tmp_path)
+    pairing = _valid_stored_pairing(label="desktop")
+    controller._pairings[pairing.pin_sha256] = pairing
+
+    assert controller.get_pairing(pairing.pin_sha256) is pairing
+    assert controller.get_pairing("b" * 64) is None


### PR DESCRIPTION
# What does this implement/fix?

Phase 7a-3 of issue #106. Closes the transparent-install loop the 7a-2b runner (#560) left half-wired. The user-visible payoff: with a healthy paired build server, clicking Install on a device transparently dispatches the compile to that server and flashes locally with the receiver's bytes — no extra UI to discover, no separate Send-builds dance.

## Two coupled pieces

### (a) `firmware/install` scheduler integration

`FirmwareController.install` / `install_bulk` now route through `helpers.build_scheduler.pick_build_path` before queueing. When an APPROVED + peer-link-connected + idle pairing is available, the constructed `FirmwareJob` carries `source=REMOTE` + `source_pin_sha256=<pin>` + `source_label=<receiver_label>`; otherwise the job stays `source=LOCAL` and runs through the existing in-process subprocess pipeline. Silent fallback by design — the user doesn't pick a build location; the scheduler routes transparently.

Serial `port` values (`/dev/ttyUSB0`, `COM3`, etc.) force LOCAL. The REMOTE flash step uses `esphome upload --file <staged_firmware.bin>` which routes through `upload_using_esptool` as a single `FlashImage(offset="0x0")`. That works for OTA / web_server pushes but corrupts an ESP32 wired flash, which needs the multi-image bootloader / partitions / OTA-data set stitched from `idedata.extra.flash_images`. Until the runner can stage the full multi-image set in a way the non-`--file` path resolves cleanly, serial REMOTE installs stay LOCAL.

New on `RemoteBuildController`:
- **`build_scheduler_snapshot()`** — frozen `BuildSchedulerInputs` view of `_pairings` / `_open_peer_links` / `_peer_queue_status` plus the `remote_builds_enabled` master toggle (hardcoded `True` for now — the 7b Settings UI lands the proper toggle alongside the per-host / force-local / version-mismatch knobs).
- **`get_pairing(pin_sha256)`** — sync `StoredPairing` lookup the install resolver uses to stamp `source_label` on the new job.

### (b) Runner UPLOAD / INSTALL chain

`remote_runner.run_remote_compile_job` previously rejected anything that wasn't `JobType.COMPILE`. Now it also accepts `UPLOAD` and `INSTALL`:

- Same compile dispatch via `client.submit_job(target="compile")` (per § Transparent install flow's load-bearing "receiver only ever compiles" policy).
- On receiver-completed, pulls the artifact tarball back through `client.download_artifacts(job_id=...)`.
- Extracts `firmware.bin` to a per-job tmpdir via the shared `extract_firmware_bin` helper.
- Spawns `esphome upload --device <port> --file <staged>` through `FirmwareController._tracked_subprocess` — the same plumbing the local subprocess path uses, so:
  - Output streams via `_ingest_output_line` (one event stream for follow_job / firmware-tasks regardless of which CPU produced the bytes).
  - The cancel handler's `_terminate_current_process` lands SIGTERM on the upload chain.
- Failures (`download_artifacts` reject, malformed tarball, missing `firmware.bin`, non-zero `esphome upload` exit) route through `_fail_locally` and honour cancel intent if the user already clicked Stop.

## Refactor — tarball helpers consolidated

The receiver-side pack helpers (`_pack_build_artifacts` / `_PackedArtifacts`, previously in `artifacts_download.py`) and the offloader-side unpack helpers (`_unpack_artifacts_response` / `_UnpackArtifactsError` / `_read_artifacts_tarball` + six private helpers, previously in `remote_build/controller.py`) moved to a new **`controllers/remote_build/artifacts_tarball.py`** module so the wire format is owned in one place. The runner imports the same `extract_firmware_bin` helper the WS unpacker uses instead of duplicating the tarfile-open logic. `artifacts_download.py` keeps the streaming flow + `ArtifactsDownloadSender`; `controller.py` keeps the WS-side dispatch + `_download_artifacts_error_to_command_error`. Test imports / monkeypatch paths follow.

## Tracking

Filed **#562** to upstream `esphome.__main__.get_port_type` to a stable public module so we can drop our local `_is_serial_port`. The matching upstream PR + dep-bump lands later; the local classifier is fine as a holding pattern.

**Related issue or feature (if applicable):**

- esphome/device-builder#106 phase 7a-3.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

No new WS commands, no wire-shape changes. The install dialog's "Building on {receiver_label}" sub-line lands in a small lockstep frontend PR — `job.source_label` is the existing field added in #556, so the frontend just reads it.

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#294

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
