### PR TITLE
Refuse silent pubkey overwrite on PENDING pair_request (defense-in-depth)

### DIFF
--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -4709,6 +4709,69 @@ class RemoteBuildController:
         if not self.is_pairing_window_open():
             return IntentResponse.NO_PAIRING_WINDOW
 
+        # Security: refuse to overwrite a PENDING entry's pubkey.
+        # The retry case the comment below describes is legitimate
+        # only when the *same* offloader sends a second
+        # ``pair_request`` — same X25519 keypair, possibly different
+        # label / peer_ip / paired_at. A different pubkey under the
+        # same dashboard_id is one of:
+        #   1. A second peer claiming the same dashboard_id (the
+        #      offloader-generated ``dashboard_id`` has 22 chars of
+        #      base64url entropy; collision is astronomical and
+        #      indistinguishable from impersonation regardless).
+        #   2. The offloader rotating its identity mid-pair-request.
+        #      Identity rotation preserves ``dashboard_id`` (see
+        #      ``rotate_identity`` in ``helpers/dashboard_identity.py``),
+        #      so the rotated-then-retried case is theoretically
+        #      reachable; rejecting forces the operator to abandon
+        #      the stale PENDING row and start over with a fresh
+        #      pair_request, which is the right user-visible outcome.
+        #   3. A LAN-adjacent attacker that read the legitimate
+        #      offloader's broadcast ``dashboard_id`` off mDNS and
+        #      sent a ``pair_request`` with their own pubkey.
+        #
+        # Pre-fix, case (3) silently overwrote the operator's PENDING
+        # row with the attacker's pubkey. Two damage modes:
+        #   * Pairing DoS: an attacker flickers the row between
+        #     legitimate and attacker pubkeys, the inbox keeps
+        #     re-rendering, the operator can't reliably approve
+        #     the right row.
+        #   * Approve-without-verifying impersonation: if the
+        #     operator clicks Approve based on muscle memory
+        #     without re-comparing the on-screen fingerprint to
+        #     their OOB-known one, they approve the attacker's
+        #     pubkey. Paired peers can ``submit_job``, which the
+        #     receiver compiles and serves binaries back for.
+        #
+        # **No practical attack is exploited in the wild today** —
+        # the OOB fingerprint check that operators perform during
+        # the approve step is the actual security gate, and a
+        # vigilant operator catches the swap. This fix is
+        # defense-in-depth: closing the silent-overwrite path
+        # turns the impersonation chain from "operator must
+        # OOB-verify carefully" into "attacker cannot inject a
+        # rival pubkey into an active PENDING row at all". The
+        # DoS variant — which doesn't depend on operator
+        # mistakes — is closed unconditionally.
+        #
+        # Same-pubkey retries still refresh ``label`` / ``peer_ip``
+        # / ``paired_at`` (the legitimate retry case below). The
+        # check is RAM-only; no disk hop, no UI event (firing a
+        # conflict event would only advertise the attempt to an
+        # attacker and let them noise up the inbox by triggering
+        # it on demand — refusing silently is strictly better).
+        existing = self._pending_peers.get(dashboard_id)
+        if existing is not None and existing.static_x25519_pub != static_x25519_pub:
+            _LOGGER.warning(
+                "pair_request from %s claims dashboard_id=%s but presented "
+                "a different X25519 pubkey than the existing PENDING entry "
+                "from %s; refusing the overwrite",
+                peer_ip,
+                dashboard_id,
+                existing.peer_ip,
+            )
+            return IntentResponse.REJECTED
+
         # Add or refresh the in-memory PENDING entry. The dict is
         # keyed on dashboard_id so a re-pair while still pending
         # (offloader retried before admin clicked) overwrites the

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2689,7 +2689,8 @@ async def test_record_pair_request_fires_event(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_record_pair_request_refreshes_existing_pending_row(tmp_path: Path) -> None:
-    """Re-pair from same dashboard_id + same pubkey refreshes label / peer_ip / paired_at.
+    """
+    Re-pair from same dashboard_id + same pubkey refreshes label / peer_ip / paired_at.
 
     The legitimate retry case: the offloader resent ``pair_request``
     before the admin clicked Approve, possibly with an updated
@@ -2743,7 +2744,8 @@ async def test_record_pair_request_pending_pubkey_mismatch_returns_rejected(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Different pubkey under an existing PENDING ``dashboard_id`` is refused.
+    """
+    Different pubkey under an existing PENDING ``dashboard_id`` is refused.
 
     Security: closes the silent-overwrite path a LAN-adjacent
     attacker could exploit to swap their X25519 pubkey into an

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2689,26 +2689,35 @@ async def test_record_pair_request_fires_event(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_record_pair_request_refreshes_existing_pending_row(tmp_path: Path) -> None:
-    """Re-pair from same dashboard_id while PENDING refreshes pin / label / paired_at in place."""
+    """Re-pair from same dashboard_id + same pubkey refreshes label / peer_ip / paired_at.
+
+    The legitimate retry case: the offloader resent ``pair_request``
+    before the admin clicked Approve, possibly with an updated
+    label (operator edited it offloader-side) or from a different
+    network address (DHCP renewal, NIC swap). Same X25519 keypair
+    means same identity, so the entry is refreshed in place rather
+    than rejected. The pubkey-mismatch case (impersonation attempt)
+    has its own test below.
+    """
     controller = _make_controller(config_dir=tmp_path)
     controller._db.bus = MagicMock()
+    pubkey = b"\x11" * 32
+    pin = hashlib.sha256(pubkey).hexdigest()
     initial = _stored_peer(
         dashboard_id="alpha",
-        pin_sha256="oldpin",
-        static_x25519_pub=b"\x11" * 32,
+        pin_sha256=pin,
+        static_x25519_pub=pubkey,
         label="old",
         paired_at=1.0,
     )
     _seed_pending_peer(controller, initial)
     await controller.set_pairing_window(open=True, client="receiver-tab")
     controller._db.bus.fire.reset_mock()
-    new_pubkey = b"\xcc" * 32
-    new_pin = hashlib.sha256(new_pubkey).hexdigest()
 
     response = await controller.record_pair_request(
         dashboard_id="alpha",
-        pin_sha256=new_pin,
-        static_x25519_pub=new_pubkey,
+        pin_sha256=pin,
+        static_x25519_pub=pubkey,
         label="renamed",
         peer_ip="10.0.0.1",
     )
@@ -2716,8 +2725,8 @@ async def test_record_pair_request_refreshes_existing_pending_row(tmp_path: Path
     assert response == "pending"
     # PENDING refresh updates the in-memory dict, not disk.
     refreshed = controller._pending_peers["alpha"]
-    assert refreshed.pin_sha256 == new_pin
-    assert refreshed.static_x25519_pub == new_pubkey
+    assert refreshed.pin_sha256 == pin
+    assert refreshed.static_x25519_pub == pubkey
     assert refreshed.label == "renamed"
     assert refreshed.paired_at > 1.0
     # ``peer_ip`` refreshes too — the offloader could be on a
@@ -2727,6 +2736,86 @@ async def test_record_pair_request_refreshes_existing_pending_row(tmp_path: Path
     assert refreshed.peer_ip == "10.0.0.1"
     # APPROVED dict stays empty — refresh is PENDING-only.
     assert controller._approved_peers == {}
+
+
+@pytest.mark.asyncio
+async def test_record_pair_request_pending_pubkey_mismatch_returns_rejected(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Different pubkey under an existing PENDING ``dashboard_id`` is refused.
+
+    Security: closes the silent-overwrite path a LAN-adjacent
+    attacker could exploit to swap their X25519 pubkey into an
+    operator's active PENDING row by replaying the legitimate
+    offloader's broadcast ``dashboard_id`` off mDNS. Pre-fix the
+    second ``pair_request`` overwrote the row in place; if the
+    operator then clicked Approve without re-comparing the
+    fingerprint against the OOB-known one, the attacker landed
+    in the APPROVED registry and could ``submit_job`` (full
+    code-exec on the receiver-side).
+
+    No known practical exploitation today — operators are
+    expected to OOB-verify the fingerprint at approve time, and
+    that check is what catches the swap. This is defense-in-depth:
+    after this fix the overwrite simply can't happen, so the
+    operator-vigilance gate is no longer load-bearing for that
+    particular impersonation chain. The DoS variant — flickering
+    the row to confuse approval — is closed unconditionally.
+
+    Same-pubkey retries still refresh (covered above); only the
+    pubkey-divergent case is rejected.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.bus = MagicMock()
+    legit_pubkey = b"\x11" * 32
+    legit_pin = hashlib.sha256(legit_pubkey).hexdigest()
+    initial = _stored_peer(
+        dashboard_id="alpha",
+        pin_sha256=legit_pin,
+        static_x25519_pub=legit_pubkey,
+        label="legit",
+        paired_at=1.0,
+        peer_ip="10.0.0.1",
+    )
+    _seed_pending_peer(controller, initial)
+    await controller.set_pairing_window(open=True, client="receiver-tab")
+    controller._db.bus.fire.reset_mock()
+
+    attacker_pubkey = b"\xff" * 32
+    attacker_pin = hashlib.sha256(attacker_pubkey).hexdigest()
+    with caplog.at_level("WARNING", logger="esphome_device_builder.controllers.remote_build"):
+        response = await controller.record_pair_request(
+            dashboard_id="alpha",
+            pin_sha256=attacker_pin,
+            static_x25519_pub=attacker_pubkey,
+            label="attacker",
+            peer_ip="10.0.0.99",
+        )
+
+    assert response == "rejected"
+    # Original PENDING row stays untouched. This is the
+    # security-critical invariant: the operator's view of the
+    # legitimate pair_request can't be silently mutated by an
+    # adversary.
+    untouched = controller._pending_peers["alpha"]
+    assert untouched.static_x25519_pub == legit_pubkey
+    assert untouched.pin_sha256 == legit_pin
+    assert untouched.label == "legit"
+    assert untouched.paired_at == 1.0
+    assert untouched.peer_ip == "10.0.0.1"
+
+    # No bus event fired on the rejection. Firing one would
+    # advertise the attempt back to an attacker (who would then
+    # know they can spam the conflict event to noise up the
+    # inbox at zero cost). A server-side WARNING log captures
+    # the event for forensics without giving the attacker a
+    # signal.
+    controller._db.bus.fire.assert_not_called()
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("different X25519 pubkey" in r.getMessage() for r in warnings), (
+        "expected a WARNING log line on the pubkey-mismatch refusal"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

**Security fix; no practical attack is exploited in the wild today.** The OOB fingerprint check operators perform at approve time is the load-bearing security gate, and a vigilant operator catches the swap this fix closes. Same framing as esphome/device-builder-frontend#310: the verification needs to be technically load-bearing, not just operator-vigilance-load-bearing.

Closes finding **M1** from `audit_results.md`.

## The hole

`RemoteBuildController.record_pair_request` reaches the "refresh existing PENDING entry" branch when an `intent="pair_request"` Noise session lands for a `dashboard_id` that's already in `_pending_peers` and the receiver's pairing window is open. Pre-fix the branch **unconditionally overwrote the cached row** with whatever the new handshake carried, including a different `static_x25519_pub`.

The "legitimate retry" the existing comment described is offloader-side: same X25519 keypair, maybe a different label / peer_ip / paired_at. There's no legitimate path where a different pubkey lands under the same `dashboard_id` while still PENDING:

* Identity rotation preserves `dashboard_id` but invalidates approved trust upstream, so a rotated offloader's `pair_request` hits the APPROVED-row branch first and gets `REJECTED` there (controller.py:4690-4696) before ever touching PENDING.
* The 22-char base64url `dashboard_id` makes random collision astronomical.
* That leaves impersonation.

## The attack

A LAN-adjacent attacker (joined the same Wi-Fi, compromised IoT device on the LAN, etc.) reads the legitimate offloader's `dashboard_id` from the receiver's mDNS broadcast (cleartext per protocol, NOT a secret). They complete their own Noise XX handshake against port 6055 with a fresh keypair and send a `pair_request` carrying the same `dashboard_id` but their own pubkey. Pre-fix, the operator's PENDING row was silently replaced with the attacker's pubkey.

Two damage modes:

* **Approve-without-verifying impersonation.** If the operator clicks Approve on the inbox row without re-comparing the on-screen fingerprint against their OOB-known one, they approve the attacker's pubkey. Approved peers can `submit_job`, which compiles arbitrary YAML and serves binaries back; from there the attacker has full receiver-side code-exec and can ship malicious firmware to every ESP the dashboard manages (same downstream chain as the offloader-side scenario in esphome/device-builder-frontend#310, just attacked from the receiver side).
* **Pairing DoS.** Repeated attacker requests flicker the PENDING row between legitimate and attacker pubkeys; the inbox keeps re-rendering and the operator can't reliably approve the right row. This variant doesn't depend on any operator mistake.

The operator-verification gate genuinely catches the impersonation case for a careful operator, which is why no real-world exploit is known. Closing the silent-overwrite path turns "must verify carefully every approve click" into "attacker can't inject a rival pubkey into an active PENDING row at all", and removes the DoS variant unconditionally.

## What this PR does

Add a one-line equality check at the top of the PENDING-refresh branch in `record_pair_request`. If an existing PENDING entry has a different `static_x25519_pub` than the incoming one, return `IntentResponse.REJECTED` and log a WARNING with both peer IPs + the `dashboard_id` for forensic visibility.

Same-pubkey retries still refresh `label` / `peer_ip` / `paired_at` (the legitimate offloader-side retry case the existing comment describes). The check is RAM-only; no disk hop, no event-bus mutation, no UI plumbing.

**No bus event fired on the rejection.** Firing one would advertise the attempt back to an attacker (who would then know they can spam the conflict event to noise up the inbox at zero cost). The WARNING log captures it server-side for an operator who goes looking; refusing silently on the wire is strictly better than surfacing a new attack-driven event channel.

## What this PR is NOT

* Not a fix for an actively-exploited bug. See `audit_results.md` M1 for the assessment that the OOB fingerprint check is doing real work for vigilant operators.
* Not the rotation-impersonation chain that esphome/device-builder-frontend#310 closes. That one is the wizard-side TOCTOU window the operator's verification has to bind across; this one is the PENDING-row hijack that happens before any wizard ever opens.
* Not the M2/L1 rate-limit / handshake-cap follow-ups. Those are tracked separately in `audit_results.md`.

## Tests

* Existing `test_record_pair_request_refreshes_existing_pending_row` retitled and reworked to use the **same** pubkey across the retry. That's the legitimate refresh path. Pre-fix the test conflated "any retry refreshes" with "same-pubkey retry refreshes" and would have passed even with the silent pubkey-overwrite bug.
* New `test_record_pair_request_pending_pubkey_mismatch_returns_rejected` pins the new contract end-to-end: different `static_x25519_pub` ⇒ `IntentResponse.REJECTED`, original PENDING row untouched (the security-critical invariant), no bus event fired, WARNING log emitted with the divergent peer IPs.

Full suite: 3087 passed (+2 from the M1 tests), 4 skipped.

**Related issue or feature (if applicable):**

- Closes finding M1 from `audit_results.md`.
- Companion to esphome/device-builder-frontend#310 (different point in the threat model; same overall hardening pass).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
