### PR TITLE
Move per-build ESPHOME_DATA_DIR up to dashboard scope

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -21,6 +21,7 @@ from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from operator import attrgetter
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -28,6 +29,7 @@ from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
 from esphome.components.libretiny.const import (
     FAMILY_COMPONENT as _LIBRETINY_FAMILY_COMPONENT,
 )
+from esphome.core import CORE
 from esphome.storage_json import StorageJSON
 
 from ...helpers.api import CommandError, api_command
@@ -1454,16 +1456,19 @@ class FirmwareController:
            cache, build directory, PlatformIO project) lands under
            one ``(dashboard_id, device)``-keyed directory.
 
-        Without step 3 the subprocess inherits the dashboard's
-        ``CORE.data_dir`` (``<config_dir>/.esphome`` in default
-        mode, ``/data`` in HA-addon mode) and the download-time
-        reader looks at a path the subprocess didn't write to —
-        silent ``build_dir_missing`` rejects on every paired
-        offloader's ``firmware/install``. The writer-side env
-        override and the reader-side
-        :func:`helpers.storage_path.resolve_data_dir` resolve to
-        the same path because both route the configuration
-        through the layout helper. The 6c TTL sweep walks
+        Without step 3 the subprocess would inherit the
+        dashboard's own ``ESPHOME_DATA_DIR`` and write storage /
+        build / idedata into the same keyspace as the user's
+        local builds — same-basename collisions across paired
+        offloaders silently mix builds. The override pins each
+        offloader's remote builds to a per-dashboard subdirectory
+        of ``CORE.data_dir`` (``<config_dir>/.esphome/.remote_builds/<id>/.esphome``
+        in default mode, ``/data/.remote_builds/<id>/.esphome``
+        on the HA addon). Anchoring on ``CORE.data_dir``
+        (not on ``settings.config_dir``) keeps the multi-GB
+        toolchain + build cache off the user's ``/config`` mount
+        on the HA addon, where it lives on the addon's
+        per-instance data volume instead. The 6c TTL sweep walks
         :meth:`RemoteBuildPath.subtree` so the whole per-build
         state reclaims in one ``shutil.rmtree``.
 
@@ -1474,7 +1479,7 @@ class FirmwareController:
         env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
         remote_build_path = parse_remote_build_path(job.configuration)
         if remote_build_path is not None:
-            env["ESPHOME_DATA_DIR"] = str(remote_build_path.data_dir(self._db.settings.config_dir))
+            env["ESPHOME_DATA_DIR"] = str(remote_build_path.data_dir(Path(CORE.data_dir)))
         return env
 
     def _build_command(

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1462,15 +1462,31 @@ class FirmwareController:
         local builds — same-basename collisions across paired
         offloaders silently mix builds. The override pins each
         offloader's remote builds to a per-dashboard subdirectory
-        of ``CORE.data_dir`` (``<config_dir>/.esphome/.remote_builds/<id>/.esphome``
+        of ``CORE.data_dir``
+        (``<config_dir>/.esphome/.remote_builds/<id>/.esphome``
         in default mode, ``/data/.remote_builds/<id>/.esphome``
-        on the HA addon). Anchoring on ``CORE.data_dir``
-        (not on ``settings.config_dir``) keeps the multi-GB
-        toolchain + build cache off the user's ``/config`` mount
-        on the HA addon, where it lives on the addon's
-        per-instance data volume instead. The 6c TTL sweep walks
-        :meth:`RemoteBuildPath.subtree` so the whole per-build
-        state reclaims in one ``shutil.rmtree``.
+        on the HA addon). Anchoring on ``CORE.data_dir`` (not on
+        ``settings.config_dir``) keeps the multi-GB toolchain +
+        build cache off the user's ``/config`` mount on the HA
+        addon, where it lives on the addon's per-instance data
+        volume instead.
+
+        Reclaim semantics (see
+        :meth:`RemoteBuildPath.data_dir` for the full notes):
+        the 6c TTL sweep
+        (:func:`helpers.remote_build_cleanup.sweep_remote_builds`)
+        still walks ``config_dir / REMOTE_BUILDS_SUBDIR`` and
+        reclaims cold per-device subtrees (the YAML extract +
+        bundle sibling) via :meth:`RemoteBuildPath.subtree`.
+        The shared per-dashboard ``.esphome/`` under
+        ``CORE.data_dir`` is intentionally not swept — that's
+        what keeps the toolchain warm across submits — at the
+        cost of per-device ``build/<name>/`` /
+        ``storage/<basename>.json`` / ``idedata/<name>.json``
+        becoming orphaned when their subtree gets reclaimed.
+        A future cleanup pass keyed on "no devices remain
+        under this dashboard_id" will reclaim the whole shared
+        tree on unpair / TTL expiry.
 
         Factored out of :meth:`_execute_job` so the receiver-side
         env override is unit-testable without standing up a real

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -204,10 +204,28 @@ class RemoteBuildPath:
           silently mix builds.
 
         Pinning keeps every remote-build artefact under one
-        ``dashboard_id``-keyed directory. The 6c TTL sweep that
-        walks an offloader's subtrees can reclaim the whole
-        offloader (including the shared toolchain cache) by
-        walking ``<dashboard_data_dir>/.remote_builds/<dashboard_id>/``.
+        ``dashboard_id``-keyed directory.
+
+        Cleanup asymmetry vs the 6c TTL sweep
+        (:func:`helpers.remote_build_cleanup.sweep_remote_builds`):
+        the sweep walks ``config_dir / REMOTE_BUILDS_SUBDIR``
+        and reclaims cold per-device subtrees (the YAML
+        extract + bundle sibling). The shared per-dashboard
+        ``.esphome/`` lives under ``CORE.data_dir`` — a
+        *different* root on the HA addon (``/data`` vs
+        ``/config/esphome``) — and is not currently walked by
+        the sweep. That asymmetry is intentional for the
+        toolchain (``.platformio/``, multi-GB, the whole point
+        of per-dashboard scope is keeping it warm across
+        submits); per-device build dirs under ``build/<name>/``
+        and their ``storage/`` / ``idedata/`` sidecars are
+        currently orphaned when their per-device subtree gets
+        reclaimed. Tracking that as a follow-up — a future
+        cleanup pass keyed on "no devices remain under this
+        ``dashboard_id``" can walk
+        ``<dashboard_data_dir>/.remote_builds/<dashboard_id>/.esphome/``
+        and reclaim the entire offloader's build cache on
+        unpair / TTL expiry.
 
         Read side: :func:`helpers.build_artifacts.load_build_artifacts`
         derives ``data_dir`` back from the configuration string

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -31,13 +31,18 @@ exactly one file: change it here once, every consumer follows.
 
 :class:`RemoteBuildPath` is the canonical key. The forward
 methods (:meth:`subtree`, :meth:`bundle`) take a
-``config_dir`` and return absolute paths; the reverse
-factory (:func:`parse_from_configuration`) takes the
-relative POSIX path :attr:`FirmwareJob.configuration` carries
-and rebuilds the key. Anything that doesn't match the layout
-shape (a locally-submitted job, a hand-edited configuration,
-a future call site that bends the path) round-trips through
-``None`` so callers can short-circuit cleanly without an
+``config_dir`` and return absolute paths under the user's
+config tree; :meth:`data_dir` takes the dashboard's
+``CORE.data_dir`` (a *different* root on the HA addon,
+``/data`` vs ``/config/esphome``) and returns the
+``ESPHOME_DATA_DIR`` the compile subprocess writes its
+build artefacts into. The reverse factory
+(:func:`parse_from_configuration`) takes the relative POSIX
+path :attr:`FirmwareJob.configuration` carries and rebuilds
+the key. Anything that doesn't match the layout shape (a
+locally-submitted job, a hand-edited configuration, a future
+call site that bends the path) round-trips through ``None``
+so callers can short-circuit cleanly without an
 ``if len(parts) >= ...`` chain at every call site.
 """
 
@@ -46,12 +51,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
-# Subdirectory under ``<config_dir>/.esphome/`` where remote-peer
-# build artefacts land. Hidden by the leading dot so a casual
-# ``ls`` of the user's main config tree doesn't show it next to
-# their own YAMLs; living under ``.esphome/`` keeps it adjacent
-# to other build artefacts (StorageJSON, build dirs).
-REMOTE_BUILDS_SUBDIR = Path(".esphome") / ".remote_builds"
+# Single segment used by every layout path. Hidden by the leading
+# dot so a casual ``ls`` of the parent tree doesn't show it next
+# to the user's own files.
+REMOTE_BUILDS_NAME = ".remote_builds"
+
+# Subdirectory under ``<config_dir>/`` where the receiver extracts
+# per-device bundles. Living under ``.esphome/`` keeps the YAML
+# extraction adjacent to the user's other ``.esphome``-bucketed
+# artefacts (StorageJSON, build dirs) and out of the way of a
+# casual ``ls`` of ``config_dir``.
+REMOTE_BUILDS_SUBDIR = Path(".esphome") / REMOTE_BUILDS_NAME
 
 # Suffix the bundle tarball lives at, as a sibling of the
 # extracted build subtree (PR #552 moved the bundle outside the
@@ -117,52 +127,95 @@ class RemoteBuildPath:
             / f"{self.device_name}{BUNDLE_SUFFIX}"
         )
 
-    def data_dir(self, config_dir: Path) -> Path:
+    def data_dir(self, dashboard_data_dir: Path) -> Path:
         """Return the ``ESPHOME_DATA_DIR`` for this per-build compile.
 
-        The receiver-side compile subprocess for a remote-build
-        job runs with ``ESPHOME_DATA_DIR`` pinned to this path so
-        :attr:`esphome.core.CORE.data_dir` (and therefore
-        ``storage_path()`` / ``build_path`` / the idedata cache
-        directory) lands under the per-build subtree —
-        independent of the dashboard process's data_dir, which
-        differs across deployment modes (default /
-        HA-addon / ``ESPHOME_DATA_DIR`` override).
+        Resolves to
+        ``<dashboard_data_dir>/.remote_builds/<dashboard_id>/.esphome``
+        — one ``.esphome`` per paired offloader, anchored
+        under whatever the dashboard process is using for its
+        own data directory (:attr:`esphome.core.CORE.data_dir`):
 
-        Why pin per-build rather than rely on esphome's default
-        ``relative_config_path(".esphome")`` rule:
+        * **Default mode**: ``<config_dir>/.esphome/.remote_builds/<dashboard_id>/.esphome``
+          — co-located with the user's local-build artefacts.
+        * **HA-addon mode**: ``/data/.remote_builds/<dashboard_id>/.esphome``
+          — on the addon's per-instance persistent volume.
+          *Critically* not under ``<config_dir>`` (=``/config/esphome``
+          on the addon): build artefacts can run to multiple
+          gigabytes (``.platformio/`` toolchain + ``build/`` cache)
+          and ``/config`` is the user's Home Assistant config
+          mount, often a small partition shared with HA core
+          and every other addon. ``/data`` is the dedicated
+          per-addon volume the addon was given exactly for this
+          kind of artefact.
+        * **``ESPHOME_DATA_DIR`` env override**:
+          ``$ESPHOME_DATA_DIR/.remote_builds/<dashboard_id>/.esphome``.
 
-        * In HA-addon mode the dashboard sets
-          ``ESPHOME_DATA_DIR=/data``; the subprocess inherits
-          that and esphome writes all per-config artefacts to
-          ``/data/storage/<basename>.json`` regardless of where
-          the YAML lives. Two paired offloaders submitting the
-          same device name collide on a single sidecar / build
-          directory — silently mixed builds, possibly delivering
-          one offloader's bytes to the other's device.
-        * In default mode esphome's rule incidentally isolates
-          remote builds (the YAML lives nested, so the rule
-          produces a per-build ``.esphome`` directory inside the
-          subtree), but the dashboard's read path goes through
-          :func:`esphome.storage_json.ext_storage_path` against
-          its own ``CORE.data_dir`` (one level higher), so the
-          download-time read silently misses the per-build write
-          and rejects ``build_dir_missing``.
+        Anchoring on ``CORE.data_dir`` rather than on
+        ``config_dir`` is the load-bearing detail — the dashboard
+        already routes its own build output through the same
+        env-override / HA-addon / default fallback chain, so the
+        remote-build artefacts land in the volume the operator
+        expects to grow.
 
-        Setting :attr:`ESPHOME_DATA_DIR` to the subtree itself
-        keeps the entire per-build state (storage, build, idedata,
-        PlatformIO caches in ``.platformio/``) under one
-        ``(dashboard_id, device_name)`` key. The 6c TTL sweep that
-        walks :meth:`subtree` then naturally reclaims everything
-        in one ``shutil.rmtree`` when the pairing goes cold.
+        Every device from the same dashboard shares one toolchain
+        cache (``.platformio/``), one storage keyspace, one
+        idedata cache, and one build root; different offloaders
+        get independent dirs.
 
-        The same value is what
-        :func:`helpers.build_artifacts.load_build_artifacts` uses
-        on the read side: derive the data_dir back from the
-        configuration string via :func:`parse_from_configuration`,
-        then call this method.
+        Why per-dashboard (and not per-device or shared):
+
+        * **Per-device** would re-download the ~1-2 GB
+          PlatformIO toolchain on every new device a paired
+          offloader submitted. Per-dashboard means device #N
+          from that offloader hits a warm cache.
+        * **Single shared** across all dashboards would bring
+          back the original problem PR #578 was solving:
+          two offloaders submitting the same YAML basename
+          (e.g. both have ``kitchen.yaml``) collide on
+          ``storage/kitchen.yaml.json``, silently delivering
+          one offloader's bytes to the other's device. The
+          ``dashboard_id`` partition is the load-bearing
+          isolation gate.
+        * **Survives prepare_bundle_for_compile's cleanup
+          walk.** Upstream :func:`esphome.bundle.prepare_bundle_for_compile`
+          wipes the non-preserved children of *target_dir*
+          (== :meth:`subtree`, the per-device subtree) before
+          extracting the new bundle. The per-device subtree
+          lives under ``<config_dir>/.esphome/.remote_builds/...``
+          and now contains only the YAML — build artefacts are
+          one tree away under ``CORE.data_dir``, so the walk
+          never sees them. No ``rmtree`` recursion over the
+          deep ``build/<env>/.pioenvs/`` tree, no race against
+          macOS Finder ``.DS_Store`` re-writes (the original
+          ``OSError(ENOTEMPTY, '.../build/.../.pioenvs')``
+          report; see #578 follow-up).
+
+        Why pin ``ESPHOME_DATA_DIR`` at all rather than just
+        inherit the dashboard's value:
+
+        * The dashboard's value points at *its own* data dir
+          (``/data`` on the addon, ``<config_dir>/.esphome``
+          in default mode). Without the override, the
+          subprocess would write the remote-build sidecar /
+          build dir into the same keyspace as the dashboard's
+          local builds — same-basename collisions across
+          dashboards (and against the user's own local YAMLs)
+          silently mix builds.
+
+        Pinning keeps every remote-build artefact under one
+        ``dashboard_id``-keyed directory. The 6c TTL sweep that
+        walks an offloader's subtrees can reclaim the whole
+        offloader (including the shared toolchain cache) by
+        walking ``<dashboard_data_dir>/.remote_builds/<dashboard_id>/``.
+
+        Read side: :func:`helpers.build_artifacts.load_build_artifacts`
+        derives ``data_dir`` back from the configuration string
+        via :func:`parse_from_configuration`, then calls this
+        method — same value as the write side because both
+        route ``Path(CORE.data_dir)`` through here.
         """
-        return self.subtree(config_dir)
+        return dashboard_data_dir / REMOTE_BUILDS_NAME / self.dashboard_id / ".esphome"
 
 
 def parse_from_configuration(configuration: str) -> RemoteBuildPath | None:

--- a/esphome_device_builder/helpers/storage_path.py
+++ b/esphome_device_builder/helpers/storage_path.py
@@ -16,17 +16,17 @@ every YAML — which is true for the user's local YAMLs (the dashboard
 process sets ``CORE.config_path`` to a sentinel inside ``config_dir``
 on startup and ``data_dir`` resolves off that) but **wrong** for the
 receiver-side remote-build flow. There the compile subprocess runs
-with ``ESPHOME_DATA_DIR`` pinned to a per-build subtree
-(``<config_dir>/.esphome/.remote_builds/<dashboard_id>/<device>/``,
+with ``ESPHOME_DATA_DIR`` pinned to a per-dashboard subdirectory of
+``CORE.data_dir`` (``<CORE.data_dir>/.remote_builds/<dashboard_id>/.esphome``,
 the same path the writer-side env override produces — see
 :meth:`FirmwareController._compose_subprocess_env`) so esphome writes
-storage / idedata / build under that one
-``(dashboard_id, device)``-keyed directory. The dashboard process's
-``CORE.data_dir`` still points at the dashboard-wide ``.esphome``
-tree, so a naive ``ext_storage_path(configuration)`` call resolves
-to a path the subprocess didn't write to — silent
-``FileNotFoundError`` on every receiver-side ``download_artifacts``
-request after a successful compile.
+storage / idedata / build under that one ``dashboard_id``-keyed
+directory. The dashboard process's own writes still land at the
+top level of ``CORE.data_dir`` (``<data_dir>/storage/...``), so a
+naive ``ext_storage_path(configuration)`` call against the bare
+configuration string resolves to a path the subprocess didn't write
+to — silent ``FileNotFoundError`` on every receiver-side
+``download_artifacts`` request after a successful compile.
 
 The fork happens once, here, keyed on whether the configuration
 parses through :func:`helpers.remote_build_layout.parse_from_configuration`
@@ -59,26 +59,32 @@ def resolve_data_dir(configuration: str) -> Path:
 
     For a receiver-side remote-build job (configuration parses
     as a :class:`RemoteBuildPath`) the compile subprocess runs
-    with ``ESPHOME_DATA_DIR`` pinned to the per-build subtree
-    (see :meth:`FirmwareController._compose_subprocess_env`),
-    so storage / idedata / build_path all land under
-    ``<config_dir>/.esphome/.remote_builds/<dashboard_id>/<device>/``
-    regardless of the dashboard process's own
-    ``CORE.data_dir``. This helper returns that per-build
-    directory so the reader looks where the writer landed; for
-    everything else (a locally-submitted job, an offloader-side
-    handle) it falls back to ``CORE.data_dir`` which honours
-    the existing deployment-mode logic (default / HA-addon /
-    ``ESPHOME_DATA_DIR`` env override).
+    with ``ESPHOME_DATA_DIR`` pinned to a per-dashboard
+    subdirectory of ``CORE.data_dir`` (see
+    :meth:`FirmwareController._compose_subprocess_env`), so
+    storage / idedata / build_path all land under
+    ``<CORE.data_dir>/.remote_builds/<dashboard_id>/.esphome/``.
+    For everything else (a locally-submitted job, an
+    offloader-side handle) it falls back to ``CORE.data_dir``
+    which honours the existing deployment-mode logic (default /
+    HA-addon / ``ESPHOME_DATA_DIR`` env override).
+
+    Anchoring on ``CORE.data_dir`` matters on the HA addon: the
+    dashboard's ``data_dir`` there is ``/data`` (the addon's
+    per-instance volume), so remote-build artefacts that can
+    run to multiple gigabytes land on the volume the operator
+    expects to grow rather than on ``/config`` (the user's
+    Home Assistant config mount).
 
     The writer-side env override and this reader-side resolver
     both route the same configuration string through
-    :func:`parse_from_configuration` so they agree on the
-    directory without an explicit handshake on the wire.
+    :func:`parse_from_configuration` AND anchor on
+    ``Path(CORE.data_dir)``, so they agree on the directory
+    without an explicit handshake on the wire.
     """
     remote_build_path = parse_remote_build_path(configuration)
     if remote_build_path is not None:
-        return remote_build_path.data_dir(Path(CORE.config_path).parent)
+        return remote_build_path.data_dir(Path(CORE.data_dir))
     return Path(CORE.data_dir)
 
 
@@ -92,7 +98,7 @@ def resolve_storage_path(configuration: str) -> Path:
     * **Receiver-side remote-build configurations**
       (``.esphome/.remote_builds/<dashboard_id>/<device>/<device>.yaml``):
       sidecar lives at
-      ``<subtree>/storage/<basename>.json``.
+      ``<CORE.data_dir>/.remote_builds/<dashboard_id>/.esphome/storage/<basename>.json``.
     * **Everything else** (the user's local YAMLs, archive /
       delete / get_binaries / get_compiled_device_info, etc.):
       ``<CORE.data_dir>/storage/<basename>.json`` — matches
@@ -114,8 +120,9 @@ def resolve_storage_path(configuration: str) -> Path:
     ``CORE.config_filename`` (which is ``Path(config_path).name``)
     so a remote-build path like
     ``.esphome/.remote_builds/<id>/kitchen/kitchen.yaml`` lands
-    its sidecar at ``<subtree>/storage/kitchen.yaml.json``, not
-    ``<subtree>/storage/.esphome/.remote_builds/...yaml.json``.
+    its sidecar at
+    ``<CORE.data_dir>/.remote_builds/<id>/.esphome/storage/kitchen.yaml.json``,
+    not at a path that re-embeds the relative configuration.
     """
     return resolve_data_dir(configuration) / "storage" / f"{Path(configuration).name}.json"
 

--- a/tests/controllers/firmware/test_subprocess_env.py
+++ b/tests/controllers/firmware/test_subprocess_env.py
@@ -3,11 +3,14 @@
 The env composition forks on the job's ``configuration`` shape:
 local jobs inherit the dashboard's deployment-mode context
 unchanged, receiver-side remote-build jobs pin
-``ESPHOME_DATA_DIR`` to the per-build subtree so esphome writes
-storage / idedata / build under one ``(dashboard_id, device)``-keyed
-directory. The fork is small but load-bearing — without the
-override the download-time reader looks at a path the subprocess
-didn't write to and the offloader sees silent ``build_dir_missing``
+``ESPHOME_DATA_DIR`` to a per-dashboard subdirectory of
+``CORE.data_dir`` so esphome writes storage / idedata / build
+under one ``dashboard_id``-keyed directory on the same volume
+the dashboard already uses for its own builds (``/data`` on
+the HA addon, ``<config_dir>/.esphome`` in default mode). The
+fork is small but load-bearing — without the override the
+download-time reader looks at a path the subprocess didn't
+write to and the offloader sees silent ``build_dir_missing``
 rejects on every install.
 """
 
@@ -16,6 +19,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from esphome.core import CORE
 
 from esphome_device_builder.controllers.firmware.constants import (
     ESPHOME_SUBPROCESS_ENV,
@@ -54,7 +59,7 @@ def test_local_job_env_does_not_override_data_dir(
         assert env[key] == value
 
 
-def test_remote_build_job_pins_data_dir_to_per_build_subtree(
+def test_remote_build_job_pins_data_dir_to_per_dashboard_esphome(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
 ) -> None:
@@ -63,22 +68,31 @@ def test_remote_build_job_pins_data_dir_to_per_build_subtree(
     The configuration is the relative POSIX path the receiver-side
     submit_job dispatch sets on the :class:`FirmwareJob`
     (``.esphome/.remote_builds/<dashboard_id>/<device>/<device>.yaml``).
-    The env override points at the per-build subtree under the
-    controller's settings ``config_dir`` so esphome's
-    ``CORE.data_dir`` resolves there and storage / idedata / build
-    all land under one ``(dashboard_id, device)``-keyed directory.
+    The env override points at the per-dashboard
+    ``<CORE.data_dir>/.remote_builds/<dashboard_id>/.esphome``
+    directory: one toolchain cache + storage keyspace shared
+    across every device that offloader submits, isolated
+    from the dashboard's local-build keyspace AND from other
+    offloaders. The ``dashboard_id`` partition prevents the
+    same-basename collision (two offloaders' ``kitchen.yaml``
+    would otherwise mix sidecars).
+
+    Anchoring on ``CORE.data_dir`` rather than on
+    ``settings.config_dir`` matters in HA-addon mode: on the
+    addon ``CORE.data_dir`` is ``/data`` (the addon's
+    per-instance persistent volume), so the toolchain + build
+    cache lands there rather than on ``/config`` (the user's
+    Home Assistant config mount, often a small partition).
+    Tests run in default mode where ``CORE.data_dir`` is
+    ``<config_dir>/.esphome`` so the resolved value is
+    equivalent — but the assertion is built from
+    ``CORE.data_dir`` to pin the *anchor*, not just the path.
     """
     controller = firmware_controller_factory(with_settings=True)
     configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
     env = controller._compose_subprocess_env(_make_job(configuration=configuration))
 
-    expected = (
-        controller._db.settings.config_dir
-        / ".esphome"
-        / ".remote_builds"
-        / "dashboard-alpha"
-        / "kitchen"
-    )
+    expected = Path(CORE.data_dir) / ".remote_builds" / "dashboard-alpha" / ".esphome"
     assert env["ESPHOME_DATA_DIR"] == str(expected)
     # The override is the only data-dir-related change; the
     # ANSI / unbuffered overlays still land.

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -59,6 +59,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from esphome.core import CORE
 
 from esphome_device_builder.helpers.build_scheduler import (
     BuildPath,
@@ -168,26 +169,29 @@ def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dic
     """Lay down a real StorageJSON sidecar + idedata.json + per-image binaries.
 
     Models the on-disk layout the receiver-side compile
-    subprocess produces under the 7a-5 per-build isolation:
-    ``ESPHOME_DATA_DIR`` is pinned to
-    ``<config_dir>/.esphome/.remote_builds/<dashboard_id>/<device>/``
+    subprocess produces: ``ESPHOME_DATA_DIR`` is pinned to
+    ``<CORE.data_dir>/.remote_builds/<dashboard_id>/.esphome``
     so esphome writes storage / idedata / build under that
-    one ``(dashboard_id, device)``-keyed subtree. Production
-    has the real ``esphome compile`` invocation produce these
-    files there; the e2e variant short-circuits the build.
+    one ``dashboard_id``-keyed directory shared across every
+    device an offloader submits. Production has the real
+    ``esphome compile`` invocation produce these files there;
+    the e2e variant short-circuits the build.
 
     The autouse ``_core_config_path_in_tmp`` fixture pins
     ``CORE.config_path`` to a sentinel inside *tmp_path*, so
-    :func:`helpers.storage_path.resolve_data_dir` resolves a
-    remote-build configuration to the per-build subtree under
-    ``tmp_path``. Mirror that exactly here.
+    ``CORE.data_dir`` resolves to ``tmp_path/.esphome`` (default
+    mode). :meth:`RemoteBuildPath.data_dir` anchors on
+    ``CORE.data_dir`` exactly the way the writer-side env
+    override does, so passing ``Path(CORE.data_dir)`` here lands
+    the test sidecars where the production read path will look
+    for them.
     """
     remote_build_path = parse_remote_build_path(configuration)
     assert remote_build_path is not None, (
         f"configuration {configuration!r} must be a remote-build path; "
         "the helper is e2e-specific and not meant for bare-basename inputs"
     )
-    data_dir = remote_build_path.data_dir(tmp_path)
+    data_dir = remote_build_path.data_dir(Path(CORE.data_dir))
     build_dir = data_dir / "build" / remote_build_path.device_name
     build_dir.mkdir(parents=True, exist_ok=True)
     images: dict[str, bytes] = {

--- a/tests/test_storage_path.py
+++ b/tests/test_storage_path.py
@@ -3,8 +3,8 @@
 The canonical storage / idedata path resolver every project-internal
 caller routes through. Local-only callers get the same behaviour as
 upstream :func:`esphome.storage_json.ext_storage_path`; receiver-side
-remote-build configurations land under the per-build subtree the
-compile subprocess writes into.
+remote-build configurations land under a per-dashboard subdirectory
+of ``CORE.data_dir`` that the compile subprocess writes into.
 """
 
 from __future__ import annotations
@@ -31,19 +31,25 @@ def test_resolve_data_dir_local_configuration_uses_core_data_dir() -> None:
     assert resolve_data_dir("kitchen.yaml") == Path(CORE.data_dir)
 
 
-def test_resolve_data_dir_remote_build_configuration_uses_per_build_subtree(
+def test_resolve_data_dir_remote_build_configuration_uses_per_dashboard_esphome(
     tmp_path: Path,
 ) -> None:
-    """A remote-build configuration resolves to its per-build subtree.
+    """A remote-build configuration resolves to its per-dashboard ``.esphome``.
 
     The receiver-side compile subprocess for that configuration
-    runs with ``ESPHOME_DATA_DIR`` pinned to the same subtree
-    (see :meth:`FirmwareController._compose_subprocess_env`), so
-    the read path here lands where the write path landed.
+    runs with ``ESPHOME_DATA_DIR`` pinned to the same per-dashboard
+    directory anchored on ``CORE.data_dir`` (see
+    :meth:`FirmwareController._compose_subprocess_env`), so the
+    read path here lands where the write path landed. In default
+    test mode ``CORE.data_dir`` is ``<tmp_path>/.esphome`` so the
+    resolved value is equivalent to the old per-build-subtree
+    location for the same configuration — but the resolver is
+    anchored on ``CORE.data_dir`` to keep HA-addon builds out of
+    the ``/config`` volume.
     """
     configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
     assert resolve_data_dir(configuration) == (
-        tmp_path / ".esphome" / ".remote_builds" / "dashboard-alpha" / "kitchen"
+        tmp_path / ".esphome" / ".remote_builds" / "dashboard-alpha" / ".esphome"
     )
 
 
@@ -88,7 +94,7 @@ def test_resolve_storage_path_remote_build_uses_basename_keyspace(tmp_path: Path
         / ".esphome"
         / ".remote_builds"
         / "dashboard-alpha"
-        / "kitchen"
+        / ".esphome"
         / "storage"
         / "kitchen.yaml.json"
     )
@@ -109,7 +115,7 @@ def test_resolve_idedata_path_remote_build(tmp_path: Path) -> None:
         / ".esphome"
         / ".remote_builds"
         / "dashboard-alpha"
-        / "kitchen"
+        / ".esphome"
         / "idedata"
         / "kitchen.json"
     )

--- a/tests/test_storage_path.py
+++ b/tests/test_storage_path.py
@@ -81,12 +81,14 @@ def test_resolve_storage_path_remote_build_uses_basename_keyspace(tmp_path: Path
     Mirrors esphome's :func:`storage_path` which keys on
     ``CORE.config_filename`` (the basename of
     ``CORE.config_path``) — a remote-build YAML at
-    ``<subtree>/kitchen.yaml`` writes its sidecar at
-    ``<subtree>/storage/kitchen.yaml.json``, not at
-    ``<subtree>/storage/.esphome/.remote_builds/...yaml.json``.
-    Pins the basename-keyed contract so a future refactor can't
-    silently regress the resolver into emitting the buggy
-    full-path key.
+    ``<per-dashboard-data-dir>/kitchen.yaml`` writes its sidecar
+    at ``<per-dashboard-data-dir>/storage/kitchen.yaml.json``,
+    where ``<per-dashboard-data-dir>`` is
+    ``<CORE.data_dir>/.remote_builds/<dashboard_id>/.esphome``.
+    The full configuration string (``.esphome/.remote_builds/<id>/<device>/<device>.yaml``)
+    is not re-embedded in the sidecar path — pins the
+    basename-keyed contract so a future refactor can't silently
+    regress the resolver into emitting the buggy full-path key.
     """
     configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
     assert resolve_storage_path(configuration) == (


### PR DESCRIPTION
# What does this implement/fix?

Bugfix for user-reported `[Errno 66] Directory not empty`
on `.../build/<env>/.pioenvs` after cancelling a remote
install (originally reported as the `.DS_Store` race in
the closed-out follow-up #586). The proximate cause is
`shutil.rmtree` racing macOS Finder `.DS_Store` re-writes,
but the **root cause** is the receiver-side
`ESPHOME_DATA_DIR` layout introduced in #578.

## Root cause walk-through

**Before #578**: `ESPHOME_DATA_DIR` wasn't pinned for
remote builds. Esphome's default rule put `.esphome` next
to the YAML — i.e. `<subtree>/.esphome`. Upstream
`prepare_bundle_for_compile`'s `_PRESERVE_DIRS` protects
`.esphome`, so the build artifacts (`build/`,
`.platformio/`, `.pioenvs/`) lived under that preserved
umbrella. The cleanup walk between submits never touched
them.

**After #578**: `ESPHOME_DATA_DIR = <subtree>`. Build
artifacts now land at `<subtree>/build/`,
`<subtree>/.platformio/`, etc. — *outside* `.esphome/`,
so the preserve logic doesn't protect them. Every
`submit_job` wipes the entire toolchain cache *and*
races Finder on the deep `build/` tree.

Confirmed from the user's failure log + `ls`: target_dir
top-level was `[build/, .DS_Store]`, with `.DS_Store`
reappearing at sub-second intervals during the multi-
second `shutil.rmtree(build/<env>/.pioenvs)` recursion.

## Fix

Move `ESPHOME_DATA_DIR` up one level — from
`<subtree>` (per-device) to
`<config>/.esphome/.remote_builds/<dashboard_id>/.esphome`
(per-dashboard, sibling to all that offloader's
per-device subtrees).

## Why per-dashboard

| Scope | Toolchain re-downloads | Same-basename collision across offloaders |
|---|---|---|
| **Per-device** (the broken state) | Every new device | None |
| **Single shared** (initial proposal) | Once ever | **Yes — brings back #578's bug** |
| **Per-dashboard** (this PR) | Once per offloader | None — `dashboard_id` partition |

Per-dashboard preserves the `dashboard_id` isolation gate
#578 was solving (two offloaders submitting `kitchen.yaml`
get distinct storage keyspaces) while letting devices
from the same offloader share the ~1-2 GB toolchain.

## Effects

- **Toolchain downloaded once per dashboard.** Device #N
  from the same offloader hits a warm `.platformio/`
  cache.
- **`.DS_Store` race window collapses.** The per-device
  subtree (= `prepare_bundle_for_compile`'s `target_dir`)
  only contains the YAML; the cleanup walk's single
  `unlink` has no `rmdir` step to race.
- **Cross-offloader collision still prevented** by the
  `dashboard_id` segment.
- 6c TTL sweep reclaims an entire offloader (including
  shared toolchain) by walking
  `<config>/.esphome/.remote_builds/<dashboard_id>/`.

## Tests

- `test_storage_path`: path assertions updated for the
  new layout (`resolve_data_dir`, `resolve_storage_path`,
  `resolve_idedata_path`).
- `test_subprocess_env`: `ESPHOME_DATA_DIR` env override
  expectation updated.
- 2990 backend tests pass.

**Related issue or feature (if applicable):**

- Follow-up to esphome/device-builder#578. The user's
  closed #586 (proactive `.DS_Store` strip) attempted a
  workaround at the wrong layer; this PR fixes the
  layout that was creating the race in the first place.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
