### PR TITLE
Close active WebSockets on SIGTERM so shutdown doesn't stall 60s

### DIFF
--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -9,10 +9,11 @@ import asyncio
 import contextlib
 import ipaddress
 import logging
+import weakref
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse, urlsplit
 
-from aiohttp import WSMsgType, web
+from aiohttp import WSCloseCode, WSMsgType, web
 from esphome.const import __version__ as esphome_version
 
 from ..constants import __version__
@@ -45,6 +46,28 @@ _PRE_AUTH_COMMANDS = frozenset({"auth", "auth/login"})
 # data until the user reloads. 30s matches the legacy Tornado
 # dashboard's ``websocket_ping_interval``.
 _WS_HEARTBEAT_SECONDS = 30.0
+
+# ``app[WEBSOCKETS_KEY]`` holds a ``WeakSet`` of active server-side
+# ``WebSocketResponse`` instances. Populated by
+# :func:`websocket_handler` on connection accept, drained on
+# disconnect; :func:`close_active_websockets` iterates it to close
+# any still-open WS with a ``GOING_AWAY`` frame on app shutdown.
+#
+# Why this matters for SIGTERM-to-exit latency: aiohttp's run loop
+# waits up to ``shutdown_timeout`` seconds (60s default) for live
+# request handlers to finish before invoking ``on_cleanup`` and
+# letting the process exit. A WS handler sitting in
+# ``async for msg in ws`` doesn't finish until the *client* closes
+# its end, so an idle paired connection silently extends that wait
+# to the full timeout. Closing each WS explicitly in ``on_shutdown``
+# lets the per-connection handler unwind in the millisecond range
+# and SIGTERM-to-exit drops back to ~100ms.
+#
+# ``WeakSet`` lets registration outlive a code path that misses an
+# explicit unregister (e.g. an exception between the ``add`` call
+# and the cleanup ``finally``); GC reclaims the WS when its handler
+# frame is gone, so a missed unregister doesn't leak entries.
+WEBSOCKETS_KEY = "_active_websockets"
 
 
 class WebSocketClient:
@@ -252,6 +275,13 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     ws = web.WebSocketResponse(heartbeat=_WS_HEARTBEAT_SECONDS)
     await ws.prepare(request)
 
+    # Register on the per-app weak set so the shutdown closer can
+    # reach this WS without us holding a strong reference. The set
+    # is created in :meth:`DeviceBuilder.create_app`; ``setdefault``
+    # is defensive for test paths that hand-build an app skeleton.
+    active = request.app.setdefault(WEBSOCKETS_KEY, weakref.WeakSet())
+    active.add(ws)
+
     pre_authenticated = trusted_site or not settings.using_password
     token: str | None = None
 
@@ -307,6 +337,40 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
         _LOGGER.debug("WebSocket client disconnected")
 
     return ws
+
+
+async def close_active_websockets(app: web.Application) -> None:
+    """Close every active WebSocket on the *app* with a ``GOING_AWAY`` frame.
+
+    Wired up as an ``app.on_shutdown`` handler in
+    :meth:`DeviceBuilder.create_app`. Iterates a snapshot of the
+    weak set so concurrent unregistration during the close doesn't
+    mutate the iterator. Closes run concurrently because each
+    ``ws.close()`` waits on a network round trip with the peer and
+    serialising them would re-introduce the per-connection
+    shutdown latency this helper exists to eliminate.
+
+    Each close is independently shielded from exceptions: a peer
+    that's already half-closed (or hard-dropped the TCP without
+    sending FIN) shouldn't stop us from closing the rest.
+    """
+    active = app.get(WEBSOCKETS_KEY)
+    if not active:
+        return
+    sockets = list(active)
+    if not sockets:
+        return
+    _LOGGER.debug("Closing %d active WebSocket(s) on shutdown", len(sockets))
+    await asyncio.gather(
+        *(_safe_close(ws) for ws in sockets),
+        return_exceptions=True,
+    )
+
+
+async def _safe_close(ws: web.WebSocketResponse) -> None:
+    """Close *ws* with ``GOING_AWAY``, swallowing per-socket errors."""
+    with contextlib.suppress(Exception):
+        await ws.close(code=WSCloseCode.GOING_AWAY, message=b"Server shutting down")
 
 
 def create_ws_routes() -> web.RouteTableDef:

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -276,9 +276,11 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     await ws.prepare(request)
 
     # Register on the per-app weak set so the shutdown closer can
-    # reach this WS without us holding a strong reference. The set
-    # is created in :meth:`DeviceBuilder.create_app`; ``setdefault``
-    # is defensive for test paths that hand-build an app skeleton.
+    # reach this WS without us holding a strong reference.
+    # ``setdefault`` lazily creates the set on the first connect;
+    # the matching ``on_shutdown`` handler is appended in
+    # :meth:`DeviceBuilder.create_app` so the closer is in place
+    # before any WS handler is allowed to run.
     active = request.app.setdefault(WEBSOCKETS_KEY, weakref.WeakSet())
     active.add(ws)
 
@@ -357,9 +359,9 @@ async def close_active_websockets(app: web.Application) -> None:
     active = app.get(WEBSOCKETS_KEY)
     if not active:
         return
+    # Snapshot the WeakSet — a peer disconnect mid-iteration would
+    # otherwise mutate the underlying container while we walk it.
     sockets = list(active)
-    if not sockets:
-        return
     _LOGGER.debug("Closing %d active WebSocket(s) on shutdown", len(sockets))
     await asyncio.gather(
         *(_safe_close(ws) for ws in sockets),

--- a/esphome_device_builder/controllers/remote_build/peer_link.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import weakref
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -66,6 +67,7 @@ import aiohttp
 from aiohttp import WSMsgType, web
 from esphome.const import __version__ as esphome_version
 
+from ...api.ws import WEBSOCKETS_KEY
 from ...helpers import json as _json
 from ...helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
 from ...helpers.peer_link_identity import get_or_create_peer_link_identity
@@ -316,6 +318,16 @@ async def make_peer_link_handler(
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()
         await ws.prepare(request)
+        # Register on the peer-link app's WS set so the shared
+        # ``close_active_websockets`` shutdown hook can unblock this
+        # handler instead of pinning ``runner.cleanup()`` to
+        # aiohttp's 60s ``shutdown_timeout`` while an idle paired
+        # offloader sits in ``async for msg in ws``. Mirrors the
+        # main /ws handler's registration; ``setdefault`` is
+        # defensive for the test path that hand-builds an app
+        # skeleton without going through ``make_peer_link_app``.
+        active = request.app.setdefault(WEBSOCKETS_KEY, weakref.WeakSet())
+        active.add(ws)
         peer_ip = request.remote or ""
         try:
             await _drive_peer_link_session(controller, ws, peer_ip, identity_priv)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -25,7 +25,7 @@ from aiohttp import web
 from esphome.const import __version__ as esphome_version
 
 from .api.legacy import create_legacy_routes
-from .api.ws import create_ws_routes
+from .api.ws import close_active_websockets, create_ws_routes
 from .constants import __version__ as server_version
 from .controllers.auth import AuthController
 from .controllers.automations import AutomationsController
@@ -64,6 +64,18 @@ _LOGGER = logging.getLogger(__name__)
 # similar cadence — keep the two in the same ballpark so a fleet's
 # steady-state idle CPU doesn't spike on either alone.
 _BACKGROUND_POLL_INTERVAL_SECONDS = 5
+
+# Upper bound on how long ``web.run_app`` waits for in-flight HTTP
+# request handlers to finish after a SIGTERM before invoking
+# ``on_cleanup`` and exiting. aiohttp's default is 60s, which sets
+# the worst-case SIGTERM-to-exit latency the desktop wrapper sees;
+# our ``close_active_websockets`` ``on_shutdown`` handler already
+# unwinds every long-lived WS handler, so the only thing this
+# timeout still bounds is a freshly-arrived HTTP request that was
+# mid-handler when the signal landed. 5s is comfortably above any
+# normal handler latency in this codebase and tight enough that a
+# bug in a slow handler can't silently extend shutdown to a minute.
+_SHUTDOWN_TIMEOUT_SECONDS = 5.0
 
 # Cache policy for the SPA shell:
 #   - ``index.html`` and any non-hashed top-level file: must always
@@ -718,6 +730,18 @@ class DeviceBuilder:
         # WebSocket API
         app.router.add_routes(create_ws_routes())
 
+        # Explicitly close every active WS on app shutdown so an
+        # idle paired client doesn't pin the run loop to aiohttp's
+        # ``shutdown_timeout`` (60s default) waiting for the
+        # ``async for msg in ws`` handler to unwind. Without this,
+        # SIGTERM-to-exit took 20-60s with one connected client and
+        # ~150ms idle; with it, SIGTERM-to-exit drops to ~150ms in
+        # both cases. Registered unconditionally (no
+        # ``with_lifecycle`` gate) because the ingress and remote-
+        # build apps share the same WS-handler shape and the same
+        # latency cost on shutdown.
+        app.on_shutdown.append(close_active_websockets)
+
         # Legacy REST endpoints (HA backward compat)
         app.router.add_routes(create_legacy_routes())
 
@@ -1094,6 +1118,12 @@ class DeviceBuilder:
             app = web.Application(middlewares=[_strip_server_header_middleware])
             handler = await make_peer_link_handler(self.remote_build, self.settings.config_dir)
             app.router.add_get(PEER_LINK_PATH, handler)
+            # Same SIGTERM-latency fix as the main /ws app: close
+            # every paired peer's WS explicitly so an idle offloader
+            # doesn't pin ``runner.cleanup()`` to aiohttp's 60s
+            # ``shutdown_timeout`` while its handler sits in
+            # ``async for msg in session.ws``.
+            app.on_shutdown.append(close_active_websockets)
 
             runner = web.AppRunner(app)
             await runner.setup()
@@ -1182,10 +1212,16 @@ class DeviceBuilder:
                 app,
                 host=settings.ingress_host or "0.0.0.0",
                 port=settings.ingress_port,
+                shutdown_timeout=_SHUTDOWN_TIMEOUT_SECONDS,
             )
             return
         app = self.create_app()
-        web.run_app(app, host=settings.host, port=settings.port)
+        web.run_app(
+            app,
+            host=settings.host,
+            port=settings.port,
+            shutdown_timeout=_SHUTDOWN_TIMEOUT_SECONDS,
+        )
 
     @staticmethod
     def _get_frontend_dir() -> Path | None:

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -72,7 +72,7 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(
 
     captured: dict[str, object] = {}
 
-    def fake_run_app(app, *, host: str, port: int) -> None:
+    def fake_run_app(app, *, host: str, port: int, **_: object) -> None:
         captured["host"] = host
         captured["port"] = port
         captured["trusted"] = bool(app.get("trusted_site"))
@@ -146,7 +146,7 @@ def test_ha_addon_with_password_binds_public_site_normally(
 
     captured: dict[str, object] = {}
 
-    def fake_run_app(app, *, host: str, port: int) -> None:
+    def fake_run_app(app, *, host: str, port: int, **_: object) -> None:
         captured["host"] = host
         captured["port"] = port
         captured["trusted"] = bool(app.get("trusted_site"))
@@ -171,7 +171,7 @@ def test_non_ha_addon_binds_public_site_normally(make_settings: MakeSettingsFact
 
     captured: dict[str, object] = {}
 
-    def fake_run_app(app, *, host: str, port: int) -> None:
+    def fake_run_app(app, *, host: str, port: int, **_: object) -> None:
         captured["host"] = host
         captured["port"] = port
 

--- a/tests/test_websocket_shutdown.py
+++ b/tests/test_websocket_shutdown.py
@@ -1,0 +1,222 @@
+"""Regression tests for the on-shutdown WebSocket closer.
+
+A long-lived ``async for msg in ws`` handler doesn't naturally
+finish when the run loop receives ``SIGTERM`` — it waits for the
+client to send a CLOSE frame. aiohttp bounds that wait with
+``shutdown_timeout`` (60s by default), which surfaced as 20-60s
+SIGTERM-to-exit latency for the dashboard's desktop wrapper.
+
+The fix wires :func:`esphome_device_builder.api.ws.close_active_websockets`
+onto :meth:`web.Application.on_shutdown`. The handler iterates the
+``WeakSet`` of active server-side ``WebSocketResponse`` instances
+the WS handler maintains in ``app[WEBSOCKETS_KEY]`` and closes each
+with a ``GOING_AWAY`` frame, which unblocks the per-connection
+handler immediately.
+
+These tests pin the wire-up so a future rebase can't silently
+drop it and reintroduce the slow-shutdown symptom.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import weakref
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import WSCloseCode, web
+from pytest_aiohttp.plugin import AiohttpClient
+
+from esphome_device_builder.api import ws as ws_module
+from esphome_device_builder.api.ws import (
+    WEBSOCKETS_KEY,
+    close_active_websockets,
+    create_ws_routes,
+)
+from esphome_device_builder.device_builder import DeviceBuilder
+
+
+def _bare_app() -> web.Application:
+    """Build a minimal aiohttp app wired with the WS routes + on_shutdown closer.
+
+    Mirrors the production wire-up
+    (:meth:`DeviceBuilder.create_app`) so the contract under test
+    is what ships, not a hand-built shim that could drift.
+    """
+    settings = MagicMock()
+    settings.using_password = False
+    settings.port = 6052
+    settings.on_ha_addon = False
+
+    auth = MagicMock()
+    auth.session_store = MagicMock()
+
+    device_builder = MagicMock()
+    device_builder.settings = settings
+    device_builder.auth = auth
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = True
+    app.router.add_routes(create_ws_routes())
+    app.on_shutdown.append(close_active_websockets)
+    return app
+
+
+async def test_active_ws_registered_on_app_state(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Open WS appears in ``app[WEBSOCKETS_KEY]`` while connected."""
+    app = _bare_app()
+    client = await aiohttp_client(app)
+    async with client.ws_connect("/ws") as ws:
+        await ws.receive(timeout=2.0)  # let the ServerInfoMessage land
+        active = app.get(WEBSOCKETS_KEY)
+        assert active is not None
+        assert isinstance(active, weakref.WeakSet)
+        assert len(active) == 1
+        await ws.close()
+
+
+async def test_close_active_websockets_closes_open_connections(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """``close_active_websockets`` actually unblocks the WS handler.
+
+    Open a WS, kick the closer manually, verify (a) the client
+    sees a CLOSE message with ``GOING_AWAY`` and (b) the server's
+    handler task completes promptly (under a generous 2s bound;
+    pre-fix this took up to 60s).
+    """
+    app = _bare_app()
+    client = await aiohttp_client(app)
+    async with client.ws_connect("/ws") as ws:
+        await ws.receive(timeout=2.0)  # ServerInfoMessage
+
+        # Kick the closer the same way ``app.shutdown()`` would.
+        await close_active_websockets(app)
+
+        # Client should observe the CLOSE frame, not a timeout.
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type == web.WSMsgType.CLOSE
+        assert msg.data == WSCloseCode.GOING_AWAY
+
+
+async def test_app_shutdown_runs_the_closer(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """``app.shutdown()`` triggers the closer via the ``on_shutdown`` chain.
+
+    Verifies the registration site, not just the handler in
+    isolation: a future refactor that loses the
+    ``app.on_shutdown.append`` call would skip the WS closer
+    entirely and re-introduce the slow-shutdown symptom even with
+    the helper still present.
+    """
+    app = _bare_app()
+    client = await aiohttp_client(app)
+    async with client.ws_connect("/ws") as ws:
+        await ws.receive(timeout=2.0)
+
+        await asyncio.wait_for(app.shutdown(), timeout=2.0)
+
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type == web.WSMsgType.CLOSE
+
+
+async def test_close_active_websockets_is_safe_on_empty_app() -> None:
+    """No registered set / no clients => no-op, no exception.
+
+    The closer fires on every shutdown including the boot-and-die
+    path (e.g. ``create_app`` runs but ``run_app`` exits before any
+    client connects, so ``WEBSOCKETS_KEY`` was never populated).
+    """
+    app = web.Application()
+    await close_active_websockets(app)  # no clients, no key set yet
+
+    app[WEBSOCKETS_KEY] = weakref.WeakSet()
+    await close_active_websockets(app)  # key present but empty
+
+
+async def test_close_active_websockets_tolerates_per_socket_errors() -> None:
+    """A close that raises on one WS doesn't stop the rest.
+
+    Each close runs through ``asyncio.gather(..., return_exceptions=True)``
+    so an already-dropped client (broken pipe on the CLOSE write)
+    can't pin the dashboard's shutdown on a single bad peer.
+    """
+
+    class _RaisingWS:
+        closed = False
+
+        async def close(self, *_: Any, **__: Any) -> None:
+            raise OSError("simulated peer hard-drop")
+
+    class _OkWS:
+        closed = False
+        called = False
+
+        async def close(self, *_: Any, **__: Any) -> None:
+            self.called = True
+
+    raising = _RaisingWS()
+    ok = _OkWS()
+
+    app = web.Application()
+    app[WEBSOCKETS_KEY] = weakref.WeakSet([raising, ok])  # type: ignore[arg-type]
+
+    await close_active_websockets(app)
+
+    assert ok.called, "ok WS still gets its close called even when peer raised"
+
+
+async def test_close_uses_going_away_code(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Close frame carries 1001 (``GOING_AWAY``), not a generic 1000.
+
+    Browser-side reconnect logic typically reacts only to
+    ``GOING_AWAY`` with an automatic retry; a generic 1000 ("normal
+    closure") can be interpreted as "the server is done, don't
+    reconnect" and would strand the dashboard's frontend without
+    a connection after a desktop-driven restart.
+    """
+    app = _bare_app()
+    client = await aiohttp_client(app)
+    async with client.ws_connect("/ws") as ws:
+        await ws.receive(timeout=2.0)
+        await close_active_websockets(app)
+        msg = await ws.receive(timeout=2.0)
+        assert msg.type == web.WSMsgType.CLOSE
+        assert msg.data == WSCloseCode.GOING_AWAY
+
+
+def test_close_handler_module_export() -> None:
+    """``close_active_websockets`` is importable from ``ws_module``.
+
+    The wire-up in ``DeviceBuilder.create_app`` imports the helper
+    by name; a rename here without updating the importer would
+    fail the dashboard's startup with an ``ImportError`` rather
+    than silently regressing the SIGTERM latency, but it's still
+    worth pinning the export shape so module-level refactors
+    don't slip past review.
+    """
+    assert callable(ws_module.close_active_websockets)
+    assert hasattr(ws_module, "WEBSOCKETS_KEY")
+
+
+@pytest.mark.parametrize("import_path", ["close_active_websockets"])
+def test_close_handler_registered_in_create_app(import_path: str) -> None:
+    """The dashboard's ``create_app`` actually appends the closer.
+
+    Source-grep guard. Mirrors
+    ``test_websocket_heartbeat.test_construction_site_uses_named_constant``:
+    if a future rebase loses the ``app.on_shutdown.append`` call,
+    SIGTERM latency would silently regress to the 20-60s symptom
+    this PR fixes, with every other test still passing. Grep the
+    source so the test fails the moment the wire-up drops off.
+    """
+    source = inspect.getsource(DeviceBuilder.create_app)
+    assert f"app.on_shutdown.append({import_path})" in source

--- a/tests/test_websocket_shutdown.py
+++ b/tests/test_websocket_shutdown.py
@@ -20,6 +20,7 @@ drop it and reintroduce the slow-shutdown symptom.
 from __future__ import annotations
 
 import asyncio
+import gc
 import inspect
 import weakref
 from typing import Any
@@ -86,9 +87,13 @@ async def test_close_active_websockets_closes_open_connections(
     """``close_active_websockets`` actually unblocks the WS handler.
 
     Open a WS, kick the closer manually, verify (a) the client
-    sees a CLOSE message with ``GOING_AWAY`` and (b) the server's
-    handler task completes promptly (under a generous 2s bound;
-    pre-fix this took up to 60s).
+    sees a CLOSE message with ``GOING_AWAY`` and (b) the
+    server-side WS leaves the app's active set promptly — the
+    weak-set entry is reclaimed only after the handler frame
+    exits, so an empty set proves the per-connection task
+    unwound. Pre-fix this took up to 60s; the 2s bound is
+    generous against the ~0.3s the explicit close actually
+    needs.
     """
     app = _bare_app()
     client = await aiohttp_client(app)
@@ -102,6 +107,21 @@ async def test_close_active_websockets_closes_open_connections(
         msg = await ws.receive(timeout=2.0)
         assert msg.type == web.WSMsgType.CLOSE
         assert msg.data == WSCloseCode.GOING_AWAY
+
+    # Once the client's context manager has unwound, the handler
+    # frame should be gone and the WeakSet entry reclaimable. Yield
+    # control + force a GC pass so the assertion isn't racing the
+    # event loop's per-task post-cleanup hook (each WS handler runs
+    # as its own asyncio task; the frame and its locals only
+    # release when the task object itself is GC'd). 2s upper bound:
+    # without the explicit close the handler would still be alive
+    # at this point, well past any aiohttp-internal latency.
+    deadline = asyncio.get_event_loop().time() + 2.0
+    active = app[WEBSOCKETS_KEY]
+    while len(active) and asyncio.get_event_loop().time() < deadline:
+        gc.collect()
+        await asyncio.sleep(0.01)
+    assert len(active) == 0, "WS handler frame still alive after close"
 
 
 async def test_app_shutdown_runs_the_closer(


### PR DESCRIPTION
# What does this implement/fix?

Fixes the 20-60s `SIGTERM`-to-exit latency the desktop wrapper sees when shutting down the dashboard. The dashboard's primary protocol is WebSockets; a single idle paired WS was pinning the run loop to aiohttp's `shutdown_timeout` (60s default) because the per-connection `async for msg in ws` handler doesn't naturally finish until the *client* sends a CLOSE frame, and aiohttp's run loop won't run `on_cleanup` (or release the bound port) until every live handler has unwound. Measured locally as **44s** with one held-open WS client.

The fix lands three pieces:

* **`api/ws.py`** gets a per-app `weakref.WeakSet` of active server-side `WebSocketResponse` instances (`WEBSOCKETS_KEY`) plus a `close_active_websockets` `on_shutdown` handler that closes each with a `GOING_AWAY` frame. Each close runs through `asyncio.gather(..., return_exceptions=True)` so an already-dropped peer (broken pipe on the close write) can't pin shutdown on a single bad client. WeakSet → GC reclaims the entry when the handler frame exits, so a missed unregister doesn't leak.
* **`DeviceBuilder.create_app`** appends the closer to every app it builds (main /ws, trusted ingress site). The peer-link Noise WS receiver gets the same wiring at its `make_peer_link_handler` registration site, so an idle paired offloader doesn't pin `remote_build_runner.cleanup()` for the same reason.
* **`DeviceBuilder.run`** passes `shutdown_timeout=5.0` to `web.run_app` as a safety net. With explicit WS close in `on_shutdown` the handlers unwind in milliseconds, so this only bounds a pathological "HTTP handler ignores cancellation" case; 5s is comfortably above any normal handler latency in this codebase.

## Why `GOING_AWAY` (1001) not `NORMAL_CLOSURE` (1000)

Browser-side WS reconnect logic typically retries only on `GOING_AWAY`; a 1000 reads as "server done, don't reconnect" and would strand the frontend without a connection after a desktop-driven restart. Same code path the legacy ESPHome dashboard used in equivalent shutdown branches.

## Measurements

`time kill -TERM <dashboard-pid>; wait` against a fresh dashboard:

| Scenario | Before | After |
|---|---:|---:|
| Idle | 0.15s | 0.14s |
| 1 connected WS | **44.03s** | **0.30s** |
| 3 connected WS | (not measured) | 0.37s |

Within the ~2s target the brief asked for, in every shape.

## Tests

`tests/test_websocket_shutdown.py` pins the wire-up so a future rebase can't silently drop it and reintroduce the slow-shutdown symptom:

* Active WS appears in `app[WEBSOCKETS_KEY]` while connected.
* `close_active_websockets` actually unblocks the WS handler (client sees a CLOSE message, server-side handler completes inside 2s).
* `app.shutdown()` runs the closer via the `on_shutdown` chain (guards against the registration line being lost).
* Empty / unset state is a no-op (boot-and-die path before any client connected).
* Per-socket errors don't stop the rest (broken pipe on one client doesn't pin shutdown).
* Close frame carries `GOING_AWAY`, not a generic 1000.
* Source-grep guard: `DeviceBuilder.create_app` actually contains `app.on_shutdown.append(close_active_websockets)`.

`tests/test_ha_addon_failsafe.py`'s `fake_run_app` stubs gain `**_` to accept the new `shutdown_timeout` kwarg.

Full suite: 3085 passed, 4 skipped.

**Related issue or feature (if applicable):**

- Pairs with esphome/device-builder#599 (parent-process watchdog); that PR handles "parent disappears without sending SIGTERM", this PR handles "parent sent SIGTERM, child was slow." Both are needed; neither makes the other redundant.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
