### PR TITLE
Hoist offloader/receiver lifecycle scaffolding to a shared base

### DIFF
--- a/esphome_device_builder/controllers/remote_build/_shared.py
+++ b/esphome_device_builder/controllers/remote_build/_shared.py
@@ -1,18 +1,41 @@
-"""Free helpers shared between the offloader and receiver siblings.
+"""Shared infrastructure for the offloader and receiver siblings.
 
 The two sibling controllers
 (:class:`~.offloader.OffloaderController`,
 :class:`~.receiver.ReceiverController`) own disjoint state and
-disjoint method sets — this module is the *only* legal coupling
-point. Kept deliberately small: a place for stateless utilities
-that both roles' lifecycles need.
+disjoint method sets but happen to need the same per-instance
+lifecycle scaffolding:
+
+* a :class:`DeviceBuilder` ref for bus access / settings lookup,
+* a strong-ref set of spawned :class:`asyncio.Task` so a
+  fire-and-forget coroutine isn't GC'd mid-await,
+* an :class:`ExitStack` to accumulate bus-listener unsubscribers,
+* a list of per-file :class:`Store` flush callbacks for the
+  ``stop()`` walk.
+
+Hoisting that scaffolding to a thin :class:`_RemoteBuildBase`
+base class collapses the duplicated ``__init__`` lines and the
+``_track_task`` method that both siblings carried verbatim. Each
+sibling still defines its own ``start`` / ``stop`` /
+role-specific state on top.
+
+Single-inheritance, not a mixin: every type checker resolves
+the four attributes through one MRO step, so the
+type-disambiguation headaches that killed the earlier mixin
+attempt don't recur.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
-from typing import Any
+from collections.abc import Coroutine, Iterable
+from contextlib import ExitStack
+from typing import TYPE_CHECKING, Any
+
+from ...helpers.storage import ShutdownCallback
+
+if TYPE_CHECKING:
+    from ...device_builder import DeviceBuilder
 
 
 async def drain_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
@@ -28,3 +51,40 @@ async def drain_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
     for task in tasks_list:
         task.cancel()
     await asyncio.gather(*tasks_list, return_exceptions=True)
+
+
+class _RemoteBuildBase:
+    """Lifecycle scaffolding shared by the offloader and receiver siblings.
+
+    Concrete subclasses
+    (:class:`~.offloader.OffloaderController`,
+    :class:`~.receiver.ReceiverController`) call
+    ``super().__init__(device_builder)`` to populate the four
+    fields below, then layer their own role-specific state on
+    top and define their own ``start`` / ``stop`` methods.
+    """
+
+    def __init__(self, device_builder: DeviceBuilder) -> None:
+        self._db = device_builder
+        self._tasks: set[asyncio.Task[None]] = set()
+        # Bus-listener unsubscribers; the role's ``stop`` closes
+        # the stack to detach all of them in one pass.
+        self._listeners = ExitStack()
+        # Per-file :class:`Store` flush callbacks; the role's
+        # ``stop`` walks them to drain debounced writes before
+        # the in-RAM dicts go away.
+        self._shutdown_callbacks: list[ShutdownCallback] = []
+
+    def _track_task(
+        self, coro: Coroutine[Any, Any, None], *, name: str | None = None
+    ) -> asyncio.Task[None]:
+        """Schedule *coro* and hold a strong ref in :attr:`_tasks` until it settles.
+
+        Distinct from :meth:`DeviceBuilder.create_background_task`
+        — this set is drained separately by each role's ``stop``
+        for ordered subsystem teardown.
+        """
+        task = asyncio.create_task(coro, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task

--- a/esphome_device_builder/controllers/remote_build/_shared.py
+++ b/esphome_device_builder/controllers/remote_build/_shared.py
@@ -1,28 +1,13 @@
-"""Shared infrastructure for the offloader and receiver siblings.
+"""Shared scaffolding for the offloader and receiver siblings.
 
-The two sibling controllers
-(:class:`~.offloader.OffloaderController`,
-:class:`~.receiver.ReceiverController`) own disjoint state and
-disjoint method sets but happen to need the same per-instance
-lifecycle scaffolding:
+Exposes:
 
-* a :class:`DeviceBuilder` ref for bus access / settings lookup,
-* a strong-ref set of spawned :class:`asyncio.Task` so a
-  fire-and-forget coroutine isn't GC'd mid-await,
-* an :class:`ExitStack` to accumulate bus-listener unsubscribers,
-* a list of per-file :class:`Store` flush callbacks for the
-  ``stop()`` walk.
-
-Hoisting that scaffolding to a thin :class:`_RemoteBuildBase`
-base class collapses the duplicated ``__init__`` lines and the
-``_track_task`` method that both siblings carried verbatim. Each
-sibling still defines its own ``start`` / ``stop`` /
-role-specific state on top.
-
-Single-inheritance, not a mixin: every type checker resolves
-the four attributes through one MRO step, so the
-type-disambiguation headaches that killed the earlier mixin
-attempt don't recur.
+* :class:`_RemoteBuildBase` — base class providing the
+  ``_db`` / ``_tasks`` / ``_listeners`` /
+  ``_shutdown_callbacks`` fields and the ``_track_task``
+  helper both siblings need.
+* :func:`drain_tasks` — stateless cancel-and-gather helper
+  the per-role ``stop`` methods feed task iterables to.
 """
 
 from __future__ import annotations
@@ -54,25 +39,20 @@ async def drain_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
 
 
 class _RemoteBuildBase:
-    """Lifecycle scaffolding shared by the offloader and receiver siblings.
+    """Base for the offloader and receiver siblings.
 
-    Concrete subclasses
-    (:class:`~.offloader.OffloaderController`,
-    :class:`~.receiver.ReceiverController`) call
-    ``super().__init__(device_builder)`` to populate the four
-    fields below, then layer their own role-specific state on
-    top and define their own ``start`` / ``stop`` methods.
+    Subclasses call ``super().__init__(device_builder)`` to
+    populate the four fields, layer role-specific state on top,
+    and define their own ``start`` / ``stop``. The role's
+    ``stop`` is responsible for closing :attr:`_listeners`,
+    walking :attr:`_shutdown_callbacks`, and draining
+    :attr:`_tasks` (via :func:`drain_tasks`).
     """
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
         self._db = device_builder
         self._tasks: set[asyncio.Task[None]] = set()
-        # Bus-listener unsubscribers; the role's ``stop`` closes
-        # the stack to detach all of them in one pass.
         self._listeners = ExitStack()
-        # Per-file :class:`Store` flush callbacks; the role's
-        # ``stop`` walks them to drain debounced writes before
-        # the in-RAM dicts go away.
         self._shutdown_callbacks: list[ShutdownCallback] = []
 
     def _track_task(
@@ -80,8 +60,8 @@ class _RemoteBuildBase:
     ) -> asyncio.Task[None]:
         """Schedule *coro* and hold a strong ref in :attr:`_tasks` until it settles.
 
-        Distinct from :meth:`DeviceBuilder.create_background_task`
-        — this set is drained separately by each role's ``stop``
+        Distinct from :meth:`DeviceBuilder.create_background_task`:
+        this set is drained separately by each role's ``stop``
         for ordered subsystem teardown.
         """
         task = asyncio.create_task(coro, name=name)

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Coroutine, Iterator
-from contextlib import ExitStack, contextmanager
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
@@ -39,7 +39,7 @@ from ...helpers.event_bus import Event
 from ...helpers.hostname import normalize_hostname
 from ...helpers.peer_link_identity import get_or_create_peer_link_identity
 from ...helpers.peer_link_resolver import PeerLinkDNSResolver, make_peer_link_resolver
-from ...helpers.storage import ShutdownCallback, Store
+from ...helpers.storage import Store
 from ...models import (
     PAIRING_VERSION_MAX_LEN,
     ErrorCode,
@@ -76,7 +76,7 @@ from ._models import (
     RebindProbeOutcome,
     RebindProbeResult,
 )
-from ._shared import drain_tasks
+from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
     OFFLOADER_PAIRINGS_FILE,
     decode_pairings,
@@ -161,15 +161,14 @@ _PAIRINGS_SAVE_DELAY_SECONDS = 1.0
 _REBIND_PROBE_COOLDOWN_SECONDS = 30.0
 
 
-class OffloaderController:  # noqa: PLR0904
+class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     """Outbound side of remote-build: pair, peer-link, submit/cancel/download."""
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
-        self._db = device_builder
+        super().__init__(device_builder)
         self._browser: AsyncServiceBrowser | None = None
         self._peer_link_resolver: PeerLinkDNSResolver | None = None
         self._peers: dict[str, RemoteBuildPeer] = {}
-        self._tasks: set[asyncio.Task[None]] = set()
         self._rebind_probe_until: dict[str, float] = {}
         self._own_instance_name: str | None = None
         self._pair_status_listeners: dict[str, asyncio.Task[None]] = {}
@@ -185,7 +184,6 @@ class OffloaderController:  # noqa: PLR0904
         self._offloader_alerts: dict[str, OffloaderAlertSnapshotEntry] = {}
         self._peer_queue_status: dict[str, PeerQueueStatusSnapshotEntry] = {}
         self._offloader_remote_jobs: dict[str, OffloaderRemoteJobSnapshotEntry] = {}
-        self._shutdown_callbacks: list[ShutdownCallback] = []
         self._pairings_store: Store[OffloaderRemoteBuildSettings] = Store(
             self._db.settings.config_dir / OFFLOADER_PAIRINGS_FILE,
             encoder=encode_pairings,
@@ -193,7 +191,6 @@ class OffloaderController:  # noqa: PLR0904
             shutdown_register=self._shutdown_callbacks.append,
             name="offloader_pairings",
         )
-        self._listeners = ExitStack()
 
     async def start(self) -> None:
         """Seed pairings from disk, cache identities, spawn peer-link clients."""
@@ -270,15 +267,6 @@ class OffloaderController:  # noqa: PLR0904
         self._rebind_probe_until.clear()
         self._peers.clear()
         await self._close_peer_link_resolver()
-
-    def _track_task(
-        self, coro: Coroutine[Any, Any, None], *, name: str | None = None
-    ) -> asyncio.Task[None]:
-        """Schedule *coro* and hold a strong ref in :attr:`_tasks` until it settles."""
-        task = asyncio.create_task(coro, name=name)
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
-        return task
 
     async def _load_offloader_identities_async(
         self,

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Callable, Coroutine, Hashable
-from contextlib import ExitStack
+from collections.abc import Callable, Hashable
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -33,7 +32,7 @@ from ...helpers.event_bus import Event
 from ...helpers.peer_link_frames import frame_schema, is_valid_frame
 from ...helpers.remote_build_cleanup import sweep_remote_builds
 from ...helpers.remote_build_layout import parse_from_configuration
-from ...helpers.storage import ShutdownCallback, Store
+from ...helpers.storage import Store
 from ...models import (
     MAX_CLEANUP_TTL_SECONDS,
     MIN_CLEANUP_TTL_SECONDS,
@@ -61,7 +60,7 @@ from ..config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
 )
-from ._shared import drain_tasks
+from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
     RECEIVER_PEERS_FILE,
     decode_peers,
@@ -98,12 +97,11 @@ _CLEANUP_SWEEP_INTERVAL_SECONDS = 60 * 60
 _PEERS_SAVE_DELAY_SECONDS = 1.0
 
 
-class ReceiverController:  # noqa: PLR0904
+class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
     """Inbound side of remote-build: pair inbox, peer-link sessions, JOB_* fan-out."""
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
-        self._db = device_builder
-        self._tasks: set[asyncio.Task[None]] = set()
+        super().__init__(device_builder)
         # True while ``rotate_identity`` is in flight. Second
         # caller gets ``ALREADY_EXISTS`` rather than queuing —
         # interleaved teardowns can leave no listener at all,
@@ -126,7 +124,6 @@ class ReceiverController:  # noqa: PLR0904
         self._submit_job_receiver: SubmitJobReceiver | None = None
         self._artifacts_download_sender: ArtifactsDownloadSender | None = None
         self._job_fanout: JobFanout | None = None
-        self._shutdown_callbacks: list[ShutdownCallback] = []
         self._peers_store: Store[ReceiverPeers] = Store(
             self._db.settings.config_dir / RECEIVER_PEERS_FILE,
             encoder=encode_peers,
@@ -134,7 +131,6 @@ class ReceiverController:  # noqa: PLR0904
             shutdown_register=self._shutdown_callbacks.append,
             name="receiver_peers",
         )
-        self._listeners = ExitStack()
 
     async def start(self) -> None:
         """Bring up the receiver-side handlers, seed RAM from disk."""
@@ -191,15 +187,6 @@ class ReceiverController:  # noqa: PLR0904
         for callback in self._shutdown_callbacks:
             await callback()
         self._approved_peers.clear()
-
-    def _track_task(
-        self, coro: Coroutine[Any, Any, None], *, name: str | None = None
-    ) -> asyncio.Task[None]:
-        """Schedule *coro* and hold a strong ref in :attr:`_tasks` until it settles."""
-        task = asyncio.create_task(coro, name=name)
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
-        return task
 
     async def _load_settings_async(self) -> RemoteBuildSettings:
         """Read the receiver-side settings sidecar off the executor.


### PR DESCRIPTION
# What does this implement/fix?

Hoists the four lines of lifecycle scaffolding that
:class:`OffloaderController` and :class:`ReceiverController`
carried verbatim into a small base class —
:class:`_RemoteBuildBase` in
`controllers/remote_build/_shared.py`.

The duplicated state:

* `self._db = device_builder` — every controller in the
  package needs the `DeviceBuilder` ref.
* `self._tasks: set[asyncio.Task[None]] = set()` — strong-ref
  set for fire-and-forget tasks.
* `self._listeners = ExitStack()` — bus-listener unsubscribers
  walked at stop time.
* `self._shutdown_callbacks: list[ShutdownCallback] = []` —
  per-file `Store` flush callbacks walked at stop time.

Plus the identical 4-line `_track_task` method.

After this PR, each sibling's `__init__` shrinks by ~5 lines
(state + `_track_task` body), the duplicate state-init order
matches between siblings by virtue of the same constructor,
and any future role controller in this package can inherit
the same scaffolding without copy-paste.

## Why single-inheritance and not a mixin

The earlier mixin attempt at the role split was rejected
because multiple-inheritance state-sharing made type-checker
attribute resolution unreliable (a mixin reaching for
`self._pairings` couldn't be statically confirmed to land on
a class that defined it). Single-inheritance doesn't have
that problem: every attribute resolves through one MRO step,
mypy sees them on the base, and the subclasses' specific
state stays on the subclasses.

## What stayed where

* `drain_tasks` is still a free function in the same module —
  it's stateless and the per-role `stop` callers already pass
  in a specific iterable (`self._tasks`,
  `self._pair_status_listeners.values()`,
  `h.task for h in self._peer_link_clients.values()`), so the
  function shape is the right one. Moving it to a method
  would force callers to instance-bind for no win.
* Each sibling's `start` and `stop` stay on the subclass —
  the sequences are role-specific (offloader brings up mDNS
  browse + peer-link clients; receiver brings up
  `SubmitJobReceiver` / `ArtifactsDownloadSender` /
  `JobFanout`), and a base-class default no-op wouldn't
  help.

## Follow-up

A wider `TaskTracker`-style base that
:class:`DeviceStateMonitor` could also share is deferred to a
follow-up PR. The monitor has the same
`task.add_done_callback(self._tasks.discard)` pattern in
three places but doesn't take a `DeviceBuilder`, doesn't keep
listeners, and doesn't manage shutdown callbacks — so the
shared base for it has to be carved out separately, and
`_RemoteBuildBase` itself would then inherit from that
smaller base.

## Behaviour preservation

Pure refactor. Each `__init__` initializes the same four
fields with the same default values; `_track_task` is the
same 4 lines just on the parent now. 3117 tests pass, ruff
+ mypy clean.

**Related issue or feature (if applicable):**

- Follow-up to #637 (the offloader/receiver role split).
  Conversation flagged the lifecycle duplication; this
  collapses it now that the role split has landed and
  type-checker behaviour is settled.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
