### PR TITLE
Bind remote-build peer-link to 0.0.0.0 by default

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -165,6 +165,25 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--remote-build-host",
+        # Real default (``0.0.0.0``) lives in
+        # ``DashboardSettings.parse_args`` so the env-var fallback
+        # and the CLI flag share one resolution path. Suppressing
+        # argparse's default rendering keeps the help text from
+        # contradicting that resolution order.
+        default=argparse.SUPPRESS,
+        help=(
+            "Bind address for the remote-build peer-link receiver. "
+            "Defaults to 0.0.0.0 (all interfaces) so paired peers on "
+            "the LAN can reach the receiver — the peer-link's "
+            "security is Noise + pre-shared pin, independent of bind "
+            "address. Override (e.g. 127.0.0.1) only if you want to "
+            "restrict the receiver to a specific interface. Falls "
+            "back to $ESPHOME_REMOTE_BUILD_HOST when unset. Only "
+            "bound when remote-build is enabled in Settings"
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         default="info",
         choices=["debug", "info", "warning", "error"],

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -77,6 +77,16 @@ class DashboardSettings:
     # haven't opted in. Lives separately from ``port`` because it
     # serves a TLS-pinned route group with its own auth gate.
     remote_build_port: int = DEFAULT_REMOTE_BUILD_PORT
+    # Bind address for the remote-build peer-link receiver. Defaults
+    # to all interfaces — the feature's whole point is letting paired
+    # peers on the LAN reach this dashboard, and the security gate is
+    # Noise + pre-shared pin (not bind address). Lives separately from
+    # ``host`` because the HTTP/WS dashboard often binds to
+    # ``127.0.0.1`` (desktop app loopback security model) while the
+    # peer-link still needs to be LAN-reachable. Operators who want
+    # to lock the receiver to a specific NIC can override via
+    # ``--remote-build-host`` / ``$ESPHOME_REMOTE_BUILD_HOST``.
+    remote_build_host: str = "0.0.0.0"
     # In dev mode the SPA shell is served with ``Cache-Control: no-cache``
     # so a re-deployed wheel isn't masked by a browser-cached
     # ``index.html`` pointing at a now-deleted hashed bundle. In
@@ -182,6 +192,21 @@ class DashboardSettings:
                     DEFAULT_REMOTE_BUILD_PORT,
                 )
                 self.remote_build_port = DEFAULT_REMOTE_BUILD_PORT
+        # ``--remote-build-host`` (or ``$ESPHOME_REMOTE_BUILD_HOST``).
+        # Same precedence pattern as the port: an explicit CLI value
+        # wins; absence means "consult the env var, then fall back to
+        # the default". The default is ``0.0.0.0`` (all interfaces) —
+        # binding the peer-link receiver to the same interface as the
+        # HTTP dashboard would break the desktop-app shape, where
+        # ``--host 127.0.0.1`` is the dashboard's security boundary
+        # but the peer-link still needs to be LAN-reachable so paired
+        # peers can actually dial the IPs the mDNS announce broadcasts.
+        cli_remote_build_host = getattr(args, "remote_build_host", None)
+        if cli_remote_build_host is not None:
+            self.remote_build_host = cli_remote_build_host
+        else:
+            env_remote_build_host = os.getenv("ESPHOME_REMOTE_BUILD_HOST", "")
+            self.remote_build_host = env_remote_build_host or "0.0.0.0"
         self.dev_mode = bool(getattr(args, "dev", False))
         # ``--trusted-domains a,b,c`` (or ``$ESPHOME_TRUSTED_DOMAINS``).
         # Comma-separated. Lower-cased for the case-insensitive match

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -71,11 +71,16 @@ class DashboardSettings:
     host: str = "0.0.0.0"
     ingress_port: int = DEFAULT_INGRESS_PORT
     ingress_host: str = ""
-    # HTTPS port for the remote-build receiver site (issue #106).
-    # The site is only bound when ``RemoteBuildSettings.enabled`` is
-    # set; default-off keeps the listener inactive on installs that
-    # haven't opted in. Lives separately from ``port`` because it
-    # serves a TLS-pinned route group with its own auth gate.
+    # Plain-TCP port for the remote-build peer-link receiver site
+    # (issue #106). The transport is Noise XX over plain HTTP/WS,
+    # not TLS — Noise provides mutual auth + forward secrecy +
+    # confidentiality at the application layer, which is why phase
+    # 4a-r1 part 4 dropped the earlier HTTPS+bearer wrapping. The
+    # site is only bound when ``RemoteBuildSettings.enabled`` is set;
+    # default-off keeps the listener inactive on installs that
+    # haven't opted in. Lives separately from ``port`` because the
+    # peer-link's auth gate (Noise + pre-shared pin pairing) is
+    # independent from the dashboard's WS gate (loopback / login).
     remote_build_port: int = DEFAULT_REMOTE_BUILD_PORT
     # Bind address for the remote-build peer-link receiver. Defaults
     # to all interfaces — the feature's whole point is letting paired
@@ -194,18 +199,28 @@ class DashboardSettings:
                 self.remote_build_port = DEFAULT_REMOTE_BUILD_PORT
         # ``--remote-build-host`` (or ``$ESPHOME_REMOTE_BUILD_HOST``).
         # Same precedence pattern as the port: an explicit CLI value
-        # wins; absence means "consult the env var, then fall back to
-        # the default". The default is ``0.0.0.0`` (all interfaces) —
-        # binding the peer-link receiver to the same interface as the
-        # HTTP dashboard would break the desktop-app shape, where
-        # ``--host 127.0.0.1`` is the dashboard's security boundary
-        # but the peer-link still needs to be LAN-reachable so paired
-        # peers can actually dial the IPs the mDNS announce broadcasts.
-        cli_remote_build_host = getattr(args, "remote_build_host", None)
-        if cli_remote_build_host is not None:
+        # wins; absence (or empty / whitespace-only) means "consult
+        # the env var, then fall back to the default". Empty-string
+        # falls through to the env var rather than passing ``""`` to
+        # ``TCPSite`` — aiohttp would translate that to a low-level
+        # ``getaddrinfo`` failure with a cryptic error rather than
+        # the obvious "0.0.0.0 default". The default is ``0.0.0.0``
+        # (all interfaces) — binding the peer-link receiver to the
+        # same interface as the HTTP dashboard would break the
+        # desktop-app shape, where ``--host 127.0.0.1`` is the
+        # dashboard's security boundary but the peer-link still needs
+        # to be LAN-reachable so paired peers can actually dial the
+        # IPs the mDNS announce broadcasts.
+        cli_remote_build_host_raw = getattr(args, "remote_build_host", None)
+        cli_remote_build_host = (
+            cli_remote_build_host_raw.strip()
+            if isinstance(cli_remote_build_host_raw, str)
+            else None
+        )
+        if cli_remote_build_host:
             self.remote_build_host = cli_remote_build_host
         else:
-            env_remote_build_host = os.getenv("ESPHOME_REMOTE_BUILD_HOST", "")
+            env_remote_build_host = os.getenv("ESPHOME_REMOTE_BUILD_HOST", "").strip()
             self.remote_build_host = env_remote_build_host or "0.0.0.0"
         self.dev_mode = bool(getattr(args, "dev", False))
         # ``--trusted-domains a,b,c`` (or ``$ESPHOME_TRUSTED_DOMAINS``).

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -1057,6 +1057,20 @@ class DeviceBuilder:
         passed ``--remote-build-port 0`` (ephemeral); otherwise the
         configured value verbatim. Reading the real port off the
         socket prevents mDNS / log lines from claiming port 0.
+
+        Bind address comes from
+        :attr:`DashboardSettings.remote_build_host` (``0.0.0.0`` by
+        default) rather than the HTTP/WS dashboard's
+        :attr:`~DashboardSettings.host`. The desktop app shape
+        passes ``--host 127.0.0.1`` for the dashboard's loopback
+        security model, but the peer-link still needs to be
+        LAN-reachable so paired peers can dial the IPs the mDNS
+        announce broadcasts (the announce carries every non-loopback
+        adapter address). The peer-link's security gate is Noise +
+        pre-shared pin, so binding to all interfaces by default is
+        the right behaviour. Operators who want to lock the receiver
+        to a specific NIC can override via ``--remote-build-host`` /
+        ``$ESPHOME_REMOTE_BUILD_HOST``.
         """
         loop = self.loop
         assert loop is not None  # caller-checked
@@ -1084,7 +1098,7 @@ class DeviceBuilder:
             # each rebuild; production deploys with a fixed port.
             site = web.TCPSite(
                 runner,
-                self.settings.host,
+                self.settings.remote_build_host,
                 configured_port,
                 reuse_address=True,
             )

--- a/tests/test_remote_build_host_env.py
+++ b/tests/test_remote_build_host_env.py
@@ -1,0 +1,103 @@
+"""Tests for ``--remote-build-host`` / ``ESPHOME_REMOTE_BUILD_HOST`` resolution.
+
+The peer-link receiver site binds to
+:attr:`DashboardSettings.remote_build_host` rather than the
+HTTP/WS dashboard's :attr:`~DashboardSettings.host`. The desktop
+app shape passes ``--host 127.0.0.1`` (loopback is the dashboard's
+security boundary in the Tauri model) but the peer-link still
+needs to be LAN-reachable so paired peers can actually dial the
+IPs the mDNS announce broadcasts. Default ``0.0.0.0`` is the
+right answer because the feature's security gate is Noise +
+pre-shared pin, not bind address — operators can still override
+to lock the receiver to a specific NIC via the flag or env var.
+
+Precedence mirrors ``--remote-build-port`` (and
+``--trusted-domains`` / ``--username``): an explicit CLI value
+wins over the env var; a missing CLI value falls back to
+``$ESPHOME_REMOTE_BUILD_HOST``; an empty / unset env var falls
+back to ``0.0.0.0``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from esphome_device_builder.controllers.config import DashboardSettings
+
+
+def _ns(configuration: str, **kwargs: object) -> SimpleNamespace:
+    """Minimal argparse-namespace stub for ``DashboardSettings.parse_args``."""
+    defaults: dict[str, object] = {
+        "ha_addon": False,
+        "configuration": configuration,
+        "username": "",
+        "password": "",
+        "log_level": "info",
+        "port": 6052,
+        "host": "0.0.0.0",
+        "ingress_port": 6053,
+        "ingress_host": "",
+        # ``None`` matches the argparse default — production passes
+        # ``None`` when the flag wasn't given so the env-var fallback
+        # can fire.
+        "remote_build_port": None,
+        "remote_build_host": None,
+        "dev": False,
+        "trusted_domains": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_default_is_all_interfaces(tmp_path: Path) -> None:
+    """Neither flag nor env → ``0.0.0.0`` (LAN-reachable)."""
+    settings = DashboardSettings()
+    # Empty string covers the inherited-but-blank case.
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": ""}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path)))
+    assert settings.remote_build_host == "0.0.0.0"
+
+
+def test_cli_flag_wins_over_env(tmp_path: Path) -> None:
+    """Explicit ``--remote-build-host`` beats the env var."""
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": "10.0.0.5"}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path), remote_build_host="192.168.1.10"))
+    assert settings.remote_build_host == "192.168.1.10"
+
+
+def test_env_used_when_cli_unset(tmp_path: Path) -> None:
+    """``None`` CLI default falls back to the env var."""
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": "10.0.0.5"}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path)))
+    assert settings.remote_build_host == "10.0.0.5"
+
+
+def test_independent_from_http_host(tmp_path: Path) -> None:
+    """``--host 127.0.0.1`` does not leak into ``remote_build_host``.
+
+    The desktop-app shape pins ``--host 127.0.0.1`` for its
+    loopback security model; the peer-link receiver must still
+    default to ``0.0.0.0`` so paired peers on the LAN can actually
+    reach the IPs the mDNS announce broadcasts. A regression that
+    re-coupled the two would silently re-introduce the
+    "advertise points at LAN IP, receiver binds to loopback,
+    peers get connection-refused" failure mode the desktop app
+    was hitting.
+    """
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": ""}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path), host="127.0.0.1"))
+    assert settings.host == "127.0.0.1"
+    assert settings.remote_build_host == "0.0.0.0"
+
+
+def test_explicit_loopback_override(tmp_path: Path) -> None:
+    """Operators who want a loopback peer-link can pin ``--remote-build-host 127.0.0.1``."""
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": ""}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path), remote_build_host="127.0.0.1"))
+    assert settings.remote_build_host == "127.0.0.1"

--- a/tests/test_remote_build_host_env.py
+++ b/tests/test_remote_build_host_env.py
@@ -1,4 +1,5 @@
-"""Tests for ``--remote-build-host`` / ``ESPHOME_REMOTE_BUILD_HOST`` resolution.
+"""
+Tests for ``--remote-build-host`` / ``ESPHOME_REMOTE_BUILD_HOST`` resolution.
 
 The peer-link receiver site binds to
 :attr:`DashboardSettings.remote_build_host` rather than the
@@ -13,9 +14,12 @@ to lock the receiver to a specific NIC via the flag or env var.
 
 Precedence mirrors ``--remote-build-port`` (and
 ``--trusted-domains`` / ``--username``): an explicit CLI value
-wins over the env var; a missing CLI value falls back to
-``$ESPHOME_REMOTE_BUILD_HOST``; an empty / unset env var falls
-back to ``0.0.0.0``.
+wins over the env var; a missing / empty / whitespace-only CLI
+value falls back to ``$ESPHOME_REMOTE_BUILD_HOST``; an empty /
+unset env var falls back to ``0.0.0.0``. Empty / whitespace CLI
+values fall through rather than passing ``""`` to ``TCPSite`` —
+that would produce a cryptic ``getaddrinfo`` failure instead of
+the obvious default.
 """
 
 from __future__ import annotations
@@ -101,3 +105,34 @@ def test_explicit_loopback_override(tmp_path: Path) -> None:
     with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": ""}, clear=False):
         settings.parse_args(_ns(configuration=str(tmp_path), remote_build_host="127.0.0.1"))
     assert settings.remote_build_host == "127.0.0.1"
+
+
+def test_empty_cli_flag_falls_through_to_env(tmp_path: Path) -> None:
+    """``--remote-build-host ""`` (empty / whitespace) falls back to the env var.
+
+    Passing an empty string straight through to ``TCPSite`` would
+    produce a cryptic low-level ``getaddrinfo`` failure rather than
+    a clean default — treat an empty / whitespace-only flag as
+    "unset" so the env-then-default fallback chain still resolves
+    to something bindable.
+    """
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": "10.0.0.5"}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path), remote_build_host="   "))
+    assert settings.remote_build_host == "10.0.0.5"
+
+
+def test_empty_cli_flag_and_empty_env_falls_through_to_default(tmp_path: Path) -> None:
+    """``--remote-build-host ""`` with empty env falls back to ``0.0.0.0``."""
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": ""}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path), remote_build_host=""))
+    assert settings.remote_build_host == "0.0.0.0"
+
+
+def test_env_whitespace_falls_through_to_default(tmp_path: Path) -> None:
+    """A whitespace-only env value (e.g. ``ESPHOME_REMOTE_BUILD_HOST=" "``) defaults."""
+    settings = DashboardSettings()
+    with patch.dict("os.environ", {"ESPHOME_REMOTE_BUILD_HOST": "   "}, clear=False):
+        settings.parse_args(_ns(configuration=str(tmp_path)))
+    assert settings.remote_build_host == "0.0.0.0"


### PR DESCRIPTION
# What does this implement/fix?

## BLUF

**No change to the dashboard's security posture.** The
HTTP/WS dashboard (port 6052) stays bound to whatever
`--host` says — `127.0.0.1` in the desktop app, unchanged
in every other deployment.

**The peer-link receiver (port 6055) is not an unauthenticated
endpoint.** It speaks Noise XX with mutual authentication +
forward secrecy at the protocol layer and requires a
pre-shared pin to pair. Unpaired peers can connect to the
TCP port but cannot authenticate, cannot submit jobs, and
cannot exchange any payload. Pairing requires out-of-band
PIN entry on both sides.

**The peer-link receiver is opt-in.** Accepting pair
requests and `submit_job` traffic is gated by the "Enable
remote build" toggle in Settings → Remote build (mapped to
`RemoteBuildSettings.enabled`, **default `False`** at
`models/remote_build.py:1634`). Port 6055 is not bound at
all until the operator flips that toggle. The toggle copy
already says: "Pairing with a peer grants it the ability to
run code on this host — only enable for dashboards you
already trust at a shell level."

For completeness on what *is* default-on: the dashboard
registers an `_esphomebuilder._tcp.local.` mDNS service so
peer dashboards / the desktop-app welcome screen can
discover it. With the toggle OFF, that announce carries
only `server_version` + `esphome_version` — no
`pin_sha256`, no `remote_build_port`, and nothing is
listening on port 6055. With the toggle ON, the TXT gains
those two fields and the receiver site is bound. This PR
only affects the bind-address of the *bound* receiver; it
does not change when the port is bound.

What this PR changes: when the operator HAS opted in, the
peer-link receiver binds to `0.0.0.0` instead of inheriting
`--host`. Bind address is not part of the peer-link's
threat model; pairing + Noise + the master toggle are.

## The bug

The peer-link Noise WS receiver previously inherited
`DashboardSettings.host` -- i.e. the `--host` flag the
operator passes for the HTTP/WS dashboard. That coupling
silently broke the desktop app shape on macOS.

`/Applications/ESPHome Builder.app` spawns the embedded
Python with `--host 127.0.0.1` (loopback is the dashboard's
security boundary -- the Tauri window is the only legitimate
client of the no-auth WS dashboard). With the inherited
binding, the peer-link receiver also landed on
`127.0.0.1:6055`. Meanwhile the mDNS announce for
`_esphomebuilder._tcp.local.` correctly broadcasts the LAN
IPs from `_local_addresses()`, so other dashboards see
"Mac" at e.g. `192.168.212.75:6055` and dial it -- only to
hit ECONNREFUSED because nothing's listening on the
LAN-facing address.

Confirmed empirically via `lsof` on the live process:

```
TCP localhost:6055 (LISTEN)   <- peer-link, loopback only
TCP localhost:6052 (LISTEN)   <- HTTP/WS dashboard
UDP *:5353                    <- mDNS multicast RX
UDP mac.koston.org:5353       <- mDNS announce TX (correct)
```

And the announce itself shows up cleanly on the wire
(verified via mDNS browser):

```
_esphomebuilder._tcp. -> Mac
  Mac.koston.org. 192.168.212.75:6052
  pin_sha256=77c51326...
  remote_build_port=6055
```

## Fix

The two binds should be independent:

- The HTTP/WS dashboard's security gate IS bind-address.
  The Tauri / desktop app shape relies on loopback to keep
  the no-auth dashboard private to the local window. **No
  change here.**
- The peer-link's security gate is **Noise XX + pre-shared
  pin pairing + the master enable toggle**. Bind address is
  not part of that threat model.

Add a parallel `--remote-build-host` flag and
`$ESPHOME_REMOTE_BUILD_HOST` env var, symmetric to the
existing `--remote-build-port` plumbing. Default `0.0.0.0`
(the feature's whole purpose is letting paired peers on
the LAN dial in). Operators who want to lock the receiver
to a specific NIC can override.

## Effects

- Desktop app: peer-link now LAN-reachable by default
  **when the operator has flipped the Enable remote build
  toggle**. Other dashboards can complete the dial from the
  mDNS announce.
- Other deployments (`--host 0.0.0.0`, HA addon): no
  observable change -- the peer-link was already
  LAN-reachable via the inherited bind.
- Operators who deliberately want a loopback-only peer-link
  can set `--remote-build-host 127.0.0.1` or
  `ESPHOME_REMOTE_BUILD_HOST=127.0.0.1`.
- Dashboard HTTP/WS bind is **unchanged**.

## Tests

`tests/test_remote_build_host_env.py` mirrors
`test_remote_build_port_env.py`:

- Default → `0.0.0.0` when neither flag nor env set
- CLI flag wins over env var
- Env var used when CLI flag absent
- Independent from `--host` (regression pin for the desktop
  app shape -- `--host 127.0.0.1` must not leak into
  `remote_build_host`)
- Explicit loopback override path works

**Related issue or feature (if applicable):**

- Follow-up to issue #106 (remote-build feature). Found
  while diagnosing why the desktop app's mDNS announce
  showed up on peers but `submit_job` round-trips refused.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
