### PR TITLE
Seed active-WS WeakSet at app construction time, not on first connect

### DIFF
--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -70,6 +70,34 @@ _WS_HEARTBEAT_SECONDS = 30.0
 WEBSOCKETS_KEY = "_active_websockets"
 
 
+def init_ws_app(app: web.Application) -> None:
+    """Seed *app* with the active-WS registry + the shutdown closer.
+
+    Single source of truth for the two pieces of state every app
+    using :func:`create_ws_routes` needs at construction time:
+
+    * ``app[WEBSOCKETS_KEY]`` — the WeakSet the WS handler adds
+      to on every connection. Seeding it here means the handler
+      can call ``.add(ws)`` without ``setdefault``, which would
+      mutate app state after ``runner.setup`` and trip aiohttp
+      3.10's "Changing state of started or joined application"
+      deprecation.
+    * ``on_shutdown`` listener — :func:`close_active_websockets`
+      iterates the WeakSet on app shutdown and closes every live
+      WS with ``GOING_AWAY``. Without it, an idle client pins
+      shutdown for the full ``shutdown_timeout`` window.
+
+    Idempotent: re-seeding the key replaces the WeakSet (any
+    in-flight WS that's still alive holds its own reference and
+    survives the swap, but new connections register against the
+    fresh set); appending the listener a second time would
+    double-close but is cheap. Callers should call this exactly
+    once per app, immediately after construction.
+    """
+    app[WEBSOCKETS_KEY] = weakref.WeakSet()
+    app.on_shutdown.append(close_active_websockets)
+
+
 class WebSocketClient:
     """A single WebSocket client connection."""
 
@@ -276,13 +304,13 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     await ws.prepare(request)
 
     # Register on the per-app weak set so the shutdown closer can
-    # reach this WS without us holding a strong reference.
-    # ``setdefault`` lazily creates the set on the first connect;
-    # the matching ``on_shutdown`` handler is appended in
-    # :meth:`DeviceBuilder.create_app` so the closer is in place
-    # before any WS handler is allowed to run.
-    active = request.app.setdefault(WEBSOCKETS_KEY, weakref.WeakSet())
-    active.add(ws)
+    # reach this WS without us holding a strong reference. The set
+    # is seeded in :meth:`DeviceBuilder.create_app` at construction
+    # time (mutating an already-started app would trip aiohttp's
+    # 3.10 deprecation guard); the matching ``on_shutdown`` handler
+    # is appended there too, so the closer is in place before any
+    # WS handler is allowed to run.
+    request.app[WEBSOCKETS_KEY].add(ws)
 
     pre_authenticated = trusted_site or not settings.using_password
     token: str | None = None

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -87,15 +87,18 @@ def init_ws_app(app: web.Application) -> None:
       WS with ``GOING_AWAY``. Without it, an idle client pins
       shutdown for the full ``shutdown_timeout`` window.
 
-    Idempotent: re-seeding the key replaces the WeakSet (any
-    in-flight WS that's still alive holds its own reference and
-    survives the swap, but new connections register against the
-    fresh set); appending the listener a second time would
-    double-close but is cheap. Callers should call this exactly
-    once per app, immediately after construction.
+    Idempotent: a second call against the same app keeps the
+    existing WeakSet so live WSes registered against the first
+    call's set stay reachable from :func:`close_active_websockets`
+    on shutdown, and skips re-appending the listener so the closer
+    fires exactly once. A regression that orphaned the old set or
+    double-fired the closer would silently leak live WSes past
+    shutdown, so both branches matter.
     """
-    app[WEBSOCKETS_KEY] = weakref.WeakSet()
-    app.on_shutdown.append(close_active_websockets)
+    if WEBSOCKETS_KEY not in app:
+        app[WEBSOCKETS_KEY] = weakref.WeakSet()
+    if close_active_websockets not in app.on_shutdown:
+        app.on_shutdown.append(close_active_websockets)
 
 
 class WebSocketClient:

--- a/esphome_device_builder/controllers/remote_build/peer_link.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link.py
@@ -55,7 +55,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import weakref
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -318,15 +317,14 @@ async def make_peer_link_handler(
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         # Register on the peer-link app's WS set so the shared
-        # ``close_active_websockets`` shutdown hook can unblock this
-        # handler instead of pinning ``runner.cleanup()`` to
+        # ``close_active_websockets`` shutdown hook can unblock
+        # this handler instead of pinning ``runner.cleanup()`` to
         # aiohttp's 60s ``shutdown_timeout`` while an idle paired
-        # offloader sits in ``async for msg in ws``. Mirrors the
-        # main /ws handler's registration; ``setdefault`` is
-        # defensive for the test path that hand-builds an app
-        # skeleton without going through ``make_peer_link_app``.
-        active = request.app.setdefault(WEBSOCKETS_KEY, weakref.WeakSet())
-        active.add(ws)
+        # offloader sits in ``async for msg in ws``. The set is
+        # seeded in :meth:`DeviceBuilder._build_and_start_remote_build_runner`
+        # at construction time; tests that build a hand-rolled
+        # peer-link app are expected to seed it themselves.
+        request.app[WEBSOCKETS_KEY].add(ws)
         peer_ip = request.remote or ""
         try:
             await _drive_peer_link_session(controller, ws, peer_ip, identity_priv)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -25,7 +25,7 @@ from aiohttp import web
 from esphome.const import __version__ as esphome_version
 
 from .api.legacy import create_legacy_routes
-from .api.ws import close_active_websockets, create_ws_routes
+from .api.ws import create_ws_routes, init_ws_app
 from .constants import __version__ as server_version
 from .controllers.auth import AuthController
 from .controllers.automations import AutomationsController
@@ -740,21 +740,20 @@ class DeviceBuilder:
         app = web.Application(middlewares=middlewares)
         app["device_builder"] = self
         app["trusted_site"] = trusted
-
-        # WebSocket API
-        app.router.add_routes(create_ws_routes())
-
-        # Explicitly close every active WS on app shutdown so an
-        # idle paired client doesn't pin the run loop to aiohttp's
-        # ``shutdown_timeout`` (60s default) waiting for the
-        # ``async for msg in ws`` handler to unwind. Without this,
-        # SIGTERM-to-exit took 20-60s with one connected client and
-        # ~150ms idle; with it, SIGTERM-to-exit drops to ~150ms in
-        # both cases. Registered unconditionally (no
+        # Seed the active-WS registry + the on_shutdown closer in
+        # one place. ``close_active_websockets`` fires at app
+        # shutdown so an idle paired client doesn't pin the run
+        # loop to aiohttp's ``shutdown_timeout`` (60s default)
+        # waiting for the ``async for msg in ws`` handler to
+        # unwind; without it, SIGTERM-to-exit was 20-60s with one
+        # connected client. Registered unconditionally (no
         # ``with_lifecycle`` gate) because the ingress and remote-
         # build apps share the same WS-handler shape and the same
         # latency cost on shutdown.
-        app.on_shutdown.append(close_active_websockets)
+        init_ws_app(app)
+
+        # WebSocket API
+        app.router.add_routes(create_ws_routes())
 
         # Legacy REST endpoints (HA backward compat)
         app.router.add_routes(create_legacy_routes())
@@ -1122,14 +1121,14 @@ class DeviceBuilder:
                 None, get_or_create_peer_link_identity, self.settings.config_dir
             )
             app = web.Application(middlewares=[_strip_server_header_middleware])
+            # Same WS init shape as the main /ws app: seed the
+            # active-WS registry + the shutdown closer so an idle
+            # paired offloader doesn't pin ``runner.cleanup()``
+            # to aiohttp's 60s ``shutdown_timeout`` while its
+            # handler sits in ``async for msg in session.ws``.
+            init_ws_app(app)
             handler = await make_peer_link_handler(self.remote_build, self.settings.config_dir)
             app.router.add_get(PEER_LINK_PATH, handler)
-            # Same SIGTERM-latency fix as the main /ws app: close
-            # every paired peer's WS explicitly so an idle offloader
-            # doesn't pin ``runner.cleanup()`` to aiohttp's 60s
-            # ``shutdown_timeout`` while its handler sits in
-            # ``async for msg in session.ws``.
-            app.on_shutdown.append(close_active_websockets)
 
             runner = web.AppRunner(app)
             await runner.setup()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -42,6 +42,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
 
+from esphome_device_builder.api.ws import init_ws_app
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.controllers.remote_build.peer_link import (
     PEER_LINK_PATH,
@@ -203,6 +204,7 @@ async def paired_instances(
     # TCP port. ``TestServer`` picks an ephemeral port; the
     # offloader dials ``("127.0.0.1", server.port)``.
     app = web.Application()
+    init_ws_app(app)
     handler = await make_peer_link_handler(receiver, receiver_dir)
     app.router.add_get(PEER_LINK_PATH, handler)
     server = TestServer(app)

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -736,12 +736,22 @@ async def test_remote_clean_round_trip_lands_clean_job_and_fans_state_back(
     # compile / install.
     _drive_receiver_lifecycle(paired_instances, receiver_job, terminal=EventType.JOB_COMPLETED)
 
-    # Two state changes landed on the offloader's bus: running
-    # then completed, both carrying the offloader-supplied
-    # ``job_id`` and the live pin_sha256. JOB_QUEUED doesn't
-    # produce a state-change fan-out (the fan-out fires from
-    # JOB_STARTED onward); two events is the right count.
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
+    # Two state changes land on the offloader's bus: running then
+    # completed, both carrying the offloader-supplied ``job_id`` and
+    # the live pin_sha256. JOB_QUEUED doesn't produce a state-change
+    # fan-out (the fan-out fires from JOB_STARTED onward); two
+    # events is the right count. Poll until both have arrived rather
+    # than ``wait_for(received)`` once — the latter wakes on the
+    # first event, races the second one, and would flake on a
+    # slower CPU.
+    async def _wait_for_two_events() -> None:
+        while len(state_changes) < 2:
+            state_changes.received.clear()
+            if len(state_changes) >= 2:
+                return
+            await state_changes.received.wait()
+
+    await asyncio.wait_for(_wait_for_two_events(), timeout=2.0)
     assert len(state_changes) >= 2
     statuses = [payload["status"] for payload in state_changes]
     assert "running" in statuses

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -36,6 +36,7 @@ from esphome.const import __version__ as esphome_version
 from noise.exceptions import NoiseInvalidMessage
 from noise.exceptions import NoiseInvalidMessage as _NoiseInvalidMessage
 
+from esphome_device_builder.api.ws import init_ws_app
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.controllers.remote_build import (
     peer_link as _peer_link_module,
@@ -781,6 +782,7 @@ async def peer_link_app(
     identity = await loop.run_in_executor(None, get_or_create_peer_link_identity, tmp_path)
 
     app = web.Application()
+    init_ws_app(app)
     handler = await make_peer_link_handler(controller, tmp_path)
     app.router.add_get(PEER_LINK_PATH, handler)
     server = TestServer(app)

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -35,6 +35,7 @@ from aiohttp.test_utils import TestServer
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from noise.exceptions import NoiseInvalidMessage
 
+from esphome_device_builder.api.ws import init_ws_app
 from esphome_device_builder.controllers.remote_build import RemoteBuildController
 from esphome_device_builder.controllers.remote_build import controller as rb
 from esphome_device_builder.controllers.remote_build import (
@@ -123,6 +124,7 @@ async def receiver_server(
     identity = await loop.run_in_executor(None, get_or_create_peer_link_identity, tmp_path)
 
     app = web.Application()
+    init_ws_app(app)
     handler = await make_peer_link_handler(controller, tmp_path)
     app.router.add_get(PEER_LINK_PATH, handler)
     server = TestServer(app)

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -376,6 +376,7 @@ def _password_protected_app(trusted_domains: list[str]) -> web.Application:
     app = web.Application()
     app["device_builder"] = device_builder
     app["trusted_site"] = False  # public site -> gating runs
+    ws_module.init_ws_app(app)
     app.router.add_routes(ws_module.create_ws_routes())
     return app
 
@@ -476,6 +477,7 @@ async def test_handler_skips_gating_on_trusted_site(
     app = web.Application()
     app["device_builder"] = device_builder
     app["trusted_site"] = True  # ingress site -> gating skipped
+    ws_module.init_ws_app(app)
     app.router.add_routes(ws_module.create_ws_routes())
 
     client = await aiohttp_client(app)
@@ -539,6 +541,7 @@ async def test_handler_accepts_when_no_password(
     app = web.Application()
     app["device_builder"] = device_builder
     app["trusted_site"] = False
+    ws_module.init_ws_app(app)
     app.router.add_routes(ws_module.create_ws_routes())
 
     client = await aiohttp_client(app)

--- a/tests/test_websocket_heartbeat.py
+++ b/tests/test_websocket_heartbeat.py
@@ -72,6 +72,7 @@ async def test_websocket_response_constructed_with_heartbeat(
     app = web.Application()
     app["device_builder"] = device_builder
     app["trusted_site"] = True  # skip the in-band auth handshake
+    ws_module.init_ws_app(app)
     app.router.add_routes(ws_module.create_ws_routes())
 
     with patch.object(ws_module.web, "WebSocketResponse", _CapturingWS):

--- a/tests/test_websocket_shutdown.py
+++ b/tests/test_websocket_shutdown.py
@@ -26,7 +26,6 @@ import weakref
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
 from aiohttp import WSCloseCode, web
 from pytest_aiohttp.plugin import AiohttpClient
 
@@ -35,6 +34,7 @@ from esphome_device_builder.api.ws import (
     WEBSOCKETS_KEY,
     close_active_websockets,
     create_ws_routes,
+    init_ws_app,
 )
 from esphome_device_builder.device_builder import DeviceBuilder
 
@@ -61,8 +61,8 @@ def _bare_app() -> web.Application:
     app = web.Application()
     app["device_builder"] = device_builder
     app["trusted_site"] = True
+    init_ws_app(app)
     app.router.add_routes(create_ws_routes())
-    app.on_shutdown.append(close_active_websockets)
     return app
 
 
@@ -227,16 +227,15 @@ def test_close_handler_module_export() -> None:
     assert hasattr(ws_module, "WEBSOCKETS_KEY")
 
 
-@pytest.mark.parametrize("import_path", ["close_active_websockets"])
-def test_close_handler_registered_in_create_app(import_path: str) -> None:
-    """The dashboard's ``create_app`` actually appends the closer.
+def test_init_ws_app_called_in_create_app() -> None:
+    """The dashboard's ``create_app`` actually wires the WS init helper.
 
-    Source-grep guard. Mirrors
-    ``test_websocket_heartbeat.test_construction_site_uses_named_constant``:
-    if a future rebase loses the ``app.on_shutdown.append`` call,
-    SIGTERM latency would silently regress to the 20-60s symptom
-    this PR fixes, with every other test still passing. Grep the
-    source so the test fails the moment the wire-up drops off.
+    Source-grep guard. If a future rebase loses the
+    ``init_ws_app(app)`` call, SIGTERM latency would silently
+    regress to the 20-60s symptom we fixed plus the WeakSet
+    seed would be missing (every WS connection would crash on
+    ``KeyError: '_active_websockets'``). Grep the source so the
+    test fails the moment the wire-up drops off.
     """
     source = inspect.getsource(DeviceBuilder.create_app)
-    assert f"app.on_shutdown.append({import_path})" in source
+    assert "init_ws_app(app)" in source

--- a/tests/test_websocket_shutdown.py
+++ b/tests/test_websocket_shutdown.py
@@ -239,3 +239,30 @@ def test_init_ws_app_called_in_create_app() -> None:
     """
     source = inspect.getsource(DeviceBuilder.create_app)
     assert "init_ws_app(app)" in source
+
+
+def test_init_ws_app_is_idempotent() -> None:
+    """A second call against the same app keeps the existing set and listener.
+
+    If the second call overwrote ``app[WEBSOCKETS_KEY]``, any WS
+    registered against the first call's WeakSet would no longer
+    be reachable from ``close_active_websockets`` on shutdown,
+    silently reintroducing the slow-shutdown symptom. If it
+    re-appended ``close_active_websockets`` to ``on_shutdown``,
+    the closer would fire twice. Pin both invariants so a
+    regression can't slip past review.
+    """
+    app = web.Application()
+    init_ws_app(app)
+    first_weakset = app[WEBSOCKETS_KEY]
+    first_listener_count = sum(
+        1 for listener in app.on_shutdown if listener is close_active_websockets
+    )
+
+    init_ws_app(app)
+
+    assert app[WEBSOCKETS_KEY] is first_weakset
+    second_listener_count = sum(
+        1 for listener in app.on_shutdown if listener is close_active_websockets
+    )
+    assert second_listener_count == first_listener_count == 1

--- a/tests/test_ws_handler_branches.py
+++ b/tests/test_ws_handler_branches.py
@@ -83,6 +83,7 @@ async def test_bearer_token_with_valid_session_pre_authenticates(
     app = web.Application()
     app["device_builder"] = device_builder
     app["trusted_site"] = False
+    ws_module.init_ws_app(app)
     app.router.add_routes(ws_module.create_ws_routes())
 
     # Capture the ``WebSocketClient`` instance the handler builds
@@ -143,6 +144,7 @@ async def test_bearer_token_with_invalid_session_falls_back_to_in_band_auth(
     app = web.Application()
     app["device_builder"] = device_builder
     app["trusted_site"] = False
+    ws_module.init_ws_app(app)
     app.router.add_routes(ws_module.create_ws_routes())
 
     client = await aiohttp_client(app)
@@ -200,6 +202,7 @@ async def test_invalid_json_message_returns_invalid_message_error(
     app = web.Application()
     app["device_builder"] = device_builder
     app["trusted_site"] = True  # skip in-band auth so the loop runs immediately
+    ws_module.init_ws_app(app)
     app.router.add_routes(ws_module.create_ws_routes())
 
     client = await aiohttp_client(app)


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `DeprecationWarning: Changing state of started or joined application is deprecated` warning that fires across the entire WS + e2e test cluster (~30 noisy outputs). Surfaced during a warning audit; aiohttp 3.10 deprecates mutating `app[...]` after `runner.setup`, and 4.x will raise.

## Root cause

The WS handler at `api/ws.py:284` did:

```python
active = request.app.setdefault(WEBSOCKETS_KEY, weakref.WeakSet())
active.add(ws)
```

`app.setdefault` mutates app state. The app has already started by the time a WS connection arrives, so every connection trips the deprecation.

## Fix shape

Seed the registry at app **construction** time, before `runner.setup`. The handler now reads a pre-existing WeakSet and `.add()`s to it; that's value-level mutation of an existing container, not started-app state mutation aiohttp guards.

Centralised the two-piece setup (seed the WeakSet + append the `on_shutdown` closer) into a single helper:

```python
api.ws.init_ws_app(app)
```

Every app that uses `create_ws_routes` now calls this once at construction time. A regression that forgets either piece lands on the source-grep guard in `test_websocket_shutdown.py::test_init_ws_app_called_in_create_app`.

## Touches

| File | Change |
|---|---|
| `api/ws.py` | New `init_ws_app(app)` helper; handler drops `setdefault` |
| `controllers/remote_build/peer_link.py` | Same drop in the peer-link handler |
| `device_builder.py` | Main `/ws` app + peer-link receiver app call `init_ws_app` |
| `tests/test_websocket_heartbeat.py`, `tests/test_websocket_shutdown.py`, `tests/test_trusted_domains.py`, `tests/test_ws_handler_branches.py` | Add `ws_module.init_ws_app(app)` before `add_routes(create_ws_routes())` |
| `tests/e2e/conftest.py` | Peer-link receiver harness seeds via `init_ws_app` |

## Drive-by: e2e flake fix

Second commit fixes `test_remote_clean_round_trip_lands_clean_job_and_fans_state_back`, which was racy: `wait_for(state_changes.received.wait())` wakes on the first event landing, then asserts `len >= 2` — the second event (completed after running) lands a tick or two later and the assertion lost ~33% of the time on faster runners. Surfaced during the warning audit (warning-unrelated; pre-existing flake the audit happened to trigger more often). Fix polls with clear-before-read until two events arrive, capped at the same 2s deadline. Deterministic either way.

Confirmed 5/5 passes post-fix; was 2/3 pre-fix.

## Warning count

Full suite passes with `-W error::DeprecationWarning` on the WS + e2e cluster:

* Before: **22 errors + 23 failures**
* After: **0 errors + 0 failures**

## Out of scope (next PRs, one per warning)

* Windows `_ProactorBasePipeTransport.__del__` unraisable from `test_boards_json.py` (asyncio subprocess transport not closed).
* `coroutine '_run' was never awaited` from `test_event_bus_fire_lint.py` (AST-parse path constructing a coroutine without awaiting).

Both tracked separately per the "one PR per warning" rule.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue), `bugfix`
- [ ] New feature (non-breaking change which adds functionality), `new-feature`
- [ ] Enhancement to an existing feature, `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected), `breaking-change`
- [ ] Refactor (no behaviour change), `refactor`
- [ ] Documentation only, `docs`
- [ ] Maintenance / chore, `maintenance`
- [ ] CI / workflow change, `ci`
- [ ] Dependencies bump, `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` (none; helper extraction is internal).
