### PR TITLE
Carry job.error through firmware/follow_job's RESULT payload

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -616,6 +616,7 @@ class FirmwareController:
         is_terminal = job.status in TERMINAL_JOB_STATUSES
         terminal_status = job.status.value if is_terminal else ""
         terminal_exit_code = job.exit_code
+        terminal_error = job.error if is_terminal else None
 
         async def _send_initial(controls: StreamControls) -> None:
             for line in snapshot:
@@ -624,7 +625,24 @@ class FirmwareController:
                 await client.send_event(
                     message_id,
                     StreamEvent.RESULT,
-                    {"status": terminal_status, "exit_code": terminal_exit_code},
+                    {
+                        "status": terminal_status,
+                        "exit_code": terminal_exit_code,
+                        # ``error`` carries the human-readable
+                        # failure reason :func:`_fail_locally` /
+                        # ``_finalize_terminal`` stamped on the job
+                        # (e.g. ``"remote build: peer-link session
+                        # lost (transport_error: ...)"``). The
+                        # frontend install dialog surfaces this in
+                        # its red error banner; without the field
+                        # the banner falls back to a generic
+                        # "Install failed." that misattributes a
+                        # receiver-restart to a broken build env.
+                        # ``None`` for successful jobs and for
+                        # jobs from before the field was set;
+                        # frontend treats both equivalently.
+                        "error": terminal_error,
+                    },
                 )
                 # No live drain — already-terminal job has nothing
                 # more to deliver; end the stream so the helper
@@ -645,6 +663,7 @@ class FirmwareController:
                         {
                             "status": status_val,
                             "exit_code": getattr(ev_job, "exit_code", None),
+                            "error": getattr(ev_job, "error", None),
                         },
                     )
                     controls.end()

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -64,7 +64,7 @@ async def test_terminal_job_replays_full_history_and_returns(
     result_events = [(StreamEvent.RESULT, d) for d in client.events_for(StreamEvent.RESULT)]
     assert [d for _e, d in output_events] == ["line a\n", "line b\n", "line c\n"]
     assert len(result_events) == 1
-    assert result_events[0][1] == {"status": "completed", "exit_code": 0}
+    assert result_events[0][1] == {"status": "completed", "exit_code": 0, "error": None}
 
 
 async def test_history_lines_arrive_before_live_lines_in_order(
@@ -383,3 +383,82 @@ async def test_cancelled_terminal_event_returns_with_status(
     assert output_lines == ["pre-cancel\n"]
     assert len(result_events) == 1
     assert result_events[0]["status"] == "cancelled"
+
+
+async def test_failed_terminal_event_carries_job_error_text(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """``JOB_FAILED`` RESULT payload carries the human-readable ``error``.
+
+    The install dialog's red error banner falls back to a generic
+    "Install failed." copy when no specific text is available; without
+    the ``error`` field on the wire it can't distinguish a C++ build
+    failure (where clean / reset is the right hint) from a session-lost
+    failure (where neither helps and the operator just needs to retry).
+    Pin the wire shape so a future refactor that drops the field
+    surfaces here.
+    """
+    job = FirmwareJob(
+        job_id="abc",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.RUNNING,
+        output=["compiling main.cpp\n"],
+    )
+    controller = _make_controller_with_job(firmware_controller_factory, job)
+    client = FakeWebSocketClient(yield_per_event=True)
+    bus = controller._db.bus
+
+    async def follower() -> None:
+        await controller.follow_job(job_id="abc", client=client, message_id="m1")
+
+    follow_task = asyncio.create_task(follower())
+    await asyncio.sleep(0)
+
+    job.status = JobStatus.FAILED
+    job.error = "remote build: peer-link session lost (transport_error: …)"
+    job.exit_code = None
+    bus.fire(EventType.JOB_FAILED, {"job": job})
+
+    await asyncio.wait_for(follow_task, timeout=2.0)
+
+    result_events = client.events_for(StreamEvent.RESULT)
+    assert len(result_events) == 1
+    assert result_events[0] == {
+        "status": "failed",
+        "exit_code": None,
+        "error": "remote build: peer-link session lost (transport_error: …)",
+    }
+
+
+async def test_send_initial_replays_error_for_already_terminal_failed_job(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """A follower that connects after the job already failed reads the error.
+
+    Covers the ``_send_initial`` branch that fires when ``follow_job``
+    is called on a job whose terminal-event already landed before the
+    subscription. The replay must include ``error`` so the late
+    follower's banner still gets the specific failure text.
+    """
+    job = FirmwareJob(
+        job_id="abc",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.FAILED,
+        output=["compile error: …\n"],
+        exit_code=1,
+        error="Process exited 1",
+    )
+    controller = _make_controller_with_job(firmware_controller_factory, job)
+    client = FakeWebSocketClient(yield_per_event=True)
+
+    await controller.follow_job(job_id="abc", client=client, message_id="m1")
+
+    result_events = client.events_for(StreamEvent.RESULT)
+    assert len(result_events) == 1
+    assert result_events[0] == {
+        "status": "failed",
+        "exit_code": 1,
+        "error": "Process exited 1",
+    }


### PR DESCRIPTION
# What does this implement/fix?

Wire-shape preparation for surfacing the specific failure reason in the install dialog's red error banner.

Today the banner renders specific text for chip_mismatch / flash_failed / no_flashable_binary / download_failed, but the compile-failed branch always falls back to a generic "Install failed." copy because `firmware/follow_job`'s RESULT payload only carries `status` + `exit_code`. `job.error` (set by `_fail_locally` / `_finalize_terminal`) never reaches the wire.

A receiver-restart mid-build is the user-visible motivator: the backend already finalises with the actionable text

```
remote build: peer-link session lost (transport_error: …)
```

but the operator can't see it in the dialog. Without `error` on the wire, the frontend also can't distinguish a C++ build failure (where the clean / reset hint is the right advice) from a session-lost failure (where neither helps).

## What lands

* **`controllers/firmware/controller.py`** — `firmware/follow_job`'s RESULT dispatch carries `error` in two places:
  - The live JOB_FAILED / JOB_COMPLETED / JOB_CANCELLED handler (`_handle_event`'s `controls.push_priority` branch).
  - The replay path for an already-terminal job that a late follower connects to (`_send_initial`).
* Wire shape is additive: `None` for successful jobs and any older job that didn't populate the field; older frontends silently ignore the extra key.
* **Tests**: two new tests in `test_follow_job_race.py` pin the field through both paths. The existing happy-path test updated to assert `error: None` on the completed row so a future regression on the field shape surfaces here.

## What this PR does *not* do

* **Frontend rendering** — coordinated frontend PR (separate) will read `error` off the resolved compile result and pass it into `_fail` so the banner shows the specific text. It'll also gate the misleading clean/reset hint when the error is a session-lost.
* **Synthetic log line for session-lost** — that's its own existing PR ([#596](https://github.com/esphome/device-builder/pull/596)) which adds a `*** remote build server lost connection ***` line right above the banner.

The three changes (synthetic log line, RESULT.error wire field, frontend rendering) compose into a clean end-to-end fix for the user's reported confusion.

## Testing

* `pytest tests/ -q` → 3074 passed, +2 new tests.

**Related issue or feature (if applicable):**

- User report about receiver-restart UX. Pairs with #596 and a follow-up frontend PR.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation only
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<TBD>

This PR is forward-safe to land on its own; the frontend renderer reads the new field when present and falls back to today's generic copy when missing.

## Checklist

- [x] Tested and works locally.
- [x] Pre-commit hooks pass.
- [x] Tests added.
- [x] `components.json` has not been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
