### PR TITLE
Extract peer_link_client value types into _client_models.py

### DIFF
--- a/esphome_device_builder/controllers/remote_build/_client_models.py
+++ b/esphome_device_builder/controllers/remote_build/_client_models.py
@@ -6,10 +6,7 @@ offloader-side intents the peer-link client drives —
 ``preview`` / ``pair_request`` / ``pair_status`` / ``peer_link``
 — plus the per-session in-flight state the long-lived
 :class:`PeerLinkClient` keeps alive between handshake and
-close. Pulled out of ``peer_link_client.py`` so the wire-shape
-data declarations sit in one place and the file holding the
-driver functions + the client class stays focused on
-behaviour.
+close.
 
 Public surface (every type without a leading underscore):
 

--- a/esphome_device_builder/controllers/remote_build/_client_models.py
+++ b/esphome_device_builder/controllers/remote_build/_client_models.py
@@ -1,0 +1,275 @@
+"""
+Offloader-side peer-link client value types: errors + results + session state.
+
+The types here describe inputs and outputs of the four
+offloader-side intents the peer-link client drives —
+``preview`` / ``pair_request`` / ``pair_status`` / ``peer_link``
+— plus the per-session in-flight state the long-lived
+:class:`PeerLinkClient` keeps alive between handshake and
+close. Pulled out of ``peer_link_client.py`` so the wire-shape
+data declarations sit in one place and the file holding the
+driver functions + the client class stays focused on
+behaviour.
+
+Public surface (every type without a leading underscore):
+
+* :class:`PeerLinkClientError`,
+  :class:`PeerLinkNoSessionError`,
+  :class:`SubmitJobTimeoutError`,
+  :class:`SubmitJobSessionLostError`,
+  :class:`DownloadArtifactsError` — the typed exceptions the
+  WS-command layer maps onto the matching
+  :class:`CommandError` shape.
+* :class:`InitiatorRoundTrip` — output of the shared Noise XX
+  driver :func:`drive_initiator_round_trip`.
+* :class:`RequestPairResult`, :class:`PairStatusResult`,
+  :class:`DownloadArtifactsResult` — outputs of the per-intent
+  drivers / :class:`PeerLinkClient` methods.
+
+Private surface (underscore-prefixed) is in-session state
+held by :class:`PeerLinkClient` and never crosses the module
+boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from ...models import IntentResponse
+
+if TYPE_CHECKING:
+    from ...helpers.peer_link_bundle import BundleAssembler
+
+
+class PeerLinkClientError(RuntimeError):
+    """Raised on transport / handshake / decrypt failure on the offloader side.
+
+    Wraps the underlying ``aiohttp.ClientError`` /
+    :class:`OSError` / :class:`asyncio.TimeoutError` /
+    :data:`NOISE_ERRORS` chain into one type the WS-command
+    layer can map to a single ``UNAVAILABLE`` :class:`CommandError`
+    without having to enumerate every transport failure mode.
+    """
+
+
+@dataclass(frozen=True)
+class InitiatorRoundTrip:
+    """One offloader-side Noise XX round-trip's outputs.
+
+    Returned by :func:`drive_initiator_round_trip`. Bundles
+    everything a caller might need from a completed handshake +
+    response: the receiver's pubkey (so :func:`preview_pair`
+    can hash it), the ``intent_response`` value (so callers can
+    branch on PENDING / APPROVED / REJECTED / NO_PAIRING_WINDOW),
+    and the full decoded response dict for any future fields a
+    caller wants beyond the discriminator.
+    """
+
+    intent_response: str
+    remote_static_pub: bytes
+    response: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RequestPairResult:
+    """Outcome of an ``intent="pair_request"`` round-trip from the offloader.
+
+    Returned by :func:`request_pair` after the Noise XX
+    handshake completes and the receiver's
+    ``intent_response`` has been received.
+
+    * :attr:`status` carries the receiver's response verbatim
+      (``IntentResponse.PENDING`` for a freshly-created /
+      refreshed pending row, ``IntentResponse.APPROVED`` for a
+      re-pair against a pre-existing approved row,
+      ``IntentResponse.REJECTED`` for receiver-side decline /
+      pin mismatch, ``IntentResponse.NO_PAIRING_WINDOW`` for
+      a closed window).
+    * :attr:`pin_sha256` is the lowercase-hex hash of the
+      receiver's static X25519 pubkey actually observed on the
+      live handshake. The caller compares this against the
+      pin the user OOB-confirmed in ``preview_pair``; a
+      mismatch indicates the receiver rotated identity (or an
+      active MITM intervened) between preview and request.
+    * :attr:`remote_static_pub` is the raw 32-byte pubkey
+      itself, for storage in :class:`StoredPairing`.
+    """
+
+    status: IntentResponse
+    pin_sha256: str
+    remote_static_pub: bytes
+
+
+@dataclass(frozen=True)
+class PairStatusResult:
+    """Outcome of an ``intent="pair_status"`` long-poll round-trip.
+
+    Returned by :func:`await_pair_status` after the Noise XX
+    handshake completes and the receiver's ``intent_response``
+    has been received. The receiver-side handler parks
+    indefinitely on the bus event channel until either an admin
+    click flips the row or the pairing window closes (firing
+    removed events that wake the wait), so the round-trip can
+    legitimately take seconds to many minutes; the caller's
+    listener task is the only thing that puts an upper bound
+    on how long the WS stays open (via cancellation on
+    ``unpair`` / controller stop).
+
+    * :attr:`status` is the receiver's verbatim response —
+      :attr:`IntentResponse.APPROVED` if the matching
+      ``StoredPeer`` row is APPROVED, or
+      :attr:`IntentResponse.REJECTED` if no row matches (admin
+      clicked Reject, or window-close cleared the receiver's
+      pending dict, or pin drift on the receiver side). The
+      caller flips local state accordingly.
+      :attr:`IntentResponse.PENDING` doesn't appear on this
+      path — the receiver doesn't return PENDING from
+      ``intent="pair_status"``; the long-poll keeps waiting.
+    * :attr:`pin_sha256` is the lowercase-hex hash of the
+      receiver's static X25519 pubkey observed on the live
+      handshake. The :class:`StoredPairing` consumer compares
+      this against its stored ``pin_sha256`` so a receiver-side
+      identity rotation between :func:`request_pair` and the
+      first :func:`await_pair_status` doesn't silently slide a
+      compromised pubkey into ``APPROVED`` state.
+    """
+
+    status: IntentResponse
+    pin_sha256: str
+
+
+class PeerLinkNoSessionError(RuntimeError):
+    """Raised when a peer-link application send needs a live session and there isn't one.
+
+    Used by every :class:`PeerLinkClient` sender that requires
+    the post-handshake dispatch loop to be parked:
+    :meth:`PeerLinkClient.submit_job` and
+    :meth:`PeerLinkClient.cancel_job`. The check funnels through
+    :meth:`PeerLinkClient._require_open_channel`,
+    so a future application-message sender that calls
+    ``_require_open_channel`` inherits the same exception
+    automatically.
+
+    The WS command on the controller side maps this to a typed
+    ``CommandError(PRECONDITION_FAILED)`` so the frontend can
+    branch on "peer is paired but currently disconnected" vs.
+    "send rejected by the receiver." Same error code at every
+    call site — the user's recovery (wait for reconnect, retry)
+    doesn't depend on which sender raised.
+    """
+
+
+class SubmitJobTimeoutError(RuntimeError):
+    """Raised by :meth:`PeerLinkClient.submit_job` when the ack didn't land in time.
+
+    The session may still be alive on the wire — the receiver
+    just hasn't acked. Surfaces a structured error to the WS
+    caller; the offloader does **not** retry mid-session
+    because the receiver may have already accepted and queued
+    the job (a duplicate send would land a second
+    :class:`FirmwareJob` on the receiver's queue under a fresh
+    ``job_id``). Operator-initiated retry on a fresh session
+    is the correct recovery.
+    """
+
+
+class SubmitJobSessionLostError(RuntimeError):
+    """Raised when the session closes during a :meth:`PeerLinkClient.submit_job` flow.
+
+    Set on every pending ack future from the receive loop's
+    ``finally`` so an in-flight :meth:`submit_job` doesn't hang
+    until the timeout — the session ended, no ack will ever
+    arrive on this connection. Same no-retry contract as
+    :class:`SubmitJobTimeoutError`.
+    """
+
+
+class DownloadArtifactsError(RuntimeError):
+    """Raised by :meth:`PeerLinkClient.download_artifacts` on failure.
+
+    Carries the structured ``reason`` the receiver included in
+    its ``artifacts_end{accepted: false}`` ack
+    (``unknown_job`` / ``job_not_completed`` /
+    ``build_dir_missing`` / ``pack_failed`` /
+    ``duplicate_download``) so the WS layer can surface it to
+    the user verbatim. Also raised for offloader-side
+    assembly failures: hash mismatch on the final tarball,
+    chunk-count drift, post-completion frames.
+
+    Same no-retry contract as :class:`SubmitJobTimeoutError` —
+    the receiver may have streamed the bytes already; a
+    duplicate request would just refetch them. Operator
+    initiates retry on a fresh download.
+    """
+
+    def __init__(self, message: str, *, reason: str = "") -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class DownloadArtifactsResult:
+    """Successful return from :meth:`PeerLinkClient.download_artifacts`.
+
+    ``tarball`` is the SHA-256-verified gzipped-tar bytes the
+    receiver streamed back; ``firmware_offset`` is the
+    receiver-resolved flash-partition offset for
+    ``firmware.bin`` (taken verbatim from the
+    :attr:`ArtifactsStartFrameData.firmware_offset` header).
+    The WS layer's unpack
+    (:func:`controllers.remote_build.controller._unpack_artifacts_response`)
+    needs both pieces — the tarball doesn't carry the
+    firmware partition's offset, only the ``extra``
+    flash-image entries do.
+    """
+
+    tarball: bytes
+    firmware_offset: str
+
+
+# Per-download state on :attr:`PeerLinkClient._artifacts_downloads`.
+# Holds the in-flight :class:`BundleAssembler` (configured
+# with :data:`FIRMWARE_MAX_TOTAL_BYTES`) plus the result
+# future :meth:`download_artifacts` is parked on. The
+# assembler is None until the receiver's ``artifacts_start``
+# header lands; the future is created upfront so the
+# ``download_artifacts`` flow can register before sending
+# the request.
+@dataclass
+class _DownloadArtifactsState:
+    """In-flight artifacts download state (per-``job_id`` on this session)."""
+
+    future: asyncio.Future[DownloadArtifactsResult]
+    assembler: BundleAssembler | None = None
+    firmware_offset: str = ""
+
+
+@dataclass
+class _SessionLoopState:
+    """Mutable state shared between the session's receive loop and heartbeat task.
+
+    Held by :meth:`PeerLinkClient._run_session_loops` and read /
+    written by both the receive loop and the heartbeat
+    callback so close-cause information flows in either
+    direction.
+
+    The receive loop bumps :attr:`last_pong_at` on each pong;
+    the heartbeat task reads it through a ``lambda`` to decide
+    whether to fire ``on_dead``. The receive loop and the
+    heartbeat task each write :attr:`close_reason` on the
+    branches they own — receive loop on transport-error /
+    terminate-from-peer / unknown-msg-type, heartbeat on
+    timeout — so the final close reason reflects the real
+    cause rather than falling back to ``peer_hung_up`` (the
+    "WS exited iteration without anyone setting a reason"
+    default).
+
+    Lifting this out of the receive loop's locals into a small
+    object avoids the ``nonlocal`` pattern that would otherwise
+    have to be threaded through the heartbeat closure.
+    """
+
+    last_pong_at: float
+    close_reason: str

--- a/esphome_device_builder/controllers/remote_build/peer_link_client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client.py
@@ -35,7 +35,6 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import aiohttp
@@ -81,6 +80,19 @@ from ...models import (
     SubmitJobAckFrameData,
     SubmitJobChunkFrameData,
     SubmitJobFrameData,
+)
+from ._client_models import (
+    DownloadArtifactsError,
+    DownloadArtifactsResult,
+    InitiatorRoundTrip,
+    PairStatusResult,
+    PeerLinkClientError,
+    PeerLinkNoSessionError,
+    RequestPairResult,
+    SubmitJobSessionLostError,
+    SubmitJobTimeoutError,
+    _DownloadArtifactsState,
+    _SessionLoopState,
 )
 from .peer_link import (
     APP_FRAME_MAX_BYTES,
@@ -164,35 +176,6 @@ _PAIR_STATUS_TIMEOUT_SECONDS = 3600.0
 # frame (~64 KiB + slack); this constant stays scoped to the
 # JSON status responses.
 _CONTROL_RESPONSE_MAX_BYTES = 64 * 1024
-
-
-class PeerLinkClientError(RuntimeError):
-    """Raised on transport / handshake / decrypt failure on the offloader side.
-
-    Wraps the underlying ``aiohttp.ClientError`` /
-    :class:`OSError` / :class:`asyncio.TimeoutError` /
-    :data:`NOISE_ERRORS` chain into one type the WS-command
-    layer can map to a single ``UNAVAILABLE`` :class:`CommandError`
-    without having to enumerate every transport failure mode.
-    """
-
-
-@dataclass(frozen=True)
-class InitiatorRoundTrip:
-    """One offloader-side Noise XX round-trip's outputs.
-
-    Returned by :func:`drive_initiator_round_trip`. Bundles
-    everything a caller might need from a completed handshake +
-    response: the receiver's pubkey (so :func:`preview_pair`
-    can hash it), the ``intent_response`` value (so callers can
-    branch on PENDING / APPROVED / REJECTED / NO_PAIRING_WINDOW),
-    and the full decoded response dict for any future fields a
-    caller wants beyond the discriminator.
-    """
-
-    intent_response: str
-    remote_static_pub: bytes
-    response: dict[str, Any]
 
 
 def _extract_receiver_esphome_version(response: dict[str, Any]) -> str:
@@ -444,36 +427,6 @@ async def preview_pair(
     return pin_sha256_for_pubkey(rt.remote_static_pub)
 
 
-@dataclass(frozen=True)
-class RequestPairResult:
-    """Outcome of an ``intent="pair_request"`` round-trip from the offloader.
-
-    Returned by :func:`request_pair` after the Noise XX
-    handshake completes and the receiver's
-    ``intent_response`` has been received.
-
-    * :attr:`status` carries the receiver's response verbatim
-      (``IntentResponse.PENDING`` for a freshly-created /
-      refreshed pending row, ``IntentResponse.APPROVED`` for a
-      re-pair against a pre-existing approved row,
-      ``IntentResponse.REJECTED`` for receiver-side decline /
-      pin mismatch, ``IntentResponse.NO_PAIRING_WINDOW`` for
-      a closed window).
-    * :attr:`pin_sha256` is the lowercase-hex hash of the
-      receiver's static X25519 pubkey actually observed on the
-      live handshake. The caller compares this against the
-      pin the user OOB-confirmed in ``preview_pair``; a
-      mismatch indicates the receiver rotated identity (or an
-      active MITM intervened) between preview and request.
-    * :attr:`remote_static_pub` is the raw 32-byte pubkey
-      itself, for storage in :class:`StoredPairing`.
-    """
-
-    status: IntentResponse
-    pin_sha256: str
-    remote_static_pub: bytes
-
-
 async def request_pair(
     *,
     hostname: str,
@@ -530,44 +483,6 @@ async def request_pair(
         pin_sha256=pin_sha256_for_pubkey(rt.remote_static_pub),
         remote_static_pub=rt.remote_static_pub,
     )
-
-
-@dataclass(frozen=True)
-class PairStatusResult:
-    """Outcome of an ``intent="pair_status"`` long-poll round-trip.
-
-    Returned by :func:`await_pair_status` after the Noise XX
-    handshake completes and the receiver's ``intent_response``
-    has been received. The receiver-side handler parks
-    indefinitely on the bus event channel until either an admin
-    click flips the row or the pairing window closes (firing
-    removed events that wake the wait), so the round-trip can
-    legitimately take seconds to many minutes; the caller's
-    listener task is the only thing that puts an upper bound
-    on how long the WS stays open (via cancellation on
-    ``unpair`` / controller stop).
-
-    * :attr:`status` is the receiver's verbatim response —
-      :attr:`IntentResponse.APPROVED` if the matching
-      ``StoredPeer`` row is APPROVED, or
-      :attr:`IntentResponse.REJECTED` if no row matches (admin
-      clicked Reject, or window-close cleared the receiver's
-      pending dict, or pin drift on the receiver side). The
-      caller flips local state accordingly.
-      :attr:`IntentResponse.PENDING` doesn't appear on this
-      path — the receiver doesn't return PENDING from
-      ``intent="pair_status"``; the long-poll keeps waiting.
-    * :attr:`pin_sha256` is the lowercase-hex hash of the
-      receiver's static X25519 pubkey observed on the live
-      handshake. The :class:`StoredPairing` consumer compares
-      this against its stored ``pin_sha256`` so a receiver-side
-      identity rotation between :func:`request_pair` and the
-      first :func:`await_pair_status` doesn't silently slide a
-      compromised pubkey into ``APPROVED`` state.
-    """
-
-    status: IntentResponse
-    pin_sha256: str
 
 
 async def await_pair_status(
@@ -758,141 +673,6 @@ _JOB_STATE_CHANGED_VALID_STATUS: frozenset[str] = frozenset(
 # Allowed ``stream`` values on inbound ``job_output`` frames,
 # mirroring :class:`JobOutputFrameData`'s ``Literal``.
 _JOB_OUTPUT_VALID_STREAM: frozenset[str] = frozenset({"stdout", "stderr"})
-
-
-class PeerLinkNoSessionError(RuntimeError):
-    """Raised when a peer-link application send needs a live session and there isn't one.
-
-    Used by every :class:`PeerLinkClient` sender that requires
-    the post-handshake dispatch loop to be parked:
-    :meth:`PeerLinkClient.submit_job` and
-    :meth:`PeerLinkClient.cancel_job`. The check funnels through
-    :meth:`PeerLinkClient._require_open_channel`,
-    so a future application-message sender that calls
-    ``_require_open_channel`` inherits the same exception
-    automatically.
-
-    The WS command on the controller side maps this to a typed
-    ``CommandError(PRECONDITION_FAILED)`` so the frontend can
-    branch on "peer is paired but currently disconnected" vs.
-    "send rejected by the receiver." Same error code at every
-    call site — the user's recovery (wait for reconnect, retry)
-    doesn't depend on which sender raised.
-    """
-
-
-class SubmitJobTimeoutError(RuntimeError):
-    """Raised by :meth:`PeerLinkClient.submit_job` when the ack didn't land in time.
-
-    The session may still be alive on the wire — the receiver
-    just hasn't acked. Surfaces a structured error to the WS
-    caller; the offloader does **not** retry mid-session
-    because the receiver may have already accepted and queued
-    the job (a duplicate send would land a second
-    :class:`FirmwareJob` on the receiver's queue under a fresh
-    ``job_id``). Operator-initiated retry on a fresh session
-    is the correct recovery.
-    """
-
-
-class SubmitJobSessionLostError(RuntimeError):
-    """Raised when the session closes during a :meth:`PeerLinkClient.submit_job` flow.
-
-    Set on every pending ack future from the receive loop's
-    ``finally`` so an in-flight :meth:`submit_job` doesn't hang
-    until the timeout — the session ended, no ack will ever
-    arrive on this connection. Same no-retry contract as
-    :class:`SubmitJobTimeoutError`.
-    """
-
-
-class DownloadArtifactsError(RuntimeError):
-    """Raised by :meth:`PeerLinkClient.download_artifacts` on failure.
-
-    Carries the structured ``reason`` the receiver included in
-    its ``artifacts_end{accepted: false}`` ack
-    (``unknown_job`` / ``job_not_completed`` /
-    ``build_dir_missing`` / ``pack_failed`` /
-    ``duplicate_download``) so the WS layer can surface it to
-    the user verbatim. Also raised for offloader-side
-    assembly failures: hash mismatch on the final tarball,
-    chunk-count drift, post-completion frames.
-
-    Same no-retry contract as :class:`SubmitJobTimeoutError` —
-    the receiver may have streamed the bytes already; a
-    duplicate request would just refetch them. Operator
-    initiates retry on a fresh download.
-    """
-
-    def __init__(self, message: str, *, reason: str = "") -> None:
-        super().__init__(message)
-        self.reason = reason
-
-
-# Per-download state on :attr:`PeerLinkClient._artifacts_downloads`.
-# Holds the in-flight :class:`BundleAssembler` (configured
-# with :data:`FIRMWARE_MAX_TOTAL_BYTES`) plus the result
-# future :meth:`download_artifacts` is parked on. The
-# assembler is None until the receiver's ``artifacts_start``
-# header lands; the future is created upfront so the
-# ``download_artifacts`` flow can register before sending
-# the request.
-@dataclass(frozen=True)
-class DownloadArtifactsResult:
-    """Successful return from :meth:`PeerLinkClient.download_artifacts`.
-
-    ``tarball`` is the SHA-256-verified gzipped-tar bytes the
-    receiver streamed back; ``firmware_offset`` is the
-    receiver-resolved flash-partition offset for
-    ``firmware.bin`` (taken verbatim from the
-    :attr:`ArtifactsStartFrameData.firmware_offset` header).
-    The WS layer's unpack
-    (:func:`controllers.remote_build.controller._unpack_artifacts_response`)
-    needs both pieces — the tarball doesn't carry the
-    firmware partition's offset, only the ``extra``
-    flash-image entries do.
-    """
-
-    tarball: bytes
-    firmware_offset: str
-
-
-@dataclass
-class _DownloadArtifactsState:
-    """In-flight artifacts download state (per-``job_id`` on this session)."""
-
-    future: asyncio.Future[DownloadArtifactsResult]
-    assembler: BundleAssembler | None = None
-    firmware_offset: str = ""
-
-
-@dataclass
-class _SessionLoopState:
-    """Mutable state shared between the session's receive loop and heartbeat task.
-
-    Held by :meth:`PeerLinkClient._run_session_loops` and read /
-    written by both the receive loop and the heartbeat
-    callback so close-cause information flows in either
-    direction.
-
-    The receive loop bumps :attr:`last_pong_at` on each pong;
-    the heartbeat task reads it through a ``lambda`` to decide
-    whether to fire ``on_dead``. The receive loop and the
-    heartbeat task each write :attr:`close_reason` on the
-    branches they own — receive loop on transport-error /
-    terminate-from-peer / unknown-msg-type, heartbeat on
-    timeout — so the final close reason reflects the real
-    cause rather than falling back to ``peer_hung_up`` (the
-    "WS exited iteration without anyone setting a reason"
-    default).
-
-    Lifting this out of the receive loop's locals into a small
-    object avoids the ``nonlocal`` pattern that would otherwise
-    have to be threaded through the heartbeat closure.
-    """
-
-    last_pong_at: float
-    close_reason: str
 
 
 class PeerLinkClient:


### PR DESCRIPTION
# What does this implement/fix?

Move the 11 module-level types out of `peer_link_client.py`
(errors, result dataclasses, and in-session state) into a
sibling `_client_models.py`. The file used to interleave
types with the driver functions that returned them
(`preview_pair` → `InitiatorRoundTrip`, `request_pair` →
`RequestPairResult`, `await_pair_status` → `PairStatusResult`)
plus a cluster of five errors + one result + two private
state dataclasses sitting between the drivers and the
`PeerLinkClient` class. Consolidating them in one
wire-shape-only file mirrors the pattern the rest of the
package settled on (`_validators.py`, `_summaries.py`,
`_models.py`, `_storage_codecs.py`).

`peer_link_client.py`: **2101 → 1881 lines** (−220).

## Types moved

* **Errors**: `PeerLinkClientError`, `PeerLinkNoSessionError`,
  `SubmitJobTimeoutError`, `SubmitJobSessionLostError`,
  `DownloadArtifactsError`.
* **Result dataclasses**: `InitiatorRoundTrip`,
  `RequestPairResult`, `PairStatusResult`,
  `DownloadArtifactsResult`.
* **Private session state**: `_DownloadArtifactsState`,
  `_SessionLoopState`.

## Import paths preserved

External import paths through `peer_link_client` keep
working: `peer_link_client` imports the names back from
`_client_models` at the top of the file, so every caller's
`from .peer_link_client import ...` /
`from esphome_device_builder.controllers.remote_build.peer_link_client import ...`
continues to resolve. No call-site changes elsewhere in the
tree.

## Behaviour preservation

Strictly mechanical. All 3116 tests pass; mypy clean across
the package.

**Related issue or feature (if applicable):**

- Follow-up to #626 (remote_build controller-internal models).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
