### PR TITLE
DRY pass on devices/controller.py: 3 reusable helpers, 10 call sites consolidated

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1193,18 +1193,11 @@ class DevicesController:
             configuration, new_content, action="update friendly name"
         )
 
-        # Atomic write — ``Path.write_text`` truncates the
-        # destination before writing, so a crash mid-write leaves
-        # a partial / corrupt YAML. ``esphome.helpers.write_file``
-        # already implements the canonical
-        # "stage-in-sibling-tempfile + atomic rename" pattern
-        # (NamedTemporaryFile in the destination directory so the
-        # rename stays within one filesystem, then ``shutil.move``
-        # which uses ``os.rename`` for same-FS targets). Lean on
-        # that helper here so this code path matches everywhere
-        # else in the upstream codebase that writes user-editable
-        # YAML.
-        await loop.run_in_executor(None, atomic_write_file, config_path, new_content)
+        # Routed through :meth:`_write_yaml_atomic_async`; the
+        # helper's docstring covers the canonical "stage-tempfile
+        # + atomic rename" rationale we lean on here for the
+        # user-editable YAML path.
+        await self._write_yaml_atomic_async(config_path, new_content)
         await self._scanner.scan()
         return {"configuration": configuration, "rewritten": True}
 
@@ -1471,21 +1464,17 @@ class DevicesController:
     @api_command("devices/get_config")
     async def get_config(self, *, configuration: str, **kwargs: Any) -> str:
         """Read device config YAML."""
-        path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, path.read_text, "utf-8")
+        return await self._read_yaml_async(self._db.settings.rel_path(configuration))
 
     @api_command("devices/update_config")
     async def update_config(self, *, configuration: str, content: str, **kwargs: Any) -> None:
-        """Write device config YAML."""
-        path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        # Atomic write — the YAML editor's "Save" button lands
-        # here, so a non-atomic write would lose the user's
-        # config on a mid-write crash. See ``CLAUDE.md`` >
-        # "Things that have bitten us before" for the full
-        # ``Path.write_text`` non-atomicity story.
-        await loop.run_in_executor(None, atomic_write_file, path, content)
+        """Write device config YAML.
+
+        Routed through :meth:`_write_yaml_atomic_async` because the YAML
+        editor's "Save" button lands here; a non-atomic write would
+        lose the user's config on a mid-write crash.
+        """
+        await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
         await self._scanner.scan()
         # Refresh ``StorageJSON`` so address / loaded_integrations /
         # config_hash etc. reflect the new YAML without waiting for a
@@ -1903,8 +1892,7 @@ class DevicesController:
                 raise ValueError(msg)
 
         config_path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        existing = await loop.run_in_executor(None, config_path.read_text, "utf-8")
+        existing = await self._read_yaml_async(config_path)
         # Honour each field's ``depends_on_component`` gate against
         # what's actually in the device YAML — drops MQTT-only options
         # (``availability:``, ``state_topic:``, ...) when the device
@@ -1914,7 +1902,7 @@ class DevicesController:
         new_yaml = merge_component_yaml(existing, component, fields)
         # Atomic write — wizard-driven add-component should not be
         # able to corrupt the source YAML on a mid-write crash.
-        await loop.run_in_executor(None, atomic_write_file, config_path, new_yaml)
+        await self._write_yaml_atomic_async(config_path, new_yaml)
         await self._scanner.scan()
 
         return AddComponentResponse(yaml=new_yaml)
@@ -2330,6 +2318,47 @@ class DevicesController:
         """Bridge for the state monitor (``self._scanner.devices`` is a property)."""
         return self._scanner.devices
 
+    def _fire_device_updated(self, device: Device) -> None:
+        """Fire ``DEVICE_UPDATED`` for *device*.
+
+        Every per-field monitor callback (``_on_ip_change``,
+        ``_on_version_change``, ``_on_mac_address_change``,
+        ``_on_api_encryption_change``, ``_on_config_hash_change``)
+        ends with the same broadcast. Centralising the construction
+        keeps the event-payload shape (``DeviceEventData(device=device)``)
+        in one place so a future field on the payload doesn't have
+        to land in five call sites.
+        """
+        self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+
+    @staticmethod
+    async def _write_yaml_atomic_async(path: Path, content: str) -> None:
+        """Atomically write *content* to *path* off the executor.
+
+        Wraps :func:`esphome.helpers.write_file` on the default
+        executor. Callers use this rather than ``Path.write_text``
+        because the latter is non-atomic (truncates before write,
+        so a mid-write crash leaves the user with an empty YAML);
+        the helper stages a same-FS tempfile and atomic-renames
+        into place. See ``CLAUDE.md`` > "Things that have bitten
+        us before" for the full ``Path.write_text`` non-atomicity
+        story.
+        """
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, atomic_write_file, path, content)
+
+    @staticmethod
+    async def _read_yaml_async(path: Path) -> str:
+        """Read *path* as UTF-8 text off the executor.
+
+        Mirror of :meth:`_write_yaml_atomic_async`; pairs the
+        read side of the YAML I/O so call sites doing
+        read-modify-write don't have to spell out the
+        ``get_running_loop`` / ``run_in_executor`` dance twice.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, path.read_text, "utf-8")
+
     def _resolve_device_metadata(self, config_dir: Path, filename: str) -> DeviceFileMetadata:
         """
         Resolve a device's persisted ``board_id`` / ``ip`` / config hash / MAC.
@@ -2634,7 +2663,7 @@ class DevicesController:
                 self._db.create_background_task(
                     self._persist_device_ip_async(device.configuration, ip)
                 )
-            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+            self._fire_device_updated(device)
 
     async def _persist_device_ip_async(self, configuration: str, ip: str) -> None:
         """Save *ip* to the device-builder metadata sidecar."""
@@ -2688,7 +2717,7 @@ class DevicesController:
                 old_version or "?",
                 version,
             )
-            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+            self._fire_device_updated(device)
 
     def _on_mac_address_change(self, name: str, mac: str) -> None:
         """
@@ -2723,7 +2752,7 @@ class DevicesController:
             self._db.create_background_task(
                 self._persist_device_metadata_async(device.configuration, mac_address=mac)
             )
-            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+            self._fire_device_updated(device)
 
     def _on_api_encryption_change(self, name: str, encryption: str) -> None:
         r"""
@@ -2759,7 +2788,7 @@ class DevicesController:
             device.api_encryption_active = encryption
             if wire_promotes_encrypted:
                 device.api_encrypted = True
-            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+            self._fire_device_updated(device)
 
     def _on_config_hash_change(self, name: str, config_hash: str) -> None:
         """
@@ -2790,7 +2819,7 @@ class DevicesController:
                 old_hash or "?",
                 config_hash,
             )
-            self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+            self._fire_device_updated(device)
 
     def _on_importable_added(self, device: AdoptableDevice) -> None:
         """Stash a newly-discovered importable device and notify subscribers."""

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -2319,43 +2319,24 @@ class DevicesController:
         return self._scanner.devices
 
     def _fire_device_updated(self, device: Device) -> None:
-        """Fire ``DEVICE_UPDATED`` for *device*.
-
-        Every per-field monitor callback (``_on_ip_change``,
-        ``_on_version_change``, ``_on_mac_address_change``,
-        ``_on_api_encryption_change``, ``_on_config_hash_change``)
-        ends with the same broadcast. Centralising the construction
-        keeps the event-payload shape (``DeviceEventData(device=device)``)
-        in one place so a future field on the payload doesn't have
-        to land in five call sites.
-        """
+        """Broadcast ``DEVICE_UPDATED`` for *device* on the event bus."""
         self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
 
     @staticmethod
     async def _write_yaml_atomic_async(path: Path, content: str) -> None:
         """Atomically write *content* to *path* off the executor.
 
-        Wraps :func:`esphome.helpers.write_file` on the default
-        executor. Callers use this rather than ``Path.write_text``
-        because the latter is non-atomic (truncates before write,
-        so a mid-write crash leaves the user with an empty YAML);
-        the helper stages a same-FS tempfile and atomic-renames
-        into place. See ``CLAUDE.md`` > "Things that have bitten
-        us before" for the full ``Path.write_text`` non-atomicity
-        story.
+        Use this for any user-editable YAML write so a mid-write
+        crash can't leave the file empty or half-written;
+        ``Path.write_text`` truncates before writing and isn't
+        safe for those paths.
         """
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, atomic_write_file, path, content)
 
     @staticmethod
     async def _read_yaml_async(path: Path) -> str:
-        """Read *path* as UTF-8 text off the executor.
-
-        Mirror of :meth:`_write_yaml_atomic_async`; pairs the
-        read side of the YAML I/O so call sites doing
-        read-modify-write don't have to spell out the
-        ``get_running_loop`` / ``run_in_executor`` dance twice.
-        """
+        """Read *path* as UTF-8 text off the executor."""
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, path.read_text, "utf-8")
 


### PR DESCRIPTION
# What does this implement/fix?

In-place DRY pass on `controllers/devices/controller.py` (3336 lines). Mirrors the shape of #620's pass on `remote_build/controller.py`: behavior-free refactor that consolidates duplicated patterns into a few helpers, setting up natural import boundaries for the eventual submodule split under the 800-line cap CLAUDE.md just landed in #619.

**10 duplicated call sites consolidated into 3 helpers.** Net +29 lines (the helper docstrings dominate the additions); the win is in centralisation, not file size.

## Helpers

* **`_fire_device_updated(device)`** (instance method) — five call sites in the per-field state-monitor callbacks (`_on_ip_change`, `_on_version_change`, `_on_mac_address_change`, `_on_api_encryption_change`, `_on_config_hash_change`). Each ended with the same `self._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))`. Centralising the construction keeps the event-payload shape in one place; a future field on `DeviceEventData` doesn't have to land in five sites.

* **`_write_yaml_atomic_async(path, content)`** (staticmethod) — three call sites (`update_config`, `_validate_rewritten_yaml_or_raise` / `edit_friendly_name`'s rewrite, `add_component`). Each ran `await loop.run_in_executor(None, atomic_write_file, path, content)` with a near-identical "atomic-write is needed because Path.write_text isn't" comment. Helper carries the rationale in its docstring; call sites just say "this is the YAML write".

* **`_read_yaml_async(path)`** (staticmethod) — two call sites (`get_config`, `add_component`). Pairs with the write helper so read-modify-write call sites don't have to spell out the `get_running_loop` / `run_in_executor` dance twice. `edit_friendly_name`'s read stays bespoke because it folds `FileNotFoundError` into a `None` return for typed-error mapping; the helper's signature would have to grow a special case for that, and the two sites aren't worth it.

## Behaviour preservation

Mechanical extraction. Each call site swaps a multi-line block for a one-line call, and the helpers do exactly what the inlined version did. All 310 devices-controller tests pass; 3116 in the full suite.

## What this is NOT

Not a submodule split. The file size moves from 3336 to 3365 (still 4× the cap); the actual split is the next PR. This one just consolidates the recurring patterns so the split has natural extension points to import from.

**Related issue or feature (if applicable):**

- N/A; same DRY-then-split pattern as #620 (remote_build/controller.py).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue), `bugfix`
- [ ] New feature (non-breaking change which adds functionality), `new-feature`
- [ ] Enhancement to an existing feature, `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected), `breaking-change`
- [x] Refactor (no behaviour change), `refactor`
- [ ] Documentation only, `docs`
- [ ] Maintenance / chore, `maintenance`
- [ ] CI / workflow change, `ci`
- [ ] Dependencies bump, `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable (n/a; pure refactor, existing 310 devices-controller tests pin the contract).
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` (none; internal-only).
