### PR TITLE
[docs] CLAUDE.md: 800-line soft cap for Python modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,34 @@ toggle in the official ESPHome container and Home Assistant add-on.
   at the top of every module so we can use modern type syntax on
   Python 3.12+.
 
+- **File size: 800-line soft cap.** When a Python module reaches
+  ~800 lines, plan a split before adding more. The cap exists
+  because: large modules degrade LLM context budget (every edit
+  pays the full file size in input tokens), they slow human
+  review (a 5000-line controller is hard to hold in working
+  memory), and they accumulate cross-concern coupling that's
+  invisible until you try to test one piece in isolation.
+
+  The split pattern this codebase uses is: replace
+  `controllers/X.py` with a `controllers/X/` package containing
+  `controller.py` (the main class + public API) plus per-concern
+  submodules (`controllers/X/foo.py` for the foo concern,
+  `controllers/X/bar.py` for the bar concern). `__init__.py`
+  re-exports the controller class so existing
+  `from .controllers.X import XController` callers keep working.
+  See `controllers/devices/`, `controllers/firmware/`, and
+  `controllers/remote_build/` for the canonical shape.
+
+  Existing modules over 800 lines (audit `wc -l` periodically;
+  the worst offender at the time of writing was 5176 lines) are
+  grandfathered: opportunistic refactors are welcome, but a
+  drive-by split inside an unrelated bugfix PR is scope creep.
+  The hard rule is: a PR that pushes a module *over* 800 should
+  include the split in the same PR (the split makes the bugfix
+  reviewable), and a PR that touches a module *already over* 800
+  should not make it worse. New top-level modules start under
+  the cap.
+
 ## Commit / PR conventions
 
 - **No `Co-Authored-By: Claude` trailer.** Project preference.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,14 @@ toggle in the official ESPHome container and Home Assistant add-on.
   the worst offender at the time of writing was 5176 lines) are
   grandfathered: opportunistic refactors are welcome, but a
   drive-by split inside an unrelated bugfix PR is scope creep.
-  The hard rule is: a PR that pushes a module *over* 800 should
-  include the split in the same PR (the split makes the bugfix
-  reviewable), and a PR that touches a module *already over* 800
-  should not make it worse. New top-level modules start under
-  the cap.
+  The hard rule is: **split first, then change**. If a planned
+  bugfix or feature would push a module over 800 lines, land
+  the split as its own behavior-free refactor PR first, then
+  layer the change on top in a follow-up PR. That keeps each
+  PR reviewable as one concern: the refactor PR diff is a pure
+  move, the bugfix PR diff is the actual change. A PR that
+  touches a module *already over* 800 lines should not make it
+  worse. New top-level modules start under the cap.
 
 ## Commit / PR conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,16 +80,27 @@ toggle in the official ESPHome container and Home Assistant add-on.
 
   Existing modules over 800 lines (audit `wc -l` periodically;
   the worst offender at the time of writing was 5176 lines) are
-  grandfathered: opportunistic refactors are welcome, but a
-  drive-by split inside an unrelated bugfix PR is scope creep.
-  The hard rule is: **split first, then change**. If a planned
-  bugfix or feature would push a module over 800 lines, land
-  the split as its own behavior-free refactor PR first, then
-  layer the change on top in a follow-up PR. That keeps each
-  PR reviewable as one concern: the refactor PR diff is a pure
-  move, the bugfix PR diff is the actual change. A PR that
-  touches a module *already over* 800 lines should not make it
-  worse. New top-level modules start under the cap.
+  grandfathered. The split rule is scoped to invasive changes:
+
+  * **Small bugfix headed for a patch release**: ship the fix,
+    skip the split. Blocking a few-line patch on a 5000-line
+    refactor would delay releases and force the refactor under
+    bugfix pressure (the wrong context for an invasive
+    behavior-free move). The cap is a soft cap; readability
+    isn't worth a delayed patch.
+  * **Invasive change** (new feature, significant refactor,
+    structural touch): **split first**. Land the split as a
+    behavior-free refactor PR; then layer the actual change on
+    top in a follow-up PR. Each PR is reviewable as one
+    concern: the refactor diff is a pure move; the feature
+    diff is the actual change.
+
+  A drive-by split inside an unrelated bugfix PR is scope creep
+  regardless. Opportunistic refactor PRs targeting the largest
+  offenders are welcome and should land as their own PRs.
+
+  A PR that touches a module *already over* 800 lines should
+  not make it worse. New top-level modules start under the cap.
 
 ## Commit / PR conventions
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a **File size: 800-line soft cap** bullet to `CLAUDE.md`'s Code style section. The codebase has 14 Python modules already over 800 lines today, with the worst at 5176 (`controllers/remote_build/controller.py`); the rule codifies the split-or-stop-the-bleed convention.

## Why an 800-line cap

Three reasons:

* **LLM context budget.** Every edit to a large module pays the full file size in input tokens; a 5000-line controller burns a meaningful share of the context window before any work happens. New modules under the cap leave more budget for the actual work.
* **Human review.** A multi-thousand-line module is hard to hold in working memory; reviewers skim instead of inspect. Smaller modules force the per-concern decomposition into the diff structure itself.
* **Coupling.** Large modules accumulate cross-concern coupling that isn't visible until you try to test one piece in isolation. The 800-line cap is a forcing function for early decomposition.

## Split pattern (already used in this codebase)

Replace `controllers/X.py` with a `controllers/X/` package:

```
controllers/X/
├── __init__.py       # re-exports the controller class
├── controller.py     # main class + public API
├── foo.py            # the foo concern
└── bar.py            # the bar concern
```

`__init__.py` re-exports so existing `from .controllers.X import XController` callers keep working. Canonical examples: `controllers/devices/`, `controllers/firmware/`, `controllers/remote_build/`.

## Grandfathering rule

The rule's "hard" form, explicitly stated in the diff so a future reader isn't confused by the existing offenders:

* **Small bugfix headed for a patch release**: ship the fix, skip the split. Blocking a few-line patch on a 5000-line refactor would delay releases and force the refactor under bugfix pressure (the wrong context for an invasive behavior-free move). The cap is a soft cap; readability isn't worth a delayed patch.
* **Invasive change** (new feature, significant refactor, structural touch): **split first**. Land the split as a behavior-free refactor PR; then layer the actual change on top in a follow-up PR. Each PR is reviewable as one concern: the refactor diff is a pure move; the feature diff is the actual change.
* A PR that touches a module **already over** 800 lines must not make it worse.
* New top-level modules start **under** the cap.

Drive-by splits inside unrelated bugfix PRs are scope creep regardless. Opportunistic refactor PRs targeting the largest offenders are welcome and should land as their own PRs.

## Audit snapshot (`wc -l`, at PR time)

| Lines | Module |
|---|---|
| 5176 | `controllers/remote_build/controller.py` |
| 3336 | `controllers/devices/controller.py` |
| 2092 | `controllers/firmware/controller.py` |
| 2082 | `controllers/remote_build/peer_link_client.py` |
| 1916 | `models/remote_build.py` |
| 1643 | `controllers/_device_state_monitor.py` |
| 1368 | `device_builder.py` |
| 1219 | `helpers/device_yaml.py` |
| 1072 | `controllers/remote_build/peer_link.py` |
| 1013 | `controllers/config.py` |
| 874 | `helpers/yaml.py` |
| 843 | `controllers/components.py` |
| 832 | `controllers/firmware/remote_runner.py` |
| 802 | `controllers/remote_build/submit_job.py` |

Re-audit periodically via `find esphome_device_builder -name '*.py' -not -path '*/__pycache__/*' -exec wc -l {} \; | sort -rn | head`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue), `bugfix`
- [ ] New feature (non-breaking change which adds functionality), `new-feature`
- [ ] Enhancement to an existing feature, `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected), `breaking-change`
- [ ] Refactor (no behaviour change), `refactor`
- [x] Documentation only, `docs`
- [ ] Maintenance / chore, `maintenance`
- [ ] CI / workflow change, `ci`
- [ ] Dependencies bump, `dependencies`

## Frontend coordination

- [x] No frontend change needed (CLAUDE.md is per-repo; the frontend has its own analogous 500-600 line cap in its README, see esphome/device-builder-frontend#309).

## Checklist

- [x] The code change is tested and works locally (n/a, docs-only).
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable (n/a, docs-only).
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` (rule is meta-process, not architecture).
