### PR TITLE
Extract TaskControllerBase, share with DeviceStateMonitor

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -50,6 +50,7 @@ from ..helpers.subscriber_presence import SubscriberPresence
 from ..models import AdoptableDevice, Device, DeviceState, ReachabilitySource
 from ._dns_cache import DNSCache
 from ._reachability_tracker import MdnsCacheInfo, ReachabilityTracker
+from ._task_controller_base import TaskControllerBase
 
 _LOGGER = logging.getLogger(__name__)
 _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
@@ -340,7 +341,7 @@ def device_name_from_service(service_name: str) -> str:
     return service_name.split(".", maxsplit=1)[0]
 
 
-class DeviceStateMonitor:  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
+class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
     """
     Drive device state from mDNS broadcasts plus periodic ICMP pings.
 
@@ -366,6 +367,7 @@ class DeviceStateMonitor:  # noqa: PLR0904 (grandfathered; new public methods ne
         get_devices_by_name: Callable[[str], list[Device]] | None = None,
         presence: SubscriberPresence | None = None,
     ) -> None:
+        super().__init__()
         self._get_devices = get_devices
         # ``get_devices_by_name`` is the O(1) name-keyed lookup that
         # the scanner exposes; mDNS / ping / MQTT observations key on
@@ -413,9 +415,8 @@ class DeviceStateMonitor:  # noqa: PLR0904 (grandfathered; new public methods ne
         # by ``service_type`` to the right per-type logic.
         self._mdns_browser: AsyncServiceBrowser | None = None
         self._ping_task: asyncio.Task | None = None
-        # Strong refs for fire-and-forget mDNS resolve tasks so the
-        # garbage collector can't reap them mid-await.
-        self._tasks: set[asyncio.Task] = set()
+        # ``self._tasks`` (fire-and-forget mDNS resolve refs) comes
+        # from :class:`TaskTracker`; see :meth:`_track_task`.
         # DNS resolutions for non-mDNS hostnames are cached here so the
         # ping sweep, OTA cache args, and device.ip tracking all share
         # the same TTL'd lookup result instead of re-resolving every
@@ -961,9 +962,7 @@ class DeviceStateMonitor:  # noqa: PLR0904 (grandfathered; new public methods ne
         if info.load_from_cache(zeroconf):
             self._apply_service_info(device_name, info)
             return
-        task = asyncio.create_task(self._resolve_and_apply(zeroconf, info, device_name))
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
+        self._track_task(self._resolve_and_apply(zeroconf, info, device_name))
 
     def revisit_importable(self, device_name: str) -> None:
         """
@@ -1085,9 +1084,7 @@ class DeviceStateMonitor:  # noqa: PLR0904 (grandfathered; new public methods ne
                 self._apply_service_info(device_name, info)
                 return
 
-            task = asyncio.create_task(self._resolve_and_apply(zeroconf, info, device_name))
-            self._tasks.add(task)
-            task.add_done_callback(self._tasks.discard)
+            self._track_task(self._resolve_and_apply(zeroconf, info, device_name))
 
         # ``DashboardImportDiscovery`` from upstream esphome owns the
         # TXT-record parsing for adoptable factory firmwares — its
@@ -1186,9 +1183,7 @@ class DeviceStateMonitor:  # noqa: PLR0904 (grandfathered; new public methods ne
         if info.load_from_cache(zeroconf):
             self._apply_http_service_info(device_name, info)
             return
-        task = asyncio.create_task(self._resolve_and_apply_http(zeroconf, info, device_name))
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
+        self._track_task(self._resolve_and_apply_http(zeroconf, info, device_name))
 
     async def _resolve_and_apply_http(
         self, zeroconf: Any, info: AsyncServiceInfo, device_name: str

--- a/esphome_device_builder/controllers/_task_controller_base.py
+++ b/esphome_device_builder/controllers/_task_controller_base.py
@@ -1,0 +1,44 @@
+"""Base class for controllers that schedule fire-and-forget background work.
+
+A bare :func:`asyncio.create_task` returns a weak reference: if no
+caller holds the task, the event loop can drop it mid-await and the
+GC reaps it. The standard remedy is "add to a set, schedule, set the
+discard-on-done callback" — repeated verbatim across several
+controllers. :class:`TaskControllerBase` provides that boilerplate
+as a single-inheritance base; subclasses ``super().__init__()`` and
+schedule via ``self._track_task(coro)`` instead of a bare
+:func:`asyncio.create_task`.
+
+Exposes:
+
+* :class:`TaskControllerBase` — base providing the ``_tasks`` set
+  and the ``_track_task`` helper.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+
+class TaskControllerBase:
+    """Base for controllers that schedule fire-and-forget tasks.
+
+    Subclasses call ``super().__init__()`` to initialise
+    :attr:`_tasks`, then schedule via ``self._track_task(coro)``.
+    Each subclass's teardown is responsible for draining
+    :attr:`_tasks` (cancel + gather) before clearing the set.
+    """
+
+    def __init__(self) -> None:
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    def _track_task(
+        self, coro: Coroutine[Any, Any, None], *, name: str | None = None
+    ) -> asyncio.Task[None]:
+        """Schedule *coro* and hold a strong ref in :attr:`_tasks` until it settles."""
+        task = asyncio.create_task(coro, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task

--- a/esphome_device_builder/controllers/remote_build/_shared.py
+++ b/esphome_device_builder/controllers/remote_build/_shared.py
@@ -3,9 +3,8 @@
 Exposes:
 
 * :class:`_RemoteBuildBase` — base class providing the
-  ``_db`` / ``_tasks`` / ``_listeners`` /
-  ``_shutdown_callbacks`` fields and the ``_track_task``
-  helper both siblings need.
+  ``_db`` / ``_listeners`` / ``_shutdown_callbacks`` fields
+  on top of :class:`TaskControllerBase`'s task scheduler.
 * :func:`drain_tasks` — stateless cancel-and-gather helper
   the per-role ``stop`` methods feed task iterables to.
 """
@@ -13,11 +12,12 @@ Exposes:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine, Iterable
+from collections.abc import Iterable
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.storage import ShutdownCallback
+from .._task_controller_base import TaskControllerBase
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -38,33 +38,19 @@ async def drain_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
     await asyncio.gather(*tasks_list, return_exceptions=True)
 
 
-class _RemoteBuildBase:
+class _RemoteBuildBase(TaskControllerBase):
     """Base for the offloader and receiver siblings.
 
     Subclasses call ``super().__init__(device_builder)`` to
-    populate the four fields, layer role-specific state on top,
-    and define their own ``start`` / ``stop``. The role's
-    ``stop`` is responsible for closing :attr:`_listeners`,
-    walking :attr:`_shutdown_callbacks`, and draining
-    :attr:`_tasks` (via :func:`drain_tasks`).
+    populate the fields, layer role-specific state on top, and
+    define their own ``start`` / ``stop``. The role's ``stop``
+    is responsible for closing :attr:`_listeners`, walking
+    :attr:`_shutdown_callbacks`, and draining :attr:`_tasks`
+    (via :func:`drain_tasks`).
     """
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
+        super().__init__()
         self._db = device_builder
-        self._tasks: set[asyncio.Task[None]] = set()
         self._listeners = ExitStack()
         self._shutdown_callbacks: list[ShutdownCallback] = []
-
-    def _track_task(
-        self, coro: Coroutine[Any, Any, None], *, name: str | None = None
-    ) -> asyncio.Task[None]:
-        """Schedule *coro* and hold a strong ref in :attr:`_tasks` until it settles.
-
-        Distinct from :meth:`DeviceBuilder.create_background_task`:
-        this set is drained separately by each role's ``stop``
-        for ordered subsystem teardown.
-        """
-        task = asyncio.create_task(coro, name=name)
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
-        return task


### PR DESCRIPTION
# What does this implement/fix?

Carves out the smallest useful shared base from
:class:`_RemoteBuildBase` (PR #638) into
:class:`TaskControllerBase`, in a new module
`controllers/_task_controller_base.py`. Two consumers adopt it:

* :class:`_RemoteBuildBase` now inherits from
  :class:`TaskControllerBase` for the task scheduler, retaining
  its `_db` / `_listeners` / `_shutdown_callbacks` fields on
  top.
* :class:`DeviceStateMonitor` now inherits from
  :class:`TaskControllerBase` too. The inline
  `asyncio.create_task / self._tasks.add /
  task.add_done_callback(self._tasks.discard)` block at three
  callsites collapses to a single `self._track_task(coro)`.

The base provides exactly what the name suggests: a strong-ref
set for fire-and-forget background tasks and a one-line helper
to schedule into it.

## Why this PR after #638

The split-PR plan from #638's discussion: land the
remote-build-specific base first, then carve out the smaller
generic base that other controllers can adopt. This is that
second step. Named `TaskControllerBase` (not `TaskTracker`) so
future controllers reading the codebase see "base class for
controllers managing tasks" rather than a generic helper.

## Placement

Mirrors the existing convention:
`controllers/_dns_cache.py`,
`controllers/_reachability_tracker.py`,
`controllers/_device_state_monitor.py`,
`controllers/_device_mqtt_coordinator.py` — leading-underscore
modules in `controllers/` that hold internal-to-the-package
helper classes other controllers import directly.

## Other candidates

`api/ws.py`'s :class:`WebSocketClient` carries the same
add-to-set / discard-on-done idiom in its
:meth:`create_task`. Different shape though — public method,
no `name` kwarg, per-WS-connection lifetime — so adopting it
would change the public API. Left for a separate decision.

## Behaviour preservation

Pure refactor — no callsite behaviour change. Each subclass
calls `super().__init__()` and gets the same `_tasks` field
and `_track_task` method it had before. 3117 tests pass; ruff
+ mypy clean.

**Related issue or feature (if applicable):**

- Follow-up to #638. Conversation flagged
  :class:`DeviceStateMonitor` carrying the same inline pattern;
  this collapses it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
