### PR TITLE
Add esphome-device-builder-discover CLI for browsing LAN dashboards

### DIFF
--- a/esphome_device_builder/discover.py
+++ b/esphome_device_builder/discover.py
@@ -110,7 +110,20 @@ def _on_service_state_change(
     )
 
 
-async def _run(argv: list[str]) -> None:
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser.
+
+    Factored out of :func:`main` so the construction site is
+    callable from tests without the rest of the bootstrap, and
+    so :func:`_run` can stay free of filesystem-touching work.
+    Python 3.14's :class:`argparse.ArgumentParser` constructor
+    calls :func:`gettext.gettext`, which does an ``os.stat``
+    under the hood; running that inside an asyncio test
+    triggers blockbuster's "no blocking calls on the event
+    loop" guard. Keeping argparse out of :func:`_run` means the
+    CLI's async body is pure orchestration and the test stays
+    quiet on every Python version.
+    """
     parser = argparse.ArgumentParser(
         "esphome-device-builder-discover",
         description=(
@@ -125,13 +138,18 @@ async def _run(argv: list[str]) -> None:
         action="store_true",
         help="Enable DEBUG-level logging (including zeroconf's own).",
     )
-    args = parser.parse_args(argv[1:])
+    return parser
 
-    logging.basicConfig(
-        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
-        level=logging.DEBUG if args.verbose else logging.INFO,
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
+
+async def _run(args: argparse.Namespace) -> None:
+    """Orchestrate the browse against pre-parsed *args*.
+
+    Async body deliberately doesn't do any filesystem-touching
+    work (no argparse construction, no logging.basicConfig with
+    a file handler) so blockbuster's event-loop guard stays
+    quiet under test. The caller in :func:`main` resolves all
+    of that synchronously before entering the loop.
+    """
     if args.verbose:
         logging.getLogger("zeroconf").setLevel(logging.DEBUG)
 
@@ -152,9 +170,23 @@ async def _run(argv: list[str]) -> None:
 
 
 def main() -> None:
-    """CLI entry point."""
+    """CLI entry point.
+
+    All filesystem-touching bootstrap (argparse construction,
+    ``logging.basicConfig``) runs synchronously here, before the
+    asyncio loop starts. :func:`_run` is then a pure async
+    orchestration coroutine — keeps Python 3.14's blockbuster
+    suite quiet (its argparse constructor calls ``os.stat`` via
+    gettext, which would otherwise trip the event-loop guard).
+    """
+    args = _build_parser().parse_args(sys.argv[1:])
+    logging.basicConfig(
+        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
     with contextlib.suppress(KeyboardInterrupt):
-        asyncio.run(_run(sys.argv))
+        asyncio.run(_run(args))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/esphome_device_builder/discover.py
+++ b/esphome_device_builder/discover.py
@@ -1,4 +1,5 @@
-"""Browse the LAN for ESPHome dashboards and print them.
+"""
+Browse the LAN for ESPHome dashboards and print them.
 
 CLI helper that browses ``_esphomebuilder._tcp.local.`` and prints
 every dashboard reachable on the LAN. Same shape as
@@ -41,73 +42,24 @@ _COLUMN_NAMES = (
 _UNKNOWN = "unknown"
 
 
-def _decode(data: str | bytes | None) -> str:
-    """Decode a TXT-record value to ``str``, or return ``unknown``."""
-    if data is None:
-        return _UNKNOWN
-    if isinstance(data, bytes):
-        try:
-            return data.decode("utf-8")
-        except UnicodeDecodeError:
-            return data.decode("utf-8", errors="replace")
-    return data
+def main() -> None:
+    """CLI entry point.
 
-
-def _truncate_pin(pin: str) -> str:
-    """Trim a 64-hex pin to its first 12 chars so it fits in the column.
-
-    The full pin is what the pairing flow asserts; the truncated
-    head is enough for an at-a-glance "is that the same fingerprint
-    I saw on the other dashboard's identity card?" sanity check.
+    All filesystem-touching bootstrap (argparse construction,
+    ``logging.basicConfig``) runs synchronously here, before the
+    asyncio loop starts. :func:`_run` is then a pure async
+    orchestration coroutine; keeps Python 3.14's blockbuster
+    suite quiet (its argparse constructor calls ``os.stat`` via
+    gettext, which would otherwise trip the event-loop guard).
     """
-    if pin == _UNKNOWN or len(pin) <= 12:
-        return pin
-    return f"{pin[:12]}…"
-
-
-def _on_service_state_change(
-    zeroconf: Zeroconf,
-    service_type: str,
-    name: str,
-    state_change: ServiceStateChange,
-) -> None:
-    """Print one row per browse event.
-
-    Resolves the cached :class:`AsyncServiceInfo` synchronously
-    (the browser already populated zeroconf's cache before
-    dispatching the callback) so the print order matches the
-    wire order. ``Removed`` events still have the cached fields
-    available, so an OFFLINE row carries the same metadata the
-    last ONLINE row did — useful for spotting which exact
-    dashboard just dropped off the network.
-    """
-    short_name = name.partition(".")[0]
-    state = "OFFLINE" if state_change is ServiceStateChange.Removed else "ONLINE"
-    info = AsyncServiceInfo(service_type, name)
-    info.load_from_cache(zeroconf)
-
-    properties = info.properties
-    server_version = _decode(properties.get(b"server_version"))
-    esphome_version = _decode(properties.get(b"esphome_version"))
-    pin_sha256 = _decode(properties.get(b"pin_sha256"))
-    remote_build_port = _decode(properties.get(b"remote_build_port"))
-
-    address = ""
-    if addresses := info.ip_addresses_by_version(IPVersion.V4Only):
-        address = str(addresses[0])
-    endpoint = f"{address}:{info.port}" if address and info.port else address or _UNKNOWN
-
-    print(
-        _FORMAT.format(
-            state,
-            short_name,
-            endpoint,
-            server_version,
-            esphome_version,
-            remote_build_port,
-            _truncate_pin(pin_sha256),
-        )
+    args = _build_parser().parse_args(sys.argv[1:])
+    logging.basicConfig(
+        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(_run(args))
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -142,7 +94,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 async def _run(args: argparse.Namespace) -> None:
-    """Orchestrate the browse against pre-parsed *args*.
+    """
+    Orchestrate the browse against pre-parsed *args*.
 
     Async body deliberately doesn't do any filesystem-touching
     work (no argparse construction, no logging.basicConfig with
@@ -169,24 +122,98 @@ async def _run(args: argparse.Namespace) -> None:
         await aiozc.async_close()
 
 
-def main() -> None:
-    """CLI entry point.
+def _decode(data: str | bytes | None) -> str:
+    """Decode a TXT-record value to ``str``, or return ``unknown``."""
+    if data is None:
+        return _UNKNOWN
+    if isinstance(data, bytes):
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            return data.decode("utf-8", errors="replace")
+    return data
 
-    All filesystem-touching bootstrap (argparse construction,
-    ``logging.basicConfig``) runs synchronously here, before the
-    asyncio loop starts. :func:`_run` is then a pure async
-    orchestration coroutine — keeps Python 3.14's blockbuster
-    suite quiet (its argparse constructor calls ``os.stat`` via
-    gettext, which would otherwise trip the event-loop guard).
+
+def _truncate_pin(pin: str) -> str:
     """
-    args = _build_parser().parse_args(sys.argv[1:])
-    logging.basicConfig(
-        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
-        level=logging.DEBUG if args.verbose else logging.INFO,
-        datefmt="%Y-%m-%d %H:%M:%S",
+    Trim a 64-hex pin to its first 12 chars so it fits in the column.
+
+    The full pin is what the pairing flow asserts; the truncated
+    head is enough for an at-a-glance "is that the same fingerprint
+    I saw on the other dashboard's identity card?" sanity check.
+    """
+    if pin == _UNKNOWN or len(pin) <= 12:
+        return pin
+    return f"{pin[:12]}…"
+
+
+def _on_service_state_change(
+    zeroconf: Zeroconf,
+    service_type: str,
+    name: str,
+    state_change: ServiceStateChange,
+) -> None:
+    """
+    Print one row per browse event.
+
+    Resolves the cached :class:`AsyncServiceInfo` synchronously
+    (the browser already populated zeroconf's cache before
+    dispatching the callback) so the print order matches the
+    wire order. ``Removed`` events still have the cached fields
+    available, so an OFFLINE row carries the same metadata the
+    last ONLINE row did, useful for spotting which exact
+    dashboard just dropped off the network.
+
+    Address resolution prefers IPv4 (operators read the
+    Address:Port column at a glance and IPv4 fits more cleanly
+    in the fixed-width column) but falls back to IPv6 when no
+    IPv4 is advertised. ``parsed_scoped_addresses`` matches the
+    rest of the project's peer-discovery sites (cf.
+    :mod:`controllers._device_state_monitor` /
+    :mod:`controllers.remote_build.controller`).
+    """
+    short_name = name.partition(".")[0]
+    state = "OFFLINE" if state_change is ServiceStateChange.Removed else "ONLINE"
+    info = AsyncServiceInfo(service_type, name)
+    # ``load_from_cache`` returns ``False`` when the browser
+    # callback fired before the resolve completed; in that case
+    # ``info.properties`` can be ``None``. Coalesce to an empty
+    # dict so the TXT-field gets fall through to the ``unknown``
+    # sentinel rather than crashing the callback (which would
+    # silently kill the browse loop). A subsequent state-change
+    # event for the same name will land a complete row once the
+    # resolve catches up.
+    info.load_from_cache(zeroconf)
+    properties = info.properties or {}
+    server_version = _decode(properties.get(b"server_version"))
+    esphome_version = _decode(properties.get(b"esphome_version"))
+    pin_sha256 = _decode(properties.get(b"pin_sha256"))
+    remote_build_port = _decode(properties.get(b"remote_build_port"))
+
+    address = ""
+    if v4_addresses := info.ip_addresses_by_version(IPVersion.V4Only):
+        address = str(v4_addresses[0])
+    elif scoped := info.parsed_scoped_addresses(IPVersion.All):
+        # IPv6-only dashboard, or a dashboard whose IPv4 hasn't
+        # resolved yet. Take the first scoped address so the
+        # column gets a meaningful value rather than ``unknown``;
+        # the scope_id suffix (``...%eth0``) helps the operator
+        # tell link-local entries apart from globally-routable
+        # ones.
+        address = scoped[0]
+    endpoint = f"{address}:{info.port}" if address and info.port else address or _UNKNOWN
+
+    print(
+        _FORMAT.format(
+            state,
+            short_name,
+            endpoint,
+            server_version,
+            esphome_version,
+            remote_build_port,
+            _truncate_pin(pin_sha256),
+        )
     )
-    with contextlib.suppress(KeyboardInterrupt):
-        asyncio.run(_run(args))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/esphome_device_builder/discover.py
+++ b/esphome_device_builder/discover.py
@@ -157,6 +157,6 @@ def main() -> None:
         asyncio.run(_run(sys.argv))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()
     sys.exit(0)

--- a/esphome_device_builder/discover.py
+++ b/esphome_device_builder/discover.py
@@ -1,0 +1,162 @@
+"""Browse the LAN for ESPHome dashboards and print them.
+
+CLI helper that browses ``_esphomebuilder._tcp.local.`` and prints
+every dashboard reachable on the LAN. Same shape as
+``aioesphomeapi-discover``; one-shot browse, no pairing flow, no
+persistence. Useful for confirming an offloader can see a build
+server, sanity-checking which TXT fields are populated, and
+verifying the rest of the network's pin fingerprints out-of-band
+before clicking ``Pair``.
+
+Run as ``esphome-device-builder-discover`` (the package's
+``[project.scripts]`` entry point) or ``python -m
+esphome_device_builder.discover``. The browse runs until Ctrl-C;
+rows print as services appear / disappear so a watcher can see
+the network's churn live.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import sys
+
+from zeroconf import IPVersion, ServiceStateChange, Zeroconf
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
+
+from .helpers.dashboard_advertise import SERVICE_TYPE
+
+_FORMAT = "{: <7}|{: <24}|{: <21}|{: <18}|{: <16}|{: <12}|{: <16}"
+_COLUMN_NAMES = (
+    "Status",
+    "Name",
+    "Address:Port",
+    "Server",
+    "ESPHome",
+    "RB Port",
+    "Pin (sha256)",
+)
+_UNKNOWN = "unknown"
+
+
+def _decode(data: str | bytes | None) -> str:
+    """Decode a TXT-record value to ``str``, or return ``unknown``."""
+    if data is None:
+        return _UNKNOWN
+    if isinstance(data, bytes):
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            return data.decode("utf-8", errors="replace")
+    return data
+
+
+def _truncate_pin(pin: str) -> str:
+    """Trim a 64-hex pin to its first 12 chars so it fits in the column.
+
+    The full pin is what the pairing flow asserts; the truncated
+    head is enough for an at-a-glance "is that the same fingerprint
+    I saw on the other dashboard's identity card?" sanity check.
+    """
+    if pin == _UNKNOWN or len(pin) <= 12:
+        return pin
+    return f"{pin[:12]}…"
+
+
+def _on_service_state_change(
+    zeroconf: Zeroconf,
+    service_type: str,
+    name: str,
+    state_change: ServiceStateChange,
+) -> None:
+    """Print one row per browse event.
+
+    Resolves the cached :class:`AsyncServiceInfo` synchronously
+    (the browser already populated zeroconf's cache before
+    dispatching the callback) so the print order matches the
+    wire order. ``Removed`` events still have the cached fields
+    available, so an OFFLINE row carries the same metadata the
+    last ONLINE row did — useful for spotting which exact
+    dashboard just dropped off the network.
+    """
+    short_name = name.partition(".")[0]
+    state = "OFFLINE" if state_change is ServiceStateChange.Removed else "ONLINE"
+    info = AsyncServiceInfo(service_type, name)
+    info.load_from_cache(zeroconf)
+
+    properties = info.properties
+    server_version = _decode(properties.get(b"server_version"))
+    esphome_version = _decode(properties.get(b"esphome_version"))
+    pin_sha256 = _decode(properties.get(b"pin_sha256"))
+    remote_build_port = _decode(properties.get(b"remote_build_port"))
+
+    address = ""
+    if addresses := info.ip_addresses_by_version(IPVersion.V4Only):
+        address = str(addresses[0])
+    endpoint = f"{address}:{info.port}" if address and info.port else address or _UNKNOWN
+
+    print(
+        _FORMAT.format(
+            state,
+            short_name,
+            endpoint,
+            server_version,
+            esphome_version,
+            remote_build_port,
+            _truncate_pin(pin_sha256),
+        )
+    )
+
+
+async def _run(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        "esphome-device-builder-discover",
+        description=(
+            "Browse the LAN for ESPHome dashboards advertising "
+            f"``{SERVICE_TYPE}`` and print each one's address, "
+            "versions, remote-build port, and cert pin (truncated)."
+        ),
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG-level logging (including zeroconf's own).",
+    )
+    args = parser.parse_args(argv[1:])
+
+    logging.basicConfig(
+        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    if args.verbose:
+        logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+
+    aiozc = AsyncZeroconf()
+    browser = AsyncServiceBrowser(
+        aiozc.zeroconf,
+        SERVICE_TYPE,
+        handlers=[_on_service_state_change],
+    )
+    print(_FORMAT.format(*_COLUMN_NAMES))
+    print("-" * 120)
+
+    try:
+        await asyncio.Event().wait()
+    finally:
+        await browser.async_cancel()
+        await aiozc.async_close()
+
+
+def main() -> None:
+    """CLI entry point."""
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(_run(sys.argv))
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ Repository = "https://github.com/esphome/device-builder"
 
 [project.scripts]
 esphome-device-builder = "esphome_device_builder.__main__:main"
+esphome-device-builder-discover = "esphome_device_builder.discover:main"
 
 [tool.setuptools]
 include-package-data = true
@@ -129,6 +130,8 @@ select = [
 # CLI scripts: noisy print is fine, late imports gate optional esphome introspection
 # behind try/except ImportError, and several subprocess invocations are inherent.
 "script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415"]
+# Discovery CLI: prints are the entire UX (mirrors aioesphomeapi-discover).
+"esphome_device_builder/discover.py" = ["T20"]
 "tests/*" = ["S105", "S106"] # hardcoded test credentials
 # GitHub Action helpers: prints are CI-log diagnostics, lazy imports keep the
 # module importable for unit tests without PyGithub installed, and the temp

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -16,16 +16,21 @@ pinning:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from zeroconf import IPVersion, ServiceStateChange
 
 from esphome_device_builder.discover import (
+    _COLUMN_NAMES,
     _UNKNOWN,
     _decode,
     _on_service_state_change,
+    _run,
     _truncate_pin,
+    main,
 )
 
 
@@ -133,3 +138,123 @@ def test_on_service_state_change_prints_offline_on_removal(
     captured = capsys.readouterr().out
     assert "OFFLINE" in captured
     assert "build-server" in captured
+
+
+@pytest.mark.asyncio
+async def test_run_prints_header_then_awaits_then_cleans_up(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``_run`` prints the column header + divider, then parks on the event.
+
+    Drives the orchestration function with mocked
+    :class:`AsyncZeroconf` and :class:`AsyncServiceBrowser` so
+    the test doesn't open a real mDNS socket. Spawns ``_run`` as
+    a task, gives it a turn of the loop to print the header and
+    park on ``asyncio.Event().wait()``, then cancels — the
+    ``finally`` block runs and we assert both the wire-shape
+    setup (browser handlers, service type, cleanup awaits) and
+    the printed header.
+    """
+    fake_aiozc = MagicMock()
+    fake_aiozc.zeroconf = MagicMock()
+    fake_aiozc.async_close = AsyncMock()
+    fake_browser = MagicMock()
+    fake_browser.async_cancel = AsyncMock()
+
+    with (
+        patch(
+            "esphome_device_builder.discover.AsyncZeroconf",
+            return_value=fake_aiozc,
+        ),
+        patch(
+            "esphome_device_builder.discover.AsyncServiceBrowser",
+            return_value=fake_browser,
+        ) as browser_ctor,
+    ):
+        runner = asyncio.create_task(_run(["esphome-device-builder-discover"]))
+        # One loop turn lets ``_run`` print the header and reach
+        # the ``asyncio.Event().wait()`` await. ``sleep(0)`` is
+        # enough because ``AsyncZeroconf()`` / ``AsyncServiceBrowser()``
+        # are sync constructors and the only awaitable before the
+        # park is the event itself.
+        await asyncio.sleep(0)
+        runner.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await runner
+
+    # Browser registered against the dashboard service type with
+    # our handler. The handler-array shape is what python-zeroconf
+    # expects; an empty / wrong-shape handler list would silently
+    # drop every browse event.
+    browser_ctor.assert_called_once()
+    args, kwargs = browser_ctor.call_args
+    assert args[1] == "_esphomebuilder._tcp.local."
+    assert len(kwargs["handlers"]) == 1
+
+    # Cleanup ran on cancel.
+    fake_browser.async_cancel.assert_awaited_once()
+    fake_aiozc.async_close.assert_awaited_once()
+
+    captured = capsys.readouterr().out
+    # Every column name lands on the printed header.
+    for column in _COLUMN_NAMES:
+        assert column in captured
+    # Divider row is the second line.
+    assert "-" * 60 in captured
+
+
+@pytest.mark.asyncio
+async def test_run_verbose_flag_enables_debug_logging() -> None:
+    """``-v`` flag flips the root + zeroconf loggers to DEBUG.
+
+    Pin the contract that ``--verbose`` does what the help text
+    says: noisy logs for debugging discovery problems. A
+    regression that quietly drops the verbose-aware branch
+    would surface here.
+    """
+    fake_aiozc = MagicMock()
+    fake_aiozc.zeroconf = MagicMock()
+    fake_aiozc.async_close = AsyncMock()
+    fake_browser = MagicMock()
+    fake_browser.async_cancel = AsyncMock()
+
+    with (
+        patch("esphome_device_builder.discover.AsyncZeroconf", return_value=fake_aiozc),
+        patch("esphome_device_builder.discover.AsyncServiceBrowser", return_value=fake_browser),
+    ):
+        runner = asyncio.create_task(_run(["esphome-device-builder-discover", "-v"]))
+        await asyncio.sleep(0)
+        runner.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await runner
+
+    assert logging.getLogger("zeroconf").level == logging.DEBUG
+
+
+def test_main_suppresses_keyboard_interrupt() -> None:
+    """Ctrl-C exits cleanly rather than dumping a traceback.
+
+    ``contextlib.suppress(KeyboardInterrupt)`` is the user-facing
+    contract that Ctrl-C is the documented way to stop the
+    browse. Without the suppression, the shell would see a
+    traceback on every clean exit.
+    """
+    with patch(
+        "esphome_device_builder.discover.asyncio.run",
+        side_effect=KeyboardInterrupt,
+    ):
+        # Doesn't raise — the ``contextlib.suppress`` swallows it.
+        main()
+
+
+def test_main_runs_to_completion_when_inner_returns() -> None:
+    """When ``asyncio.run`` returns cleanly, ``main`` returns cleanly.
+
+    The orchestration's happy path: ``_run`` finishes (e.g. the
+    parked event was set externally — which production never
+    does, but the contract is that ``main`` doesn't add error
+    paths beyond the Ctrl-C suppression).
+    """
+    with patch("esphome_device_builder.discover.asyncio.run", return_value=None) as mock_run:
+        main()
+    mock_run.assert_called_once()

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -16,6 +16,7 @@ pinning:
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -26,6 +27,7 @@ from zeroconf import IPVersion, ServiceStateChange
 from esphome_device_builder.discover import (
     _COLUMN_NAMES,
     _UNKNOWN,
+    _build_parser,
     _decode,
     _on_service_state_change,
     _run,
@@ -171,7 +173,7 @@ async def test_run_prints_header_then_awaits_then_cleans_up(
             return_value=fake_browser,
         ) as browser_ctor,
     ):
-        runner = asyncio.create_task(_run(["esphome-device-builder-discover"]))
+        runner = asyncio.create_task(_run(argparse.Namespace(verbose=False)))
         # One loop turn lets ``_run`` print the header and reach
         # the ``asyncio.Event().wait()`` await. ``sleep(0)`` is
         # enough because ``AsyncZeroconf()`` / ``AsyncServiceBrowser()``
@@ -222,7 +224,7 @@ async def test_run_verbose_flag_enables_debug_logging() -> None:
         patch("esphome_device_builder.discover.AsyncZeroconf", return_value=fake_aiozc),
         patch("esphome_device_builder.discover.AsyncServiceBrowser", return_value=fake_browser),
     ):
-        runner = asyncio.create_task(_run(["esphome-device-builder-discover", "-v"]))
+        runner = asyncio.create_task(_run(argparse.Namespace(verbose=True)))
         await asyncio.sleep(0)
         runner.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -239,9 +241,15 @@ def test_main_suppresses_keyboard_interrupt() -> None:
     browse. Without the suppression, the shell would see a
     traceback on every clean exit.
     """
-    with patch(
-        "esphome_device_builder.discover.asyncio.run",
-        side_effect=KeyboardInterrupt,
+    with (
+        patch(
+            "esphome_device_builder.discover.sys.argv",
+            ["esphome-device-builder-discover"],
+        ),
+        patch(
+            "esphome_device_builder.discover.asyncio.run",
+            side_effect=KeyboardInterrupt,
+        ),
     ):
         # Doesn't raise — the ``contextlib.suppress`` swallows it.
         main()
@@ -255,6 +263,28 @@ def test_main_runs_to_completion_when_inner_returns() -> None:
     does, but the contract is that ``main`` doesn't add error
     paths beyond the Ctrl-C suppression).
     """
-    with patch("esphome_device_builder.discover.asyncio.run", return_value=None) as mock_run:
+    with (
+        patch(
+            "esphome_device_builder.discover.sys.argv",
+            ["esphome-device-builder-discover"],
+        ),
+        patch("esphome_device_builder.discover.asyncio.run", return_value=None) as mock_run,
+    ):
         main()
     mock_run.assert_called_once()
+
+
+def test_build_parser_accepts_verbose_flag() -> None:
+    """The CLI parser carries the documented ``-v`` / ``--verbose`` flag.
+
+    Pin the argparse surface — a future copy / refactor that
+    drops the flag without updating callers would silently
+    stop honouring DEBUG-log requests.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(["-v"])
+    assert args.verbose is True
+    long_args = parser.parse_args(["--verbose"])
+    assert long_args.verbose is True
+    default_args = parser.parse_args([])
+    assert default_args.verbose is False

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,135 @@
+"""
+Tests for :mod:`esphome_device_builder.discover` (CLI browse helper).
+
+The CLI itself is a thin wrapper around python-zeroconf's
+``AsyncServiceBrowser`` — there's no orchestration logic worth
+end-to-end-testing against a live mDNS responder. What's worth
+pinning:
+
+* The TXT-decode helper handles every wire shape (``bytes`` /
+  ``str`` / missing).
+* The pin truncator collapses a 64-hex pin to 12 chars + a
+  trailing ellipsis but leaves shorter sentinel values alone.
+* The state-change callback handles both ``Added`` and
+  ``Removed`` events and resolves the cached ServiceInfo.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from zeroconf import IPVersion, ServiceStateChange
+
+from esphome_device_builder.discover import (
+    _UNKNOWN,
+    _decode,
+    _on_service_state_change,
+    _truncate_pin,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (b"hello", "hello"),
+        ("plain", "plain"),
+        (None, _UNKNOWN),
+        # ``bytes`` containing a non-UTF-8 sequence falls through
+        # the strict decode and lands on the replacement-char path
+        # (rather than raising) so a malformed TXT entry doesn't
+        # crash the browse loop.
+        (b"\xff\xfe", "��"),
+    ],
+)
+def test_decode_handles_every_txt_wire_shape(raw: str | bytes | None, expected: str) -> None:
+    """``_decode`` round-trips bytes, leaves strings alone, marks missing."""
+    assert _decode(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("pin", "expected"),
+    [
+        # Full 64-hex pin gets head + ellipsis.
+        ("a" * 64, "aaaaaaaaaaaa…"),
+        # Anything ≤ 12 chars passes through unchanged so the
+        # ``unknown`` sentinel and short test fixtures stay
+        # readable.
+        ("unknown", "unknown"),
+        ("abc", "abc"),
+        ("a" * 12, "a" * 12),
+        ("a" * 13, "aaaaaaaaaaaa…"),
+    ],
+)
+def test_truncate_pin_trims_to_12_with_ellipsis_above_threshold(pin: str, expected: str) -> None:
+    """``_truncate_pin`` collapses long pins, leaves short / sentinel alone."""
+    assert _truncate_pin(pin) == expected
+
+
+def test_on_service_state_change_prints_resolved_info(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``Added`` event prints an ``ONLINE`` row with TXT-derived columns.
+
+    Mocks the cached :class:`AsyncServiceInfo` so the test doesn't
+    need a live zeroconf responder. The shape of the printed row
+    is what the CLI's stdout contract guarantees; downstream
+    tooling (operators piping the output through ``grep`` /
+    ``awk``) leans on the column widths staying stable.
+    """
+    fake_info = MagicMock()
+    fake_info.properties = {
+        b"server_version": b"0.1.62",
+        b"esphome_version": b"2026.5.0-dev",
+        b"pin_sha256": b"a" * 64,
+        b"remote_build_port": b"6053",
+    }
+    fake_info.ip_addresses_by_version.return_value = ["192.168.1.10"]
+    fake_info.port = 6052
+
+    with patch("esphome_device_builder.discover.AsyncServiceInfo", return_value=fake_info):
+        _on_service_state_change(
+            MagicMock(),
+            "_esphomebuilder._tcp.local.",
+            "build-server._esphomebuilder._tcp.local.",
+            ServiceStateChange.Added,
+        )
+
+    captured = capsys.readouterr().out
+    assert "ONLINE" in captured
+    assert "build-server" in captured
+    assert "192.168.1.10:6052" in captured
+    assert "0.1.62" in captured
+    assert "2026.5.0-dev" in captured
+    assert "6053" in captured
+    # Truncated pin lands on the row.
+    assert "aaaaaaaaaaaa…" in captured
+    fake_info.ip_addresses_by_version.assert_called_once_with(IPVersion.V4Only)
+
+
+def test_on_service_state_change_prints_offline_on_removal(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``Removed`` event prints an ``OFFLINE`` row with the cached fields.
+
+    The cached :class:`AsyncServiceInfo` survives the removal so
+    the OFFLINE row carries the same metadata the last ONLINE
+    row did. Useful for spotting which exact dashboard just
+    dropped off when watching a churning network.
+    """
+    fake_info = MagicMock()
+    fake_info.properties = {b"server_version": b"0.1.62"}
+    fake_info.ip_addresses_by_version.return_value = ["192.168.1.10"]
+    fake_info.port = 6052
+
+    with patch("esphome_device_builder.discover.AsyncServiceInfo", return_value=fake_info):
+        _on_service_state_change(
+            MagicMock(),
+            "_esphomebuilder._tcp.local.",
+            "build-server._esphomebuilder._tcp.local.",
+            ServiceStateChange.Removed,
+        )
+
+    captured = capsys.readouterr().out
+    assert "OFFLINE" in captured
+    assert "build-server" in captured

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -142,6 +142,71 @@ def test_on_service_state_change_prints_offline_on_removal(
     assert "build-server" in captured
 
 
+def test_on_service_state_change_falls_back_to_ipv6_when_no_ipv4(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An IPv6-only dashboard renders with its scoped address.
+
+    Pins the address-resolution fallback: when the browser
+    callback fires for a dashboard whose mDNS announcement only
+    carries an AAAA record (IPv6-only host, or IPv4 not resolved
+    yet), the row still gets a meaningful Address:Port column
+    value instead of ``unknown``.
+    ``parsed_scoped_addresses(IPVersion.All)`` is the project-
+    wide convention for this fallback (cf.
+    ``_device_state_monitor`` / ``remote_build.controller``).
+    """
+    fake_info = MagicMock()
+    fake_info.properties = {b"server_version": b"0.1.62"}
+    fake_info.ip_addresses_by_version.return_value = []  # no IPv4
+    fake_info.parsed_scoped_addresses.return_value = ["fe80::1%eth0", "2001:db8::1"]
+    fake_info.port = 6052
+
+    with patch("esphome_device_builder.discover.AsyncServiceInfo", return_value=fake_info):
+        _on_service_state_change(
+            MagicMock(),
+            "_esphomebuilder._tcp.local.",
+            "build-server._esphomebuilder._tcp.local.",
+            ServiceStateChange.Added,
+        )
+
+    captured = capsys.readouterr().out
+    assert "fe80::1%eth0:6052" in captured
+    fake_info.parsed_scoped_addresses.assert_called_once_with(IPVersion.All)
+
+
+def test_on_service_state_change_handles_none_properties(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A cache miss with ``properties = None`` doesn't crash the callback.
+
+    ``AsyncServiceInfo.load_from_cache`` can return ``False``
+    when the browser callback fires before the resolve
+    completes; in that case ``info.properties`` is ``None``.
+    The callback must guard so the browse loop survives — a
+    crash here would silently kill all subsequent rows.
+    """
+    fake_info = MagicMock()
+    fake_info.properties = None  # cache miss
+    fake_info.ip_addresses_by_version.return_value = []
+    fake_info.parsed_scoped_addresses.return_value = []
+    fake_info.port = 6052
+
+    with patch("esphome_device_builder.discover.AsyncServiceInfo", return_value=fake_info):
+        _on_service_state_change(
+            MagicMock(),
+            "_esphomebuilder._tcp.local.",
+            "build-server._esphomebuilder._tcp.local.",
+            ServiceStateChange.Added,
+        )
+
+    captured = capsys.readouterr().out
+    # No traceback escaped; the row landed with every TXT field
+    # showing the ``unknown`` sentinel.
+    assert "ONLINE" in captured
+    assert captured.count("unknown") >= 4  # 4 TXT fields all unknown
+
+
 @pytest.mark.asyncio
 async def test_run_prints_header_then_awaits_then_cleans_up(
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
# What does this implement/fix?

Adds an `esphome-device-builder-discover` CLI for browsing the LAN for dashboards advertising `_esphomebuilder._tcp.local.` and printing each one's address, versions, remote-build port, and pin fingerprint.

Direct mirror of `aioesphomeapi-discover` (the existing helper for browsing `_esphomelib._tcp.local.` devices), shipped as a sibling entry point in the same package.

## Why

Three concrete uses:

1. **"Can the offloader actually see the build server?"** — first sanity check before the operator gives up and assumes pairing's broken.
2. **Out-of-band pin verification** — the receiver's identity card UI shows its own pin; the discover CLI shows what the offloader sees from the network. Comparing the two before clicking Pair catches mDNS-spoofing scenarios that auto-rebind's probe-before-mutate (4a-o part 7) defends against in production.
3. **TXT-field debugging** — `server_version` / `esphome_version` / `remote_build_port` / `pin_sha256` all appear; an empty / wrong field on a paired peer narrows the diagnosis without enabling DEBUG logging across the whole dashboard.

Sample output:

```
Status |Name                    |Address:Port         |Server            |ESPHome         |RB Port     |Pin (sha256)
------------------------------------------------------------------------------------------------------------------------
ONLINE |build-server            |192.168.1.10:6052    |0.1.62            |2026.5.0-dev    |6053        |a3f9b2c1d4e7…
ONLINE |laptop                  |192.168.1.20:6052    |0.1.62            |2026.5.0-dev    |6053        |e8c2d1a5f4b9…
OFFLINE|build-server            |192.168.1.10:6052    |0.1.62            |2026.5.0-dev    |6053        |a3f9b2c1d4e7…
```

## What lands

* **`esphome_device_builder/discover.py`** — new module. Browses `_esphomebuilder._tcp.local.` via `zeroconf.asyncio.AsyncServiceBrowser`, prints one line per ONLINE / OFFLINE event. Pin is truncated to 12 chars + ellipsis so the column fits in standard terminal widths; the full fingerprint is what the pairing flow asserts, the truncated head is enough for an at-a-glance "is that the same fingerprint I saw on the other dashboard?" check.
* **`pyproject.toml`** — new `[project.scripts]` entry `esphome-device-builder-discover` → `esphome_device_builder.discover:main`. Also runs as `python -m esphome_device_builder.discover`.
* **`tests/test_discover.py`** — 11 tests pinning the TXT-decode helper (every wire shape including a malformed-bytes path), the pin-truncator (boundary at 12 chars), and both the `Added` and `Removed` callback paths against a mocked `AsyncServiceInfo`. No live zeroconf responder needed.

## Testing

* `pytest tests/ -q` → 3048 passed, 4 skipped (+11 new).
* `python -m esphome_device_builder.discover --help` shows the expected CLI surface.

**Related issue or feature (if applicable):**

- Issue #106 — diagnostic tooling for the phase 1 dashboard advertise. Not a sub-phase; this is a sibling helper to the existing `aioesphomeapi-discover` shape.

## Types of changes

- [ ] Bugfix
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation only
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass.
- [x] Tests have been added.
- [x] `components.json` has not been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
