### PR TITLE
[docs] Document Send builds / Build server pairing flow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,85 @@ every few minutes.
 
 </details>
 
+## Send builds to another dashboard
+
+Compiling ESPHome firmware is CPU-heavy, especially for ESP-IDF
+targets. If your dashboard runs on a low-power host (the Home
+Assistant add-on on a Raspberry Pi or HA Green, say), you can
+pair it to a beefier dashboard on the same LAN — ESPHome Desktop
+on a workstation, for example — and offload compiles there. The
+firmware bytes still install from the original dashboard; only
+the build runs elsewhere.
+
+Two roles:
+
+- **Build server** — the dashboard that lends its CPU. Surfaced
+  under **Settings → Build server**. Accepts pair requests,
+  compiles incoming jobs, returns artefacts.
+- **Send builds** — the dashboard that delegates compiles.
+  Surfaced under **Settings → Send builds**. Lists dashboards
+  the LAN discovered and the ones you've paired with.
+
+A single dashboard can play both roles at once. The Home
+Assistant add-on defaults to send-only (it doesn't accept
+inbound build jobs without opt-in — sensible default for a
+typically-shared host); ESPHome Desktop and standalone installs
+default to both roles on.
+
+### Pairing in four steps
+
+1. Start both dashboards on the same subnet (or with a working
+   mDNS reflector between subnets). Each one advertises itself
+   over mDNS as long as the receiver listener is bound.
+2. On the dashboard you want to **send** builds from, open
+   **Settings → Send builds → Known dashboards**. The list shows
+   every dashboard the LAN discovered.
+3. Find the dashboard you want to send to and click **Pair**.
+   Both dashboards now display a pairing **fingerprint** rendered
+   as a row of emoji. Compare the two fingerprints out of band —
+   they must match for the pairing to be safe to accept. (Hex
+   bytes are tucked behind a "Show details" disclosure if you
+   prefer that form, but the emoji grid is the primary
+   verification surface.)
+4. Click **Accept** on the receiving dashboard's **Pairing
+   requests** screen. The pairing persists on both sides and
+   survives restarts.
+
+After pairing, clicking Install on a device automatically routes
+through the paired receiver when it's online and idle. The
+install dialog shows a "Building on `{receiver}`" sub-line so you
+can see which side is doing the work. You can override per-install
+via the **Build locally instead** link in the install dialog, or
+disable auto-routing entirely from **Settings → Send builds →
+Auto-route installs to remote build**.
+
+### Manual entry (no mDNS)
+
+If the dashboards are on different subnets and your LAN has no
+mDNS reflector, type the receiver's hostname and port directly
+into the field at the bottom of **Known dashboards**. The
+peer-link uses plain TCP on port 6055 by default; the pairing
+flow runs identically to the discovered-dashboard case from there.
+
+### Known limitations
+
+Remote build works end-to-end for OTA installs over Wi-Fi or
+Ethernet across every chip family ESPHome's OTA component
+supports (ESP32, ESP8266, RP2040 / RP2350, the LibreTiny family
+— BK72xx, RTL87xx, LN882x — and the nRF52 line). Open
+follow-ups tracked separately:
+
+- Serial installs (USB-attached devices) don't route through a
+  paired receiver yet — the runner's local flash step expects a
+  single-image upload, but a wired flash needs the full
+  bootloader / partitions / firmware set stitched at their own
+  offsets. See [#570](https://github.com/esphome/device-builder/issues/570).
+- A toggle to allow major-version mismatches between paired
+  dashboards is planned but not shipped. Pairings whose receiver
+  runs a different ESPHome major version than the sender still
+  build today (no enforcement gate yet); that gate lands together
+  with the toggle. See [#607](https://github.com/esphome/device-builder/issues/607).
+
 ## Roadmap
 
 - ✅ Standalone backend with WS-first API, persistent compile queue, mDNS device discovery
@@ -127,6 +206,9 @@ every few minutes.
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — controllers, event bus,
   firmware queue, catalog sync, deployment.
+- **[docs/ARCHITECTURE.md § Remote build](docs/ARCHITECTURE.md#remote-build)** —
+  internals of the pair flow, peer-link transport, and build scheduler
+  behind the "Send builds" feature above.
 - **[docs/API.md](docs/API.md)** — every WebSocket command, request/response
   shapes, event types.
 - **[esphome_device_builder/definitions/README.md](esphome_device_builder/definitions/README.md)** —

--- a/README.md
+++ b/README.md
@@ -132,12 +132,15 @@ default to both roles on.
 
 1. Start both dashboards on the same subnet, or with a working
    mDNS reflector between subnets. Outside the Home Assistant
-   add-on, a dashboard advertises itself over mDNS automatically;
-   the receiver listener publishes its port into the same TXT
-   record once it's bound, so peers can find both the dashboard
-   and the right port in one lookup. (HA add-on instances stay
-   silent on the network; two add-on dashboards on the same LAN
-   need the manual-entry flow below.)
+   add-on, a dashboard advertises itself over mDNS as soon as it
+   starts, independently of whether **Build server** is enabled.
+   The receiver's peer-link port lands in the same TXT record
+   only once **Build server** is enabled and the listener has
+   bound; a dashboard without **Build server** enabled still
+   appears in **Known dashboards** but can't be paired with until
+   the receiving side flips that toggle. (HA add-on instances
+   stay silent on the network; two add-on dashboards on the same
+   LAN need the manual-entry flow below.)
 2. On the dashboard you want to **send** builds from, open
    **Settings → Send builds → Known dashboards**. The list shows
    every dashboard the LAN discovered.
@@ -191,8 +194,11 @@ itself on mDNS), use the **Pair with another dashboard** section
 beneath **Known dashboards**. Click **Pair with a build server**,
 type the receiver's hostname and port, and submit; the pairing
 flow runs identically to the discovered-dashboard case from
-there. The peer-link listens on TCP port 6055 by default; the
-wire is Noise-encrypted regardless of how you reach it, and the
+there. The peer-link is a WebSocket served at
+`/remote-build/peer-link` over TCP port 6055 by default; if a
+reverse proxy or firewall sits between the two dashboards it
+needs to allow WebSocket upgrades on that path. The wire is
+Noise-encrypted regardless of how you reach it, and the
 emoji-fingerprint comparison still gates pairing the same way.
 
 ### Known limitations

--- a/README.md
+++ b/README.md
@@ -152,6 +152,25 @@ default to both roles on.
    requests** screen. The pairing persists on both sides and
    survives restarts.
 
+If a dashboard you expected to show up doesn't appear in
+**Known dashboards**, run `esphome-device-builder-discover` on
+the sending host before troubleshooting the UI. The CLI browses
+the same mDNS service the dashboard does and prints what it
+sees, including the receiver's peer-link port and identity
+fingerprint:
+
+```
+Status |Name |Address:Port        |Server   |ESPHome   |RB Port |Pin (sha256)
+-------+-----+--------------------+---------+----------+--------+--------------
+ONLINE |mac  |192.168.1.75:6052   |0.1.0b39 |2026.4.5  |6055    |3968ef58…
+```
+
+If the receiver shows up in the CLI but not in the UI, the
+discovery layer is fine and the gap is somewhere downstream; if
+neither side sees the other, mDNS isn't crossing the network
+(different subnet without a reflector, container without host
+networking, firewall blocking 5353/udp).
+
 After pairing, clicking Install on a device automatically routes
 through the paired receiver as soon as one is online. The
 scheduler prefers an idle receiver, but if every paired receiver

--- a/README.md
+++ b/README.md
@@ -106,81 +106,95 @@ every few minutes.
 ## Send builds to another dashboard
 
 Compiling ESPHome firmware is CPU-heavy, especially for ESP-IDF
-targets. If your dashboard runs on a low-power host (the Home
-Assistant add-on on a Raspberry Pi or HA Green, say), you can
-pair it to a beefier dashboard on the same LAN — ESPHome Desktop
-on a workstation, for example — and offload compiles there. The
-firmware bytes still install from the original dashboard; only
-the build runs elsewhere.
+targets. If your dashboard runs on a low-power host, say the Home
+Assistant add-on on a Raspberry Pi or HA Green, you can pair it to
+a beefier dashboard on the same LAN, for example ESPHome Desktop
+running on a workstation, and offload compiles there. The firmware
+bytes still install from the original dashboard; only the build
+runs elsewhere.
 
 Two roles:
 
-- **Build server** — the dashboard that lends its CPU. Surfaced
+- **Build server**, the dashboard that lends its CPU. Surfaced
   under **Settings → Build server**. Accepts pair requests,
   compiles incoming jobs, returns artefacts.
-- **Send builds** — the dashboard that delegates compiles.
+- **Send builds**, the dashboard that delegates compiles.
   Surfaced under **Settings → Send builds**. Lists dashboards
   the LAN discovered and the ones you've paired with.
 
-A single dashboard can play both roles at once. The Home
-Assistant add-on defaults to send-only (it doesn't accept
-inbound build jobs without opt-in — sensible default for a
-typically-shared host); ESPHome Desktop and standalone installs
+A single dashboard can play both roles at once. The Home Assistant
+add-on defaults to send-only, since it doesn't accept inbound
+build jobs without opt-in, which is the sensible default for a
+typically-shared host; ESPHome Desktop and standalone installs
 default to both roles on.
 
 ### Pairing in four steps
 
-1. Start both dashboards on the same subnet (or with a working
-   mDNS reflector between subnets). Each one advertises itself
-   over mDNS as long as the receiver listener is bound.
+1. Start both dashboards on the same subnet, or with a working
+   mDNS reflector between subnets. Outside the Home Assistant
+   add-on, a dashboard advertises itself over mDNS automatically;
+   the receiver listener publishes its port into the same TXT
+   record once it's bound, so peers can find both the dashboard
+   and the right port in one lookup. (HA add-on instances stay
+   silent on the network; two add-on dashboards on the same LAN
+   need the manual-entry flow below.)
 2. On the dashboard you want to **send** builds from, open
    **Settings → Send builds → Known dashboards**. The list shows
    every dashboard the LAN discovered.
 3. Find the dashboard you want to send to and click **Pair**.
    Both dashboards now display a pairing **fingerprint** rendered
-   as a row of emoji. Compare the two fingerprints out of band —
-   they must match for the pairing to be safe to accept. (Hex
-   bytes are tucked behind a "Show details" disclosure if you
-   prefer that form, but the emoji grid is the primary
-   verification surface.)
+   as an emoji grid. Compare the two fingerprints out of band;
+   they must match for the pairing to be safe to accept. Hex
+   bytes are tucked behind a **Show hex bytes** disclosure if
+   you prefer that form, but the emoji grid is the primary
+   verification surface.
 4. Click **Accept** on the receiving dashboard's **Pairing
    requests** screen. The pairing persists on both sides and
    survives restarts.
 
 After pairing, clicking Install on a device automatically routes
-through the paired receiver when it's online and idle. The
-install dialog shows a "Building on `{receiver}`" sub-line so you
-can see which side is doing the work. You can override per-install
-via the **Build locally instead** link in the install dialog, or
-disable auto-routing entirely from **Settings → Send builds →
+through the paired receiver as soon as one is online. The
+scheduler prefers an idle receiver, but if every paired receiver
+is busy it queues the install behind the in-flight work rather
+than silently building locally; that keeps the toolchain warm and
+the artefacts coming from one place. The install dialog shows a
+"Building on `{receiver}`" sub-line so you can see which side is
+doing the work. You can override per-install via the **Build
+locally instead** link in the install dialog, or disable
+auto-routing entirely from **Settings → Send builds →
 Auto-route installs to remote build**.
 
 ### Manual entry (no mDNS)
 
-If the dashboards are on different subnets and your LAN has no
-mDNS reflector, type the receiver's hostname and port directly
-into the field at the bottom of **Known dashboards**. The
-peer-link uses plain TCP on port 6055 by default; the pairing
-flow runs identically to the discovered-dashboard case from there.
+If the dashboards are on different subnets, or if either side is
+running as the Home Assistant add-on (which doesn't advertise
+itself on mDNS), use the **Pair with another dashboard** section
+beneath **Known dashboards**. Click **Pair with a build server**,
+type the receiver's hostname and port, and submit; the pairing
+flow runs identically to the discovered-dashboard case from
+there. The peer-link listens on TCP port 6055 by default; the
+wire is Noise-encrypted regardless of how you reach it, and the
+emoji-fingerprint comparison still gates pairing the same way.
 
 ### Known limitations
 
 Remote build works end-to-end for OTA installs over Wi-Fi or
 Ethernet across every chip family ESPHome's OTA component
-supports (ESP32, ESP8266, RP2040 / RP2350, the LibreTiny family
-— BK72xx, RTL87xx, LN882x — and the nRF52 line). Open
-follow-ups tracked separately:
+supports: ESP32, ESP8266, RP2040 / RP2350, the LibreTiny family
+(BK72xx, RTL87xx, LN882x), and the nRF52 line. Open follow-ups
+tracked separately:
 
 - Serial installs (USB-attached devices) don't route through a
-  paired receiver yet — the runner's local flash step expects a
+  paired receiver yet; the runner's local flash step expects a
   single-image upload, but a wired flash needs the full
   bootloader / partitions / firmware set stitched at their own
   offsets. See [#570](https://github.com/esphome/device-builder/issues/570).
 - A toggle to allow major-version mismatches between paired
   dashboards is planned but not shipped. Pairings whose receiver
   runs a different ESPHome major version than the sender still
-  build today (no enforcement gate yet); that gate lands together
-  with the toggle. See [#607](https://github.com/esphome/device-builder/issues/607).
+  build today, with no enforcement gate yet; that gate lands
+  together with the toggle. See
+  [#607](https://github.com/esphome/device-builder/issues/607).
 
 ## Roadmap
 
@@ -206,9 +220,9 @@ follow-ups tracked separately:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — controllers, event bus,
   firmware queue, catalog sync, deployment.
-- **[docs/ARCHITECTURE.md § Remote build](docs/ARCHITECTURE.md#remote-build)** —
-  internals of the pair flow, peer-link transport, and build scheduler
-  behind the "Send builds" feature above.
+- **[docs/ARCHITECTURE.md § Remote build](docs/ARCHITECTURE.md#remote-build)**,
+  the internals of the pair flow, peer-link transport, and build
+  scheduler behind the "Send builds" feature above.
 - **[docs/API.md](docs/API.md)** — every WebSocket command, request/response
   shapes, event types.
 - **[esphome_device_builder/definitions/README.md](esphome_device_builder/definitions/README.md)** —


### PR DESCRIPTION
# What does this implement/fix?

Adds a top-level **"Send builds to another dashboard"** section to README.md walking through the offloader / receiver pairing flow. The README has zero mentions of `offloader` / `receiver` / `build server` / remote build today, so a user looking at it has no way to know the feature exists.

## What lands

* **New top-level section** placed between "Try it" and "Roadmap"; "Try it" gets the user running, "Roadmap" looks forward, the feature walkthrough slots naturally in between.
* **Two-role overview**, Build server (receiver) vs Send builds (offloader), with the exact in-UI nav labels so grepping the README after clicking through the UI finds the right spot.
* **Four-step pairing walkthrough**: discovery, pair button, emoji-fingerprint comparison (with the out-of-band hint spelled out, not the OOB acronym), accept on the receiver's Pairing requests. Uses "fingerprint" (the in-UI term) consistently rather than "pin" or "pairing code".
* **`esphome-device-builder-discover` CLI reference** for the user troubleshooting why a dashboard they expected to see isn't appearing in Known dashboards. Includes an example output block and an if-not-this-then-that diagnostic hint so the reference is useful rather than a name-drop.
* **Post-pairing UX call-outs**: the install dialog's "Building on `{receiver}`" sub-line, the per-install "Build locally instead" override, and the "Auto-route installs to remote build" master toggle. All UI strings match `en.json` verbatim.
* **Manual hostname-entry escape hatch** for the no-mDNS case, including the HA-addon caveat (the addon doesn't advertise itself on mDNS, so two addon instances need this flow).
* **Known limitations** section honestly framing what's open: serial installs ([#570](https://github.com/esphome/device-builder/issues/570)) and a major-version-mismatch toggle ([#607](https://github.com/esphome/device-builder/issues/607)). Verified both issues exist and OPEN before linking.

The platform-support claim in "Known limitations" lists everything ESPHome's OTA component covers (ESP32, ESP8266, RP2040 / RP2350, LibreTiny family with BK72xx, RTL87xx, LN882x, and nRF52) rather than a conservative ESP32-only framing. The actual code-level constraint is just `_is_serial_port` forces LOCAL; no platform gate exists, so OTA-capable platforms all route through remote build today.

## Audit-correct pass against the codebase

Before settling on the prose, ran a verification pass against this repo and the paired frontend (`~/device-builder-frontend_2`) and corrected seven inaccuracies in the first draft:

| Claim | Resolution |
|---|---|
| "mDNS advertise as long as the receiver listener is bound" | Reworded: advertise happens regardless of the listener; the peer-link port lands in TXT once the listener binds. HA-addon skip noted parenthetically. |
| "row of emoji" / "emoji grid" inconsistency | Picked "emoji grid" throughout (matches the `pin-emoji-grid` component). |
| "Show details" disclosure label | Actual label in `en.json` is "Show hex bytes"; used verbatim. |
| "online and idle" routing condition | Scheduler is two-tier (idle preferred, busy-queued fallback); reworded to describe both tiers. |
| "field at the bottom of Known dashboards" | Actually a separate "Pair with another dashboard" section with a button that opens a dialog; reworded to match. |
| "plain TCP on port 6055" | Technically true but read as "no encryption"; reworded to "TCP port 6055; wire is Noise-encrypted regardless of how you reach it." |
| Documentation pointer line's em-dash | Replaced with a comma continuation. |

## Documentation section

Also adds a pointer line to the Documentation section linking `docs/ARCHITECTURE.md § Remote build` so readers who want the internals (pair flow, peer-link transport, build scheduler) can find their way down without grepping the source tree.

## Constraints honoured

- No human handles or names anywhere (grepped to confirm).
- UI labels match `en.json` exactly: `build_server`, `build_offload`, `remote_build_known_dashboards`, `pairing_requests`, `offloader_remote_builds_enabled`, `force_local_action`, `remote_builder_sub_line`, `pair_build_server_section_heading`, `pair_build_server_pin_hex_summary`.
- Stays at user-facing intro depth; the maintainer-facing internals (X25519 keypair, TOFU vs cert-pinning trade-offs, pairing window state machine, transport details) stay only in ARCHITECTURE.md.
- No Discord / chat references beyond the existing one at line 8.
- No CLI invocation examples for *pairing* (the flow is UI-only); the `esphome-device-builder-discover` mention is a diagnostic tool, not a pairing path.
- No em-dashes or en-dashes anywhere in the new prose (no-dashes convention; pre-existing dashes in the rest of the README stay untouched).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue), `bugfix`
- [ ] New feature (non-breaking change which adds functionality), `new-feature`
- [ ] Enhancement to an existing feature, `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected), `breaking-change`
- [ ] Refactor (no behaviour change), `refactor`
- [x] Documentation only, `docs`
- [ ] Maintenance / chore, `maintenance`
- [ ] CI / workflow change, `ci`
- [ ] Dependencies bump, `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable (n/a, docs-only).
- [x] `components.json` has **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` (cross-link from README to ARCHITECTURE.md § Remote build added).
