### PR TITLE
Log a synthetic 'receiver lost connection' line on mid-build session loss

### DIFF
--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -403,10 +403,32 @@ async def _await_terminal(
                 # visible in the dialog's main scroll buffer
                 # without requiring the user to read the (often
                 # truncated) red error toast.
+                #
+                # ``reason`` covers more than just transport drops:
+                # ``transport_error`` is a network cut, but the
+                # receiver can also push ``server_shutting_down``
+                # (graceful restart), ``superseded`` (a fresh
+                # session displaced this one), ``pin_mismatch`` /
+                # ``peer_revoked`` (security), and the offloader
+                # itself can close with ``client_stopped``. Use
+                # "session closed" as the umbrella wording and
+                # let the embedded ``text`` carry the specific
+                # cause, instead of falsely framing every close
+                # as a connection loss.
+                #
+                # Leading-newline avoidance: only insert a
+                # separator newline when the previous buffered
+                # output line doesn't already end with one. The
+                # receiver-side compile streams ``\n``-terminated
+                # lines, so the common case skips the prefix and
+                # the synthetic line lands flush against the
+                # last compile output rather than adding a blank
+                # line.
+                prefix = "" if job.output and job.output[-1].endswith(("\n", "\r")) else "\n"
                 _ingest_output_line(
                     job,
                     controller.bus,
-                    f"\n*** remote build server lost connection ({text}); "
+                    f"{prefix}*** remote build session closed ({text}); "
                     "the build was aborted ***\n",
                 )
                 _fail_locally(

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -393,6 +393,22 @@ async def _await_terminal(
                 reason = closed["reason"]
                 detail = closed["error_detail"]
                 text = f"{reason}: {detail}" if detail else reason
+                # Push a synthetic output line BEFORE firing
+                # JOB_FAILED so the live log stream ends with a
+                # clear explanation of what cut the build off,
+                # not the half-rendered compile line the receiver
+                # had streamed before the link dropped.
+                # ``job.error`` carries the same text for the
+                # error banner; the log line makes the cause
+                # visible in the dialog's main scroll buffer
+                # without requiring the user to read the (often
+                # truncated) red error toast.
+                _ingest_output_line(
+                    job,
+                    controller.bus,
+                    f"\n*** remote build server lost connection ({text}); "
+                    "the build was aborted ***\n",
+                )
                 _fail_locally(
                     controller,
                     job,

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -906,17 +906,58 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
     # A synthetic output line names the cause in the live log
     # stream too so the install dialog's main scroll buffer
-    # ends with a clear "build server lost connection" message
-    # right above the red "Install failed." banner — without it,
-    # the operator sees the last (half-rendered) compile line
-    # and no indication that the receiver dropped.
+    # ends with a clear "session closed" message right above the
+    # red "Install failed." banner. Without it, the operator
+    # sees the last (half-rendered) compile line and no
+    # indication that the receiver dropped. Wording is umbrella
+    # ("session closed") because the same code path covers
+    # transport_error, server_shutting_down, superseded,
+    # pin_mismatch / peer_revoked, and client_stopped — calling
+    # all of them "lost connection" would mislead operators
+    # about the cause.
     output_lines = [data["line"] for data in captured[EventType.JOB_OUTPUT]]
     assert any(
-        "remote build server lost connection" in line
+        "remote build session closed" in line
         and "transport_error" in line
         and "build was aborted" in line
         for line in output_lines
     ), output_lines
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_session_lost_synthetic_line_skips_leading_newline(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    r"""
+    Synthetic line skips its leading newline when prior output already ends with one.
+
+    The receiver-side compile streams ``\n``-terminated lines via the
+    fan-out, so the common case has ``job.output[-1]`` already ending
+    in ``\n``. A blanket leading ``\n`` on the synthetic line would
+    add a visible empty row between the last compile line and the
+    "session closed" message.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
+    await _wait_until_dispatched(client)
+    # Seed an output line so the synthetic line's leading-newline
+    # heuristic has a previous line to test against.
+    _fire_output(controller, job_id=job.job_id, line="Compiling main.cpp\n")
+    _fire_session_closed(controller, reason="server_shutting_down")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    output_lines = [data["line"] for data in captured[EventType.JOB_OUTPUT]]
+    synthetic = next(line for line in output_lines if "remote build session closed" in line)
+    # No leading newline because the previous line already
+    # ended with one.
+    assert not synthetic.startswith("\n"), repr(synthetic)
+    assert "server_shutting_down" in synthetic
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -904,6 +904,19 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     assert "transport_error" in job.error
     assert "ConnectionResetError" in job.error
     assert len(captured[EventType.JOB_FAILED]) == 1
+    # A synthetic output line names the cause in the live log
+    # stream too so the install dialog's main scroll buffer
+    # ends with a clear "build server lost connection" message
+    # right above the red "Install failed." banner — without it,
+    # the operator sees the last (half-rendered) compile line
+    # and no indication that the receiver dropped.
+    output_lines = [data["line"] for data in captured[EventType.JOB_OUTPUT]]
+    assert any(
+        "remote build server lost connection" in line
+        and "transport_error" in line
+        and "build was aborted" in line
+        for line in output_lines
+    ), output_lines
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

When the remote build server restarts in the middle of a build, the offloader's install dialog renders confusingly:

```
Compiling .pioenvs/apollo-pump-1-5d9bdc/esp_system/int_wdt.c.o
[red banner] Install failed.

It looks like you're having trouble with your build. Try cleaning the build
files for this device first; if that doesn't help, try resetting the build
environment.
```

The hint is wrong — neither cleaning the build files nor resetting the build environment fixes a receiver-restart. The operator can't tell from the screenshot that the cause was the receiver dropping; the half-rendered compile line just trails off.

## What the backend already knows

`remote_runner._await_terminal` already handles the receiver-restart case via the `OFFLOADER_PEER_LINK_CLOSED` → `session_lost` path. It finalises the job FAILED with a clear `job.error`:

```
remote build: peer-link session lost (transport_error: ConnectionResetError: ...)
```

But `job.error` only surfaces in the firmware-tasks dialog's error toast — it's not in the live log scroll buffer where the user is staring at the cut-off compile.

## Fix

Push a synthetic `JOB_OUTPUT` line just before `_fail_locally` in the session-lost branch so the log itself ends with the cause:

```
Compiling .pioenvs/apollo-pump-1-5d9bdc/esp_system/int_wdt.c.o
*** remote build server lost connection (transport_error: ConnectionResetError: ...);
    the build was aborted ***
[red banner] Install failed.
```

Operator immediately sees the cause without decoding the error toast or correlating against the receiver's logs.

5-line code change in `remote_runner.py`; routes through the existing `_ingest_output_line` helper so the synthetic line is captured in `job.output` for follower replay AND fired as `JOB_OUTPUT` for live followers.

## What this PR does *not* do

Two related follow-ups worth their own PRs, intentionally out of scope here:

1. **Frontend session-lost classification** — the install dialog could detect this failure mode by inspecting the error string and render a hint like "the build server lost connection; try again" instead of the generic clean/reset staircase. Backend change required: include `error` in `firmware/follow_job`'s RESULT payload. Coordinated frontend renderer.

2. **`SubmitJobSessionLostError` pre-ack path** — when the session drops *before* the receiver acks the submit, no compile output has streamed yet so the synthetic-output-line trick adds less value; the existing `"remote build: dispatch failed: SubmitJobSessionLostError: ..."` error text is already specific.

## Testing

* `pytest tests/ -q` → 3072 passed (test extension on the existing session-lost test asserts the synthetic line landed in the captured JOB_OUTPUT stream).
* The new line is captured by both `job.output` (for snapshot-replay on reconnect) and `JOB_OUTPUT` (for live followers), matching every other output-line semantic in the runner.

**Related issue or feature (if applicable):**

- Issue #106 — remote-build offload UX polish.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature
- [ ] Enhancement to an existing feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation only
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

The synthetic line shows up in the existing log buffer the dialog already renders; no new wire fields or frontend changes.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass.
- [x] Tests have been added.
- [x] `components.json` has not been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
