### PR TITLE
Reset firmware-job progress at compile→upload seam on REMOTE installs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -156,7 +156,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 - Queued jobs flip to `cancelled` immediately.
 - Running jobs receive SIGTERM, with SIGKILL escalation after a 3 s grace period. The job's status becomes `cancelled` (not `failed`) and `JOB_CANCELLED` fires.
 
-**Progress**: `FirmwareJob.progress` is an `int | null` 0–100 latched from the highest percentage seen in `[ 17%] Compiling …` (PlatformIO) or `Writing at 0x… (45 %)` (esptool) lines. `null` means the tooling hasn't emitted a percentage yet — most early compile output is opaque. The value is monotonically non-decreasing within a job so the UI doesn't appear to regress between phases.
+**Progress**: `FirmwareJob.progress` is an `int | null` 0–100 latched from the highest percentage seen in `[ 17%] Compiling …` (PlatformIO) or `Writing at 0x… (45 %)` (esptool) lines. `null` means the tooling hasn't emitted a percentage yet — most early compile output is opaque. The value is monotonically non-decreasing *within a phase*; at known phase seams (REMOTE install's compile → upload boundary) the runner explicitly resets to 0 and fires `job_progress{progress: 0}` so the next phase's percents aren't silently clamped against the previous phase's peak. Subscribers should render the bar from the latest event rather than asserting non-decreasing progress.
 
 **Job events** (broadcast to all subscribed clients):
 - `job_queued`, `job_started`, `job_output`, `job_progress`, `job_completed`, `job_failed`, `job_cancelled`

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -324,6 +324,24 @@ async def _verify_esphome_importable(cmd: list[str]) -> tuple[bool, str]:
     return True, output
 
 
+def _fire_job_progress(job: FirmwareJob, bus: EventBus, progress: int) -> None:
+    """
+    Stamp ``job.progress`` and fan out :attr:`EventType.JOB_PROGRESS`.
+
+    The "set the field, fire the event" pair is invariant across
+    every callsite — the only thing that differs is whether the
+    caller has already gated the new value against the previous
+    one (the streaming ingest does; the compile → upload phase
+    transition deliberately doesn't, since the whole point there
+    is to drop the gauge back to zero). The helper carries no
+    clamp of its own so the gating policy stays at the callsite
+    where it's readable.
+    """
+    job.progress = progress
+    payload: JobProgressData = {"job_id": job.job_id, "progress": progress}
+    bus.fire(EventType.JOB_PROGRESS, payload)
+
+
 def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     """
     Append *line* to ``job.output`` and fire local follower events.
@@ -342,10 +360,13 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     3. Fan it out as ``JOB_OUTPUT`` so live followers see it.
     4. Parse a coarse 0-100 progress percentage; if it
        advances the previous value, update the job and fire
-       ``JOB_PROGRESS``. Monotonic-clamp behaviour matches the
-       local subprocess path (esptool's "100%" followed by
-       PlatformIO's "0%" would otherwise look like a
-       regression to the progress-bar renderer).
+       ``JOB_PROGRESS`` via :func:`_fire_job_progress`.
+       Monotonic-clamp behaviour matches the local subprocess
+       path (esptool's "100%" followed by PlatformIO's "0%"
+       would otherwise look like a regression to the
+       progress-bar renderer). Explicit phase transitions
+       (compile → upload) call the helper directly to bypass
+       the clamp and reset the gauge.
 
     Does **not** handle error-pattern detection — that's a
     local-only concern (the remote path gets a structured
@@ -360,6 +381,4 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     progress = _parse_progress(line)
     if progress is None or progress <= (job.progress or 0):
         return
-    job.progress = progress
-    prog_payload: JobProgressData = {"job_id": job.job_id, "progress": progress}
-    bus.fire(EventType.JOB_PROGRESS, prog_payload)
+    _fire_job_progress(job, bus, progress)

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -55,7 +55,7 @@ from ..remote_build.peer_link_client import (
     SubmitJobTimeoutError,
 )
 from .constants import ESPHOME_SUBPROCESS_ENV
-from .helpers import _ingest_output_line
+from .helpers import _fire_job_progress, _ingest_output_line
 
 if TYPE_CHECKING:
     from ...helpers.event_bus import Event, EventBus
@@ -515,6 +515,21 @@ async def _fetch_and_run_local_upload(
     yaml_path = await loop.run_in_executor(
         None, controller._db.settings.rel_path, job.configuration
     )
+
+    # Reset the gauge at the compile → upload seam.
+    # :func:`helpers._ingest_output_line` monotonically clamps:
+    # any parsed percent that isn't strictly greater than
+    # ``job.progress`` is dropped. The receiver-side compile
+    # streams PIO / linker ``(N%)`` lines through the same
+    # ingest and can push the gauge near 100; without this
+    # reset every ``Uploading: [..] 5% / 10% / ...`` line the
+    # local flash subprocess emits would fall below the
+    # compile's high-water and the progress bar would appear
+    # frozen at the compile peak for the entire upload phase.
+    # Firing through :func:`_fire_job_progress` (no clamp)
+    # rather than the ingest path keeps the reset explicit at
+    # this phase boundary.
+    _fire_job_progress(job, bus, 0)
 
     # ``tempfile.TemporaryDirectory`` ctor calls
     # :func:`os.mkdir` synchronously — blockbuster catches

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -94,7 +94,12 @@ class FirmwareJob(DataClassORJSONMixin):
     # ``esphome rename`` CLI. Empty for every other job type.
     new_name: str = ""
     # Coarse progress estimate parsed from PlatformIO/esptool output
-    # (0-100, monotonically non-decreasing while the job runs).
+    # (0-100). Monotonically non-decreasing *within a phase* — the
+    # streaming ingest only latches a higher parsed percent. At
+    # known phase seams (REMOTE install's compile → upload boundary
+    # in :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`)
+    # the runner explicitly resets to 0 so subsequent phase percents
+    # aren't silently clamped against the previous phase's peak.
     # ``None`` when the underlying tooling hasn't emitted a percentage
     # yet -- most compile output is opaque, but the heavy phases (PIO
     # build, esptool flash) do emit percentages we can latch onto.
@@ -243,10 +248,16 @@ class JobProgressData(TypedDict):
     Payload for ``EventType.JOB_PROGRESS``.
 
     Coarse 0-100 progress estimate parsed from PlatformIO /
-    esptool output. ``progress`` is monotonically non-decreasing
-    while the job runs (the runner only fires when the parsed
-    percentage advances). The dashboard renders this as a
-    progress bar in the firmware-tasks panel.
+    esptool output. The streaming ingest only fires this event
+    when the parsed percent advances, so the gauge climbs
+    monotonically *within a phase*. At known phase seams
+    (REMOTE install's compile → upload boundary —
+    :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`)
+    the runner explicitly fires a ``progress=0`` reset so the
+    next phase's percents don't get clamped against the
+    previous phase's peak. Subscribers should render the bar
+    from the latest event rather than asserting non-decreasing
+    progress.
     """
 
     job_id: str

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1278,6 +1278,54 @@ def patch_extract_firmware(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
 
 
 @pytest.mark.asyncio
+async def test_remote_install_resets_progress_between_compile_and_upload(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+    patch_extract_firmware: MagicMock,
+) -> None:
+    """
+    The compile → upload seam fires ``JOB_PROGRESS{0}`` and clears ``job.progress``.
+
+    Pins the phase-transition reset. :func:`helpers._ingest_output_line`
+    monotonically clamps, so a receiver-side compile that pushed
+    the gauge near 100 via linker / PIO ``(N%)`` lines would
+    silently suppress every ``Uploading: [..] 5% / 10% / ...``
+    line the local flash subprocess emits (5 isn't > 95).
+    Without an explicit reset at the boundary the progress bar
+    appears frozen at the compile peak for the entire upload
+    phase. The runner fires a 0% event at the start of
+    :func:`remote_runner._fetch_and_run_local_upload` so the
+    frontend visibly resets and subsequent upload percents
+    advance the gauge from 0.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
+    _wire_remote_build(controller, client=client)
+    _wire_upload_subprocess(controller, exit_code=0)
+    job = _make_remote_install_job()
+    # Pre-seed the gauge near 100, the way a receiver-side
+    # compile's linker / PIO ``(95%)`` line would. Without the
+    # phase reset the upload's lower percents would all be
+    # silently clamped against this value.
+    job.progress = 95
+
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=5.0)
+
+    # The phase-transition reset is the first ``JOB_PROGRESS``
+    # event the local bus sees from the upload half (we
+    # pre-seeded ``job.progress=95`` directly on the model so
+    # the compile half didn't go through the bus).
+    assert captured[EventType.JOB_PROGRESS]
+    assert captured[EventType.JOB_PROGRESS][0]["progress"] == 0
+    assert captured[EventType.JOB_PROGRESS][0]["job_id"] == job.job_id
+
+
+@pytest.mark.asyncio
 async def test_remote_install_completes_after_local_upload_succeeds(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,


### PR DESCRIPTION
# What does this implement/fix?

Resets the firmware-job progress gauge at the compile → upload seam on REMOTE installs, so the firmware-tasks progress bar visibly drops back to 0% between the receiver-side compile and the local flash phase.

`helpers._ingest_output_line` monotonically clamps parsed progress percentages — any line whose parsed percent isn't strictly greater than `job.progress` is silently dropped. The receiver-side compile streams PIO / linker `(N%)` lines through the same ingest fan-out and can push the gauge near 100. Without a reset at the phase boundary, every `Uploading: [..] 5% / 10% / ...` line the local `esphome upload` subprocess emits falls below the compile's high-water and `JOB_PROGRESS` never fires. Observed against a 22-second OTA upload where the progress bar never moved.

This factors the "stamp `job.progress` + fire `JOB_PROGRESS`" pair out of `_ingest_output_line` into a new `_fire_job_progress` helper (no clamp; the clamp gate stays at the ingest callsite where the policy is readable). `remote_runner._fetch_and_run_local_upload` calls the helper with `progress=0` immediately after resolving `yaml_path`, so the frontend visibly resets at the phase boundary and subsequent upload percents advance the gauge from 0.

A regression test pre-seeds `job.progress = 95` (mimicking the receiver compile peak), runs the runner through the upload phase, and asserts the first captured `JOB_PROGRESS` event carries `progress=0`. Verified the test passes with the fix and fails without it.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

The `JobProgressData` wire shape is unchanged — this is a server-side fix-up of *when* `JOB_PROGRESS` fires.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
