### PR TITLE
[docs] Clarify rotate_identity conditional rebuild + fix OPENED payload, bridge role/UI terms

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -274,7 +274,14 @@ The 15-character RFC 6335 §5.1 cap on service-type labels is why the new type i
 
 ## Remote build
 
-The dashboard can play *receiver* (lend its CPU to other dashboards) and *offloader* (delegate compiles to a paired receiver). Transport is Noise XX over plain-TCP WebSocket — the original HTTPS-plus-bearer-token shape was pivoted out during the receiver-side rewrite when the Noise XX peer-link replaced both transport security and auth on a single channel.
+The dashboard can play two roles, often both at once:
+
+* **Receiver** — lends its CPU to other dashboards. Accepts pair requests, compiles, returns artifacts. Surfaced in the UI as **"Build server"** (Settings → Build server, the card that shows this dashboard's identity fingerprint + paired senders).
+* **Offloader** — delegates compiles to a paired receiver. The dashboard the user clicks Install on. Surfaced in the UI as **"Send builds"** (Settings → Send builds, the section that lists known + paired receivers).
+
+A single dashboard can be both roles simultaneously — the HA add-on ships offloader-on / receiver-off by default (a typically-shared host shouldn't accept inbound build jobs without opt-in), while ESPHome Desktop and standalone installs default to both roles on. The two surfaces don't conflict: a dashboard can have receivers paired to it AND be paired to other receivers itself.
+
+Transport is Noise XX over plain-TCP WebSocket — the original HTTPS-plus-bearer-token shape was pivoted out during the receiver-side rewrite when the Noise XX peer-link replaced both transport security and auth on a single channel.
 
 ### Pairing auth flow (Noise XX)
 
@@ -357,7 +364,12 @@ sequenceDiagram
 
 **Window-state disclosure.** The `no_pairing_window` response from `record_pair_request` only reaches an offloader whose `dashboard_id` doesn't match an APPROVED row (the APPROVED check short-circuits ahead of the window gate). Random callers / unknown peers get the same NO_PAIRING_WINDOW response when window is closed, so the window flag is observable to anyone who can reach the listener — but it's not informationally useful: the listener's mDNS TXT broadcasts `pin_sha256` + `remote_build_port` only while bound, which is itself the strongest signal of the receiver's overall pair-acceptance state.
 
-**Identity rotation.** `rotate_identity` mints a fresh X25519 peer-link keypair, writes it to `.device-builder-peer-link-key.bin`, and tears down + rebuilds the listener so the in-flight Noise dispatch closure picks up the new private bytes. The `dashboard_id` stays stable across rotation but `pin_sha256` (the SHA-256 of the new pubkey) changes; every paired peer sees a `pin_mismatch` event on the next handshake and has to re-pair. That's the intended UX for "operator suspects compromise" — a single rotation revokes every existing trust on this side without touching anything else.
+**Identity rotation.** `rotate_identity` mints a fresh X25519 peer-link keypair and writes it to `.device-builder-peer-link-key.bin`. The follow-up listener-rebuild step is conditional on the listener's current bind state:
+
+* **Listener bound** — `DeviceBuilder.reload_remote_build_identity` tears down the current runner (the in-flight Noise dispatch closure holds the old private bytes; without a rebuild the next session would still handshake against the old key), clears `pin_sha256` + `remote_build_port` from the mDNS TXT (TXT contract: those fields appear iff the listener is currently bound), and re-runs the bind path to load the new identity. Fail-soft: a rebuild failure leaves the dashboard running without a receiver listener.
+* **Listener not bound** — no-op beyond the disk write. The new key sits at the canonical path and the next successful bind picks it up; no mDNS push happens because there's no port to advertise.
+
+The `dashboard_id` stays stable across rotation either way; `pin_sha256` (the SHA-256 of the new pubkey) changes, so every paired peer sees a `pin_mismatch` event on the next handshake and has to re-pair. That's the intended UX for "operator suspects compromise" — one rotation revokes every existing trust on this side without touching anything else.
 
 ### Listener internals
 
@@ -391,7 +403,7 @@ Once an offloader and receiver are paired (APPROVED on both sides), the offloade
 * `queue_status` broadcast on every firmware-queue transition.
 * `job_state_changed` / `job_output` per-job fan-out: `JobFanout` subscribes to firmware `JOB_*` bus events, filters to jobs whose `remote_peer` matches an active peer-link session, and routes through the submitting session's `send_app_frame`.
 
-**Offloader-side.** `PeerLinkClient` builds a `PeerLinkChannel` over `(noise, ws)`, fires `EventType.OFFLOADER_PEER_LINK_OPENED` with `{receiver_hostname, receiver_port}`, and parks on its own receive loop with a parallel heartbeat task. The frontend Settings UI's "connected" indicator subscribes to this event.
+**Offloader-side.** `PeerLinkClient` builds a `PeerLinkChannel` over `(noise, ws)`, fires `EventType.OFFLOADER_PEER_LINK_OPENED` with `{receiver_hostname, receiver_port, pin_sha256, esphome_version}`, and parks on its own receive loop with a parallel heartbeat task. The frontend Settings UI's "connected" indicator subscribes to this event; `pin_sha256` lets subscribers correlate to a specific paired row without an additional lookup, and `esphome_version` carries the receiver's `esphome.const.__version__` from the post-handshake `intent_response` so paired-row UI can render it without a follow-up RPC.
 
 *Inbound dispatch:*
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to merged #611 — addresses two Copilot inline comments + a related role/UI-term gap I caught while looking at the same section.

## Copilot fixes

### 1. `rotate_identity` rebuild claim (line 360)

#611's prose said rotate_identity "tears down + rebuilds the listener" unconditionally. In code, `DeviceBuilder.reload_remote_build_identity` ([`device_builder.py:1001-1100`](https://github.com/esphome/device-builder/blob/main/esphome_device_builder/device_builder.py#L1001)) only rebuilds when the listener is currently bound; otherwise rotation just writes the new X25519 keypair to disk and the next successful bind picks it up.

Rewritten as two clear branches:
- **Listener bound** — teardown → mDNS clear → rebuild path (sequencing matters: clear comes before rebuild so the cleared state is the steady state on rebuild failure).
- **Listener not bound** — no-op beyond the disk write; next bind picks up the new key.

### 2. `OFFLOADER_PEER_LINK_OPENED` payload (line 394)

#611's prose listed the payload as `{receiver_hostname, receiver_port}`. The real shape from `peer_link_client.py:2019-2026` (and the matching `OffloaderPeerLinkOpenedData` TypedDict at `models/remote_build.py:497+`) also includes `pin_sha256` and `esphome_version`:

```python
payload: OffloaderPeerLinkOpenedData = {
    "receiver_hostname": self._hostname,
    "receiver_port": self._port,
    "pin_sha256": self._pin_sha256,
    "esphome_version": esphome_version,
}
```

Documenting the full payload + the rationale for each extra field — `pin_sha256` lets subscribers correlate to a paired row without a follow-up lookup; `esphome_version` carries the receiver's version from the post-handshake `intent_response` so paired-row UI can render it without an extra RPC.

## Related fix: role / UI-term bridge

While reviewing the same section, noticed the architecture doc names the roles `receiver` and `offloader` but the UI labels them differently — **"Build server"** (Settings → Build server) and **"Send builds"** (Settings → Send builds). A user who saw the label in the UI couldn't find the architectural section by searching for it.

Expanded the role-intro paragraph to bullet each role with both names + a one-liner on the HA-addon default shape (offloader-on / receiver-off).

Net: 3 paragraphs touched, no structural change. All three are documentation accuracy fixes.

**Related issue or feature (if applicable):**

- follow-up to #611; addresses Copilot inline review on that PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
