### PR TITLE
Pre-clean macOS .DS_Store / AppleDouble sidecars before bundle extract

### DIFF
--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -58,6 +58,8 @@ from __future__ import annotations
 import asyncio
 import binascii
 import logging
+import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -694,5 +696,75 @@ def _validate_write_extract_bundle(
         raise _PathEscapeError(str(target_dir)) from exc
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     bundle_path.write_bytes(bundle_bytes)
+    _strip_macos_metadata(target_dir)
     extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)
     return extracted
+
+
+def _strip_macos_metadata(target_dir: Path) -> None:
+    """Remove ``.DS_Store`` / ``._*`` sidecars under *target_dir*.
+
+    macOS Finder / QuickLook re-create ``.DS_Store`` inside any
+    directory a user views. AppleDouble ``._<name>`` resource
+    forks appear on copies to non-HFS+ filesystems. Both get
+    re-created between ``shutil.rmtree``'s scandir step and its
+    final ``os.rmdir``, surfacing as
+    ``OSError(ENOTEMPTY, "Directory not empty: build")`` inside
+    upstream :func:`prepare_bundle_for_compile`. Pre-cleaning
+    the sidecars shrinks the race window — the upstream walk
+    still has to finish its multi-second recursion through the
+    build tree, but it starts from a state where the top-level
+    directories don't contain re-creatable sidecars and the
+    odds of Finder racing back in during the few-ms scandir →
+    rmdir window drop sharply.
+
+    Uses :func:`os.walk` rather than :meth:`Path.rglob` —
+    same pattern :func:`helpers.build_size._compute_build_dir_size`
+    uses: ``os.walk`` delegates to :func:`os.scandir` and
+    gets cached ``d_type`` from ``readdir`` so we don't pay
+    a stat syscall per entry. ``rglob`` allocates a
+    :class:`Path` per entry and re-stats for ``is_file()``,
+    which roughly doubles the syscall count. A typical
+    ESP-IDF build is 5000+ entries; the install path is on
+    the user-visible latency budget, so the cheap walk
+    matters.
+
+    Best-effort: an :exc:`OSError` on the unlink (race with
+    a concurrent process, permissions, …) doesn't fail the
+    install. Upstream's cleanup walk is the real line of
+    defence; re-raising here would prevent it from running.
+    Counts removals + logs once at the end so the operator
+    sees how many sidecars the pre-clean caught, without one
+    log line per sidecar drowning the log on a 200+-folder
+    build tree.
+    """
+    if not target_dir.is_dir():
+        return
+    removed = 0
+    started = time.monotonic()
+    # ``onerror`` swallows top-level failures (missing dir,
+    # permission denied at root). Per-file ``unlink`` errors
+    # are caught individually below so a vanishing file
+    # mid-walk doesn't abort the whole pre-clean.
+    for dirpath, _dirnames, filenames in os.walk(target_dir, onerror=lambda _e: None):
+        for name in filenames:
+            if name == ".DS_Store" or name.startswith("._"):
+                path = os.path.join(dirpath, name)
+                try:
+                    os.unlink(path)
+                except OSError as exc:
+                    _LOGGER.debug(
+                        "strip_macos_metadata: unlink %s failed (errno=%s); "
+                        "deferring to upstream cleanup",
+                        path,
+                        exc.errno,
+                    )
+                    continue
+                removed += 1
+    if removed:
+        _LOGGER.info(
+            "strip_macos_metadata: removed %d sidecar file(s) under %s in %.3fs",
+            removed,
+            target_dir,
+            time.monotonic() - started,
+        )

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -28,6 +28,7 @@ from esphome.bundle import EsphomeError
 
 from esphome_device_builder.controllers.remote_build.submit_job import (
     SubmitJobReceiver,
+    _strip_macos_metadata,
     _validate_configuration_filename,
 )
 from esphome_device_builder.helpers.peer_link_bundle import BUNDLE_CHUNK_SIZE_BYTES
@@ -722,3 +723,78 @@ def test_discard_session_unknown_is_noop(tmp_path: Path) -> None:
     """Discarding a session that never registered is a no-op."""
     receiver = _make_receiver(tmp_path)
     receiver.discard_session("never-seen")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# _strip_macos_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_strip_macos_metadata_removes_ds_store_and_apple_double(
+    tmp_path: Path,
+) -> None:
+    """
+    MacOS sidecars under target_dir are removed; real files survive.
+
+    Pin the bug we shipped this for: a ``.DS_Store`` created by
+    macOS Finder inside the per-device subtree's ``build/``
+    directory used to break the next ``submit_job`` for the same
+    device. Upstream :func:`prepare_bundle_for_compile`'s cleanup
+    walk scans the dir, unlinks the sidecar, and then races
+    Finder re-creating it before the final ``os.rmdir`` — the
+    rmdir then fails with ``ENOTEMPTY``. Pre-cleaning the
+    sidecars before handing off to the upstream walk avoids the
+    race window.
+    """
+    target = tmp_path / "device"
+    target.mkdir()
+    (target / ".DS_Store").write_bytes(b"x")
+    (target / "build").mkdir()
+    (target / "build" / ".DS_Store").write_bytes(b"x")
+    (target / "build" / "._sdkconfig").write_bytes(b"x")  # AppleDouble
+    (target / "build" / "real_file.txt").write_bytes(b"keep me")
+    (target / "build" / "real_dir").mkdir()
+    (target / "build" / "real_dir" / ".DS_Store").write_bytes(b"x")
+
+    _strip_macos_metadata(target)
+
+    assert not (target / ".DS_Store").exists()
+    assert not (target / "build" / ".DS_Store").exists()
+    assert not (target / "build" / "._sdkconfig").exists()
+    assert not (target / "build" / "real_dir" / ".DS_Store").exists()
+    # Real files untouched.
+    assert (target / "build" / "real_file.txt").exists()
+    assert (target / "build" / "real_dir").exists()
+
+
+def test_strip_macos_metadata_missing_target_is_noop(tmp_path: Path) -> None:
+    """
+    First-submit case: target_dir doesn't exist yet → no-op.
+
+    On a fresh receiver the per-device subtree is created by
+    ``prepare_bundle_for_compile`` itself; we only get a chance
+    to pre-clean on the second-and-later submit. A missing dir
+    must be tolerated silently rather than raising.
+    """
+    _strip_macos_metadata(tmp_path / "nonexistent")  # no raise
+
+
+def test_strip_macos_metadata_swallows_unlink_errors(tmp_path: Path) -> None:
+    """
+    Best-effort: an unlink failure doesn't fail the install.
+
+    Upstream's cleanup walk is the real line of defence; if a
+    sidecar is held open by a concurrent process and our
+    pre-unlink fails, we hand off to the upstream walk anyway.
+    Re-raising here would silently prevent the upstream cleanup
+    from running.
+    """
+    target = tmp_path / "device"
+    target.mkdir()
+    (target / ".DS_Store").write_bytes(b"x")
+    # Pre-remove out of band so the unlink inside the helper
+    # raises FileNotFoundError (a subclass of OSError) — the
+    # easiest way to drive the "best-effort" branch without
+    # stubbing os.unlink.
+    (target / ".DS_Store").unlink()
+    _strip_macos_metadata(target)  # no raise


### PR DESCRIPTION
# What does this implement/fix?

User-reported: after cancelling a remote install, the next
`submit_job` for the same device on the receiver fails with

```
[Errno 66] Directory not empty: PosixPath(
  '/Users/.../wD8XFQEYxwjRMhg.../apollo-r-pro-1-eth-5938e0/build'
)
```

The failure persisted across retries even after a 15s
wait, ruling out a subprocess-reap race.

## Root cause

macOS Finder / QuickLook re-creates `.DS_Store` inside
any directory it has viewed. The receiver-side build tree
under
`.esphome/.remote_builds/<dashboard>/<device>/build/`
ends up with a `.DS_Store` sidecar after the user (or any
indexing daemon) views it. Upstream
`esphome.bundle.prepare_bundle_for_compile` cleans the
non-preserved entries via `shutil.rmtree` before
extracting the new bundle:

```
scandir(build/) → [.DS_Store, <env>/]
unlink .DS_Store
rmtree <env>/ (5000+ files, multi-second)
rmdir build/   ← Finder re-created .DS_Store; rmdir → ENOTEMPTY
```

The Finder write happens during the multi-second
`shutil.rmtree(<env>/)` recursion, and lands before the
final `rmdir(build)`.

Confirmed locally — `ls -la build/` after the failure
showed exactly one entry: `.DS_Store` at the top of
`build/`, alongside the still-present `<env>/` subdir.
Once Finder stopped re-creating it, a manual
`shutil.rmtree(build/)` succeeded.

## Fix

Pre-clean `.DS_Store` and AppleDouble (`._<name>`)
sidecars under `target_dir` before handing off to
`prepare_bundle_for_compile`. Shrinks the race window —
Finder can still re-create the sidecar mid-walk, but with
the sidecar gone at the start, the upstream walk has the
full multi-second window to finish without one present,
and the few-ms `scandir → rmdir` window at the end is
unlikely to race a fresh Finder write.

```python
_strip_macos_metadata(target_dir)
extracted = prepare_bundle_for_compile(bundle_path, target_dir)
```

## Performance

- Uses `os.walk` (delegates to `os.scandir` for cached
  `d_type`), mirroring the pattern in
  `helpers/build_size.py`. ~tenths of a second on a
  typical 5000-entry ESP-IDF build vs. ~seconds for
  `Path.rglob` with its per-entry stat syscalls.
- Best-effort: per-file unlink failures are swallowed +
  debug-logged so a permission error doesn't block the
  install — upstream's cleanup walk is the real line of
  defence and would catch the same files anyway.
- Single `info` log at the end summarising sidecar count
  + elapsed time, so the operator sees the pre-clean
  effectiveness without a per-file log line drowning the
  signal on a 200+ folder build tree.

## Tests

Three new in `tests/test_remote_build_submit_job.py`:

- Removes `.DS_Store` / AppleDouble sidecars at every
  level under `target_dir`, leaving real files +
  directories alone.
- No-op when `target_dir` doesn't exist (first submit
  case).
- Swallows unlink errors (best-effort contract).
- 44 submit-job tests still pass.

**Related issue or feature (if applicable):**

- Bug surfaced in the local dev loop on macOS while
  testing the transparent install flow
  (esphome/device-builder#106).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
