### PR TITLE
DNM: Log upload-subprocess output + JOB_PROGRESS fires for progress-bar debugging

### DIFF
--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -338,6 +338,7 @@ def _fire_job_progress(job: FirmwareJob, bus: EventBus, progress: int) -> None:
     where it's readable.
     """
     job.progress = progress
+    _LOGGER.info("[PROGRESS-DEBUG] fire JOB_PROGRESS job_id=%s progress=%s", job.job_id, progress)
     payload: JobProgressData = {"job_id": job.job_id, "progress": progress}
     bus.fire(EventType.JOB_PROGRESS, payload)
 
@@ -379,6 +380,20 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
     bus.fire(EventType.JOB_OUTPUT, out_payload)
     progress = _parse_progress(line)
-    if progress is None or progress <= (job.progress or 0):
+    if progress is None:
         return
+    if progress <= (job.progress or 0):
+        _LOGGER.info(
+            "[PROGRESS-DEBUG] clamped parsed=%s current=%s line=%r",
+            progress,
+            job.progress,
+            line[:200],
+        )
+        return
+    _LOGGER.info(
+        "[PROGRESS-DEBUG] parsed progress=%s (was %s) line=%r",
+        progress,
+        job.progress,
+        line[:200],
+    )
     _fire_job_progress(job, bus, progress)

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -374,18 +374,18 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     ``failed`` status from the receiver instead of having to
     scrape stderr).
     """
+    # DNM: log EVERY line that flows into _ingest_output_line.
+    # Noisy by design — receiver-side compile is ~thousands of
+    # lines per job — but the user explicitly asked for the
+    # full byte stream rather than a filtered view, so we can
+    # see whether any upload-phase frames slip in via a path
+    # we didn't expect. Strip when the DNM is ripped out.
+    _LOGGER.info("[PROGRESS-DEBUG] ingest job_id=%s line=%r", job.job_id, line[:400])
     job.output.append(line)
     if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
         _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
     out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
     bus.fire(EventType.JOB_OUTPUT, out_payload)
-    # Unconditional log for any line containing upload-phase
-    # markers, whether or not _parse_progress matched. Lets a
-    # receiver-side log surface the full flash-phase byte
-    # stream without firehosing the (thousands of) compile
-    # lines. Strip when the DNM is ripped out.
-    if "Uploading" in line or "Writing at" in line or "Done..." in line:
-        _LOGGER.info("[PROGRESS-DEBUG] upload-marker job_id=%s line=%r", job.job_id, line[:300])
     progress = _parse_progress(line)
     if progress is None:
         return

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -379,6 +379,13 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
         _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
     out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
     bus.fire(EventType.JOB_OUTPUT, out_payload)
+    # Unconditional log for any line containing upload-phase
+    # markers, whether or not _parse_progress matched. Lets a
+    # receiver-side log surface the full flash-phase byte
+    # stream without firehosing the (thousands of) compile
+    # lines. Strip when the DNM is ripped out.
+    if "Uploading" in line or "Writing at" in line or "Done..." in line:
+        _LOGGER.info("[PROGRESS-DEBUG] upload-marker job_id=%s line=%r", job.job_id, line[:300])
     progress = _parse_progress(line)
     if progress is None:
         return

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -555,6 +555,7 @@ async def _fetch_and_run_local_upload(
     # Firing through :func:`_fire_job_progress` (no clamp)
     # rather than the ingest path keeps the reset explicit at
     # this phase boundary.
+    _LOGGER.info("[PROGRESS-DEBUG] seam reset entering upload phase for job_id=%s", job.job_id)
     _fire_job_progress(job, bus, 0)
 
     # ``tempfile.TemporaryDirectory`` ctor calls
@@ -633,6 +634,7 @@ async def _run_upload_subprocess(
     ``firmware/cancel`` lands SIGTERM on the upload chain
     just like it does for the local-only path.
     """
+    _LOGGER.info("[PROGRESS-DEBUG] upload subprocess spawning cmd=%s", " ".join(cmd))
     async with controller._tracked_subprocess(
         *cmd,
         stdout=asyncio.subprocess.PIPE,
@@ -651,10 +653,29 @@ async def _run_upload_subprocess(
             await controller._terminate_current_process()
 
         assert proc.stdout is not None  # type narrowing
+        line_count = 0
         async for line in iter_lines_with_progress(proc.stdout):
+            line_count += 1
+            # Log every yielded line from the upload subprocess
+            # so we can see the raw bytes (including ``\r``-only
+            # frames) that arrive on the pipe. ``%r`` preserves
+            # the carriage-return / newline characters so the
+            # frame boundary is unambiguous in the log.
+            _LOGGER.info(
+                "[PROGRESS-DEBUG] upload-line #%d job_id=%s line=%r",
+                line_count,
+                job.job_id,
+                line[:300],
+            )
             _ingest_output_line(job, bus, line)
 
         exit_code = await proc.wait()
+        _LOGGER.info(
+            "[PROGRESS-DEBUG] upload subprocess EOF job_id=%s exit=%s total_lines=%d",
+            job.job_id,
+            exit_code,
+            line_count,
+        )
 
     if job.job_id in controller._cancel_requested:
         controller._finalize_cancelled(job)


### PR DESCRIPTION
# What does this implement/fix?

**DO NOT MERGE — diagnostic logging only.**

Adds temporary `[PROGRESS-DEBUG]` `_LOGGER.info` lines to investigate why the firmware-tasks progress bar doesn't animate during the local upload phase of a REMOTE install, despite the seam reset that landed in #580.

The hypothesis being tested: does the local `esphome upload --file <staged>` subprocess actually emit `espota2.ProgressBar`'s `\rUploading: [...] NN%` frames on its stdout pipe? Code inspection says yes — `perform_ota` unconditionally calls `ProgressBar.update` on every 8 KB chunk — but the observed log on the offloader side shows only `INFO Uploading <path>` and no progress frames at all.

Log lines added:

- `helpers._fire_job_progress` — logs every `JOB_PROGRESS` fire (`job_id`, `progress`)
- `helpers._ingest_output_line` — logs every parsed percent: whether it advanced the gauge or got clamped, with the source line (truncated to 200 chars via `%r` so `\r`/`\n` are visible)
- `remote_runner._fetch_and_run_local_upload` — logs the seam reset entry
- `remote_runner._run_upload_subprocess` — logs the subprocess spawn (cmd), every line yielded from the upload subprocess (with `%r` so frame boundaries are unambiguous), plus EOF + exit code + total line count

How to use:

1. `gh pr checkout` this branch on the offloader build server.
2. Restart the dashboard.
3. Trigger a REMOTE install whose progress bar would otherwise look frozen.
4. Grep the dashboard logs for `[PROGRESS-DEBUG]` and share the lines from `upload subprocess spawning` to `upload subprocess EOF`.

The result tells us:

- If we see `upload-line` entries with `\r`-prefixed `Uploading: NN%` content but no matching `parsed progress=` / `fire JOB_PROGRESS` → the parse path is dropping them (parser bug).
- If we see no `upload-line` entries between `spawning` and `EOF` → the subprocess's stdout pipe truly doesn't carry the ProgressBar frames (upstream `esphome` issue, not ours).
- If we see `fire JOB_PROGRESS` fires advancing 0→100 → the backend is correct and the bug is in the frontend's rendering of the upload phase.

**Related issue or feature (if applicable):**

- diagnostic for #580 followup; do not merge

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
