### PR TITLE
Surface receiver-side download_artifacts rejects at WARNING with paths

### DIFF
--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -454,6 +454,11 @@ async def _fetch_and_run_local_upload(
     via the cancel-aware ``_fail_locally`` when the user
     raced a Stop).
     """
+    _LOGGER.info(
+        "Remote job %s: requesting build artefacts for configuration=%r from receiver",
+        job.job_id,
+        job.configuration,
+    )
     try:
         packed = await client.download_artifacts(job_id=job.job_id)
     except (
@@ -461,10 +466,19 @@ async def _fetch_and_run_local_upload(
         SubmitJobSessionLostError,
         DownloadArtifactsError,
     ) as exc:
+        # Hint the operator at the receiver-side log for the
+        # path-level detail. The receiver logs the configuration
+        # string and (for ``build_dir_missing``) the actual file
+        # that couldn't be opened at WARNING — that's the
+        # actionable bit; the offloader-side error text only
+        # carries the structured reason code.
         _fail_locally(
             controller,
             job,
-            error=f"remote build: download_artifacts failed: {exc}",
+            error=(
+                f"remote build: download_artifacts failed: {exc} "
+                f"(check the build server's log for the missing path)"
+            ),
         )
         return
 

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -466,18 +466,20 @@ async def _fetch_and_run_local_upload(
         SubmitJobSessionLostError,
         DownloadArtifactsError,
     ) as exc:
-        # Hint the operator at the receiver-side log for the
-        # path-level detail. The receiver logs the configuration
-        # string and (for ``build_dir_missing``) the actual file
-        # that couldn't be opened at WARNING — that's the
-        # actionable bit; the offloader-side error text only
-        # carries the structured reason code.
+        # Receiver-side WARNING logs carry the actionable
+        # detail (configuration, missing path, current status)
+        # for every soft-reject; point operators at the build
+        # server log either way. The previous shape only
+        # mentioned "missing path", which was misleading for
+        # non-``build_dir_missing`` rejects (``unknown_job`` /
+        # ``job_not_completed`` / session lost — none of which
+        # involve a path).
         _fail_locally(
             controller,
             job,
             error=(
                 f"remote build: download_artifacts failed: {exc} "
-                f"(check the build server's log for the missing path)"
+                f"(check the build server logs for details)"
             ),
         )
         return

--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -199,14 +199,39 @@ class ArtifactsDownloadSender:
         job_id = typed["job_id"]
 
         if session.dashboard_id in self._inflight:
+            _LOGGER.warning(
+                "download_artifacts from %s: rejecting job %s as duplicate "
+                "(another download is already streaming for this session)",
+                session.dashboard_id,
+                job_id,
+            )
             await self._send_reject(session, job_id, _REASON_DUPLICATE_DOWNLOAD)
             return
 
         firmware_job = self._find_remote_job(session.dashboard_id, job_id)
         if firmware_job is None:
+            _LOGGER.warning(
+                "download_artifacts from %s: no matching firmware job for "
+                "remote_job_id=%s (peer's submitted jobs: %s)",
+                session.dashboard_id,
+                job_id,
+                [
+                    j.remote_job_id
+                    for j in self._firmware._jobs.values()
+                    if j.remote_peer == session.dashboard_id
+                ],
+            )
             await self._send_reject(session, job_id, _REASON_UNKNOWN_JOB)
             return
         if firmware_job.status != JobStatus.COMPLETED:
+            _LOGGER.warning(
+                "download_artifacts from %s: job %s (configuration=%r) is "
+                "%s, not COMPLETED — rejecting",
+                session.dashboard_id,
+                job_id,
+                firmware_job.configuration,
+                firmware_job.status,
+            )
             await self._send_reject(session, job_id, _REASON_JOB_NOT_COMPLETED)
             return
 
@@ -217,20 +242,38 @@ class ArtifactsDownloadSender:
                 packed = await loop.run_in_executor(
                     None, pack_build_artifacts, firmware_job.configuration
                 )
-            except FileNotFoundError:
-                _LOGGER.debug(
-                    "download_artifacts from %s: build dir / idedata missing for job %s",
+            except FileNotFoundError as exc:
+                # ``FileNotFoundError`` from
+                # :func:`load_build_artifacts` carries the actual
+                # path that couldn't be opened (StorageJSON
+                # sidecar, ``firmware_bin_path`` value, or
+                # ``idedata.json``). Surface that path in the log
+                # at WARNING so operators can compare the read
+                # path against where esphome actually wrote the
+                # build artefacts — the original symptom was
+                # "Install failed" on the offloader with no
+                # actionable detail because this log lived at
+                # DEBUG. Production trips this when the receiver
+                # crashes mid-build (no sidecar written) or when
+                # the configuration string the offloader-submitted
+                # job carries doesn't match the storage path
+                # esphome uses for the compile.
+                _LOGGER.warning(
+                    "download_artifacts from %s: build artefacts missing for "
+                    "job %s (configuration=%r): %s",
                     session.dashboard_id,
                     job_id,
-                    exc_info=True,
+                    firmware_job.configuration,
+                    exc,
                 )
                 await self._send_reject(session, job_id, _REASON_BUILD_DIR_MISSING)
                 return
             except Exception:
                 _LOGGER.exception(
-                    "download_artifacts from %s: pack failed for job %s",
+                    "download_artifacts from %s: pack failed for job %s (configuration=%r)",
                     session.dashboard_id,
                     job_id,
+                    firmware_job.configuration,
                 )
                 await self._send_reject(session, job_id, _REASON_PACK_FAILED)
                 return

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -131,7 +131,8 @@ async def test_download_artifacts_malformed_terminates(broken_frame: dict[str, A
 async def test_download_artifacts_unknown_job_rejected(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """An unknown job_id rejects ``unknown_job`` (no terminate).
+    """
+    An unknown job_id rejects ``unknown_job`` (no terminate).
 
     Receiver-side WARNING log carries the requested ``job_id``
     plus the list of ``remote_job_id`` values the receiver does
@@ -160,7 +161,8 @@ async def test_download_artifacts_unknown_job_rejected(
 async def test_download_artifacts_job_not_completed_rejected(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A job in ``RUNNING`` status rejects ``job_not_completed``.
+    """
+    A job in ``RUNNING`` status rejects ``job_not_completed``.
 
     Receiver-side WARNING log carries the configuration string
     and the actual status so operators can see *why* the
@@ -206,7 +208,8 @@ async def test_download_artifacts_build_dir_missing_rejected(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A ``FileNotFoundError`` from the packer rejects ``build_dir_missing``.
+    """
+    A ``FileNotFoundError`` from the packer rejects ``build_dir_missing``.
 
     Also pins the receiver-side log: the WARNING includes the
     configuration string and the actual missing-path text from

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -128,35 +128,59 @@ async def test_download_artifacts_malformed_terminates(broken_frame: dict[str, A
 
 
 @pytest.mark.asyncio
-async def test_download_artifacts_unknown_job_rejected() -> None:
-    """An unknown job_id rejects ``unknown_job`` (no terminate)."""
+async def test_download_artifacts_unknown_job_rejected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unknown job_id rejects ``unknown_job`` (no terminate).
+
+    Receiver-side WARNING log carries the requested ``job_id``
+    plus the list of ``remote_job_id`` values the receiver does
+    have on file for this peer — keeps the failure debuggable
+    when a frontend retry sends a stale id after a restart.
+    """
     firmware = _make_firmware_with_job(remote_job_id="another")
     sender = _make_sender(firmware)
     session = _make_session()
 
     frame: DownloadArtifactsFrameData = {"type": "download_artifacts", "job_id": "missing"}
-    await sender.handle_download_artifacts(session, cast(dict[str, Any], frame))
+    with caplog.at_level("WARNING"):
+        await sender.handle_download_artifacts(session, cast(dict[str, Any], frame))
 
     session.terminate.assert_not_awaited()
     payload = _last_app_frame(session)
     assert payload["type"] == "artifacts_end"
     assert payload["accepted"] is False
     assert payload["reason"] == "unknown_job"
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "missing" in log_text  # requested job_id
+    assert "another" in log_text  # the receiver's known job_ids
 
 
 @pytest.mark.asyncio
-async def test_download_artifacts_job_not_completed_rejected() -> None:
-    """A job in ``RUNNING`` status rejects ``job_not_completed``."""
-    firmware = _make_firmware_with_job(status=JobStatus.RUNNING)
+async def test_download_artifacts_job_not_completed_rejected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A job in ``RUNNING`` status rejects ``job_not_completed``.
+
+    Receiver-side WARNING log carries the configuration string
+    and the actual status so operators can see *why* the
+    receiver refused the download (still compiling vs.
+    cancelled vs. failed).
+    """
+    firmware = _make_firmware_with_job(status=JobStatus.RUNNING, configuration="kitchen.yaml")
     sender = _make_sender(firmware)
     session = _make_session()
 
     frame: DownloadArtifactsFrameData = {"type": "download_artifacts", "job_id": "remote-1"}
-    await sender.handle_download_artifacts(session, cast(dict[str, Any], frame))
+    with caplog.at_level("WARNING"):
+        await sender.handle_download_artifacts(session, cast(dict[str, Any], frame))
 
     payload = _last_app_frame(session)
     assert payload["accepted"] is False
     assert payload["reason"] == "job_not_completed"
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "kitchen.yaml" in log_text
+    assert "running" in log_text.lower()
 
 
 @pytest.mark.asyncio
@@ -180,25 +204,40 @@ async def test_download_artifacts_duplicate_rejected_without_terminate(
 @pytest.mark.asyncio
 async def test_download_artifacts_build_dir_missing_rejected(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A ``FileNotFoundError`` from the packer rejects ``build_dir_missing``."""
+    """A ``FileNotFoundError`` from the packer rejects ``build_dir_missing``.
+
+    Also pins the receiver-side log: the WARNING includes the
+    configuration string and the actual missing-path text from
+    the :class:`FileNotFoundError` so operators can see *which*
+    file the receiver looked for. Without the path in the log
+    the failure surfaces on the offloader as a bare
+    ``build_dir_missing`` with no actionable detail.
+    """
 
     def _raise_missing(_configuration: str) -> Any:
-        raise FileNotFoundError("build dir gone")
+        raise FileNotFoundError("StorageJSON sidecar missing for kitchen.yaml")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.remote_build.artifacts_download.pack_build_artifacts",
         _raise_missing,
     )
-    sender = _make_sender()
+    sender = _make_sender(_make_firmware_with_job(configuration="kitchen.yaml"))
     session = _make_session()
 
     frame: DownloadArtifactsFrameData = {"type": "download_artifacts", "job_id": "remote-1"}
-    await sender.handle_download_artifacts(session, cast(dict[str, Any], frame))
+    with caplog.at_level("WARNING"):
+        await sender.handle_download_artifacts(session, cast(dict[str, Any], frame))
 
     payload = _last_app_frame(session)
     assert payload["accepted"] is False
     assert payload["reason"] == "build_dir_missing"
+    # Receiver-side log carries the configuration + the
+    # FileNotFoundError detail (the actual missing path).
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "kitchen.yaml" in log_text
+    assert "StorageJSON sidecar missing" in log_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

User hit `Install failed` on the offloader after a successful remote compile. The offloader log only carried the bare reason code:

```
WARNING [remote_runner] Remote job f83b06ee351c failed: remote build: download_artifacts failed: download_artifacts: receiver rejected (build_dir_missing)
```

The actual actionable detail (which file the receiver was looking for) lived at DEBUG inside `ArtifactsDownloadSender.handle_download_artifacts`, so production didn't see it. This PR bumps the four soft-reject log sites to WARNING and includes the context an operator needs to diagnose without re-running with `--log-level debug`.

## Receiver-side

Each of the four reject branches now logs at WARNING with the bits a human needs:

* **`build_dir_missing`** — `firmware_job.configuration` (the path the receiver thinks the YAML is at) + the `FileNotFoundError`'s text. The error carries the resolved storage / firmware_bin / idedata path from `load_build_artifacts`, so the log now answers "which file?".
* **`pack_failed`** — keeps `_LOGGER.exception` (we want the traceback) but adds `configuration` to the message so it shows up in the one-line summary too.
* **`unknown_job`** — requested `job_id` + the list of `remote_job_id` values the receiver currently has for the peer. Makes a stale offloader-side id (e.g. retry after a receiver restart) obvious instead of a silent reject.
* **`job_not_completed`** — `configuration` + actual status. Distinguishes "still compiling" from "failed" / "cancelled" without digging into the firmware queue.
* **`duplicate_download`** — session + job_id, so concurrent retries are debuggable.

## Offloader-side

* INFO log at `_fetch_and_run_local_upload` entry recording the configuration string — gives operators a correlation point between offloader and receiver logs.
* User-facing `job.error` text now appends `(check the build server's log for the missing path)` so the dashboard's red error toast points at the receiver-side log explicitly.

## What lands

* **`controllers/remote_build/artifacts_download.py`** — five reject paths logged at WARNING with structured context.
* **`controllers/firmware/remote_runner.py`** — pre-log on entry to the artefact fetch; hint appended to the user-facing error string.
* **`tests/test_remote_build_artifacts_download.py`** — extended three existing reject tests to pin the new log content (`caplog` captures + content asserts).

## Testing

* `pytest tests/ -q` → 2988 passed, 4 skipped.
* The existing `test_remote_install_download_artifacts_failure_fires_job_failed` in `tests/controllers/firmware/test_remote_runner.py` still passes — it checks `"build dir wiped" in job.error`, and the new error string preserves the original `exc` text before the appended hint.

**Related issue or feature (if applicable):**

- Surfaced during debugging of a post-#575 user report; the next PR will dig into the root cause of the `build_dir_missing` reject itself (likely a path-resolution mismatch between submit_job's full-relative `configuration` and esphome's basename-keyed `storage_path()`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
