### PR TITLE
Close the unawaited _run coroutine in test_discover

### DIFF
--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -306,6 +306,16 @@ def test_main_suppresses_keyboard_interrupt() -> None:
     browse. Without the suppression, the shell would see a
     traceback on every clean exit.
     """
+
+    def _close_and_interrupt(coro: object) -> None:
+        # ``main()`` constructs ``_run(args)`` synchronously and
+        # passes the coroutine into ``asyncio.run``; a bare
+        # ``side_effect=KeyboardInterrupt`` would leak the
+        # never-awaited coro and trip the suite's
+        # ``coroutine '_run' was never awaited`` RuntimeWarning.
+        coro.close()  # type: ignore[attr-defined]
+        raise KeyboardInterrupt
+
     with (
         patch(
             "esphome_device_builder.discover.sys.argv",
@@ -313,7 +323,7 @@ def test_main_suppresses_keyboard_interrupt() -> None:
         ),
         patch(
             "esphome_device_builder.discover.asyncio.run",
-            side_effect=KeyboardInterrupt,
+            side_effect=_close_and_interrupt,
         ),
     ):
         # Doesn't raise — the ``contextlib.suppress`` swallows it.
@@ -328,12 +338,22 @@ def test_main_runs_to_completion_when_inner_returns() -> None:
     does, but the contract is that ``main`` doesn't add error
     paths beyond the Ctrl-C suppression).
     """
+
+    def _close_and_return(coro: object) -> None:
+        # Same coro-leak guard as ``_close_and_interrupt`` above —
+        # close the never-awaited ``_run(args)`` to keep the
+        # ``never awaited`` warning out of the suite.
+        coro.close()  # type: ignore[attr-defined]
+
     with (
         patch(
             "esphome_device_builder.discover.sys.argv",
             ["esphome-device-builder-discover"],
         ),
-        patch("esphome_device_builder.discover.asyncio.run", return_value=None) as mock_run,
+        patch(
+            "esphome_device_builder.discover.asyncio.run",
+            side_effect=_close_and_return,
+        ) as mock_run,
     ):
         main()
     mock_run.assert_called_once()

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+from collections.abc import Coroutine
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -307,13 +309,13 @@ def test_main_suppresses_keyboard_interrupt() -> None:
     traceback on every clean exit.
     """
 
-    def _close_and_interrupt(coro: object) -> None:
+    def _close_and_interrupt(coro: Coroutine[Any, Any, Any]) -> None:
         # ``main()`` constructs ``_run(args)`` synchronously and
         # passes the coroutine into ``asyncio.run``; a bare
         # ``side_effect=KeyboardInterrupt`` would leak the
         # never-awaited coro and trip the suite's
         # ``coroutine '_run' was never awaited`` RuntimeWarning.
-        coro.close()  # type: ignore[attr-defined]
+        coro.close()
         raise KeyboardInterrupt
 
     with (
@@ -339,11 +341,11 @@ def test_main_runs_to_completion_when_inner_returns() -> None:
     paths beyond the Ctrl-C suppression).
     """
 
-    def _close_and_return(coro: object) -> None:
+    def _close_and_return(coro: Coroutine[Any, Any, Any]) -> None:
         # Same coro-leak guard as ``_close_and_interrupt`` above —
         # close the never-awaited ``_run(args)`` to keep the
         # ``never awaited`` warning out of the suite.
-        coro.close()  # type: ignore[attr-defined]
+        coro.close()
 
     with (
         patch(


### PR DESCRIPTION
# What does this implement/fix?

Eliminates the random `RuntimeWarning: coroutine '_run' was never awaited` that surfaced under `-W error::RuntimeWarning` on every test platform (Linux, macOS, Windows; Python 3.12 and 3.14).

`tests/test_discover.py::test_main_suppresses_keyboard_interrupt` and `tests/test_discover.py::test_main_runs_to_completion_when_inner_returns` patched `asyncio.run` with a bare `side_effect=KeyboardInterrupt` / `return_value=None`. `main()` constructs `_run(args)` synchronously and passes the coroutine into the mocked `asyncio.run`; the mock never consumed it, so the coroutine became eligible for GC at an arbitrary later point. pytest's warning collector then surfaced "coroutine '_run' was never awaited" against whatever test happened to be running when the collection fired.

Wrap each `side_effect` with a small helper that closes the coroutine it receives before raising or returning. That keeps the contract under test (Ctrl-C suppression; clean return on completion) intact and matches what the real `asyncio.run` would do with the coro.

Production code is unchanged.

**Related issue or feature (if applicable):**

- fixes none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
