### PR TITLE
Add force_local flag to firmware/install to override scheduler

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -346,7 +346,14 @@ class FirmwareController:
         return await self._enqueue(job)
 
     @api_command("firmware/install")
-    async def install(self, *, configuration: str, port: str = "OTA", **kwargs: Any) -> FirmwareJob:
+    async def install(
+        self,
+        *,
+        configuration: str,
+        port: str = "OTA",
+        force_local: bool = False,
+        **kwargs: Any,
+    ) -> FirmwareJob:
         """Queue a device update (compile + upload).
 
         ``port`` defaults to ``"OTA"`` — the CLI resolves the
@@ -359,7 +366,7 @@ class FirmwareController:
 
         Routes through :func:`helpers.build_scheduler.pick_build_path`
         before queuing: when a paired receiver is APPROVED +
-        peer-link-connected + idle, the resulting job carries
+        peer-link-connected, the resulting job carries
         ``source=REMOTE`` + ``source_pin_sha256=<pin>`` +
         ``source_label=<receiver_label>`` so the source-routed
         runner (7a-2b) dispatches the compile to that receiver
@@ -369,10 +376,25 @@ class FirmwareController:
         pipeline. Silent fallback by design — the user doesn't
         choose a build location; the scheduler routes
         transparently.
+
+        ``force_local`` opts out of the scheduler decision: the
+        install runs LOCAL regardless of what
+        :func:`pick_build_path` would have picked. Used by the
+        install dialog's "Build locally instead" override link
+        next to the "Building on {receiver}" sub-line — the
+        operator sees the scheduler picked REMOTE, decides
+        they want LOCAL anyway (cache hot locally, paired
+        receiver slow this week, network flakey, …), cancels
+        the in-flight remote and resubmits with this flag.
+        Default ``False`` preserves the transparent-install
+        behaviour for every existing caller.
         """
         _validate_port(port)
         await self._validate_configuration_boundary(configuration)
-        source, pin_sha256, label = self._resolve_install_source(configuration, port)
+        if force_local:
+            source, pin_sha256, label = JobSource.LOCAL, "", ""
+        else:
+            source, pin_sha256, label = self._resolve_install_source(configuration, port)
         job = self._create_job(
             configuration,
             JobType.INSTALL,

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -340,6 +340,65 @@ async def test_install_routes_to_remote_when_pairing_is_idle_and_connected(
 
 
 @pytest.mark.asyncio
+async def test_install_force_local_bypasses_scheduler(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """
+    ``force_local=True`` keeps the install LOCAL even with an idle pairing.
+
+    Pins the override path the install dialog's "Build
+    locally instead" link uses: an idle APPROVED paired
+    receiver would normally route REMOTE, but the operator
+    can opt out and get a LOCAL build regardless. Mirrors
+    the scheduler-disabled-by-master-switch shape but is a
+    per-install decision rather than a global one — the
+    next install (without the flag) routes REMOTE again as
+    usual.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing(label="desktop")
+    _stub_remote_build(
+        controller,
+        pairings=[pairing],
+        open_pins=frozenset({_PIN}),
+        idle_pins=frozenset({_PIN}),
+    )
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.install(configuration="kitchen.yaml", force_local=True)
+
+    assert job.source is JobSource.LOCAL
+    assert job.source_pin_sha256 == ""
+    assert job.source_label == ""
+
+
+@pytest.mark.asyncio
+async def test_install_force_local_default_false_keeps_scheduler_behaviour(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """
+    Default ``force_local=False`` keeps the transparent-install routing.
+
+    Pin the default to catch a future regression that flips
+    the flag's default to ``True`` — every existing caller
+    would silently lose the transparent-install routing.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing(label="desktop")
+    _stub_remote_build(
+        controller,
+        pairings=[pairing],
+        open_pins=frozenset({_PIN}),
+        idle_pins=frozenset({_PIN}),
+    )
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.install(configuration="kitchen.yaml")
+
+    assert job.source is JobSource.REMOTE
+
+
+@pytest.mark.asyncio
 async def test_install_still_routes_remote_when_receiver_is_busy(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Backend half of the install-dialog "Build locally
instead" override link. When the scheduler routes an
install REMOTE the operator may have a reason to want
LOCAL anyway — local cache hot, paired receiver slow this
week, network flakey, debugging the local toolchain.
Today there's no escape hatch; the user has to either
disable remote-build globally (Settings toggle) or unpair
the receiver.

## Fix

`firmware/install` gains `force_local: bool = False`. When
`True`, the scheduler decision is bypassed and the install
runs LOCAL regardless of paired receivers:

```python
if force_local:
    source, pin_sha256, label = JobSource.LOCAL, "", ""
else:
    source, pin_sha256, label = self._resolve_install_source(configuration, port)
```

Default `False` preserves the transparent-install
routing every existing caller depends on.

## Tests

- New `test_install_force_local_bypasses_scheduler` pins
  the override path with an idle pairing that would
  otherwise route REMOTE.
- New `test_install_force_local_default_false_keeps_scheduler_behaviour`
  pins the default so a future regression flipping it
  doesn't silently lose transparent-install for every
  caller.
- All 20 install-handler tests pass.

## Frontend coordination

The companion frontend PR will:

1. Add a "Build locally instead" link next to the
   "Building on {receiver}" sub-line in the install
   dialog, visible only for REMOTE-routed in-flight
   jobs.
2. Click handler: cancel the current job (`firmware/cancel`)
   then submit a fresh install with `force_local=true`
   and re-attach the dialog to the new `job_id` returned.

The flag default is `False`, so the frontend can ship
without coordination on the backend's side (existing
behaviour unchanged); coordination matters only for the
new link to function.

**Related issue or feature (if applicable):**

- refs esphome/device-builder#106 (remote build) — phase
  7a-3 user-facing override.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD> (override link in install dialog)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
