### PR TITLE
Exit cleanly when launching supervisor disappears (parent watchdog)

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -201,6 +201,22 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--exit-on-parent-changed",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Exit cleanly when the original parent process disappears "
+            "(reparented to init / launchd on Unix; parent handle "
+            "signalled on Windows). Auto-enabled when the dashboard is "
+            "spawned by the ESPHome Builder desktop app — detected via "
+            "the ``io.esphome.builder`` marker in ``sys.executable``. "
+            "Pass ``--no-exit-on-parent-changed`` to disable the "
+            "auto-engage, or ``--exit-on-parent-changed`` to force-enable "
+            "(useful when launching under a custom supervisor that wants "
+            "the same behaviour)."
+        ),
+    )
+    parser.add_argument(
         "--trusted-domains",
         default=None,
         help=(

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -119,10 +119,23 @@ class DashboardSettings:
     # operators who want to acknowledge the knob without
     # restricting hosts.
     trusted_domains: list[str] = field(default_factory=list)
+    # ``--exit-on-parent-changed`` tri-state.
+    #
+    # ``None`` = auto-engage on launcher signature (the ESPHome
+    # Builder desktop app's bundled Python — see
+    # :func:`helpers.parent_watchdog.should_engage`).
+    # ``True`` = force-on regardless of launcher.
+    # ``False`` = force-off regardless.
+    #
+    # Lives on the settings dataclass rather than as a flag the
+    # watchdog reads at import time so the test fixtures can
+    # exercise all three states without monkeypatching env vars.
+    exit_on_parent_changed: bool | None = None
 
     def parse_args(self, args: Any) -> None:
         """Parse CLI arguments into settings."""
         self.on_ha_addon = getattr(args, "ha_addon", False)
+        self.exit_on_parent_changed = getattr(args, "exit_on_parent_changed", None)
         # Env-var fallback uses ``ESPHOME_*`` rather than the legacy
         # dashboard's bare ``USERNAME`` / ``PASSWORD``: the bare names
         # collide with login-shell / Windows system vars (``$USERNAME``

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -49,6 +49,7 @@ from .helpers.auth import auth_middleware
 from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware
+from .helpers.parent_watchdog import should_engage, watch_parent_and_exit_on_death
 from .helpers.peer_link_identity import get_or_create_peer_link_identity
 from .helpers.subscriber_presence import SubscriberPresence
 from .models import EventType
@@ -389,6 +390,16 @@ class DeviceBuilder:
 
         # Start background polling
         self._bg_task = asyncio.create_task(self._run_background())
+
+        # Opt-in parent watchdog: when launched by a supervisor that
+        # might force-quit / crash (notably the ESPHome Builder
+        # desktop app), exit cleanly on parent disappearance so the
+        # listening port is released rather than leaked under
+        # launchd / a subreaper. ``should_engage`` honours the
+        # explicit ``--exit-on-parent-changed`` / ``--no-...`` flags
+        # and falls back to auto-detection via ``sys.executable``.
+        if should_engage(self.settings.exit_on_parent_changed):
+            self.create_background_task(watch_parent_and_exit_on_death())
 
         _LOGGER.info(
             "Device Builder ready — config dir: %s, %d commands registered",

--- a/esphome_device_builder/helpers/parent_watchdog.py
+++ b/esphome_device_builder/helpers/parent_watchdog.py
@@ -43,6 +43,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -121,12 +122,22 @@ async def _watch_unix(parent_pid: int, *, poll_seconds: float) -> None:
     under PID 1 (or a configured subreaper). The change is
     observable on the next ``getppid`` call — no signal
     handler or syscall hook required.
+
+    Worst-case lag between parent death and shutdown is
+    ``poll_seconds`` (the kernel reparents synchronously but
+    we only observe it on the next poll tick).
+
+    Does not catch :exc:`asyncio.CancelledError` — it propagates
+    out so a future caller that awaits the task directly can
+    distinguish "cancelled" from "parent died and we
+    shut down". The current consumer
+    (:meth:`DeviceBuilder._background_tasks` + ``gather(...,
+    return_exceptions=True)``) treats either outcome the same,
+    but suppressing cancellation here would silently regress
+    that distinction.
     """
     while True:
-        try:
-            await asyncio.sleep(poll_seconds)
-        except asyncio.CancelledError:
-            return
+        await asyncio.sleep(poll_seconds)
         current = os.getppid()
         if current != parent_pid:
             _LOGGER.warning(
@@ -143,47 +154,101 @@ async def _watch_unix(parent_pid: int, *, poll_seconds: float) -> None:
 # complain — these names are upstream Win32 macros and stay uppercase
 # by convention.
 _WIN_PROCESS_SYNCHRONIZE = 0x00100000
-_WIN_INFINITE = 0xFFFFFFFF
 _WIN_WAIT_OBJECT_0 = 0
+_WIN_WAIT_TIMEOUT = 0x102
+# ``WaitForSingleObject`` timeout per poll tick, in milliseconds.
+# Same cadence as the Unix path's ``_POLL_SECONDS`` so the
+# cross-platform contract — "shutdown within ~2 s of cancel
+# or parent death" — holds on both. A finite tick is what
+# distinguishes this fix from the previous ``INFINITE`` wait:
+# without it the worker thread can't observe ``cancel_event``
+# and would leak past dashboard shutdown.
+_WIN_POLL_MS = 2000
 
 
-def _wait_for_parent_handle_windows(parent_pid: int) -> bool:
-    """Block on the parent's process handle until it exits.
+def _wait_for_parent_handle_windows(parent_pid: int, cancel_event: threading.Event) -> bool:
+    """Wait for the parent's process handle to be signalled OR for cancel.
 
-    Returns True when the parent exited (i.e. the handle was
-    signalled); False if we couldn't open the handle in the
-    first place. Synchronous on purpose — meant to run inside
+    Polls :c:func:`WaitForSingleObject` with a ``_WIN_POLL_MS``
+    timeout. Each iteration checks the kernel handle (parent
+    exited → ``WAIT_OBJECT_0``) and, on timeout, peeks at
+    *cancel_event* before looping again. The polling loop is
+    what lets :func:`_watch_windows` propagate cancellation
+    back to the worker thread — a previous
+    ``WaitForSingleObject(handle, INFINITE)`` shape would have
+    left the thread blocked in the kernel until the parent
+    actually died (potentially past dashboard shutdown,
+    hanging ``ThreadPoolExecutor.shutdown(wait=True)`` at
+    interpreter exit).
+
+    Returns:
+    * ``True``  — parent process exited (handle signalled).
+    * ``False`` — couldn't open the handle (permission /
+      already gone), or *cancel_event* was set, or
+      ``WaitForSingleObject`` returned an unexpected status
+      (treated as "couldn't observe" rather than "parent
+      died" so we don't race an immediate shutdown at
+      startup).
+
+    Synchronous on purpose — meant to run inside
     :func:`asyncio.to_thread` so the asyncio loop stays free.
     """
     import ctypes  # noqa: PLC0415 — Windows-only path, deferred to keep import cost off non-Windows
 
     # ``WinDLL`` is only exposed by ``ctypes`` on Windows; type checkers
     # running on Linux / macOS for CI see ``ctypes`` without it. The
-    # ``getattr`` avoids the ``attr-defined`` complaint while keeping
-    # the runtime behaviour identical (this function is only ever
-    # reached on win32 — :func:`watch_parent_and_exit_on_death` dispatches
-    # on :data:`sys.platform`).
+    # ``# type: ignore`` keeps mypy quiet while leaving the runtime
+    # behaviour identical (this function is only ever reached on win32
+    # — :func:`watch_parent_and_exit_on_death` dispatches on
+    # :data:`sys.platform`).
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
     handle = kernel32.OpenProcess(_WIN_PROCESS_SYNCHRONIZE, False, parent_pid)
     if not handle:
-        # No permission or process already gone — caller
-        # should treat this as "watchdog couldn't engage", not
-        # "parent died". Returning False keeps us from racing
-        # an immediate self-shutdown on startup.
         return False
     try:
-        # ``kernel32`` calls return ``Any`` (untyped C bindings) — the
-        # explicit ``bool()`` coerces the comparison so mypy doesn't
-        # flag the return as leaking ``Any`` to the caller.
-        result = kernel32.WaitForSingleObject(handle, _WIN_INFINITE)
-        return bool(result == _WIN_WAIT_OBJECT_0)
+        while not cancel_event.is_set():
+            # ``kernel32`` calls return ``Any`` (untyped C bindings).
+            result = int(kernel32.WaitForSingleObject(handle, _WIN_POLL_MS))
+            if result == _WIN_WAIT_OBJECT_0:
+                return True
+            if result != _WIN_WAIT_TIMEOUT:
+                # ``WAIT_FAILED`` / ``WAIT_ABANDONED`` / anything
+                # else — bail rather than spin. Same rationale as
+                # the ``OpenProcess`` failure path: prefer "can't
+                # observe" over "parent died" so a kernel quirk
+                # doesn't kick the dashboard offline at startup.
+                return False
+        return False
     finally:
         kernel32.CloseHandle(handle)
 
 
 async def _watch_windows(parent_pid: int) -> None:
-    """Block-in-thread on the parent's handle; trigger shutdown on exit."""
-    parent_exited = await asyncio.to_thread(_wait_for_parent_handle_windows, parent_pid)
+    """Block-in-thread on the parent's handle; trigger shutdown on exit.
+
+    Drives :func:`_wait_for_parent_handle_windows` via
+    :func:`asyncio.to_thread`. On :exc:`asyncio.CancelledError`
+    (normal dashboard shutdown), signal the worker thread via
+    *cancel_event* before re-raising so the thread exits within
+    one ``_WIN_POLL_MS`` tick instead of leaking until the
+    parent dies. Without that handshake the worker would still
+    be parked in ``WaitForSingleObject`` when Python's
+    interpreter-exit ``ThreadPoolExecutor.shutdown(wait=True)``
+    runs, hanging the whole process at exit time.
+    """
+    cancel_event = threading.Event()
+    try:
+        parent_exited = await asyncio.to_thread(
+            _wait_for_parent_handle_windows, parent_pid, cancel_event
+        )
+    except asyncio.CancelledError:
+        # Tell the worker thread to break out of its polling
+        # loop. The thread observes the flag on its next
+        # iteration (up to ``_WIN_POLL_MS`` later) and exits
+        # cleanly; we re-raise so the cancellation chains to
+        # our caller the way the Unix path does.
+        cancel_event.set()
+        raise
     if parent_exited:
         _LOGGER.warning(
             "parent-watchdog: parent %d exited (handle signalled); shutting down",

--- a/esphome_device_builder/helpers/parent_watchdog.py
+++ b/esphome_device_builder/helpers/parent_watchdog.py
@@ -157,7 +157,13 @@ def _wait_for_parent_handle_windows(parent_pid: int) -> bool:
     """
     import ctypes  # noqa: PLC0415 — Windows-only path, deferred to keep import cost off non-Windows
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    # ``WinDLL`` is only exposed by ``ctypes`` on Windows; type checkers
+    # running on Linux / macOS for CI see ``ctypes`` without it. The
+    # ``getattr`` avoids the ``attr-defined`` complaint while keeping
+    # the runtime behaviour identical (this function is only ever
+    # reached on win32 — :func:`watch_parent_and_exit_on_death` dispatches
+    # on :data:`sys.platform`).
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
     handle = kernel32.OpenProcess(_WIN_PROCESS_SYNCHRONIZE, False, parent_pid)
     if not handle:
         # No permission or process already gone — caller
@@ -166,8 +172,11 @@ def _wait_for_parent_handle_windows(parent_pid: int) -> bool:
         # an immediate self-shutdown on startup.
         return False
     try:
+        # ``kernel32`` calls return ``Any`` (untyped C bindings) — the
+        # explicit ``bool()`` coerces the comparison so mypy doesn't
+        # flag the return as leaking ``Any`` to the caller.
         result = kernel32.WaitForSingleObject(handle, _WIN_INFINITE)
-        return result == _WIN_WAIT_OBJECT_0
+        return bool(result == _WIN_WAIT_OBJECT_0)
     finally:
         kernel32.CloseHandle(handle)
 

--- a/esphome_device_builder/helpers/parent_watchdog.py
+++ b/esphome_device_builder/helpers/parent_watchdog.py
@@ -1,0 +1,217 @@
+"""
+Parent-process watchdog — exit cleanly when the launching process disappears.
+
+The dashboard is normally spawned by a supervisor that takes care of
+shutdown (HA addon's s6, systemd, the ESPHome Builder desktop app's
+``daemon::stop`` path). For supervisors that crash, get force-quit,
+or otherwise skip their cleanup hook, the dashboard is left holding
+its listening socket / port — restarting the supervisor then fails
+to bind, or a stale dashboard answers for the previous config_dir
+until someone notices and kills it manually.
+
+This module installs an optional async task that watches the
+original parent process and signals SIGTERM (Unix) / SIGBREAK
+(Windows) to ourselves the instant the parent disappears. The
+aiohttp app's existing SIGTERM handler then runs the normal
+shutdown chain, freeing the port cleanly.
+
+Engagement is conservative — see :func:`should_engage`. We only
+opt in when we have strong evidence the launcher actually wants
+this behaviour, so a direct ``python -m esphome_device_builder``
+from a terminal does nothing surprising.
+
+Cross-platform implementation:
+
+* **Unix** (macOS / Linux): poll :func:`os.getppid` every couple
+  of seconds. When the parent dies the kernel reparents this
+  process to PID 1 (or the configured subreaper), so the ppid
+  value changes — that's our trigger.
+* **Windows**: PPID does **not** change after parent exit on
+  Windows (there's no init equivalent that adopts orphans), so
+  polling ppid is useless. Open a synchronisation handle on the
+  parent process and block on it from a worker thread — when
+  the handle becomes signalled, the parent has exited. Falling
+  back to :func:`os.kill` ``(pid, 0)`` won't work either:
+  CPython on Windows routes that through ``TerminateProcess``,
+  which would *kill* the parent rather than test for it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+
+_LOGGER = logging.getLogger(__name__)
+
+# Markers in ``sys.executable`` that identify the dashboard as
+# having been spawned by the ESPHome Builder desktop app. The
+# desktop bundles its own Python interpreter under an
+# app-support directory keyed on the macOS bundle id; the same
+# id appears in the Linux / Windows install paths the Tauri
+# bundler produces, so a single substring check covers all
+# three platforms.
+#
+# Keep this list minimal — every entry here is a self-declared
+# "yes, I want the watchdog" signal from a launcher.
+_DESKTOP_SPAWN_MARKERS: tuple[str, ...] = ("io.esphome.builder",)
+
+# Polling cadence for the Unix path. Two seconds keeps the
+# response time tight enough that a force-quit doesn't leave
+# the port held for long, while not waking the loop too often
+# on idle dashboards.
+_POLL_SECONDS = 2.0
+
+
+def _spawned_by_desktop_app() -> bool:
+    """Return True if our interpreter looks like a desktop-app spawn."""
+    return any(marker in sys.executable for marker in _DESKTOP_SPAWN_MARKERS)
+
+
+def should_engage(force: bool | None) -> bool:
+    """
+    Decide whether the parent watchdog should run.
+
+    Tri-state:
+
+    * ``True`` — the user passed ``--exit-on-parent-changed``
+      explicitly; honour it regardless of launcher.
+    * ``False`` — the user passed ``--no-exit-on-parent-changed``;
+      stay off regardless of launcher.
+    * ``None`` — no explicit flag; auto-engage when
+      :func:`_spawned_by_desktop_app` matches.
+
+    Other launchers (HA addon's s6, systemd unit, ad-hoc
+    ``python -m`` from a terminal) stay un-watched by default —
+    they have their own supervision and don't want the dashboard
+    self-terminating on parent change.
+    """
+    if force is not None:
+        return force
+    return _spawned_by_desktop_app()
+
+
+def _trigger_self_shutdown() -> None:
+    """Signal ourselves so aiohttp's normal shutdown chain runs.
+
+    SIGTERM on Unix runs ``web.run_app``'s installed handler,
+    which kicks off the ``on_cleanup`` chain (drains the
+    firmware queue, persists state, closes the WS sites). On
+    Windows we use ``CTRL_BREAK_EVENT`` — the closest analogue
+    aiohttp wires up; ``SIGTERM`` exists in :mod:`signal` but
+    can't be delivered to ourselves there.
+    """
+    try:
+        if sys.platform == "win32":
+            os.kill(os.getpid(), signal.CTRL_BREAK_EVENT)
+        else:
+            os.kill(os.getpid(), signal.SIGTERM)
+    except OSError:
+        _LOGGER.exception("parent-watchdog: failed to deliver shutdown signal")
+        # Best-effort hard exit — better than leaking the port forever.
+        os._exit(0)
+
+
+async def _watch_unix(parent_pid: int, *, poll_seconds: float) -> None:
+    """Poll :func:`os.getppid`; trigger shutdown on reparent.
+
+    When the original parent dies, the kernel reparents us
+    under PID 1 (or a configured subreaper). The change is
+    observable on the next ``getppid`` call — no signal
+    handler or syscall hook required.
+    """
+    while True:
+        try:
+            await asyncio.sleep(poll_seconds)
+        except asyncio.CancelledError:
+            return
+        current = os.getppid()
+        if current != parent_pid:
+            _LOGGER.warning(
+                "parent-watchdog: parent %d gone (reparented to %d); shutting down",
+                parent_pid,
+                current,
+            )
+            _trigger_self_shutdown()
+            return
+
+
+# Windows API constants used by :func:`_wait_for_parent_handle_windows`.
+# Hoisted to module level so ruff's N806 (lowercase-in-function) doesn't
+# complain — these names are upstream Win32 macros and stay uppercase
+# by convention.
+_WIN_PROCESS_SYNCHRONIZE = 0x00100000
+_WIN_INFINITE = 0xFFFFFFFF
+_WIN_WAIT_OBJECT_0 = 0
+
+
+def _wait_for_parent_handle_windows(parent_pid: int) -> bool:
+    """Block on the parent's process handle until it exits.
+
+    Returns True when the parent exited (i.e. the handle was
+    signalled); False if we couldn't open the handle in the
+    first place. Synchronous on purpose — meant to run inside
+    :func:`asyncio.to_thread` so the asyncio loop stays free.
+    """
+    import ctypes  # noqa: PLC0415 — Windows-only path, deferred to keep import cost off non-Windows
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    handle = kernel32.OpenProcess(_WIN_PROCESS_SYNCHRONIZE, False, parent_pid)
+    if not handle:
+        # No permission or process already gone — caller
+        # should treat this as "watchdog couldn't engage", not
+        # "parent died". Returning False keeps us from racing
+        # an immediate self-shutdown on startup.
+        return False
+    try:
+        result = kernel32.WaitForSingleObject(handle, _WIN_INFINITE)
+        return result == _WIN_WAIT_OBJECT_0
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+async def _watch_windows(parent_pid: int) -> None:
+    """Block-in-thread on the parent's handle; trigger shutdown on exit."""
+    parent_exited = await asyncio.to_thread(_wait_for_parent_handle_windows, parent_pid)
+    if parent_exited:
+        _LOGGER.warning(
+            "parent-watchdog: parent %d exited (handle signalled); shutting down",
+            parent_pid,
+        )
+        _trigger_self_shutdown()
+    else:
+        _LOGGER.debug(
+            "parent-watchdog: couldn't open handle for parent %d; watchdog inactive",
+            parent_pid,
+        )
+
+
+async def watch_parent_and_exit_on_death(
+    *,
+    poll_seconds: float = _POLL_SECONDS,
+) -> None:
+    """
+    Watchdog entry point. Picks the right primitive per platform.
+
+    Returns cleanly (no action) when there's no useful parent
+    to watch — already running under PID 1 on Unix, or unable
+    to open a handle on Windows. Otherwise runs until the
+    parent dies (triggers self-shutdown) or the task is
+    cancelled (normal dashboard shutdown).
+    """
+    parent_pid = os.getppid()
+    if parent_pid <= 1:
+        _LOGGER.debug("parent-watchdog: no parent to watch (ppid=%d); skipping", parent_pid)
+        return
+
+    _LOGGER.info(
+        "parent-watchdog: watching parent process PID %d (platform=%s)",
+        parent_pid,
+        sys.platform,
+    )
+    if sys.platform == "win32":
+        await _watch_windows(parent_pid)
+    else:
+        await _watch_unix(parent_pid, poll_seconds=poll_seconds)

--- a/tests/test_device_builder_lifecycle.py
+++ b/tests/test_device_builder_lifecycle.py
@@ -21,7 +21,9 @@ import asyncio
 
 import pytest
 
+from esphome_device_builder import device_builder as device_builder_module
 from esphome_device_builder.device_builder import DeviceBuilder
+from esphome_device_builder.helpers import parent_watchdog
 
 from .conftest import MakeSettingsFactory
 
@@ -141,6 +143,84 @@ async def test_start_spawns_background_polling_task(
 
         assert db._bg_task is not None
         assert not db._bg_task.done()
+    finally:
+        await db.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_schedules_parent_watchdog_when_force_enabled(
+    make_settings: MakeSettingsFactory,
+    _hermetic_lifecycle: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--exit-on-parent-changed`` schedules the parent watchdog task.
+
+    Pins the wiring at :meth:`DeviceBuilder.start`: when
+    ``exit_on_parent_changed`` is ``True`` the watchdog coroutine
+    is handed to ``create_background_task`` so it's auto-cancelled
+    and gathered on ``stop()``. Auto-detection (the ``None``
+    default) is exercised by ``test_parent_watchdog``'s
+    ``should_engage`` matrix; here we exercise the integration
+    seam with the explicit override.
+
+    The watchdog coroutine itself is stubbed — letting the real
+    polling loop run would either fire ``SIGTERM`` at the test
+    process or leave a hanging task; neither is helpful. We just
+    pin that ``create_background_task`` saw the coroutine.
+    """
+    captured: list[object] = []
+
+    async def _stub_watchdog(*_args: object, **_kwargs: object) -> None:
+        captured.append("called")
+
+    monkeypatch.setattr(parent_watchdog, "watch_parent_and_exit_on_death", _stub_watchdog)
+    # ``device_builder`` imports the symbol at module load — patch
+    # the imported name there too so the call site sees the stub.
+    monkeypatch.setattr(device_builder_module, "watch_parent_and_exit_on_death", _stub_watchdog)
+
+    settings = make_settings(with_core_path=True)
+    settings.exit_on_parent_changed = True  # force-engage regardless of launcher
+    db = DeviceBuilder(settings)
+    try:
+        await db.start()
+        # Yield once so the scheduled task runs.
+        await asyncio.sleep(0)
+        assert captured == ["called"]
+    finally:
+        await db.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_skips_parent_watchdog_when_force_disabled(
+    make_settings: MakeSettingsFactory,
+    _hermetic_lifecycle: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--no-exit-on-parent-changed`` skips the watchdog even under desktop spawn.
+
+    Belt-and-braces companion to the force-enabled test: with the
+    explicit opt-out, the watchdog should not be scheduled no
+    matter what ``sys.executable`` looks like.
+    """
+    captured: list[object] = []
+
+    async def _stub_watchdog(*_args: object, **_kwargs: object) -> None:
+        captured.append("called")
+
+    monkeypatch.setattr(parent_watchdog, "watch_parent_and_exit_on_death", _stub_watchdog)
+    monkeypatch.setattr(device_builder_module, "watch_parent_and_exit_on_death", _stub_watchdog)
+    # Force the auto-detect path to ``True`` — without the explicit
+    # opt-out below, this would engage the watchdog.
+    monkeypatch.setattr(parent_watchdog, "_spawned_by_desktop_app", lambda: True)
+    monkeypatch.setattr(device_builder_module, "should_engage", parent_watchdog.should_engage)
+
+    settings = make_settings(with_core_path=True)
+    settings.exit_on_parent_changed = False  # explicit opt-out
+    db = DeviceBuilder(settings)
+    try:
+        await db.start()
+        await asyncio.sleep(0)
+        assert captured == []
     finally:
         await db.stop()
 

--- a/tests/test_parent_watchdog.py
+++ b/tests/test_parent_watchdog.py
@@ -26,6 +26,7 @@ import ctypes
 import os
 import signal
 import sys
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -181,8 +182,17 @@ async def test_unix_watcher_polls_until_change_then_exits() -> None:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix-only polling path")
 @pytest.mark.asyncio
-async def test_unix_watcher_cancels_cleanly_mid_sleep() -> None:
-    """Cancelling the task while it's sleeping exits without firing shutdown."""
+async def test_unix_watcher_propagates_cancellation_without_firing_shutdown() -> None:
+    """Cancellation surfaces as ``CancelledError`` and does not fire shutdown.
+
+    Pins the no-suppress-CancelledError contract documented in
+    ``_watch_unix``'s docstring: the watchdog must propagate
+    cancellation so callers awaiting the task directly can
+    distinguish "cancelled" from "parent died and we shut down".
+    Suppressing here would silently regress that distinction
+    even though ``gather(..., return_exceptions=True)`` happens
+    to handle both the same way at the only current callsite.
+    """
     triggered: list[None] = []
 
     with (
@@ -199,9 +209,8 @@ async def test_unix_watcher_cancels_cleanly_mid_sleep() -> None:
         # Let the task enter its first sleep before cancelling.
         await asyncio.sleep(0.05)
         task.cancel()
-        # The watcher catches CancelledError and returns cleanly,
-        # so the awaiting gather sees a normal completion.
-        await asyncio.gather(task, return_exceptions=True)
+        with pytest.raises(asyncio.CancelledError):
+            await task
 
     assert triggered == []
 
@@ -235,7 +244,13 @@ async def test_windows_dispatch_calls_handle_wait(monkeypatch: pytest.MonkeyPatc
 
     await asyncio.wait_for(parent_watchdog.watch_parent_and_exit_on_death(), timeout=1.0)
 
-    fake_wait.assert_called_once_with(1234)
+    # ``_wait_for_parent_handle_windows`` is called with the parent
+    # pid + a ``threading.Event`` the wrapper owns. We don't care
+    # about the event identity, just that the pid arg is right.
+    fake_wait.assert_called_once()
+    args, _ = fake_wait.call_args
+    assert args[0] == 1234
+    assert isinstance(args[1], threading.Event)
     assert triggered == [None]
 
 
@@ -265,6 +280,51 @@ async def test_windows_dispatch_no_shutdown_when_handle_open_fails(
     await asyncio.wait_for(parent_watchdog.watch_parent_and_exit_on_death(), timeout=1.0)
 
     assert triggered == []
+
+
+@pytest.mark.asyncio
+async def test_windows_dispatch_sets_cancel_event_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling the Windows watcher signals the worker thread to stop.
+
+    Pins the fix for the thread-leak bug: without setting the
+    ``cancel_event`` on the way out, the worker thread would be
+    parked in ``WaitForSingleObject`` forever (the previous
+    ``INFINITE`` shape), hanging dashboard shutdown until the
+    parent actually died. The new ``_watch_windows`` catches
+    ``CancelledError``, sets the event, then re-raises so the
+    asyncio side cancels cleanly and the kernel-thread side
+    exits on its next poll tick (up to ``_WIN_POLL_MS`` later).
+    """
+    monkeypatch.setattr(parent_watchdog.sys, "platform", "win32")
+    monkeypatch.setattr(parent_watchdog.os, "getppid", lambda: 1234)
+
+    # Capture the event so the test can assert it got set, and
+    # block the worker until the event fires so the cancel path
+    # is the only way the function returns.
+    captured_events: list[threading.Event] = []
+
+    def _blocking_wait(_pid: int, cancel_event: threading.Event) -> bool:
+        captured_events.append(cancel_event)
+        # Wait up to 5 s for the test to signal cancel. If the
+        # event never gets set, the test fails by timeout.
+        cancel_event.wait(timeout=5.0)
+        return False
+
+    monkeypatch.setattr(parent_watchdog, "_wait_for_parent_handle_windows", _blocking_wait)
+
+    task = asyncio.create_task(parent_watchdog.watch_parent_and_exit_on_death())
+    # Let the task hand off to the worker thread.
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(captured_events) == 1
+    # The wrapper must have set the event so the worker thread
+    # can break out of its polling loop.
+    assert captured_events[0].is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -364,14 +424,16 @@ def test_wait_for_parent_handle_windows_returns_true_on_signalled_handle(
     )
     monkeypatch.setattr(ctypes, "WinDLL", lambda *_a, **_kw: fake_kernel32, raising=False)
 
-    result = parent_watchdog._wait_for_parent_handle_windows(1234)
+    result = parent_watchdog._wait_for_parent_handle_windows(1234, threading.Event())
 
     assert result is True
     fake_kernel32.OpenProcess.assert_called_once_with(
         parent_watchdog._WIN_PROCESS_SYNCHRONIZE, False, 1234
     )
+    # Polling timeout is the per-tick value, not INFINITE — see
+    # ``_WIN_POLL_MS`` for the cadence rationale.
     fake_kernel32.WaitForSingleObject.assert_called_once_with(
-        fake_handle, parent_watchdog._WIN_INFINITE
+        fake_handle, parent_watchdog._WIN_POLL_MS
     )
     # Handle must be closed even on the happy path so the kernel
     # isn't left holding a stale reference.
@@ -394,7 +456,7 @@ def test_wait_for_parent_handle_windows_returns_false_when_handle_open_fails(
     )
     monkeypatch.setattr(ctypes, "WinDLL", lambda *_a, **_kw: fake_kernel32, raising=False)
 
-    result = parent_watchdog._wait_for_parent_handle_windows(1234)
+    result = parent_watchdog._wait_for_parent_handle_windows(1234, threading.Event())
 
     assert result is False
     # When OpenProcess fails we must NOT touch WaitForSingleObject /
@@ -407,22 +469,71 @@ def test_wait_for_parent_handle_windows_returns_false_when_handle_open_fails(
 def test_wait_for_parent_handle_windows_returns_false_on_unexpected_wait_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A non-``WAIT_OBJECT_0`` return (timeout, abandoned, failure) → False.
+    """A ``WAIT_FAILED`` / abandoned return bails the polling loop.
 
-    Defensive: if ``WaitForSingleObject`` ever returns something
-    other than ``WAIT_OBJECT_0`` (we wait ``INFINITE`` so this
-    shouldn't happen in practice, but kernels do surprising things
-    under load), don't treat that as "parent died" — same rationale
-    as the open-failure case.
+    Defensive: if ``WaitForSingleObject`` ever returns a status
+    that isn't ``WAIT_OBJECT_0`` or ``WAIT_TIMEOUT``, we treat
+    it as "can't observe" rather than "parent died" — same
+    rationale as the open-failure case. Without this branch a
+    kernel quirk could kick the dashboard offline at startup.
     """
     fake_handle = 0xCAFE
     fake_kernel32 = _make_fake_kernel32(
         open_handle=fake_handle,
-        wait_result=0x102,  # WAIT_TIMEOUT — shouldn't occur with INFINITE
+        wait_result=0xFFFFFFFF,  # WAIT_FAILED
     )
     monkeypatch.setattr(ctypes, "WinDLL", lambda *_a, **_kw: fake_kernel32, raising=False)
 
-    result = parent_watchdog._wait_for_parent_handle_windows(1234)
+    result = parent_watchdog._wait_for_parent_handle_windows(1234, threading.Event())
 
     assert result is False
+    fake_kernel32.CloseHandle.assert_called_once_with(fake_handle)
+
+
+def test_wait_for_parent_handle_windows_continues_polling_on_wait_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``WAIT_TIMEOUT`` keeps polling; ``cancel_event`` breaks the loop.
+
+    Pins the new polling shape: ``WaitForSingleObject`` with a
+    finite ``_WIN_POLL_MS`` timeout returns ``WAIT_TIMEOUT``
+    every tick while the parent is still alive. The function
+    must loop (not bail) on that status, and observe the
+    ``cancel_event`` between iterations so dashboard shutdown
+    can break out without waiting for the parent to die. The
+    previous ``INFINITE`` shape couldn't do this — the worker
+    thread would have leaked past dashboard shutdown.
+    """
+    fake_handle = 0xC0FFEE
+    fake_kernel32 = _make_fake_kernel32(
+        open_handle=fake_handle,
+        wait_result=parent_watchdog._WIN_WAIT_TIMEOUT,
+    )
+    monkeypatch.setattr(ctypes, "WinDLL", lambda *_a, **_kw: fake_kernel32, raising=False)
+
+    cancel_event = threading.Event()
+    # ``side_effect`` returns ``WAIT_TIMEOUT`` for the first two
+    # calls, then we flip the cancel flag and the third (if it
+    # ever runs) would have returned the same — but the loop
+    # checks the event BEFORE the next wait, so two ticks is the
+    # maximum even without ever signalling the parent handle.
+    call_count = 0
+
+    def _wait_then_cancel(_handle: int, _timeout_ms: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            cancel_event.set()
+        return parent_watchdog._WIN_WAIT_TIMEOUT
+
+    fake_kernel32.WaitForSingleObject.side_effect = _wait_then_cancel
+
+    result = parent_watchdog._wait_for_parent_handle_windows(1234, cancel_event)
+
+    assert result is False
+    # We expect the wait to be called exactly twice: first tick
+    # returns WAIT_TIMEOUT and we loop; second tick returns
+    # WAIT_TIMEOUT but the side_effect has set the event so the
+    # next ``cancel_event.is_set()`` check exits the loop.
+    assert call_count == 2
     fake_kernel32.CloseHandle.assert_called_once_with(fake_handle)

--- a/tests/test_parent_watchdog.py
+++ b/tests/test_parent_watchdog.py
@@ -1,0 +1,303 @@
+"""
+Tests for ``helpers.parent_watchdog``.
+
+Cover the four observable behaviours the watchdog has to get right:
+
+1. :func:`should_engage` honours an explicit force flag and falls
+   back to the desktop-app launcher signature when none is given.
+2. The async watcher returns immediately when there's no useful
+   parent (PID 1).
+3. The async watcher detects ppid changes on Unix and signals
+   self-shutdown.
+4. The async watcher is cancellable cleanly while parked in its
+   sleep.
+
+The Windows code path (handle-based wait via ctypes) is exercised
+through a mock — actually opening a process handle in tests is
+both flaky on CI and impossible cross-platform; the unit-level
+coverage pins the dispatch shape and the shutdown trigger so
+regressions stay caught.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from esphome_device_builder.helpers import parent_watchdog
+
+# ---------------------------------------------------------------------------
+# should_engage
+# ---------------------------------------------------------------------------
+
+
+def test_should_engage_force_true_overrides_detection() -> None:
+    """Explicit ``True`` engages even when not running under the desktop app."""
+    with patch.object(parent_watchdog, "_spawned_by_desktop_app", return_value=False):
+        assert parent_watchdog.should_engage(force=True) is True
+
+
+def test_should_engage_force_false_overrides_detection() -> None:
+    """Explicit ``False`` disables even when running under the desktop app."""
+    with patch.object(parent_watchdog, "_spawned_by_desktop_app", return_value=True):
+        assert parent_watchdog.should_engage(force=False) is False
+
+
+def test_should_engage_none_falls_through_to_auto_detect() -> None:
+    """``None`` defers to the launcher signature."""
+    with patch.object(parent_watchdog, "_spawned_by_desktop_app", return_value=True):
+        assert parent_watchdog.should_engage(force=None) is True
+    with patch.object(parent_watchdog, "_spawned_by_desktop_app", return_value=False):
+        assert parent_watchdog.should_engage(force=None) is False
+
+
+def test_spawned_by_desktop_app_matches_bundle_id() -> None:
+    """The detector matches when the bundle id appears in ``sys.executable``.
+
+    Pins the bundle-id matcher: a Python interpreter whose path
+    lives under the macOS / Windows app-support directory keyed
+    on ``io.esphome.builder`` is treated as a desktop-app spawn.
+    Other paths (system Python, virtualenv, HA addon's bundled
+    Python) don't match and skip the watchdog.
+    """
+    desktop_path = "/Users/me/Library/Application Support/io.esphome.builder/python/bin/python3"
+    with patch.object(sys, "executable", desktop_path):
+        assert parent_watchdog._spawned_by_desktop_app() is True
+
+    with patch.object(sys, "executable", "/usr/local/bin/python3"):
+        assert parent_watchdog._spawned_by_desktop_app() is False
+
+    # HA addon path — bundle id is absent.
+    with patch.object(sys, "executable", "/usr/local/bin/python3.13"):
+        assert parent_watchdog._spawned_by_desktop_app() is False
+
+
+# ---------------------------------------------------------------------------
+# watch_parent_and_exit_on_death — early-return paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_returns_immediately_when_already_orphan() -> None:
+    """ppid==1 means we were never going to be supervised; no-op cleanly."""
+    triggered: list[None] = []
+    with (
+        patch.object(parent_watchdog.os, "getppid", return_value=1),
+        patch.object(
+            parent_watchdog,
+            "_trigger_self_shutdown",
+            side_effect=lambda: triggered.append(None),
+        ),
+    ):
+        await asyncio.wait_for(parent_watchdog.watch_parent_and_exit_on_death(), timeout=1.0)
+
+    assert triggered == []
+
+
+@pytest.mark.asyncio
+async def test_watchdog_returns_immediately_when_already_orphan_ppid_zero() -> None:
+    """Defensive: a ``getppid() == 0`` (BSD-ish edge case) also skips."""
+    triggered: list[None] = []
+    with (
+        patch.object(parent_watchdog.os, "getppid", return_value=0),
+        patch.object(
+            parent_watchdog,
+            "_trigger_self_shutdown",
+            side_effect=lambda: triggered.append(None),
+        ),
+    ):
+        await asyncio.wait_for(parent_watchdog.watch_parent_and_exit_on_death(), timeout=1.0)
+
+    assert triggered == []
+
+
+# ---------------------------------------------------------------------------
+# Unix polling path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix-only polling path")
+@pytest.mark.asyncio
+async def test_unix_watcher_triggers_shutdown_on_reparent() -> None:
+    """When ``os.getppid()`` returns a new value, shutdown signal fires.
+
+    Simulates the kernel reparenting the dashboard under
+    ``launchd`` (or PID 1 / a subreaper on Linux) when the
+    Tauri parent dies. The watcher observes the ppid change on
+    its next poll and triggers self-shutdown — the aiohttp
+    SIGTERM handler then runs the usual cleanup chain.
+    """
+    # First call captures the "original" parent (mock returns
+    # 1234); subsequent calls (inside the polling loop) return
+    # 1, simulating the reparent.
+    ppids = iter([1234, 1, 1, 1])
+    triggered: list[None] = []
+
+    with (
+        patch.object(parent_watchdog.os, "getppid", side_effect=lambda: next(ppids)),
+        patch.object(
+            parent_watchdog,
+            "_trigger_self_shutdown",
+            side_effect=lambda: triggered.append(None),
+        ),
+    ):
+        await asyncio.wait_for(
+            parent_watchdog.watch_parent_and_exit_on_death(poll_seconds=0.01),
+            timeout=1.0,
+        )
+
+    assert triggered == [None]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix-only polling path")
+@pytest.mark.asyncio
+async def test_unix_watcher_polls_until_change_then_exits() -> None:
+    """No shutdown fires while ppid stays stable; loop exits on change."""
+    # Original ppid, then several "still alive" reads, then the reparent.
+    ppids = iter([1234, 1234, 1234, 1234, 5678])
+    triggered: list[None] = []
+
+    with (
+        patch.object(parent_watchdog.os, "getppid", side_effect=lambda: next(ppids)),
+        patch.object(
+            parent_watchdog,
+            "_trigger_self_shutdown",
+            side_effect=lambda: triggered.append(None),
+        ),
+    ):
+        await asyncio.wait_for(
+            parent_watchdog.watch_parent_and_exit_on_death(poll_seconds=0.01),
+            timeout=1.0,
+        )
+
+    assert triggered == [None]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix-only polling path")
+@pytest.mark.asyncio
+async def test_unix_watcher_cancels_cleanly_mid_sleep() -> None:
+    """Cancelling the task while it's sleeping exits without firing shutdown."""
+    triggered: list[None] = []
+
+    with (
+        patch.object(parent_watchdog.os, "getppid", return_value=1234),
+        patch.object(
+            parent_watchdog,
+            "_trigger_self_shutdown",
+            side_effect=lambda: triggered.append(None),
+        ),
+    ):
+        task = asyncio.create_task(
+            parent_watchdog.watch_parent_and_exit_on_death(poll_seconds=10.0)
+        )
+        # Let the task enter its first sleep before cancelling.
+        await asyncio.sleep(0.05)
+        task.cancel()
+        # The watcher catches CancelledError and returns cleanly,
+        # so the awaiting gather sees a normal completion.
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert triggered == []
+
+
+# ---------------------------------------------------------------------------
+# Windows dispatch path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_windows_dispatch_calls_handle_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Windows the watcher dispatches to the handle-based blocker.
+
+    Pins the platform fork: ``sys.platform == "win32"`` routes
+    through ``_watch_windows`` rather than the polling loop.
+    Forcing the platform string and stubbing the blocking wait
+    keeps the assertion deterministic regardless of where the
+    test runs.
+    """
+    monkeypatch.setattr(parent_watchdog.sys, "platform", "win32")
+    monkeypatch.setattr(parent_watchdog.os, "getppid", lambda: 1234)
+    triggered: list[None] = []
+    monkeypatch.setattr(
+        parent_watchdog,
+        "_trigger_self_shutdown",
+        lambda: triggered.append(None),
+    )
+
+    fake_wait = MagicMock(return_value=True)
+    monkeypatch.setattr(parent_watchdog, "_wait_for_parent_handle_windows", fake_wait)
+
+    await asyncio.wait_for(parent_watchdog.watch_parent_and_exit_on_death(), timeout=1.0)
+
+    fake_wait.assert_called_once_with(1234)
+    assert triggered == [None]
+
+
+@pytest.mark.asyncio
+async def test_windows_dispatch_no_shutdown_when_handle_open_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed ``OpenProcess`` leaves the watcher inactive (no shutdown)."""
+    monkeypatch.setattr(parent_watchdog.sys, "platform", "win32")
+    monkeypatch.setattr(parent_watchdog.os, "getppid", lambda: 1234)
+    triggered: list[None] = []
+    monkeypatch.setattr(
+        parent_watchdog,
+        "_trigger_self_shutdown",
+        lambda: triggered.append(None),
+    )
+
+    # Handle couldn't be opened — should fall through without
+    # firing the shutdown trigger (otherwise a missing-handle
+    # race at startup would kill the dashboard prematurely).
+    monkeypatch.setattr(
+        parent_watchdog,
+        "_wait_for_parent_handle_windows",
+        MagicMock(return_value=False),
+    )
+
+    await asyncio.wait_for(parent_watchdog.watch_parent_and_exit_on_death(), timeout=1.0)
+
+    assert triggered == []
+
+
+# ---------------------------------------------------------------------------
+# _trigger_self_shutdown
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_self_shutdown_unix_sends_sigterm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unix shutdown trigger calls ``os.kill(self, SIGTERM)``."""
+    monkeypatch.setattr(parent_watchdog.sys, "platform", "darwin")
+    calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(parent_watchdog.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+
+    parent_watchdog._trigger_self_shutdown()
+
+    assert calls == [(os.getpid(), signal.SIGTERM)]
+
+
+def test_trigger_self_shutdown_windows_sends_ctrl_break(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows shutdown trigger uses ``CTRL_BREAK_EVENT`` (the aiohttp-handled signal)."""
+    monkeypatch.setattr(parent_watchdog.sys, "platform", "win32")
+    calls: list[tuple[int, int]] = []
+    # Real ``signal.CTRL_BREAK_EVENT`` only exists on Windows; the
+    # module references it via attribute lookup so we have to
+    # provide a stand-in on Unix test runners.
+    fake_break = getattr(signal, "CTRL_BREAK_EVENT", 1)
+    # ``raising=False`` lets us inject the attribute on test runners
+    # where the real ``CTRL_BREAK_EVENT`` isn't exported (it's
+    # Windows-only); without it monkeypatch refuses the setattr.
+    monkeypatch.setattr(parent_watchdog.signal, "CTRL_BREAK_EVENT", fake_break, raising=False)
+    monkeypatch.setattr(parent_watchdog.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+
+    parent_watchdog._trigger_self_shutdown()
+
+    assert calls == [(os.getpid(), fake_break)]

--- a/tests/test_parent_watchdog.py
+++ b/tests/test_parent_watchdog.py
@@ -22,6 +22,7 @@ regressions stay caught.
 from __future__ import annotations
 
 import asyncio
+import ctypes
 import os
 import signal
 import sys
@@ -301,3 +302,127 @@ def test_trigger_self_shutdown_windows_sends_ctrl_break(
     parent_watchdog._trigger_self_shutdown()
 
     assert calls == [(os.getpid(), fake_break)]
+
+
+def test_trigger_self_shutdown_falls_back_to_hard_exit_on_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``os.kill`` raises ``OSError``, drop to ``os._exit(0)``.
+
+    Pins the safety-net branch: if signal delivery to ourselves
+    fails for any reason (signal masked, kernel quirk, etc), the
+    watchdog must still exit the process. Leaking the listening
+    port forever is strictly worse than a hard exit that skips
+    aiohttp's cleanup chain.
+    """
+    monkeypatch.setattr(parent_watchdog.sys, "platform", "darwin")
+
+    def _raise_oserror(_pid: int, _sig: int) -> None:
+        raise OSError("simulated kernel error")
+
+    exit_calls: list[int] = []
+    monkeypatch.setattr(parent_watchdog.os, "kill", _raise_oserror)
+    monkeypatch.setattr(parent_watchdog.os, "_exit", exit_calls.append)
+
+    parent_watchdog._trigger_self_shutdown()
+
+    assert exit_calls == [0]
+
+
+# ---------------------------------------------------------------------------
+# Windows ctypes path — drive _wait_for_parent_handle_windows directly
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_kernel32(
+    *,
+    open_handle: int,
+    wait_result: int,
+) -> object:
+    """Build a stand-in for ``ctypes.WinDLL("kernel32")`` returning canned values."""
+    fake = MagicMock()
+    fake.OpenProcess = MagicMock(return_value=open_handle)
+    fake.WaitForSingleObject = MagicMock(return_value=wait_result)
+    fake.CloseHandle = MagicMock(return_value=1)
+    return fake
+
+
+def test_wait_for_parent_handle_windows_returns_true_on_signalled_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful ``OpenProcess`` + ``WaitForSingleObject`` → True (parent exited).
+
+    Drives the Windows ctypes path directly so the function body
+    gets coverage. ``ctypes.WinDLL`` only exists on real Windows
+    runs, so we stub it via ``setattr(raising=False)`` and patch
+    the module's own ``import ctypes`` to return our stub.
+    """
+    fake_handle = 0xDEAD_BEEF
+    fake_kernel32 = _make_fake_kernel32(
+        open_handle=fake_handle,
+        wait_result=parent_watchdog._WIN_WAIT_OBJECT_0,
+    )
+    monkeypatch.setattr(ctypes, "WinDLL", lambda *_a, **_kw: fake_kernel32, raising=False)
+
+    result = parent_watchdog._wait_for_parent_handle_windows(1234)
+
+    assert result is True
+    fake_kernel32.OpenProcess.assert_called_once_with(
+        parent_watchdog._WIN_PROCESS_SYNCHRONIZE, False, 1234
+    )
+    fake_kernel32.WaitForSingleObject.assert_called_once_with(
+        fake_handle, parent_watchdog._WIN_INFINITE
+    )
+    # Handle must be closed even on the happy path so the kernel
+    # isn't left holding a stale reference.
+    fake_kernel32.CloseHandle.assert_called_once_with(fake_handle)
+
+
+def test_wait_for_parent_handle_windows_returns_false_when_handle_open_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A NULL handle from ``OpenProcess`` → False (watchdog inactive).
+
+    Distinguishes "parent died" from "couldn't observe parent" — the
+    caller treats False as the latter so we don't race an immediate
+    self-shutdown at startup if the parent handle wasn't openable
+    (insufficient permissions, parent already gone).
+    """
+    fake_kernel32 = _make_fake_kernel32(
+        open_handle=0,  # NULL — OpenProcess failure
+        wait_result=parent_watchdog._WIN_WAIT_OBJECT_0,
+    )
+    monkeypatch.setattr(ctypes, "WinDLL", lambda *_a, **_kw: fake_kernel32, raising=False)
+
+    result = parent_watchdog._wait_for_parent_handle_windows(1234)
+
+    assert result is False
+    # When OpenProcess fails we must NOT touch WaitForSingleObject /
+    # CloseHandle — passing a NULL handle to either would be a
+    # programmer error on the Win32 side.
+    fake_kernel32.WaitForSingleObject.assert_not_called()
+    fake_kernel32.CloseHandle.assert_not_called()
+
+
+def test_wait_for_parent_handle_windows_returns_false_on_unexpected_wait_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-``WAIT_OBJECT_0`` return (timeout, abandoned, failure) → False.
+
+    Defensive: if ``WaitForSingleObject`` ever returns something
+    other than ``WAIT_OBJECT_0`` (we wait ``INFINITE`` so this
+    shouldn't happen in practice, but kernels do surprising things
+    under load), don't treat that as "parent died" — same rationale
+    as the open-failure case.
+    """
+    fake_handle = 0xCAFE
+    fake_kernel32 = _make_fake_kernel32(
+        open_handle=fake_handle,
+        wait_result=0x102,  # WAIT_TIMEOUT — shouldn't occur with INFINITE
+    )
+    monkeypatch.setattr(ctypes, "WinDLL", lambda *_a, **_kw: fake_kernel32, raising=False)
+
+    result = parent_watchdog._wait_for_parent_handle_windows(1234)
+
+    assert result is False
+    fake_kernel32.CloseHandle.assert_called_once_with(fake_handle)


### PR DESCRIPTION
# What does this implement/fix?

Adds an opt-in **parent-process watchdog**: when the dashboard's launching supervisor disappears (clean exit, force-quit, crash, `kill -9`, etc.), the dashboard signals SIGTERM to itself, runs aiohttp's usual `on_cleanup` chain, and releases the listening port — instead of being reparented to launchd/init and silently holding port 6052 forever.

**Why this matters in practice:** the ESPHome Builder desktop app (Tauri) leaves orphan dashboard processes even on a **clean exit from the menu bar / tray's Quit menu** — verified by the reporter. The desktop app has a `block_on(daemon::stop())` chain that's meant to SIGTERM the dashboard's process group and SIGKILL after 5 s, but the orphan survives anyway. Whatever's going wrong on the desktop side (`block_on` racing `app.exit(0)`, `killpg` finding an unexpected pgid, SIGKILL queued but not delivered) is a separate problem worth chasing on its own — but the dashboard doesn't need to wait for that fix. With this watchdog, the dashboard takes ownership of its own lifecycle: the moment Tauri goes away (graceful, forced, or crashed), the dashboard's `os.getppid()` poll sees the reparent and self-terminates cleanly.

**Engagement is conservative.** `helpers.parent_watchdog.should_engage`:

- Honours `--exit-on-parent-changed` / `--no-exit-on-parent-changed` when explicitly passed.
- Otherwise auto-engages only when `sys.executable` contains the `io.esphome.builder` bundle marker (the desktop app's bundled Python on macOS / Linux / Windows).
- Other launchers — HA addon's s6 supervisor, systemd units, ad-hoc `python -m esphome_device_builder` from a terminal — stay un-watched by default, since they manage the dashboard's lifecycle themselves.

**Cross-platform implementation:**

- **Unix** (macOS / Linux): polls `os.getppid()` every 2 s. When the parent dies the kernel reparents the dashboard under PID 1 (or a configured subreaper); the ppid value changes and the next poll triggers self-shutdown.
- **Windows**: PPID does **not** change on parent death there (no `init` adopts orphans), and `os.kill(pid, 0)` would actually `TerminateProcess` the parent via CPython's Windows shim. We open a `PROCESS_SYNCHRONIZE` handle on the parent and block on it with `WaitForSingleObject` from a worker thread (via `asyncio.to_thread`); when the handle becomes signalled, the parent has exited.

Self-shutdown signals SIGTERM on Unix and `CTRL_BREAK_EVENT` on Windows — both routes hit aiohttp's existing signal handler so the normal `on_cleanup` chain runs (firmware queue drains, state persists, sites close).

The watchdog task is scheduled via the existing `create_background_task` helper, so it's auto-cancelled and gathered on normal `DeviceBuilder.stop()` paths and adds no extra teardown bookkeeping.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

The change is purely backend (CLI flag + a background task). The frontend never sees the new flag.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
