### PR TITLE
Push initial queue_status when registering a peer-link session

### DIFF
--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -1784,19 +1784,82 @@ class RemoteBuildController:
         self._peer_link_sessions[session.dashboard_id] = session
         if existing is not None and existing is not session:
             await existing.terminate(TerminateReason.SUPERSEDED)
+        # Send the receiver's current queue_status to the just-
+        # connected offloader. The transition-driven broadcast
+        # (``_on_firmware_queue_transition`` → ``_broadcast_queue_status``)
+        # only fires when the receiver's local firmware queue
+        # mutates — a cold-connected offloader that pairs before
+        # the receiver builds anything would otherwise never
+        # observe an idle entry, and the 7a-3 install scheduler's
+        # ``pick_build_path`` requires an entry in
+        # ``_peer_queue_status`` to consider a pairing eligible
+        # (the "no signal that the receiver can accept work"
+        # gate). Without this initial push the offloader's
+        # ``firmware/install`` silently falls back to LOCAL on
+        # every paired receiver until the receiver happens to
+        # build something locally — the exact bug that surfaced
+        # in production after #568 landed.
+        if self._db.firmware is not None:
+            try:
+                idle, running, queue_depth = self._db.firmware.queue_status_snapshot()
+            except Exception:
+                # Best-effort: a snapshot read failure mustn't
+                # poison session registration. The transition-
+                # driven broadcast (``_on_firmware_queue_transition``)
+                # will still catch up the offloader on the next
+                # queue change. Mirrors the swallow-and-log stance
+                # of :meth:`_broadcast_queue_status`.
+                _LOGGER.exception(
+                    "firmware.queue_status_snapshot() raised on session register; "
+                    "skipping initial queue_status push to %s",
+                    session.dashboard_id,
+                )
+            else:
+                self._db.create_background_task(
+                    self._send_initial_queue_status(session, idle, running, queue_depth)
+                )
         # Fire AFTER the dict insert so any subscriber lookup of
         # ``_peer_link_sessions[dashboard_id]`` from inside the
-        # listener observes the just-registered session. The
-        # 5b ``queue_status`` broadcast path can layer onto this
-        # hook to send the initial snapshot to a freshly-
-        # connected offloader without a lookup-then-push race
-        # window (today 5b only pushes on firmware queue
-        # transitions; a follow-up subscribing to this event
-        # closes the cold-connect gap).
+        # listener observes the just-registered session.
         if self._db.bus is not None:
             self._db.bus.fire(
                 EventType.RECEIVER_PEER_LINK_SESSION_OPENED,
                 ReceiverPeerLinkSessionOpenedData(dashboard_id=session.dashboard_id),
+            )
+
+    async def _send_initial_queue_status(
+        self,
+        session: PeerLinkSession,
+        idle: bool,
+        running: bool,
+        queue_depth: int,
+    ) -> None:
+        """Push a one-shot ``queue_status`` frame to a freshly-connected session.
+
+        Mirror of :meth:`_broadcast_queue_status` but addressed
+        to a single session — invoked from
+        :meth:`register_peer_link_session` so the offloader gets
+        an idle / running signal on cold-connect rather than
+        waiting for the receiver's next firmware queue
+        transition. Best-effort: a session that has already
+        torn down between the registry insert and this send
+        no-ops cleanly (``send_app_frame`` is gated on the
+        session's ``_closing`` flag) and the offloader's next
+        reconnect tries again.
+        """
+        payload = QueueStatusFrameData(
+            type="queue_status",
+            idle=idle,
+            running=running,
+            queue_depth=queue_depth,
+        )
+        try:
+            await session.send_app_frame(dict(payload))
+        except Exception:
+            _LOGGER.exception(
+                "initial queue_status to session %s raised; "
+                "offloader will catch up on the next queue transition",
+                session.dashboard_id,
             )
 
     def unregister_peer_link_session(self, session: PeerLinkSession) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,14 @@ def make_remote_build_controller(
     db.settings = MagicMock()
     db.settings.config_dir = config_dir
     db.create_background_task = asyncio.create_task
+    # ``register_peer_link_session`` calls ``firmware.queue_status_snapshot()``
+    # to push an initial idle / running / depth signal to a
+    # freshly-connected offloader (cold-connect gap fix). The
+    # default MagicMock auto-attribute returns a MagicMock that
+    # doesn't unpack as a 3-tuple, so pin a sane "fresh queue is
+    # idle" shape here — same value the production firmware
+    # controller returns on a never-built queue.
+    db.firmware.queue_status_snapshot = MagicMock(return_value=(True, False, 0))
     if bus is not None:
         db.bus = bus
     return RemoteBuildController(db)

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -70,7 +70,6 @@ from esphome_device_builder.models import (
     JobLifecycleData,
     JobStatus,
     JobType,
-    PeerQueueStatusSnapshotEntry,
 )
 
 from .._storage_fixtures import write_storage_json
@@ -223,97 +222,59 @@ def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dic
     return images
 
 
-def _seed_idle_queue_status(instances: PairedInstances) -> None:
-    """Pretend the receiver broadcast a single idle ``queue_status`` snapshot.
-
-    The 7a-3 install routing reads
-    :attr:`RemoteBuildController._peer_queue_status` through
-    :meth:`build_scheduler_snapshot` and refuses to pick REMOTE
-    for any pin without an idle entry — the scheduler's
-    "no signal that the receiver can accept work" gate. In
-    production the receiver's
-    :meth:`FirmwareController.queue_status_snapshot` fires on
-    queue idle/run transitions and the offloader's
-    :meth:`_on_offloader_queue_status_changed` listener
-    populates the cache. The harness's receiver-side firmware
-    controller is a :class:`MagicMock`, so the live broadcast
-    never fires; seed the offloader cache directly with the
-    shape the scheduler expects.
-    """
-    instances.offloader._peer_queue_status[instances.pin_sha256] = PeerQueueStatusSnapshotEntry(
-        receiver_hostname="127.0.0.1",
-        receiver_port=instances.receiver_server.port or 0,
-        pin_sha256=instances.pin_sha256,
-        idle=True,
-        running=False,
-        queue_depth=0,
-    )
-
-
 @pytest.mark.asyncio
-async def test_paired_offloader_scheduler_picks_remote_for_idle_receiver(
+async def test_cold_connect_offloader_observes_initial_queue_status_then_picks_remote(
     paired_instances: PairedInstances,
 ) -> None:
-    """The live paired-instances RAM state resolves to ``BuildPath.REMOTE``.
+    """Cold-connect offloader gets an idle entry via the receiver's auto-push.
 
-    Pins the 7a-3 install routing's RAM-canonical contract:
+    The bug this test pins: previously the receiver only
+    broadcast ``queue_status`` on its own firmware queue
+    transitions (``_on_firmware_queue_transition``). A
+    cold-connected offloader that paired before the receiver
+    built anything never observed an idle entry, and the 7a-3
+    install scheduler's ``pick_build_path`` requires an entry
+    in ``_peer_queue_status`` to consider a pairing eligible —
+    so ``firmware/install`` silently fell back to LOCAL on
+    every paired receiver. The fix has the receiver send a
+    one-shot ``queue_status`` to a freshly-registered session
+    inside :meth:`register_peer_link_session`.
 
-    * :meth:`RemoteBuildController.build_scheduler_snapshot`
-      reads ``_pairings`` (APPROVED + paired_at-sorted),
-      ``_open_peer_links`` (live peer-link session set), and
-      ``_peer_queue_status`` (per-pin idle/running cache) into
-      one :class:`BuildSchedulerInputs`.
-    * :func:`helpers.build_scheduler.pick_build_path` returns
-      ``BuildPath.REMOTE`` with the pin matching the harness's
-      live receiver.
+    The previous shape of this test pre-seeded
+    ``offloader._peer_queue_status[pin]`` to model the
+    transition-driven path, masking the cold-connect gap. The
+    new test asserts the offloader observes the idle entry by
+    waiting on its ``OFFLOADER_QUEUE_STATUS_CHANGED`` event
+    (fired by the receive loop after parsing the receiver's
+    one-shot frame) — no manual seeding. A regression that
+    removes the initial push or otherwise breaks the cold-
+    connect path will surface here.
 
-    The unit tests in ``test_remote_build_controller.py`` cover
-    ``build_scheduler_snapshot`` against a stub controller's
-    pre-seeded dicts. The e2e value here is pinning that a
-    real-handshake / real-approve / real-peer-link-session
-    lifecycle lands the RAM state in the shape the scheduler
-    expects — without an explicit gate in between, a future
-    regression on any of those three mutation sites would slip
-    past the unit suite (which doesn't drive the live
-    transitions) but surface here.
+    Once the cache entry has landed,
+    :func:`build_scheduler_snapshot` + :func:`pick_build_path`
+    resolve to ``BuildPath.REMOTE`` against the same pin.
     """
+    queue_status_landed = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED
+    )
     await paired_instances.wait_until_session_opened()
-    _seed_idle_queue_status(paired_instances)
+    # Wait for the offloader to observe the receiver's initial
+    # ``queue_status`` push. Cold-connect contract:
+    # the offloader's ``_peer_queue_status`` must populate from
+    # the wire without any local-side seeding.
+    await asyncio.wait_for(queue_status_landed.received.wait(), timeout=2.0)
+    payload = queue_status_landed[-1]
+    assert payload["pin_sha256"] == paired_instances.pin_sha256
+    assert payload["idle"] is True
+    assert payload["running"] is False
+    assert payload["queue_depth"] == 0
 
+    # Now that the offloader-side cache reflects the receiver's
+    # signal, the scheduler routes REMOTE.
     snapshot = paired_instances.offloader.build_scheduler_snapshot()
     decision = pick_build_path(snapshot)
-
     assert decision.path is BuildPath.REMOTE
     assert decision.pin_sha256 == paired_instances.pin_sha256
-
-
-@pytest.mark.asyncio
-async def test_paired_offloader_scheduler_falls_back_local_without_queue_snapshot(
-    paired_instances: PairedInstances,
-) -> None:
-    """No idle queue snapshot → scheduler falls back to LOCAL.
-
-    Same APPROVED + live-session state as the previous test but
-    no ``_peer_queue_status`` entry. The scheduler's "missing
-    entry disqualifies the pairing" rule is what's pinned here —
-    the design's safe-fallback stance, asserted against the
-    live paired state to catch a future regression that pre-
-    seeds the snapshot from the pairing row (which would
-    silently route to a receiver whose queue depth we have no
-    signal on).
-    """
-    await paired_instances.wait_until_session_opened()
-    # Deliberately don't seed _peer_queue_status — production
-    # populates it from the receiver's queue_status broadcast,
-    # which the harness's MagicMock firmware controller never
-    # fires.
-    assert paired_instances.pin_sha256 not in paired_instances.offloader._peer_queue_status
-
-    snapshot = paired_instances.offloader.build_scheduler_snapshot()
-    decision = pick_build_path(snapshot)
-
-    assert decision.path is BuildPath.LOCAL
-    assert decision.pin_sha256 is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1688,6 +1688,41 @@ async def test_register_peer_link_session_swallows_snapshot_exception(tmp_path: 
     assert controller._peer_link_sessions["alpha"] is session
 
 
+@pytest.mark.asyncio
+async def test_register_peer_link_session_swallows_send_app_frame_exception(
+    tmp_path: Path,
+) -> None:
+    """A ``send_app_frame`` raise inside the background task is logged, not propagated.
+
+    ``send_app_frame`` already swallows the common transport /
+    encrypt / serialise failures and returns ``False``; the
+    inner ``except Exception`` in :meth:`_send_initial_queue_status`
+    is the catch-all for an unexpected raise (mock contract
+    drift, future code path that raises before the inner gate).
+    Pins that an unhandled raise from the send doesn't leak into
+    the background task's exception handler — the offloader
+    catches up on the next queue transition instead.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    controller._db.firmware = MagicMock()
+    controller._db.firmware.queue_status_snapshot = MagicMock(return_value=(True, False, 0))
+
+    session = MagicMock(spec=PeerLinkSession)
+    session.dashboard_id = "alpha"
+    session.send_app_frame = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await controller.register_peer_link_session(session)
+    # Drain the background task; the inner swallow must keep
+    # the raise from surfacing as an unhandled task exception.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    session.send_app_frame.assert_awaited_once()
+    # Session still registered — the failed push doesn't roll it back.
+    assert controller._peer_link_sessions["alpha"] is session
+
+
 def test_unregister_peer_link_session_no_op_when_replaced(tmp_path: Path) -> None:
     """Unregistering a session that has already been replaced doesn't evict the new one."""
     controller = _make_controller(config_dir=tmp_path)

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1074,6 +1074,13 @@ async def _drive_peer_link_session_open(
     await ws.send_bytes(msg3)
     encrypted_response = await ws.receive_bytes()
     assert _decode_intent_response(session, encrypted_response) == IntentResponse.OK
+    # The receiver pushes a one-shot ``queue_status`` frame right
+    # after registering the session (cold-connect signal for the
+    # 7a-3 install scheduler). Drain it here so callers asserting
+    # on subsequent application frames don't have to special-case
+    # the initial push at every call site.
+    initial_app_frame = await ws.receive_bytes()
+    assert _decode_app_frame(session, initial_app_frame)["type"] == "queue_status"
     return session, ws, initiator_pub
 
 
@@ -1590,6 +1597,64 @@ async def test_register_peer_link_session_kicks_existing(tmp_path: Path) -> None
     new.terminate.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_register_peer_link_session_pushes_initial_queue_status(tmp_path: Path) -> None:
+    """A freshly-registered session gets a one-shot ``queue_status`` frame.
+
+    The cold-connect signal for the 7a-3 install scheduler: the
+    transition-driven broadcast (``_on_firmware_queue_transition``)
+    only fires when the receiver's local firmware queue mutates.
+    Without the initial push, an offloader that pairs against a
+    receiver whose queue is permanently idle would never see a
+    ``_peer_queue_status`` entry, and ``pick_build_path`` would
+    silently fall back to LOCAL on every install request.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    controller._db.firmware = MagicMock()
+    controller._db.firmware.queue_status_snapshot = MagicMock(return_value=(True, False, 0))
+
+    session = MagicMock(spec=PeerLinkSession)
+    session.dashboard_id = "alpha"
+    session.send_app_frame = AsyncMock(return_value=True)
+
+    await controller.register_peer_link_session(session)
+    # The send is dispatched as a background task; let it drain.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    session.send_app_frame.assert_awaited_once_with(
+        {"type": "queue_status", "idle": True, "running": False, "queue_depth": 0}
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_peer_link_session_skips_initial_queue_status_when_firmware_missing(
+    tmp_path: Path,
+) -> None:
+    """A controller without a firmware backend registers without a push.
+
+    Firmware queue is wired lazily by ``DeviceBuilder.start()``;
+    a session-register that races a not-yet-wired
+    :attr:`_db.firmware` must not crash. Mirror of the
+    ``self._db.firmware is None`` short-circuit in
+    :meth:`_on_firmware_queue_transition`.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    controller._db.firmware = None  # production pre-``start`` state
+
+    session = MagicMock(spec=PeerLinkSession)
+    session.dashboard_id = "alpha"
+    session.send_app_frame = AsyncMock()
+
+    await controller.register_peer_link_session(session)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    session.send_app_frame.assert_not_called()
+
+
 def test_unregister_peer_link_session_no_op_when_replaced(tmp_path: Path) -> None:
     """Unregistering a session that has already been replaced doesn't evict the new one."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1993,6 +2058,16 @@ async def test_run_peer_link_session_heartbeat_closures_route_to_session(
     # the heartbeat task — the helper sets ``heartbeat_started``
     # the moment its callbacks land in ``captured``.
     await asyncio.wait_for(heartbeat_started.wait(), timeout=2.0)
+    # ``register_peer_link_session`` now schedules a one-shot
+    # ``queue_status`` push on session open (cold-connect signal
+    # for the 7a-3 install scheduler). Wait for that frame to
+    # land in ``ws.sends`` and decrypt it so the initiator's
+    # nonce counter advances; subsequent ping / terminate
+    # decrypts on the same Noise session are then aligned.
+    while not ws.sends:
+        await asyncio.sleep(0)
+    initial = _json.loads(initiator.decrypt(ws.sends[-1]))
+    assert initial["type"] == "queue_status"
 
     # Exercise ``_send_ping`` — the closure encrypts and sends a
     # ping frame through ``send_app_frame``.

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1655,6 +1655,39 @@ async def test_register_peer_link_session_skips_initial_queue_status_when_firmwa
     session.send_app_frame.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_register_peer_link_session_swallows_snapshot_exception(tmp_path: Path) -> None:
+    """A ``queue_status_snapshot`` raise mustn't poison session registration.
+
+    Best-effort contract: the initial push is a cold-connect
+    optimisation, not a load-bearing step. A raise from
+    ``firmware.queue_status_snapshot`` (mock contract drift,
+    unexpected internal error, etc.) gets logged and swallowed
+    so the session still registers cleanly; the transition-
+    driven broadcast catches the offloader up on the next
+    queue change. Mirrors the swallow-and-log stance of
+    :meth:`_broadcast_queue_status` for per-session sends.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    controller._db.firmware = MagicMock()
+    controller._db.firmware.queue_status_snapshot = MagicMock(side_effect=RuntimeError("boom"))
+
+    session = MagicMock(spec=PeerLinkSession)
+    session.dashboard_id = "alpha"
+    session.send_app_frame = AsyncMock()
+
+    # Must not raise — register completes cleanly even on a bad
+    # snapshot read.
+    await controller.register_peer_link_session(session)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    # Push skipped, but the session is registered.
+    session.send_app_frame.assert_not_called()
+    assert controller._peer_link_sessions["alpha"] is session
+
+
 def test_unregister_peer_link_session_no_op_when_replaced(tmp_path: Path) -> None:
     """Unregistering a session that has already been replaced doesn't evict the new one."""
     controller = _make_controller(config_dir=tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

Fixes the production bug a user hit immediately after #568 landed: paired a remote build server, clicked Install, and the build still ran locally.

## Root cause

The receiver only broadcasts `queue_status` from `_on_firmware_queue_transition` — i.e. **only when its own firmware queue mutates**. A cold-connected offloader that paired against a receiver whose queue hasn't been touched yet never observed an entry in `_peer_queue_status`, and the 7a-3 install scheduler's `pick_build_path` requires that entry to consider a pairing eligible ("no signal that the receiver can accept work" gate). Result: `firmware/install` silently fell back to LOCAL on every paired receiver until the receiver happened to build something itself.

This was actually documented as a known gap in the original code:

```python
# The 5b ``queue_status`` broadcast path can layer onto this
# hook to send the initial snapshot to a freshly-
# connected offloader without a lookup-then-push race
# window (today 5b only pushes on firmware queue
# transitions; a follow-up subscribing to this event
# closes the cold-connect gap).
```

The follow-up was deferred when 5b landed; 7a-3 made it load-bearing.

## Fix

`register_peer_link_session` now reads the receiver's current `queue_status_snapshot` and schedules a one-shot `_send_initial_queue_status` to the freshly-registered session. Mirror of `_broadcast_queue_status` but addressed to a single session.

* Snapshot read failure → logged and skipped; transition-driven path catches the offloader up on the next change. Mirrors the swallow-and-log stance the existing broadcast path uses.
* Missing firmware controller (pre-`DeviceBuilder.start()` race) → short-circuits cleanly.

## Honest answer on test coverage

This is the part that's worth flagging: **the e2e test I shipped in #573 worked around the exact gap rather than catching it.** `_seed_idle_queue_status` hand-injected an entry into `offloader._peer_queue_status[pin]`, modelling the transition-driven path that the harness's `MagicMock` firmware controller never fires. The cold-connect path was invisible to the test, which is exactly why the production bug slipped through.

This PR rewrites that test to wait on `OFFLOADER_QUEUE_STATUS_CHANGED` after `wait_until_session_opened`, with no manual seeding — the receiver's auto-push must populate the cache. Verified empirically: without the fix the new test fails with `TimeoutError`; with it, passes.

## What lands

* **`controllers/remote_build/controller.py`** — `register_peer_link_session` reads `queue_status_snapshot` (guarded by try/except) and schedules `_send_initial_queue_status` as a background task. The new helper sits next to `_broadcast_queue_status`.
* **`tests/test_remote_build_peer_link.py`** — two new unit tests:
  - `test_register_peer_link_session_pushes_initial_queue_status` — happy path: snapshot is read, `send_app_frame` awaited once with the matching `{type: "queue_status", idle, running, queue_depth}` payload.
  - `test_register_peer_link_session_skips_initial_queue_status_when_firmware_missing` — the `_db.firmware is None` short-circuit (covers the pre-`start()` race).
* **`tests/e2e/test_install_round_trip.py`** — rewrote `test_paired_offloader_scheduler_picks_remote_for_idle_receiver` as `test_cold_connect_offloader_observes_initial_queue_status_then_picks_remote`, dropping the manual `_seed_idle_queue_status` seed. Removed the no-longer-relevant `test_paired_offloader_scheduler_falls_back_local_without_queue_snapshot` — the unit suite at `test_build_scheduler.py` already pins `pick_build_path`'s idle-gate rule, and the receiver now always pushes the snapshot on session open so the "no entry" condition no longer matches reality on the harness.
* **`tests/test_remote_build_peer_link.py`** wire helper — `_drive_peer_link_session_open` now drains the initial `queue_status` frame so each test asserting on subsequent application frames doesn't have to special-case the new push.
* **`tests/test_remote_build_peer_link.py`** heartbeat test — `_send_ping`/`_on_dead` closure test advances the initiator's Noise nonce past the new initial frame before asserting on subsequent ping/terminate.
* **`tests/conftest.py`** — `make_remote_build_controller` pins `firmware.queue_status_snapshot` to `(True, False, 0)` so the shared two-instance harness has a sane initial-broadcast shape; mirrors a production "fresh queue is idle" state.

## Testing

* `pytest tests/e2e -q` → 18 passed (one removed).
* `pytest tests/ -q --ignore=tests/e2e` → 2966 passed.
* Verified the new e2e cold-connect test fails (TimeoutError) without the fix and passes with it.

**Related issue or feature (if applicable):**

- Issue #106 phase 7a-3 — bug surfaced in production after #568 landed.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
