### PR TITLE
Two-tier scheduler: prefer idle remotes, queue on busy before LOCAL

### DIFF
--- a/esphome_device_builder/helpers/build_scheduler.py
+++ b/esphome_device_builder/helpers/build_scheduler.py
@@ -206,17 +206,33 @@ def pick_build_path(inputs: BuildSchedulerInputs) -> BuildPathDecision:
       orphaned via ``pin_mismatch`` / ``superseded``) doesn't
       qualify; the design doc's "silent fallback to local"
       stance is what falls out here.
-    * **Idle queue.** ``inputs.peer_queue_status`` carries the
-      most recent 5b ``queue_status`` snapshot per pin. A busy
-      receiver isn't a candidate today — first-cut policy is
-      "idle or fall back to local"; future iterations may
-      queue work onto a non-idle pairing if every candidate is
-      busy and the local fallback is more expensive than
-      waiting (cf. design doc edge case 4 — local cache hot).
-      Missing entry (no snapshot received yet) also disqualifies
-      the pairing: we have no signal that the receiver can
-      actually accept work, so falling through to local is the
-      safe move.
+    The pick is **two-tier**:
+
+    1. **First pass — idle preference.** Walk pairings in
+       oldest-``paired_at`` order; pick the first APPROVED +
+       connected pairing whose ``queue_status`` snapshot
+       reports ``idle=True``. This fans new installs out
+       across multiple idle remotes (request 1 lands on
+       remote A, A's snapshot flips to running, request 2
+       lands on the next idle remote B) so the fleet's
+       compile capacity is actually used.
+    2. **Second pass — busy fallback.** If no idle candidate
+       qualified, walk again and pick the first
+       APPROVED + connected pairing regardless of queue
+       state (busy or missing snapshot). The receiver runs
+       its own firmware queue, so the dispatch lands behind
+       whatever's currently building and runs when the
+       queue drains. Silent fallback to LOCAL here used to
+       split the fleet across two compile contexts (warm
+       receiver toolchain vs cold local) and re-flash from
+       a different build than the first Install — confusing
+       and surprising for the user who didn't pick a build
+       location.
+
+    Falls back to LOCAL only when **no** APPROVED + connected
+    pairing exists. A future per-install "Force local"
+    override link in the install dialog is the user-facing
+    way to opt out when the scheduler picks REMOTE.
 
     The status gate uses ``is PeerStatus.APPROVED`` rather than
     a negative match against the current PENDING enum value, so
@@ -251,21 +267,31 @@ def pick_build_path(inputs: BuildSchedulerInputs) -> BuildPathDecision:
         inputs.pairings.items(),
         key=lambda item: (item[1].paired_at, item[0]),
     )
-    for pin_sha256, pairing in ordered:
-        if pairing.status is not PeerStatus.APPROVED:
-            continue
-        if not pairing.enabled:
-            # 7b per-pairing toggle off — operator wants this
-            # receiver paired (Send-builds power-user surface
-            # still works) but doesn't want transparent
-            # install to route here.
-            continue
-        if pin_sha256 not in inputs.open_peer_links:
-            continue
+    # Collect eligible pairings once so both passes walk the
+    # same filtered set. Filtering here (rather than inside
+    # each pass) keeps the eligible-set definition in one
+    # place — a future PeerStatus addition or peer-link gate
+    # added below lands once. ``pairing.enabled`` is the 7b
+    # per-pairing toggle: operator wants this receiver paired
+    # (Send-builds power-user surface still works) but doesn't
+    # want transparent install to route here.
+    eligible: list[tuple[str, StoredPairing]] = [
+        (pin_sha256, pairing)
+        for pin_sha256, pairing in ordered
+        if pairing.status is PeerStatus.APPROVED
+        and pairing.enabled
+        and pin_sha256 in inputs.open_peer_links
+    ]
+    # First pass: pick the oldest idle pairing so multiple
+    # concurrent installs fan out across all idle remotes
+    # before any of them queue.
+    for pin_sha256, _pairing in eligible:
         snapshot = inputs.peer_queue_status.get(pin_sha256)
-        if snapshot is None:
-            continue
-        if not snapshot["idle"]:
-            continue
+        if snapshot is not None and snapshot["idle"]:
+            return BuildPathDecision.remote(pin_sha256)
+    # Second pass: no idle candidate; queue on the oldest
+    # busy receiver rather than falling back to LOCAL.
+    if eligible:
+        pin_sha256, _pairing = eligible[0]
         return BuildPathDecision.remote(pin_sha256)
     return BuildPathDecision.local()

--- a/esphome_device_builder/helpers/build_scheduler.py
+++ b/esphome_device_builder/helpers/build_scheduler.py
@@ -12,14 +12,15 @@ receiver.
 
 The decision function is intentionally side-effect-free: no
 controller references, no event-bus interaction, no I/O. The
-caller (eventually the ``firmware/install`` WS handler in 7a-3)
+caller (the ``firmware/install`` WS handler in 7a-3)
 gathers the state and threads it in. Two reasons for that shape:
 
 * **Unit-testability.** The candidate-filter rules
-  (PENDING vs APPROVED, connected vs not, idle vs running) all
-  flow through one function with simple inputs; the test suite
-  covers them without standing up the controllers or the event
-  bus.
+  (PENDING vs APPROVED, connected vs not) and the two-tier
+  pick (idle preference then queue-on-busy fallback) all
+  flow through one function with simple inputs; the test
+  suite covers them without standing up the controllers or
+  the event bus.
 * **Lifetime.** The state the function reads is RAM-canonical
   and lives on :class:`RemoteBuildController` (``_pairings``,
   ``_open_peer_links``, ``_peer_queue_status``). Passing it in
@@ -38,16 +39,21 @@ What this module *does not* do:
   through the pair-time handshake into the persisted row. Wiring
   that needs a separate piece of work; the placeholder is
   documented inline at the filter site so the gate's home is
-  obvious when the value lands. Until then, every connected +
-  idle APPROVED pairing is a candidate regardless of receiver
+  obvious when the value lands. Until then, every connected
+  APPROVED pairing is a candidate regardless of receiver
   version.
-* **Load-balancing across multiple candidates.** Picks the
-  first connected + idle pairing in the dict-iteration order
-  the caller passes in (insertion-order = ``paired_at``-order
-  for ``RemoteBuildController._pairings``). Round-robin /
-  least-loaded / cache-hot-affinity are 7a-3+ concerns; the
-  design doc explicitly puts the picking policy beyond this
-  first cut.
+* **Load-balancing across multiple candidates.** Pick policy
+  is two-tier: first pass walks eligible pairings sorted by
+  oldest ``paired_at`` and picks the first one whose
+  ``queue_status`` snapshot reports ``idle=True``; second
+  pass picks the oldest eligible pairing regardless of idle
+  state. Concurrent installs fan out across idle remotes
+  (first pass), and when every paired remote is busy the
+  oldest queues a job behind whatever's running (second
+  pass) rather than silently falling back to LOCAL.
+  Round-robin / least-loaded / cache-hot-affinity are
+  later-iteration concerns; the design doc explicitly puts
+  richer picking policy beyond this first cut.
 * **Caller integration.** The ``firmware/install`` WS handler
   route-through lands in 7a-3 alongside the event-stream
   bridge that re-fires ``OFFLOADER_JOB_*`` as local-shaped
@@ -204,8 +210,9 @@ def pick_build_path(inputs: BuildSchedulerInputs) -> BuildPathDecision:
       ``OFFLOADER_PEER_LINK_OPENED`` / ``_CLOSED`` events. An
       APPROVED pairing whose session is reconnecting (or
       orphaned via ``pin_mismatch`` / ``superseded``) doesn't
-      qualify; the design doc's "silent fallback to local"
-      stance is what falls out here.
+      qualify and falls through to LOCAL when no other
+      eligible pairing exists.
+
     The pick is **two-tier**:
 
     1. **First pass — idle preference.** Walk pairings in

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -242,13 +242,22 @@ def _stub_remote_build(
     open_pins: frozenset[str] = frozenset(),
     idle_pins: frozenset[str] = frozenset(),
 ) -> None:
-    """Wire a stub ``_db.remote_build`` with a scripted scheduler snapshot.
+    """
+    Wire a stub ``_db.remote_build`` with a scripted scheduler snapshot.
 
-    The scheduler walks ``pairings`` and gates each entry on
-    membership in ``open_pins`` + an idle entry in the queue
-    snapshot — so tests parametrise the three slices
-    independently and assert the resulting LOCAL / REMOTE
-    routing.
+    The scheduler walks ``pairings`` (APPROVED-only) and
+    requires membership in ``open_pins`` for the peer-link
+    session gate. ``idle_pins`` controls which pairings get
+    an ``idle=True`` snapshot entry; pairings *not* listed in
+    ``idle_pins`` have no entry at all. Under the two-tier
+    scheduler policy the first pass picks oldest-idle and
+    the second pass queues on oldest-otherwise — so a busy
+    receiver (open + not idle) routes REMOTE on the second
+    pass when no idle candidate exists. Pre-two-tier this
+    helper's docstring claimed "open_pins + idle entry"
+    *gated* the candidate; that's no longer accurate. Tests
+    that want LOCAL routing have to omit the pairing from
+    ``open_pins`` or skip the pairing fixture entirely.
     """
     rows = pairings or []
     pairings_map = {p.pin_sha256: p for p in rows}
@@ -334,7 +343,8 @@ async def test_install_routes_to_remote_when_pairing_is_idle_and_connected(
 async def test_install_still_routes_remote_when_receiver_is_busy(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """A busy paired receiver still wins REMOTE — receiver queues the dispatch.
+    """
+    A busy paired receiver still wins REMOTE — receiver queues the dispatch.
 
     The scheduler's two-tier pick prefers idle pairings first
     but falls through to busy ones (rather than LOCAL) when

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -331,27 +331,33 @@ async def test_install_routes_to_remote_when_pairing_is_idle_and_connected(
 
 
 @pytest.mark.asyncio
-async def test_install_falls_back_to_local_when_receiver_is_busy(
+async def test_install_still_routes_remote_when_receiver_is_busy(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """A paired receiver that isn't idle falls back to LOCAL (silent fallback).
+    """A busy paired receiver still wins REMOTE — receiver queues the dispatch.
 
-    The scheduler's first-cut policy is "idle or local"; a
-    busy receiver doesn't queue work today. The install
-    handler honours that silently — the user doesn't see a
-    "remote build server busy" message, the install just
-    runs locally.
+    The scheduler's two-tier pick prefers idle pairings first
+    but falls through to busy ones (rather than LOCAL) when
+    no idle candidate exists. Receiver-side firmware queues
+    drain the backlog; silent fallback to LOCAL here used to
+    split the fleet across two compile contexts (warm
+    receiver toolchain vs cold local) and re-flash from a
+    different build than the first Install. A future
+    per-install "Force local" override link in the install
+    dialog is the user-facing opt-out.
     """
     controller = firmware_controller_factory(with_queue=True)
     pairing = _make_pairing()
     # APPROVED + connected, but ``idle_pins`` is empty so the
-    # snapshot has no queue entry → scheduler skips.
+    # first-pass idle preference skips it. Second pass picks
+    # the same (only) pairing and queues on the receiver.
     _stub_remote_build(controller, pairings=[pairing], open_pins=frozenset({_PIN}))
     (tmp_path / "kitchen.yaml").write_text("")
 
     job = await controller.install(configuration="kitchen.yaml")
 
-    assert job.source is JobSource.LOCAL
+    assert job.source is JobSource.REMOTE
+    assert job.source_pin_sha256 == _PIN
 
 
 @pytest.mark.asyncio

--- a/tests/test_build_scheduler.py
+++ b/tests/test_build_scheduler.py
@@ -190,19 +190,21 @@ def test_approved_but_session_not_open_skipped() -> None:
 
 
 def test_approved_open_busy_still_returns_remote() -> None:
-    """A connected receiver currently running a job → still REMOTE.
+    """
+    A connected-but-busy receiver still wins via the second pass.
 
-    The receiver runs its own firmware queue; a remote
-    dispatch lands behind whatever's currently building and
-    runs when the queue drains. Silent fallback to LOCAL
-    here used to split the fleet across two compile contexts
-    (warm receiver toolchain vs cold local) and re-flash from
-    a different build than the first Install — confusing and
-    surprising for the user who didn't pick a build location.
-    The scheduler now ignores the idle / running / depth
-    signal; that snapshot is informational (UI-only) and a
-    future per-install "Force local" override link is the
-    user-facing way to opt out.
+    Single eligible pairing, snapshot reports
+    ``idle=False`` → first-pass idle preference finds no
+    candidate, second pass picks the same pairing and
+    queues the dispatch behind whatever's currently
+    building. Pre-policy-change the scheduler fell back to
+    LOCAL here, which split the fleet across two compile
+    contexts (warm receiver toolchain vs cold local) and
+    re-flashed from a different build than the first
+    Install — confusing and surprising for a user who
+    didn't pick a build location. A future per-install
+    "Force local" override link in the install dialog is
+    the user-facing opt-out.
     """
     pin = "a" * 64
     decision = pick_build_path(
@@ -218,13 +220,18 @@ def test_approved_open_busy_still_returns_remote() -> None:
 
 
 def test_approved_open_missing_queue_snapshot_still_returns_remote() -> None:
-    """No queue snapshot yet → still REMOTE.
+    """
+    No queue snapshot for the pairing yet → REMOTE via the second pass.
 
-    The first 5b ``queue_status`` push fires immediately on
-    session open, but there's a tiny window between
+    The first 5b ``queue_status`` push fires immediately
+    on session open, but there's a tiny window between
     ``OFFLOADER_PEER_LINK_OPENED`` and the first snapshot
-    arriving. Pre-policy-change the scheduler treated the
-    unknown window as busy and fell back to LOCAL; now the
+    arriving. During that window the first-pass idle
+    preference can't qualify the pairing (no explicit
+    ``idle=True`` to read), but the second pass treats it
+    as eligible-with-unknown-state and queues there.
+    Pre-policy-change the scheduler treated the unknown
+    window as busy and fell back to LOCAL; now the
     receiver's queue absorbs the dispatch regardless of
     snapshot state, so the window stops affecting routing.
     """
@@ -383,7 +390,8 @@ def test_skips_pending_picks_next_approved() -> None:
 
 
 def test_all_candidates_busy_picks_oldest_to_queue_remote() -> None:
-    """Every paired receiver is busy → REMOTE on oldest paired_at.
+    """
+    Every paired receiver is busy → REMOTE on oldest paired_at.
 
     Pins the two-tier policy: when no idle candidate
     qualifies the second pass picks the oldest connected
@@ -414,7 +422,8 @@ def test_all_candidates_busy_picks_oldest_to_queue_remote() -> None:
 
 
 def test_no_idle_candidate_with_some_missing_snapshots_picks_oldest_to_queue() -> None:
-    """No snapshot + busy snapshot → REMOTE on oldest paired_at.
+    """
+    Missing snapshot + busy snapshot → REMOTE on oldest paired_at.
 
     The first-pass idle preference requires an explicit
     ``idle=True`` snapshot. A pairing whose snapshot hasn't
@@ -445,7 +454,8 @@ def test_no_idle_candidate_with_some_missing_snapshots_picks_oldest_to_queue() -
 
 
 def test_first_busy_oldest_then_idle_younger_prefers_idle() -> None:
-    """Idle younger pairing beats busy oldest in the first pass.
+    """
+    Idle younger pairing beats busy oldest in the first pass.
 
     Pins the fan-out-on-idle goal: given a busy oldest A and
     an idle younger B, the first pass picks B so concurrent

--- a/tests/test_build_scheduler.py
+++ b/tests/test_build_scheduler.py
@@ -189,8 +189,21 @@ def test_approved_but_session_not_open_skipped() -> None:
     assert decision == BuildPathDecision.local()
 
 
-def test_approved_open_but_busy_skipped() -> None:
-    """A connected receiver currently running a job → not eligible."""
+def test_approved_open_busy_still_returns_remote() -> None:
+    """A connected receiver currently running a job → still REMOTE.
+
+    The receiver runs its own firmware queue; a remote
+    dispatch lands behind whatever's currently building and
+    runs when the queue drains. Silent fallback to LOCAL
+    here used to split the fleet across two compile contexts
+    (warm receiver toolchain vs cold local) and re-flash from
+    a different build than the first Install — confusing and
+    surprising for the user who didn't pick a build location.
+    The scheduler now ignores the idle / running / depth
+    signal; that snapshot is informational (UI-only) and a
+    future per-install "Force local" override link is the
+    user-facing way to opt out.
+    """
     pin = "a" * 64
     decision = pick_build_path(
         _inputs(
@@ -201,20 +214,19 @@ def test_approved_open_but_busy_skipped() -> None:
             },
         )
     )
-    assert decision == BuildPathDecision.local()
+    assert decision == BuildPathDecision.remote(pin)
 
 
-def test_approved_open_but_missing_queue_snapshot_skipped() -> None:
-    """A connected receiver with no queue snapshot yet → not eligible.
+def test_approved_open_missing_queue_snapshot_still_returns_remote() -> None:
+    """No queue snapshot yet → still REMOTE.
 
     The first 5b ``queue_status`` push fires immediately on
     session open, but there's a tiny window between
     ``OFFLOADER_PEER_LINK_OPENED`` and the first snapshot
-    arriving. During that window the receiver could be busy
-    with the queue we haven't been told about yet; routing
-    blind would risk dispatching onto a saturated peer. The
-    safer move is "treat unknown as busy" and fall back to
-    local.
+    arriving. Pre-policy-change the scheduler treated the
+    unknown window as busy and fell back to LOCAL; now the
+    receiver's queue absorbs the dispatch regardless of
+    snapshot state, so the window stops affecting routing.
     """
     pin = "a" * 64
     decision = pick_build_path(
@@ -224,7 +236,7 @@ def test_approved_open_but_missing_queue_snapshot_skipped() -> None:
             # No queue snapshot received yet.
         )
     )
-    assert decision == BuildPathDecision.local()
+    assert decision == BuildPathDecision.remote(pin)
 
 
 # ---------------------------------------------------------------------------
@@ -281,26 +293,6 @@ def test_picks_oldest_eligible_pairing() -> None:
         )
     )
     assert decision == BuildPathDecision.remote(pin_a)
-
-
-def test_skips_busy_candidate_picks_next() -> None:
-    """A busy first candidate falls through to the next eligible entry."""
-    pin_a = "a" * 64
-    pin_b = "b" * 64
-    decision = pick_build_path(
-        _inputs(
-            pairings={
-                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
-                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
-            },
-            open_peer_links={pin_a, pin_b},
-            peer_queue_status={
-                pin_a: _stub_queue_status(pin_sha256=pin_a, idle=False, running=True),
-                pin_b: _stub_queue_status(pin_sha256=pin_b),
-            },
-        )
-    )
-    assert decision == BuildPathDecision.remote(pin_b)
 
 
 def test_skips_disconnected_picks_next() -> None:
@@ -390,15 +382,18 @@ def test_skips_pending_picks_next_approved() -> None:
     assert decision == BuildPathDecision.remote(pin_b)
 
 
-def test_all_candidates_busy_returns_local() -> None:
-    """Every paired receiver is busy → LOCAL.
+def test_all_candidates_busy_picks_oldest_to_queue_remote() -> None:
+    """Every paired receiver is busy → REMOTE on oldest paired_at.
 
-    Pins the loop-exhaustion exit: the prior multi-candidate
-    tests verify a single failing candidate falls through to a
-    sibling, but exhausting *every* candidate has to land at
-    LOCAL (not stick on the last sibling in the chain). Pins
-    the design doc's "silent fallback to local" stance for
-    the saturation case explicitly.
+    Pins the two-tier policy: when no idle candidate
+    qualifies the second pass picks the oldest connected
+    APPROVED pairing and queues the dispatch behind whatever's
+    currently building. Receiver-side firmware queues drain
+    the backlog; silent fallback to LOCAL here used to split
+    the fleet across two compile contexts (warm receiver
+    toolchain vs cold local) and re-flash from a different
+    build than the first Install — confusing for the user
+    who didn't pick a build location.
     """
     pin_a = "a" * 64
     pin_b = "b" * 64
@@ -415,7 +410,65 @@ def test_all_candidates_busy_returns_local() -> None:
             },
         )
     )
-    assert decision == BuildPathDecision.local()
+    assert decision == BuildPathDecision.remote(pin_a)
+
+
+def test_no_idle_candidate_with_some_missing_snapshots_picks_oldest_to_queue() -> None:
+    """No snapshot + busy snapshot → REMOTE on oldest paired_at.
+
+    The first-pass idle preference requires an explicit
+    ``idle=True`` snapshot. A pairing whose snapshot hasn't
+    arrived yet (just-connected window) is *not* treated as
+    idle by the first pass. The second pass then queues on
+    the oldest pairing regardless. Pins that "snapshot
+    missing" doesn't crash or short-circuit to LOCAL — it
+    just routes through the second-pass queue-anyway branch.
+    """
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
+            },
+            open_peer_links={pin_a, pin_b},
+            peer_queue_status={
+                # A has no snapshot at all; B is busy. First
+                # pass finds neither idle; second pass picks
+                # the oldest (A).
+                pin_b: _stub_queue_status(pin_sha256=pin_b, idle=False, running=True),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin_a)
+
+
+def test_first_busy_oldest_then_idle_younger_prefers_idle() -> None:
+    """Idle younger pairing beats busy oldest in the first pass.
+
+    Pins the fan-out-on-idle goal: given a busy oldest A and
+    an idle younger B, the first pass picks B so concurrent
+    installs spread across the idle remotes before any of
+    them queue. The "second pass" (busy fallback) only fires
+    when *no* idle candidate exists.
+    """
+    pin_a = "a" * 64
+    pin_b = "b" * 64
+    decision = pick_build_path(
+        _inputs(
+            pairings={
+                pin_a: _stub_pairing(pin_sha256=pin_a, paired_at=1.0),
+                pin_b: _stub_pairing(pin_sha256=pin_b, paired_at=2.0),
+            },
+            open_peer_links={pin_a, pin_b},
+            peer_queue_status={
+                pin_a: _stub_queue_status(pin_sha256=pin_a, idle=False, running=True),
+                pin_b: _stub_queue_status(pin_sha256=pin_b),
+            },
+        )
+    )
+    assert decision == BuildPathDecision.remote(pin_b)
 
 
 def test_all_candidates_disconnected_returns_local() -> None:


### PR DESCRIPTION
# What does this implement/fix?

User-reported: a second Install while a paired receiver
was busy silently fell back to LOCAL.

```
Install 1 → routes REMOTE to receiver-A → receiver-A busy
Install 2 → scheduler sees receiver-A.idle=False → routes LOCAL
```

The scheduler's first-cut "idle or LOCAL" policy was the
cause. Receiver-side firmware queues are perfectly capable
of queueing a dispatch, but the offloader rejected the
pairing as soon as its `queue_status` snapshot reported
`running=True`.

Silent fallback split the fleet across two compile
contexts (warm receiver toolchain vs cold local) and
re-flashed from a different build than the first Install
— confusing and surprising for a user who didn't pick a
build location.

## Two-tier policy

1. **First pass — idle preference.** Walk pairings in
   oldest-`paired_at` order; pick the first APPROVED +
   connected pairing whose `queue_status` snapshot reports
   `idle=True`. This fans concurrent installs across idle
   remotes (request 1 lands on receiver A, A's snapshot
   flips to running, request 2 lands on the next idle
   remote B) so the fleet's compile capacity is actually
   used.
2. **Second pass — busy fallback.** If no idle candidate
   qualified, pick the oldest connected APPROVED pairing
   regardless of queue state (busy or missing snapshot).
   The receiver runs its own firmware queue; the dispatch
   lands behind whatever's currently building and runs
   when the queue drains.
3. **LOCAL fallback** only when no APPROVED + connected
   pairing exists at all.

A future per-install "Force local" override link in the
install dialog is the user-facing way to opt out when the
scheduler picks REMOTE.

## Behaviour matrix

| Pairings (paired_at order) | Eligible+idle | Eligible+busy | Pick |
|---|---|---|---|
| A (idle) | [A] | [] | REMOTE(A) |
| A (busy), B (idle) | [B] | [A] | REMOTE(B) |
| A (busy), B (busy) | [] | [A, B] | **REMOTE(A)** (was LOCAL) |
| A (busy), B (no snapshot) | [] | [A, B] | **REMOTE(A)** (was LOCAL) |
| A (disconnected) | [] | [] | LOCAL |
| no pairings | [] | [] | LOCAL |

## Tests

- New `test_approved_open_busy_still_returns_remote` pins
  the busy-doesn't-block contract.
- New `test_approved_open_missing_queue_snapshot_still_returns_remote`
  pins the just-connected window.
- New `test_first_busy_oldest_then_idle_younger_prefers_idle`
  pins the fan-out goal (busy oldest vs idle younger).
- New `test_no_idle_candidate_with_some_missing_snapshots_picks_oldest_to_queue`
  pins the second-pass snapshot-missing path.
- Renamed `test_all_candidates_busy_returns_local` →
  `..._picks_oldest_to_queue_remote` (now asserts REMOTE
  on oldest, not LOCAL).
- Install-handler test asserting the busy-falls-to-LOCAL
  behaviour renamed + updated to assert the
  busy-stays-on-REMOTE one.
- Removed `test_busy_first_candidate_still_wins_on_oldest_paired_at`
  (redundant with the new fan-out test; was a dead-end
  experiment).
- All 2974 backend tests pass.

**Related issue or feature (if applicable):**

- refs esphome/device-builder#106 (remote build) — phase
  7a-3 scheduler policy refinement.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed (the scheduler decision is
  server-side; the install dialog already renders
  `source_label` for REMOTE jobs regardless of the
  receiver's busy state)
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
