### PR TITLE
Mock peer-link spawn in cold-start test to drop 5s teardown leak

### DIFF
--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -1291,6 +1291,7 @@ async def test_peer_link_opened_for_unknown_pin_is_silent_no_op(
 @pytest.mark.asyncio
 async def test_start_seeds_pairings_dict_from_disk(
     offloader_controller_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``start()`` loads APPROVED pairings off disk into ``_pairings``.
 
@@ -1299,7 +1300,22 @@ async def test_start_seeds_pairings_dict_from_disk(
     and assert the dict is populated. Pins the cold-start
     contract — APPROVED rows survive a controller restart so the
     user doesn't have to re-pair on every dashboard bounce.
+
+    ``_spawn_peer_link_client`` is monkeypatched to a no-op so
+    ``start()`` doesn't kick off real ``PeerLinkClient.run()``
+    tasks against the unreachable ``seeded.local`` hostname.
+    Pre-monkeypatch the test took ~5s of wall-clock waiting for
+    DNS-failure-driven reconnect backoff during pytest's
+    background-task teardown; the contract under test is
+    "pairings dict populates from disk" which doesn't depend on
+    the spawn side effect.
     """
+    monkeypatch.setattr(
+        RemoteBuildController,
+        "_spawn_peer_link_client",
+        lambda self, pairing: None,
+    )
+
     # Stand up an offloader, write a row through its store, flush.
     seeder = _make_offloader_controller(config_dir=offloader_controller_dir)
     seeder._db.bus = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

## BLUF

Fixes a 5-second wall-clock teardown leak in
`tests/test_remote_build_peer_link_client.py::test_start_seeds_pairings_dict_from_disk`.
Full unit-test suite drops from **17.78s → 11.95s** (-33%).

## The leak

`test_start_seeds_pairings_dict_from_disk` verifies that
`RemoteBuildController.start()` loads APPROVED pairings off disk
into the `_pairings` dict. The fixture pairing references
`seeded.local:6055` which doesn't resolve — and `start()`'s
side-effect spawn of `PeerLinkClient.run()` for every APPROVED
pairing immediately starts a long-lived connect/handshake/reconnect
loop against that unreachable host. The test's assertions pass in
~50ms but pytest-asyncio's teardown then waits for the leaked
peer-link client task to unwind (macOS `getaddrinfo` slow path on
non-existent `.local` names + the client's reconnect backoff)
which took ~5s wall-clock.

## The fix

Monkeypatch `RemoteBuildController._spawn_peer_link_client` to a
no-op for this test's lifetime. The peer-link client spawn is a
side effect verified separately in the per-status-transition tests
(`test_apply_pair_status_result_approved_promotes_and_fires` and
friends); this test's contract is just "pairings dict populates
from the on-disk store", which doesn't depend on the spawn.

Same test post-fix: 0.15s.

## Top 10 slowest tests, before vs after

| Pre-fix | Post-fix |
|---|---|
| **5.00s** teardown `test_start_seeds_pairings_dict_from_disk` | **0.53s** call `test_boards_json_matches_manifests` |
| 0.57s call `test_boards_json_matches_manifests` | 0.49s setup `test_top_level_components_resolved` |
| 0.48s setup `test_top_level_components_resolved` | 0.22s call `test_get_components_excludes_featured_by_default` |
| 0.23s call `test_get_components_excludes_featured_by_default` | 0.21s call `test_async_delay_save_extends_deadline_on_later_call` |
| 0.21s call `test_async_delay_save_extends_deadline_on_later_call` | 0.20s call `test_pairing_window_auto_closes_when_clients_age_out` |
| 0.20s call `test_pairing_window_auto_closes_when_clients_age_out` | 0.17s call `test_get_components_mixed_category_unions` |
| 0.18s call `test_contention_handles_unreadable_lock_file_gracefully` | 0.16s call `test_contention_handles_unreadable_lock_file_gracefully` |
| 0.17s call `test_get_components_mixed_category_unions` | 0.12s call `test_terminate_kills_grandchild_via_process_group` |
| 0.13s call `test_build_featured_registry_skips_and_warns_on_unknown_component_id` | 0.11s call `test_contention_with_running_instance_returns_exit_code_1` |
| 0.12s call `test_contention_with_running_instance_returns_exit_code_1` | 0.11s call `test_async_delay_save_collapses_within_window` |

The 5s outlier disappears; everything else shifts up one position. The remaining tail is dominated by tests that exercise behavior worth keeping at this cost:

- **`test_boards_json_matches_manifests`** (~0.5s): rebuilds the entire board catalog from the YAML manifests and compares against `boards.json` — load-bearing drift check, can't be trimmed without losing the sync-detection guarantee.
- **Components catalog session-scoped fixture** (~0.5s, one-time): ~40MB JSON parse + ~900 entry objects, already amortized across every test that uses it.
- **`async_delay_save` / `pairing_window` timer tests** (~0.2s each): real timer behavior with CI-safe slack documented inline. Reducing the slack would flake on Windows CI.
- **Subprocess + file-contention tests** (~0.1-0.2s each): real fork/exec to pin process-group / file-lock semantics.

## Result vs goals from `slow_tests_cleanup.md`

| Goal | Target | Actual |
|---|---|---|
| Primary: full suite ≤ 30s | ≤ 30s | **11.95s** ✓ |
| Stretch: full suite ≤ 10s | ≤ 10s | 11.95s (close but not under) |
| No coverage loss | No tests skipped or marked `@pytest.mark.slow` | ✓ |

To hit ≤ 10s I'd need to attack the real-I/O tests above and the choice was: accept ~12s with full coverage, vs ~9s by skipping the drift / contention / timer tests. Picked accuracy over the stretch number, per the cleanup doc's "don't reduce coverage" rule.

## Tests

3065 passed, 26 skipped (same as before). No new tests added; no tests deleted or marked slow.

**Related issue or feature (if applicable):**

- Driven by `slow_tests_cleanup.md` checked into the repo root.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
