### PR TITLE
Add e2e coverage for submit_job's display-string passthrough (#587)

### DIFF
--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -130,7 +130,10 @@ def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmwar
         job_type: JobType,
         *,
         remote_peer: str = "",
+        remote_peer_label: str = "",
         remote_job_id: str = "",
+        device_name: str = "",
+        device_friendly_name: str = "",
         **_: Any,
     ) -> FirmwareJob:
         job = FirmwareJob(
@@ -139,7 +142,10 @@ def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmwar
             job_type=job_type,
             status=JobStatus.QUEUED,
             remote_peer=remote_peer,
+            remote_peer_label=remote_peer_label,
             remote_job_id=remote_job_id,
+            device_name=device_name,
+            device_friendly_name=device_friendly_name,
         )
         created_jobs.append(job)
         return job
@@ -147,6 +153,14 @@ def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmwar
     firmware = instances.receiver._db.firmware
     firmware._create_job = MagicMock(side_effect=_create_job)
     firmware._enqueue = AsyncMock(side_effect=lambda job: job)
+    # ``submit_job`` resolves the offloader's display label by
+    # going through ``self._firmware._db.remote_build.approved_peer_label``.
+    # The firmware controller is a MagicMock in this harness, so
+    # the ``_db.remote_build`` chain returns yet-another MagicMock;
+    # pin it to the real receiver-side controller so the label
+    # lookup at job-create time hits the actual approved-peer
+    # registry the pairing fixture populated.
+    firmware._db.remote_build = instances.receiver
     return created_jobs
 
 
@@ -290,3 +304,72 @@ async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
     assert payload["job_id"] == "off-job-1"  # offloader's tag echoed back
     assert payload["status"] == "running"
     assert payload["pin_sha256"] == paired_instances.pin_sha256
+
+
+@pytest.mark.asyncio
+async def test_submit_job_round_trip_carries_display_strings_to_receiver_job(
+    paired_instances: PairedInstances,
+) -> None:
+    """``submit_job``'s display-string header lands on the receiver-side FirmwareJob.
+
+    Pins the wire contract from esphome/device-builder#587 end-to-end:
+    the offloader-side frontend has the device's display strings
+    (``device_name`` / ``device_friendly_name``) when it kicks the
+    install off and threads them through ``client.submit_job(...)``;
+    the receiver-side dispatch coerces them off the
+    ``SubmitJobFrameData`` header and lands them on the queued
+    :class:`FirmwareJob` so the receiver's own task-list dialog can
+    show "AC Float Monitor 32 (kitchen)" from "offloader" without
+    having to parse the YAML it just extracted. ``remote_peer_label``
+    rides through the same path; it isn't a wire-header field (the
+    receiver looks it up locally off its approved-peer registry at
+    job-create time), but it's part of the same display-string
+    triple a regression in any one of the three would break, so
+    pin all three here.
+
+    The unit tests cover each side in isolation
+    (``test_remote_build_submit_job.py``, ``test_remote_runner.py``);
+    this e2e wires them up over a real Noise session so a future
+    rebase that swaps the wire header's spelling, drops a field
+    from ``_coerce_display_field``'s coverage, or changes the
+    ``approved_peer_label`` lookup site lands on this test instead
+    of going silent until a frontend bug report.
+    """
+    await paired_instances.wait_until_session_opened()
+    created_jobs = _wire_receiver_firmware_recorder(paired_instances)
+
+    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    ack = await handle.client.submit_job(
+        job_id="off-job-display",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=_build_real_bundle(),
+        device_name="kitchen",
+        device_friendly_name="AC Float Monitor 32",
+    )
+
+    assert ack["accepted"] is True
+    assert len(created_jobs) == 1
+    job = created_jobs[0]
+
+    # device_name / device_friendly_name flow off the SubmitJobFrameData
+    # header through ``_coerce_display_field`` onto the queued job.
+    assert job.device_name == "kitchen"
+    assert job.device_friendly_name == "AC Float Monitor 32"
+
+    # remote_peer_label isn't on the wire — the receiver looks it
+    # up at job-create time off its approved-peer registry, which
+    # was populated by the pair_request flow in the conftest. The
+    # pairing fixture stored "offloader" as the offloader-supplied
+    # label; assert against whatever the registry currently
+    # reports so a future fixture change doesn't pin a magic
+    # string here.
+    expected_label = paired_instances.receiver.approved_peer_label(
+        paired_instances.offloader_dashboard_id
+    )
+    assert expected_label, (
+        "test precondition: pairing fixture should leave the offloader "
+        "approved with a non-empty label so the receiver-side lookup "
+        "has something to find"
+    )
+    assert job.remote_peer_label == expected_label

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -324,7 +324,7 @@ async def test_submit_job_round_trip_carries_display_strings_to_receiver_job(
     rides through the same path; it isn't a wire-header field (the
     receiver looks it up locally off its approved-peer registry at
     job-create time), but it's part of the same display-string
-    triple a regression in any one of the three would break, so
+    triple; a regression in any one of the three would break it, so
     pin all three here.
 
     The unit tests cover each side in isolation


### PR DESCRIPTION
# What does this implement/fix?

Adds the missing e2e coverage for the display-string passthrough that esphome/device-builder#587 landed: the offloader-side frontend has the device's display strings (`device_name` / `device_friendly_name`) when it kicks off an install, threads them through `client.submit_job(...)`, and the receiver-side dispatch coerces them off the `SubmitJobFrameData` header and lands them on the queued `FirmwareJob` so the receiver's own task-list dialog can render "AC Float Monitor 32 (kitchen) from offloader" without re-parsing the bundled YAML.

The unit tests already cover each side in isolation (`test_remote_build_submit_job.py`, `test_remote_runner.py`); the e2e harness skipped the wire-up end-to-end. A regression that changed the wire-header spelling, dropped a field from `_coerce_display_field`'s coverage, or moved the `approved_peer_label` lookup site would have stayed silent until a frontend bug report.

## What lands

* **New test** `test_submit_job_round_trip_carries_display_strings_to_receiver_job` exercises the full round-trip:
  * Offloader calls `submit_job(..., device_name="kitchen", device_friendly_name="AC Float Monitor 32")` over the real Noise session.
  * Asserts the receiver-side queued `FirmwareJob` carries `device_name="kitchen"` / `device_friendly_name="AC Float Monitor 32"` (wire header → `_coerce_display_field` → `_create_job`).
  * Asserts `remote_peer_label` equals whatever the receiver's approved-peer registry reports for the offloader's `dashboard_id`. The label isn't on the wire (the receiver looks it up locally at job-create time via `RemoteBuildController.approved_peer_label`), but it's part of the same display-string triple, so a regression in any one of the three would break "from {label}" rendering. Asserting against the registry rather than a magic `"offloader"` string keeps the test resilient to a future pairing-fixture rename.
* **Recorder extension** in `_wire_receiver_firmware_recorder`: `_create_job` now captures `device_name` / `device_friendly_name` / `remote_peer_label` (previously swallowed via `**_`); the receiver's mocked firmware controller has its `_db.remote_build` pinned at the real paired controller so the production `approved_peer_label` lookup hits the actual approved-peer registry rather than a MagicMock chain.

## Remaining e2e gaps

Two related gaps from the same wave aren't in this PR; they're documented here so they don't fall through:

* **#596** (synthetic "remote build session closed" log line on session-lost): unit-tested in `tests/controllers/firmware/test_remote_runner.py`, no e2e. Would require an e2e that drops the peer-link session mid-compile and verifies the synthetic line appears in the offloader-side job output stream.
* **#597** (`error` field on `firmware/follow_job` RESULT envelope): unit-tested in `tests/controllers/firmware/test_follow_job_race.py`. The existing `test_remote_peer_terminal_failure_carries_error_message` covers the `JOB_FAILED` bus side; the follow_job RESULT envelope's `error` is unverified end-to-end.

Both are tractable but want a slightly bigger harness for the mid-flight session drop. Filing as follow-ups rather than bundling here.

**Related issue or feature (if applicable):**

- Pairs with esphome/device-builder#587 (the feature this covers).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
