### PR TITLE
Address Copilot review on #639 (TaskControllerBase doc nits)

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -416,7 +416,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         self._mdns_browser: AsyncServiceBrowser | None = None
         self._ping_task: asyncio.Task | None = None
         # ``self._tasks`` (fire-and-forget mDNS resolve refs) comes
-        # from :class:`TaskTracker`; see :meth:`_track_task`.
+        # from :class:`TaskControllerBase`; see :meth:`_track_task`.
         # DNS resolutions for non-mDNS hostnames are cached here so the
         # ping sweep, OTA cache args, and device.ip tracking all share
         # the same TTL'd lookup result instead of re-resolving every

--- a/esphome_device_builder/controllers/_task_controller_base.py
+++ b/esphome_device_builder/controllers/_task_controller_base.py
@@ -1,18 +1,9 @@
 """Base class for controllers that schedule fire-and-forget background work.
 
-A bare :func:`asyncio.create_task` returns a weak reference: if no
-caller holds the task, the event loop can drop it mid-await and the
-GC reaps it. The standard remedy is "add to a set, schedule, set the
-discard-on-done callback" — repeated verbatim across several
-controllers. :class:`TaskControllerBase` provides that boilerplate
-as a single-inheritance base; subclasses ``super().__init__()`` and
-schedule via ``self._track_task(coro)`` instead of a bare
-:func:`asyncio.create_task`.
-
-Exposes:
-
-* :class:`TaskControllerBase` — base providing the ``_tasks`` set
-  and the ``_track_task`` helper.
+The event loop keeps only a weak ref to each
+:class:`~asyncio.Task`; an unreferenced task can be GC'd mid-await.
+:class:`TaskControllerBase` provides the strong-ref set + schedule
+helper so subclasses don't repeat the idiom inline.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
# What does this implement/fix?

Two Copilot comments on #639 (the `TaskControllerBase` PR),
deferred to this follow-up rather than amending the original.

* `_device_state_monitor.py:419` — stale `TaskTracker`
  reference in an inline comment. Leftover from the rename
  during #639's review. Now points at `TaskControllerBase`.
* `_task_controller_base.py:5` — the module docstring said
  `asyncio.create_task` "returns a weak reference", which
  isn't quite right (`create_task` returns a
  :class:`~asyncio.Task`; the event loop keeps only a weak
  ref internally). Tightened to a single sentence that
  matches the stdlib docs' actual claim.

**Related issue or feature (if applicable):**

- Follow-up to #639.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
