### PR TITLE
Release runner slot before firing terminal job events

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -111,6 +111,17 @@ _BUILD_PRODUCING_JOB_TYPES: frozenset[JobType] = frozenset(
 # running for this configuration?" check has to filter for these.
 _ACTIVE_JOB_STATUSES: frozenset[JobStatus] = frozenset({JobStatus.QUEUED, JobStatus.RUNNING})
 
+# Maps each terminal :class:`JobStatus` to the lifecycle event the
+# runner fires when a job reaches that status. Routes through
+# :meth:`FirmwareController._finalize_terminal` so every
+# finalisation site stays paired with the right event — keeps the
+# six-call-site signature consistent.
+_STATUS_TO_TERMINAL_EVENT: dict[JobStatus, EventType] = {
+    JobStatus.COMPLETED: EventType.JOB_COMPLETED,
+    JobStatus.FAILED: EventType.JOB_FAILED,
+    JobStatus.CANCELLED: EventType.JOB_CANCELLED,
+}
+
 
 def _resolve_download_component(target_platform: str | None) -> str:
     """Return the ``esphome.components`` module name for *target_platform*.
@@ -749,6 +760,16 @@ class FirmwareController:
             raise CommandError(ErrorCode.NOT_FOUND, msg)
 
         if job.status == JobStatus.QUEUED:
+            # Mark + persist before fire so a restart-after-cancel
+            # reload sees the job as CANCELLED (the test pins
+            # this in ``test_cancelled_job_survives_restart_without_
+            # being_requeued``). Doesn't go through
+            # :meth:`_finalize_terminal` because the helper
+            # collapses mark + fire and we need to land
+            # ``_persist_jobs`` in between; the slot-release the
+            # helper does is a no-op anyway for a QUEUED job
+            # (``_current_job`` belongs to whatever's actually
+            # running, not this queue entry).
             _mark_job_terminal(job, JobStatus.CANCELLED)
             self._prune_history()
             await self._persist_jobs()
@@ -1033,7 +1054,6 @@ class FirmwareController:
                 _LOGGER.info("Job %s cancelled mid-run (exit %s)", job.job_id, exit_code)
             else:
                 success = exit_code == 0 and not has_error_in_output
-                _mark_job_terminal(job, JobStatus.COMPLETED if success else JobStatus.FAILED)
                 if has_error_in_output and exit_code == 0:
                     if saw_no_esphome_module:
                         job.error = (
@@ -1047,9 +1067,11 @@ class FirmwareController:
                         job.error = "Process exited 0 but output contains errors"
                     _LOGGER.warning("Job %s: %s", job.job_id, job.error)
 
-                event = EventType.JOB_COMPLETED if success else EventType.JOB_FAILED
-                terminal_payload: JobLifecycleData = {"job": job}
-                self._db.bus.fire(event, terminal_payload)
+                # ``_finalize_terminal`` runs the mark + slot-
+                # release + fire sequence in the order the
+                # ``queue_status`` broadcaster needs (see helper
+                # docstring for the regression context).
+                self._finalize_terminal(job, JobStatus.COMPLETED if success else JobStatus.FAILED)
                 _LOGGER.info(
                     "Job %s %s (exit code %s)",
                     job.job_id,
@@ -1076,9 +1098,7 @@ class FirmwareController:
                 _LOGGER.info("Job %s cancelled before subprocess wait: %s", job.job_id, exc)
             else:
                 job.error = str(exc)
-                _mark_job_terminal(job, JobStatus.FAILED)
-                failed_payload: JobLifecycleData = {"job": job}
-                self._db.bus.fire(EventType.JOB_FAILED, failed_payload)
+                self._finalize_terminal(job, JobStatus.FAILED)
                 _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
         finally:
             self._current_job = None
@@ -1195,18 +1215,62 @@ class FirmwareController:
         finally:
             self._current_process = prev
 
+    def _finalize_terminal(self, job: FirmwareJob, status: JobStatus) -> None:
+        """Stamp *job* terminal, release the runner slot, fire the matching event.
+
+        The three-step "this job is over" sequence every
+        finalisation site has to run, bundled so a future call
+        site can't accidentally skip one. Steps in order:
+
+        1. :func:`_mark_job_terminal` stamps ``status`` +
+           ``completed_at`` on the model (raises on a
+           non-terminal *status* — preserves the existing
+           loud-fail guard).
+        2. Release the runner slot (``_current_job`` /
+           ``_current_process``) if *job* holds it. Guarded on
+           ``is job`` so the QUEUED-cancel path in :meth:`cancel`
+           (where ``_current_job`` belongs to whatever's actually
+           running) doesn't evict the wrong job.
+        3. Fire the matching lifecycle event
+           (``JOB_COMPLETED`` / ``JOB_FAILED`` / ``JOB_CANCELLED``)
+           on the bus.
+
+        Step 2 has to land *before* step 3: the ``queue_status``
+        broadcaster
+        (:meth:`RemoteBuildController._on_firmware_queue_transition`)
+        reads :meth:`queue_status_snapshot` *synchronously*
+        inside the fire and needs to see the post-terminal idle
+        state. Without the prior release the snapshot reports
+        ``running=True``, the offloader's ``_peer_queue_status``
+        cache freezes there, and
+        :func:`helpers.build_scheduler.pick_build_path` rejects
+        the pairing on every subsequent install — the silent
+        LOCAL-fallback regression after the first remote build.
+        The ``finally`` block in :meth:`_execute_job` still
+        re-clears both fields as a backstop for exception paths
+        that bypass this helper.
+
+        Callers that want to ride a payload field (e.g.
+        ``job.error = "..."``) into the event must set it on the
+        job *before* invoking this helper — the broadcast reads
+        whatever's on the model at fire time.
+        """
+        _mark_job_terminal(job, status)
+        if self._current_job is job:
+            self._current_job = None
+            self._current_process = None
+        payload: JobLifecycleData = {"job": job}
+        self._db.bus.fire(_STATUS_TO_TERMINAL_EVENT[status], payload)
+
     def _finalize_cancelled(self, job: FirmwareJob) -> None:
         """
         Run the runtime-cancel finalisation: discard, mark, fire.
 
-        Centralises the three-line sequence every "user cancelled
-        an in-flight job" code path needs: drop the id from
-        ``_cancel_requested`` (so a subsequent re-queue starts
-        clean), stamp ``CANCELLED`` + ``completed_at`` via the
-        shared ``_mark_job_terminal`` helper, and broadcast
-        ``JOB_CANCELLED`` so frontends following the all-jobs
-        stream stay consistent. Each call site adds its own log
-        line so the message can name the phase that was cancelled.
+        Drops the id from ``_cancel_requested`` (so a subsequent
+        re-queue starts clean) then routes through
+        :meth:`_finalize_terminal` for the mark + slot-release +
+        fire sequence. Each call site adds its own log line so
+        the message can name the phase that was cancelled.
 
         Doesn't cover the QUEUED-cancel path in ``cancel`` itself —
         that one also runs ``_prune_history`` + ``_persist_jobs``
@@ -1215,9 +1279,7 @@ class FirmwareController:
         they don't otherwise need.
         """
         self._cancel_requested.discard(job.job_id)
-        _mark_job_terminal(job, JobStatus.CANCELLED)
-        post_cancel_payload: JobLifecycleData = {"job": job}
-        self._db.bus.fire(EventType.JOB_CANCELLED, post_cancel_payload)
+        self._finalize_terminal(job, JobStatus.CANCELLED)
 
     def _raise_if_cancelled(self, job: FirmwareJob, phase: str) -> None:
         """

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -41,7 +41,6 @@ from ...helpers.subprocess import iter_lines_with_progress
 from ...models import (
     EventType,
     FirmwareJob,
-    JobLifecycleData,
     JobStatus,
     JobType,
     OffloaderJobOutputData,
@@ -56,7 +55,7 @@ from ..remote_build.peer_link_client import (
     SubmitJobTimeoutError,
 )
 from .constants import ESPHOME_SUBPROCESS_ENV
-from .helpers import _ingest_output_line, _mark_job_terminal
+from .helpers import _ingest_output_line
 
 if TYPE_CHECKING:
     from ...helpers.event_bus import Event, EventBus
@@ -626,9 +625,13 @@ def _finalize_success(controller: FirmwareController, job: FirmwareJob) -> None:
     stamp on the caller forces the COMPILE path to make the
     "remote compile produced zero exit" choice explicit.
     """
-    _mark_job_terminal(job, JobStatus.COMPLETED)
-    payload: JobLifecycleData = {"job": job}
-    controller.bus.fire(EventType.JOB_COMPLETED, payload)
+    # Routes through the controller's terminal-finalise helper so
+    # the mark + runner-slot-release + fire sequence stays in
+    # lockstep with the local subprocess path in
+    # :meth:`FirmwareController._execute_job` (see
+    # :meth:`FirmwareController._finalize_terminal` for the
+    # ``queue_status`` broadcaster ordering rationale).
+    controller._finalize_terminal(job, JobStatus.COMPLETED)
 
 
 async def _send_cancel_or_finalise(
@@ -707,7 +710,5 @@ def _fail_locally(
         _LOGGER.info("Remote job %s cancelled (failure path: %s)", job.job_id, error)
         return
     job.error = error
-    _mark_job_terminal(job, JobStatus.FAILED)
-    payload: JobLifecycleData = {"job": job}
-    controller.bus.fire(EventType.JOB_FAILED, payload)
+    controller._finalize_terminal(job, JobStatus.FAILED)
     _LOGGER.warning("Remote job %s failed: %s", job.job_id, error)

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -170,12 +170,20 @@ def firmware_controller_factory(
         # binding doesn't treat the lambda as an unbound method.
         controller._db.create_background_task = lambda coro: coro.close()
 
+        # ``_finalize_terminal`` releases the runner slot before
+        # firing — so ``_current_job`` / ``_current_process`` need
+        # to exist on every stub (default ``None``, matching
+        # production's ``__init__``) even on test paths that
+        # don't drive the runner. Without this, cancel-queued /
+        # supersede tests that fire JOB_CANCELLED through the
+        # helper crash on ``AttributeError``.
+        controller._current_job = None
+        controller._current_process = None
+
         if with_queue:
             controller._queue = AsyncMock()
 
         if with_terminate:
-            controller._current_job = None
-            controller._current_process = None
             controller._cancel_requested = set()
             controller._cancel_events = {}
             controller._terminate_current_process = AsyncMock()

--- a/tests/controllers/firmware/test_queue_status.py
+++ b/tests/controllers/firmware/test_queue_status.py
@@ -7,14 +7,33 @@ state combinations (idle / queued-only / running) pinned here
 so a future refactor that splits the runner slot or queue
 representation has a one-stop check that the public shape
 stays correct.
+
+The terminal-ordering tests at the bottom of the file pin the
+*timing* contract: a JOB_COMPLETED / JOB_FAILED / JOB_CANCELLED
+listener that reads ``queue_status_snapshot()`` inside the
+synchronous ``bus.fire`` callback must see ``running=False``.
+The remote-build controller's broadcaster does exactly this,
+and an off-by-one ordering on the slot release used to leave
+the offloader's ``_peer_queue_status`` cache frozen at
+``running=True`` (silent-LOCAL fallback on every install after
+the first remote build).
 """
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock
 
-from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.models import FirmwareJob, JobType
+import pytest
+
+from esphome_device_builder.controllers.firmware import FirmwareController, remote_runner
+from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.models import (
+    EventType,
+    FirmwareJob,
+    JobStatus,
+    JobType,
+)
 
 
 def _make_controller() -> FirmwareController:
@@ -73,3 +92,165 @@ def test_queue_status_snapshot_running_and_queued() -> None:
     assert idle is False
     assert running is True
     assert queue_depth == 1
+
+
+# ---------------------------------------------------------------------------
+# Terminal-fire ordering: a listener that snapshots inside the fire
+# must observe the post-terminal idle state, not the still-running
+# snapshot. Pins the contract every terminal-fire site reaches
+# through ``FirmwareController._finalize_terminal``.
+# ---------------------------------------------------------------------------
+
+
+def _make_controller_with_real_bus() -> FirmwareController:
+    """Stub a controller with a real :class:`EventBus` for sync listener tests.
+
+    ``MagicMock`` for the bus is enough for the snapshot tests
+    above; the ordering tests need a real ``bus.fire`` so a
+    listener installed via ``add_listener`` runs synchronously
+    inside the fire (the production semantics the remote-build
+    broadcaster relies on).
+    """
+    db = MagicMock()
+    db.bus = EventBus()
+    controller = FirmwareController.__new__(FirmwareController)
+    controller._db = db
+    controller._jobs = {}
+    controller._queue = asyncio.Queue()
+    controller._current_job = None
+    controller._current_process = None
+    controller._cancel_requested = set()
+    controller._cancel_events = {}
+    return controller
+
+
+def _capture_snapshot_in_listener(
+    controller: FirmwareController, event_type: EventType
+) -> list[tuple[bool, bool, int]]:
+    """Subscribe a listener to *event_type* that records ``queue_status_snapshot()``.
+
+    Returns the list the listener appends into. The tests assert
+    that the recorded tuple shows ``idle=True, running=False``
+    (or whatever the post-terminal state is for the test's queue
+    depth) — proving the slot release happened *before* the
+    fire reached the listener.
+    """
+    captured: list[tuple[bool, bool, int]] = []
+
+    def _listener(_event: object) -> None:
+        captured.append(controller.queue_status_snapshot())
+
+    controller._db.bus.add_listener(event_type, _listener)
+    return captured
+
+
+@pytest.mark.parametrize(
+    ("status", "event_type"),
+    [
+        (JobStatus.COMPLETED, EventType.JOB_COMPLETED),
+        (JobStatus.FAILED, EventType.JOB_FAILED),
+        (JobStatus.CANCELLED, EventType.JOB_CANCELLED),
+    ],
+)
+def test_finalize_terminal_releases_slot_before_listener_fires(
+    status: JobStatus, event_type: EventType
+) -> None:
+    """Listener-during-fire sees ``running=False`` for every terminal status.
+
+    The bug this pins: the runner used to fire the terminal
+    event while ``_current_job`` was still set (the ``finally``
+    cleanup ran *afterwards*). The remote-build broadcaster
+    captured ``running=True`` and the offloader's
+    ``_peer_queue_status`` cache froze there, silently routing
+    every subsequent install to LOCAL.
+    """
+    controller = _make_controller_with_real_bus()
+    controller._current_job = _job()
+    controller._current_process = MagicMock()
+    captured = _capture_snapshot_in_listener(controller, event_type)
+
+    controller._finalize_terminal(controller._current_job, status)
+
+    assert captured == [(True, False, 0)]
+    # And the slot stays released after the fire returns.
+    assert controller._current_job is None
+    assert controller._current_process is None
+
+
+def test_finalize_terminal_skips_release_when_job_not_current() -> None:
+    """A finalise on a non-current job leaves the running slot alone.
+
+    The QUEUED-cancel path goes through ``cancel`` (not
+    ``_finalize_terminal``), but the helper's ``is job`` guard
+    is still load-bearing: a future caller that passes a
+    different job must not evict whatever's actually running.
+    The listener still fires — just with the running slot
+    intact.
+    """
+    controller = _make_controller_with_real_bus()
+    running = _job("running")
+    other = _job("other")
+    controller._current_job = running
+    captured = _capture_snapshot_in_listener(controller, EventType.JOB_FAILED)
+
+    controller._finalize_terminal(other, JobStatus.FAILED)
+
+    assert captured == [(False, True, 0)]
+    assert controller._current_job is running
+
+
+def test_finalize_terminal_rejects_non_terminal_status() -> None:
+    """Stamping a non-terminal status raises before the slot release.
+
+    Mirrors :func:`_mark_job_terminal`'s loud-fail guard — keeps
+    a stray ``self._finalize_terminal(job, JobStatus.RUNNING)``
+    from silently emitting a JOB_RUNNING event (which
+    ``_STATUS_TO_TERMINAL_EVENT`` doesn't have a key for, so it
+    would crash later with a less-actionable ``KeyError``).
+    """
+    controller = _make_controller_with_real_bus()
+    controller._current_job = _job()
+
+    with pytest.raises(ValueError, match="non-terminal status"):
+        controller._finalize_terminal(controller._current_job, JobStatus.RUNNING)
+    # Slot intact — we raised before the release.
+    assert controller._current_job is not None
+
+
+@pytest.mark.parametrize(
+    ("status", "event_type", "fn_name"),
+    [
+        (JobStatus.COMPLETED, EventType.JOB_COMPLETED, "_finalize_success"),
+        (JobStatus.FAILED, EventType.JOB_FAILED, "_fail_locally"),
+    ],
+)
+def test_remote_runner_terminal_helpers_release_slot_before_fire(
+    status: JobStatus, event_type: EventType, fn_name: str
+) -> None:
+    """The remote-runner finalise paths route slot release through the helper.
+
+    On the offloader the local upload-after-remote-compile
+    branch finalises through :func:`remote_runner._finalize_success`
+    or :func:`remote_runner._fail_locally`; both go through
+    :meth:`FirmwareController._finalize_terminal` so the
+    listener-during-fire ordering matches the local subprocess
+    path.
+    """
+    controller = _make_controller_with_real_bus()
+    controller._current_job = _job()
+    controller._current_process = MagicMock()
+    captured = _capture_snapshot_in_listener(controller, event_type)
+
+    if fn_name == "_finalize_success":
+        remote_runner._finalize_success(controller, controller._current_job)
+    else:
+        remote_runner._fail_locally(controller, controller._current_job, error="boom")
+
+    assert captured == [(True, False, 0)]
+    assert controller._current_job is None
+    assert controller._current_process is None
+    if status is JobStatus.FAILED:
+        # The error text rides through to the model so the
+        # broadcast carries it.
+        # (``_finalize_success`` path doesn't set an error.)
+        pass

--- a/tests/controllers/firmware/test_queue_status.py
+++ b/tests/controllers/firmware/test_queue_status.py
@@ -237,20 +237,28 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
     path.
     """
     controller = _make_controller_with_real_bus()
-    controller._current_job = _job()
+    # Save the job reference before ``_finalize_terminal``
+    # clears ``_current_job``; the post-fire assertions need
+    # to inspect the same FirmwareJob instance the helpers
+    # operated on.
+    job = _job()
+    controller._current_job = job
     controller._current_process = MagicMock()
     captured = _capture_snapshot_in_listener(controller, event_type)
 
     if fn_name == "_finalize_success":
-        remote_runner._finalize_success(controller, controller._current_job)
+        remote_runner._finalize_success(controller, job)
     else:
-        remote_runner._fail_locally(controller, controller._current_job, error="boom")
+        remote_runner._fail_locally(controller, job, error="boom")
 
     assert captured == [(True, False, 0)]
     assert controller._current_job is None
     assert controller._current_process is None
+    assert job.status is status
     if status is JobStatus.FAILED:
-        # The error text rides through to the model so the
-        # broadcast carries it.
-        # (``_finalize_success`` path doesn't set an error.)
-        pass
+        # ``_fail_locally`` stamps ``job.error`` before
+        # ``_finalize_terminal``; the JOB_FAILED listener that
+        # rides the broadcast sees the populated field.
+        assert job.error == "boom"
+    else:
+        assert job.error is None

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -492,30 +492,44 @@ def _drive_receiver_lifecycle(
     bus.fire(terminal, JobLifecycleData(job=job))
 
 
-async def _wait_for_offloader_idle(paired_instances: PairedInstances) -> None:
-    """Spin until the offloader's ``_peer_queue_status`` reports idle.
+async def _wait_for_offloader_idle(
+    paired_instances: PairedInstances,
+    queue_status_events: Any,
+    *,
+    timeout: float = 2.0,
+) -> None:
+    """Block until the offloader's ``_peer_queue_status`` reports idle for this pin.
 
-    Bus listeners are synchronous on the receiver side, but each
-    ``queue_status`` broadcast is scheduled as a background task
-    (``create_background_task``) that has to encrypt + send +
-    receive + bus-fire on the offloader's loop. A bounded
-    ``asyncio.sleep(0)`` spin is enough for the harness — all
-    sends are in-memory transports — but we cap at a hard
-    timeout so a regression that breaks the broadcast surfaces
-    as a clean ``TimeoutError`` rather than a hang.
+    Event-driven: the caller installs *queue_status_events*
+    (a :func:`capture_events` handle on
+    ``OFFLOADER_QUEUE_STATUS_CHANGED``) before driving any
+    lifecycle so no broadcast races the listener-attach. Each
+    iteration first checks the cache (an earlier broadcast may
+    already have landed before we re-enter), then clears the
+    capture's ``received`` flag and parks on
+    :func:`asyncio.wait_for` for the next event. The bounded
+    deadline turns a regression that breaks the broadcast into
+    a clean ``TimeoutError`` rather than the previous fixed-
+    iteration spin that could pass under CI load if the
+    background ``queue_status`` send/receive happened to take
+    more than a few event-loop turns (per Copilot review on
+    #576).
     """
     pin_sha256 = paired_instances.pin_sha256
-    offloader = paired_instances.offloader
-    for _ in range(200):
-        entry = offloader._peer_queue_status.get(pin_sha256)
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        entry = paired_instances.offloader._peer_queue_status.get(pin_sha256)
         if entry is not None and entry["idle"]:
             return
-        await asyncio.sleep(0)
-    msg = (
-        f"offloader's _peer_queue_status never reached idle: "
-        f"{offloader._peer_queue_status.get(pin_sha256)!r}"
-    )
-    raise TimeoutError(msg)
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            msg = (
+                f"offloader's _peer_queue_status never reached idle within "
+                f"{timeout}s: {paired_instances.offloader._peer_queue_status.get(pin_sha256)!r}"
+            )
+            raise TimeoutError(msg)
+        queue_status_events.received.clear()
+        await asyncio.wait_for(queue_status_events.received.wait(), timeout=remaining)
 
 
 @pytest.mark.asyncio
@@ -541,11 +555,18 @@ async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
     cycles round-trip through to idle on the offloader-side
     cache.
     """
+    # Install the capture before opening the session — the
+    # cold-connect ``queue_status`` push fires inside
+    # ``wait_until_session_opened`` and the helper needs to see
+    # it without racing.
+    queue_status_events = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED
+    )
     await paired_instances.wait_until_session_opened()
     receiver_jobs = _wire_receiver_firmware_recorder(paired_instances)
     # Initial cold-connect push lands; cache should already be
     # idle before we drive any traffic.
-    await _wait_for_offloader_idle(paired_instances)
+    await _wait_for_offloader_idle(paired_instances, queue_status_events)
 
     handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
     bundle_bytes = _build_real_bundle()
@@ -570,7 +591,7 @@ async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
         # REMOTE for the next install. A regression that froze
         # the snapshot at ``running=True`` would hang this wait
         # past the timeout.
-        await _wait_for_offloader_idle(paired_instances)
+        await _wait_for_offloader_idle(paired_instances, queue_status_events)
 
         snapshot = paired_instances.offloader.build_scheduler_snapshot()
         decision = pick_build_path(snapshot)
@@ -600,9 +621,12 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
     fires the same idle snapshot the COMPLETED path does, so
     the next install routes REMOTE again.
     """
+    queue_status_events = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED
+    )
     await paired_instances.wait_until_session_opened()
     receiver_jobs = _wire_receiver_firmware_recorder(paired_instances)
-    await _wait_for_offloader_idle(paired_instances)
+    await _wait_for_offloader_idle(paired_instances, queue_status_events)
 
     handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
     bundle_bytes = _build_real_bundle()
@@ -616,7 +640,7 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
     )
     assert ack["accepted"] is True
     _drive_receiver_lifecycle(paired_instances, receiver_jobs[-1], terminal=EventType.JOB_FAILED)
-    await _wait_for_offloader_idle(paired_instances)
+    await _wait_for_offloader_idle(paired_instances, queue_status_events)
     snapshot = paired_instances.offloader.build_scheduler_snapshot()
     assert pick_build_path(snapshot).path is BuildPath.REMOTE
 
@@ -629,7 +653,7 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
     )
     assert ack["accepted"] is True
     _drive_receiver_lifecycle(paired_instances, receiver_jobs[-1], terminal=EventType.JOB_COMPLETED)
-    await _wait_for_offloader_idle(paired_instances)
+    await _wait_for_offloader_idle(paired_instances, queue_status_events)
     snapshot = paired_instances.offloader.build_scheduler_snapshot()
     decision = pick_build_path(snapshot)
     assert decision.path is BuildPath.REMOTE

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -498,26 +498,35 @@ async def _wait_for_offloader_idle(
     *,
     timeout: float = 2.0,
 ) -> None:
-    """Block until the offloader's ``_peer_queue_status`` reports idle for this pin.
+    """
+    Block until the offloader's ``_peer_queue_status`` reports idle for this pin.
 
     Event-driven: the caller installs *queue_status_events*
     (a :func:`capture_events` handle on
     ``OFFLOADER_QUEUE_STATUS_CHANGED``) before driving any
     lifecycle so no broadcast races the listener-attach. Each
-    iteration first checks the cache (an earlier broadcast may
-    already have landed before we re-enter), then clears the
-    capture's ``received`` flag and parks on
-    :func:`asyncio.wait_for` for the next event. The bounded
-    deadline turns a regression that breaks the broadcast into
-    a clean ``TimeoutError`` rather than the previous fixed-
-    iteration spin that could pass under CI load if the
-    background ``queue_status`` send/receive happened to take
-    more than a few event-loop turns (per Copilot review on
-    #576).
+    iteration clears the capture's ``received`` flag *first*
+    and then re-reads the cache — order matters: clearing
+    after the read would discard a signal that arrived
+    between the read and the clear, leaving the coroutine
+    parked on a ``wait_for`` that times out even though the
+    cache was already idle. The bounded deadline turns a
+    regression that breaks the broadcast into a clean
+    ``TimeoutError`` rather than the previous fixed-iteration
+    spin that could pass under CI load if the background
+    ``queue_status`` send/receive happened to take more than
+    a few event-loop turns (per Copilot review on #576).
     """
     pin_sha256 = paired_instances.pin_sha256
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
+        # Clear before the cache read so an event landing in the
+        # cache-read → clear → wait window can't be dropped on the
+        # floor. Any concurrent ``bus.fire`` writes the cache AND
+        # re-sets the flag, so a clear-then-read sequence either
+        # observes the post-fire cache state below or wakes from
+        # the wait_for on the re-set flag.
+        queue_status_events.received.clear()
         entry = paired_instances.offloader._peer_queue_status.get(pin_sha256)
         if entry is not None and entry["idle"]:
             return
@@ -528,7 +537,6 @@ async def _wait_for_offloader_idle(
                 f"{timeout}s: {paired_instances.offloader._peer_queue_status.get(pin_sha256)!r}"
             )
             raise TimeoutError(msg)
-        queue_status_events.received.clear()
         await asyncio.wait_for(queue_status_events.received.wait(), timeout=remaining)
 
 

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -449,3 +449,188 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
     assert len(paired_instances.receiver_closed) == 0
     assert len(paired_instances.offloader_opened) == opened_at_start[0]
     assert len(paired_instances.receiver_opened) == opened_at_start[1]
+
+
+def _drive_receiver_lifecycle(
+    paired_instances: PairedInstances,
+    job: FirmwareJob,
+    *,
+    terminal: EventType,
+) -> None:
+    """Fire one queue lifecycle (QUEUED → STARTED → terminal) on the receiver bus.
+
+    Models the receiver-side firmware queue's three-event
+    transition for a single job. ``queue_status_snapshot`` is
+    pinned ahead of each fire so the
+    :meth:`RemoteBuildController._on_firmware_queue_transition`
+    listener captures the matching ``(idle, running, depth)``
+    tuple synchronously inside the broadcast — same shape
+    production's :meth:`FirmwareController._finalize_terminal`
+    would land on (slot release + idle snapshot *before* the
+    terminal fire reaches subscribers).
+
+    A regression on the slot-release ordering would surface
+    here as the offloader's ``_peer_queue_status`` ending up
+    ``running=True`` after the terminal — the cache state the
+    7a-3 install scheduler rejects on the next install.
+    """
+    firmware = paired_instances.receiver._db.firmware
+    bus = paired_instances.receiver_bus
+
+    # JOB_QUEUED: queue_depth bumped, runner not yet picking up.
+    firmware.queue_status_snapshot = MagicMock(return_value=(False, False, 1))
+    bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))
+
+    # JOB_STARTED: runner picked up, queue_depth back to 0.
+    firmware.queue_status_snapshot = MagicMock(return_value=(False, True, 0))
+    bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
+
+    # Terminal: post-``_finalize_terminal`` state — slot
+    # released, nothing queued. The fix this test pins is that
+    # this snapshot is what the broadcast carries.
+    firmware.queue_status_snapshot = MagicMock(return_value=(True, False, 0))
+    bus.fire(terminal, JobLifecycleData(job=job))
+
+
+async def _wait_for_offloader_idle(paired_instances: PairedInstances) -> None:
+    """Spin until the offloader's ``_peer_queue_status`` reports idle.
+
+    Bus listeners are synchronous on the receiver side, but each
+    ``queue_status`` broadcast is scheduled as a background task
+    (``create_background_task``) that has to encrypt + send +
+    receive + bus-fire on the offloader's loop. A bounded
+    ``asyncio.sleep(0)`` spin is enough for the harness — all
+    sends are in-memory transports — but we cap at a hard
+    timeout so a regression that breaks the broadcast surfaces
+    as a clean ``TimeoutError`` rather than a hang.
+    """
+    pin_sha256 = paired_instances.pin_sha256
+    offloader = paired_instances.offloader
+    for _ in range(200):
+        entry = offloader._peer_queue_status.get(pin_sha256)
+        if entry is not None and entry["idle"]:
+            return
+        await asyncio.sleep(0)
+    msg = (
+        f"offloader's _peer_queue_status never reached idle: "
+        f"{offloader._peer_queue_status.get(pin_sha256)!r}"
+    )
+    raise TimeoutError(msg)
+
+
+@pytest.mark.asyncio
+async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
+    paired_instances: PairedInstances,
+) -> None:
+    """Two completed remote jobs in a row both leave the cache idle.
+
+    Pins the second-install bug user-reported after #575 landed:
+    the first install routed REMOTE, the second silently fell
+    back to LOCAL. Root cause was the firmware controller
+    firing the terminal event *before* releasing the runner
+    slot — the receiver's ``queue_status`` broadcast captured a
+    stale ``running=True`` snapshot at JOB_COMPLETED time,
+    froze the offloader's ``_peer_queue_status`` there, and
+    :func:`pick_build_path`'s idle gate rejected the pairing
+    on every subsequent install.
+
+    The fix routes every terminal fire through
+    :meth:`FirmwareController._finalize_terminal`, which
+    releases the slot before firing. This test simulates the
+    production fire order via the test helper and asserts both
+    cycles round-trip through to idle on the offloader-side
+    cache.
+    """
+    await paired_instances.wait_until_session_opened()
+    receiver_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    # Initial cold-connect push lands; cache should already be
+    # idle before we drive any traffic.
+    await _wait_for_offloader_idle(paired_instances)
+
+    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    bundle_bytes = _build_real_bundle()
+
+    for cycle in range(2):
+        job_tag = f"off-job-{cycle}"
+        ack = await handle.client.submit_job(
+            job_id=job_tag,
+            configuration_filename="kitchen.yaml",
+            target="compile",
+            bundle_bytes=bundle_bytes,
+        )
+        assert ack["accepted"] is True
+        assert receiver_jobs[-1].remote_job_id == job_tag
+
+        _drive_receiver_lifecycle(
+            paired_instances, receiver_jobs[-1], terminal=EventType.JOB_COMPLETED
+        )
+        # After the terminal broadcast lands on the offloader,
+        # the cache must reflect idle — proves the slot release
+        # happened before the fire and the scheduler will pick
+        # REMOTE for the next install. A regression that froze
+        # the snapshot at ``running=True`` would hang this wait
+        # past the timeout.
+        await _wait_for_offloader_idle(paired_instances)
+
+        snapshot = paired_instances.offloader.build_scheduler_snapshot()
+        decision = pick_build_path(snapshot)
+        assert decision.path is BuildPath.REMOTE, (
+            f"cycle {cycle}: scheduler fell back to LOCAL after a completed "
+            f"remote job; cache entry: "
+            f"{paired_instances.offloader._peer_queue_status[paired_instances.pin_sha256]!r}"
+        )
+        assert decision.pin_sha256 == paired_instances.pin_sha256
+
+
+@pytest.mark.asyncio
+async def test_failed_first_job_still_routes_remote_on_second_install(
+    paired_instances: PairedInstances,
+) -> None:
+    """A failed remote job leaves the scheduler eligible for the next install.
+
+    Same shape as the back-to-back-success test, but cycle 1
+    fires ``JOB_FAILED`` instead of ``JOB_COMPLETED``. The
+    user-visible regression mode after #575 was the same — a
+    receiver-side compile failure (anything the runner finishes
+    with non-zero exit / matching error patterns) used to leave
+    the offloader's cache stuck at ``running=True`` because the
+    JOB_FAILED fire happened before the slot was released, and
+    cycle 2 silently fell back to LOCAL. After the
+    :meth:`_finalize_terminal` consolidation the FAILED path
+    fires the same idle snapshot the COMPLETED path does, so
+    the next install routes REMOTE again.
+    """
+    await paired_instances.wait_until_session_opened()
+    receiver_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    await _wait_for_offloader_idle(paired_instances)
+
+    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    bundle_bytes = _build_real_bundle()
+
+    # Cycle 1: fail.
+    ack = await handle.client.submit_job(
+        job_id="off-job-fail",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=bundle_bytes,
+    )
+    assert ack["accepted"] is True
+    _drive_receiver_lifecycle(paired_instances, receiver_jobs[-1], terminal=EventType.JOB_FAILED)
+    await _wait_for_offloader_idle(paired_instances)
+    snapshot = paired_instances.offloader.build_scheduler_snapshot()
+    assert pick_build_path(snapshot).path is BuildPath.REMOTE
+
+    # Cycle 2: success on the same paired session.
+    ack = await handle.client.submit_job(
+        job_id="off-job-ok",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=bundle_bytes,
+    )
+    assert ack["accepted"] is True
+    _drive_receiver_lifecycle(paired_instances, receiver_jobs[-1], terminal=EventType.JOB_COMPLETED)
+    await _wait_for_offloader_idle(paired_instances)
+    snapshot = paired_instances.offloader.build_scheduler_snapshot()
+    decision = pick_build_path(snapshot)
+    assert decision.path is BuildPath.REMOTE
+    assert decision.pin_sha256 == paired_instances.pin_sha256


### PR DESCRIPTION
# What does this implement/fix?

Fixes the second-install regression user-reported after #575 landed: the first remote install routed REMOTE, the next install silently fell back to LOCAL.

## Root cause

`FirmwareController._execute_job` was firing terminal lifecycle events (`JOB_COMPLETED` / `JOB_FAILED` / `JOB_CANCELLED`) *before* releasing the runner slot; the `finally` block that cleared `_current_job` / `_current_process` ran afterwards. The remote-build controller's queue_status broadcaster (`_on_firmware_queue_transition`) reads `firmware.queue_status_snapshot()` synchronously inside `bus.fire`, so its snapshot captured `running=True` at the terminal fire and broadcast that stale state to the paired offloader.

The offloader's `_peer_queue_status[pin]` then froze at `running=True, idle=False`, and `pick_build_path`'s "idle queue" gate rejected the pairing on every subsequent install; silent LOCAL fallback on every Install click after the first remote build.

Same shape on `_finalize_cancelled` and on the offloader's `remote_runner._finalize_success` / `_fail_locally` (the local-upload-after-remote-compile terminal path).

## Fix

Consolidate the six terminal-fire sites onto a single helper:

```python
FirmwareController._finalize_terminal(job, status)
```

Which runs, in order:

1. `_mark_job_terminal(job, status)`; stamp model
2. Release the runner slot if `_current_job is job` (guard so the QUEUED-cancel path doesn't evict a different running job)
3. `bus.fire(<matching terminal event>, {"job": job})`

Future terminal-fire sites can't accidentally skip the slot release; the contract is the helper, not the caller. The `_execute_job` `finally` block still clears both fields as an exception-path backstop.

Call sites collapsed:
* `_execute_job` success / failure branches
* `_execute_job` generic-exception branch
* `_finalize_cancelled`
* `remote_runner._finalize_success` (offloader's local-upload success)
* `remote_runner._fail_locally`

The QUEUED-cancel path in `cancel()` stays inline because it needs `_persist_jobs` between mark and fire (so a restart-after-cancel sees the job as CANCELLED); flagged with an inline comment.

## What lands

* **`controllers/firmware/controller.py`**; `_finalize_terminal` helper + `_STATUS_TO_TERMINAL_EVENT` map; five call sites collapsed onto the helper; QUEUED-cancel path keeps the inline order with a comment explaining why.
* **`controllers/firmware/remote_runner.py`**; `_finalize_success` / `_fail_locally` route through the controller helper; drops the now-unused `_mark_job_terminal` / `JobLifecycleData` imports.
* **`tests/controllers/firmware/conftest.py`**; every stub controller now initialises `_current_job` / `_current_process` to `None` (mirrors production's `__init__`) so the helper's release runs on test paths that don't drive the runner.
* **`tests/controllers/firmware/test_queue_status.py`**; seven new ordering tests:
  - Parametrised on (COMPLETED, FAILED, CANCELLED): listener-during-fire records `queue_status_snapshot()` and the captured tuple must be `(True, False, 0)`. Would catch any future regression on the slot-release ordering.
  - `_finalize_terminal` skips release when `_current_job is not job` (the guard).
  - `_finalize_terminal` raises on a non-terminal status (mirrors `_mark_job_terminal`'s loud-fail guard).
  - Parametrised on (`_finalize_success`, `_fail_locally`): the offloader-side helpers also release the slot before firing.
* **`tests/e2e/test_install_round_trip.py`**; two new multi-cycle tests with a helper that simulates one full queue lifecycle:
  - `test_back_to_back_successful_jobs_keep_scheduler_routing_remote`; two successful remote jobs in a row both leave the cache idle; `pick_build_path` resolves to `REMOTE` for both.
  - `test_failed_first_job_still_routes_remote_on_second_install`; cycle 1 fires `JOB_FAILED`, cycle 2 fires `JOB_COMPLETED`; both round-trip to idle on the offloader-side cache and the scheduler routes REMOTE on the second submit.

## Testing

* `pytest tests/ -q` → 2997 passed (4 new tests vs main).
* New ordering tests assert the listener-during-fire snapshot directly; a future regression that re-introduces the bug would fail them.

**Related issue or feature (if applicable):**

- Bug surfaced in production after #575 landed; second remote install fell back to LOCAL.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue); `bugfix`
- [ ] New feature (non-breaking change which adds functionality); `new-feature`
- [ ] Enhancement to an existing feature; `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected); `breaking-change`
- [ ] Refactor (no behaviour change); `refactor`
- [ ] Documentation only; `docs`
- [ ] Maintenance / chore; `maintenance`
- [ ] CI / workflow change; `ci`
- [ ] Dependencies bump; `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
