### PR TITLE
Carry device + peer display strings through to receiver-side FirmwareJob

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1612,10 +1612,13 @@ class FirmwareController:
         port: str = "",
         new_name: str = "",
         remote_peer: str = "",
+        remote_peer_label: str = "",
         remote_job_id: str = "",
         source: JobSource = JobSource.LOCAL,
         source_pin_sha256: str = "",
         source_label: str = "",
+        device_name: str = "",
+        device_friendly_name: str = "",
     ) -> FirmwareJob:
         """Create a new job and add it to the in-memory map.
 
@@ -1630,7 +1633,17 @@ class FirmwareController:
         is the offloader's submit-tagged ``job_id`` from the
         same flow; the receiver-side ``job_id`` above is
         generated independently so the two id-spaces don't
-        collide.
+        collide. ``remote_peer_label`` is the offloader's
+        display label (:attr:`StoredPeer.label`) snapshotted at
+        submit time so the receiver's firmware-tasks UI can
+        render "from {label}" without a separate lookup —
+        symmetric to ``source_label`` on the offloader side.
+
+        ``device_name`` / ``device_friendly_name`` are the
+        ``esphome.name`` / ``esphome.friendly_name`` parsed from
+        the bundled YAML on receiver-side remote-build jobs.
+        Empty for locally-submitted jobs (the dashboard's own
+        Device list already carries the friendly name).
 
         ``source`` / ``source_pin_sha256`` / ``source_label`` are
         the offloader-side dispatch-origin fields (7a-2a):
@@ -1649,10 +1662,13 @@ class FirmwareController:
             port=port,
             new_name=new_name,
             remote_peer=remote_peer,
+            remote_peer_label=remote_peer_label,
             remote_job_id=remote_job_id,
             source=source,
             source_pin_sha256=source_pin_sha256,
             source_label=source_label,
+            device_name=device_name,
+            device_friendly_name=device_friendly_name,
         )
         self._jobs[job.job_id] = job
         return job

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1640,10 +1640,17 @@ class FirmwareController:
         symmetric to ``source_label`` on the offloader side.
 
         ``device_name`` / ``device_friendly_name`` are the
-        ``esphome.name`` / ``esphome.friendly_name`` parsed from
-        the bundled YAML on receiver-side remote-build jobs.
-        Empty for locally-submitted jobs (the dashboard's own
-        Device list already carries the friendly name).
+        ``esphome.name`` / ``esphome.friendly_name`` the
+        offloader sends on the :class:`SubmitJobFrameData`
+        header — the offloader already has both off its local
+        Device scanner at install time, so the receiver doesn't
+        re-parse the bundled YAML. Peer-controlled at the wire
+        boundary; the receive-side handler
+        (:meth:`SubmitJobReceiver.handle_submit_job`) coerces +
+        length-caps them via ``_coerce_display_field`` before
+        passing them here. Empty for locally-submitted jobs
+        (the dashboard's own Device list already carries the
+        friendly name).
 
         ``source`` / ``source_pin_sha256`` / ``source_label`` are
         the offloader-side dispatch-origin fields (7a-2a):

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -267,12 +267,38 @@ async def _dispatch_and_drive(  # noqa: PLR0911
         )
         return
 
+    # Look up the local Device entry so the receiver's
+    # firmware-tasks UI can render the device's actual name +
+    # friendly name instead of the cryptic
+    # ``.esphome/.remote_builds/<id>/<device>/<device>.yaml``
+    # path. The offloader already has both from its scanner —
+    # sending them on the wire avoids the receiver having to
+    # re-parse the bundled YAML just to render a title.
+    # ``getattr`` falls through cleanly when the devices
+    # controller isn't wired yet (pre-``start()`` race, test
+    # stubs without a Device list). A missing scanner entry
+    # for a real lookup leaves the fields empty and the
+    # receiver falls back to the path's device segment —
+    # happens for newly-added YAMLs whose scanner entry
+    # hasn't refreshed yet, not worth blocking on.
+    device_name = ""
+    device_friendly_name = ""
+    devices_controller = getattr(controller._db, "devices", None)
+    if devices_controller is not None:
+        for device in devices_controller.get_devices():
+            if device.configuration == job.configuration:
+                device_name = device.name
+                device_friendly_name = device.friendly_name
+                break
+
     try:
         ack = await client.submit_job(
             job_id=job.job_id,
             configuration_filename=job.configuration,
             target="compile",
             bundle_bytes=bundle_bytes,
+            device_name=device_name,
+            device_friendly_name=device_friendly_name,
         )
     except (PeerLinkNoSessionError, SubmitJobTimeoutError, SubmitJobSessionLostError) as exc:
         _fail_locally(

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -2686,6 +2686,27 @@ class RemoteBuildController:
             for p in self._approved_peers.values()
         ]
 
+    def approved_peer_label(self, dashboard_id: str) -> str:
+        """Return the APPROVED peer's display label, or ``""`` if not found.
+
+        Public-by-convention accessor over the private
+        ``_approved_peers`` dict so external consumers don't
+        couple to the registry's internal layout. Read-only
+        snapshot: returns the label as it stands right now;
+        callers that need a time-of-event snapshot (e.g. the
+        receiver-side ``submit_job`` flow stamping
+        :attr:`FirmwareJob.remote_peer_label`) call this at the
+        decisive moment rather than holding a long-lived
+        reference.
+
+        A future refactor of the peer registry (e.g. moving
+        APPROVED rows into a per-file ``Store`` like
+        ``_pairings``) only has to keep this accessor's
+        contract; the call sites stay unchanged.
+        """
+        peer = self._approved_peers.get(dashboard_id)
+        return peer.label if peer is not None else ""
+
     def peers_snapshot(self) -> list[PeerSummary]:
         """
         Return the in-memory peers snapshot (PENDING + APPROVED).

--- a/esphome_device_builder/controllers/remote_build/peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client.py
@@ -1109,6 +1109,8 @@ class PeerLinkClient:
         configuration_filename: str,
         target: Literal["compile", "upload"],
         bundle_bytes: bytes,
+        device_name: str = "",
+        device_friendly_name: str = "",
     ) -> SubmitJobAckFrameData:
         """Send a ``submit_job`` header + chunked bundle and await the receiver's ack.
 
@@ -1166,6 +1168,8 @@ class PeerLinkClient:
                 configuration_filename=configuration_filename,
                 target=target,
                 bundle_bytes=bundle_bytes,
+                device_name=device_name,
+                device_friendly_name=device_friendly_name,
             )
             return await self._await_submit_job_ack(ack_fut, job_id=job_id)
         finally:
@@ -1304,6 +1308,8 @@ class PeerLinkClient:
         configuration_filename: str,
         target: Literal["compile", "upload"],
         bundle_bytes: bytes,
+        device_name: str = "",
+        device_friendly_name: str = "",
     ) -> None:
         """Send the ``submit_job`` header and every chunk frame, in order.
 
@@ -1332,6 +1338,8 @@ class PeerLinkClient:
             "total_bundle_bytes": total_bytes,
             "num_chunks": num_chunks,
             "bundle_sha256": compute_bundle_sha256(bundle_bytes),
+            "device_name": device_name,
+            "device_friendly_name": device_friendly_name,
         }
         if not await channel.send_frame(cast(dict[str, Any], header)):
             raise SubmitJobSessionLostError(

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -240,6 +240,18 @@ class _PendingSubmit:
     configuration_filename: str
     target: str
     assembler: BundleAssembler
+    # Display strings carried on the SUBMIT_JOB header; empty
+    # for older offloaders that don't set the (NotRequired)
+    # wire fields. The receiver stamps both onto the
+    # :class:`FirmwareJob` so the firmware-tasks UI renders the
+    # device's actual name + friendly name instead of the
+    # ``.esphome/.remote_builds/<id>/<device>/<device>.yaml``
+    # path. No semantic meaning beyond display: the path-level
+    # security gate (``_validate_configuration_filename``) is
+    # what keeps the receiver safe; these fields are purely UI
+    # plumbing.
+    device_name: str = ""
+    device_friendly_name: str = ""
 
 
 class SubmitJobReceiver:
@@ -351,6 +363,13 @@ class SubmitJobReceiver:
             configuration_filename=frame["configuration_filename"],
             target=target,
             assembler=assembler,
+            # Pull display strings off the header. ``.get`` keeps
+            # backwards-compat with older offloaders that don't
+            # send the NotRequired fields; defaults to empty
+            # strings the receiver-side title surface treats as
+            # "fall back to the configuration path".
+            device_name=frame.get("device_name", ""),
+            device_friendly_name=frame.get("device_friendly_name", ""),
         )
 
     async def handle_submit_job_chunk(
@@ -547,12 +566,37 @@ class SubmitJobReceiver:
         rel_yaml = extracted_yaml.relative_to(self._config_dir)
         configuration = rel_yaml.as_posix()
 
+        # Snapshot the offloader's display label so the
+        # firmware-tasks UI can render "from {label}" without
+        # re-looking-up the (potentially since-renamed) peer.
+        # ``_db.remote_build`` is the controller this receiver
+        # lives inside; the indirection through the firmware
+        # controller stays consistent with how other receiver-
+        # side helpers reach back to peer metadata.
+        remote_peer_label = ""
+        remote_build = self._firmware._db.remote_build
+        if remote_build is not None:
+            peer = remote_build._approved_peers.get(session.dashboard_id)
+            if peer is not None:
+                remote_peer_label = peer.label
+
         try:
             job = self._firmware._create_job(
                 configuration=configuration,
                 job_type=_TARGET_TO_JOB_TYPE[pending.target],
                 remote_peer=session.dashboard_id,
+                remote_peer_label=remote_peer_label,
                 remote_job_id=pending.job_id,
+                # ``device_name`` / ``device_friendly_name`` come
+                # off the wire header — the offloader already
+                # knows both from its local Device list at install
+                # time, so the receiver doesn't re-parse the
+                # bundled YAML just to render a title. Defaults
+                # to ``""`` for older offloaders that don't set
+                # the (NotRequired) fields; the frontend's title
+                # then falls back to the configuration path.
+                device_name=pending.device_name,
+                device_friendly_name=pending.device_friendly_name,
             )
             await self._firmware._enqueue(job)
         except Exception as exc:

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -102,6 +102,19 @@ _REASON_CHUNK_DECODE_FAILED = "chunk_decode_failed"
 _REASON_EXTRACT_FAILED = "extract_failed"
 _REASON_QUEUE_REJECTED = "queue_rejected"
 
+# Cap on the peer-controlled display strings the header carries
+# (``device_name`` / ``device_friendly_name``). The schema gate
+# leaves these fields untyped, so a malicious / buggy offloader
+# could ship a non-string or a multi-megabyte string that we'd
+# end up stamping onto :class:`FirmwareJob` and replaying through
+# the firmware-tasks WS stream. 256 chars is twice
+# :data:`StoredPairing._MAX_LABEL_LEN` (128) and well above the
+# longest reasonable device / friendly name anyone would write
+# in YAML — values above the cap get truncated to empty rather
+# than rejected, since the field is display-only and an empty
+# title gracefully falls back to the configuration path.
+_DEVICE_DISPLAY_FIELD_MAX_LEN = 256
+
 # Shape contracts for the two peer-controlled wire frames.
 # :func:`parse_app_frame` already confirms inbound bytes parse
 # to a ``dict[str, Any]``, but a malicious / buggy offloader
@@ -175,6 +188,38 @@ _RECOVERABLE_ASSEMBLER_ERRORS: frozenset[BundleAssemblerErrorCode] = frozenset(
 # defence-in-depth gate that catches anything an exotic filename
 # would slip past this.
 _FORBIDDEN_FILENAME_CHARS: frozenset[str] = frozenset({"/", "\\", "\x00"})
+
+
+def _coerce_display_field(value: Any) -> str:
+    """Coerce a peer-supplied display string to a safe, bounded ``str``.
+
+    The ``NotRequired`` ``device_name`` / ``device_friendly_name``
+    fields on :class:`SubmitJobFrameData` bypass the schema gate
+    (the gate validates a known-keys subset; extras pass
+    through), so a non-``str`` value or a multi-megabyte string
+    from a malicious / buggy offloader would otherwise reach
+    the in-flight :class:`_PendingSubmit` and land on the
+    :class:`FirmwareJob` we replay through the firmware-tasks
+    WS stream. Soft-coerce rather than reject:
+
+    * Non-``str`` → ``""``. The display surface treats empty as
+      "fall back to the configuration path" — a clear UI signal
+      vs. a hard reject the operator can't recover from.
+    * Length > :data:`_DEVICE_DISPLAY_FIELD_MAX_LEN` → ``""``,
+      same rationale. The cap is well above any legitimate
+      device / friendly name; values past it are signalling
+      abuse, not a long but legitimate string.
+
+    The display fields are UI plumbing, not load-bearing for the
+    build (the path-level gates in
+    :func:`_validate_configuration_filename` are what keep the
+    extract step safe). Empty fallback is the safe default.
+    """
+    if not isinstance(value, str):
+        return ""
+    if len(value) > _DEVICE_DISPLAY_FIELD_MAX_LEN:
+        return ""
+    return value
 
 
 def _validate_configuration_filename(filename: str) -> str | None:
@@ -363,13 +408,16 @@ class SubmitJobReceiver:
             configuration_filename=frame["configuration_filename"],
             target=target,
             assembler=assembler,
-            # Pull display strings off the header. ``.get`` keeps
-            # backwards-compat with older offloaders that don't
-            # send the NotRequired fields; defaults to empty
-            # strings the receiver-side title surface treats as
-            # "fall back to the configuration path".
-            device_name=frame.get("device_name", ""),
-            device_friendly_name=frame.get("device_friendly_name", ""),
+            # Coerce + cap the peer-controlled display strings.
+            # The schema gate leaves these ``NotRequired`` fields
+            # untyped at the wire boundary, so a non-string or an
+            # oversized string would otherwise reach the
+            # :class:`FirmwareJob` and the WS stream. Soft-coerce
+            # to ``""`` rather than rejecting the submit — the
+            # display fields are UI plumbing, not load-bearing
+            # for the build.
+            device_name=_coerce_display_field(frame.get("device_name")),
+            device_friendly_name=_coerce_display_field(frame.get("device_friendly_name")),
         )
 
     async def handle_submit_job_chunk(
@@ -569,16 +617,16 @@ class SubmitJobReceiver:
         # Snapshot the offloader's display label so the
         # firmware-tasks UI can render "from {label}" without
         # re-looking-up the (potentially since-renamed) peer.
-        # ``_db.remote_build`` is the controller this receiver
-        # lives inside; the indirection through the firmware
-        # controller stays consistent with how other receiver-
-        # side helpers reach back to peer metadata.
+        # Goes through :meth:`RemoteBuildController.approved_peer_label`
+        # so the receiver doesn't couple to the private
+        # ``_approved_peers`` layout — a future refactor of the
+        # peer registry (e.g. moving APPROVED rows into a per-
+        # file ``Store`` like ``_pairings``) only has to keep
+        # the accessor's contract.
         remote_peer_label = ""
         remote_build = self._firmware._db.remote_build
         if remote_build is not None:
-            peer = remote_build._approved_peers.get(session.dashboard_id)
-            if peer is not None:
-                remote_peer_label = peer.label
+            remote_peer_label = remote_build.approved_peer_label(session.dashboard_id)
 
         try:
             job = self._firmware._create_job(

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -130,19 +130,32 @@ class FirmwareJob(DataClassORJSONMixin):
     # the pair without re-querying that half's mutable state.
     remote_peer_label: str = ""
     # The device's ``esphome.name`` (machine handle) and
-    # ``esphome.friendly_name`` (display string), parsed from
-    # the bundled YAML at submit time. Populated only on
-    # receiver-side remote-build jobs — the configuration field
-    # carries the full ``.esphome/.remote_builds/<id>/<device>/...``
-    # path which is useless as a title; these fields let the
-    # firmware-tasks UI render the device's actual name and
-    # friendly name instead. Empty for locally-submitted jobs
-    # (the dashboard's own Device list already knows the
-    # friendly name for those — no need to duplicate it on the
-    # job). ``device_friendly_name`` may legitimately be empty
-    # for a YAML that doesn't set ``esphome.friendly_name``;
-    # callers fall back to ``device_name`` (then to the
-    # configuration path's device segment) for the title.
+    # ``esphome.friendly_name`` (display string). Carried on
+    # the receiver-side row only — the offloader puts both on
+    # the wire via the :class:`SubmitJobFrameData` header
+    # (``device_name`` / ``device_friendly_name``) because it
+    # already has them off its local Device scanner at install
+    # time; the receiver doesn't re-parse the bundled YAML.
+    # Peer-controlled input on the receiver side — coerced +
+    # length-capped by
+    # :func:`controllers.remote_build.submit_job._coerce_display_field`
+    # before landing here so a malicious / buggy header can't
+    # ship a non-string or a multi-megabyte value through to
+    # the firmware-tasks WS stream.
+    #
+    # The configuration field carries the full
+    # ``.esphome/.remote_builds/<id>/<device>/...`` path which
+    # is useless as a title; these fields let the firmware-
+    # tasks UI render the device's actual name and friendly
+    # name instead. Empty for locally-submitted jobs (the
+    # dashboard's own Device list already knows the friendly
+    # name for those — no need to duplicate it on the job),
+    # and empty for receiver-side jobs whose offloader didn't
+    # set the ``NotRequired`` wire fields (older offloader)
+    # or whose YAML legitimately doesn't define
+    # ``esphome.friendly_name``. The frontend's title surface
+    # falls back from ``device_friendly_name`` → ``device_name``
+    # → configuration-path device segment.
     device_name: str = ""
     device_friendly_name: str = ""
     # Where the build's bytes come from. The offloader-side

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -119,6 +119,32 @@ class FirmwareJob(DataClassORJSONMixin):
     # offloader matches against its own submit-tagged id, not
     # the receiver's local one.
     remote_job_id: str = ""
+    # Display label for the offloader that submitted this job,
+    # when ``remote_peer`` is set. Empty for locally-submitted
+    # jobs and for offloader-side rows.
+    # Snapshot of :attr:`StoredPeer.label` at submit time —
+    # doesn't track later renames of the peer's label (the
+    # log entry reflects what was true when the work landed).
+    # Symmetric to :attr:`source_label` on the offloader side:
+    # both surfaces want a human handle on the OTHER half of
+    # the pair without re-querying that half's mutable state.
+    remote_peer_label: str = ""
+    # The device's ``esphome.name`` (machine handle) and
+    # ``esphome.friendly_name`` (display string), parsed from
+    # the bundled YAML at submit time. Populated only on
+    # receiver-side remote-build jobs — the configuration field
+    # carries the full ``.esphome/.remote_builds/<id>/<device>/...``
+    # path which is useless as a title; these fields let the
+    # firmware-tasks UI render the device's actual name and
+    # friendly name instead. Empty for locally-submitted jobs
+    # (the dashboard's own Device list already knows the
+    # friendly name for those — no need to duplicate it on the
+    # job). ``device_friendly_name`` may legitimately be empty
+    # for a YAML that doesn't set ``esphome.friendly_name``;
+    # callers fall back to ``device_name`` (then to the
+    # configuration path's device segment) for the title.
+    device_name: str = ""
+    device_friendly_name: str = ""
     # Where the build's bytes come from. The offloader-side
     # firmware-queue runner branches on this to choose its
     # pipeline (local subprocess vs peer-link dispatch).
@@ -180,8 +206,10 @@ class FirmwareJob(DataClassORJSONMixin):
         - **Preserves identity** — ``configuration`` /
           ``job_type`` / ``port`` / ``new_name`` / ``created_at``
           / ``job_id`` / ``source`` / ``source_pin_sha256`` /
-          ``source_label`` / ``remote_peer`` / ``remote_job_id``
-          describe the job rather than the run, so they stay
+          ``source_label`` / ``remote_peer`` / ``remote_peer_label`` /
+          ``remote_job_id`` / ``device_name`` /
+          ``device_friendly_name`` describe the job rather than
+          the run, so they stay
           intact.
         """
         self.output = [*self.output, _RECOVERY_NOTICE]

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -827,6 +827,18 @@ class SubmitJobFrameData(TypedDict):
     integrity check on top of the per-frame Noise AEAD;
     catches a chunk-reassembly bug (e.g. a missed
     ``is_last``) that AEAD wouldn't surface.
+
+    ``device_name`` / ``device_friendly_name`` carry the
+    offloader's view of the device for the receiver-side
+    firmware-tasks UI — the offloader already has both off
+    its local Device list at install time, so the receiver
+    avoids re-parsing the bundled YAML just to render a
+    title. ``NotRequired`` so an older offloader that
+    doesn't set them still produces a valid frame; the
+    receiver-side title then falls back to the last segment
+    of the configuration path. New offloaders always set
+    both (empty string for ``device_friendly_name`` when the
+    YAML doesn't define one).
     """
 
     type: Literal["submit_job"]
@@ -836,6 +848,8 @@ class SubmitJobFrameData(TypedDict):
     total_bundle_bytes: int
     num_chunks: int
     bundle_sha256: str
+    device_name: NotRequired[str]
+    device_friendly_name: NotRequired[str]
 
 
 class SubmitJobChunkFrameData(TypedDict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,7 +280,13 @@ def make_tar_bundle(yaml_filename: str, yaml_body: bytes) -> bytes:
 
 
 def make_submit_job_frames(
-    *, job_id: str, configuration_filename: str, target: str, bundle: bytes
+    *,
+    job_id: str,
+    configuration_filename: str,
+    target: str,
+    bundle: bytes,
+    device_name: str = "",
+    device_friendly_name: str = "",
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Build the wire-shape ``submit_job`` header + chunk frames for *bundle*.
 
@@ -290,6 +296,13 @@ def make_submit_job_frames(
     Wraps :func:`chunk_bundle` so the chunk envelope (b64
     encoding, indices, ``is_last`` flag, repeated ``job_id``)
     lives in one place.
+
+    ``device_name`` / ``device_friendly_name`` are the
+    ``NotRequired`` display fields the receiver stamps onto
+    :class:`FirmwareJob` for the firmware-tasks UI title. Both
+    default to empty so existing callers stay one-liners; a
+    test that wants to pin the round-trip passes them
+    explicitly.
     """
     from esphome_device_builder.helpers.peer_link_bundle import (  # noqa: PLC0415
         chunk_bundle,
@@ -315,6 +328,8 @@ def make_submit_job_frames(
         "total_bundle_bytes": len(bundle),
         "num_chunks": len(chunks),
         "bundle_sha256": compute_bundle_sha256(bundle),
+        "device_name": device_name,
+        "device_friendly_name": device_friendly_name,
     }
     return header, chunks
 

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -369,6 +369,58 @@ async def test_remote_compile_translates_output_and_completes(
         configuration_filename="kitchen.yaml",
         target="compile",
         bundle_bytes=b"FAKEBUNDLE",
+        device_name="",
+        device_friendly_name="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_plumbs_device_names_from_local_scanner(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """The offloader looks up the local Device entry and sends names on the wire.
+
+    Pins the receiver-side title-rendering contract: the
+    offloader already has ``esphome.name`` /
+    ``esphome.friendly_name`` from its local scanner at install
+    time, so the receiver doesn't have to re-parse the bundled
+    YAML just to render the firmware-tasks title. Stub the
+    devices controller's ``get_devices`` to return one Device
+    matching the job's configuration; assert ``submit_job`` is
+    called with both names.
+
+    A regression that dropped the lookup (or fell back to
+    parsing the YAML on the receiver) would surface here.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+
+    fake_device = MagicMock()
+    fake_device.configuration = "kitchen.yaml"
+    fake_device.name = "kitchen"
+    fake_device.friendly_name = "AC Float Monitor 32"
+    devices_stub = MagicMock()
+    devices_stub.get_devices.return_value = [fake_device]
+    controller._db.devices = devices_stub
+
+    job = _make_remote_job()
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.COMPLETED
+    assert len(captured[EventType.JOB_COMPLETED]) == 1
+    client.submit_job.assert_awaited_once_with(
+        job_id=job.job_id,
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=b"FAKEBUNDLE",
+        device_name="kitchen",
+        device_friendly_name="AC Float Monitor 32",
     )
 
 

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1904,6 +1904,41 @@ def test_peers_snapshot_returns_empty_when_none_stored(tmp_path: Path) -> None:
     assert controller.peers_snapshot() == []
 
 
+def test_approved_peer_label_returns_label_for_known_peer(tmp_path: Path) -> None:
+    """Public accessor returns the APPROVED peer's label."""
+    controller = _make_controller(config_dir=tmp_path)
+    _seed_peer(controller, _stored_peer(dashboard_id="alpha", label="MacBook Pro"))
+
+    assert controller.approved_peer_label("alpha") == "MacBook Pro"
+
+
+def test_approved_peer_label_returns_empty_for_unknown_peer(tmp_path: Path) -> None:
+    """Public accessor returns ``""`` rather than raising on a miss.
+
+    Empty is the correct fallback because the only caller —
+    the receiver-side ``submit_job`` flow — uses the label as
+    UI plumbing. A miss is a legitimate state (PENDING peers
+    aren't in ``_approved_peers``, and a peer can be removed
+    between the offloader's submit and the receiver's stamp).
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    assert controller.approved_peer_label("unknown") == ""
+
+
+def test_approved_peer_label_ignores_pending_peers(tmp_path: Path) -> None:
+    """PENDING peers live in ``_pending_peers``, not ``_approved_peers``.
+
+    The accessor reads only the APPROVED dict; a PENDING peer
+    whose ``submit_job`` somehow reached the receiver (it
+    shouldn't, but the gate is in another module) should not
+    contribute a label.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    _seed_pending_peer(controller, _stored_peer(dashboard_id="alpha", label="Pending Lap"))
+
+    assert controller.approved_peer_label("alpha") == ""
+
+
 def test_peers_snapshot_returns_summary_for_each_row(tmp_path: Path) -> None:
     """``peers_snapshot`` merges in-memory PENDING + APPROVED rows from RAM."""
     controller = _make_controller(config_dir=tmp_path)

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1346,13 +1346,19 @@ def _install_stub_submit_job_receiver(
         configuration: str,
         job_type: Any,
         remote_peer: str = "",
+        remote_peer_label: str = "",
         remote_job_id: str = "",
+        device_name: str = "",
+        device_friendly_name: str = "",
     ) -> Any:
         job = MagicMock()
         job.job_id = f"local-{len(queued_jobs)}"
         job.configuration = configuration
         job.remote_peer = remote_peer
+        job.remote_peer_label = remote_peer_label
         job.remote_job_id = remote_job_id
+        job.device_name = device_name
+        job.device_friendly_name = device_friendly_name
         return job
 
     async def _enqueue(job: Any) -> Any:

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -55,13 +55,23 @@ def _make_firmware_controller() -> Any:
     created_jobs: list[Any] = []
 
     def _create_job(
-        configuration: str, job_type: JobType, *, remote_peer: str = "", **_: Any
+        configuration: str,
+        job_type: JobType,
+        *,
+        remote_peer: str = "",
+        remote_peer_label: str = "",
+        device_name: str = "",
+        device_friendly_name: str = "",
+        **_: Any,
     ) -> Any:
         job = MagicMock()
         job.job_id = f"local-{len(created_jobs)}"
         job.configuration = configuration
         job.job_type = job_type
         job.remote_peer = remote_peer
+        job.remote_peer_label = remote_peer_label
+        job.device_name = device_name
+        job.device_friendly_name = device_friendly_name
         created_jobs.append(job)
         return job
 
@@ -506,6 +516,143 @@ async def test_submit_job_happy_path_extracts_and_queues(
     # the same form.
     assert job.configuration == expected_yaml.relative_to(tmp_path).as_posix()
     firmware._enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_carries_display_fields_through_to_firmware_job(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The submit_job header's display fields land on the created FirmwareJob.
+
+    Pins the round-trip for the firmware-tasks title surface:
+
+    * ``device_name`` / ``device_friendly_name`` come off the
+      wire header (the offloader knows both from its local
+      Device list at install time, so the receiver doesn't
+      re-parse the bundled YAML).
+    * ``remote_peer_label`` is snapshotted from the receiver's
+      ``_approved_peers[dashboard_id].label`` at submit time —
+      symmetric to ``source_label`` on the offloader side.
+
+    A regression that drops any of the three would leave the
+    firmware-tasks UI rendering the cryptic
+    ``.esphome/.remote_builds/<id>/<device>/<device>.yaml``
+    path instead of "AC Float Monitor 32 / from MacBook Pro".
+    """
+    firmware = _make_firmware_controller()
+    # Wire the receiver's peer lookup: ``submit_job._handle_complete``
+    # walks ``self._firmware._db.remote_build._approved_peers`` so
+    # stub the chain. Production initialises this in
+    # ``RemoteBuildController.start``.
+    firmware._db = MagicMock()
+    fake_peer = MagicMock()
+    fake_peer.label = "MacBook Pro"
+    firmware._db.remote_build._approved_peers = {"alpha-dashboard": fake_peer}
+
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session(dashboard_id="alpha-dashboard")
+    bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+    expected_yaml = (
+        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+    )
+
+    def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        expected_yaml.parent.mkdir(parents=True, exist_ok=True)
+        expected_yaml.write_bytes(b"esphome:\n  name: kitchen\n")
+        return expected_yaml
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        _stub_prepare,
+    )
+
+    header, chunks = make_submit_job_frames(
+        job_id="off-job-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle=bundle,
+        device_name="kitchen",
+        device_friendly_name="AC Float Monitor 32",
+    )
+    await receiver.handle_submit_job(session, cast(SubmitJobFrameData, header))
+    for chunk in chunks:
+        await receiver.handle_submit_job_chunk(session, cast(SubmitJobChunkFrameData, chunk))
+
+    assert _ack_payload(session)["accepted"] is True
+    assert len(firmware.created_jobs) == 1
+    job = firmware.created_jobs[0]
+    assert job.device_name == "kitchen"
+    assert job.device_friendly_name == "AC Float Monitor 32"
+    assert job.remote_peer_label == "MacBook Pro"
+
+
+@pytest.mark.asyncio
+async def test_submit_job_missing_display_fields_falls_through_to_empty_strings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A header without the NotRequired display fields produces empty strings.
+
+    Backwards-compat: older offloaders won't set
+    ``device_name`` / ``device_friendly_name``. The receiver
+    must accept the header and create the job with empty
+    display fields; the frontend title surface then falls back
+    to the configuration path's device segment.
+    """
+    firmware = _make_firmware_controller()
+    firmware._db = MagicMock()
+    firmware._db.remote_build._approved_peers = {}  # no peer label either
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session(dashboard_id="alpha-dashboard")
+    bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+    expected_yaml = (
+        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+    )
+
+    def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        expected_yaml.parent.mkdir(parents=True, exist_ok=True)
+        expected_yaml.write_bytes(b"esphome:\n  name: kitchen\n")
+        return expected_yaml
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        _stub_prepare,
+    )
+
+    # Hand-roll the header WITHOUT the NotRequired fields, mimicking
+    # an older offloader. ``make_submit_job_frames`` always sets them
+    # so we build the header directly.
+    from esphome_device_builder.helpers.peer_link_bundle import (  # noqa: PLC0415
+        compute_bundle_sha256,
+    )
+
+    _hdr_with_fields, chunks = make_submit_job_frames(
+        job_id="off-job-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle=bundle,
+    )
+    legacy_header = {
+        "type": "submit_job",
+        "job_id": "off-job-1",
+        "configuration_filename": "kitchen.yaml",
+        "target": "compile",
+        "total_bundle_bytes": len(bundle),
+        "num_chunks": len(chunks),
+        "bundle_sha256": compute_bundle_sha256(bundle),
+        # Intentionally no device_name / device_friendly_name.
+    }
+
+    await receiver.handle_submit_job(session, cast(SubmitJobFrameData, legacy_header))
+    for chunk in chunks:
+        await receiver.handle_submit_job_chunk(session, cast(SubmitJobChunkFrameData, chunk))
+
+    assert _ack_payload(session)["accepted"] is True
+    job = firmware.created_jobs[0]
+    assert job.device_name == ""
+    assert job.device_friendly_name == ""
+    assert job.remote_peer_label == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -27,7 +27,9 @@ import pytest
 from esphome.bundle import EsphomeError
 
 from esphome_device_builder.controllers.remote_build.submit_job import (
+    _DEVICE_DISPLAY_FIELD_MAX_LEN,
     SubmitJobReceiver,
+    _coerce_display_field,
     _validate_configuration_filename,
 )
 from esphome_device_builder.helpers.peer_link_bundle import BUNDLE_CHUNK_SIZE_BYTES
@@ -125,6 +127,50 @@ def _ack_payload(session: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("kitchen", "kitchen"),
+        ("AC Float Monitor 32", "AC Float Monitor 32"),
+        ("", ""),
+        # Non-strings coerce to empty — the schema gate leaves
+        # these NotRequired fields untyped at the wire boundary,
+        # so a malicious / buggy offloader could land a non-str.
+        (None, ""),
+        (12345, ""),
+        ({"injected": "dict"}, ""),
+        (["a", "b"], ""),
+        # Oversized strings coerce to empty rather than truncate;
+        # the display surface treats empty as "fall back to the
+        # configuration path", which is a clear UI signal vs. a
+        # silently-truncated half-name.
+        ("x" * (_DEVICE_DISPLAY_FIELD_MAX_LEN + 1), ""),
+    ],
+)
+def test_coerce_display_field_rejects_unsafe_values(raw: Any, expected: str) -> None:
+    """Peer-controlled display strings are type-checked + length-capped.
+
+    The ``NotRequired`` ``device_name`` / ``device_friendly_name``
+    fields on the wire bypass the schema gate (which only
+    validates required keys), so the coerce helper is the gate
+    that keeps non-strings and oversized strings out of the
+    :class:`FirmwareJob` we replay through the firmware-tasks
+    WS stream.
+    """
+    assert _coerce_display_field(raw) == expected
+
+
+def test_coerce_display_field_accepts_string_at_cap() -> None:
+    """A string exactly at the cap passes through unchanged.
+
+    Boundary check — the cap is inclusive (``>`` not ``>=``)
+    so a value of exactly :data:`_DEVICE_DISPLAY_FIELD_MAX_LEN`
+    characters is the longest legitimate input.
+    """
+    at_cap = "y" * _DEVICE_DISPLAY_FIELD_MAX_LEN
+    assert _coerce_display_field(at_cap) == at_cap
 
 
 @pytest.mark.parametrize(
@@ -530,8 +576,8 @@ async def test_submit_job_carries_display_fields_through_to_firmware_job(
       wire header (the offloader knows both from its local
       Device list at install time, so the receiver doesn't
       re-parse the bundled YAML).
-    * ``remote_peer_label`` is snapshotted from the receiver's
-      ``_approved_peers[dashboard_id].label`` at submit time —
+    * ``remote_peer_label`` is snapshotted at submit time via
+      :meth:`RemoteBuildController.approved_peer_label` —
       symmetric to ``source_label`` on the offloader side.
 
     A regression that drops any of the three would leave the
@@ -540,14 +586,12 @@ async def test_submit_job_carries_display_fields_through_to_firmware_job(
     path instead of "AC Float Monitor 32 / from MacBook Pro".
     """
     firmware = _make_firmware_controller()
-    # Wire the receiver's peer lookup: ``submit_job._handle_complete``
-    # walks ``self._firmware._db.remote_build._approved_peers`` so
-    # stub the chain. Production initialises this in
-    # ``RemoteBuildController.start``.
+    # Wire the receiver's peer-label lookup. The receiver
+    # routes through :meth:`RemoteBuildController.approved_peer_label`
+    # so stub that accessor directly rather than seeding the
+    # private ``_approved_peers`` dict.
     firmware._db = MagicMock()
-    fake_peer = MagicMock()
-    fake_peer.label = "MacBook Pro"
-    firmware._db.remote_build._approved_peers = {"alpha-dashboard": fake_peer}
+    firmware._db.remote_build.approved_peer_label.return_value = "MacBook Pro"
 
     receiver = _make_receiver(tmp_path, firmware)
     session = _make_session(dashboard_id="alpha-dashboard")
@@ -588,6 +632,64 @@ async def test_submit_job_carries_display_fields_through_to_firmware_job(
 
 
 @pytest.mark.asyncio
+async def test_submit_job_malformed_display_fields_coerce_to_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-string / oversized peer-supplied display fields land as empty.
+
+    A malicious offloader could put a non-``str`` or a multi-
+    megabyte string on the ``NotRequired`` display fields (the
+    schema gate doesn't type-check them). The receiver must
+    coerce to empty so the malformed value doesn't reach the
+    :class:`FirmwareJob` and the firmware-tasks WS stream.
+    Pairs with ``test_coerce_display_field_rejects_unsafe_values``
+    which covers the helper in isolation; this test pins the
+    end-to-end behaviour through the receive loop.
+    """
+    firmware = _make_firmware_controller()
+    firmware._db = MagicMock()
+    firmware._db.remote_build.approved_peer_label.return_value = ""
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session(dashboard_id="alpha-dashboard")
+    bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+    expected_yaml = (
+        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+    )
+
+    def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        expected_yaml.parent.mkdir(parents=True, exist_ok=True)
+        expected_yaml.write_bytes(b"esphome:\n  name: kitchen\n")
+        return expected_yaml
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        _stub_prepare,
+    )
+
+    # Header with a non-string ``device_name`` and an oversized
+    # ``device_friendly_name``. ``cast`` so mypy doesn't complain;
+    # the wire boundary itself is untyped at this point.
+    header, chunks = make_submit_job_frames(
+        job_id="off-job-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle=bundle,
+    )
+    header["device_name"] = 12345  # type: ignore[typeddict-item]
+    header["device_friendly_name"] = "x" * 99_999
+
+    await receiver.handle_submit_job(session, cast(SubmitJobFrameData, header))
+    for chunk in chunks:
+        await receiver.handle_submit_job_chunk(session, cast(SubmitJobChunkFrameData, chunk))
+
+    assert _ack_payload(session)["accepted"] is True
+    job = firmware.created_jobs[0]
+    assert job.device_name == ""
+    assert job.device_friendly_name == ""
+
+
+@pytest.mark.asyncio
 async def test_submit_job_missing_display_fields_falls_through_to_empty_strings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -601,7 +703,7 @@ async def test_submit_job_missing_display_fields_falls_through_to_empty_strings(
     """
     firmware = _make_firmware_controller()
     firmware._db = MagicMock()
-    firmware._db.remote_build._approved_peers = {}  # no peer label either
+    firmware._db.remote_build.approved_peer_label.return_value = ""
     receiver = _make_receiver(tmp_path, firmware)
     session = _make_session(dashboard_id="alpha-dashboard")
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")


### PR DESCRIPTION
# What does this implement/fix?

The receiver-side firmware-tasks UI renders the raw remote-build path as the job title:

```
.esphome/.remote_builds/8Ja02_-QQeziVZemmcO2BZOnaLAaVSgq/a...
Compile / Running... / started 18 seconds ago
```

Compare the offloader side, which knows the device's friendly name from its local scanner and renders cleanly:

```
AC Float Monitor 32
Install / Completed / finished 01:35 AM
Building on Mac.koston.org
```

The receiver has everything it needs to render the same way; the data just wasn't on the `FirmwareJob`. Add three fields and plumb them through.

## What lands

### Wire shape

`SubmitJobFrameData` gains two `NotRequired[str]` fields:
- `device_name` — the YAML's `esphome.name` (machine handle).
- `device_friendly_name` — the YAML's `esphome.friendly_name` (display string).

The offloader already has both off its local Device list at install time; sending them on the header avoids the receiver having to re-parse the bundled YAML just to render a title. Older offloaders that omit the fields produce a valid header (the receiver-side defaults are empty strings) — the frontend then falls back to the configuration path's device segment.

### Backend (offloader)

`remote_runner._dispatch_and_drive` looks up the local Device entry from `controller._db.devices.get_devices()` matching `job.configuration` and passes the names to `PeerLinkClient.submit_job(...)`. Guards on `getattr(controller._db, "devices", None)` for test stubs and the pre-`start()` race.

### Backend (receiver)

* `SubmitJobReceiver.handle_submit_job` reads both display fields off the header and stashes them on the in-flight `_PendingSubmit`.
* `_handle_complete` looks up the offloader's `StoredPeer.label` from `remote_build._approved_peers[session.dashboard_id]` and passes it to `_create_job(...)`.
* `FirmwareJob` gains three fields:
  - `remote_peer_label: str = ""` — snapshot of `StoredPeer.label` at submit time. Doesn't track later label edits (symmetric to `source_label` on the offloader side; the log entry reflects what was true when the work landed).
  - `device_name: str = ""` / `device_friendly_name: str = ""` — populated from the header for receiver-side jobs; empty for locally-submitted ones (the dashboard's own Device list already carries the friendly name for those).
* `_create_job` accepts and threads the three new fields through.

### Frontend

Coordinated PR (separate; not in this diff). The new wire fields exist on every `FirmwareJob` payload the WS dispatcher streams, so the frontend can render:

```
AC Float Monitor 32
Compile / Running... / started 18 seconds ago
from MacBook Pro
```

… for jobs where `remote_peer != ""`. Backwards-compat: if either new field is empty (older receiver / older offloader), the renderer falls back to the device segment from the configuration path.

## Testing

* `pytest tests/ -q` → 3024 passed, 4 skipped (+3 new tests).
* `test_submit_job_carries_display_fields_through_to_firmware_job` — round-trips header → `_PendingSubmit` → `FirmwareJob` with all three display fields populated.
* `test_submit_job_missing_display_fields_falls_through_to_empty_strings` — pins the backwards-compat contract for older offloaders that omit the `NotRequired` fields.
* `test_remote_compile_plumbs_device_names_from_local_scanner` — the offloader's local Device lookup → wire-send round-trip.

**Related issue or feature (if applicable):**

- Tracked under issue #106 as the receiver-side UI follow-up to phase 7a-5 (per-build data_dir isolation). Not assigned a sub-phase number; it's a small wire/UX addition rather than a flow change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD>

The new wire fields are `NotRequired` so this PR is forward-safe to land on its own; the frontend PR renders them.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
