### PR TITLE
Fix mDNS SRV target publishing the system FQDN instead of a .local hostname

### DIFF
--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -199,18 +199,45 @@ def _default_hostname() -> str:
     """
     System mDNS hostname for the ``ServiceInfo.server`` SRV target.
 
-    Returns ``socket.gethostname()`` with ``.local`` appended when
-    the result has no dot. Doesn't use ``socket.getfqdn()``: on
-    macOS that resolver can return the reverse-DNS arpa form (e.g.
-    ``...ip6.arpa``) when reverse lookup fails, which is worse
-    than no hostname at all.
+    Always returns the leftmost label of ``socket.gethostname()``
+    with ``.local`` appended. The mDNS spec (RFC 6762) requires
+    SRV targets on the ``.local`` domain to end in ``.local.``;
+    a FQDN like ``mac.koston.org`` is not a valid mDNS hostname
+    and won't resolve on the ``.local`` domain peers are browsing.
+
+    ``socket.gethostname()`` returns whatever the kernel was
+    given at boot; that's often a bare label (``mac``,
+    ``MacBook-Pro``) but on macOS or Linux with a configured
+    domain, or under some DHCP setups, it can come back as the
+    full FQDN (``mac.koston.org``). The previous "if there's a
+    dot, trust it as-is" branch published that FQDN verbatim
+    into the SRV target, which broke discovery for any peer
+    expecting a ``.local`` hostname.
+
+    Doesn't use ``socket.getfqdn()``: on macOS that resolver can
+    return the reverse-DNS arpa form (e.g. ``...ip6.arpa``) when
+    reverse lookup fails, which is worse than no hostname at all.
     """
     raw = (socket.gethostname() or "").strip()
     if not raw:
         return ""
-    if "." in raw:
-        return raw
-    return f"{raw}.local"
+    # Strip any domain suffix the OS may have appended; the SRV
+    # target must live on the ``.local`` mDNS domain regardless
+    # of how the system's own resolver names itself.
+    label = raw.split(".", 1)[0]
+    if not label:
+        return ""
+    # Lowercase the label. mDNS hostnames are case-insensitive
+    # per RFC 6762 §16, but downstream consumers (URLs, log
+    # strings, dedupe keys keyed on hostname) may compare
+    # case-sensitively. Bonjour, Avahi, and ESPHome itself all
+    # advertise hostnames lowercase; normalising at the publish
+    # site stops the same machine showing up as ``Mac.local``
+    # in some flows and ``mac.local`` in others. The
+    # service-instance name (``_default_friendly_name``) keeps
+    # its case because that's user-visible display text the
+    # operator picked deliberately.
+    return f"{label.lower()}.local"
 
 
 class DashboardAdvertiser:

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -70,16 +70,100 @@ def test_default_friendly_name_falls_back_when_empty(monkeypatch: pytest.MonkeyP
     assert _default_friendly_name() == "esphome-dashboard"
 
 
+def test_default_friendly_name_preserves_case(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    The user-visible friendly name keeps its case verbatim.
+
+    The friendly name lands in the mDNS service-instance name
+    (``<name>._esphomebuilder._tcp.local.``) and shows up in
+    browsers + dashboard UIs. Operators name their machines with
+    intentional case ("MacBook-Pro", "Office Server"); lowercasing
+    here would degrade their UX. Only the SRV hostname target
+    (``_default_hostname``) normalises to lowercase, because
+    that's a wire-protocol identifier where case-sensitive
+    consumers can drift.
+    """
+    monkeypatch.setattr(socket, "gethostname", lambda: "MacBook-Pro.local")
+    assert _default_friendly_name() == "MacBook-Pro"
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "Office-Server")
+    assert _default_friendly_name() == "Office-Server"
+
+
 def test_default_hostname_appends_local_when_no_dot(monkeypatch: pytest.MonkeyPatch) -> None:
     """A bare ``desktop`` becomes ``desktop.local`` for the TXT field."""
     monkeypatch.setattr(socket, "gethostname", lambda: "desktop")
     assert _default_hostname() == "desktop.local"
 
 
-def test_default_hostname_keeps_dotted(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A hostname with a dot is trusted as already-FQDN-ish."""
+def test_default_hostname_lowercases_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Mixed-case hostnames lowercase before the ``.local`` append.
+
+    mDNS hostnames are case-insensitive per RFC 6762 §16, but
+    downstream consumers may compare case-sensitively. Pin the
+    publish-site lowercase so the same machine doesn't show up
+    as ``Mac.local`` in one flow and ``mac.local`` in another.
+
+    The service-instance name (a separate
+    ``_default_friendly_name`` helper) keeps its case because
+    that's user-visible display text; only the SRV target gets
+    normalised.
+    """
+    monkeypatch.setattr(socket, "gethostname", lambda: "MacBook-Pro")
+    assert _default_hostname() == "macbook-pro.local"
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "Mac")
+    assert _default_hostname() == "mac.local"
+
+
+def test_default_hostname_strips_fqdn_and_appends_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A FQDN from ``gethostname`` is stripped to its leftmost label and gets ``.local``.
+
+    Regression test for the bug where ``socket.gethostname()``
+    returned a fully-qualified domain like ``mac.koston.org`` (which
+    happens on macOS / Linux with a configured search domain, or
+    under some DHCP setups) and the advertiser passed it through
+    verbatim into the SRV target. The mDNS spec (RFC 6762)
+    requires SRV targets on the ``.local`` domain to end in
+    ``.local.``, so publishing a ``.org`` FQDN broke discovery
+    for any peer expecting the canonical mDNS form.
+
+    Three shapes, same expected normalisation (lowercase + ``.local``):
+
+    * ``mac.koston.org`` → ``mac.local`` (the user's reported
+      shape, already lowercase).
+    * ``MacBook-Pro.local`` → ``macbook-pro.local`` (mixed-case
+      hostname; the label survives but lowercases).
+    * ``desktop.lan`` → ``desktop.local`` (corporate non-.local
+      search domain; same fix).
+    """
+    monkeypatch.setattr(socket, "gethostname", lambda: "mac.koston.org")
+    assert _default_hostname() == "mac.local"
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "MacBook-Pro.local")
+    assert _default_hostname() == "macbook-pro.local"
+
     monkeypatch.setattr(socket, "gethostname", lambda: "desktop.lan")
-    assert _default_hostname() == "desktop.lan"
+    assert _default_hostname() == "desktop.local"
+
+
+def test_default_hostname_handles_leading_dot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A pathological leading-dot hostname yields ``""`` rather than ``.local``.
+
+    ``socket.gethostname()`` returning ``".koston.org"`` (no
+    leading label) is implausible in practice but the boundary is
+    worth pinning: the leftmost label is empty, so the function
+    returns ``""`` and the advertiser falls back to whatever its
+    construction-time hostname was. Better than publishing
+    ``.local`` which would collide with the mDNS root.
+    """
+    monkeypatch.setattr(socket, "gethostname", lambda: ".koston.org")
+    assert _default_hostname() == ""
 
 
 def test_default_hostname_returns_empty_when_gethostname_blank(


### PR DESCRIPTION
# What does this implement/fix?

The dashboard's mDNS SRV record target was sometimes published as the system's full FQDN (e.g. `mac.koston.org`) instead of the canonical mDNS form (`<label>.local`). The same machine could even show up under two different names on the same network depending on which code path queried it: `MacBook-Pro.local` from `hostname`, `mac.koston.org` from the advertiser's TXT record. The mDNS spec (RFC 6762) requires SRV targets on the `.local` domain to end in `.local.`; publishing a `.org` FQDN isn't a valid mDNS hostname and won't resolve for any peer browsing the `.local` domain.

## Root cause

`_default_hostname()` had a "trust any dotted form as already FQDN-ish" branch:

```python
if "." in raw:
    return raw          # ← publishes "mac.koston.org" verbatim
return f"{raw}.local"
```

`socket.gethostname()` returns whatever the kernel was given at boot. That's often a bare label (`mac`, `MacBook-Pro`) but on macOS or Linux with a configured search domain, or under some DHCP setups, it can come back as the full FQDN. The previous branch trusted it and published the FQDN into the SRV target.

## What this PR does

Two changes in `_default_hostname()`:

1. **Strip to the leftmost label and always append `.local`.** Same machine no longer reports two flavours of itself; both `mac.koston.org` and `MacBook-Pro.local` now normalise to a correct mDNS hostname regardless of OS, DHCP, or search-domain config.

2. **Lowercase the resulting label.** mDNS hostnames are case-insensitive per RFC 6762 §16, but downstream consumers (URLs, log strings, dedupe keys keyed on hostname) may compare case-sensitively. Bonjour, Avahi, and ESPHome itself all advertise hostnames lowercase; normalising at the publish site stops the same machine showing up as `Mac.local` in some flows and `mac.local` in others.

## What this PR explicitly does NOT change

The **service-instance name** (`_default_friendly_name`) stays case-preserving. That's user-visible display text in mDNS browsers / dashboard UIs; operators name their machines with intentional case ("MacBook-Pro", "Office Server"), and lowercasing the friendly name would degrade UX. Only the SRV hostname target normalises, because that's a wire-protocol identifier where case-sensitive consumers can drift. A new test (`test_default_friendly_name_preserves_case`) pins both contracts together so a future refactor that collapses the two helpers gets the right shape.

## Tests

| Test | Pins |
|---|---|
| `test_default_hostname_strips_fqdn_and_appends_local` | `mac.koston.org` → `mac.local` (the user's reported shape); `MacBook-Pro.local` → `macbook-pro.local`; `desktop.lan` → `desktop.local`. |
| `test_default_hostname_lowercases_label` | `MacBook-Pro` → `macbook-pro.local`; `Mac` → `mac.local`. |
| `test_default_hostname_handles_leading_dot` | Pathological `.koston.org` (no leftmost label) yields `""` rather than `.local`. |
| `test_default_friendly_name_preserves_case` | `MacBook-Pro.local` → `MacBook-Pro` (NOT lowercased); `Office-Server` → `Office-Server`. |

Existing `test_default_hostname_keeps_dotted` asserted the bug as a feature; replaced with the three above. Full suite: 3101 passed (+2 net new), 4 skipped, lint clean.

**Related issue or feature (if applicable):**

- User report: a single machine showing up as both `mac.koston.org` and `MacBook-Pro.local` on the dashboard, depending on which code path queried it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue), `bugfix`
- [ ] New feature (non-breaking change which adds functionality), `new-feature`
- [ ] Enhancement to an existing feature, `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected), `breaking-change`
- [ ] Refactor (no behaviour change), `refactor`
- [ ] Documentation only, `docs`
- [ ] Maintenance / chore, `maintenance`
- [ ] CI / workflow change, `ci`
- [ ] Dependencies bump, `dependencies`

## Frontend coordination

- [x] No frontend change needed (the frontend reads whatever the advertise publishes; the fix is purely backend-side).

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
