### PR TITLE
Resolve peer-link .local hostnames through the shared AsyncZeroconf

### DIFF
--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -88,6 +88,7 @@ from ...helpers.json import dumps as json_dumps
 from ...helpers.json import loads as json_loads
 from ...helpers.peer_link_frames import frame_schema, is_valid_frame
 from ...helpers.peer_link_identity import get_or_create_peer_link_identity
+from ...helpers.peer_link_resolver import PeerLinkDNSResolver, make_peer_link_resolver
 from ...helpers.remote_build_cleanup import sweep_remote_builds
 from ...helpers.remote_build_layout import parse_from_configuration
 from ...helpers.storage import ShutdownCallback, Store
@@ -985,6 +986,20 @@ class RemoteBuildController:
     def __init__(self, device_builder: DeviceBuilder) -> None:
         self._db = device_builder
         self._browser: AsyncServiceBrowser | None = None
+        # Shared ``aiohttp`` resolver wired to the dashboard's
+        # :class:`AsyncEsphomeZeroconf` so outbound peer-link
+        # connects resolve ``*.local`` receiver hostnames through
+        # mDNS rather than the host OS's ``getaddrinfo``. Built
+        # in :meth:`start` once the device-state monitor's
+        # zeroconf is available; cleared in :meth:`stop`. Stays
+        # ``None`` when the shared zeroconf isn't up (HA-addon
+        # mode without an explicit ``ports:`` override, or any
+        # path where zeroconf failed to start) — call sites fall
+        # back to ``aiohttp``'s default OS resolver, which
+        # preserves the pre-mDNS-resolver behaviour for the
+        # subset of deployments that already had working mDNS in
+        # the OS.
+        self._peer_link_resolver: PeerLinkDNSResolver | None = None
         self._peers: dict[str, RemoteBuildPeer] = {}
         # Strong refs for fire-and-forget resolve tasks so the
         # garbage collector can't reap them mid-await.
@@ -1414,6 +1429,15 @@ class RemoteBuildController:
         )
         self._offloader_peer_link_priv = peer_link_identity.private_bytes
         self._offloader_dashboard_id = dashboard_identity.dashboard_id
+        # Wire the shared mDNS-aware aiohttp resolver before
+        # spawning peer-link clients so each client picks it up
+        # at construction. The device-state monitor owns the
+        # underlying :class:`AsyncZeroconf`; if it isn't up yet
+        # (or failed to start in HA-addon mode), the resolver
+        # stays ``None`` and outbound connects fall through to
+        # ``aiohttp``'s default OS resolver — same fail-soft
+        # contract as :meth:`_start_discovery` below.
+        self._setup_peer_link_resolver()
         # Spawn one peer-link client task per APPROVED pairing
         # already in the dict. Each task drives the connect →
         # handshake → receive loop with auto-reconnect; the
@@ -1527,6 +1551,27 @@ class RemoteBuildController:
             )
         )
         self._start_discovery()
+
+    def _setup_peer_link_resolver(self) -> None:
+        """
+        Build the shared mDNS-aware aiohttp resolver if zeroconf is up.
+
+        Reads the same ``self._db.devices.zeroconf`` reference
+        the discovery browser uses, so resolver-availability
+        and browser-availability are bound together — either
+        both run or both stay off. Stores the resolver on
+        :attr:`_peer_link_resolver`; leaves it ``None`` when
+        the shared zeroconf isn't available (devices controller
+        not constructed, monitor failed to bind, HA-addon mode
+        without zeroconf). Fail-soft: the next ``aiohttp``
+        connect falls back to the OS resolver in that case.
+        """
+        if self._db.devices is None:
+            return
+        zeroconf = self._db.devices.zeroconf
+        if zeroconf is None:
+            return
+        self._peer_link_resolver = make_peer_link_resolver(zeroconf)
 
     def _start_discovery(self) -> None:
         """
@@ -2139,6 +2184,34 @@ class RemoteBuildController:
         # ``subscribe_events`` initial_state. Symmetric with the
         # offloader-side ``_pairings.clear()`` above.
         self._approved_peers.clear()
+        await self._close_peer_link_resolver()
+
+    async def _close_peer_link_resolver(self) -> None:
+        """
+        Release the shared mDNS-aware aiohttp resolver, if any.
+
+        Extracted from :meth:`stop` so the teardown branch lives
+        next to :meth:`_setup_peer_link_resolver` (the matching
+        bring-up step) instead of bloating ``stop``'s branch
+        count. Safe to call multiple times: the resolver
+        reference is cleared after the first call so any later
+        invocation is a no-op.
+
+        ``real_close`` releases the underlying ``aiodns``
+        resources; the borrowed :class:`AsyncZeroconf` belongs
+        to the device-state monitor and is closed separately on
+        its stop path. The :meth:`stop` caller already drained
+        every :class:`PeerLinkClient` before reaching this
+        method, so no live ``aiohttp`` connector is still
+        holding the resolver.
+        """
+        if self._peer_link_resolver is None:
+            return
+        try:
+            await self._peer_link_resolver.real_close()
+        except Exception:
+            _LOGGER.debug("peer-link resolver close failed", exc_info=True)
+        self._peer_link_resolver = None
 
     # ------------------------------------------------------------------
     # mDNS plumbing
@@ -2412,6 +2485,7 @@ class RemoteBuildController:
                 hostname=new_hostname,
                 port=new_port,
                 identity_priv=self._offloader_peer_link_priv,
+                resolver=self._peer_link_resolver,
             )
         except PeerLinkClientError as exc:
             return _RebindProbeResult(_RebindProbeOutcome.UNREACHABLE, transport_error=exc)
@@ -3007,6 +3081,7 @@ class RemoteBuildController:
                 hostname=clean_host,
                 port=clean_port,
                 identity_priv=identity.private_bytes,
+                resolver=self._peer_link_resolver,
             )
         except PeerLinkClientError as exc:
             raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
@@ -3126,6 +3201,7 @@ class RemoteBuildController:
                 identity_priv=peer_link_identity.private_bytes,
                 label=clean_offloader_label,
                 dashboard_id=dashboard_identity.dashboard_id,
+                resolver=self._peer_link_resolver,
             )
         except PeerLinkClientError as exc:
             raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
@@ -4061,6 +4137,7 @@ class RemoteBuildController:
             pin_sha256=pairing.pin_sha256,
             receiver_label=pairing.label,
             bus=self._db.bus,
+            resolver=self._peer_link_resolver,
         )
         task = asyncio.create_task(
             client.run(),
@@ -4148,6 +4225,7 @@ class RemoteBuildController:
                         port=pairing.receiver_port,
                         identity_priv=peer_link_identity.private_bytes,
                         dashboard_id=dashboard_identity.dashboard_id,
+                        resolver=self._peer_link_resolver,
                     )
                 except PeerLinkClientError as exc:
                     _LOGGER.debug(

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -1563,15 +1563,28 @@ class RemoteBuildController:
         :attr:`_peer_link_resolver`; leaves it ``None`` when
         the shared zeroconf isn't available (devices controller
         not constructed, monitor failed to bind, HA-addon mode
-        without zeroconf). Fail-soft: the next ``aiohttp``
-        connect falls back to the OS resolver in that case.
+        without zeroconf) **or** when the resolver constructor
+        itself raises (e.g. the upstream
+        :class:`aiohttp.resolver.AsyncResolver` ``__init__``
+        raises ``RuntimeError`` when ``aiodns`` isn't installed,
+        which can happen in lean env paths that drop the
+        transitive dep). Fail-soft: the next ``aiohttp`` connect
+        falls back to the OS resolver in either case, same
+        contract as :meth:`_start_discovery`.
         """
         if self._db.devices is None:
             return
         zeroconf = self._db.devices.zeroconf
         if zeroconf is None:
             return
-        self._peer_link_resolver = make_peer_link_resolver(zeroconf)
+        try:
+            self._peer_link_resolver = make_peer_link_resolver(zeroconf)
+        except Exception:
+            _LOGGER.exception(
+                "Could not build peer-link mDNS resolver; outbound peer-link connects "
+                "will fall back to the OS resolver"
+            )
+            self._peer_link_resolver = None
 
     def _start_discovery(self) -> None:
         """

--- a/esphome_device_builder/controllers/remote_build/peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client.py
@@ -59,6 +59,7 @@ from ...helpers.peer_link_noise import (
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
+from ...helpers.peer_link_resolver import make_peer_link_http_session
 from ...models import (
     PAIRING_VERSION_MAX_LEN,
     ArtifactsChunkFrameData,
@@ -91,6 +92,8 @@ from .peer_link import (
 )
 
 if TYPE_CHECKING:
+    from aiohttp.resolver import AbstractResolver
+
     from ...helpers.event_bus import EventBus
 
 _LOGGER = logging.getLogger(__name__)
@@ -305,6 +308,7 @@ async def drive_initiator_round_trip(
     intent: PeerLinkIntent,
     msg3_payload: bytes = b"",
     timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    resolver: AbstractResolver | None = None,
 ) -> InitiatorRoundTrip:
     """Run one Noise XX round-trip from the initiator side.
 
@@ -360,7 +364,7 @@ async def drive_initiator_round_trip(
     try:
         url = _build_ws_url(hostname, port)
         async with (
-            aiohttp.ClientSession(timeout=timeout) as http,
+            make_peer_link_http_session(timeout=timeout, resolver=resolver) as http,
             http.ws_connect(url, max_msg_size=_CONTROL_RESPONSE_MAX_BYTES) as ws,
         ):
             response_ct = await _drive_initiator_handshake_and_read_response(
@@ -412,6 +416,7 @@ async def preview_pair(
     hostname: str,
     port: int,
     identity_priv: bytes,
+    resolver: AbstractResolver | None = None,
 ) -> str:
     """Run an ``intent="preview"`` round-trip; return the receiver's pin_sha256.
 
@@ -431,6 +436,7 @@ async def preview_pair(
         port=port,
         identity_priv=identity_priv,
         intent=PeerLinkIntent.PREVIEW,
+        resolver=resolver,
     )
     if rt.intent_response != IntentResponse.OK.value:
         msg = f"peer-link preview rejected with intent_response={rt.intent_response!r}"
@@ -475,6 +481,7 @@ async def request_pair(
     identity_priv: bytes,
     label: str,
     dashboard_id: str,
+    resolver: AbstractResolver | None = None,
 ) -> RequestPairResult:
     """Run an ``intent="pair_request"`` round-trip; return the receiver's response.
 
@@ -511,6 +518,7 @@ async def request_pair(
         identity_priv=identity_priv,
         intent=PeerLinkIntent.PAIR_REQUEST,
         msg3_payload=msg3_payload,
+        resolver=resolver,
     )
     try:
         status = IntentResponse(rt.intent_response)
@@ -568,6 +576,7 @@ async def await_pair_status(
     port: int,
     identity_priv: bytes,
     dashboard_id: str,
+    resolver: AbstractResolver | None = None,
 ) -> PairStatusResult:
     """Run an ``intent="pair_status"`` long-poll round-trip.
 
@@ -624,6 +633,7 @@ async def await_pair_status(
         intent=PeerLinkIntent.PAIR_STATUS,
         msg3_payload=msg3_payload,
         timeout_seconds=_PAIR_STATUS_TIMEOUT_SECONDS,
+        resolver=resolver,
     )
     try:
         status = IntentResponse(rt.intent_response)
@@ -922,11 +932,20 @@ class PeerLinkClient:
         pin_sha256: str,
         receiver_label: str,
         bus: EventBus,
+        resolver: AbstractResolver | None = None,
     ) -> None:
         self._hostname = receiver_hostname
         self._port = receiver_port
         self._identity_priv = identity_priv
         self._dashboard_id = dashboard_id
+        # Shared :class:`aiohttp` resolver wired to the
+        # dashboard's :class:`AsyncZeroconf` so ``.local``
+        # receiver hostnames resolve through mDNS instead of the
+        # OS resolver (which often doesn't have mDNS plumbed).
+        # ``None`` falls back to ``aiohttp``'s default resolver,
+        # which is the only viable shape for unit tests that
+        # don't construct a real Zeroconf.
+        self._resolver = resolver
         # Pinned receiver pubkey from the OOB-verified pair flow,
         # captured during ``preview_pair`` and stored on
         # :class:`StoredPairing.static_x25519_pub`. Compared
@@ -1498,7 +1517,7 @@ class PeerLinkClient:
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=_DEFAULT_TIMEOUT_SECONDS)
         try:
             async with (
-                aiohttp.ClientSession(timeout=timeout) as http,
+                make_peer_link_http_session(timeout=timeout, resolver=self._resolver) as http,
                 http.ws_connect(url, max_msg_size=APP_FRAME_MAX_BYTES) as ws,
             ):
                 session = PeerLinkNoiseSession.initiator(self._identity_priv)

--- a/esphome_device_builder/helpers/peer_link_resolver.py
+++ b/esphome_device_builder/helpers/peer_link_resolver.py
@@ -1,0 +1,134 @@
+"""
+Shared aiohttp resolver + session factory for the outbound peer-link client.
+
+The peer-link client (offloader-side) connects to receivers whose
+hostnames are typically advertised over mDNS as ``*.local`` (the
+LAN browse path) or persisted from an earlier discovery into
+:attr:`~models.remote_build.StoredPairing.receiver_hostname`. The
+host OS's ``getaddrinfo`` may or may not have mDNS wired in —
+Linux without ``nss-mdns``, headless macOS without an Avahi
+shim, and most container deployments resolve ``.local`` names
+through unicast DNS only and fall through to ``NXDOMAIN``. That
+silently breaks every outbound connect to an mDNS-only peer.
+
+This module wires the existing :class:`AsyncEsphomeZeroconf`
+instance the :class:`~controllers._device_state_monitor.DeviceStateMonitor`
+already owns into an :class:`AsyncDualMDNSResolver` so the
+outbound peer-link client's ``aiohttp.ClientSession`` resolves
+``.local`` names through that shared Zeroconf rather than the OS
+resolver. Non-``.local`` hostnames fall through to the regular
+DNS path.
+
+Sharing the resolver across all peer-link sessions matters for
+two reasons:
+
+* Only one mDNS responder can bind ``5353/udp`` per process —
+  constructing a fresh :class:`AsyncZeroconf` per session would
+  fight the device-state monitor's responder over the socket.
+* The :class:`AsyncDualMDNSResolver`'s cache is per-instance; a
+  shared instance amortises the lookup across the
+  :func:`drive_initiator_round_trip` + :class:`PeerLinkClient`
+  flows (preview, request_pair, pair_status long-poll, the
+  long-lived peer-link session) which all hit the same handful
+  of receiver hostnames.
+
+The resolver's :meth:`close` is intentionally a no-op so the
+:class:`aiohttp.TCPConnector` that owns it during a request can
+be closed without tearing down the underlying
+:class:`AsyncZeroconf` (which the device-state monitor still
+needs). :meth:`real_close` performs the actual teardown of the
+``aiodns`` side; the shared zeroconf is closed separately by
+the monitor's stop path because the resolver was constructed
+with ``async_zeroconf=`` (so
+:attr:`AsyncDualMDNSResolver._aiozc_owner` is ``False``).
+
+Mirrors Home Assistant core's ``HassAsyncDNSResolver`` +
+``_async_create_clientsession`` pattern in
+``homeassistant/helpers/aiohttp_client.py``: a single resolver
+is wired once, and a session-factory helper builds
+:class:`aiohttp.ClientSession` instances with the resolver
+pre-attached so call sites don't repeat the
+``TCPConnector(resolver=...)`` construction. HA gets to share
+one :class:`aiohttp.ClientSession` across all requests because
+its timeouts live on each ``session.get(...)`` call; our
+per-call timeouts (10s short round-trip vs unbounded peer-link
+session vs 1h pair_status long-poll) are session-level in
+``aiohttp`` so we share the resolver but build a fresh session
+per call. The factory keeps the resolver-wiring step from
+duplicating across call sites.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import aiohttp
+from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
+
+if TYPE_CHECKING:
+    from aiohttp.resolver import AbstractResolver
+    from zeroconf.asyncio import AsyncZeroconf
+
+
+class PeerLinkDNSResolver(AsyncDualMDNSResolver):
+    """
+    Shared aiohttp resolver for outbound peer-link sessions.
+
+    Wraps :class:`AsyncDualMDNSResolver` so per-request
+    :class:`aiohttp.TCPConnector` instances can be opened and
+    closed independently of the resolver's lifetime — the
+    connector's close path delegates to :meth:`close`, which is
+    a no-op here. The dashboard's shutdown path calls
+    :meth:`real_close` exactly once to release the underlying
+    ``aiodns`` resources.
+    """
+
+    async def real_close(self) -> None:
+        """Release the underlying ``aiodns`` resources."""
+        await super().close()
+
+    async def close(self) -> None:
+        """No-op so per-request connectors don't tear down the shared resolver."""
+
+
+def make_peer_link_resolver(async_zeroconf: AsyncZeroconf) -> PeerLinkDNSResolver:
+    """
+    Build a :class:`PeerLinkDNSResolver` bound to *async_zeroconf*.
+
+    The resolver does **not** take ownership of the
+    :class:`AsyncZeroconf` instance — the caller (the device-
+    state monitor) keeps it for the LAN browser path; the
+    resolver borrows it for ``.local`` lookups only.
+    :attr:`AsyncDualMDNSResolver._aiozc_owner` resolves to
+    ``False`` because we pass the instance via the
+    ``async_zeroconf=`` keyword.
+    """
+    return PeerLinkDNSResolver(async_zeroconf=async_zeroconf)
+
+
+def make_peer_link_http_session(
+    *,
+    timeout: aiohttp.ClientTimeout,
+    resolver: AbstractResolver | None,
+) -> aiohttp.ClientSession:
+    """
+    Build an :class:`aiohttp.ClientSession` for one peer-link call.
+
+    Encapsulates the "wire the shared resolver into a fresh
+    :class:`~aiohttp.TCPConnector` if one is available" step so
+    every outbound peer-link call site
+    (:func:`drive_initiator_round_trip`,
+    :meth:`PeerLinkClient._run_one_session`) shares a single
+    construction path. When *resolver* is ``None`` (no shared
+    zeroconf, tests, fallback paths) the session falls through
+    to ``aiohttp``'s default OS resolver so the legacy plumbing
+    behaviour is preserved.
+
+    The caller owns the returned session — use it as an
+    ``async with`` context manager and let it close the
+    connector on exit. The resolver itself is shared and
+    survives the connector's close (its :meth:`close` is a
+    no-op; see :class:`PeerLinkDNSResolver`).
+    """
+    connector = aiohttp.TCPConnector(resolver=resolver) if resolver is not None else None
+    return aiohttp.ClientSession(timeout=timeout, connector=connector)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ classifiers = [
 dependencies = [
   "esphome-device-builder-frontend==0.1.69",
   "aiohttp>=3.9.0",
+  # Provides an ``aiohttp.AsyncResolver`` that resolves ``.local``
+  # hostnames through an injected ``AsyncZeroconf`` (the same
+  # instance the device-state monitor already owns), so the
+  # outbound peer-link client doesn't depend on the host OS
+  # having a working mDNS responder wired into ``getaddrinfo``.
+  "aiohttp-asyncmdnsresolver>=0.1.1",
   "colorlog>=6.8.0",
   "cryptography>=42.0.2",
   "mashumaro>=3.13",

--- a/tests/test_peer_link_resolver.py
+++ b/tests/test_peer_link_resolver.py
@@ -1,0 +1,165 @@
+"""
+Tests for the shared mDNS-aware aiohttp resolver helper.
+
+Covers two surfaces:
+
+* :class:`PeerLinkDNSResolver` — the
+  :class:`AsyncDualMDNSResolver` wrapper whose :meth:`close` is
+  a no-op so per-request :class:`aiohttp.TCPConnector` instances
+  don't tear down the shared resolver; :meth:`real_close` is the
+  explicit teardown.
+* :func:`make_peer_link_http_session` — the session factory that
+  encapsulates the "wire the resolver into a fresh
+  :class:`aiohttp.TCPConnector`" step so both
+  :func:`drive_initiator_round_trip` and
+  :meth:`PeerLinkClient._run_one_session` share one construction
+  path.
+
+The resolver's actual mDNS resolution is exercised end-to-end
+by ``tests/e2e/test_pair_and_session.py`` against a real
+:class:`AsyncZeroconf`; here we only pin the lifecycle + wiring
+contracts that are easy to misregress.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+from aiohttp_asyncmdnsresolver._impl import _AsyncMDNSResolverBase
+from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
+from zeroconf.asyncio import AsyncZeroconf
+
+from esphome_device_builder.helpers.peer_link_resolver import (
+    PeerLinkDNSResolver,
+    make_peer_link_http_session,
+    make_peer_link_resolver,
+)
+
+
+def _fake_async_zeroconf() -> AsyncZeroconf:
+    """Return a :class:`MagicMock` standing in for :class:`AsyncZeroconf`.
+
+    Passing a real one would open a UDP socket per test; the
+    resolver only stores the reference and reads ``.zeroconf``
+    when it actually resolves a name (which these tests don't
+    do), so a mock is sufficient for the lifecycle checks.
+    """
+    return MagicMock(spec=AsyncZeroconf)
+
+
+async def test_make_peer_link_resolver_borrows_the_zeroconf() -> None:
+    """Constructed resolver doesn't own the shared :class:`AsyncZeroconf`.
+
+    ``_aiozc_owner`` is ``False`` when an external
+    :class:`AsyncZeroconf` is passed via ``async_zeroconf=`` —
+    the upstream :class:`AsyncDualMDNSResolver` uses this flag
+    to skip closing the borrowed instance on :meth:`close`. The
+    device-state monitor owns the real instance and tears it
+    down separately on its own stop path.
+    """
+    aiozc = _fake_async_zeroconf()
+    resolver = make_peer_link_resolver(aiozc)
+    assert resolver._aiozc is aiozc
+    assert resolver._aiozc_owner is False
+
+
+async def test_resolver_close_is_no_op_so_connector_close_keeps_it_usable() -> None:
+    """``close()`` doesn't release ``aiodns`` or drop the zeroconf reference.
+
+    A per-request :class:`aiohttp.TCPConnector` that closes its
+    own resolver on connector-close must NOT tear down the
+    shared resolver — multiple peer-link sessions reuse it.
+    The wrapper's no-op :meth:`close` is what enforces this.
+    """
+    resolver = make_peer_link_resolver(_fake_async_zeroconf())
+    captured_aiozc = resolver._aiozc
+    await resolver.close()
+    assert resolver._aiozc is captured_aiozc
+
+
+async def test_real_close_releases_aiodns_resources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``real_close()`` is the explicit teardown entry point.
+
+    Mirrors Home Assistant's ``HassAsyncDNSResolver`` pattern:
+    the dashboard's shutdown path calls :meth:`real_close`
+    exactly once after every connector that referenced the
+    resolver has been closed, so the underlying ``aiodns``
+    resources can be released without being dragged down by an
+    intermediate connector teardown.
+
+    Patches the upstream parent's :meth:`close` directly rather
+    than standing up a real ``aiodns`` resolver — the contract
+    we want to pin is "``real_close`` walks through to the
+    parent's close" and that's the smallest reproducer.
+    """
+    real_close = AsyncMock()
+    monkeypatch.setattr(_AsyncMDNSResolverBase, "close", real_close)
+    resolver = make_peer_link_resolver(_fake_async_zeroconf())
+    await resolver.real_close()
+    real_close.assert_awaited_once()
+
+
+async def test_make_peer_link_http_session_with_resolver_wires_connector() -> None:
+    """A non-``None`` resolver lands on the session's :class:`TCPConnector`.
+
+    Pins the contract :func:`drive_initiator_round_trip` and
+    :meth:`PeerLinkClient._run_one_session` both rely on:
+    the factory builds a fresh :class:`TCPConnector` keyed to
+    the shared resolver so outbound ``.local`` hostnames are
+    resolved through mDNS.
+    """
+    resolver = make_peer_link_resolver(_fake_async_zeroconf())
+    timeout = aiohttp.ClientTimeout(total=5.0)
+    async with make_peer_link_http_session(timeout=timeout, resolver=resolver) as session:
+        connector = session.connector
+        assert isinstance(connector, aiohttp.TCPConnector)
+        assert connector._resolver is resolver
+
+
+async def test_make_peer_link_http_session_with_no_resolver_falls_through() -> None:
+    """``resolver=None`` returns a session with ``aiohttp``'s default resolver.
+
+    Preserves the pre-mDNS-resolver behaviour for paths where
+    no shared :class:`AsyncZeroconf` is available (HA-addon
+    mode without ``ports:``, unit-test paths, controllers
+    constructed without a device-state monitor).
+    """
+    timeout = aiohttp.ClientTimeout(total=5.0)
+    async with make_peer_link_http_session(timeout=timeout, resolver=None) as session:
+        # No assertion on the resolver type — that's an aiohttp
+        # implementation detail we don't want to pin. The
+        # important contract is "session is usable as-is", which
+        # the ``async with`` exit on close will surface if
+        # broken.
+        assert session.connector is not None
+
+
+def test_peer_link_dns_resolver_is_async_dual_mdns_resolver_subclass() -> None:
+    """Sanity check the inheritance contract.
+
+    Downstream code (the offloader's ``ws_connect`` path) reads
+    the resolver as an :class:`aiohttp.resolver.AbstractResolver`
+    purely on duck typing, but the wrapper inheriting from
+    :class:`AsyncDualMDNSResolver` is what makes the
+    ``.local``-via-mDNS branch reachable on a plain
+    :class:`TCPConnector(resolver=...)` construction.
+    """
+    assert issubclass(PeerLinkDNSResolver, AsyncDualMDNSResolver)
+
+
+@pytest.mark.parametrize("hostname", ["receiver.local", "RECEIVER.LOCAL.", "receiver.local."])
+def test_resolver_subclass_hits_mdns_branch_for_local_hostnames(hostname: str) -> None:
+    """Document the ``.local`` discrimination the upstream resolver does.
+
+    The upstream :class:`AsyncDualMDNSResolver.resolve` branches
+    on ``host.endswith(".local")`` / ``".local."``: matched
+    hostnames go through the mDNS path (which uses our shared
+    :class:`AsyncZeroconf`), everything else falls through to
+    the unicast-DNS parent. We don't test the resolve call
+    itself here (it would need a real zeroconf instance), just
+    pin that the strings the dashboard cares about are the ones
+    the upstream split honours.
+    """
+    assert hostname.lower().endswith((".local", ".local."))

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -21,7 +21,9 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
 from zeroconf import ServiceStateChange
+from zeroconf.asyncio import AsyncZeroconf
 
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.controllers.remote_build import controller as rb
@@ -1319,6 +1321,70 @@ async def test_start_skips_when_zeroconf_unavailable(tmp_path: Path) -> None:
     controller._db.devices.zeroconf = None
     await controller.start()
     assert controller._browser is None
+
+
+@pytest.mark.asyncio
+async def test_start_leaves_peer_link_resolver_none_when_devices_controller_missing(
+    tmp_path: Path,
+) -> None:
+    """
+    No devices controller → no shared zeroconf → no mDNS resolver.
+
+    The peer-link clients accept ``resolver=None`` and fall back
+    to ``aiohttp``'s default OS resolver, preserving the
+    pre-mDNS-resolver behaviour for paths where the device-state
+    monitor never came up.
+    """
+    db = MagicMock()
+    db.devices = None
+    db.settings = MagicMock()
+    db.settings.config_dir = tmp_path
+    controller = RemoteBuildController(db)
+    await controller.start()
+    assert controller._peer_link_resolver is None
+
+
+@pytest.mark.asyncio
+async def test_start_leaves_peer_link_resolver_none_when_zeroconf_failed_to_bind(
+    tmp_path: Path,
+) -> None:
+    """
+    Devices controller up but zeroconf missing → no mDNS resolver.
+
+    Mirrors :class:`DeviceStateMonitor`'s fail-soft contract:
+    a zeroconf-side failure leaves the dashboard running but
+    without mDNS, and outbound peer-link connects fall back to
+    the OS resolver the same way the legacy plumbing did.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.devices.zeroconf = None
+    await controller.start()
+    assert controller._peer_link_resolver is None
+
+
+@pytest.mark.asyncio
+async def test_start_constructs_peer_link_resolver_when_zeroconf_is_up(
+    tmp_path: Path,
+) -> None:
+    """A bound zeroconf builds the shared mDNS resolver during ``start``.
+
+    The resolver is then handed to every :class:`PeerLinkClient`
+    spawned for an APPROVED pairing, so outbound ``.local``
+    receiver hostnames resolve through mDNS rather than the OS
+    resolver.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    # The shared fixture defaults ``zeroconf = None``; swap in a
+    # mock so the resolver-setup path doesn't bail on the
+    # availability gate.
+    controller._db.devices.zeroconf = MagicMock(spec=AsyncZeroconf)
+    await controller.start()
+    try:
+        assert controller._peer_link_resolver is not None
+        assert isinstance(controller._peer_link_resolver, AsyncDualMDNSResolver)
+    finally:
+        await controller.stop()
+        assert controller._peer_link_resolver is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1363,6 +1363,38 @@ async def test_start_leaves_peer_link_resolver_none_when_zeroconf_failed_to_bind
 
 
 @pytest.mark.asyncio
+async def test_stop_swallows_peer_link_resolver_close_failures(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A failure in ``real_close`` doesn't crash ``stop``.
+
+    The teardown path must finish unwinding the rest of the
+    controller's state — peer-link clients, listener
+    unregistrations, debounced-save flush — even if the
+    underlying ``aiodns`` close raises. Logged at DEBUG and
+    swallowed; the resolver reference is cleared either way so
+    a subsequent ``start`` reconstructs cleanly.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.devices.zeroconf = MagicMock(spec=AsyncZeroconf)
+    await controller.start()
+    assert controller._peer_link_resolver is not None
+    # Force the close path to raise; the controller should
+    # catch + log + clear the reference rather than propagate.
+    controller._peer_link_resolver.real_close = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("aiodns gone")
+    )
+    with caplog.at_level(
+        "DEBUG", logger="esphome_device_builder.controllers.remote_build.controller"
+    ):
+        await controller.stop()
+    assert controller._peer_link_resolver is None
+    assert any("peer-link resolver close failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_start_constructs_peer_link_resolver_when_zeroconf_is_up(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1363,6 +1363,41 @@ async def test_start_leaves_peer_link_resolver_none_when_zeroconf_failed_to_bind
 
 
 @pytest.mark.asyncio
+async def test_start_swallows_peer_link_resolver_construction_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A constructor-side resolver failure leaves the controller in a no-resolver state.
+
+    The upstream :class:`aiohttp.resolver.AsyncResolver`
+    ``__init__`` raises ``RuntimeError("Resolver requires
+    aiodns library")`` when ``aiodns`` isn't installed; the
+    transitive dep is usually present but a lean env path could
+    legitimately drop it. The controller must keep startup
+    going (same contract as the zeroconf-down branch) — the
+    resolver stays ``None`` and outbound connects fall back to
+    the OS resolver.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.controller.make_peer_link_resolver",
+        MagicMock(side_effect=RuntimeError("aiodns not installed")),
+    )
+    controller = _make_controller(config_dir=tmp_path)
+    controller._db.devices.zeroconf = MagicMock(spec=AsyncZeroconf)
+    with caplog.at_level(
+        "ERROR", logger="esphome_device_builder.controllers.remote_build.controller"
+    ):
+        await controller.start()
+    try:
+        assert controller._peer_link_resolver is None
+        assert any("Could not build peer-link mDNS resolver" in r.message for r in caplog.records)
+    finally:
+        await controller.stop()
+
+
+@pytest.mark.asyncio
 async def test_stop_swallows_peer_link_resolver_close_failures(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
# What does this implement/fix?

The offloader-side peer-link client connects to receivers whose
hostnames are typically advertised over mDNS as `*.local` (the
LAN browse path) or persisted from an earlier discovery into
`StoredPairing.receiver_hostname`. The host OS's `getaddrinfo`
may or may not have mDNS plumbed — container deployments and
most Linux installs without `nss-mdns` resolve `.local` only
through unicast DNS and return `NXDOMAIN`, which silently
breaks every outbound connect to an mDNS-only peer.

This wires `aiohttp-asyncmdnsresolver`'s `AsyncDualMDNSResolver`
into the existing `AsyncEsphomeZeroconf` instance the
device-state monitor already owns, so the outbound
`aiohttp.ClientSession` resolves `.local` names through that
shared Zeroconf rather than the OS resolver. Non-`.local`
hostnames fall through to regular DNS.

## New `helpers/peer_link_resolver.py`

* `PeerLinkDNSResolver` wraps `AsyncDualMDNSResolver` so
  per-request `TCPConnector` close paths don't tear down the
  shared resolver. Mirrors Home Assistant core's
  `HassAsyncDNSResolver` pattern in
  `homeassistant/helpers/aiohttp_client.py`: `close()` is a
  no-op, `real_close()` is the explicit teardown.
* `make_peer_link_http_session(*, timeout, resolver)` factory
  encapsulates the `TCPConnector(resolver=resolver)` wiring so
  both call sites (`drive_initiator_round_trip` and
  `PeerLinkClient._run_one_session`) share one construction
  path instead of duplicating it.

## Controller wiring

* `RemoteBuildController._setup_peer_link_resolver` runs in
  `start` before the peer-link client spawn loop so each client
  picks the resolver up at construction. Same fail-soft gates
  as `_start_discovery`: when the device-state monitor's
  zeroconf isn't up (HA-addon without `ports:` override,
  monitor failed to bind), the resolver stays `None` and
  outbound connects fall back to `aiohttp`'s default OS
  resolver — pre-resolver behaviour preserved.
* `_close_peer_link_resolver` extracts the teardown branch out
  of `stop` so the branch count stays under the lint ceiling.

Threaded through every offloader-side outbound call: peer-link
client spawn, the two pair-flow WS commands (`preview_pair`,
`request_pair`), the pair-status long-poll
(`await_pair_status`), and the rebind-probe path
(`_probe_pairing_endpoint` — used by both #539 mDNS auto-rebind
and #548 user-driven endpoint edits).

## Tests

* `tests/test_peer_link_resolver.py` — resolver helper's
  lifecycle contracts (no-op `close`, `real_close` teardown,
  session factory with / without a resolver).
* `tests/test_remote_build_controller.py` — three new
  fallback-path tests covering each branch of
  `_setup_peer_link_resolver` (no devices controller, zeroconf
  failed to bind, zeroconf up).

**Related issue or feature (if applicable):**

- N/A — this is a quality-of-life fix for the existing
  remote-build feature; surfaces in user reports as "pairing
  works the first time but reconnect after a dashboard restart
  fails."

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
