### PR TITLE
Reap subprocess in tracked-subprocess exception test

### DIFF
--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -829,7 +829,14 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
             "import sys\nsys.exit(0)\n",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
-        ):
+        ) as proc:
+            # Reap the subprocess before raising so the transport
+            # tears down inside the event loop's lifetime; without
+            # this, a later GC pass surfaces an unraisable
+            # ``BaseSubprocessTransport.__del__`` warning because
+            # the transport's deferred ``connection_lost`` call hits
+            # an already-closed loop.
+            await proc.wait()
             msg = "boom"
             raise RuntimeError(msg)
 


### PR DESCRIPTION
# What does this implement/fix?

Eliminates the random `PytestUnraisableExceptionWarning: Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x...>: RuntimeError: Event loop is closed` that surfaced on every test platform (Linux, macOS, Windows; Python 3.12 and 3.14) under `-W error::pytest.PytestUnraisableExceptionWarning`.

The culprit is `tests/controllers/firmware/test_verify_chip_e2e.py::test_tracked_subprocess_restores_prior_value_on_exception`. It spawned a real Python subprocess inside the `_tracked_subprocess` context, then raised `RuntimeError` before calling `proc.wait()`. `_tracked_subprocess`'s non-`CancelledError` branch only restores `_current_process` and re-raises, so the transport survived. A later GC pass caught the orphaned transport and tried to call `loop.call_soon(_call_connection_lost)` on an already-closed loop, surfacing as an unraisable warning on whichever test happened to be running at the time (commonly `tests/controllers/test_build_size_refresher.py`).

Add `await proc.wait()` inside the body before the raise so the transport tears down inside the live event loop, matching the pattern the two sibling tests in the same file already use. Production code is unchanged; both real call sites (`_verify_chip` and `_execute_job`) already `proc.wait()` inside their body.

**Related issue or feature (if applicable):**

- fixes none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
