### PR TITLE
Fix pycares thread leak in resolver tests (120s teardown flake)

### DIFF
--- a/tests/test_peer_link_resolver.py
+++ b/tests/test_peer_link_resolver.py
@@ -23,10 +23,12 @@ contracts that are easy to misregress.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
+import pytest_asyncio
 from aiohttp_asyncmdnsresolver._impl import _AsyncMDNSResolverBase
 from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
 from zeroconf.asyncio import AsyncZeroconf
@@ -49,7 +51,30 @@ def _fake_async_zeroconf() -> AsyncZeroconf:
     return MagicMock(spec=AsyncZeroconf)
 
 
-async def test_make_peer_link_resolver_borrows_the_zeroconf() -> None:
+@pytest_asyncio.fixture
+async def resolver() -> AsyncIterator[PeerLinkDNSResolver]:
+    """Yield a :class:`PeerLinkDNSResolver` and guarantee teardown.
+
+    The resolver's parent :class:`aiohttp.resolver.AsyncResolver`
+    constructor spawns a ``pycares`` background thread
+    (``_run_safe_shutdown_loop``); without an explicit
+    :meth:`real_close` the thread leaks and a later test's
+    teardown waits on it indefinitely. The leak surfaced as a
+    flaky 120s ``pytest-timeout`` on an unrelated downstream
+    test running in the same xdist worker. Every test in this
+    file that needs a real resolver takes this fixture instead
+    of constructing one inline.
+    """
+    instance = make_peer_link_resolver(_fake_async_zeroconf())
+    try:
+        yield instance
+    finally:
+        await instance.real_close()
+
+
+async def test_make_peer_link_resolver_borrows_the_zeroconf(
+    resolver: PeerLinkDNSResolver,
+) -> None:
     """Constructed resolver doesn't own the shared :class:`AsyncZeroconf`.
 
     ``_aiozc_owner`` is ``False`` when an external
@@ -59,13 +84,13 @@ async def test_make_peer_link_resolver_borrows_the_zeroconf() -> None:
     device-state monitor owns the real instance and tears it
     down separately on its own stop path.
     """
-    aiozc = _fake_async_zeroconf()
-    resolver = make_peer_link_resolver(aiozc)
-    assert resolver._aiozc is aiozc
+    assert isinstance(resolver._aiozc, MagicMock)
     assert resolver._aiozc_owner is False
 
 
-async def test_resolver_close_is_no_op_so_connector_close_keeps_it_usable() -> None:
+async def test_resolver_close_is_no_op_so_connector_close_keeps_it_usable(
+    resolver: PeerLinkDNSResolver,
+) -> None:
     """``close()`` doesn't release ``aiodns`` or drop the zeroconf reference.
 
     A per-request :class:`aiohttp.TCPConnector` that closes its
@@ -73,13 +98,12 @@ async def test_resolver_close_is_no_op_so_connector_close_keeps_it_usable() -> N
     shared resolver — multiple peer-link sessions reuse it.
     The wrapper's no-op :meth:`close` is what enforces this.
     """
-    resolver = make_peer_link_resolver(_fake_async_zeroconf())
     captured_aiozc = resolver._aiozc
     await resolver.close()
     assert resolver._aiozc is captured_aiozc
 
 
-async def test_real_close_releases_aiodns_resources(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_real_close_releases_aiodns_resources(resolver: PeerLinkDNSResolver) -> None:
     """``real_close()`` is the explicit teardown entry point.
 
     Mirrors Home Assistant's ``HassAsyncDNSResolver`` pattern:
@@ -89,19 +113,21 @@ async def test_real_close_releases_aiodns_resources(monkeypatch: pytest.MonkeyPa
     resources can be released without being dragged down by an
     intermediate connector teardown.
 
-    Patches the upstream parent's :meth:`close` directly rather
-    than standing up a real ``aiodns`` resolver — the contract
-    we want to pin is "``real_close`` walks through to the
-    parent's close" and that's the smallest reproducer.
+    Patches the upstream parent's :meth:`close` as a context
+    manager so the patch is removed before the ``resolver``
+    fixture's cleanup calls :meth:`real_close` on the real code
+    path — that second call is what actually shuts down
+    ``pycares`` and keeps the thread from leaking.
     """
     real_close = AsyncMock()
-    monkeypatch.setattr(_AsyncMDNSResolverBase, "close", real_close)
-    resolver = make_peer_link_resolver(_fake_async_zeroconf())
-    await resolver.real_close()
-    real_close.assert_awaited_once()
+    with patch.object(_AsyncMDNSResolverBase, "close", real_close):
+        await resolver.real_close()
+        real_close.assert_awaited_once()
 
 
-async def test_make_peer_link_http_session_with_resolver_wires_connector() -> None:
+async def test_make_peer_link_http_session_with_resolver_wires_connector(
+    resolver: PeerLinkDNSResolver,
+) -> None:
     """A non-``None`` resolver lands on the session's :class:`TCPConnector`.
 
     Pins the contract :func:`drive_initiator_round_trip` and
@@ -110,7 +136,6 @@ async def test_make_peer_link_http_session_with_resolver_wires_connector() -> No
     the shared resolver so outbound ``.local`` hostnames are
     resolved through mDNS.
     """
-    resolver = make_peer_link_resolver(_fake_async_zeroconf())
     timeout = aiohttp.ClientTimeout(total=5.0)
     async with make_peer_link_http_session(timeout=timeout, resolver=resolver) as session:
         connector = session.connector


### PR DESCRIPTION
# What does this implement/fix?

CI on the Python 3.14 matrix hit a 120s `pytest-timeout` during
teardown of `test_controller_request_pair_persists_pending_row`
on PR #623 — but that test isn't the culprit. The stack trace
showed `Thread-1 (_run_safe_shutdown_loop)` from `pycares`
blocked on its work queue. That thread is spawned by every
`aiohttp.resolver.AsyncResolver` construction and only exits
when the resolver's `close()` is awaited.

Four tests in `test_peer_link_resolver.py` constructed a
`PeerLinkDNSResolver` without ever calling `real_close()` on it:

* `test_make_peer_link_resolver_borrows_the_zeroconf` —
  built + abandoned.
* `test_resolver_close_is_no_op_so_connector_close_keeps_it_usable`
  — called `close()` which is a no-op on our subclass.
* `test_real_close_releases_aiodns_resources` — patched the
  parent's `close` with an `AsyncMock`, so the real `pycares`
  cleanup never ran.
* `test_make_peer_link_http_session_with_resolver_wires_connector`
  — built a connector around the resolver, but
  `aiohttp.TCPConnector` doesn't close a resolver it doesn't
  own (`_resolver_owner=False`).

The leaked `pycares` thread persisted into the xdist worker's
next test teardown, where the teardown awaited on it and hit
the timeout.

## Fix

Add a `resolver` async pytest fixture that constructs the
resolver and calls `real_close()` in teardown. Tests that need
a real resolver take it as a parameter; the four leaking sites
collapse to one fixture body. The
`test_real_close_releases_aiodns_resources` variant patches
the parent's `close` with `mock.patch.object` as a context
manager so the patch is removed before the fixture's
`real_close()` cleanup runs on the real code path — that
second call is what actually shuts down `pycares` and keeps
the thread from leaking.

## Why a separate PR

The failing test (`test_controller_request_pair_persists_pending_row`)
isn't new — it landed in #501 (4a-o part 3). The flake's been
latent since #618 added the resolver tests and the underlying
`aiodns` / `pycares` deps. The leak finally surfaced on the
Python 3.14 matrix during the #623 CI run, where the timing
shook out unfavourably.

**Related issue or feature (if applicable):**

- Surfaces in #623's CI run:
  https://github.com/esphome/device-builder/actions/runs/25702526607/job/75465564216?pr=623

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
