### PR TITLE
Default remote-build receiver to enabled for non-HA-addon

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -646,12 +646,40 @@ def load_remote_build_settings(config_dir: Path) -> RemoteBuildSettings:
     """
     Load the receiver-side remote-build settings.
 
-    Returns defaults (``enabled=False``) when the metadata file is
-    missing or the ``_remote_build`` key isn't present. A wholly
-    malformed blob falls back to defaults rather than crashing
-    dashboard startup.
+    Returns defaults (``RemoteBuildSettings()``, i.e.
+    ``enabled=True``) when the metadata file is missing or the
+    ``_remote_build`` key isn't present. A wholly malformed blob
+    falls back to defaults rather than crashing dashboard startup.
+
+    HA-addon callers that need to suppress the auto-bind on a
+    fresh install should pair this with
+    :func:`has_remote_build_settings_persisted` and gate
+    accordingly — the load function returns the data dataclass
+    semantically; the deployment-mode rule lives at the bind
+    site so the toggle's "operator opted in" signal isn't lost.
     """
     return _settings_from_raw(_load_metadata(config_dir).get(_REMOTE_BUILD_KEY, {}))
+
+
+def has_remote_build_settings_persisted(config_dir: Path) -> bool:
+    """
+    Return ``True`` when ``_remote_build`` has been explicitly written.
+
+    Distinguishes "fresh install, never touched the toggle"
+    (returns ``False``) from "operator deliberately set a value,
+    even if that value matches the dataclass default" (returns
+    ``True``). The HA-addon default-off rule keys on this so a
+    fresh addon install doesn't bind port 6055 (the container
+    doesn't expose it anyway) but an operator who flips the
+    toggle in Settings still gets the receiver bound regardless
+    of deployment mode.
+
+    Implementation: ``set_settings`` writes a full
+    ``RemoteBuildSettings.to_dict()`` blob, so presence of the
+    key is the load-bearing signal — even a write that lands
+    on the dataclass defaults still flips this to ``True``.
+    """
+    return _REMOTE_BUILD_KEY in _load_metadata(config_dir)
 
 
 def save_remote_build_settings(config_dir: Path, settings: RemoteBuildSettings) -> None:

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -614,24 +614,45 @@ def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
         data[_PREFS_KEY] = prefs.to_dict()
 
 
+_REMOTE_BUILD_FAIL_SAFE = RemoteBuildSettings(enabled=False)
+
+
 def _settings_from_raw(raw: Any) -> RemoteBuildSettings:
     """
-    Decode a ``_remote_build`` blob, falling back to defaults on shape mismatch.
+    Decode a ``_remote_build`` blob, failing safe on shape mismatch.
 
-    A wholly malformed blob resets to defaults loudly so a
-    schema break is visible at startup rather than silently
-    producing wrong state. Legacy ``tokens`` / ``manual_hosts`` /
-    ``peers`` entries on older ``.device-builder.json`` files are
-    silently dropped — mashumaro's ``DataClassORJSONMixin``
-    ignores unknown keys by default. The ``tokens`` field went
-    with the dormant bearer machinery (phase 4a-r2);
+    With the default ``RemoteBuildSettings.enabled=True``, a
+    malformed blob can no longer silently fall through to
+    "defaults" — that path would enable the listener on a
+    corrupted sidecar without any operator opt-in. Instead:
+
+    * A non-dict raw value (None / list / scalar from a hand-
+      edit or partial-write) returns ``enabled=False``.
+    * A dict that fails ``from_dict`` decode (schema break,
+      type-incompatible value on a known field) returns
+      ``enabled=False``.
+
+    Both paths log a warning at the call site so the operator
+    can spot the corrupted sidecar.
+
+    Legacy ``tokens`` / ``manual_hosts`` / ``peers`` entries
+    on older ``.device-builder.json`` files are silently
+    dropped — mashumaro's ``DataClassORJSONMixin`` ignores
+    unknown keys by default. The ``tokens`` field went with
+    the dormant bearer machinery (phase 4a-r2);
     ``manual_hosts`` was removed once the pair dialog started
     typing hostnames straight into ``request_pair``; ``peers``
     moved to its own per-file ``Store`` at
     ``.receiver_peers.json``.
     """
     if not isinstance(raw, dict):
-        return RemoteBuildSettings()
+        _LOGGER.warning(
+            "Malformed ``_remote_build`` block in metadata "
+            "(expected dict, got %s); failing safe to enabled=False. "
+            "Fix or remove the block to recover default behaviour.",
+            type(raw).__name__,
+        )
+        return _REMOTE_BUILD_FAIL_SAFE
     # Drop the legacy ``tokens`` key explicitly so a corrupt
     # token row in an older sidecar can't crash the whole
     # ``from_dict`` decode of an otherwise-valid blob.
@@ -639,7 +660,12 @@ def _settings_from_raw(raw: Any) -> RemoteBuildSettings:
     try:
         return RemoteBuildSettings.from_dict(cleaned)
     except Exception:
-        return RemoteBuildSettings()
+        _LOGGER.exception(
+            "Failed to decode ``_remote_build`` block in metadata; "
+            "failing safe to enabled=False. Fix or remove the block "
+            "to recover default behaviour."
+        )
+        return _REMOTE_BUILD_FAIL_SAFE
 
 
 def load_remote_build_settings(config_dir: Path) -> RemoteBuildSettings:
@@ -648,17 +674,24 @@ def load_remote_build_settings(config_dir: Path) -> RemoteBuildSettings:
 
     Returns defaults (``RemoteBuildSettings()``, i.e.
     ``enabled=True``) when the metadata file is missing or the
-    ``_remote_build`` key isn't present. A wholly malformed blob
-    falls back to defaults rather than crashing dashboard startup.
+    ``_remote_build`` key isn't present (fresh install). A
+    present-but-malformed block fails safe to
+    ``enabled=False`` rather than silently inheriting the
+    permissive default — see :func:`_settings_from_raw` for
+    the corruption-path rationale.
 
     HA-addon callers that need to suppress the auto-bind on a
     fresh install should pair this with
     :func:`has_remote_build_settings_persisted` and gate
-    accordingly — the load function returns the data dataclass
+    accordingly — the load function returns the dataclass
     semantically; the deployment-mode rule lives at the bind
-    site so the toggle's "operator opted in" signal isn't lost.
+    site so the toggle's "operator opted in" signal isn't
+    lost.
     """
-    return _settings_from_raw(_load_metadata(config_dir).get(_REMOTE_BUILD_KEY, {}))
+    metadata = _load_metadata(config_dir)
+    if _REMOTE_BUILD_KEY not in metadata:
+        return RemoteBuildSettings()
+    return _settings_from_raw(metadata[_REMOTE_BUILD_KEY])
 
 
 def has_remote_build_settings_persisted(config_dir: Path) -> bool:
@@ -674,12 +707,17 @@ def has_remote_build_settings_persisted(config_dir: Path) -> bool:
     toggle in Settings still gets the receiver bound regardless
     of deployment mode.
 
-    Implementation: ``set_settings`` writes a full
-    ``RemoteBuildSettings.to_dict()`` blob, so presence of the
-    key is the load-bearing signal — even a write that lands
-    on the dataclass defaults still flips this to ``True``.
+    The block must also have the expected on-disk shape (a
+    dict). A malformed ``_remote_build`` value (list, scalar,
+    null) doesn't count as opt-in — ``set_settings`` writes
+    ``RemoteBuildSettings.to_dict()`` which is always a dict,
+    so any non-dict value reached the sidecar via a hand-edit
+    or partial-write, not an operator interaction with the
+    toggle. Returning ``False`` for that shape keeps the
+    HA-addon gate consistent with the fail-safe shape in
+    :func:`_settings_from_raw`.
     """
-    return _REMOTE_BUILD_KEY in _load_metadata(config_dir)
+    return isinstance(_load_metadata(config_dir).get(_REMOTE_BUILD_KEY), dict)
 
 
 def save_remote_build_settings(config_dir: Path, settings: RemoteBuildSettings) -> None:

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -34,6 +34,7 @@ from .controllers.components import ComponentCatalog
 from .controllers.config import (
     ConfigController,
     DashboardSettings,
+    has_remote_build_settings_persisted,
     load_remote_build_settings,
 )
 from .controllers.devices import DevicesController
@@ -775,34 +776,64 @@ class DeviceBuilder:
         """
         Bind the peer-link Noise WS listener if remote-build is enabled.
 
-        Default-off: the listener only binds when
-        ``RemoteBuildSettings.enabled`` is true. Loads the X25519
-        peer-link identity off disk via
+        Default-on for non-HA-addon deployments: a fresh sidecar
+        deserialises to ``RemoteBuildSettings(enabled=True)`` and
+        the listener binds without an extra operator step. The
+        receiver-side **pair-approval dialog** is the privilege
+        gate — an unpaired peer can connect to the TCP port but
+        the Noise XX handshake fails without a matching pubkey, so
+        binding the port grants nothing on its own. Loads the
+        X25519 peer-link identity off disk via
         :func:`get_or_create_peer_link_identity` (separate from the
         3a Ed25519 cert; the cert is no longer involved on this
         listener). Hops through ``run_in_executor`` because the
         helper is sync-blocking by design.
 
+        **HA addon: default-off but operator-overridable.** The
+        addon's docker container doesn't expose port 6055 to the
+        LAN by default, and the mDNS advertise is already skipped
+        on HA addon — so binding by default would produce a port
+        that's invisible to LAN peers. But some legacy-dashboard
+        users DID expose port 6052 (and historically other addon
+        ports) via the addon's ``ports:`` config, so a hard skip
+        would lock them out. The compromise: on HA addon, skip
+        the bind unless the operator has *explicitly persisted*
+        ``_remote_build`` in metadata via the Settings toggle.
+        ``has_remote_build_settings_persisted`` returns ``True``
+        the moment ``set_settings`` writes the block — even a
+        write that lands on the dataclass defaults still flips
+        the signal. This means: fresh addon install → no bind;
+        addon operator flips the toggle in Settings → bind
+        respects the persisted ``enabled`` field. The HA-addon
+        operator path stays open; the fresh-install default
+        stops burning a port nothing can reach.
+
         Fail-soft: any exception during identity load or bind is
         caught and logged. The main dashboard keeps running; the
         operator gets a warning and the listener is simply absent
         until the next restart with the issue resolved.
-
-        On HA addon mode with the listener enabled, logs a warning
-        that the addon's ``ports:`` config must expose the bound
-        port for LAN peers to actually reach it. The bind itself
-        proceeds; "not supported by default today" rather than
-        "hard-refused forever."
         """
         if self.remote_build is None or self.loop is None:
             return
         loop = self.loop
+        if self.settings.on_ha_addon:
+            persisted = await loop.run_in_executor(
+                None, has_remote_build_settings_persisted, self.settings.config_dir
+            )
+            if not persisted:
+                _LOGGER.debug(
+                    "Skipping remote-build peer-link site: running as HA addon "
+                    "without an explicit ``_remote_build`` block in metadata "
+                    "(addon container doesn't expose port 6055 to the LAN by "
+                    "default; flip the toggle in Settings to override)"
+                )
+                return
         rb_settings = await loop.run_in_executor(
             None, load_remote_build_settings, self.settings.config_dir
         )
         if not rb_settings.enabled:
             _LOGGER.debug(
-                "Skipping remote-build peer-link site: not enabled in settings "
+                "Skipping remote-build peer-link site: disabled in settings "
                 "(set ``remote_build/set_settings`` enabled=true to bind)"
             )
             return
@@ -828,21 +859,12 @@ class DeviceBuilder:
             remote_build_port=port,
         )
 
-        if self.settings.on_ha_addon:
-            _LOGGER.warning(
-                "Remote-build peer-link site bound on %s:%d while running as HA "
-                "addon. Peers won't reach this port unless the addon's "
-                "``ports:`` config exposes it to the host.",
-                self.settings.host,
-                port,
-            )
-        else:
-            _LOGGER.info(
-                "Remote-build peer-link site listening on %s:%d (peer-link pin %s)",
-                self.settings.host,
-                port,
-                identity.pin_sha256_formatted,
-            )
+        _LOGGER.info(
+            "Remote-build peer-link site listening on %s:%d (peer-link pin %s)",
+            self.settings.remote_build_host,
+            port,
+            identity.pin_sha256_formatted,
+        )
 
     async def _publish_remote_build_advertise(
         self,

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -1619,6 +1619,32 @@ class RemoteBuildSettings(DataClassORJSONMixin):
     the ``tokens`` list (hash-only bearer tokens) went with the
     dormant bearer machinery in phase 4a-r2.
 
+    ``enabled`` is the master gate the dashboard checks before
+    binding the receiver site. Defaults to ``True`` so fresh
+    installs are LAN-discoverable and pairable without an
+    extra operator step — the feature's discoverability is the
+    point, and the actual privilege grant happens at the
+    receiver-side **pair-approval dialog** (a paired peer can
+    submit jobs, but pairing requires explicit user approval
+    on this dashboard, so binding the port alone grants
+    nothing).
+
+    HA-addon deployments override this default at the bind
+    site: a fresh addon install with no persisted
+    ``_remote_build`` block in metadata does not bind. The
+    addon's docker container doesn't expose port 6055 to the
+    LAN by default, so binding it would waste the port and
+    confuse operators. HA-addon operators who DO want the
+    feature (e.g. they've added ``6055/tcp`` to the addon's
+    ``ports:`` config, as some legacy-dashboard operators have
+    historically done with the HTTP port) flip the toggle in
+    Settings; the resulting write persists the block, the
+    "explicit operator opt-in" signal flips, and the next
+    boot's bind site respects the persisted ``enabled`` field
+    exactly like every other deployment mode. See
+    :meth:`device_builder.DeviceBuilder._maybe_start_remote_build_site`
+    for the gate.
+
     ``cleanup_ttl_seconds`` is the operator-tunable threshold
     the 6c background sweep uses to decide a remote-build
     subtree is cold enough to delete. Defaults to 24h
@@ -1631,7 +1657,7 @@ class RemoteBuildSettings(DataClassORJSONMixin):
     field default.
     """
 
-    enabled: bool = False
+    enabled: bool = True
     cleanup_ttl_seconds: int = DEFAULT_CLEANUP_TTL_SECONDS
 
     def __post_init__(self) -> None:
@@ -1692,7 +1718,7 @@ class RemoteBuildSettingsView(DataClassORJSONMixin):
     consistent shape with what the snapshot delivered.
     """
 
-    enabled: bool = False
+    enabled: bool = True
     cleanup_ttl_seconds: int = DEFAULT_CLEANUP_TTL_SECONDS
     peers: list[PeerSummary] = field(default_factory=list)
 

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import threading
 from pathlib import Path
@@ -410,25 +411,57 @@ def test_load_remote_build_settings_returns_defaults_on_missing(tmp_path: Path) 
     assert load_remote_build_settings(tmp_path).enabled is True
 
 
-def test_load_remote_build_settings_returns_defaults_on_bad_data(
-    tmp_path: Path,
+def test_load_remote_build_settings_fails_safe_on_non_dict_block(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Corrupted ``_remote_build`` blob → default object, not partial recovery.
+    """Non-dict ``_remote_build`` blob → ``enabled=False``, not the permissive default.
 
-    Same fallback semantics as ``load_preferences``: an older
-    version's payload that doesn't deserialise under the current
-    mashumaro schema lands on defaults rather than crashing
-    dashboard startup. Pinning ``RemoteBuildSettings()`` keeps
-    the recovery shape stable so a future regression that
-    silently mutates the fallback would surface here.
+    With the default ``RemoteBuildSettings.enabled=True``, a
+    corrupted block that fell through to the dataclass defaults
+    would silently bind the listener without any operator opt-in.
+    Fail safe: a list / scalar / null value lands on
+    ``enabled=False`` and emits a warning so the operator can
+    spot the corrupted sidecar.
     """
-    # Use a payload mashumaro can't coerce — a list where a dict
-    # was expected. (A bare ``"not-a-bool"`` for ``enabled`` would
-    # silently coerce to truthy, masking the fallback path.)
     metadata_path = tmp_path / ".device-builder.json"
     metadata_path.write_bytes(b'{"_remote_build": [1, 2, 3]}')
 
-    assert load_remote_build_settings(tmp_path) == RemoteBuildSettings()
+    with caplog.at_level(logging.WARNING, logger="esphome_device_builder.controllers.config"):
+        settings = load_remote_build_settings(tmp_path)
+    assert settings.enabled is False
+    assert any("Malformed" in r.getMessage() for r in caplog.records)
+
+
+def test_load_remote_build_settings_fails_safe_on_decode_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dict that fails ``from_dict`` decode → ``enabled=False``.
+
+    Same fail-safe shape as the non-dict path: a schema break
+    that raises out of mashumaro's ``from_dict`` lands on
+    ``enabled=False`` rather than silently enabling via the
+    permissive default. Monkeypatched rather than crafted: most
+    real-world malformed values are coerced by mashumaro
+    (``["not", "a", "bool"]`` truthy-coerces to ``True``, etc.),
+    so the cleanest way to exercise the except-arm is to force
+    ``from_dict`` to raise — which is what a hypothetical future
+    schema break would do.
+    """
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(b'{"_remote_build": {"enabled": true}}')
+
+    def _boom(*args: object, **kwargs: object) -> RemoteBuildSettings:
+        msg = "synthetic schema break"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(RemoteBuildSettings, "from_dict", classmethod(_boom))
+
+    with caplog.at_level(logging.ERROR, logger="esphome_device_builder.controllers.config"):
+        settings = load_remote_build_settings(tmp_path)
+    assert settings.enabled is False
+    assert any("Failed to decode" in r.getMessage() for r in caplog.records)
 
 
 def test_save_remote_build_settings_round_trip(tmp_path: Path) -> None:
@@ -481,6 +514,27 @@ def test_has_remote_build_settings_persisted_true_for_explicit_disable(tmp_path:
     """
     save_remote_build_settings(tmp_path, RemoteBuildSettings(enabled=False))
     assert has_remote_build_settings_persisted(tmp_path) is True
+
+
+def test_has_remote_build_settings_persisted_false_on_malformed_block(tmp_path: Path) -> None:
+    """A malformed (non-dict) ``_remote_build`` value doesn't count as opt-in.
+
+    ``set_settings`` always writes ``RemoteBuildSettings.to_dict()``
+    which is a dict. A non-dict value (list, scalar, null) on
+    disk reached the sidecar via a hand-edit or partial-write,
+    not an operator interaction with the toggle. The HA-addon
+    gate must treat that as "not opted in" so a corrupted
+    sidecar doesn't silently bind the listener on the addon
+    path.
+    """
+    (tmp_path / ".device-builder.json").write_bytes(b'{"_remote_build": [1, 2, 3]}')
+    assert has_remote_build_settings_persisted(tmp_path) is False
+
+    (tmp_path / ".device-builder.json").write_bytes(b'{"_remote_build": null}')
+    assert has_remote_build_settings_persisted(tmp_path) is False
+
+    (tmp_path / ".device-builder.json").write_bytes(b'{"_remote_build": "string"}')
+    assert has_remote_build_settings_persisted(tmp_path) is False
 
 
 @pytest.mark.parametrize(
@@ -548,17 +602,25 @@ def test_remote_build_settings_post_init_preserves_valid_ttl() -> None:
     assert settings.cleanup_ttl_seconds == 7200
 
 
-def test_remote_build_settings_transaction_falls_back_on_bad_data(
+def test_remote_build_settings_transaction_fails_safe_on_bad_data(
     tmp_path: Path,
 ) -> None:
-    """Corrupted blob → the transaction yields defaults, not crashes."""
+    """Corrupted blob → the transaction yields ``enabled=False``, not the permissive default.
+
+    Same fail-safe shape as :func:`load_remote_build_settings`:
+    a non-dict ``_remote_build`` value lands on
+    ``enabled=False`` rather than the model default ``True``.
+    Mutating the yielded settings inside the block replaces the
+    corrupt blob with the new canonical state on commit.
+    """
     metadata_path = tmp_path / ".device-builder.json"
     metadata_path.write_bytes(b'{"_remote_build": [1, 2, 3]}')
 
     with remote_build_settings_transaction(tmp_path) as settings:
-        # Yielded value is the defaults; any mutation persists as
-        # the new canonical state, replacing the corrupt blob.
-        assert settings == RemoteBuildSettings()
+        # Yielded value is the fail-safe shape; any mutation
+        # persists as the new canonical state, replacing the
+        # corrupt blob.
+        assert settings.enabled is False
         settings.enabled = True
 
     assert load_remote_build_settings(tmp_path) == RemoteBuildSettings(enabled=True)

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -43,6 +43,7 @@ from esphome_device_builder.controllers.config import (
     delete_label_cascade,
     get_device_ip,
     get_device_metadata,
+    has_remote_build_settings_persisted,
     labels_transaction,
     load_labels,
     load_preferences,
@@ -396,8 +397,17 @@ def test_load_preferences_returns_defaults_on_bad_data(tmp_path: Path) -> None:
 
 
 def test_load_remote_build_settings_returns_defaults_on_missing(tmp_path: Path) -> None:
-    """Fresh config dir → ``RemoteBuildSettings()`` with ``enabled=False``."""
+    """Fresh config dir → ``RemoteBuildSettings()`` with ``enabled=True``.
+
+    Default-on so fresh installs are discoverable + pairable
+    without an extra operator step. The HA-addon path overrides
+    this at the bind site via
+    :func:`has_remote_build_settings_persisted` rather than at
+    load time, so the load function returns the same shape
+    regardless of deployment mode.
+    """
     assert load_remote_build_settings(tmp_path) == RemoteBuildSettings()
+    assert load_remote_build_settings(tmp_path).enabled is True
 
 
 def test_load_remote_build_settings_returns_defaults_on_bad_data(
@@ -426,6 +436,51 @@ def test_save_remote_build_settings_round_trip(tmp_path: Path) -> None:
     settings = RemoteBuildSettings(enabled=True)
     save_remote_build_settings(tmp_path, settings)
     assert load_remote_build_settings(tmp_path) == settings
+
+
+def test_has_remote_build_settings_persisted_false_on_fresh_install(tmp_path: Path) -> None:
+    """No metadata file → operator has not opted in via the toggle."""
+    assert has_remote_build_settings_persisted(tmp_path) is False
+
+
+def test_has_remote_build_settings_persisted_false_when_other_keys_set(tmp_path: Path) -> None:
+    """A metadata file with unrelated keys is still ``False`` (no toggle write)."""
+    (tmp_path / ".device-builder.json").write_bytes(b'{"some_other_key": {}}')
+    assert has_remote_build_settings_persisted(tmp_path) is False
+
+
+def test_has_remote_build_settings_persisted_true_after_save(tmp_path: Path) -> None:
+    """``save_remote_build_settings`` flips the persistence signal to ``True``.
+
+    Pins the load-bearing contract the HA-addon bind gate
+    depends on:
+    :meth:`device_builder.DeviceBuilder._maybe_start_remote_build_site`
+    skips the bind on HA addon UNTIL this returns ``True``,
+    which only happens after ``set_settings`` writes a
+    ``_remote_build`` block. Even a write that lands on the
+    dataclass defaults still flips the signal -- the existence
+    of the block is the "operator opted in" marker, not its
+    contents.
+    """
+    save_remote_build_settings(tmp_path, RemoteBuildSettings(enabled=True))
+    assert has_remote_build_settings_persisted(tmp_path) is True
+
+
+def test_has_remote_build_settings_persisted_true_for_explicit_disable(tmp_path: Path) -> None:
+    """An operator who explicitly disabled the toggle still counts as "opted in".
+
+    Once the operator interacts with the toggle (in either
+    direction) the persistence signal flips to True. That's the
+    right shape for the HA-addon gate: the operator has shown
+    they know the feature exists and made a deliberate choice
+    -- subsequent boots should respect their choice without
+    re-asking. (The bind site then also reads
+    ``RemoteBuildSettings.enabled`` and skips the bind because
+    that's still False; the gate only suppresses the
+    fresh-install default-on path.)
+    """
+    save_remote_build_settings(tmp_path, RemoteBuildSettings(enabled=False))
+    assert has_remote_build_settings_persisted(tmp_path) is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -923,6 +923,16 @@ async def test_device_builder_constructs_advertiser_when_zeroconf_present(
             self.register = AsyncMock()
             self.registered = False
             self.unregister = AsyncMock()
+            # With the default-on remote-build setting,
+            # ``db.start()`` now binds the peer-link site and
+            # then pushes pin + port into the advertiser via
+            # ``_publish_remote_build_advertise``. Stub the
+            # setter calls so the test can keep asserting on
+            # advertiser-construction without the bind path
+            # raising on a missing attribute.
+            self.set_pin_sha256 = MagicMock()
+            self.set_remote_build_port = MagicMock()
+            self.refresh = AsyncMock()
             instances.append(self)
 
     monkeypatch.setattr(db_module, "DashboardAdvertiser", _FakeAdvertiser)
@@ -931,6 +941,10 @@ async def test_device_builder_constructs_advertiser_when_zeroconf_present(
     settings = make_settings(with_core_path=True)
     settings.on_ha_addon = False
     settings.port = 6052
+    # Use an ephemeral peer-link port so the now-default-on bind
+    # doesn't collide with whatever's actually listening on the
+    # configured default port on the test host.
+    settings.remote_build_port = 0
     db = DeviceBuilder(settings)
     # Seed ``adv`` to ``None`` so the ``finally`` block can guard
     # against a failure in ``db.start()`` that would otherwise leave

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1193,10 +1193,18 @@ def test_hosts_snapshot_empty_when_no_peers(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_get_settings_defaults_when_unset(tmp_path: Path) -> None:
-    """A fresh dashboard with no metadata returns ``enabled=False``."""
+    """A fresh dashboard with no metadata returns ``enabled=True``.
+
+    Default-on for non-HA-addon deployments: a fresh sidecar
+    deserialises to ``RemoteBuildSettings(enabled=True)`` and the
+    bind site treats that as opt-in by default. The HA-addon path
+    overrides at the bind site (see
+    :func:`has_remote_build_settings_persisted`); the settings
+    surface returns the same shape regardless of deployment mode.
+    """
     controller = _make_controller(config_dir=tmp_path)
     settings = await controller.get_settings()
-    assert settings == RemoteBuildSettingsView(enabled=False)
+    assert settings == RemoteBuildSettingsView(enabled=True)
 
 
 @pytest.mark.asyncio
@@ -1223,9 +1231,12 @@ async def test_set_settings_rejects_non_bool(tmp_path: Path) -> None:
     with pytest.raises(CommandError) as exc:
         await controller.set_settings(enabled="false")  # type: ignore[arg-type]
     assert exc.value.code == ErrorCode.INVALID_ARGS
-    # No write happened — disk still at default.
+    # No write happened — disk still at model default (``enabled=True``).
+    # The point of the assertion is "the write was rejected", not the
+    # specific default value; the read confirms the rejection path
+    # didn't leak partial state.
     settings = await controller.get_settings()
-    assert settings.enabled is False
+    assert settings.enabled is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_listener.py
+++ b/tests/test_remote_build_listener.py
@@ -42,24 +42,67 @@ from esphome_device_builder.helpers.event_bus import EventBus
 
 
 @pytest.mark.asyncio
-async def test_maybe_start_remote_build_site_skips_when_disabled(tmp_path: Path) -> None:
+async def test_maybe_start_remote_build_site_skips_when_explicitly_disabled(
+    tmp_path: Path,
+) -> None:
     """
-    Default-off: ``_maybe_start_remote_build_site`` early-returns when ``enabled=False``.
+    Operator-disabled: ``_maybe_start_remote_build_site`` early-returns when ``enabled=False``.
 
-    Pins the gate at the lifecycle hook, not just at the
-    settings layer — a refactor that bound the listener
-    unconditionally (or read the wrong field) would fail here
-    even if ``RemoteBuildSettings.enabled`` still defaulted to
-    ``False``.
+    Persist ``enabled=False`` via the settings sidecar so the
+    operator's explicit-disable choice is what's under test, not
+    the model default (which is ``True``). Pins the gate at the
+    lifecycle hook, not just at the settings layer — a refactor
+    that bound the listener unconditionally (or read the wrong
+    field) would fail here.
     """
+    loop = asyncio.get_running_loop()
+
+    def _disable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = False
+
+    await loop.run_in_executor(None, _disable)
+
     settings = DashboardSettings(config_dir=tmp_path)
     db = DeviceBuilder(settings)
-    db.loop = asyncio.get_running_loop()
+    db.loop = loop
     db.remote_build = MagicMock()
     db.remote_build._db.settings.config_dir = tmp_path
 
     await db._maybe_start_remote_build_site()
     assert db._remote_build_runner is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_binds_by_default_on_fresh_install(
+    tmp_path: Path,
+) -> None:
+    """
+    Fresh install (no ``_remote_build`` block in metadata) binds by default.
+
+    Default-on for non-HA-addon deployments: the model default
+    ``RemoteBuildSettings.enabled = True`` carries through the
+    load path so a fresh sidecar with no ``_remote_build`` key
+    still ends up with the listener bound. The privilege gate
+    is the receiver-side pair-approval dialog, not the bind
+    address. Pins the new default so a regression that
+    re-introduced ``enabled: bool = False`` would fail here.
+    """
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0  # ephemeral so the bind doesn't collide
+    db = DeviceBuilder(settings)
+    db.loop = asyncio.get_running_loop()
+    db.remote_build = MagicMock()
+    db.remote_build._db.settings.config_dir = tmp_path
+    db._publish_remote_build_advertise = AsyncMock()
+
+    try:
+        await db._maybe_start_remote_build_site()
+        assert db._remote_build_runner is not None
+    finally:
+        if db._remote_build_runner is not None:
+            await db._remote_build_runner.cleanup()
 
 
 @pytest.mark.asyncio
@@ -262,11 +305,45 @@ async def test_maybe_start_remote_build_site_advertises_actual_port_for_ephemera
 
 
 @pytest.mark.asyncio
-async def test_maybe_start_remote_build_site_warns_on_ha_addon(
+async def test_maybe_start_remote_build_site_skips_ha_addon_without_persisted_opt_in(
     tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """HA-addon mode logs a warning when the listener binds."""
+    """
+    HA addon + no persisted ``_remote_build`` block → skip the bind.
+
+    The addon's docker container doesn't expose port 6055 to the
+    LAN by default, and the mDNS advertise is already skipped on
+    HA addon, so binding by default would burn the port without
+    making the feature reachable. Skip until the operator
+    explicitly opts in via the Settings toggle.
+    """
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0
+    settings.on_ha_addon = True  # the branch under test
+    db = DeviceBuilder(settings)
+    db.loop = asyncio.get_running_loop()
+    db.remote_build = MagicMock()
+    db.remote_build._db.settings.config_dir = tmp_path
+
+    await db._maybe_start_remote_build_site()
+    assert db._remote_build_runner is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_binds_ha_addon_after_explicit_opt_in(
+    tmp_path: Path,
+) -> None:
+    """
+    HA addon + persisted ``enabled=True`` → bind (operator override).
+
+    Some legacy-dashboard operators historically added the
+    receiver port to their addon's ``ports:`` config to expose
+    it. Once they flip the toggle in Settings (which persists
+    ``_remote_build``), the bind site respects that explicit
+    opt-in exactly like every other deployment mode — no
+    deployment-mode short-circuit at this point.
+    """
     loop = asyncio.get_running_loop()
 
     def _enable() -> None:
@@ -278,21 +355,55 @@ async def test_maybe_start_remote_build_site_warns_on_ha_addon(
     settings = DashboardSettings(config_dir=tmp_path)
     settings.host = "127.0.0.1"
     settings.remote_build_port = 0
-    settings.on_ha_addon = True  # the branch under test
+    settings.on_ha_addon = True
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build = MagicMock()
+    db.remote_build._db.settings.config_dir = tmp_path
+    db._publish_remote_build_advertise = AsyncMock()
+
+    try:
+        await db._maybe_start_remote_build_site()
+        assert db._remote_build_runner is not None
+    finally:
+        if db._remote_build_runner is not None:
+            await db._remote_build_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_respects_ha_addon_explicit_disable(
+    tmp_path: Path,
+) -> None:
+    """
+    HA addon + persisted ``enabled=False`` → skip (operator explicit-off).
+
+    An operator who explicitly disabled the toggle on HA addon
+    triggers the second gate (``rb_settings.enabled`` check),
+    not the first (HA-addon "no persisted block") -- because
+    persisting any value flips the persistence signal to ``True``.
+    Pins that the gate composition is correct: HA-addon shortcut
+    only suppresses the *fresh-install default-on* path, never
+    overrides an explicit operator choice.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _disable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = False
+
+    await loop.run_in_executor(None, _disable)
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.host = "127.0.0.1"
+    settings.remote_build_port = 0
+    settings.on_ha_addon = True
     db = DeviceBuilder(settings)
     db.loop = loop
     db.remote_build = MagicMock()
     db.remote_build._db.settings.config_dir = tmp_path
 
-    with caplog.at_level("WARNING", logger="esphome_device_builder.device_builder"):
-        try:
-            await db._maybe_start_remote_build_site()
-            assert db._remote_build_runner is not None
-        finally:
-            if db._remote_build_runner is not None:
-                await db._remote_build_runner.cleanup()
-    warnings = [r for r in caplog.records if "HA addon" in r.getMessage()]
-    assert warnings, "expected an HA-addon warning"
+    await db._maybe_start_remote_build_site()
+    assert db._remote_build_runner is None
 
 
 @pytest.mark.asyncio
@@ -525,9 +636,21 @@ async def test_apply_remote_build_enabled_tears_down_when_disk_says_false(
     tmp_path: Path,
 ) -> None:
     """Convergence: disk ``enabled=False`` + listener bound → teardown + advertiser clear."""
+    loop = asyncio.get_running_loop()
+
+    # Persist an explicit ``enabled=False`` so the test exercises
+    # the disabled-on-disk path. With the new default-on model
+    # value an empty sidecar would load as ``enabled=True`` and
+    # this test would no longer cover its named contract.
+    def _disable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = False
+
+    await loop.run_in_executor(None, _disable)
+
     settings = DashboardSettings(config_dir=tmp_path)
     db = DeviceBuilder(settings)
-    db.loop = asyncio.get_running_loop()
+    db.loop = loop
 
     advertiser = MagicMock()
     advertiser.refresh = AsyncMock()


### PR DESCRIPTION
# What does this implement/fix?

## BLUF

**The desktop app is the intended build server.** The
powerful Mac / Windows machine with the full PlatformIO
toolchain, RAM for parallel compiles, and SSD for the build
cache. The whole reason that app exists is for HA-addon and
other dashboards to **offload** their compile jobs to it
over the LAN.

**This PR flips the receiver-side feature to default-on for
non-HA-addon deployments** so the desktop app, the moment
it launches, is ready to be the build target. Fresh installs
are LAN-discoverable AND pairable without an extra operator
step. Operators who explicitly want their desktop NOT to
serve as a receiver flip the toggle off.

**The privilege gate is the receiver-side pair-approval
dialog.** An unpaired peer can connect to the TCP port; Noise
XX fails without a matching pubkey; a pair request lands as a
modal the operator on this dashboard has to click "Approve"
on before any privileges are granted. Binding the port alone
does not grant code execution.

**Honest about residual risk.** Default-on still opens a port
that wasn't open before, and "open port + binary protocol
parser" is a non-zero attack surface:

- A vulnerability in our Noise XX handshake / framing /
  pair-flow state machine *could* let a malicious LAN
  peer get further than handshake-fail.
- Resource consumption: unauthenticated peers can repeatedly
  initiate handshakes, costing CPU / memory.
- Pair-modal bypass / race would let a peer pair without
  visible operator approval.

We've audited these paths hard (pairing flow, frame parser,
state-machine transitions) and the trade-off favors default-on:
the mDNS advertise was already always-on for non-HA-addon
deployments (so peers could *see* this dashboard exists),
and refusing the connection peers were trying to make was a
worse UX without eliminating the discoverability surface.
The audited residual risk is "real but small"; the UX win
(zero-config peer discovery + pairing) is concrete.

**HA addon: still default-off, still operator-overridable.**
The addon's docker container doesn't expose port 6055 to
the LAN by default. A fresh addon install does NOT bind.
HA-addon operators who DO want remote-build (e.g. they
exposed the port via the addon's `ports:` config, as some
legacy-dashboard operators historically did) still flip
the toggle in Settings; the bind site respects that
explicit opt-in exactly like every other deployment mode.

## Gate composition

| Deployment | `_remote_build` block persisted? | `enabled` value | Bind? |
|---|---|---|---|
| Non-HA-addon | (any) | `True` (default or explicit) | **Yes** |
| Non-HA-addon | (any) | `False` (explicit) | No |
| HA addon | No (fresh install) | (default `True`) | **No** |
| HA addon | Yes | `True` | **Yes** |
| HA addon | Yes | `False` (explicit) | No |

The "persisted" signal flips to `True` the moment
`set_settings` writes the block (regardless of value) -- so
once an HA-addon operator interacts with the toggle in
either direction, subsequent boots respect their choice.

## Implementation

- `models/remote_build.py`: `enabled: bool = True` on both
  `RemoteBuildSettings` (storage shape) and the matching
  `RemoteBuildSettingsView` (wire shape). Docstring covers
  the HA-addon override semantics and references the bind
  site.
- `controllers/config.py`: new `has_remote_build_settings_persisted`
  helper that returns `True` iff `_remote_build` exists in
  metadata. Distinguishes "fresh install, never touched the
  toggle" from "operator deliberately set a value, even if
  it matches the dataclass default" -- the load-bearing
  signal for the HA-addon gate.
- `device_builder.py`: `_maybe_start_remote_build_site`
  checks `settings.on_ha_addon` AND
  `has_remote_build_settings_persisted`; skips only on the
  fresh-addon-install path. Existing `rb_settings.enabled`
  check still runs after the gate so an explicit-off
  operator choice is respected on every deployment mode.
  Removed the stale post-bind HA-addon WARNING and pinned
  the log line to `settings.remote_build_host` (catches up
  a stale reference from before #590).

## Tests

- `test_config_controller.py`: pins the model-default flip
  plus four new tests covering
  `has_remote_build_settings_persisted` across fresh /
  other-key-only / save-with-True / save-with-False
  inputs.
- `test_remote_build_controller.py`:
  `test_get_settings_defaults_when_unset` retargeted to
  `enabled=True`.
- `test_remote_build_listener.py`: persists `enabled=False`
  explicitly where tests previously relied on the model
  default. New tests pin: default-on bind on fresh
  non-HA-addon install; HA-addon-without-opt-in skips;
  HA-addon-after-opt-in binds; HA-addon-explicit-disable
  skips.
- `test_dashboard_advertise.py`: stubbed setter methods on
  the `_FakeAdvertiser` so the now-default-on bind path
  doesn't fail on missing attrs; pinned ephemeral port.

3030 tests pass; 26 skipped (unchanged).

**Related issue or feature (if applicable):**

- Follow-up to #590 (peer-link bind address). #590 fixed
  WHERE the receiver binds when active; this PR addresses
  WHEN it's active by default.
- Issue #106 (the remote-build feature itself).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD>

The toggle copy on the frontend currently reads "Enable
remote build / only enable for dashboards you already
trust at a shell level" -- written assuming default-off.
With default-on, the warning belongs on the **pair-approval
dialog** ("Approving this pair grants the peer the ability
to run code on this host"), and the toggle copy should
flip to "Allow other dashboards to send firmware compile
jobs to this dashboard" or similar opt-out phrasing. Will
file the companion frontend PR after this lands.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

