### PR TITLE
ruff: enable PLR0904 (too-many-public-methods); grandfather the 4 existing controllers

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -340,7 +340,7 @@ def device_name_from_service(service_name: str) -> str:
     return service_name.split(".", maxsplit=1)[0]
 
 
-class DeviceStateMonitor:
+class DeviceStateMonitor:  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
     """
     Drive device state from mDNS broadcasts plus periodic ICMP pings.
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -142,7 +142,7 @@ _REGEN_FAILURE_TTL_SECONDS: float = 3600.0
 _YAML_SEARCH_PER_FILE_MATCH_CAP = 5
 
 
-class DevicesController:
+class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
     """Manage device configurations, file watching, and CLI operations."""
 
     def __init__(self, device_builder: DeviceBuilder) -> None:

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -147,7 +147,7 @@ def _resolve_download_component(target_platform: str | None) -> str:
     return platform
 
 
-class FirmwareController:
+class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
     """
     Manage firmware build jobs with a persistent queue.
 

--- a/esphome_device_builder/controllers/remote_build/controller.py
+++ b/esphome_device_builder/controllers/remote_build/controller.py
@@ -394,7 +394,7 @@ _CLEANUP_SWEEP_INTERVAL_SECONDS = 60 * 60
 _REBIND_PROBE_COOLDOWN_SECONDS = 30.0
 
 
-class RemoteBuildController:
+class RemoteBuildController:  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
     """
     Discover peer dashboards and own the receiver-side settings.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,14 @@ target-version = "py312"
 line-ending = "lf"
 
 [tool.ruff.lint]
+# PLR0904 (too-many-public-methods) is still in ruff's preview set;
+# enabling preview + explicit-preview-rules opts that single rule in
+# without pulling every other unstable rule along with it. The intent
+# is to catch *new* god-classes before they grow — the four pre-existing
+# offenders are grandfathered with inline ``# noqa: PLR0904`` so this
+# rule doesn't block existing work while they're refactored down.
+preview = true
+explicit-preview-rules = true
 ignore = [
   "D101", # missing docstring in public class (too noisy for now)
   "D102", # missing docstring in public method (too noisy for now)
@@ -107,6 +115,13 @@ ignore = [
   "D417", # false positives
   "PLR0913", # too many arguments — not a useful constraint here
   "PLR2004", # magic value comparison — too noisy for status codes / structural checks
+  # RUF001 / RUF002 flag U+00B5 (MICRO SIGN) as "ambiguous" against U+03BC
+  # (GREEK SMALL LETTER MU). U+00B5 is the canonical SI micro-prefix
+  # character (e.g. µs, µA, µHz) and is what ESPHome itself emits for
+  # unit_of_measurement; component-catalog code and unit-extraction tests
+  # need to handle that codepoint literally. False-positive for this codebase.
+  "RUF001", # ambiguous-unicode-character-string
+  "RUF002", # ambiguous-unicode-character-docstring
   "S101", # assert used for type checking
   "S104", # binding to all interfaces
 ]
@@ -123,6 +138,7 @@ select = [
   "N", # pep8-naming
   "PERF", # performance
   "PL", # pylint
+  "PLR0904", # too-many-public-methods (preview) — cap new god-classes at 20
   "RET", # flake8-return
   "RUF", # ruff-specific
   "S", # flake8-bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,13 +115,15 @@ ignore = [
   "D417", # false positives
   "PLR0913", # too many arguments — not a useful constraint here
   "PLR2004", # magic value comparison — too noisy for status codes / structural checks
-  # RUF001 / RUF002 flag U+00B5 (MICRO SIGN) as "ambiguous" against U+03BC
-  # (GREEK SMALL LETTER MU). U+00B5 is the canonical SI micro-prefix
+  # RUF001 / RUF002 / RUF003 flag U+00B5 (MICRO SIGN) as "ambiguous" against
+  # U+03BC (GREEK SMALL LETTER MU). U+00B5 is the canonical SI micro-prefix
   # character (e.g. µs, µA, µHz) and is what ESPHome itself emits for
-  # unit_of_measurement; component-catalog code and unit-extraction tests
-  # need to handle that codepoint literally. False-positive for this codebase.
+  # unit_of_measurement; component-catalog code, unit-extraction tests,
+  # and the explainer comment in script/sync_components.py all need to
+  # handle that codepoint literally. False-positive for this codebase.
   "RUF001", # ambiguous-unicode-character-string
   "RUF002", # ambiguous-unicode-character-docstring
+  "RUF003", # ambiguous-unicode-character-comment
   "S101", # assert used for type checking
   "S104", # binding to all interfaces
 ]

--- a/tests/test_helpers_logging.py
+++ b/tests/test_helpers_logging.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import logging.handlers
 from collections.abc import Generator
 
 import pytest


### PR DESCRIPTION
# What does this implement/fix?

Code-review feedback flagged controllers drifting toward 30-40 public methods without anything in CI catching it. Ruff already has `PLR0904` (pylint's `R0904`, "too-many-public-methods") for exactly this; the rule just wasn't on for this project.

## Wiring

* `PLR0904` lives in ruff's **preview** set, so selecting it alone doesn't enable it. `preview = true` + `explicit-preview-rules = true` is the canonical way to opt into a single preview rule without activating every other unstable rule alongside it.
* Default threshold is kept at 20. The current offenders sit at 22 / 37 / 21 / 39, so the cap is loud but achievable; we can ratchet later if it becomes restrictive.
* Four pre-existing god-classes are grandfathered with an inline `# noqa: PLR0904`:
  * `DeviceStateMonitor` (22)
  * `DevicesController` (37)
  * `FirmwareController` (21)
  * `RemoteBuildController` (39)

  The annotation is loud on the class line so a future reader adding a 23rd / 38th / 40th method to one of these has to acknowledge the noqa and the count — that's the cue to extract a helper rather than pile on. The four are already on the refactor radar (see #123 for the firmware-subpackage split shape; remote_build already started DRY-ing in #620).

## Side effect: RUF001 / RUF002 (ambiguous-unicode)

Activating preview mode also pulls in stricter behaviour on the existing `RUF001` / `RUF002` rules, which now flag `µ` (U+00B5 MICRO SIGN) as "ambiguous" against `μ` (U+03BC GREEK SMALL LETTER MU). U+00B5 is the canonical SI micro-prefix character (`µs`, `µA`, `µHz`) and is what ESPHome itself emits in `unit_of_measurement` strings — the component-catalog unit-extraction tests + a timing docstring in `_device_state_monitor.py` both need to handle that codepoint literally. Adding `RUF001` / `RUF002` to the project-wide ignore list with an inline comment explaining why this codebase has to keep U+00B5 verbatim.

## Drive-by

`tests/test_helpers_logging.py` had a stale `import logging.handlers` that ruff's `--fix` removed during the preview-on run. Genuinely unused (grep confirms nothing references `logging.handlers` in the file); included in the same commit.

## Verification

```
$ ruff check esphome_device_builder/ tests/
All checks passed!
$ pytest tests/ -q
3094 passed, 26 skipped in 13.18s
```

Smoke-tested the rule by feeding a synthetic 21-method class through `ruff check --config pyproject.toml`:

```
error[PLR0904] Too many public methods (21 > 20)
Found 1 error.
```

Rule fires for new code; existing grandfathered classes pass.

**Related issue or feature (if applicable):**

- Driven by recent review feedback on controller growth.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
