### PR TITLE
[docs] Strip planning-doc phase tags from code comments and docstrings

### DIFF
--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -36,11 +36,8 @@ DEFAULT_INGRESS_PORT = 8099
 # surface, and so paired peers can resolve "the remote-build URL"
 # off the mDNS SRV record without ambiguity.
 #
-# Transport changed across phases (the port number didn't): phases
-# 3b1-3c shipped HTTPS + bearer auth; phase 4a-r1 part 4 swaps the
-# bind to plain TCP serving a Noise XX WebSocket at
-# ``/remote-build/peer-link`` (Noise provides confidentiality +
-# mutual auth + forward secrecy at the application layer, so no
-# SSLContext to manage). The constant survives unchanged because
-# pre-release has no installed base of port-config to migrate.
+# The bind serves a Noise XX WebSocket at ``/remote-build/peer-link``
+# over plain TCP — Noise provides confidentiality + mutual auth +
+# forward secrecy at the application layer, so there's no SSLContext
+# to manage.
 DEFAULT_REMOTE_BUILD_PORT = 6055

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -639,11 +639,10 @@ def _settings_from_raw(raw: Any) -> RemoteBuildSettings:
     on older ``.device-builder.json`` files are silently
     dropped — mashumaro's ``DataClassORJSONMixin`` ignores
     unknown keys by default. The ``tokens`` field went with
-    the dormant bearer machinery (phase 4a-r2);
-    ``manual_hosts`` was removed once the pair dialog started
-    typing hostnames straight into ``request_pair``; ``peers``
-    moved to its own per-file ``Store`` at
-    ``.receiver_peers.json``.
+    the pre-Noise bearer machinery; ``manual_hosts`` was
+    removed once the pair dialog started typing hostnames
+    straight into ``request_pair``; ``peers`` moved to its
+    own per-file ``Store`` at ``.receiver_peers.json``.
     """
     if not isinstance(raw, dict):
         _LOGGER.warning(

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -76,7 +76,7 @@ _NO_ESPHOME_MODULE_MARKER = "No module named 'esphome'"
 #     Anchored to the ``Uploading:`` prefix.
 # Force ANSI colour through even when stdout isn't a TTY. The local
 # subprocess path and the source-routed remote runner's local upload
-# step (7a-3) share this — both spawn an ``esphome`` subprocess whose
+# step share this — both spawn an ``esphome`` subprocess whose
 # output the dashboard pipes verbatim to the firmware-tasks UI, so a
 # divergence between the two would produce visually-different streams
 # for jobs subscribers can't tell apart by source. Pulling the dict

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -210,8 +210,8 @@ class FirmwareController:
         fields aren't strictly redundant — the
         ``running=False, queue_depth>0`` window exists between
         ``await _queue.put(job)`` and the runner's ``_queue.get()``
-        landing the same item, so a phase-7 scheduler that reads
-        only ``running`` would misclassify a fully-loaded receiver
+        landing the same item, so a scheduler that reads only
+        ``running`` would misclassify a fully-loaded receiver
         as accepting more work.
         """
         running = self._current_job is not None
@@ -1669,7 +1669,7 @@ class FirmwareController:
 
         ``remote_peer`` is the offloader's ``dashboard_id`` when
         this job came in via the peer-link ``submit_job`` flow
-        (issue #106 phase 5c), empty otherwise. ``remote_job_id``
+        (issue #106), empty otherwise. ``remote_job_id``
         is the offloader's submit-tagged ``job_id`` from the
         same flow; the receiver-side ``job_id`` above is
         generated independently so the two id-spaces don't

--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -128,7 +128,7 @@ class _InflightDownload:
 
 
 class ArtifactsDownloadSender:
-    """Drives the receiver side of a ``download_artifacts`` flow (6a).
+    """Drives the receiver side of a ``download_artifacts`` flow.
 
     One instance per :class:`RemoteBuildController` (created
     in :meth:`RemoteBuildController.start` alongside the

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -17,7 +17,7 @@ dashboard restart for the listener state to follow. The 3c
 Settings UI surfaces this constraint; a future PR can wire
 the start / stop hooks if interactive toggling matters.
 
-Pairing model (phase 4a-r1):
+Pairing model:
 
 * Receiver-side state is a list of :class:`StoredPeer` rows
   keyed on ``dashboard_id``, with X25519 ``pin_sha256`` +
@@ -34,13 +34,11 @@ Pairing model (phase 4a-r1):
   the same ``/remote-build/peer-link`` endpoint without
   re-prompting the receiver-side user.
 
-The HTTPS+bearer receiver site that shipped in phases 3b1-3c
-(token CRUD, ``StoredToken`` persistence, bearer auth
-middleware, first-use binding) was wound down across phases
-4a-r1 (listener body swap to Noise WS) and 4a-r2 (helper
-deletion); only ``StoredPeer`` + the peer-link Noise dispatch
-ship in production today. See issue #106 for the historical
-trail.
+Only ``StoredPeer`` + the peer-link Noise dispatch ship today;
+the legacy HTTPS+bearer receiver site (token CRUD,
+``StoredToken`` persistence, bearer auth middleware, first-use
+binding) was wound down before release. See issue #106 for the
+historical trail.
 
 Manual hosts have no version / fingerprint resolution yet;
 they land in ``list_hosts`` with empty ``server_version`` /
@@ -182,8 +180,8 @@ def _load_offloader_identities(
     """Load both offloader-side identities in one executor hop.
 
     The peer-link X25519 keypair drives the Noise XX handshake;
-    the dashboard cert (phase 3a) carries the stable
-    ``dashboard_id`` we send in msg3 so the receiver's
+    the dashboard cert carries the stable ``dashboard_id`` we
+    send in msg3 so the receiver's
     ``StoredPeer`` row keys on it. The two are both lazy-create
     on first read, both protected by per-process locks
     in their respective helpers, and both involve disk I/O
@@ -328,8 +326,8 @@ def _peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPee
     # ``pin_sha256`` and ``remote_build_port`` are emitted by the
     # advertiser only when the peer-link listener is bound (see
     # :class:`DashboardAdvertiser`). The offloader-side mDNS
-    # auto-rebind path (4a-o part 7) reads both: pin to match a
-    # broadcast against a stored pairing, port to dial the
+    # auto-rebind path reads both: pin to match a broadcast
+    # against a stored pairing, port to dial the
     # peer-link Noise WS on the new endpoint. ``""`` / ``0`` for
     # receivers that haven't published them; the rebind path
     # silently skips those rows.
@@ -393,13 +391,13 @@ class _PairLabelField(StrEnum):
 class _RebindProbeOutcome(StrEnum):
     """Typed outcome of :meth:`RemoteBuildController._probe_pairing_endpoint`.
 
-    The probe is shared between mDNS-driven auto-rebind (4a-o
-    part 7) and user-driven manual edit (8b); each caller maps
-    the outcome onto its own surface (silent log + cooldown for
-    auto, typed :class:`CommandError` for the WS-driven user
-    path). The enum factors out the four distinct probe
-    failure modes so the surface mapping lives at the call site
-    instead of in a per-caller bespoke probe body.
+    The probe is shared between mDNS-driven auto-rebind and
+    user-driven manual edit; each caller maps the outcome onto
+    its own surface (silent log + cooldown for auto, typed
+    :class:`CommandError` for the WS-driven user path). The
+    enum factors out the four distinct probe failure modes so
+    the surface mapping lives at the call site instead of in a
+    per-caller bespoke probe body.
     """
 
     OK = "ok"
@@ -505,9 +503,9 @@ def _validate_hostname(
     so ``Desktop.local`` and ``desktop.local`` should be the same
     entry. The stored form is the trimmed, lowercased string (so
     two adds with different casing collapse to one entry rather
-    than registering twice). Phase 4 attempts the actual
-    connection (and discovers DNS / TLS validity); phase 2b
-    deliberately doesn't pre-flight an "is this resolvable now?"
+    than registering twice). The actual connection runs when
+    pairing attempts it (and discovers DNS / TLS validity); we
+    deliberately don't pre-flight an "is this resolvable now?"
     check, which would fail on offline laptops adding a peer
     for later.
     """
@@ -748,12 +746,12 @@ _OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES: frozenset[str] = frozenset(
 )
 
 
-# Required fields on inbound ``cancel_job`` peer-link frames
-# (5d). The frame is offloader → receiver direction; the
-# receiver's :meth:`RemoteBuildController.handle_cancel_job`
-# validates this shape before reaching into the
-# :class:`JobFanout` correlation cache. Same defensive idiom
-# the 5c-2 / 5c-3 dispatchers use.
+# Required fields on inbound ``cancel_job`` peer-link frames.
+# The frame is offloader → receiver direction; the receiver's
+# :meth:`RemoteBuildController.handle_cancel_job` validates
+# this shape before reaching into the :class:`JobFanout`
+# correlation cache. Same defensive idiom the ``submit_job``
+# dispatchers use.
 _CANCEL_JOB_SCHEMA = frame_schema({"job_id": str})
 
 
@@ -910,9 +908,9 @@ _PAIRINGS_SAVE_DELAY_SECONDS = 1.0
 # :data:`DEFAULT_CLEANUP_TTL_SECONDS`).
 _CLEANUP_SWEEP_INTERVAL_SECONDS = 60 * 60
 
-# Sliding window enforced per-pin between mDNS rebind probes
-# (4a-o part 7). Doubles as the in-flight guard (set when
-# scheduling, cleared only on probe success) and the
+# Sliding window enforced per-pin between mDNS rebind probes.
+# Doubles as the in-flight guard (set when scheduling, cleared
+# only on probe success) and the
 # retry-throttle (failure leaves the entry in place until the
 # window elapses, so a permanently-unreachable host doesn't
 # trigger one probe per mDNS Updated burst). 30 s is plenty
@@ -991,8 +989,8 @@ class RemoteBuildController:
         # Strong refs for fire-and-forget resolve tasks so the
         # garbage collector can't reap them mid-await.
         self._tasks: set[asyncio.Task[None]] = set()
-        # mDNS auto-rebind probe slot per pin (4a-o part 7),
-        # mapping ``pin_sha256`` to the monotonic timestamp at
+        # mDNS auto-rebind probe slot per pin, mapping
+        # ``pin_sha256`` to the monotonic timestamp at
         # which another probe is allowed. Doubles as the
         # in-flight guard (set on schedule) and the
         # retry-throttle (failure leaves it in place until the
@@ -1072,10 +1070,10 @@ class RemoteBuildController:
         # ``subscribe_pairings`` channel needed.
         #
         # Keyed on ``pin_sha256`` to match the unified
-        # ``_pairings`` dict (4a-o part 6 — re-keyed offloader
-        # state from ``(host, port)`` to pin so a receiver
-        # rename is a one-line value mutation rather than a
-        # multi-dict atomic remap).
+        # ``_pairings`` dict (offloader state is keyed on pin
+        # rather than ``(host, port)`` so a receiver rename
+        # is a one-line value mutation rather than a multi-
+        # dict atomic remap).
         self._pair_status_listeners: dict[str, asyncio.Task[None]] = {}
         # PENDING StoredPeer rows live here, keyed on dashboard_id.
         # Never persisted — the per-file ``_peers_store``
@@ -1120,7 +1118,7 @@ class RemoteBuildController:
         # offloader takes over its previous slot rather than
         # doubling. Drained in :meth:`stop`.
         self._peer_link_sessions: dict[str, PeerLinkSession] = {}
-        # Receiver-side ``submit_job`` flow handler (5c-2).
+        # Receiver-side ``submit_job`` flow handler.
         # Holds per-session in-flight bundle reception state and
         # drives the receiver's accept path
         # (assemble → write tarball → extract → queue
@@ -1133,7 +1131,7 @@ class RemoteBuildController:
         # after ``start``, so the not-yet-installed window is
         # never reachable on a healthy code path.
         self._submit_job_receiver: SubmitJobReceiver | None = None
-        # Receiver-side ``download_artifacts`` flow handler (6a).
+        # Receiver-side ``download_artifacts`` flow handler.
         # Same lifecycle as :attr:`_submit_job_receiver`:
         # constructed in :meth:`start` once the firmware
         # controller is available, accessed by the peer-link
@@ -1146,13 +1144,12 @@ class RemoteBuildController:
         # ``start``).
         self._artifacts_download_sender: ArtifactsDownloadSender | None = None
         # Receiver-side fan-out from firmware ``JOB_*`` events to
-        # ``job_state_changed`` / ``job_output`` peer-link frames
-        # (5c-2b). Subscribes in :meth:`start`, detaches in
-        # :meth:`stop`. Filters firmware events by
-        # ``FirmwareJob.remote_peer`` so only remote-peer jobs
-        # (queued by 5c-2a's submit path) fan out — local
-        # operator-driven compiles never reach a peer-link
-        # session.
+        # ``job_state_changed`` / ``job_output`` peer-link frames.
+        # Subscribes in :meth:`start`, detaches in :meth:`stop`.
+        # Filters firmware events by ``FirmwareJob.remote_peer``
+        # so only remote-peer jobs (queued by the submit path)
+        # fan out — local operator-driven compiles never reach a
+        # peer-link session.
         self._job_fanout: JobFanout | None = None
         # Offloader-side long-lived peer-link clients, one per
         # APPROVED ``StoredPairing``, keyed on the receiver's
@@ -1165,8 +1162,8 @@ class RemoteBuildController:
         # the connect-handshake-park-reconnect loop in
         # :meth:`PeerLinkClient.run`. The client object is
         # retained alongside its task so the
-        # ``remote_build/submit_job`` WS command (5c-3) can
-        # reach :meth:`PeerLinkClient.submit_job` to drive a
+        # ``remote_build/submit_job`` WS command can reach
+        # :meth:`PeerLinkClient.submit_job` to drive a
         # bundle through the live session — the task itself
         # exposes only ``cancel`` / ``done``, not the per-flow
         # send API.
@@ -1223,8 +1220,8 @@ class RemoteBuildController:
         # :meth:`build_scheduler_snapshot` on every install.
         self._remote_builds_enabled: bool = True
         # RAM-only offloader-side pair alerts. Keyed on
-        # ``pin_sha256`` to match ``_pairings`` (4a-o part 6).
-        # Populated by ``_apply_pair_status_result`` when a
+        # ``pin_sha256`` to match ``_pairings``. Populated by
+        # ``_apply_pair_status_result`` when a
         # pair-status round-trip detects a pin drift
         # (pin_mismatch) or a receiver-side rejection
         # (peer_revoked); cleared only by the two resolution
@@ -1238,7 +1235,7 @@ class RemoteBuildController:
         # Never persisted: the alert describes a transient
         # detection, and a process restart with the row still
         # gone leaves nothing for the listener to re-detect
-        # against; phase 5+ peer-link sessions re-trigger the
+        # against; live peer-link sessions re-trigger the
         # underlying condition the next time the row is *used*.
         # ``subscribe_events.initial_state.offloader_alerts``
         # carries the snapshot so a tab subscribing AFTER the
@@ -1247,8 +1244,8 @@ class RemoteBuildController:
         self._offloader_alerts: dict[str, OffloaderAlertSnapshotEntry] = {}
         # RAM-only offloader-side cache of the most recent
         # ``queue_status`` snapshot received from each paired
-        # receiver, keyed on ``pin_sha256`` (4a-o part 6 —
-        # mirrors ``_pairings`` keying). Updated on every
+        # receiver, keyed on ``pin_sha256`` (mirrors
+        # ``_pairings`` keying). Updated on every
         # inbound ``OFFLOADER_QUEUE_STATUS_CHANGED`` (the
         # :class:`PeerLinkClient` receive loop fires the event
         # after parsing a wire frame). Surfaced through
@@ -1339,7 +1336,7 @@ class RemoteBuildController:
         fail-soft; same contract as
         :class:`DashboardAdvertiser`.
         """
-        # Stand up the receiver-side ``submit_job`` handler (5c-2)
+        # Stand up the receiver-side ``submit_job`` handler
         # before the peer-link listener can possibly fire its
         # first SUBMIT_JOB dispatch. The handler has no work to
         # do on cold start beyond holding its empty in-flight
@@ -1920,7 +1917,7 @@ class RemoteBuildController:
                 )
 
     async def handle_cancel_job(self, session: PeerLinkSession, frame: dict[str, Any]) -> None:
-        """Receiver-side dispatch for inbound ``cancel_job`` frames (5d).
+        """Receiver-side dispatch for inbound ``cancel_job`` frames.
 
         Resolves the offloader-supplied ``job_id`` to the
         receiver-local :class:`FirmwareJob` via
@@ -1991,7 +1988,7 @@ class RemoteBuildController:
             )
 
     def get_submit_job_receiver(self) -> SubmitJobReceiver:
-        """Receiver-side ``submit_job`` flow handler (5c-2).
+        """Receiver-side ``submit_job`` flow handler.
 
         Accessor used by
         :func:`controllers.remote_build_peer_link._receive_loop`
@@ -2017,7 +2014,7 @@ class RemoteBuildController:
         return self._submit_job_receiver
 
     def get_artifacts_download_sender(self) -> ArtifactsDownloadSender:
-        """Receiver-side ``download_artifacts`` flow handler (6a).
+        """Receiver-side ``download_artifacts`` flow handler.
 
         Same shape as :meth:`get_submit_job_receiver`: accessed
         by :func:`controllers.remote_build.peer_link._receive_loop`
@@ -2229,8 +2226,8 @@ class RemoteBuildController:
             return
         self._peers[name] = peer
         self._db.bus.fire(EventType.REMOTE_BUILD_HOST_ADDED, peer.to_dict())
-        # mDNS auto-rebind (4a-o part 7). Same callback that fires
-        # the discovered-hosts event also drives the per-pairing
+        # mDNS auto-rebind. Same callback that fires the
+        # discovered-hosts event also drives the per-pairing
         # rebind: if this broadcast carries a ``pin_sha256`` we
         # have a stored pairing for AND its ``(host, port)``
         # differs from what we have on disk, kick off a
@@ -2280,8 +2277,8 @@ class RemoteBuildController:
 
         Distinct from :meth:`DeviceBuilder.create_background_task`
         because the controller's :meth:`stop` gathers
-        :attr:`_tasks` separately (4a-o subsystem teardown
-        ordering); mixing the two sets would change shutdown
+        :attr:`_tasks` separately for ordered subsystem
+        teardown; mixing the two sets would change shutdown
         semantics.
         """
         task = asyncio.create_task(coro, name=name)
@@ -2290,7 +2287,7 @@ class RemoteBuildController:
         return task
 
     async def _run_cleanup_loop(self) -> None:
-        """Sweep cold remote-build subtrees on a periodic tick (6c).
+        """Sweep cold remote-build subtrees on a periodic tick.
 
         Reads the operator-configured TTL off
         :attr:`RemoteBuildSettings.cleanup_ttl_seconds`,
@@ -2464,11 +2461,11 @@ class RemoteBuildController:
           so subscribed frontends update display fields without
           a snapshot read.
 
-        Used by :meth:`_probe_and_rebind_endpoint` today; the
-        eventual phase 8b "manually edit a paired sender's
-        hostname/port" surface lands on the same epilogue
-        (different validate-and-mutate prologue, identical
-        respawn-and-announce shape).
+        Used by :meth:`_probe_and_rebind_endpoint`; a future
+        "manually edit a paired sender's hostname/port" surface
+        would land on the same epilogue (different validate-
+        and-mutate prologue, identical respawn-and-announce
+        shape).
         """
         self._cancel_peer_link_client(pairing.pin_sha256)
         self._spawn_peer_link_client(pairing)
@@ -2479,7 +2476,7 @@ class RemoteBuildController:
         )
 
     # ------------------------------------------------------------------
-    # mDNS auto-rebind (4a-o part 7)
+    # mDNS auto-rebind
     # ------------------------------------------------------------------
 
     def _maybe_schedule_rebind_probe(self, peer: RemoteBuildPeer) -> None:
@@ -2835,8 +2832,8 @@ class RemoteBuildController:
         return view
 
     # ------------------------------------------------------------------
-    # Offloader-side settings (phase 7b) — the master "Remote builds
-    # enabled" toggle + per-pairing enable switch. These configure the
+    # Offloader-side settings — the master "Remote builds enabled"
+    # toggle + per-pairing enable switch. These configure the
     # ``pick_build_path`` scheduler that ``firmware/install`` routes
     # through. Mutations persist via the existing
     # ``_pairings_store`` (the master toggle lives on
@@ -2851,7 +2848,7 @@ class RemoteBuildController:
 
         Bundles the master ``remote_builds_enabled`` toggle
         with the projected :class:`PairingSummary` list so the
-        7b Settings UI's first paint reads everything it needs
+        Settings UI's first paint reads everything it needs
         from one round-trip. Subsequent live updates flow
         through ``OFFLOADER_REMOTE_BUILDS_TOGGLED`` /
         ``OFFLOADER_PAIRING_ENABLED_CHANGED`` /
@@ -2961,8 +2958,8 @@ class RemoteBuildController:
         return self._pairing_summary_for(pairing)
 
     # ------------------------------------------------------------------
-    # Offloader-side pair flow (phase 4a-o) — initiator commands that
-    # open Noise XX WebSockets to a receiver's peer-link endpoint. The
+    # Offloader-side pair flow — initiator commands that open Noise XX
+    # WebSockets to a receiver's peer-link endpoint. The
     # wire-shape driver lives in
     # :mod:`controllers.remote_build_peer_link_client`; the WS command
     # here owns input validation, identity loading, and error mapping.
@@ -2978,7 +2975,7 @@ class RemoteBuildController:
         renders the returned ``pin_sha256`` for the user to
         OOB-verify against the receiver's "Build server"
         Settings card; only after that confirmation does the
-        offloader call ``request_pair`` (phase 4a-o part 3).
+        offloader call ``request_pair``.
 
         Args:
             hostname: Receiver's hostname / IP (validated as for
@@ -3243,9 +3240,9 @@ class RemoteBuildController:
         receiver's ownership concern. The next ``intent="peer_link"``
         from this offloader will return ``REJECTED`` because the
         offloader's local row is gone, but the receiver-side row
-        won't auto-clean — phase 8's re-auth wizard surfaces the
-        "stale on receiver, removed locally" case as a UI affordance
-        for the receiver-side admin to clean up.
+        won't auto-clean — a future re-auth wizard would surface
+        the "stale on receiver, removed locally" case as a UI
+        affordance for the receiver-side admin to clean up.
 
         If a pair-status listener task is in flight for this row
         (admin hadn't clicked Accept/Reject yet), it gets cancelled
@@ -3651,7 +3648,7 @@ class RemoteBuildController:
         job_id: str,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Fetch the build's flash-artifact set for *job_id* from the paired receiver (6a).
+        """Fetch the build's flash-artifact set for *job_id* from the paired receiver.
 
         Sends ``download_artifacts{job_id}`` over the open
         peer-link to *pin_sha256*, parks on the assembled-bytes
@@ -3659,9 +3656,9 @@ class RemoteBuildController:
         ``artifacts_start`` / ``artifacts_chunk`` /
         ``artifacts_end`` frames land, then unpacks the
         SHA-256-verified gzipped tarball into a structured
-        response the offloader's frontend (6b) can hand
-        directly to its install paths (Web Serial / network
-        OTA / download-to-disk).
+        response the offloader's frontend can hand directly to
+        its install paths (Web Serial / network OTA /
+        download-to-disk).
 
         Validation gates (cheapest first, so user-input errors
         short-circuit before any wire work):
@@ -3742,7 +3739,7 @@ class RemoteBuildController:
         job_id: str,
         **kwargs: Any,
     ) -> dict[str, bool]:
-        """Send a ``cancel_job`` frame to the receiver behind *pin_sha256* (5d).
+        """Send a ``cancel_job`` frame to the receiver behind *pin_sha256*.
 
         Cooperative cancellation for a previously-submitted
         remote-driven job. *job_id* is the offloader-local id
@@ -3854,9 +3851,9 @@ class RemoteBuildController:
         time) — flagged here so the surface choice is a
         deliberate move, not a silent assumption.
 
-        ``remote_builds_enabled`` reads :attr:`_remote_builds_enabled`
-        (7b), the master switch the offloader Settings UI
-        flips through ``set_offloader_settings``. ``False``
+        ``remote_builds_enabled`` reads :attr:`_remote_builds_enabled`,
+        the master switch the offloader Settings UI flips
+        through ``set_offloader_settings``. ``False``
         gates every install to LOCAL without tearing down the
         peer-link sessions — the Send-builds power-user dialog
         and the receiver-side housekeeping (queue_status push,
@@ -3995,9 +3992,9 @@ class RemoteBuildController:
         )
 
     # ------------------------------------------------------------------
-    # Pair-status listeners (phase 4a-o part 4) — one task per PENDING
-    # StoredPairing, each holding an open Noise WS to its receiver
-    # with ``intent="pair_status"``. Receiver-side responder waits on
+    # Pair-status listeners — one task per PENDING StoredPairing, each
+    # holding an open Noise WS to its receiver with
+    # ``intent="pair_status"``. Receiver-side responder waits on
     # its own bus event for an admin click and pushes the response
     # back, so the offloader sees the flip with sub-second latency
     # without polling.
@@ -4335,8 +4332,7 @@ class RemoteBuildController:
         Mirrors :meth:`_fire_pair_status_changed` (receiver-side)
         for shape; both methods are the named-intent boundary
         between controller logic and the bus payload format.
-        ``pin_sha256`` is the canonical row identifier (4a-o
-        part 6 — re-keyed offloader state on pin); receiver
+        ``pin_sha256`` is the canonical row identifier; receiver
         coords stay on the payload as display fields.
         """
         payload: OffloaderPairStatusChangedData = {
@@ -4396,8 +4392,8 @@ class RemoteBuildController:
         to "the receiver isn't going to talk to us"; the alert
         copy stays generic. Fires alongside
         ``status="removed"``. ``pin_sha256`` is the canonical
-        row identifier (4a-o part 6); receiver coords stay on
-        the payload as display fields.
+        row identifier; receiver coords stay on the payload as
+        display fields.
         """
         payload: OffloaderPairPeerRevokedData = {
             "receiver_hostname": receiver_hostname,
@@ -4408,10 +4404,10 @@ class RemoteBuildController:
         self._db.bus.fire(EventType.OFFLOADER_PAIR_PEER_REVOKED, payload)
 
     # ------------------------------------------------------------------
-    # Identity (phase 3c1) — surface the receiver's own dashboard_id +
-    # cert pin to the Settings UI without making it reach into the
-    # cert PEM directly. Rotation lives next door so the "rotate"
-    # button can land in the same controller.
+    # Identity — surface the receiver's own dashboard_id + cert pin to
+    # the Settings UI without making it reach into the cert PEM
+    # directly. Rotation lives next door so the "rotate" button can
+    # land in the same controller.
     # ------------------------------------------------------------------
 
     @api_command("remote_build/get_identity")
@@ -4515,11 +4511,10 @@ class RemoteBuildController:
             self._rotation_in_flight = False
 
     # ------------------------------------------------------------------
-    # Peer CRUD (phase 4a-r1 part 3) — receiver-UI surface for the
-    # Pairing requests inbox and the approved-peers list. The peer-link
-    # listener (phase 4a-r1 part 4) is the actual creator of PENDING
-    # rows; these commands are the receiver-side admin's UI surface for
-    # acting on them.
+    # Peer CRUD — receiver-UI surface for the Pairing requests inbox
+    # and the approved-peers list. The peer-link listener is the
+    # actual creator of PENDING rows; these commands are the
+    # receiver-side admin's UI surface for acting on them.
     # ------------------------------------------------------------------
 
     @api_command("remote_build/approve_peer")
@@ -4578,7 +4573,7 @@ class RemoteBuildController:
           fires the same
           :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED`
           ``status="removed"`` event so the offloader can
-          surface a ``peer_revoked`` UI alert (phase 4b-3).
+          surface a ``peer_revoked`` UI alert.
 
         ``NOT_FOUND`` if neither dict has a row.
         """
@@ -4627,10 +4622,10 @@ class RemoteBuildController:
         return self._to_view(settings)
 
     # ------------------------------------------------------------------
-    # Peer-link Noise WS dispatch helpers (phase 4a-r1 part 4) — called
-    # by the post-handshake intent dispatcher in
-    # :mod:`controllers.remote_build_peer_link`. These methods own the
-    # storage / event-firing side; the dispatcher owns the wire side.
+    # Peer-link Noise WS dispatch helpers — called by the post-handshake
+    # intent dispatcher in :mod:`controllers.remote_build_peer_link`.
+    # These methods own the storage / event-firing side; the dispatcher
+    # owns the wire side.
     # ------------------------------------------------------------------
 
     async def record_pair_request(
@@ -4813,7 +4808,7 @@ class RemoteBuildController:
         * :attr:`IntentResponse.OK` — peer is APPROVED and the
           handshake's pubkey hash matches the stored
           ``pin_sha256``. Caller can keep the WS open for
-          application messages (phase 5+).
+          application messages.
         * :attr:`IntentResponse.PENDING` — peer's row exists in
           the receiver's in-memory PENDING dict (admin hasn't
           clicked Accept yet). The offloader's frontend reflects
@@ -4957,10 +4952,10 @@ class RemoteBuildController:
         return approved_response
 
     # ------------------------------------------------------------------
-    # Pairing window (phase 4a-r1 part 3) — in-process deadline that
-    # gates ``intent="pair_request"`` Noise frames at the listener
-    # (phase 4a-r1 part 4 consumes :meth:`is_pairing_window_open`).
-    # See issue #106 design choice (c).
+    # Pairing window — in-process deadline that gates
+    # ``intent="pair_request"`` Noise frames at the listener (the
+    # listener consumes :meth:`is_pairing_window_open`). See issue
+    # #106 design choice (c).
     # ------------------------------------------------------------------
 
     @api_command("remote_build/set_pairing_window")
@@ -5044,8 +5039,8 @@ class RemoteBuildController:
         """
         Return whether the pairing window is currently open.
 
-        Consumed by the peer-link listener (phase 4a-r1 part 4) to
-        gate ``intent="pair_request"`` Noise frames. A closed window
+        Consumed by the peer-link listener to gate
+        ``intent="pair_request"`` Noise frames. A closed window
         rejects the frame with ``intent_response=no_pairing_window``
         and closes the WS without creating a row.
         """

--- a/esphome_device_builder/controllers/remote_build/peer_link.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link.py
@@ -282,7 +282,7 @@ class AppMessageType(StrEnum):
     # partitions.bin + firmware.bin + idedata.json in one
     # atomic transport with a single SHA-256, and the wire
     # format doesn't grow when a future platform adds another
-    # required output. See phase 6a in #106.
+    # required output. See issue #106.
     DOWNLOAD_ARTIFACTS = "download_artifacts"
     ARTIFACTS_START = "artifacts_start"
     ARTIFACTS_CHUNK = "artifacts_chunk"

--- a/esphome_device_builder/controllers/remote_build/peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client.py
@@ -1,5 +1,5 @@
 """
-Offloader-side peer-link Noise WS client (issue #106 phase 4a-o part 2).
+Offloader-side peer-link Noise WS client (issue #106).
 
 Initiator counterpart of
 :mod:`controllers.remote_build_peer_link`'s responder. Opens a
@@ -21,12 +21,12 @@ one place.
 The wire-flow shape — TCP connect, 3 Noise XX messages, post-
 handshake transport frame, error mapping — is identical across
 every initiator-side intent the offloader needs (``preview``,
-``pair_request``, ``pair_status``, eventually ``peer_link``);
-only the msg3 payload and which response codes count as success
-differ. :func:`drive_initiator_round_trip` owns the shared flow;
-each public ``preview_pair`` / ``request_pair`` / ``await_pair_status``
-function (parts 2-4 of phase 4a-o) is a thin wrapper that
-provides the intent + msg3 payload + accepted-response set.
+``pair_request``, ``pair_status``, ``peer_link``); only the
+msg3 payload and which response codes count as success differ.
+:func:`drive_initiator_round_trip` owns the shared flow; each
+public ``preview_pair`` / ``request_pair`` /
+``await_pair_status`` function is a thin wrapper that provides
+the intent + msg3 payload + accepted-response set.
 """
 
 from __future__ import annotations
@@ -151,15 +151,15 @@ _PAIR_STATUS_TIMEOUT_SECONDS = 3600.0
 # max while still giving aiohttp a reasonable header-and-frame
 # slack.
 #
-# This cap explicitly does NOT apply to the future firmware-bytes
-# ``peer_link`` intent (issue #106 phase 4c onward). That payload
-# is megabytes of compiled firmware and will use a separate
-# streaming driver — Noise has a hard 65535-byte ciphertext frame
-# limit, so the firmware path will read many small frames and
-# stream them to disk, not a single ``receive_bytes()`` call.
-# When that driver lands, it gets its own ``max_msg_size``
-# tuned to one Noise frame (~64 KiB + slack); this constant
-# stays scoped to the JSON status responses.
+# This cap explicitly does NOT apply to the firmware-bytes
+# ``peer_link`` intent (issue #106). That payload is megabytes
+# of compiled firmware and uses a separate streaming driver —
+# Noise has a hard 65535-byte ciphertext frame limit, so the
+# firmware path reads many small frames and streams them to
+# disk rather than a single ``receive_bytes()`` call. The
+# streaming driver tunes its own ``max_msg_size`` to one Noise
+# frame (~64 KiB + slack); this constant stays scoped to the
+# JSON status responses.
 _CONTROL_RESPONSE_MAX_BYTES = 64 * 1024
 
 
@@ -199,8 +199,7 @@ def _extract_receiver_esphome_version(response: dict[str, Any]) -> str:
     payload (see :func:`controllers.remote_build.peer_link._send_response`)
     so the offloader can land it on
     :attr:`StoredPairing.esphome_version` and pick_build_path's
-    deferred version-compat gate (7a-2) can read it without an
-    extra round-trip.
+    version-compat gate can read it without an extra round-trip.
 
     Returns:
         The receiver's ``esphome.const.__version__`` as a string,
@@ -425,7 +424,7 @@ async def preview_pair(
     The frontend renders the returned ``pin_sha256`` for the
     user to OOB-verify against the receiver's "Build server"
     Settings card; only after that confirmation does the
-    offloader call ``request_pair`` (phase 4a-o part 3).
+    offloader call ``request_pair``.
     """
     rt = await drive_initiator_round_trip(
         hostname=hostname,
@@ -756,9 +755,9 @@ class PeerLinkNoSessionError(RuntimeError):
 
     Used by every :class:`PeerLinkClient` sender that requires
     the post-handshake dispatch loop to be parked:
-    :meth:`PeerLinkClient.submit_job` (phase 5c-3) and
-    :meth:`PeerLinkClient.cancel_job` (phase 5d). The check
-    funnels through :meth:`PeerLinkClient._require_open_channel`,
+    :meth:`PeerLinkClient.submit_job` and
+    :meth:`PeerLinkClient.cancel_job`. The check funnels through
+    :meth:`PeerLinkClient._require_open_channel`,
     so a future application-message sender that calls
     ``_require_open_channel`` inherits the same exception
     automatically.
@@ -938,8 +937,8 @@ class PeerLinkClient:
         # SHA-256 of the same pubkey, carried on every event the
         # client fires so the controller's listener can key into
         # ``_open_peer_links`` / ``_offloader_alerts`` /
-        # ``_peer_queue_status`` (4a-o part 6 — pin-keyed
-        # offloader state). ``receiver_label`` is carried so
+        # ``_peer_queue_status`` (pin-keyed offloader state).
+        # ``receiver_label`` is carried so
         # the pin-mismatch alert can name the row at firing time.
         self._pinned_static_x25519_pub = pinned_static_x25519_pub
         self._pin_sha256 = pin_sha256
@@ -998,7 +997,7 @@ class PeerLinkClient:
         # successful reconnect. Empty on a never-connected pairing
         # where the client task hasn't completed its first attempt.
         self._last_connect_error: str = ""
-        # Per-job download state for ``download_artifacts`` (6a).
+        # Per-job download state for ``download_artifacts``.
         # Populated by :meth:`download_artifacts` before the
         # request goes out, drained by the receive loop's
         # ``artifacts_start`` / ``artifacts_chunk`` /
@@ -1046,9 +1045,9 @@ class PeerLinkClient:
           — a newer offloader instance with the same
           ``dashboard_id`` has taken our slot. Reconnecting
           would collide with that instance.
-        * Pin-mismatch on the post-handshake pin-check (4a-o
-          part 5) — ``session.remote_static_pub`` didn't match
-          the OOB-confirmed pubkey, so we're talking to a
+        * Pin-mismatch on the post-handshake pin-check —
+          ``session.remote_static_pub`` didn't match the
+          OOB-confirmed pubkey, so we're talking to a
           rotated-but-legitimate receiver or to an attacker.
           Either way the operator's resolution (re-pair to
           confirm the new identity, or unpair) is the only
@@ -1176,7 +1175,7 @@ class PeerLinkClient:
             self._submit_job_acks.pop(job_id, None)
 
     async def cancel_job(self, *, job_id: str) -> bool:
-        """Send a ``cancel_job`` frame for *job_id* over the live session (5d).
+        """Send a ``cancel_job`` frame for *job_id* over the live session.
 
         Fire-and-forget — the receiver's :class:`JobFanout`
         will fan out the resulting ``JOB_CANCELLED`` event as a
@@ -1202,7 +1201,7 @@ class PeerLinkClient:
         return await channel.send_frame(cast(dict[str, Any], frame))
 
     async def download_artifacts(self, *, job_id: str) -> DownloadArtifactsResult:
-        """Fetch the build-artifact tarball for *job_id* from the paired receiver (6a).
+        """Fetch the build-artifact tarball for *job_id* from the paired receiver.
 
         Sends ``download_artifacts{job_id}``, parks on a per-
         job future the receive-loop dispatch fills as

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -91,8 +91,8 @@ _LOGGER = logging.getLogger(__name__)
 # bundle problems): these cover the receiver-side dispatch path
 # where the bundle assembled cleanly but something else went
 # wrong (path traversal, extraction failure, queue rejection).
-# The offloader's submitter (5c-3) maps these to user-facing
-# error messages.
+# The offloader's submitter maps these to user-facing error
+# messages.
 _REASON_DUPLICATE_SUBMIT = "duplicate_submit"
 _REASON_INVALID_HEADER = "invalid_header"
 _REASON_INVALID_CHUNK = "invalid_chunk"

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -269,9 +269,8 @@ class DeviceBuilder:
 
         self._ingress_runner: web.AppRunner | None = None
         # Peer-link Noise WS receiver site for
-        # ``/remote-build/peer-link`` (issue #106 phase 4a-r1).
-        # Bound only when ``RemoteBuildSettings.enabled`` is true;
-        # ``None`` otherwise.
+        # ``/remote-build/peer-link`` (issue #106). Bound only when
+        # ``RemoteBuildSettings.enabled`` is true; ``None`` otherwise.
         self._remote_build_runner: web.AppRunner | None = None
         # Serialises listener-state mutations so two clients
         # toggling ``set_settings`` (or a ``rotate_identity``
@@ -610,27 +609,26 @@ class DeviceBuilder:
                 # ``OFFLOADER_PAIR_ALERT_DISMISSED`` events drive
                 # subsequent mutations.
                 initial["offloader_alerts"] = list(self.remote_build.offloader_alerts_snapshot())
-                # Offloader-side per-peer queue-status snapshot
-                # (phase 5b). RAM-only on the controller;
-                # populated by inbound ``queue_status`` frames
-                # from each paired receiver. Late-subscribers
-                # pick up the most recent value the offloader
-                # has observed for each peer without waiting on
-                # the next live ``OFFLOADER_QUEUE_STATUS_CHANGED``.
+                # Offloader-side per-peer queue-status snapshot.
+                # RAM-only on the controller; populated by inbound
+                # ``queue_status`` frames from each paired
+                # receiver. Late-subscribers pick up the most
+                # recent value the offloader has observed for each
+                # peer without waiting on the next live
+                # ``OFFLOADER_QUEUE_STATUS_CHANGED``.
                 initial["peer_queue_status"] = list(self.remote_build.peer_queue_status_snapshot())
-                # Offloader-side in-flight remote-job snapshot
-                # (phase 5c-3). RAM-only on the controller;
-                # populated by inbound ``job_state_changed``
-                # frames the offloader received for jobs we
-                # submitted. Terminal entries are dropped on
-                # transition so the snapshot only carries
-                # actively-running rows. A tab subscribing
+                # Offloader-side in-flight remote-job snapshot.
+                # RAM-only on the controller; populated by inbound
+                # ``job_state_changed`` frames the offloader
+                # received for jobs we submitted. Terminal entries
+                # are dropped on transition so the snapshot only
+                # carries actively-running rows. A tab subscribing
                 # AFTER ``running`` lands sees the job alive
                 # without waiting for the next event.
                 initial["remote_jobs"] = [
                     dict(entry) for entry in self.remote_build.offloader_remote_jobs_snapshot()
                 ]
-                # 7b master toggle. The Settings UI reads the
+                # Master toggle. The Settings UI reads the
                 # initial switch state from here; live updates
                 # flow through ``OFFLOADER_REMOTE_BUILDS_TOGGLED``
                 # events on the same ``subscribe_events``
@@ -1068,19 +1066,13 @@ class DeviceBuilder:
         """
         Construct the runner and bind the peer-link Noise WS listener.
 
-        Loads the X25519 peer-link identity (separate from the 3a
-        Ed25519 cert; see PR #473) and binds a plain-TCP TCPSite
-        serving exactly one route: the WS upgrade at
-        ``/remote-build/peer-link``. Noise XX provides
+        Loads the X25519 peer-link identity (separate from the
+        dashboard's Ed25519 cert; see PR #473) and binds a
+        plain-TCP TCPSite serving exactly one route: the WS upgrade
+        at ``/remote-build/peer-link``. Noise XX provides
         confidentiality + mutual auth + forward secrecy at the
         application layer, so there's no SSL context to manage and
-        no cert hot-swap when the 3a cert rotates.
-
-        Phases 3b1-3c shipped this same listener as HTTPS+bearer;
-        phase 4a-r1 part 4 swaps the body to plain-TCP / Noise WS
-        on the same port + flag + constant + runner slot. The
-        bearer machinery (token CRUD, auth middleware, models) is
-        now dormant and gets deleted in 4a-r2.
+        no cert hot-swap when the dashboard cert rotates.
 
         Returns ``(runner, identity, bound_port)`` on success; on
         any exception, cleans up the partial runner before

--- a/esphome_device_builder/helpers/build_artifacts.py
+++ b/esphome_device_builder/helpers/build_artifacts.py
@@ -4,9 +4,9 @@ Locate + collect a build's flash artifacts on the dashboard's filesystem.
 Wraps ESPHome's per-build manifest (``idedata.json``) into a
 typed accessor that surfaces just the "files to flash" view
 the dashboard needs. Used by the remote-build receiver-side
-download path (phase 6a) to pack the artifacts into a
-tarball, and by future install-related flows that need to
-enumerate the same set without re-running platformio.
+download path to pack the artifacts into a tarball, and by
+future install-related flows that need to enumerate the same
+set without re-running platformio.
 
 Background:
 

--- a/esphome_device_builder/helpers/build_scheduler.py
+++ b/esphome_device_builder/helpers/build_scheduler.py
@@ -197,7 +197,7 @@ def pick_build_path(inputs: BuildSchedulerInputs) -> BuildPathDecision:
       receiver yet; using them silently would route bytes to a
       not-yet-trusted peer.
     * **Per-pairing enabled toggle.** :attr:`StoredPairing.enabled`
-      gates the row independently of status / connection (7b).
+      gates the row independently of status / connection.
       The operator may have a paired receiver they want to keep
       reachable via the Send-builds power-user surface but
       *not* receive transparent install routing — e.g. a build

--- a/esphome_device_builder/helpers/config_bundle.py
+++ b/esphome_device_builder/helpers/config_bundle.py
@@ -2,9 +2,9 @@
 Build a self-contained ESPHome bundle from a YAML on disk.
 
 Wraps the ``esphome bundle <yaml> -o <tarball>`` CLI for the
-offloader-side ``submit_job`` flow (issue #106 phase 5c-3):
-the WS handler hands a YAML path, this module returns the
-gzipped-tar bytes ready for chunking onto the peer-link.
+offloader-side ``submit_job`` flow (issue #106): the WS
+handler hands a YAML path, this module returns the gzipped-
+tar bytes ready for chunking onto the peer-link.
 
 Subprocess rather than in-process
 :class:`esphome.bundle.ConfigBundleCreator` so the bundle

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -22,8 +22,8 @@ browse response on its own:
   peer can flag a release-skew warning before pairing.
 * ``esphome_version`` — the ``esphome`` library version this
   dashboard would compile against, so the version-mismatch warning
-  in phase 7 can fire on the listing page rather than waiting for
-  an upload to come back with a surprise build.
+  can fire on the listing page rather than waiting for an upload
+  to come back with a surprise build.
 * ``pin_sha256`` (optional) — the receiver's SPKI fingerprint
   (lowercase hex). Peers cross-check the cert they observe on
   connect against this TXT entry; the fingerprint is also what

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -62,10 +62,10 @@ BUNDLE_CHUNK_SIZE_BYTES = 32 * 1024
 # tree can push to a few hundred KiB. 4 MiB is well above the
 # realistic ceiling but small enough that a misbehaving
 # offloader can't pin gigabytes of memory pretending to send
-# a bundle. 5c-2 may revise based on production bundle sizes.
+# a bundle. May be revisited based on production bundle sizes.
 BUNDLE_MAX_TOTAL_BYTES = 4 * 1024 * 1024
 
-# Hard cap on the assembled firmware binary (phase 6a). Typical
+# Hard cap on the assembled firmware binary. Typical
 # ESP32 firmware is 800 KiB - 1.5 MiB; ESP32-S3 with PSRAM
 # can reach ~4 MiB; future variants may grow further. 16 MiB
 # is well above the realistic ceiling but bounded enough that
@@ -81,7 +81,7 @@ class BundleAssemblerErrorCode(StrEnum):
     Reason a :class:`BundleAssembler` rejected a chunk.
 
     Surfaced on :class:`BundleAssemblerError` so the receiver-
-    side dispatch (5c-2) can map to a typed
+    side dispatch can map to a typed
     :class:`SubmitJobAckFrameData.reason` and a matching
     ``terminate{reason: malformed_frame}`` close.
     """

--- a/esphome_device_builder/helpers/peer_link_identity.py
+++ b/esphome_device_builder/helpers/peer_link_identity.py
@@ -13,13 +13,13 @@ is derived from the private key via :mod:`cryptography`'s
 half is recomputed each load rather than persisted, so a corrupted
 public-key file can't desync from the private half.
 
-This identity is **separate** from the phase-3a Ed25519 cert
+This identity is **separate** from the dashboard's Ed25519 cert
 keypair (``.device-builder-key.pem``). The cert remains the
 dashboard's TLS identity for any externally-fronted HTTPS use;
 the X25519 keypair here is the dashboard's identity for
 :class:`~esphome_device_builder.helpers.peer_link_noise.PeerLinkNoiseSession`
-(the Noise XX peer-link channel from phase 4a). The two have
-independent rotation lifecycles.
+(the Noise XX peer-link channel). The two have independent
+rotation lifecycles.
 
 Generation is one ``X25519PrivateKey.generate()`` call plus a
 single atomic file write. Sync and blocking; async callers must

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -77,27 +77,24 @@ class EventType(StrEnum):
     # Receiver rotated its TLS keypair via
     # ``remote_build/rotate_identity``. Payload carries
     # ``{dashboard_id, pin_sha256}``: subscribers (the offloader-
-    # side peer-link in phase 4+, the receiver Settings UI in
-    # 3c2) can refresh their cached pin without polling
-    # ``get_identity``. The event fires after the on-disk
-    # rotation succeeds; the listener rebuild may still
-    # fail-soft, in which case the rotater's ``IdentityView``
-    # response carries ``listener_bound=False`` while the event
-    # itself reflects only that the cert + key on disk
-    # changed.
+    # side peer-link, the receiver Settings UI) can refresh
+    # their cached pin without polling ``get_identity``. The
+    # event fires after the on-disk rotation succeeds; the
+    # listener rebuild may still fail-soft, in which case the
+    # rotater's ``IdentityView`` response carries
+    # ``listener_bound=False`` while the event itself reflects
+    # only that the cert + key on disk changed.
     REMOTE_BUILD_IDENTITY_ROTATED = "remote_build_identity_rotated"
 
     # A pair_request Noise frame landed for a previously-unknown
-    # peer while the receiver's pairing window was open (phase 4
-    # auth flow; see issue #106 design choice (b)/(c)). Payload:
+    # peer while the receiver's pairing window was open (see
+    # issue #106 design choice (b)/(c)). Payload:
     # ``{dashboard_id, pin_sha256, label, peer_ip}``. The receiver
     # Settings UI surfaces this in the Pairing requests inbox.
     # Fires only when the pairing window is open; closed-window
     # pair_requests are rejected at the listener with
     # ``intent_response=no_pairing_window`` and don't create a
-    # row. The listener (part 4) is the actual emitter; this
-    # entry is added in part 3 alongside the receiver-UI WS
-    # commands so the model surface lands together.
+    # row. The peer-link listener is the actual emitter.
     REMOTE_BUILD_PAIR_REQUEST_RECEIVED = "remote_build_pair_request_received"
 
     # A peer entry's status changed. Payload:
@@ -152,7 +149,7 @@ class EventType(StrEnum):
     # one against the new coordinates by the time this fires;
     # frontends update the row's display fields off the new
     # ``receiver_hostname`` / ``receiver_port`` without a
-    # re-fetch (4a-o part 7).
+    # re-fetch.
     OFFLOADER_PAIR_ENDPOINT_REBOUND = "offloader_pair_endpoint_rebound"
 
     # Pairing window opened, extended, or closed. Payload:
@@ -317,9 +314,7 @@ class EventType(StrEnum):
     # ``(host, port)``), and re-broadcasts via the global
     # ``subscribe_events`` stream so frontend clients can
     # render the per-peer queue depth live without polling.
-    # Phase 5b is the first real application message exercising
-    # the dispatch loop end-to-end against the 5a foundation;
-    # the scheduler in phase 7 reads the same cache.
+    # The scheduler reads the same cache.
     OFFLOADER_QUEUE_STATUS_CHANGED = "offloader_queue_status_changed"
 
     # Offloader-side: a paired receiver pushed a

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -105,16 +105,16 @@ class FirmwareJob(DataClassORJSONMixin):
     # build, esptool flash) do emit percentages we can latch onto.
     progress: int | None = None
     # Offloader's ``dashboard_id`` when this job came in via the
-    # peer-link ``submit_job`` flow (issue #106 phase 5c). Empty
-    # for locally-submitted jobs. Surfaced in the firmware-tasks
-    # UI as a "from <peer>" badge so the receiver-side admin can
+    # peer-link ``submit_job`` flow (issue #106). Empty for
+    # locally-submitted jobs. Surfaced in the firmware-tasks UI
+    # as a "from <peer>" badge so the receiver-side admin can
     # tell their own work apart from delegated builds.
     remote_peer: str = ""
     # Offloader's job_id from the ``submit_job`` header. Empty for
     # locally-submitted jobs. The receiver-side ``job_id`` above
     # is generated independently (uuid4 hex) so the two id-spaces
     # don't collide; this field carries the offloader's tag so
-    # 5c-2b's fan-out path can echo it back on
+    # the receiver-side fan-out path can echo it back on
     # ``job_state_changed`` / ``job_output`` frames — the
     # offloader matches against its own submit-tagged id, not
     # the receiver's local one.

--- a/esphome_device_builder/models/remote_build.py
+++ b/esphome_device_builder/models/remote_build.py
@@ -52,7 +52,7 @@ class PeerStatus(StrEnum):
     No explicit ``REJECTED`` terminal state — a rejected request
     deletes the row. If the same offloader retries, it lands as
     a fresh pending row and the admin chooses again. Avoids the
-    bookkeeping a rejected-list would need; phase 8's re-auth
+    bookkeeping a rejected-list would need; a future re-auth
     wizard can revisit if blocklisting becomes useful.
     """
 
@@ -106,7 +106,7 @@ class IntentResponse(StrEnum):
     * ``OK`` — success on ``intent="preview"`` (handshake captured
       pubkey, nothing else needed) or on ``intent="peer_link"``
       from an APPROVED peer (caller can keep the WS open for
-      application messages in phase 5+).
+      application messages).
     * ``APPROVED`` — ``intent="pair_status"`` poll observing an
       APPROVED row, or ``intent="pair_request"`` from a peer
       that's already APPROVED (we don't demote them; the offloader
@@ -237,11 +237,10 @@ class OffloaderPairStatusChangedData(TypedDict):
     ``subscribe_events`` stream — no separate subscription
     channel.
 
-    Carries ``pin_sha256`` as the canonical identifier (4a-o
-    part 6 re-keyed offloader-side state on pin instead of
-    ``(hostname, port)``); receiver coords stay on the payload
-    as display fields the frontend can show without a
-    follow-up lookup.
+    Carries ``pin_sha256`` as the canonical identifier (offloader-
+    side state is keyed on pin, not ``(hostname, port)``); receiver
+    coords stay on the payload as display fields the frontend can
+    show without a follow-up lookup.
     """
 
     receiver_hostname: str
@@ -339,12 +338,11 @@ class OffloaderPairAlertDismissedData(TypedDict):
     on the global ``subscribe_events`` stream sync their local
     alerts list without re-fetching the snapshot.
 
-    Carries ``pin_sha256`` as the canonical row identifier (4a-o
-    part 6 re-keyed `_offloader_alerts` on pin); receiver
-    coordinates stay on the payload as display fields. No
-    discriminator on *which* resolution path got us here — the
-    user-facing outcome (the alert disappears) is the same
-    either way.
+    Carries ``pin_sha256`` as the canonical row identifier
+    (``_offloader_alerts`` is keyed on pin); receiver coordinates
+    stay on the payload as display fields. No discriminator on
+    *which* resolution path got us here — the user-facing outcome
+    (the alert disappears) is the same either way.
     """
 
     receiver_hostname: str
@@ -423,19 +421,18 @@ class OffloaderPairPeerRevokedData(TypedDict):
 
     Fires *alongside* ``OFFLOADER_PAIR_STATUS_CHANGED
     status="removed"``; the distinct event lets the frontend's
-    4b-4 alert plumbing reshape surface a different CTA
-    ("contact the receiver admin") versus a pin-mismatch alert
-    ("re-pair right now to pick up the new identity"). The
-    operator action differs.
+    alert plumbing surface a different CTA ("contact the receiver
+    admin") versus a pin-mismatch alert ("re-pair right now to
+    pick up the new identity"). The operator action differs.
 
     The ``receiver_label`` is carried so the alert can name the
     row even after the pairings list has dropped it.
-    ``pin_sha256`` carries the row's primary key (4a-o part 6
-    re-keyed offloader-side state on pin) so the controller's
-    listener has a direct lookup. No extra diagnostic detail;
-    the receiver doesn't tell us *why* REJECTED, and the
-    offloader can't distinguish admin-Reject from window-close
-    from row-never-existed at this layer.
+    ``pin_sha256`` carries the row's primary key (offloader-side
+    state is keyed on pin) so the controller's listener has a
+    direct lookup. No extra diagnostic detail; the receiver
+    doesn't tell us *why* REJECTED, and the offloader can't
+    distinguish admin-Reject from window-close from
+    row-never-existed at this layer.
     """
 
     receiver_hostname: str
@@ -506,10 +503,9 @@ class OffloaderPeerLinkOpenedData(TypedDict):
     offloader's frontend Settings UI) update the
     per-receiver "connected" indicator on this event.
 
-    ``pin_sha256`` is the canonical offloader-side row key
-    (4a-o part 6 re-keyed offloader state on pin); receiver
-    coords stay on the payload as display fields the frontend
-    can render without a follow-up lookup.
+    ``pin_sha256`` is the canonical offloader-side row key;
+    receiver coords stay on the payload as display fields the
+    frontend can render without a follow-up lookup.
 
     ``esphome_version`` is the receiver's
     :data:`esphome.const.__version__` lifted off the
@@ -561,9 +557,8 @@ class OffloaderPeerLinkClosedData(TypedDict):
     61] Connection refused" instead of just the
     ``transport_error`` category.
 
-    ``pin_sha256`` is the canonical offloader-side row key
-    (4a-o part 6 re-keyed offloader state on pin); receiver
-    coords stay on the payload as display fields.
+    ``pin_sha256`` is the canonical offloader-side row key;
+    receiver coords stay on the payload as display fields.
     """
 
     receiver_hostname: str
@@ -623,9 +618,9 @@ class QueueStatusFrameData(TypedDict):
     The three fields aren't strictly redundant: the
     ``running=False, queue_depth>0`` window exists between
     ``await _queue.put(job)`` and the runner's ``_queue.get()``
-    landing the same item, so a phase-7 scheduler that reads
-    only ``running`` would misclassify a fully-loaded receiver
-    as accepting more work. ``idle`` and ``running`` carry both
+    landing the same item, so a scheduler that reads only
+    ``running`` would misclassify a fully-loaded receiver as
+    accepting more work. ``idle`` and ``running`` carry both
     edges so the consumer can render any of "available",
     "busy", "queued" without re-deriving.
     """
@@ -645,13 +640,11 @@ class OffloaderQueueStatusChangedData(TypedDict):
     ``queue_status`` application frame from a paired receiver.
     The remote-build controller listens, updates its
     RAM-only ``_peer_queue_status`` cache (keyed on
-    ``pin_sha256`` since 4a-o part 6), and re-broadcasts via
-    the global ``subscribe_events`` stream so frontend clients
-    can render per-peer queue depth without polling. Phase-5b
-    is the first real application message exercising the 5a
-    peer-link foundation end-to-end; the scheduler in phase 7
-    reads the same cache to pick the least-busy peer on each
-    new offload.
+    ``pin_sha256``), and re-broadcasts via the global
+    ``subscribe_events`` stream so frontend clients can render
+    per-peer queue depth without polling. The scheduler reads
+    the same cache to pick the least-busy peer on each new
+    offload.
     """
 
     receiver_hostname: str
@@ -725,13 +718,12 @@ class OffloaderRemoteBuildsToggledData(TypedDict):
 
     Fires from :meth:`RemoteBuildController.set_offloader_settings`
     when the operator flips the master "Remote builds enabled"
-    switch on the offloader Settings UI (7b). Subscribers are
-    the 7b Settings UI on every connected tab — one toggle on
-    one tab should flip the switch state on every other open
-    tab without a refresh. The scheduler doesn't need this
-    event because it reads
-    :attr:`RemoteBuildController._remote_builds_enabled` on
-    every install via :meth:`build_scheduler_snapshot`; the
+    switch on the offloader Settings UI. Subscribers are the
+    Settings UI on every connected tab — one toggle on one tab
+    should flip the switch state on every other open tab without
+    a refresh. The scheduler doesn't need this event because it
+    reads :attr:`RemoteBuildController._remote_builds_enabled`
+    on every install via :meth:`build_scheduler_snapshot`; the
     event is purely cross-tab UI sync.
     """
 
@@ -744,15 +736,13 @@ class OffloaderPairingEnabledChangedData(TypedDict):
 
     Fires from :meth:`RemoteBuildController.set_pairing_enabled`
     when the operator flips an individual paired-receiver
-    enable switch on the offloader Settings UI (7b).
-    Subscribers update the matching row's switch state. The
-    scheduler reads :attr:`StoredPairing.enabled` directly
-    off the in-RAM ``_pairings`` dict via the snapshot, so no
-    scheduler-side listener is needed; the event is the
-    cross-tab UI sync seam.
+    enable switch on the offloader Settings UI. Subscribers
+    update the matching row's switch state. The scheduler reads
+    :attr:`StoredPairing.enabled` directly off the in-RAM
+    ``_pairings`` dict via the snapshot, so no scheduler-side
+    listener is needed; the event is the cross-tab UI sync seam.
 
-    ``pin_sha256`` is the canonical row key (4a-o part 6
-    re-keyed offloader state on pin); receivers
+    ``pin_sha256`` is the canonical row key; receivers
     ``(hostname, port)`` aren't on the payload — frontends
     that need them join through their own
     :class:`PairingSummary` snapshot.
@@ -972,8 +962,8 @@ class DownloadArtifactsFrameData(TypedDict):
     Application-frame payload for ``AppMessageType.DOWNLOAD_ARTIFACTS``.
 
     Offloader → receiver request to fetch the build-artifact
-    bundle for a previously-completed remote build (phase 6a).
-    ``job_id`` is the offloader-supplied id from the original
+    bundle for a previously-completed remote build. ``job_id``
+    is the offloader-supplied id from the original
     ``submit_job`` header — the value the receiver stashed as
     :attr:`FirmwareJob.remote_job_id`. The receiver resolves
     it to the local :class:`FirmwareJob` by walking
@@ -1011,8 +1001,8 @@ class ArtifactsStartFrameData(TypedDict):
 
     Receiver-pushed header announcing a build-artifact
     tarball stream for the offloader's previously-requested
-    ``download_artifacts`` (phase 6a). Carries
-    ``total_bytes`` so the offloader can pre-size the
+    ``download_artifacts``. Carries ``total_bytes`` so the
+    offloader can pre-size the
     assembly buffer + reject a mismatched stream cleanly;
     ``num_chunks`` matches the chunk count the receiver will
     actually send (assembler validates against this on every
@@ -1053,8 +1043,8 @@ class ArtifactsChunkFrameData(TypedDict):
     """
     Application-frame payload for ``AppMessageType.ARTIFACTS_CHUNK``.
 
-    One slice of the build-artifact tarball (phase 6a). Same
-    wire shape as :class:`SubmitJobChunkFrameData` but for
+    One slice of the build-artifact tarball. Same wire shape
+    as :class:`SubmitJobChunkFrameData` but for
     the reverse direction — bytes are base64-encoded inside
     the JSON envelope so the dispatch seam stays uniform
     across the bundle-upload and artifacts-download flows.
@@ -1079,7 +1069,7 @@ class ArtifactsEndFrameData(TypedDict):
     Application-frame payload for ``AppMessageType.ARTIFACTS_END``.
 
     Receiver's terminator frame for a ``download_artifacts``
-    request (phase 6a). Doubles as the success/failure ack:
+    request. Doubles as the success/failure ack:
 
     * **Success path** — fires after the last chunk
       (``is_last=true``) has been sent; ``accepted=true``,
@@ -1110,8 +1100,8 @@ class CancelJobFrameData(TypedDict):
     Application-frame payload for ``AppMessageType.CANCEL_JOB``.
 
     Offloader → receiver cooperative cancel for a previously-
-    submitted job (phase 5d). ``job_id`` is the
-    offloader-supplied id from the original ``submit_job``
+    submitted job. ``job_id`` is the offloader-supplied id from
+    the original ``submit_job``
     header — i.e. the value the offloader generated and the
     receiver stashed as :attr:`FirmwareJob.remote_job_id`. The
     receiver resolves the offloader-side id back to its local
@@ -1159,10 +1149,10 @@ class StoredPeer(DataClassORJSONMixin):
     hex SHA-256, used for log lines / event payloads / wire
     fields where we already have a hex-pin convention.
 
-    ``dashboard_id`` is the offloader's stable identity from
-    phase 3a; sent in the pair_request payload so the admin UI
-    has a friendly identifier (the X25519 pubkey alone doesn't
-    carry one). Primary key for the receiver WS surface
+    ``dashboard_id`` is the offloader's stable identity; sent
+    in the pair_request payload so the admin UI has a friendly
+    identifier (the X25519 pubkey alone doesn't carry one).
+    Primary key for the receiver WS surface
     (``approve_peer({dashboard_id})`` etc.) so a future X25519
     keypair rotation on the offloader's side doesn't change the
     user-facing handle.
@@ -1397,8 +1387,8 @@ _PAIRING_VALIDATOR = vol.Schema(
         # existed); pick_build_path's version-compat gate
         # accepts empty as "unknown, fall through to compat".
         vol.Required("esphome_version"): vol.All(str, vol.Length(max=PAIRING_VERSION_MAX_LEN)),
-        # Per-pairing master toggle (7b). The 7b Settings UI
-        # exposes one switch per paired build server; when
+        # Per-pairing master toggle. The Settings UI exposes
+        # one switch per paired build server; when
         # ``False`` the scheduler skips this row entirely (the
         # operator wants this receiver paired but doesn't want
         # transparent install to route here). ``not_bool`` not
@@ -1614,18 +1604,18 @@ class RemoteBuildSettings(DataClassORJSONMixin):
 
     Stored in ``.device-builder.json`` under the ``_remote_build``
     top-level key. Carries the master ``enabled`` toggle and the
-    6c TTL sweep's ``cleanup_ttl_seconds`` knob. APPROVED
+    TTL sweep's ``cleanup_ttl_seconds`` knob. APPROVED
     :class:`StoredPeer` rows live in their own per-file
     :class:`~helpers.storage.Store` at
     ``<config_dir>/.receiver_peers.json`` (mirrors the offloader-
     side :class:`OffloaderRemoteBuildSettings` shape) so reads
     short-circuit through RAM and don't race a write in flight.
-    Legacy ``peers`` and ``manual_hosts`` entries on older
-    sidecars are silently ignored at load time — the
-    ``manual_hosts`` flow was removed once the pair dialog
-    started typing hostnames straight into ``request_pair``, and
-    the ``tokens`` list (hash-only bearer tokens) went with the
-    dormant bearer machinery in phase 4a-r2.
+    Legacy ``peers``, ``manual_hosts``, and ``tokens`` entries on
+    older sidecars are silently ignored at load time — the
+    ``manual_hosts`` flow was removed once the pair dialog started
+    typing hostnames straight into ``request_pair``, and the
+    ``tokens`` list (hash-only bearer tokens) went with the
+    pre-Noise bearer machinery.
 
     ``enabled`` is the master gate the dashboard checks before
     binding the receiver site. Defaults to ``True`` so fresh
@@ -1771,10 +1761,10 @@ class OffloaderRemoteBuildSettings(DataClassORJSONMixin):
     "split offloader / receiver into separate processes" refactor
     only has to move one file.
 
-    ``pairings`` carries phase-4a-o :class:`StoredPairing`
-    rows: the offloader's pinned receivers.
+    ``pairings`` carries :class:`StoredPairing` rows: the
+    offloader's pinned receivers.
 
-    ``remote_builds_enabled`` (7b) is the master switch the
+    ``remote_builds_enabled`` is the master switch the
     scheduler reads. When ``False`` the transparent install
     flow short-circuits to LOCAL for every device — paired
     receivers stay paired and the peer-link sessions stay
@@ -1801,7 +1791,7 @@ class OffloaderRemoteBuildSettingsView(DataClassORJSONMixin):
     ``static_x25519_pub``); same projection-seam pattern as
     :class:`RemoteBuildSettingsView`.
 
-    ``remote_builds_enabled`` (7b) mirrors the storage-shape
+    ``remote_builds_enabled`` mirrors the storage-shape
     master toggle so the frontend's "Remote builds enabled"
     switch can read its initial state from the same
     ``get_offloader_settings`` round-trip that already
@@ -1863,10 +1853,7 @@ class RemoteBuildPeer(DataClassORJSONMixin):
       than truncating to ``"192"``. ``hostname`` is the same
       user-entered string, ``port`` is the user-entered port,
       ``addresses`` is empty, and version fields are blank until
-      phase 4 attempts the connection.
-
-    Phase 2 stops at discovery + manual entry; pairing / connection
-    / fingerprint pinning lands in later phases.
+      a pairing attempt runs the connection.
     """
 
     name: str
@@ -1886,8 +1873,8 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     # ``helpers/peer_link_identity.py``). The offloader uses
     # both to match a discovered broadcast against a stored
     # pairing's ``pin_sha256`` and dial the right peer-link
-    # port for the auto-rebind probe (4a-o part 7). Empty
-    # string / 0 for: receivers that haven't bound the
+    # port for the auto-rebind probe. Empty string / 0 for:
+    # receivers that haven't bound the
     # peer-link listener (default-off mode), and ``MANUAL``
     # rows (which never go through the mDNS resolve path; the
     # user typed the hostname/port and the pair flow captures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,7 +248,7 @@ async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# submit_job test helpers (5c-2)
+# submit_job test helpers
 #
 # Bundle construction + wire-frame builders shared between the
 # unit tests in ``test_remote_build_submit_job.py`` and the

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -215,7 +215,7 @@ async def test_install_registers_job_in_jobs_map(
 
 
 # ---------------------------------------------------------------------------
-# Scheduler integration (7a-3) — install routes through pick_build_path
+# Scheduler integration — install routes through pick_build_path
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_build_artifacts.py
+++ b/tests/test_build_artifacts.py
@@ -1,8 +1,8 @@
 """Tests for :mod:`helpers.build_artifacts`.
 
 Pins the disk-walking discovery layer the receiver-side
-``download_artifacts`` flow (phase 6a, issue #106) leans on,
-plus the ``firmware.bin`` flash-offset platform-detection that
+``download_artifacts`` flow (issue #106) leans on, plus the
+``firmware.bin`` flash-offset platform-detection that
 keeps the offloader from having to reimplement upstream
 esphome's ``CORE.is_esp32`` decision.
 """

--- a/tests/test_peer_link_bundle.py
+++ b/tests/test_peer_link_bundle.py
@@ -1,8 +1,8 @@
 """
 Tests for the bundle chunking + reassembly helpers from ``peer_link_bundle``.
 
-Shared between the receiver-side dispatch (5c-2) and offloader-side
-``submit_job`` flow (5c-3). Pure helpers; no controller / WS state. The wire
+Shared between the receiver-side dispatch and offloader-side
+``submit_job`` flow. Pure helpers; no controller / WS state. The wire
 format is exercised end-to-end (chunk → encode → decode → assemble → finalise)
 so a contract drift in either direction surfaces here before it lands at the
 channel layer.

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -1,5 +1,5 @@
 """
-Tests for the receiver-side ``download_artifacts`` flow (issue #106 phase 6a).
+Tests for the receiver-side ``download_artifacts`` flow (issue #106).
 
 Two layers, mirroring :mod:`tests.test_remote_build_submit_job`'s
 shape so the seam between this module's unit tests and the e2e
@@ -753,7 +753,7 @@ def test_load_build_artifacts_rejects_non_dict_idedata(
 
 
 # ---------------------------------------------------------------------------
-# extract_firmware_bin — runner-side single-image extractor (7a-3)
+# extract_firmware_bin — runner-side single-image extractor
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -1,5 +1,5 @@
 """
-Tests for the receiver-side TTL cleanup sweep (issue #106 phase 6c).
+Tests for the receiver-side TTL cleanup sweep (issue #106).
 
 Drives the helper directly against real on-disk subtrees + bundle
 tarballs constructed under :class:`tmp_path`; the controller's

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -295,7 +295,7 @@ def test_upsert_host_drops_self_endpoint(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# mDNS auto-rebind (4a-o part 7)
+# mDNS auto-rebind
 # ---------------------------------------------------------------------------
 
 
@@ -1608,7 +1608,7 @@ def test_validate_port_rejects_out_of_range(port: int) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Identity (phase 3c1) — get_identity / rotate_identity
+# Identity — get_identity / rotate_identity
 # ---------------------------------------------------------------------------
 
 
@@ -3209,7 +3209,7 @@ async def test_lookup_peer_for_status_long_poll_ignores_other_dashboard_ids(
 
 
 # ---------------------------------------------------------------------------
-# Offloader-side pair-flow helpers (phase 4a-o part 3)
+# Offloader-side pair-flow helpers
 # ---------------------------------------------------------------------------
 
 
@@ -3609,7 +3609,7 @@ async def test_broadcast_queue_status_continues_past_failed_session(
 def test_on_offloader_pair_pin_mismatch_caches_alert(tmp_path: Path) -> None:
     """``OFFLOADER_PAIR_PIN_MISMATCH`` listener caches the alert in ``_offloader_alerts``.
 
-    The peer-link path's pin-check (4a-o part 5) fires
+    The peer-link path's pin-check fires
     ``OFFLOADER_PAIR_PIN_MISMATCH`` from the
     :class:`PeerLinkClient` when ``session.remote_static_pub``
     drifts from the pinned pubkey. The controller listens and

--- a/tests/test_remote_build_listener.py
+++ b/tests/test_remote_build_listener.py
@@ -9,10 +9,8 @@ ephemeral binds; warn on HA-addon mode; rebuild the listener
 (now serving the peer-link Noise WS at
 ``/remote-build/peer-link``) on identity rotation.
 
-The pre-pivot HTTPS+bearer auth tests that used to live here
-were deleted in phase 4a-r2 along with the bearer machinery
-they covered. Pin-vs-handshake verification is the pairing
-flow's job (``test_remote_build_peer_link.py``).
+Pin-vs-handshake verification is the pairing flow's job
+(``test_remote_build_peer_link.py``).
 """
 
 from __future__ import annotations

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1926,7 +1926,7 @@ async def test_receive_loop_routes_cancel_job_to_controller(tmp_path: Path) -> N
 
 @pytest.mark.asyncio
 async def test_receive_loop_routes_download_artifacts_to_sender(tmp_path: Path) -> None:
-    """A ``download_artifacts`` Noise frame routes through the artifacts-download sender (6a)."""
+    """A ``download_artifacts`` Noise frame routes through the artifacts-download sender."""
     initiator, responder = _noise_pair()
     session, ws = _make_unit_session(responder)
     payload = {"type": "download_artifacts", "job_id": "remote-7"}

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -1,5 +1,5 @@
 """
-Tests for the offloader-side peer-link Noise WS client (phase 4a-o part 2).
+Tests for the offloader-side peer-link Noise WS client.
 
 Two layers:
 
@@ -960,7 +960,7 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     assert result == {"removed": True}
     assert "a" * 64 not in offloader._pairings
     # ``unpair`` popped the listener entry from the registry —
-    # the row is gone from the pin-keyed dict (4a-o part 6).
+    # the row is gone from the pin-keyed dict.
     assert "a" * 64 not in offloader._pair_status_listeners
     # The captured task reference was cancelled by ``unpair``'s
     # ``_cancel_pair_status_listener``; drain via ``gather`` so
@@ -3142,8 +3142,8 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
 ) -> None:
     """A pinned pubkey that doesn't match the receiver's actual key aborts the connect.
 
-    Pin-check (4a-o part 5) — the offloader's outbound
-    ``peer_link`` handshake must compare ``session.remote_static_pub``
+    Pin-check — the offloader's outbound ``peer_link``
+    handshake must compare ``session.remote_static_pub``
     against the value OOB-confirmed during preview. Drives a
     real handshake against the receiver but passes the WRONG
     ``pinned_static_x25519_pub``: the server's static key is
@@ -4972,7 +4972,7 @@ async def test_controller_cancel_job_no_session_raises_precondition_failed(
 
 
 # ---------------------------------------------------------------------------
-# PeerLinkClient.download_artifacts — flow tests (issue #106 phase 6a)
+# PeerLinkClient.download_artifacts — flow tests (issue #106)
 # ---------------------------------------------------------------------------
 
 
@@ -5378,7 +5378,7 @@ async def test_dispatch_artifacts_end_finalise_failure_resolves_with_error() -> 
 
 
 # ---------------------------------------------------------------------------
-# remote_build/download_artifacts WS command (issue #106 phase 6a)
+# remote_build/download_artifacts WS command (issue #106)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -1,5 +1,5 @@
 """
-Tests for the receiver-side ``submit_job`` flow (issue #106 phase 5c-2).
+Tests for the receiver-side ``submit_job`` flow (issue #106).
 
 Two layers, mirroring :mod:`tests.test_remote_build_peer_link`'s
 shape so the seam between this module's unit tests and the


### PR DESCRIPTION
# What does this implement/fix?

Code companion to #606 (docs phase-ref cleanup). Strips the planning-doc phase-tag shorthand from comments and docstrings across `esphome_device_builder/` and `tests/`. The remote-build feature shipped end-to-end ([#106](https://github.com/esphome/device-builder/issues/106) closed); slice labels like `phase 5c-3` / `(6a)` / `phase 7b` are now noise for a maintainer reading the running code.

### What's removed

Inline tag patterns dropped from comments and docstrings:

- `phase 3a`, `phase 4a-r1` (+ `part 2` / `part 4`), `phase 4a-o`, `phase 4b`
- `phase 5b`, `phase 5c-2a`, `phase 5c-2b`, `phase 5c-3`, `phase 5d`
- `phase 6a`, `phase 6c`
- `phase 7a-1`, `phase 7a-2a`, `phase 7a-2b`, `phase 7a-3`, `phase 7a-4`, `phase 7b`
- `phase 8a`, `phase 8b`
- Bare parentheticals like `(5b)`, `(5c-3)`, `(6a)`, `(7a-1)`, `(7b)`, `(4a-r1)`, `(4a-o part 7)`

### What's kept

- Every function-level description, rationale for non-obvious choices, and the prose voice the codebase uses for maintainer-facing comments.
- PR refs (`#553`, `#560`, `#568`, etc.) — they still aid traceability.
- Issue refs (`issue #106`) — the trailing phase tag goes, the issue link stays.

Historical-context sentences that only made sense as a slice progression (`phase 4a-r1 part 4 swaps the bind to plain TCP serving a Noise XX WebSocket`) get rewritten as present-tense state (`the bind serves a Noise XX WebSocket … over plain TCP`).

### Scope

30 files, +303 / −341 lines. Concentrated in:

- `controllers/remote_build/` (controller + submit_job + peer_link + peer_link_client + artifacts_download)
- `controllers/firmware/` (controller + constants + the remote_runner via prior cleanups)
- `models/remote_build.py`, `models/firmware.py`, `models/common.py`
- `helpers/peer_link_*.py`, `helpers/build_*.py`, `helpers/config_bundle.py`, `helpers/dashboard_advertise.py`
- `device_builder.py`, `constants.py`, `controllers/config.py`
- Test files updated to drop tags from in-line docstrings; assertions / behaviour untouched.

### Verified

- `pytest -q -x --ignore=tests/e2e` → 3044 passed, 26 skipped
- `ruff check` → All checks passed
- `grep -rnE` for the phase patterns across `esphome_device_builder/` + `tests/` Python files → 0 matches remaining

If any references slipped past the sweep, a follow-up round can mop them up — none would block this PR's intent.

**Related issue or feature (if applicable):**

- companion to #606; no behavioural change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
