### PR TITLE
Materialise remote-build artifacts locally on the offloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Thumbs.db
 
 # Configs (user data, not shipped)
 configs/
+secrets.yaml
 
 # Script caches (cloned repos for sync)
 .cache/

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -65,7 +65,6 @@ from .helpers import (
     _find_esphome_cmd,
     _ingest_output_line,
     _is_no_module_named_esphome,
-    _is_serial_port,
     _mark_job_terminal,
     _names_touched_by_job,
     _trim_job_output,
@@ -247,10 +246,38 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     # ------------------------------------------------------------------
 
     @api_command("firmware/compile")
-    async def compile(self, *, configuration: str, **kwargs: Any) -> FirmwareJob:
-        """Queue a compile job."""
+    async def compile(
+        self,
+        *,
+        configuration: str,
+        force_local: bool = False,
+        **kwargs: Any,
+    ) -> FirmwareJob:
+        """Queue a compile job.
+
+        Routes through :func:`helpers.build_scheduler.pick_build_path`
+        same as :meth:`install`: a paired-connected receiver makes
+        the resulting job ``source=REMOTE`` so the remote runner
+        dispatches the compile to the build server and the
+        offloader-side materialiser stages the artifacts back
+        locally. The frontend's "Download firmware binary" button
+        reads from the staged tree via ``firmware/download``.
+
+        ``force_local`` opts out so a user can build locally
+        despite an available paired receiver.
+        """
         await self._validate_configuration_boundary(configuration)
-        job = self._create_job(configuration, JobType.COMPILE)
+        if force_local:
+            source, pin_sha256, label = JobSource.LOCAL, "", ""
+        else:
+            source, pin_sha256, label = self._resolve_install_source(configuration, port="OTA")
+        job = self._create_job(
+            configuration,
+            JobType.COMPILE,
+            source=source,
+            source_pin_sha256=pin_sha256,
+            source_label=label,
+        )
         return await self._enqueue(job)
 
     @api_command("firmware/upload")
@@ -576,12 +603,22 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         Per-device errors (most commonly the rename lock) skip that
         device and keep going so a single locked configuration in a
         bulk request doesn't abort the queue for everyone else.
+        Each job routes through :meth:`_resolve_install_source` so
+        paired-build auto-routing applies (mirrors
+        :meth:`compile` / :meth:`install_bulk`).
         """
         await self._validate_configurations_boundary(configurations)
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:
-                job = self._create_job(config, JobType.COMPILE)
+                source, pin_sha256, label = self._resolve_install_source(config, port="OTA")
+                job = self._create_job(
+                    config,
+                    JobType.COMPILE,
+                    source=source,
+                    source_pin_sha256=pin_sha256,
+                    source_label=label,
+                )
                 await self._enqueue(job)
             except CommandError as exc:
                 _LOGGER.info("Skipping %s in compile_bulk: %s", config, exc.message)
@@ -1826,42 +1863,12 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         return job
 
     def _resolve_install_source(self, configuration: str, port: str) -> tuple[JobSource, str, str]:
+        """Pick LOCAL or REMOTE for *configuration*; return ``(source, pin, label)``.
+
+        Pure sync helper. Returns LOCAL when remote-build isn't
+        wired up yet (firmware-queue restart-recovery can fire
+        before remote-build's ``start()``).
         """
-        Pick LOCAL or REMOTE for an install of *configuration*.
-
-        Calls :func:`helpers.build_scheduler.pick_build_path` with
-        a snapshot from the remote-build controller. Returns
-        ``(source, pin_sha256, label)`` — for LOCAL decisions
-        ``pin_sha256`` and ``label`` are empty strings.
-
-        Pure sync helper so the install handlers can call it
-        without an additional executor hop; the snapshot read
-        is RAM-only and the scheduler is a pure function.
-        Returns LOCAL whenever the remote-build controller
-        hasn't been wired up — :class:`DeviceBuilder`
-        initialises ``self.remote_build`` to ``None`` in
-        ``__init__`` and only sets the controller during
-        ``start()``, so a firmware-queue restart-recovery
-        path that fires before remote-build start would
-        otherwise reach into ``None``.
-
-        Serial *port* values also force LOCAL: the runner's
-        REMOTE flash step spawns ``esphome upload --file
-        <staged_firmware.bin>`` against the staged bytes,
-        which upstream wires through to a single FlashImage
-        at offset ``0x0`` (see
-        :func:`esphome.__main__.upload_using_esptool`). That
-        single-image shape works for OTA / web-server pushes
-        (where one binary is the entire upload) but corrupts
-        an ESP32 wired flash, which needs bootloader /
-        partitions / OTA-data at their own offsets stitched
-        from ``idedata.extra.flash_images``. Until the runner
-        can stage the full multi-image set in a way the
-        non-``--file`` path resolves cleanly, serial REMOTE
-        installs stay LOCAL.
-        """
-        if _is_serial_port(port):
-            return JobSource.LOCAL, "", ""
         offloader = self._db.remote_build_offloader
         if offloader is None:
             return JobSource.LOCAL, "", ""
@@ -1871,13 +1878,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         pairing = offloader.get_pairing(decision.pin_sha256)
         if pairing is None:
             # Scheduler picked a pin that's no longer paired (race
-            # against an ``unpair`` on the same loop tick); silent
-            # fallback to local. The scheduler's filters already
-            # reject non-APPROVED rows so this is a near-impossible
-            # window, but the typed return keeps the install handler
-            # from feeding an empty ``source_pin_sha256`` to the
-            # runner, which would land on the runner's missing-pin
-            # FAILED branch.
+            # vs an ``unpair`` on the same loop tick).
             return JobSource.LOCAL, "", ""
         return JobSource.REMOTE, pairing.pin_sha256, pairing.label
 

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -270,7 +270,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         if force_local:
             source, pin_sha256, label = JobSource.LOCAL, "", ""
         else:
-            source, pin_sha256, label = self._resolve_install_source(configuration, port="OTA")
+            source, pin_sha256, label = self._resolve_install_source(configuration)
         job = self._create_job(
             configuration,
             JobType.COMPILE,
@@ -528,7 +528,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         if force_local:
             source, pin_sha256, label = JobSource.LOCAL, "", ""
         else:
-            source, pin_sha256, label = self._resolve_install_source(configuration, port)
+            source, pin_sha256, label = self._resolve_install_source(configuration)
         job = self._create_job(
             configuration,
             JobType.INSTALL,
@@ -597,21 +597,29 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         return await self._enqueue(job)
 
     @api_command("firmware/compile_bulk")
-    async def compile_bulk(self, *, configurations: list[str], **kwargs: Any) -> list[FirmwareJob]:
+    async def compile_bulk(
+        self,
+        *,
+        configurations: list[str],
+        force_local: bool = False,
+        **kwargs: Any,
+    ) -> list[FirmwareJob]:
         """Queue compile for multiple devices.
 
         Per-device errors (most commonly the rename lock) skip that
-        device and keep going so a single locked configuration in a
-        bulk request doesn't abort the queue for everyone else.
-        Each job routes through :meth:`_resolve_install_source` so
-        paired-build auto-routing applies (mirrors
-        :meth:`compile` / :meth:`install_bulk`).
+        device and keep going. Each job routes through
+        :meth:`_resolve_install_source` so paired-build auto-routing
+        applies (mirrors :meth:`compile` / :meth:`install_bulk`);
+        ``force_local=True`` keeps every job LOCAL.
         """
         await self._validate_configurations_boundary(configurations)
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:
-                source, pin_sha256, label = self._resolve_install_source(config, port="OTA")
+                if force_local:
+                    source, pin_sha256, label = JobSource.LOCAL, "", ""
+                else:
+                    source, pin_sha256, label = self._resolve_install_source(config)
                 job = self._create_job(
                     config,
                     JobType.COMPILE,
@@ -646,7 +654,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:
-                source, pin_sha256, label = self._resolve_install_source(config, port)
+                source, pin_sha256, label = self._resolve_install_source(config)
                 job = self._create_job(
                     config,
                     JobType.INSTALL,
@@ -1862,7 +1870,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         self._jobs[job.job_id] = job
         return job
 
-    def _resolve_install_source(self, configuration: str, port: str) -> tuple[JobSource, str, str]:
+    def _resolve_install_source(self, configuration: str) -> tuple[JobSource, str, str]:
         """Pick LOCAL or REMOTE for *configuration*; return ``(source, pin, label)``.
 
         Pure sync helper. Returns LOCAL when remote-build isn't

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -223,7 +223,7 @@ async def run_remote_job(
         controller._cancel_events.pop(job.job_id, None)
 
 
-async def _dispatch_and_drive(  # noqa: PLR0911
+async def _dispatch_and_drive(  # noqa: PLR0911, PLR0912
     *,
     controller: FirmwareController,
     job: FirmwareJob,
@@ -352,16 +352,19 @@ async def _dispatch_and_drive(  # noqa: PLR0911
         # left to do.
         return
 
-    # Receiver finished its half successfully. For COMPILE
-    # and CLEAN that's the whole job; for UPLOAD / INSTALL we
-    # still owe the local flash step using the receiver's
-    # bytes.
-    if job.job_type in (JobType.COMPILE, JobType.CLEAN):
-        # Stamp ``exit_code=0`` because the remote work didn't
-        # run a local subprocess. The legacy ``follow_job``
-        # framing coerces ``None`` to a failure code (``1``),
-        # so a missing stamp would land a successful run as a
-        # failure on the wire.
+    # Receiver finished its half. CLEAN is wipe-only (no
+    # artifacts to fetch); COMPILE needs the artifacts staged
+    # locally so firmware/download serves them; UPLOAD / INSTALL
+    # need that plus the local flash subprocess.
+    if job.job_type is JobType.CLEAN:
+        # ``exit_code=0`` stamp keeps the legacy follow_job
+        # framing from coercing ``None`` to a failure code.
+        job.exit_code = 0
+        _finalize_success(controller, job)
+        return
+    if not await _fetch_and_materialise(controller=controller, job=job, client=client):
+        return
+    if job.job_type is JobType.COMPILE:
         job.exit_code = 0
         _finalize_success(controller, job)
         return
@@ -503,46 +506,18 @@ async def _await_terminal(
     return status
 
 
-async def _fetch_and_run_local_upload(
+async def _fetch_and_materialise(
     *,
     controller: FirmwareController,
     job: FirmwareJob,
     client: PeerLinkClient,
-) -> None:
-    """
-    Pull the receiver's compile artifacts and flash the device locally.
+) -> bool:
+    """Download the receiver's tarball and materialise it on the offloader.
 
-    Called once the receiver returned ``completed`` for an
-    ``UPLOAD`` / ``INSTALL`` job. The transparent install
-    contract says the offloader owns the flash step — only
-    the *compile* hops to the receiver. So:
-
-    1. Fetch the artifact tarball via
-       :meth:`PeerLinkClient.download_artifacts`.
-    2. Materialise the tarball into ``<data_dir>/build/<name>/``
-       via :func:`helpers.remote_artifacts_materialise.materialise_remote_artifacts`.
-       After this returns the offloader's filesystem looks as
-       if a local compile produced the build — esphome's upload
-       dispatch resolves through ``CORE.firmware_bin`` /
-       ``CORE.relative_pioenvs_path`` / the cached idedata at
-       ``<data_dir>/idedata/<name>.json`` against the staged
-       tree.
-    3. Spawn ``esphome upload <yaml> --device <port>`` (no
-       ``--file``, no per-platform code on our side) through
-       :meth:`FirmwareController._tracked_subprocess` so the
-       cancel handler's SIGTERM lands on the subprocess if the
-       user clicks Stop mid-upload.
-    4. Stream stdout through :func:`helpers._ingest_output_line`
-       — same per-line bookkeeping (buffer / trim / fire
-       ``JOB_OUTPUT`` + ``JOB_PROGRESS``) every local
-       subscriber already consumes.
-    5. Finalise based on exit code + cancel state, same shape
-       the local subprocess path uses.
-
-    Wire failures, materialise failures, and a non-zero upload
-    exit fail the job locally with ``JOB_FAILED`` (or
-    ``JOB_CANCELLED`` via the cancel-aware ``_fail_locally``
-    when the user raced a Stop).
+    Returns ``True`` when staging succeeded and the caller
+    should continue, ``False`` when it already finalised the
+    job (download / materialise failure, or a cancel raced in
+    after the receiver completed).
     """
     _LOGGER.info(
         "Remote job %s: requesting build artefacts for configuration=%r from receiver",
@@ -556,14 +531,6 @@ async def _fetch_and_run_local_upload(
         SubmitJobSessionLostError,
         DownloadArtifactsError,
     ) as exc:
-        # Receiver-side WARNING logs carry the actionable
-        # detail (configuration, missing path, current status)
-        # for every soft-reject; point operators at the build
-        # server log either way. The previous shape only
-        # mentioned "missing path", which was misleading for
-        # non-``build_dir_missing`` rejects (``unknown_job`` /
-        # ``job_not_completed`` / session lost — none of which
-        # involve a path).
         _fail_locally(
             controller,
             job,
@@ -572,30 +539,47 @@ async def _fetch_and_run_local_upload(
                 f"(check the build server logs for details)"
             ),
         )
-        return
+        return False
 
-    # Materialise the receiver's tarball into the offloader's
-    # canonical build / storage / idedata paths so the upload
-    # subprocess can spawn against a tree that looks like a
-    # local compile produced it. Synchronous; runs in an executor
-    # because tarfile + multiple file writes are blocking.
     try:
         await asyncio.get_running_loop().run_in_executor(
             None, materialise_remote_artifacts, packed.tarball, job.configuration
         )
     except MaterialiseError as exc:
-        _fail_locally(
-            controller,
-            job,
-            error=f"remote build: materialise failed: {exc}",
-        )
-        return
+        _fail_locally(controller, job, error=f"remote build: materialise failed: {exc}")
+        return False
+    except OSError as exc:
+        # Disk full / permission denied / transient IO. Catch
+        # at this seam so the runner task doesn't crash; the
+        # MaterialiseError branch covers the wire-shape failures.
+        _fail_locally(controller, job, error=f"remote build: materialise IO error: {exc}")
+        return False
 
     # Honour a cancel that arrived between the receiver's
-    # completed frame and us getting here — no point spawning
-    # a flash subprocess for a job the user already aborted.
-    # ``_fail_locally`` is cancel-aware and routes through
-    # ``_finalize_cancelled`` in this case.
+    # completed frame and us getting here.
+    if job.job_id in controller._cancel_requested:
+        controller._finalize_cancelled(job)
+        return False
+    return True
+
+
+async def _fetch_and_run_local_upload(
+    *,
+    controller: FirmwareController,
+    job: FirmwareJob,
+    client: PeerLinkClient,
+) -> None:
+    """Flash the device locally after the receiver's COMPILE half is staged.
+
+    Pre-condition: :func:`_fetch_and_materialise` has already
+    pulled the tarball and staged it; the offloader's filesystem
+    now looks as if a local compile produced the build, so
+    ``esphome upload <yaml> --device <port>`` resolves through
+    esphome's per-platform dispatch (no ``--file`` needed).
+    """
+    # Cancel that landed after ``_fetch_and_materialise``'s
+    # own check returned True — same race window the old
+    # one-shot helper covered.
     if job.job_id in controller._cancel_requested:
         controller._finalize_cancelled(job)
         return

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -30,13 +30,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import shutil
-import tempfile
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from ...helpers.api import CommandError
 from ...helpers.config_bundle import BundleBuildError, build_yaml_bundle
+from ...helpers.remote_artifacts_materialise import (
+    MaterialiseError,
+    materialise_remote_artifacts,
+)
 from ...helpers.subprocess import iter_lines_with_progress
 from ...models import (
     EventType,
@@ -47,7 +48,6 @@ from ...models import (
     OffloaderJobStateChangedData,
     OffloaderPeerLinkClosedData,
 )
-from ..remote_build.artifacts_tarball import UnpackArtifactsError, extract_firmware_bin
 from ..remote_build.peer_link_client import (
     DownloadArtifactsError,
     PeerLinkNoSessionError,
@@ -519,15 +519,19 @@ async def _fetch_and_run_local_upload(
 
     1. Fetch the artifact tarball via
        :meth:`PeerLinkClient.download_artifacts`.
-    2. Extract ``firmware.bin`` to a per-run tmpdir (the
-       only piece the OTA / web_server flash paths need; the
-       multi-image set required for ESP32 wired flash isn't
-       supported by transparent install — serial REMOTE installs
-       are rejected at the install handler).
-    3. Spawn ``esphome upload --device <port> --file
-       <staged>`` through :meth:`FirmwareController._tracked_subprocess`
-       so the cancel handler's SIGTERM lands on the subprocess
-       if the user clicks Stop mid-upload.
+    2. Materialise the tarball into ``<data_dir>/build/<name>/``
+       via :func:`helpers.remote_artifacts_materialise.materialise_remote_artifacts`.
+       After this returns the offloader's filesystem looks as
+       if a local compile produced the build — esphome's upload
+       dispatch resolves through ``CORE.firmware_bin`` /
+       ``CORE.relative_pioenvs_path`` / the cached idedata at
+       ``<data_dir>/idedata/<name>.json`` against the staged
+       tree.
+    3. Spawn ``esphome upload <yaml> --device <port>`` (no
+       ``--file``, no per-platform code on our side) through
+       :meth:`FirmwareController._tracked_subprocess` so the
+       cancel handler's SIGTERM lands on the subprocess if the
+       user clicks Stop mid-upload.
     4. Stream stdout through :func:`helpers._ingest_output_line`
        — same per-line bookkeeping (buffer / trim / fire
        ``JOB_OUTPUT`` + ``JOB_PROGRESS``) every local
@@ -535,10 +539,10 @@ async def _fetch_and_run_local_upload(
     5. Finalise based on exit code + cancel state, same shape
        the local subprocess path uses.
 
-    Wire / unpack failures and a non-zero upload exit fail
-    the job locally with ``JOB_FAILED`` (or ``JOB_CANCELLED``
-    via the cancel-aware ``_fail_locally`` when the user
-    raced a Stop).
+    Wire failures, materialise failures, and a non-zero upload
+    exit fail the job locally with ``JOB_FAILED`` (or
+    ``JOB_CANCELLED`` via the cancel-aware ``_fail_locally``
+    when the user raced a Stop).
     """
     _LOGGER.info(
         "Remote job %s: requesting build artefacts for configuration=%r from receiver",
@@ -570,29 +574,28 @@ async def _fetch_and_run_local_upload(
         )
         return
 
-    # Extract firmware.bin from the receiver's gzipped tarball.
-    # The receiver-side packer guarantees ``firmware.bin`` is
-    # always present (see ``ArtifactsDownloadSender``); a
-    # missing entry means the wire shape drifted, so surface
-    # as a clean error rather than letting the upload step
-    # silently flash whatever was at the tmpdir path.
+    # Materialise the receiver's tarball into the offloader's
+    # canonical build / storage / idedata paths so the upload
+    # subprocess can spawn against a tree that looks like a
+    # local compile produced it. Synchronous; runs in an executor
+    # because tarfile + multiple file writes are blocking.
     try:
-        firmware_bytes = await asyncio.get_running_loop().run_in_executor(
-            None, extract_firmware_bin, packed.tarball
+        await asyncio.get_running_loop().run_in_executor(
+            None, materialise_remote_artifacts, packed.tarball, job.configuration
         )
-    except UnpackArtifactsError as exc:
+    except MaterialiseError as exc:
         _fail_locally(
             controller,
             job,
-            error=f"remote build: tarball: {exc}",
+            error=f"remote build: materialise failed: {exc}",
         )
         return
 
     # Honour a cancel that arrived between the receiver's
-    # completed frame and us getting here — no point staging
-    # bytes or spawning a flash subprocess for a job the user
-    # already aborted. ``_fail_locally`` is cancel-aware and
-    # routes through ``_finalize_cancelled`` in this case.
+    # completed frame and us getting here — no point spawning
+    # a flash subprocess for a job the user already aborted.
+    # ``_fail_locally`` is cancel-aware and routes through
+    # ``_finalize_cancelled`` in this case.
     if job.job_id in controller._cancel_requested:
         controller._finalize_cancelled(job)
         return
@@ -618,41 +621,26 @@ async def _fetch_and_run_local_upload(
     # this phase boundary.
     _fire_job_progress(job, bus, 0)
 
-    # ``tempfile.TemporaryDirectory`` ctor calls
-    # :func:`os.mkdir` synchronously — blockbuster catches
-    # that on CI. Use :func:`tempfile.mkdtemp` via an executor
-    # and clean up by hand in the ``finally`` so the blocking
-    # syscalls (``os.mkdir`` / ``shutil.rmtree``) never run on
-    # the event loop.
-    tmpdir = await loop.run_in_executor(None, tempfile.mkdtemp, "", "esphome-remote-firmware-")
-    try:
-        firmware_path = Path(tmpdir) / "firmware.bin"
-        await loop.run_in_executor(None, firmware_path.write_bytes, firmware_bytes)
+    cache_args = controller._build_cache_args(job)
+    cmd = [
+        *controller._esphome_cmd,
+        "--dashboard",
+        *cache_args,
+        "upload",
+        str(yaml_path),
+        "--device",
+        job.port,
+    ]
+    _LOGGER.debug("Remote upload subprocess: %s", " ".join(cmd))
 
-        cache_args = controller._build_cache_args(job)
-        cmd = [
-            *controller._esphome_cmd,
-            "--dashboard",
-            *cache_args,
-            "upload",
-            str(yaml_path),
-            "--device",
-            job.port,
-            "--file",
-            str(firmware_path),
-        ]
-        _LOGGER.debug("Remote upload subprocess: %s", " ".join(cmd))
-
-        env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
-        exit_code = await _run_upload_subprocess(
-            controller=controller,
-            job=job,
-            bus=bus,
-            cmd=cmd,
-            env=env,
-        )
-    finally:
-        await loop.run_in_executor(None, shutil.rmtree, tmpdir, True)
+    env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
+    exit_code = await _run_upload_subprocess(
+        controller=controller,
+        job=job,
+        bus=bus,
+        cmd=cmd,
+        env=env,
+    )
 
     if exit_code is None:
         # ``_run_upload_subprocess`` already finalised the

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -122,19 +122,14 @@ async def run_remote_job(
         _fail_locally(
             controller,
             job,
-            error=(
-                "remote source supports COMPILE/UPLOAD/INSTALL/CLEAN only "
-                f"(got {job.job_type.value})"
+            reason=(
+                f"unsupported job_type {job.job_type.value!r} (COMPILE/UPLOAD/INSTALL/CLEAN only)"
             ),
         )
         return
 
     if not job.source_pin_sha256:
-        _fail_locally(
-            controller,
-            job,
-            error="remote source missing source_pin_sha256",
-        )
+        _fail_locally(controller, job, reason="missing source_pin_sha256")
         return
 
     bus = controller.bus
@@ -223,7 +218,7 @@ async def run_remote_job(
         controller._cancel_events.pop(job.job_id, None)
 
 
-async def _dispatch_and_drive(  # noqa: PLR0911, PLR0912
+async def _dispatch_and_drive(
     *,
     controller: FirmwareController,
     job: FirmwareJob,
@@ -233,83 +228,99 @@ async def _dispatch_and_drive(  # noqa: PLR0911, PLR0912
 ) -> None:
     """Build the bundle, submit, then wait for the receiver's terminal frame.
 
-    Split out from :func:`run_remote_job` so the
-    listener attach / detach lives in one ``with`` block at the
-    outer call site — every early-return failure path here
-    still releases the bus subscriptions.
+    Split out from :func:`run_remote_job` so the listener
+    attach / detach lives in one ``with`` block at the outer
+    call site — every early-return failure path here still
+    releases the bus subscriptions.
     """
+    bundle_bytes = await _build_bundle_or_fail(controller, job)
+    if bundle_bytes is None:
+        return
+    client = _open_peer_link_client_or_fail(controller, job)
+    if client is None:
+        return
+    if not await _submit_job_to_receiver(
+        controller=controller, job=job, client=client, bundle_bytes=bundle_bytes
+    ):
+        return
+
+    wire_status = await _await_terminal(
+        controller=controller,
+        job=job,
+        terminal=terminal,
+        session_lost=session_lost,
+        cancel_event=cancel_event,
+    )
+    if wire_status != "completed":
+        # ``_await_terminal`` already finalised the job.
+        return
+
+    await _finalise_after_receiver_completed(controller=controller, job=job, client=client)
+
+
+async def _build_bundle_or_fail(controller: FirmwareController, job: FirmwareJob) -> bytes | None:
+    """Build the YAML bundle; ``None`` + ``_fail_locally`` on failure."""
     loop = asyncio.get_running_loop()
     yaml_path = await loop.run_in_executor(
         None, controller._db.settings.rel_path, job.configuration
     )
-
     try:
-        bundle_bytes = await build_yaml_bundle(yaml_path)
+        return await build_yaml_bundle(yaml_path)
     except FileNotFoundError:
-        _fail_locally(
-            controller,
-            job,
-            error=f"remote build: configuration not found: {job.configuration}",
-        )
-        return
+        _fail_locally(controller, job, reason=f"configuration not found: {job.configuration}")
     except BundleBuildError as exc:
-        _fail_locally(
-            controller,
-            job,
-            error=f"remote build: bundle failed: {exc.output or exc}",
-        )
-        return
+        _fail_locally(controller, job, reason=f"bundle failed: {exc.output or exc}")
+    return None
 
+
+def _open_peer_link_client_or_fail(
+    controller: FirmwareController, job: FirmwareJob
+) -> PeerLinkClient | None:
+    """Look up the offloader's open peer-link client; ``None`` on failure."""
     offloader = controller._db.remote_build_offloader
     if offloader is None:
-        _fail_locally(
-            controller,
-            job,
-            error="remote build: controller not initialised",
-        )
-        return
+        _fail_locally(controller, job, reason="controller not initialised")
+        return None
     try:
-        client = offloader._lookup_open_peer_link_client(
+        return offloader._lookup_open_peer_link_client(
             job.source_pin_sha256, label="firmware_remote"
         )
     except CommandError as exc:
-        _fail_locally(
-            controller,
-            job,
-            error=f"remote build: receiver not reachable: {exc.message}",
-        )
-        return
+        _fail_locally(controller, job, reason=f"receiver not reachable: {exc.message}")
+        return None
 
-    # Look up the local Device entry so the receiver's
-    # firmware-tasks UI can render the device's actual name +
-    # friendly name instead of the cryptic
-    # ``.esphome/.remote_builds/<id>/<device>/<device>.yaml``
-    # path. The offloader already has both from its scanner —
-    # sending them on the wire avoids the receiver having to
-    # re-parse the bundled YAML just to render a title.
-    # ``getattr`` falls through cleanly when the devices
-    # controller isn't wired yet (pre-``start()`` race, test
-    # stubs without a Device list). A missing scanner entry
-    # for a real lookup leaves the fields empty and the
-    # receiver falls back to the path's device segment —
-    # happens for newly-added YAMLs whose scanner entry
-    # hasn't refreshed yet, not worth blocking on.
-    device_name = ""
-    device_friendly_name = ""
+
+def _local_device_display_for_job(
+    controller: FirmwareController, job: FirmwareJob
+) -> tuple[str, str]:
+    """Return ``(name, friendly_name)`` for *job*'s configuration; ``("", "")`` if unknown.
+
+    The receiver renders these in its firmware-tasks UI; sending
+    them on the wire avoids re-parsing the bundled YAML for a
+    title. ``getattr`` falls through cleanly when the devices
+    controller isn't wired yet.
+    """
     devices_controller = getattr(controller._db, "devices", None)
-    if devices_controller is not None:
-        for device in devices_controller.get_devices():
-            if device.configuration == job.configuration:
-                device_name = device.name
-                device_friendly_name = device.friendly_name
-                break
+    if devices_controller is None:
+        return "", ""
+    for device in devices_controller.get_devices():
+        if device.configuration == job.configuration:
+            return device.name, device.friendly_name
+    return "", ""
 
-    # Wire ``target`` is keyed off ``job.job_type``: CLEAN
-    # dispatches as ``target="clean"`` so the receiver runs
+
+async def _submit_job_to_receiver(
+    *,
+    controller: FirmwareController,
+    job: FirmwareJob,
+    client: PeerLinkClient,
+    bundle_bytes: bytes,
+) -> bool:
+    """Send ``submit_job`` and return ``True`` on accepted ack, ``False`` otherwise."""
+    device_name, device_friendly_name = _local_device_display_for_job(controller, job)
+    # CLEAN goes as target="clean" so the receiver runs
     # ``esphome clean`` after extract; everything else stays on
-    # ``target="compile"`` (the receiver only ever compiles —
-    # UPLOAD / INSTALL come back to flash locally via the
-    # post-completion artifact fetch below).
+    # "compile" — the receiver only ever compiles.
     wire_target: Literal["compile", "clean"] = (
         "clean" if job.job_type is JobType.CLEAN else "compile"
     )
@@ -323,42 +334,28 @@ async def _dispatch_and_drive(  # noqa: PLR0911, PLR0912
             device_friendly_name=device_friendly_name,
         )
     except (PeerLinkNoSessionError, SubmitJobTimeoutError, SubmitJobSessionLostError) as exc:
-        _fail_locally(
-            controller,
-            job,
-            error=f"remote build: dispatch failed: {exc}",
-        )
-        return
-
+        _fail_locally(controller, job, reason=f"dispatch failed: {exc}")
+        return False
     if not ack["accepted"]:
         reason = ack.get("reason", "no reason given")
-        _fail_locally(
-            controller,
-            job,
-            error=f"remote build: receiver rejected job: {reason}",
-        )
-        return
+        _fail_locally(controller, job, reason=f"receiver rejected job: {reason}")
+        return False
+    return True
 
-    wire_status = await _await_terminal(
-        controller=controller,
-        job=job,
-        terminal=terminal,
-        session_lost=session_lost,
-        cancel_event=cancel_event,
-    )
-    if wire_status != "completed":
-        # ``_await_terminal`` already finalised the job (cancel
-        # / failed / session-lost / explicit-cancelled). Nothing
-        # left to do.
-        return
 
-    # Receiver finished its half. CLEAN is wipe-only (no
-    # artifacts to fetch); COMPILE needs the artifacts staged
-    # locally so firmware/download serves them; UPLOAD / INSTALL
-    # need that plus the local flash subprocess.
+async def _finalise_after_receiver_completed(
+    *,
+    controller: FirmwareController,
+    job: FirmwareJob,
+    client: PeerLinkClient,
+) -> None:
+    """Wire the post-completed dispatch by job_type.
+
+    CLEAN finalises immediately (wipe-only). COMPILE / UPLOAD /
+    INSTALL all materialise first; UPLOAD / INSTALL then spawn
+    the local flash subprocess.
+    """
     if job.job_type is JobType.CLEAN:
-        # ``exit_code=0`` stamp keeps the legacy follow_job
-        # framing from coercing ``None`` to a failure code.
         job.exit_code = 0
         _finalize_success(controller, job)
         return
@@ -460,7 +457,7 @@ async def _await_terminal(
                 _fail_locally(
                     controller,
                     job,
-                    error=f"remote build: peer-link session lost ({text})",
+                    reason=f"peer-link session lost ({text})",
                 )
                 return None
             if cancel_event.is_set() and not cancel_sent:
@@ -490,15 +487,10 @@ async def _await_terminal(
         controller._finalize_cancelled(job)
         return None
     if status == "failed":
-        # Receiver-supplied error text rides into ``job.error``;
-        # an empty ``error_message`` (older receiver, internal
-        # bug) falls back to a generic string so subscribers
-        # always see a non-empty reason.
-        _fail_locally(
-            controller,
-            job,
-            error=data["error_message"] or "remote build failed",
-        )
+        # Receiver-supplied error text rides into job.error; an
+        # empty error_message (older receiver, internal bug)
+        # falls back so subscribers always see a non-empty reason.
+        _fail_locally(controller, job, reason=data["error_message"] or "compile failed")
         return None
     # ``completed`` — the only status the caller must act on.
     # Don't finalise here; the caller owes a local flash step
@@ -534,10 +526,7 @@ async def _fetch_and_materialise(
         _fail_locally(
             controller,
             job,
-            error=(
-                f"remote build: download_artifacts failed: {exc} "
-                f"(check the build server logs for details)"
-            ),
+            reason=(f"download_artifacts failed: {exc} (check the build server logs for details)"),
         )
         return False
 
@@ -546,13 +535,13 @@ async def _fetch_and_materialise(
             None, materialise_remote_artifacts, packed.tarball, job.configuration
         )
     except MaterialiseError as exc:
-        _fail_locally(controller, job, error=f"remote build: materialise failed: {exc}")
+        _fail_locally(controller, job, reason=f"materialise failed: {exc}")
         return False
     except OSError as exc:
         # Disk full / permission denied / transient IO. Catch
         # at this seam so the runner task doesn't crash; the
         # MaterialiseError branch covers the wire-shape failures.
-        _fail_locally(controller, job, error=f"remote build: materialise IO error: {exc}")
+        _fail_locally(controller, job, reason=f"materialise IO error: {exc}")
         return False
 
     # Honour a cancel that arrived between the receiver's
@@ -637,7 +626,7 @@ async def _fetch_and_run_local_upload(
         _fail_locally(
             controller,
             job,
-            error=f"remote build: local upload failed (exit {exit_code})",
+            reason=f"local upload failed (exit {exit_code})",
         )
 
 
@@ -771,30 +760,23 @@ async def _send_cancel_or_finalise(
     return True
 
 
+_REMOTE_BUILD_ERROR_PREFIX = "remote build: "
+
+
 def _fail_locally(
     controller: FirmwareController,
     job: FirmwareJob,
     *,
-    error: str,
+    reason: str,
 ) -> None:
-    """Mark *job* FAILED with *error* and fire ``JOB_FAILED`` on the local bus.
+    """Mark *job* FAILED with ``"remote build: {reason}"`` and fire ``JOB_FAILED`` locally.
 
-    Centralises the "remote path can't proceed, finalise
-    terminally" sequence so every early-exit failure branch
-    above stays one line at the call site. The text rides
-    into ``job.error`` so a frontend that already renders
-    ``error`` for local failures shows the remote failure
-    with no special-case code.
-
-    Cancel intent wins: if the user already flipped
-    ``_cancel_requested`` for this job (Stop click landed
-    during bundle build / lookup / dispatch / session-lost
-    detection — anywhere before the receiver could emit a
-    terminal frame), finalise as CANCELLED instead. Mirrors
-    the local subprocess path's contract — a Stop that
-    happened to race a failure should not show up as a red
-    error badge.
+    Cancel intent wins: a Stop that flipped
+    ``_cancel_requested`` before the receiver's terminal frame
+    finalises as CANCELLED instead, mirroring the local
+    subprocess path's contract.
     """
+    error = f"{_REMOTE_BUILD_ERROR_PREFIX}{reason}"
     if job.job_id in controller._cancel_requested:
         controller._finalize_cancelled(job)
         _LOGGER.info("Remote job %s cancelled (failure path: %s)", job.job_id, error)

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/__init__.py
@@ -1,24 +1,9 @@
-"""
-Per-platform build-tree inclusion lists for the remote-build artifact tarball.
+"""Per-platform build-tree inclusion lists for the remote-build artifact tarball.
 
-Each module here exposes ``TARGET_PLATFORM`` (the canonical
-``StorageJSON.target_platform`` value) and ``BUILD_FILES`` (a
-tuple of ``<build_path>``-relative paths the offloader needs to
-flash). Adding a new platform = one new module + one import line
-below.
-
-The libretiny family (``bk72xx`` / ``rtl87xx`` / ``ln882x``)
-re-exports a shared :data:`BUILD_FILES` from :mod:`._libretiny`
-so the three platforms can carry their own ``TARGET_PLATFORM``
-while sharing one inclusion tuple — divergence (if it ever
-happens) costs replacing the alias with a local tuple.
-
-Platform-independent metadata files (``platformio.ini``,
-``<data_dir>/idedata/<name>.json``,
-``<data_dir>/storage/<basename>.json``) ride alongside the
-build tree at fixed top-level tarball names — see
-:func:`controllers.remote_build.artifacts_tarball.pack_build_artifacts`.
-The per-platform modules only carry the build-tree slice.
+Each module exposes ``TARGET_PLATFORM`` and ``BUILD_FILES``
+(basenames under ``<build_path>/.pioenvs/<name>/``). The
+libretiny variants re-export ``BUILD_FILES`` from
+:mod:`._libretiny`.
 """
 
 from __future__ import annotations
@@ -33,17 +18,11 @@ _BY_TARGET: dict[str, tuple[str, ...]] = {
 
 
 def build_files_for_platform(target_platform: str) -> tuple[str, ...]:
-    """Return the build-relative files to include for *target_platform*.
+    """Return basenames under ``.pioenvs/<name>/`` to ship for *target_platform*.
 
-    Empty tuple for an unrecognised platform. The packer treats
-    that as a structural failure and raises so a new platform
-    can't silently ship an under-specified tarball.
-
-    *target_platform* is matched case-insensitively against each
-    module's ``TARGET_PLATFORM`` — upstream's StorageJSON
-    serialises ``esph.target_platform.upper()``
-    (``storage_json.py:160``) so on-disk sidecars carry
-    uppercased values, but lowercase is the canonical form
-    everywhere else in the dashboard.
+    Empty tuple for an unrecognised platform; the packer raises
+    so a new platform can't silently ship an under-specified
+    tarball. Lookup is case-insensitive because upstream
+    StorageJSON stores ``target_platform.upper()``.
     """
     return _BY_TARGET.get(target_platform.lower(), ())

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/__init__.py
@@ -1,0 +1,49 @@
+"""
+Per-platform build-tree inclusion lists for the remote-build artifact tarball.
+
+Each module here exposes ``TARGET_PLATFORM`` (the canonical
+``StorageJSON.target_platform`` value) and ``BUILD_FILES`` (a
+tuple of ``<build_path>``-relative paths the offloader needs to
+flash). Adding a new platform = one new module + one import line
+below.
+
+The libretiny family (``bk72xx`` / ``rtl87xx`` / ``ln882x``)
+re-exports a shared :data:`BUILD_FILES` from :mod:`._libretiny`
+so the three platforms can carry their own ``TARGET_PLATFORM``
+while sharing one inclusion tuple — divergence (if it ever
+happens) costs replacing the alias with a local tuple.
+
+Platform-independent metadata files (``platformio.ini``,
+``<data_dir>/idedata/<name>.json``,
+``<data_dir>/storage/<basename>.json``) ride alongside the
+build tree at fixed top-level tarball names — see
+:func:`controllers.remote_build.artifacts_tarball.pack_build_artifacts`.
+The per-platform modules only carry the build-tree slice.
+"""
+
+from __future__ import annotations
+
+from . import bk72xx, esp32, esp8266, ln882x, nrf52, rp2040, rtl87xx
+
+_PLATFORMS = (bk72xx, esp8266, esp32, ln882x, nrf52, rp2040, rtl87xx)
+
+_BY_TARGET: dict[str, tuple[str, ...]] = {
+    mod.TARGET_PLATFORM.lower(): mod.BUILD_FILES for mod in _PLATFORMS
+}
+
+
+def build_files_for_platform(target_platform: str) -> tuple[str, ...]:
+    """Return the build-relative files to include for *target_platform*.
+
+    Empty tuple for an unrecognised platform. The packer treats
+    that as a structural failure and raises so a new platform
+    can't silently ship an under-specified tarball.
+
+    *target_platform* is matched case-insensitively against each
+    module's ``TARGET_PLATFORM`` — upstream's StorageJSON
+    serialises ``esph.target_platform.upper()``
+    (``storage_json.py:160``) so on-disk sidecars carry
+    uppercased values, but lowercase is the canonical form
+    everywhere else in the dashboard.
+    """
+    return _BY_TARGET.get(target_platform.lower(), ())

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/__init__.py
@@ -1,12 +1,15 @@
 """Per-platform build-tree inclusion lists for the remote-build artifact tarball.
 
 Each module exposes ``TARGET_PLATFORM`` and ``BUILD_FILES``
-(basenames under ``<build_path>/.pioenvs/<name>/``). The
+(build-relative paths with ``{name}`` substitution). The
 libretiny variants re-export ``BUILD_FILES`` from
-:mod:`._libretiny`.
+:mod:`._libretiny`. ESP32 chip variants (``ESP32S3``,
+``ESP32C3``, …) all fold to the ``esp32`` module.
 """
 
 from __future__ import annotations
+
+from esphome.components.esp32 import VARIANTS as _ESP32_VARIANTS
 
 from . import bk72xx, esp32, esp8266, ln882x, nrf52, rp2040, rtl87xx
 
@@ -16,13 +19,15 @@ _BY_TARGET: dict[str, tuple[str, ...]] = {
     mod.TARGET_PLATFORM.lower(): mod.BUILD_FILES for mod in _PLATFORMS
 }
 
+# ESP32 chip variants StorageJSON stores as ``target_platform``
+# (``ESP32S3``, ``ESP32C3``, ``ESP32H2``, …) all build through the
+# umbrella ``esp32`` component, so resolve them to the same module.
+# Sourced from upstream so a new variant lands here without an
+# edit. The base ``"esp32"`` is already in ``_BY_TARGET``.
+for _variant in _ESP32_VARIANTS:
+    _BY_TARGET.setdefault(_variant.lower(), esp32.BUILD_FILES)
+
 
 def build_files_for_platform(target_platform: str) -> tuple[str, ...]:
-    """Return basenames under ``.pioenvs/<name>/`` to ship for *target_platform*.
-
-    Empty tuple for an unrecognised platform; the packer raises
-    so a new platform can't silently ship an under-specified
-    tarball. Lookup is case-insensitive because upstream
-    StorageJSON stores ``target_platform.upper()``.
-    """
+    """Return BUILD_FILES for *target_platform*; empty tuple if unrecognised."""
     return _BY_TARGET.get(target_platform.lower(), ())

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/_libretiny.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/_libretiny.py
@@ -1,26 +1,9 @@
-"""
-Shared BUILD_FILES for the libretiny family (bk72xx / rtl87xx / ln882x).
-
-Upstream's libretiny PlatformIO platform writes the same on-disk
-layout for every variant in the family, so the per-platform modules
-``bk72xx.py`` / ``rtl87xx.py`` / ``ln882x.py`` all re-export this
-tuple. Splitting into three tiny modules keeps the registry walk
-loop-level uniform (one module per ``target_platform`` value) while
-avoiding the maintenance cost of three identical copies.
-
-Esphome's ``CORE.firmware_bin`` for libretiny returns
-``.pioenvs/<name>/firmware.uf2`` (esphome/core/__init__.py:778),
-which is the artefact ``ltchiptool`` flashes over UART. The same
-build also emits ``firmware.bin`` for the native API / web_server
-OTA paths plus ``firmware.elf`` for symbol resolution; we ship all
-three so every install path resolves cleanly against the staged
-tree.
-"""
+"""Shared BUILD_FILES for the libretiny family (bk72xx / rtl87xx / ln882x)."""
 
 from __future__ import annotations
 
 BUILD_FILES: tuple[str, ...] = (
-    ".pioenvs/{name}/firmware.uf2",
-    ".pioenvs/{name}/firmware.bin",
-    ".pioenvs/{name}/firmware.elf",
+    "firmware.uf2",
+    "firmware.bin",
+    "firmware.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/_libretiny.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/_libretiny.py
@@ -1,0 +1,26 @@
+"""
+Shared BUILD_FILES for the libretiny family (bk72xx / rtl87xx / ln882x).
+
+Upstream's libretiny PlatformIO platform writes the same on-disk
+layout for every variant in the family, so the per-platform modules
+``bk72xx.py`` / ``rtl87xx.py`` / ``ln882x.py`` all re-export this
+tuple. Splitting into three tiny modules keeps the registry walk
+loop-level uniform (one module per ``target_platform`` value) while
+avoiding the maintenance cost of three identical copies.
+
+Esphome's ``CORE.firmware_bin`` for libretiny returns
+``.pioenvs/<name>/firmware.uf2`` (esphome/core/__init__.py:778),
+which is the artefact ``ltchiptool`` flashes over UART. The same
+build also emits ``firmware.bin`` for the native API / web_server
+OTA paths plus ``firmware.elf`` for symbol resolution; we ship all
+three so every install path resolves cleanly against the staged
+tree.
+"""
+
+from __future__ import annotations
+
+BUILD_FILES: tuple[str, ...] = (
+    ".pioenvs/{name}/firmware.uf2",
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.elf",
+)

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/_libretiny.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/_libretiny.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 BUILD_FILES: tuple[str, ...] = (
-    "firmware.uf2",
-    "firmware.bin",
-    "firmware.elf",
+    ".pioenvs/{name}/firmware.uf2",
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/bk72xx.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/bk72xx.py
@@ -1,0 +1,17 @@
+"""
+Libretiny BK72xx (Beken) build-tree files.
+
+Shares the libretiny family's BUILD_FILES; see ``_libretiny.py``
+for the rationale and the layout. UART flash on BK72xx uses
+``ltchiptool`` via the PIO upload recipe (``pio run -t upload
+-t nobuild`` reaches it through ``upload_using_platformio``,
+esphome/__main__.py:1155).
+"""
+
+from __future__ import annotations
+
+from ._libretiny import BUILD_FILES
+
+__all__ = ["BUILD_FILES", "TARGET_PLATFORM"]
+
+TARGET_PLATFORM = "bk72xx"

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
@@ -1,0 +1,37 @@
+"""
+ESP32 build-tree files (covers Arduino-on-IDF and native ESP-IDF).
+
+Upstream's ``CORE.firmware_bin`` (esphome/core/__init__.py:774)
+returns ``.pioenvs/<name>/firmware.bin`` for non-libretiny
+non-native-IDF builds; on ESP32 that branch covers both Arduino
+(now built as a framework on top of IDF) and pure ESP-IDF. The
+multi-image flash (``bootloader.bin`` at ``0x1000``,
+``partitions.bin`` at ``0x8000``, ``ota_data_initial.bin`` at
+``0xe000``, ``firmware.bin`` at ``0x10000``) lives entirely under
+``.pioenvs/<name>/``; esptool reads the offsets from idedata's
+``extra.flash_images`` array — the materialiser stages the
+idedata cache file so that lookup hits without invoking
+``pio run -t idedata`` on the offloader.
+
+The native-IDF feature flag (``KEY_NATIVE_IDF``) would push the
+firmware to ``build/<name>.bin`` instead, but device-builder
+doesn't currently surface that flag. If upstream lands it, add a
+new ``esp32_native_idf.py`` module rather than forking the
+inclusion list inside this one.
+"""
+
+from __future__ import annotations
+
+TARGET_PLATFORM = "esp32"
+
+# Build-relative paths. ``{name}`` is filled in with
+# ``StorageJSON.name`` at pack time. Files that don't exist on
+# disk are silently skipped (e.g. a build that didn't emit
+# ``ota_data_initial.bin``).
+BUILD_FILES: tuple[str, ...] = (
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.elf",
+    ".pioenvs/{name}/bootloader.bin",
+    ".pioenvs/{name}/partitions.bin",
+    ".pioenvs/{name}/ota_data_initial.bin",
+)

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 TARGET_PLATFORM = "esp32"
 
-# Basenames under <build_path>/.pioenvs/<name>/. Files that don't
-# exist on disk are silently skipped.
+# Build-relative paths. ``{name}`` substitutes ``StorageJSON.name``
+# at pack time. Files missing on disk are silently skipped. Paths
+# outside ``.pioenvs/<name>/`` are fine — native ESP-IDF's
+# ``build/firmware.factory.bin`` would land here without
+# special-casing if/when device-builder surfaces it.
 BUILD_FILES: tuple[str, ...] = (
-    "firmware.bin",
-    "firmware.elf",
-    "bootloader.bin",
-    "partitions.bin",
-    "ota_data_initial.bin",
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.elf",
+    ".pioenvs/{name}/firmware.factory.bin",
+    ".pioenvs/{name}/bootloader.bin",
+    ".pioenvs/{name}/partitions.bin",
+    ".pioenvs/{name}/ota_data_initial.bin",
+    # Native ESP-IDF (non-PIO) layout — only present when the
+    # build went through ``KEY_NATIVE_IDF``; harmlessly skipped
+    # otherwise.
+    "build/firmware.factory.bin",
+    "build/{name}.bin",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
@@ -1,37 +1,15 @@
-"""
-ESP32 build-tree files (covers Arduino-on-IDF and native ESP-IDF).
-
-Upstream's ``CORE.firmware_bin`` (esphome/core/__init__.py:774)
-returns ``.pioenvs/<name>/firmware.bin`` for non-libretiny
-non-native-IDF builds; on ESP32 that branch covers both Arduino
-(now built as a framework on top of IDF) and pure ESP-IDF. The
-multi-image flash (``bootloader.bin`` at ``0x1000``,
-``partitions.bin`` at ``0x8000``, ``ota_data_initial.bin`` at
-``0xe000``, ``firmware.bin`` at ``0x10000``) lives entirely under
-``.pioenvs/<name>/``; esptool reads the offsets from idedata's
-``extra.flash_images`` array — the materialiser stages the
-idedata cache file so that lookup hits without invoking
-``pio run -t idedata`` on the offloader.
-
-The native-IDF feature flag (``KEY_NATIVE_IDF``) would push the
-firmware to ``build/<name>.bin`` instead, but device-builder
-doesn't currently surface that flag. If upstream lands it, add a
-new ``esp32_native_idf.py`` module rather than forking the
-inclusion list inside this one.
-"""
+"""ESP32 build-tree files (covers Arduino-on-IDF and native ESP-IDF)."""
 
 from __future__ import annotations
 
 TARGET_PLATFORM = "esp32"
 
-# Build-relative paths. ``{name}`` is filled in with
-# ``StorageJSON.name`` at pack time. Files that don't exist on
-# disk are silently skipped (e.g. a build that didn't emit
-# ``ota_data_initial.bin``).
+# Basenames under <build_path>/.pioenvs/<name>/. Files that don't
+# exist on disk are silently skipped.
 BUILD_FILES: tuple[str, ...] = (
-    ".pioenvs/{name}/firmware.bin",
-    ".pioenvs/{name}/firmware.elf",
-    ".pioenvs/{name}/bootloader.bin",
-    ".pioenvs/{name}/partitions.bin",
-    ".pioenvs/{name}/ota_data_initial.bin",
+    "firmware.bin",
+    "firmware.elf",
+    "bootloader.bin",
+    "partitions.bin",
+    "ota_data_initial.bin",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
@@ -12,7 +12,11 @@ TARGET_PLATFORM = "esp32"
 BUILD_FILES: tuple[str, ...] = (
     ".pioenvs/{name}/firmware.bin",
     ".pioenvs/{name}/firmware.elf",
+    # ``firmware.factory.bin`` + ``firmware.ota.bin`` are the
+    # download options esphome's ``get_download_types`` lists
+    # for ESP32.
     ".pioenvs/{name}/firmware.factory.bin",
+    ".pioenvs/{name}/firmware.ota.bin",
     ".pioenvs/{name}/bootloader.bin",
     ".pioenvs/{name}/partitions.bin",
     ".pioenvs/{name}/ota_data_initial.bin",

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp8266.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp8266.py
@@ -1,21 +1,10 @@
-"""
-ESP8266 build-tree files.
-
-Single-image flash: the eboot bootloader is integrated into the
-firmware image, so there's no separate ``bootloader.bin`` /
-``partitions.bin``. ``esphome upload`` dispatches through
-``upload_using_esptool`` for serial flash (esphome/__main__.py:1152)
-and through the native API / web_server OTA path for everything
-else, both keying off ``CORE.firmware_bin`` which lands at
-``.pioenvs/<name>/firmware.bin`` (esphome/core/__init__.py:780).
-``firmware.elf`` rides along for crash-dump symbol resolution.
-"""
+"""ESP8266 build-tree files (eboot bootloader is in the firmware image — single flash)."""
 
 from __future__ import annotations
 
 TARGET_PLATFORM = "esp8266"
 
 BUILD_FILES: tuple[str, ...] = (
-    ".pioenvs/{name}/firmware.bin",
-    ".pioenvs/{name}/firmware.elf",
+    "firmware.bin",
+    "firmware.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp8266.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp8266.py
@@ -5,6 +5,6 @@ from __future__ import annotations
 TARGET_PLATFORM = "esp8266"
 
 BUILD_FILES: tuple[str, ...] = (
-    "firmware.bin",
-    "firmware.elf",
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp8266.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp8266.py
@@ -1,0 +1,21 @@
+"""
+ESP8266 build-tree files.
+
+Single-image flash: the eboot bootloader is integrated into the
+firmware image, so there's no separate ``bootloader.bin`` /
+``partitions.bin``. ``esphome upload`` dispatches through
+``upload_using_esptool`` for serial flash (esphome/__main__.py:1152)
+and through the native API / web_server OTA path for everything
+else, both keying off ``CORE.firmware_bin`` which lands at
+``.pioenvs/<name>/firmware.bin`` (esphome/core/__init__.py:780).
+``firmware.elf`` rides along for crash-dump symbol resolution.
+"""
+
+from __future__ import annotations
+
+TARGET_PLATFORM = "esp8266"
+
+BUILD_FILES: tuple[str, ...] = (
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.elf",
+)

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/ln882x.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/ln882x.py
@@ -1,0 +1,14 @@
+"""
+Libretiny LN882x (Lightning) build-tree files.
+
+Shares the libretiny family's BUILD_FILES; see ``_libretiny.py``
+for the rationale and the layout.
+"""
+
+from __future__ import annotations
+
+from ._libretiny import BUILD_FILES
+
+__all__ = ["BUILD_FILES", "TARGET_PLATFORM"]
+
+TARGET_PLATFORM = "ln882x"

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/nrf52.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/nrf52.py
@@ -1,27 +1,12 @@
-"""
-nRF52 (Zephyr) build-tree files.
-
-The nRF52 platform component ships its own ``upload_program``
-(esphome/components/nrf52/__init__.py:407) which reads
-``CORE.relative_pioenvs_path(CORE.name, "zephyr", "app_update.bin")``
-for BLE OTA via smpclient. We ship that file plus ``zephyr.elf``
-for symbol resolution; both live under ``.pioenvs/<name>/zephyr/``.
-
-``CORE.firmware_bin`` falls through to the default branch
-(esphome/core/__init__.py:780) returning
-``.pioenvs/<name>/firmware.bin`` — Zephyr also emits that file
-as a side-effect of the smpclient build, so we ship it too for
-any fallback path that resolves through StorageJSON.firmware_bin_path
-(the dashboard's firmware/download endpoint, build_size helpers).
-"""
+"""nRF52 (Zephyr) build-tree files (BLE OTA reads zephyr/app_update.bin)."""
 
 from __future__ import annotations
 
 TARGET_PLATFORM = "nrf52"
 
 BUILD_FILES: tuple[str, ...] = (
-    ".pioenvs/{name}/firmware.bin",
-    ".pioenvs/{name}/firmware.elf",
-    ".pioenvs/{name}/zephyr/app_update.bin",
-    ".pioenvs/{name}/zephyr/zephyr.elf",
+    "firmware.bin",
+    "firmware.elf",
+    "zephyr/app_update.bin",
+    "zephyr/zephyr.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/nrf52.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/nrf52.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 TARGET_PLATFORM = "nrf52"
 
 BUILD_FILES: tuple[str, ...] = (
-    "firmware.bin",
-    "firmware.elf",
-    "zephyr/app_update.bin",
-    "zephyr/zephyr.elf",
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.elf",
+    ".pioenvs/{name}/zephyr/app_update.bin",
+    ".pioenvs/{name}/zephyr/zephyr.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/nrf52.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/nrf52.py
@@ -7,6 +7,13 @@ TARGET_PLATFORM = "nrf52"
 BUILD_FILES: tuple[str, ...] = (
     ".pioenvs/{name}/firmware.bin",
     ".pioenvs/{name}/firmware.elf",
+    # ``get_download_types`` for nRF52 lists zephyr.uf2 +
+    # firmware.zip when the UF2 build is present, or zephyr.hex
+    # / merged.hex + app_update.bin for the SWD/BLE-OTA path.
+    ".pioenvs/{name}/zephyr/zephyr.uf2",
+    ".pioenvs/{name}/firmware.zip",
+    ".pioenvs/{name}/zephyr/zephyr.hex",
+    ".pioenvs/{name}/zephyr/merged.hex",
     ".pioenvs/{name}/zephyr/app_update.bin",
     ".pioenvs/{name}/zephyr/zephyr.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/nrf52.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/nrf52.py
@@ -1,0 +1,27 @@
+"""
+nRF52 (Zephyr) build-tree files.
+
+The nRF52 platform component ships its own ``upload_program``
+(esphome/components/nrf52/__init__.py:407) which reads
+``CORE.relative_pioenvs_path(CORE.name, "zephyr", "app_update.bin")``
+for BLE OTA via smpclient. We ship that file plus ``zephyr.elf``
+for symbol resolution; both live under ``.pioenvs/<name>/zephyr/``.
+
+``CORE.firmware_bin`` falls through to the default branch
+(esphome/core/__init__.py:780) returning
+``.pioenvs/<name>/firmware.bin`` — Zephyr also emits that file
+as a side-effect of the smpclient build, so we ship it too for
+any fallback path that resolves through StorageJSON.firmware_bin_path
+(the dashboard's firmware/download endpoint, build_size helpers).
+"""
+
+from __future__ import annotations
+
+TARGET_PLATFORM = "nrf52"
+
+BUILD_FILES: tuple[str, ...] = (
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.elf",
+    ".pioenvs/{name}/zephyr/app_update.bin",
+    ".pioenvs/{name}/zephyr/zephyr.elf",
+)

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
@@ -1,0 +1,30 @@
+"""
+RP2040 build-tree files.
+
+Two flash paths share this module:
+
+* **BOOTSEL** (``upload_using_picotool``, esphome/__main__.py:992) —
+  reads ``idedata.firmware_elf_path`` and uses ``cc_path`` to
+  locate ``picotool`` in the same PIO packages dir. The
+  materialiser remaps ``cc_path``'s PIO core prefix so picotool
+  resolves on the offloader (see
+  ``helpers.remote_artifacts_materialise._remap_pio_toolchain_path``).
+* **Serial** (``upload_using_platformio``, esphome/__main__.py:961) —
+  spawns ``pio run -t upload -t nobuild`` which reads ``firmware.uf2``
+  / ``firmware.bin`` per the PIO recipe.
+
+``firmware.elf`` is mandatory for BOOTSEL (picotool needs the
+ELF, not just the UF2); ``firmware.uf2`` is mandatory for both
+the BOOTSEL "drag onto mass-storage" path and the PIO upload
+recipe; ``firmware.bin`` rides along for OTA.
+"""
+
+from __future__ import annotations
+
+TARGET_PLATFORM = "rp2040"
+
+BUILD_FILES: tuple[str, ...] = (
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.uf2",
+    ".pioenvs/{name}/firmware.elf",
+)

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
@@ -7,5 +7,7 @@ TARGET_PLATFORM = "rp2040"
 BUILD_FILES: tuple[str, ...] = (
     ".pioenvs/{name}/firmware.bin",
     ".pioenvs/{name}/firmware.uf2",
+    # ``get_download_types`` lists firmware.uf2 + firmware.ota.bin.
+    ".pioenvs/{name}/firmware.ota.bin",
     ".pioenvs/{name}/firmware.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 TARGET_PLATFORM = "rp2040"
 
 BUILD_FILES: tuple[str, ...] = (
-    "firmware.bin",
-    "firmware.uf2",
-    "firmware.elf",
+    ".pioenvs/{name}/firmware.bin",
+    ".pioenvs/{name}/firmware.uf2",
+    ".pioenvs/{name}/firmware.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
@@ -1,30 +1,11 @@
-"""
-RP2040 build-tree files.
-
-Two flash paths share this module:
-
-* **BOOTSEL** (``upload_using_picotool``, esphome/__main__.py:992) —
-  reads ``idedata.firmware_elf_path`` and uses ``cc_path`` to
-  locate ``picotool`` in the same PIO packages dir. The
-  materialiser remaps ``cc_path``'s PIO core prefix so picotool
-  resolves on the offloader (see
-  ``helpers.remote_artifacts_materialise._remap_pio_toolchain_path``).
-* **Serial** (``upload_using_platformio``, esphome/__main__.py:961) —
-  spawns ``pio run -t upload -t nobuild`` which reads ``firmware.uf2``
-  / ``firmware.bin`` per the PIO recipe.
-
-``firmware.elf`` is mandatory for BOOTSEL (picotool needs the
-ELF, not just the UF2); ``firmware.uf2`` is mandatory for both
-the BOOTSEL "drag onto mass-storage" path and the PIO upload
-recipe; ``firmware.bin`` rides along for OTA.
-"""
+"""RP2040 build-tree files (BOOTSEL via picotool + .uf2; serial via PIO)."""
 
 from __future__ import annotations
 
 TARGET_PLATFORM = "rp2040"
 
 BUILD_FILES: tuple[str, ...] = (
-    ".pioenvs/{name}/firmware.bin",
-    ".pioenvs/{name}/firmware.uf2",
-    ".pioenvs/{name}/firmware.elf",
+    "firmware.bin",
+    "firmware.uf2",
+    "firmware.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/rtl87xx.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/rtl87xx.py
@@ -1,0 +1,14 @@
+"""
+Libretiny RTL87xx (Realtek) build-tree files.
+
+Shares the libretiny family's BUILD_FILES; see ``_libretiny.py``
+for the rationale and the layout.
+"""
+
+from __future__ import annotations
+
+from ._libretiny import BUILD_FILES
+
+__all__ = ["BUILD_FILES", "TARGET_PLATFORM"]
+
+TARGET_PLATFORM = "rtl87xx"

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -105,46 +105,13 @@ class PackedArtifacts:
 def pack_build_artifacts(configuration: str) -> PackedArtifacts:
     """Pack the build for *configuration* into the materialise-locally tarball.
 
-    Synchronous; meant to run inside an executor. Reads the
-    receiver's StorageJSON sidecar to discover the build path
-    and target platform, picks the build-tree inclusion list
-    from :mod:`controllers.remote_build.artifact_platforms`,
-    and tars three platform-independent metadata members
-    (``storage.json``, ``idedata.json``, ``platformio.ini``)
-    plus every existing per-platform build-tree file into one
-    gzipped stream.
-
-    Tarball layout matches the module docstring. The offloader
-    side has two consumers:
-
-    * :func:`helpers.remote_artifacts_materialise.materialise_remote_artifacts`
-      reads ``storage.json`` + ``idedata.json``, rewrites
-      receiver-absolute path fields, stages everything at the
-      offloader's canonical paths so ``esphome upload`` /
-      ``firmware/download`` resolve cleanly.
-    * :func:`unpack_artifacts_response` reads ``idedata.json``
-      + every flash image (keyed by basename, ignoring
-      ``storage.json`` / ``platformio.ini``) and returns the
-      multi-image response shape the browser-side Web Serial
-      flasher consumes.
-
-    Raises :class:`FileNotFoundError` when the StorageJSON
-    sidecar / its required path fields / the cached idedata /
-    ``platformio.ini`` aren't on disk. Raises
-    :class:`RuntimeError` on unknown ``target_platform`` (a
-    platform that doesn't have an
-    :mod:`controllers.remote_build.artifact_platforms` module
-    is treated as a structural drift between the dashboard's
-    inclusion lists and ESPHome's platform support) or when
-    the artifact set exceeds :data:`FIRMWARE_MAX_TOTAL_BYTES`.
-    Two cap checks: a per-member walking sum inside the tar loop
-    (short-circuits when an individual file would already push
-    the total past the limit) plus a final compressed-size check
-    on the rendered tarball (the offloader's BundleAssembler caps
-    on ``ArtifactsStartFrameData.total_bytes``, the wire-side
-    length, so the two sides must agree). The caller
-    (:meth:`ArtifactsDownloadSender.handle_download_artifacts`)
-    catches both and surfaces a structured reject reason.
+    Synchronous; meant to run inside an executor. Raises
+    :class:`FileNotFoundError` when the StorageJSON sidecar /
+    cached idedata / platformio.ini aren't on disk;
+    :class:`RuntimeError` on unknown ``target_platform`` or
+    when the artifact set exceeds :data:`FIRMWARE_MAX_TOTAL_BYTES`
+    (per-member walking sum + post-render check, the latter
+    matching the offloader-side BundleAssembler cap).
     """
     storage_path = resolve_storage_path(configuration)
     storage = StorageJSON.load(storage_path)
@@ -312,41 +279,47 @@ def read_artifacts_tarball(tarball: bytes) -> tuple[dict[str, Any], dict[str, by
     bound would let a hostile peer expand a few-KiB tarball
     into multi-GiB memory.
     """
-    idedata: dict[str, Any] | None = None
-    image_bytes_by_name: dict[str, bytes] = {}
-    # Track which full member path each basename came from so
-    # the duplicate-basename error message can name both.
-    basename_origin: dict[str, str] = {}
-    total_bytes = 0
     try:
         with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
-            for member in tar:
-                _check_member_size(member, total_so_far=total_bytes)
-                payload = _read_tarball_member(tar, member)
-                total_bytes += len(payload)
-                if member.name == IDEDATA_MEMBER_NAME:
-                    idedata = _parse_idedata(payload)
-                    continue
-                if member.name in _METADATA_MEMBERS:
-                    # storage.json + platformio.ini are
-                    # materialiser-only; the WS-adapter doesn't
-                    # surface them.
-                    continue
-                basename = Path(member.name).name
-                if basename in image_bytes_by_name:
-                    msg = (
-                        f"duplicate basename {basename!r} in artifacts tarball: "
-                        f"{basename_origin[basename]!r} and {member.name!r}"
-                    )
-                    raise UnpackArtifactsError(msg)
-                image_bytes_by_name[basename] = payload
-                basename_origin[basename] = member.name
+            idedata, image_bytes_by_name = _walk_artifacts_members(tar)
     except tarfile.TarError as exc:
         msg = f"artifacts tarball is malformed: {exc}"
         raise UnpackArtifactsError(msg) from exc
     if idedata is None:
         msg = "artifacts tarball missing idedata.json"
         raise UnpackArtifactsError(msg)
+    return idedata, image_bytes_by_name
+
+
+def _walk_artifacts_members(
+    tar: tarfile.TarFile,
+) -> tuple[dict[str, Any] | None, dict[str, bytes]]:
+    """Walk *tar*'s members; return (idedata-or-None, basename → bytes)."""
+    idedata: dict[str, Any] | None = None
+    image_bytes_by_name: dict[str, bytes] = {}
+    # Origin path per basename so the duplicate-basename error
+    # message can name both members.
+    basename_origin: dict[str, str] = {}
+    total_bytes = 0
+    for member in tar:
+        _check_member_size(member, total_so_far=total_bytes)
+        payload = _read_tarball_member(tar, member)
+        total_bytes += len(payload)
+        if member.name == IDEDATA_MEMBER_NAME:
+            idedata = _parse_idedata(payload)
+            continue
+        if member.name in _METADATA_MEMBERS:
+            # storage.json + platformio.ini are materialiser-only.
+            continue
+        basename = Path(member.name).name
+        if basename in image_bytes_by_name:
+            msg = (
+                f"duplicate basename {basename!r} in artifacts tarball: "
+                f"{basename_origin[basename]!r} and {member.name!r}"
+            )
+            raise UnpackArtifactsError(msg)
+        image_bytes_by_name[basename] = payload
+        basename_origin[basename] = member.name
     return idedata, image_bytes_by_name
 
 

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -226,7 +226,7 @@ def _download_type_files(storage: StorageJSON) -> list[str]:
         module = importlib.import_module(f"esphome.components.{component}")
         return [entry["file"] for entry in module.get_download_types(storage)]
     except Exception:
-        _LOGGER.warning(
+        _LOGGER.exception(
             "Could not determine download types for target_platform=%r",
             storage.target_platform,
         )

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -102,7 +102,7 @@ class PackedArtifacts:
     firmware_offset: str
 
 
-def pack_build_artifacts(configuration: str) -> PackedArtifacts:
+def pack_build_artifacts(configuration: str) -> PackedArtifacts:  # noqa: PLR0915
     """Pack the build for *configuration* into the materialise-locally tarball.
 
     Synchronous; meant to run inside an executor. Raises
@@ -123,6 +123,9 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:
         raise FileNotFoundError(msg)
     if storage.build_path is None:
         msg = f"build_path unset in StorageJSON for {configuration}"
+        raise FileNotFoundError(msg)
+    if not isinstance(storage.name, str) or not storage.name:
+        msg = f"StorageJSON name unset / non-string for {configuration}: {storage.name!r}"
         raise FileNotFoundError(msg)
 
     target_platform = (storage.target_platform or "").lower()
@@ -167,15 +170,18 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:
     total_uncompressed = 0
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         for arcname, src in (*metadata_members, *build_members):
-            payload = src.read_bytes()
-            total_uncompressed += len(payload)
-            if total_uncompressed > FIRMWARE_MAX_TOTAL_BYTES:
+            # Stat before read so a runaway build artefact trips
+            # the cap before we allocate its bytes into memory.
+            file_size = src.stat().st_size
+            if total_uncompressed + file_size > FIRMWARE_MAX_TOTAL_BYTES:
                 msg = (
                     f"build artifacts for {configuration} would exceed "
                     f"FIRMWARE_MAX_TOTAL_BYTES uncompressed "
-                    f"({total_uncompressed} > {FIRMWARE_MAX_TOTAL_BYTES})"
+                    f"({total_uncompressed + file_size} > {FIRMWARE_MAX_TOTAL_BYTES})"
                 )
                 raise RuntimeError(msg)
+            payload = src.read_bytes()
+            total_uncompressed += len(payload)
             info = tarfile.TarInfo(name=arcname)
             info.size = len(payload)
             tar.addfile(info, io.BytesIO(payload))

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -2,50 +2,84 @@
 Pack / unpack the receiver's build-artifact tarball.
 
 The remote-build feature ships compiled firmware between two
-dashboards by serialising the receiver's flash-artifact set
-(``firmware.bin`` plus the platform's auxiliary images +
-``idedata.json``) into a single gzipped tarball. This module
-owns the pack + unpack helpers — pure data transforms with no
-WS / wire-flow knowledge — so the two end-to-end surfaces that
-consume the format (the receiver-side
-:class:`ArtifactsDownloadSender` streamer and the offloader-side
-``download_artifacts`` WS unpacker / source-routed runner) call
-into one place instead of re-implementing the format twice.
+dashboards by serialising the receiver's build tree into a
+single gzipped tarball. This module owns the pack + unpack
+helpers — pure data transforms with no WS / wire-flow
+knowledge — so the two end-to-end surfaces that consume the
+format (the receiver-side :class:`ArtifactsDownloadSender`
+streamer and the offloader-side ``download_artifacts`` WS
+unpacker / source-routed runner) call into one place instead
+of re-implementing the format twice.
 
-Tarball layout (flat — no subdirectories):
+Tarball layout (materialise-locally wire format):
 
 .. code-block:: text
 
-    idedata.json
-    firmware.bin
-    bootloader.bin       (ESP32 / native IDF only)
-    partitions.bin       (ESP32 / native IDF only)
-    ota_data_initial.bin (ESP32 / native IDF only)
+    storage.json     # receiver's <data_dir>/storage/<basename>.json
+    idedata.json     # receiver's <data_dir>/idedata/<name>.json (esphome's cache copy)
+    platformio.ini   # receiver's <build_path>/platformio.ini
+    <per-platform build-tree files>  # see artifact_platforms/*.py
 
-The offsets for each image live inside ``idedata.json``'s
-``extra.flash_images`` array (and on the receiver-resolved
-``firmware_offset`` for ``firmware.bin`` itself, which upstream
-tracks separately from the ``extra`` block). The receiver's
-absolute build-dir paths in the manifest are rewritten to
-basenames on the offloader side — see
-:func:`_rewrite_idedata_paths`.
+The three metadata members at the top of the tarball are
+platform-independent — every build ships them. The
+:mod:`controllers.remote_build.artifact_platforms` registry
+drives which build-tree files travel alongside them; see the
+per-platform modules for the exact paths each platform ships.
+
+The offloader-side materialiser
+(:func:`helpers.remote_artifacts_materialise.materialise_remote_artifacts`)
+reads ``storage.json`` + ``idedata.json``, rewrites their
+receiver-absolute path fields to offloader-absolute, and stages
+them at the offloader's canonical cache locations:
+``<data_dir>/storage/<basename>.json`` and
+``<data_dir>/idedata/<name>.json``. The build tree extracts as-is
+under ``<data_dir>/build/<name>/``.
+
+The :func:`unpack_artifacts_response` adapter is a separate
+consumer — it serves the multi-image set to the browser-side
+Web Serial flasher via the offloader's
+``remote_build/download_artifacts`` WS command, keyed by image
+basename (the frontend doesn't care about the build-tree
+layout). See :func:`_rewrite_idedata_paths` for the basename
+rewrite the frontend's lookup relies on.
 """
 
 from __future__ import annotations
 
 import base64
 import io
+import logging
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from ...helpers.build_artifacts import load_build_artifacts
+from esphome.storage_json import StorageJSON
+
+from ...helpers.build_artifacts import _firmware_offset_for_platform
 from ...helpers.json import loads as json_loads
 from ...helpers.peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
+from ...helpers.storage_path import resolve_idedata_path, resolve_storage_path
+from .artifact_platforms import build_files_for_platform
 
 if TYPE_CHECKING:
     from .peer_link_client import DownloadArtifactsResult
+
+_LOGGER = logging.getLogger(__name__)
+
+# Tarball member names that ride alongside the build tree. The
+# offloader-side materialiser pulls these out of the tarball and
+# stages them at the offloader's canonical cache locations; the
+# WS-adapter (:func:`unpack_artifacts_response`) ignores
+# ``storage.json`` / ``platformio.ini`` (they're not flash images)
+# and reads ``idedata.json`` to recover the upstream-canonical
+# flash-image manifest.
+STORAGE_MEMBER_NAME = "storage.json"
+IDEDATA_MEMBER_NAME = "idedata.json"
+PLATFORMIO_INI_MEMBER_NAME = "platformio.ini"
+_METADATA_MEMBERS: frozenset[str] = frozenset(
+    {STORAGE_MEMBER_NAME, IDEDATA_MEMBER_NAME, PLATFORMIO_INI_MEMBER_NAME}
+)
 
 
 # ---------------------------------------------------------------------------
@@ -72,31 +106,43 @@ class PackedArtifacts:
 
 
 def pack_build_artifacts(configuration: str) -> PackedArtifacts:
-    """Pack the build's flash artifacts for *configuration* into a gzipped tarball.
+    """Pack the build for *configuration* into the materialise-locally tarball.
 
-    Synchronous; meant to run inside an executor. Calls
-    :func:`helpers.build_artifacts.load_build_artifacts` to
-    discover the flash-image set + idedata bytes, then packs
-    every image (flattened to its basename) +
-    ``idedata.json`` into a single gzipped tarball.
+    Synchronous; meant to run inside an executor. Reads the
+    receiver's StorageJSON sidecar to discover the build path
+    and target platform, picks the build-tree inclusion list
+    from :mod:`controllers.remote_build.artifact_platforms`,
+    and tars three platform-independent metadata members
+    (``storage.json``, ``idedata.json``, ``platformio.ini``)
+    plus every existing per-platform build-tree file into one
+    gzipped stream.
 
-    Tarball layout matches the module docstring; flat files
-    only. The offloader-side install path needs the bytes +
-    the offsets from ``idedata.extra.flash_images`` (plus
-    ``firmware.bin``'s offset on the start frame because
-    upstream tracks the firmware partition separately).
+    Tarball layout matches the module docstring. The offloader
+    side has two consumers:
 
-    Raises :class:`FileNotFoundError` from
-    :func:`load_build_artifacts` when the StorageJSON sidecar
-    or any required artifact is missing. Raises
-    :class:`RuntimeError` on duplicate-basename collision
-    (defensive — upstream esphome doesn't emit this shape
-    today, but we fail loudly rather than ship a silently-
-    truncated set) or when the artifact set exceeds
-    :data:`FIRMWARE_MAX_TOTAL_BYTES`. Two cap checks fire:
-    the uncompressed walking sum (cheap, lets us short-
-    circuit before reading huge files), and a final
-    compressed-size check on the rendered tarball (the
+    * :func:`helpers.remote_artifacts_materialise.materialise_remote_artifacts`
+      reads ``storage.json`` + ``idedata.json``, rewrites
+      receiver-absolute path fields, stages everything at the
+      offloader's canonical paths so ``esphome upload`` /
+      ``firmware/download`` resolve cleanly.
+    * :func:`unpack_artifacts_response` reads ``idedata.json``
+      + every flash image (keyed by basename, ignoring
+      ``storage.json`` / ``platformio.ini``) and returns the
+      multi-image response shape the browser-side Web Serial
+      flasher consumes.
+
+    Raises :class:`FileNotFoundError` when the StorageJSON
+    sidecar / its required path fields / the cached idedata /
+    ``platformio.ini`` aren't on disk. Raises
+    :class:`RuntimeError` on unknown ``target_platform`` (a
+    platform that doesn't have an
+    :mod:`controllers.remote_build.artifact_platforms` module
+    is treated as a structural drift between the dashboard's
+    inclusion lists and ESPHome's platform support) or when
+    the artifact set exceeds :data:`FIRMWARE_MAX_TOTAL_BYTES`.
+    Two cap checks fire: the uncompressed walking sum (cheap,
+    lets us short-circuit before reading huge files), and a
+    final compressed-size check on the rendered tarball (the
     offloader's :class:`BundleAssembler` caps on
     ``ArtifactsStartFrameData.total_bytes``, the wire-side
     length, so the receiver-side ceiling needs to match).
@@ -108,31 +154,62 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:
     (:meth:`ArtifactsDownloadSender.handle_download_artifacts`)
     catches both and surfaces a structured reject reason.
     """
-    artifacts = load_build_artifacts(configuration)
-    buf = io.BytesIO()
-    total_uncompressed = len(artifacts.idedata_bytes)
-    if total_uncompressed > FIRMWARE_MAX_TOTAL_BYTES:
+    storage_path = resolve_storage_path(configuration)
+    storage = StorageJSON.load(storage_path)
+    if storage is None:
+        msg = f"StorageJSON sidecar missing for {configuration}: {storage_path}"
+        raise FileNotFoundError(msg)
+    if storage.firmware_bin_path is None:
+        msg = f"firmware_bin_path unset in StorageJSON for {configuration}"
+        raise FileNotFoundError(msg)
+    if storage.build_path is None:
+        msg = f"build_path unset in StorageJSON for {configuration}"
+        raise FileNotFoundError(msg)
+
+    target_platform = (storage.target_platform or "").lower()
+    build_templates = build_files_for_platform(target_platform)
+    if not build_templates:
         msg = (
-            f"idedata.json for {configuration} ({total_uncompressed} bytes) "
-            f"already exceeds FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
+            f"no artifact_platforms module for target_platform="
+            f"{storage.target_platform!r} (configuration={configuration!r})"
         )
         raise RuntimeError(msg)
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        # ``idedata.json`` first so the offloader can peek at
-        # the manifest before chunking the binaries.
-        info = tarfile.TarInfo(name="idedata.json")
-        info.size = len(artifacts.idedata_bytes)
-        tar.addfile(info, io.BytesIO(artifacts.idedata_bytes))
 
-        seen_names: set[str] = set()
-        for image in artifacts.flash_images:
-            name = image.path.name
-            if name in seen_names:
-                msg = f"duplicate flash image basename {name!r} in idedata"
-                raise RuntimeError(msg)
-            seen_names.add(name)
-            image_bytes = image.path.read_bytes()
-            total_uncompressed += len(image_bytes)
+    build_path = Path(storage.build_path)
+    idedata_cache_path = resolve_idedata_path(configuration, name=storage.name)
+    platformio_ini = build_path / "platformio.ini"
+    if not idedata_cache_path.is_file():
+        msg = f"idedata cache missing for {configuration}: {idedata_cache_path}"
+        raise FileNotFoundError(msg)
+    if not platformio_ini.is_file():
+        msg = f"platformio.ini missing for {configuration}: {platformio_ini}"
+        raise FileNotFoundError(msg)
+
+    firmware_offset = _firmware_offset_for_platform(storage.target_platform or "")
+
+    # Build the file list: three platform-independent metadata
+    # members at the top, then every existing build-tree file
+    # from the platform's BUILD_FILES. Files that don't exist
+    # on disk are silently skipped (a build that didn't emit
+    # ``ota_data_initial.bin`` shouldn't fail the pack).
+    metadata_members: list[tuple[str, Path]] = [
+        (STORAGE_MEMBER_NAME, storage_path),
+        (IDEDATA_MEMBER_NAME, idedata_cache_path),
+        (PLATFORMIO_INI_MEMBER_NAME, platformio_ini),
+    ]
+    build_members: list[tuple[str, Path]] = []
+    for template in build_templates:
+        rel_path = template.format(name=storage.name)
+        abs_path = build_path / rel_path
+        if abs_path.is_file():
+            build_members.append((rel_path, abs_path))
+
+    buf = io.BytesIO()
+    total_uncompressed = 0
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for arcname, src in (*metadata_members, *build_members):
+            payload = src.read_bytes()
+            total_uncompressed += len(payload)
             if total_uncompressed > FIRMWARE_MAX_TOTAL_BYTES:
                 msg = (
                     f"build artifacts for {configuration} would exceed "
@@ -140,27 +217,15 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:
                     f"({total_uncompressed} > {FIRMWARE_MAX_TOTAL_BYTES})"
                 )
                 raise RuntimeError(msg)
-            info = tarfile.TarInfo(name=name)
-            info.size = len(image_bytes)
-            tar.addfile(info, io.BytesIO(image_bytes))
+            info = tarfile.TarInfo(name=arcname)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
 
-    # ``flash_images[0]`` is firmware.bin (load_build_artifacts
-    # invariant) — its offset is the value the offloader needs
-    # for the start frame, since idedata.json's manifest
-    # doesn't include the firmware partition itself.
     tarball = buf.getvalue()
-    # Final post-render cap on the wire-side length. The
-    # uncompressed-walking gate above already short-circuits
-    # the common case, but tar adds 512-byte headers per
-    # member and gzip can grow incompressible data by a few
-    # percent — for an artifact set that lands right at the
-    # limit, ``len(tarball)`` could in principle exceed the
-    # uncompressed total even though the body fits. The
-    # offloader's ``BundleAssembler`` caps on
-    # ``ArtifactsStartFrameData.total_bytes`` (the
-    # post-render length), so without this match the receiver
-    # could deterministically ship a stream the offloader
-    # rejects.
+    # Final post-render cap on the wire-side length. See the
+    # docstring for the rationale on why the post-render check
+    # exists even when the uncompressed walking gate above
+    # already passed.
     if len(tarball) > FIRMWARE_MAX_TOTAL_BYTES:
         msg = (
             f"build artifacts tarball for {configuration} would exceed "
@@ -168,7 +233,7 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:
             f"({len(tarball)} > {FIRMWARE_MAX_TOTAL_BYTES})"
         )
         raise RuntimeError(msg)
-    return PackedArtifacts(tarball=tarball, firmware_offset=artifacts.flash_images[0].offset)
+    return PackedArtifacts(tarball=tarball, firmware_offset=firmware_offset)
 
 
 # ---------------------------------------------------------------------------
@@ -232,76 +297,34 @@ def unpack_artifacts_response(packed: DownloadArtifactsResult, job_id: str) -> d
     }
 
 
-def extract_firmware_bin(tarball_bytes: bytes) -> bytes:
-    """
-    Pull ``firmware.bin`` out of the receiver's gzipped tarball.
-
-    Synchronous; meant to run in an executor — the
-    :func:`tarfile.open` + member read are blocking
-    syscalls. Used by the source-routed runner's UPLOAD /
-    INSTALL branch: the runner only needs the firmware
-    image to feed into ``esphome upload --file``, not the
-    full idedata + multi-image set the WS unpacker
-    returns to a Web Serial / esptool consumer.
-
-    Raises :class:`UnpackArtifactsError` on any structural
-    problem (missing entry, non-file member, malformed
-    tarball) or when ``firmware.bin``'s declared size exceeds
-    :data:`FIRMWARE_MAX_TOTAL_BYTES`. The size gate is a
-    decompression-bomb guard: gzip can compress huge
-    zero-filled / sparse data to a tiny on-the-wire payload,
-    so reading without a header-side bound would let a hostile
-    peer expand a few-KiB tarball into multi-GiB memory.
-    """
-    try:
-        with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
-            try:
-                member = tar.getmember("firmware.bin")
-            except KeyError as exc:
-                msg = "firmware.bin missing from receiver's tarball"
-                raise UnpackArtifactsError(msg) from exc
-            # ``isfile()`` rejects symlinks / hardlinks /
-            # device nodes / FIFOs / directories — anything
-            # that isn't a plain file entry. Load-bearing
-            # against a hostile peer: ``tarfile.extractfile()``
-            # follows symlinks + hardlinks transparently and
-            # returns a readable stream for them, so reading
-            # ``firmware.bin`` without this gate would
-            # silently flash whatever the link target resolved
-            # to on the receiver's filesystem. Matches
-            # :func:`_read_tarball_member`'s gate on the
-            # general-purpose unpack path.
-            if not member.isfile():
-                msg = f"firmware.bin in tarball is not a regular file ({member.type!r})"
-                raise UnpackArtifactsError(msg)
-            _check_member_size(member, total_so_far=0)
-            # ``isfile() == True`` is the stdlib contract for
-            # ``extractfile()`` returning a readable stream;
-            # the cast is safe because we've already gated on
-            # ``isfile()`` above.
-            payload = cast(io.BufferedReader, tar.extractfile(member))
-            bytes_payload: bytes = payload.read()
-            return bytes_payload
-    except tarfile.TarError as exc:
-        msg = f"malformed tarball: {exc}"
-        raise UnpackArtifactsError(msg) from exc
-
-
 def read_artifacts_tarball(tarball: bytes) -> tuple[dict[str, Any], dict[str, bytes]]:
     """
     Read every member of *tarball* into ``(idedata, files-by-basename)``.
 
     ``idedata`` is the parsed ``idedata.json`` object;
-    ``files-by-basename`` excludes ``idedata.json``. Raises
-    :class:`UnpackArtifactsError` on any structural problem
-    in the tarball, or when the cumulative decompressed
-    payload would exceed :data:`FIRMWARE_MAX_TOTAL_BYTES`
-    (decompression-bomb guard — see
-    :func:`extract_firmware_bin` for the same rationale on the
-    per-member size check).
+    ``files-by-basename`` carries every non-metadata tarball
+    member keyed on its basename (``Path(member.name).name``)
+    so the WS-adapter consumer's lookup ignores the
+    build-tree nesting the receiver shipped them under.
+    ``storage.json`` / ``platformio.ini`` are filtered out:
+    they belong to the materialiser, not the flash-image set.
+
+    Raises :class:`UnpackArtifactsError` on any structural
+    problem in the tarball (missing idedata, duplicate
+    basename across different build-tree members, malformed
+    gzip / tar framing) or when the cumulative decompressed
+    payload would exceed :data:`FIRMWARE_MAX_TOTAL_BYTES`.
+    The size gate is a decompression-bomb guard: gzip can
+    compress huge zero-filled / sparse data to a tiny
+    on-the-wire payload, so reading without a header-side
+    bound would let a hostile peer expand a few-KiB tarball
+    into multi-GiB memory.
     """
     idedata: dict[str, Any] | None = None
     image_bytes_by_name: dict[str, bytes] = {}
+    # Track which full member path each basename came from so
+    # the duplicate-basename error message can name both.
+    basename_origin: dict[str, str] = {}
     total_bytes = 0
     try:
         with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
@@ -309,10 +332,23 @@ def read_artifacts_tarball(tarball: bytes) -> tuple[dict[str, Any], dict[str, by
                 _check_member_size(member, total_so_far=total_bytes)
                 payload = _read_tarball_member(tar, member)
                 total_bytes += len(payload)
-                if member.name == "idedata.json":
+                if member.name == IDEDATA_MEMBER_NAME:
                     idedata = _parse_idedata(payload)
-                else:
-                    image_bytes_by_name[member.name] = payload
+                    continue
+                if member.name in _METADATA_MEMBERS:
+                    # storage.json + platformio.ini are
+                    # materialiser-only; the WS-adapter doesn't
+                    # surface them.
+                    continue
+                basename = Path(member.name).name
+                if basename in image_bytes_by_name:
+                    msg = (
+                        f"duplicate basename {basename!r} in artifacts tarball: "
+                        f"{basename_origin[basename]!r} and {member.name!r}"
+                    )
+                    raise UnpackArtifactsError(msg)
+                image_bytes_by_name[basename] = payload
+                basename_origin[basename] = member.name
     except tarfile.TarError as exc:
         msg = f"artifacts tarball is malformed: {exc}"
         raise UnpackArtifactsError(msg) from exc
@@ -390,13 +426,17 @@ def _build_images_response(
     Pop bytes from *image_bytes_by_name* in canonical order; base64-encode.
 
     Order is ``firmware.bin`` first, then every entry from
-    ``idedata.extra.flash_images`` in their declared order
-    (matches :attr:`BuildArtifacts.flash_images` on the
-    receiver side). Mutates *image_bytes_by_name*: every
-    image referenced by the manifest is popped; on return
-    the dict should be empty, and any leftover entry means
-    the tarball carried a file the manifest didn't account
-    for.
+    ``idedata.extra.flash_images`` in their declared order.
+    Mutates *image_bytes_by_name*: only the images the
+    manifest names are popped; leftover entries (the
+    materialise-locally tarball legitimately ships per-platform
+    aux files like ``firmware.elf`` for picotool symbol
+    resolution and ``firmware.uf2`` for libretiny/RP2040
+    ltchiptool flashing, neither of which is in
+    ``idedata.extra.flash_images``) are ignored. The size cap
+    in :func:`_check_member_size` already gates total payload,
+    so we don't need a "no leftovers" check to reject a
+    bloated tarball.
     """
     images: list[dict[str, Any]] = []
     firmware_bytes = image_bytes_by_name.pop("firmware.bin", None)
@@ -420,12 +460,6 @@ def _build_images_response(
             msg = f"artifacts tarball missing flash image {basename!r}"
             raise UnpackArtifactsError(msg)
         images.append(_image_entry(basename, offset, image_bytes))
-    if image_bytes_by_name:
-        msg = (
-            f"artifacts tarball contains unexpected files not referenced by idedata: "
-            f"{sorted(image_bytes_by_name)}"
-        )
-        raise UnpackArtifactsError(msg)
     return images
 
 

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -47,7 +47,9 @@ rewrite the frontend's lookup relies on.
 from __future__ import annotations
 
 import base64
+import importlib
 import io
+import logging
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -63,6 +65,8 @@ from .artifact_platforms import build_files_for_platform
 
 if TYPE_CHECKING:
     from .peer_link_client import DownloadArtifactsResult
+
+_LOGGER = logging.getLogger(__name__)
 
 # Tarball member names that ride alongside the build tree. The
 # offloader-side materialiser pulls these out of the tarball and
@@ -176,23 +180,57 @@ def _collect_pack_members(
         (IDEDATA_MEMBER_NAME, idedata_cache_path),
         (PLATFORMIO_INI_MEMBER_NAME, platformio_ini),
     ]
+    seen: set[str] = set()
     for template in build_files:
         rel = template.format(name=storage.name)
         abs_path = build_path / rel
-        if abs_path.is_file():
+        if abs_path.is_file() and rel not in seen:
             members.append((rel, abs_path))
+            seen.add(rel)
+
+    # Every file ``get_download_types`` lists for this platform
+    # must travel too so the offloader's ``firmware/get_binaries``
+    # + ``firmware/download`` surface matches the legacy
+    # esphome.dashboard set (factory.bin, ota.bin, libretiny's
+    # per-chip outputs from firmware.json, nRF52's zephyr.uf2 /
+    # zephyr.hex / etc.).
+    firmware_bin = Path(storage.firmware_bin_path)
+    pioenvs_rel = _relative_or_raise(firmware_bin.parent, build_path, configuration=configuration)
+    for download_file in _download_type_files(storage):
+        rel = f"{pioenvs_rel}/{download_file}"
+        abs_path = build_path / rel
+        if abs_path.is_file() and rel not in seen:
+            members.append((rel, abs_path))
+            seen.add(rel)
 
     # firmware_bin_path MUST be in the tarball — otherwise the
     # offloader stages a tree where firmware/download misses.
-    firmware_bin = Path(storage.firmware_bin_path)
     firmware_bin_rel = _relative_or_raise(firmware_bin, build_path, configuration=configuration)
-    if not any(rel == firmware_bin_rel for rel, _ in members):
+    if firmware_bin_rel not in seen:
         msg = (
             f"firmware_bin_path {firmware_bin_rel!r} not covered by BUILD_FILES "
             f"for target_platform={storage.target_platform!r}"
         )
         raise RuntimeError(msg)
     return members
+
+
+def _download_type_files(storage: StorageJSON) -> list[str]:
+    """Return paths (relative to firmware_bin_path.parent) listed by ``get_download_types``."""
+    from ..firmware.controller import _resolve_download_component  # noqa: PLC0415
+
+    component = _resolve_download_component(storage.target_platform)
+    if not component:
+        return []
+    try:
+        module = importlib.import_module(f"esphome.components.{component}")
+        return [entry["file"] for entry in module.get_download_types(storage)]
+    except Exception:
+        _LOGGER.warning(
+            "Could not determine download types for target_platform=%r",
+            storage.target_platform,
+        )
+        return []
 
 
 def _render_tarball(members: list[tuple[str, Path]], *, configuration: str) -> bytes:

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -102,7 +102,7 @@ class PackedArtifacts:
     firmware_offset: str
 
 
-def pack_build_artifacts(configuration: str) -> PackedArtifacts:  # noqa: PLR0915
+def pack_build_artifacts(configuration: str) -> PackedArtifacts:
     """Pack the build for *configuration* into the materialise-locally tarball.
 
     Synchronous; meant to run inside an executor. Raises
@@ -113,6 +113,21 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:  # noqa: PLR091
     (per-member walking sum + post-render check, the latter
     matching the offloader-side BundleAssembler cap).
     """
+    storage_path, storage = _load_storage_for_pack(configuration)
+    build_path = Path(storage.build_path)
+    members = _collect_pack_members(
+        configuration=configuration,
+        storage=storage,
+        storage_path=storage_path,
+        build_path=build_path,
+    )
+    firmware_offset = _firmware_offset_for_platform(storage.target_platform or "")
+    tarball = _render_tarball(members, configuration=configuration)
+    return PackedArtifacts(tarball=tarball, firmware_offset=firmware_offset)
+
+
+def _load_storage_for_pack(configuration: str) -> tuple[Path, StorageJSON]:
+    """Load + validate the StorageJSON sidecar for the receiver-side pack."""
     storage_path = resolve_storage_path(configuration)
     storage = StorageJSON.load(storage_path)
     if storage is None:
@@ -127,7 +142,17 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:  # noqa: PLR091
     if not isinstance(storage.name, str) or not storage.name:
         msg = f"StorageJSON name unset / non-string for {configuration}: {storage.name!r}"
         raise FileNotFoundError(msg)
+    return storage_path, storage
 
+
+def _collect_pack_members(
+    *,
+    configuration: str,
+    storage: StorageJSON,
+    storage_path: Path,
+    build_path: Path,
+) -> list[tuple[str, Path]]:
+    """Return ``(arcname, src_path)`` pairs for the tarball, in write order."""
     target_platform = (storage.target_platform or "").lower()
     build_files = build_files_for_platform(target_platform)
     if not build_files:
@@ -137,7 +162,6 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:  # noqa: PLR091
         )
         raise RuntimeError(msg)
 
-    build_path = Path(storage.build_path)
     idedata_cache_path = resolve_idedata_path(configuration, name=storage.name)
     platformio_ini = build_path / "platformio.ini"
     if not idedata_cache_path.is_file():
@@ -147,29 +171,36 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:  # noqa: PLR091
         msg = f"platformio.ini missing for {configuration}: {platformio_ini}"
         raise FileNotFoundError(msg)
 
-    firmware_offset = _firmware_offset_for_platform(storage.target_platform or "")
-
-    # Platform-independent metadata at the top, then every
-    # existing per-platform BUILD_FILES entry under
-    # .pioenvs/<name>/. Missing files are skipped (a build that
-    # didn't emit ``ota_data_initial.bin`` shouldn't fail).
-    metadata_members: list[tuple[str, Path]] = [
+    members: list[tuple[str, Path]] = [
         (STORAGE_MEMBER_NAME, storage_path),
         (IDEDATA_MEMBER_NAME, idedata_cache_path),
         (PLATFORMIO_INI_MEMBER_NAME, platformio_ini),
     ]
-    pioenvs_prefix = f".pioenvs/{storage.name}"
-    pioenvs_dir = build_path / ".pioenvs" / storage.name
-    build_members: list[tuple[str, Path]] = []
-    for rel in build_files:
-        abs_path = pioenvs_dir / rel
+    for template in build_files:
+        rel = template.format(name=storage.name)
+        abs_path = build_path / rel
         if abs_path.is_file():
-            build_members.append((f"{pioenvs_prefix}/{rel}", abs_path))
+            members.append((rel, abs_path))
 
+    # firmware_bin_path MUST be in the tarball — otherwise the
+    # offloader stages a tree where firmware/download misses.
+    firmware_bin = Path(storage.firmware_bin_path)
+    firmware_bin_rel = _relative_or_raise(firmware_bin, build_path, configuration=configuration)
+    if not any(rel == firmware_bin_rel for rel, _ in members):
+        msg = (
+            f"firmware_bin_path {firmware_bin_rel!r} not covered by BUILD_FILES "
+            f"for target_platform={storage.target_platform!r}"
+        )
+        raise RuntimeError(msg)
+    return members
+
+
+def _render_tarball(members: list[tuple[str, Path]], *, configuration: str) -> bytes:
+    """Write *members* to a gzipped tarball, capping declared + rendered bytes."""
     buf = io.BytesIO()
     total_uncompressed = 0
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        for arcname, src in (*metadata_members, *build_members):
+        for arcname, src in members:
             # Stat before read so a runaway build artefact trips
             # the cap before we allocate its bytes into memory.
             file_size = src.stat().st_size
@@ -185,12 +216,10 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:  # noqa: PLR091
             info = tarfile.TarInfo(name=arcname)
             info.size = len(payload)
             tar.addfile(info, io.BytesIO(payload))
-
     tarball = buf.getvalue()
-    # Final post-render cap on the wire-side length. See the
-    # docstring for the rationale on why the post-render check
-    # exists even when the uncompressed walking gate above
-    # already passed.
+    # Final post-render cap on the wire-side length so the
+    # receiver-side ceiling matches the offloader's
+    # BundleAssembler check on ArtifactsStartFrameData.total_bytes.
     if len(tarball) > FIRMWARE_MAX_TOTAL_BYTES:
         msg = (
             f"build artifacts tarball for {configuration} would exceed "
@@ -198,7 +227,7 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:  # noqa: PLR091
             f"({len(tarball)} > {FIRMWARE_MAX_TOTAL_BYTES})"
         )
         raise RuntimeError(msg)
-    return PackedArtifacts(tarball=tarball, firmware_offset=firmware_offset)
+    return tarball
 
 
 # ---------------------------------------------------------------------------
@@ -327,6 +356,18 @@ def _walk_artifacts_members(
         image_bytes_by_name[basename] = payload
         basename_origin[basename] = member.name
     return idedata, image_bytes_by_name
+
+
+def _relative_or_raise(path: Path, base: Path, *, configuration: str) -> str:
+    """Return *path* relative to *base* as a posix string, or raise."""
+    try:
+        return path.relative_to(base).as_posix()
+    except ValueError as err:
+        msg = (
+            f"firmware_bin_path {path} for {configuration} not under "
+            f"build_path {base}; can't include in tarball"
+        )
+        raise RuntimeError(msg) from err
 
 
 def _check_member_size(member: tarfile.TarInfo, *, total_so_far: int) -> None:

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -180,33 +180,40 @@ def _collect_pack_members(
         (IDEDATA_MEMBER_NAME, idedata_cache_path),
         (PLATFORMIO_INI_MEMBER_NAME, platformio_ini),
     ]
-    seen: set[str] = set()
-    for template in build_files:
-        rel = template.format(name=storage.name)
+    # Dedupe by basename, not full path: the WS-unpack adapter
+    # keys flash images by basename, so a build emitting both
+    # ``.pioenvs/<name>/firmware.factory.bin`` and
+    # ``build/firmware.factory.bin`` would otherwise produce a
+    # tarball the offloader's adapter rejects. First-wins
+    # ordering (BUILD_FILES list order) picks the canonical copy.
+    seen_basenames: set[str] = set()
+
+    def _maybe_add(rel: str) -> None:
         abs_path = build_path / rel
-        if abs_path.is_file() and rel not in seen:
-            members.append((rel, abs_path))
-            seen.add(rel)
+        if not abs_path.is_file():
+            return
+        basename = Path(rel).name
+        if basename in seen_basenames:
+            return
+        members.append((rel, abs_path))
+        seen_basenames.add(basename)
+
+    for template in build_files:
+        _maybe_add(template.format(name=storage.name))
 
     # Every file ``get_download_types`` lists for this platform
     # must travel too so the offloader's ``firmware/get_binaries``
     # + ``firmware/download`` surface matches the legacy
-    # esphome.dashboard set (factory.bin, ota.bin, libretiny's
-    # per-chip outputs from firmware.json, nRF52's zephyr.uf2 /
-    # zephyr.hex / etc.).
+    # esphome.dashboard set.
     firmware_bin = Path(storage.firmware_bin_path)
     pioenvs_rel = _relative_or_raise(firmware_bin.parent, build_path, configuration=configuration)
     for download_file in _download_type_files(storage):
-        rel = f"{pioenvs_rel}/{download_file}"
-        abs_path = build_path / rel
-        if abs_path.is_file() and rel not in seen:
-            members.append((rel, abs_path))
-            seen.add(rel)
+        _maybe_add(f"{pioenvs_rel}/{download_file}")
 
     # firmware_bin_path MUST be in the tarball — otherwise the
     # offloader stages a tree where firmware/download misses.
     firmware_bin_rel = _relative_or_raise(firmware_bin, build_path, configuration=configuration)
-    if firmware_bin_rel not in seen:
+    if firmware_bin.name not in seen_basenames:
         msg = (
             f"firmware_bin_path {firmware_bin_rel!r} not covered by BUILD_FILES "
             f"for target_platform={storage.target_platform!r}"

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 
 import base64
 import io
-import logging
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,8 +63,6 @@ from .artifact_platforms import build_files_for_platform
 
 if TYPE_CHECKING:
     from .peer_link_client import DownloadArtifactsResult
-
-_LOGGER = logging.getLogger(__name__)
 
 # Tarball member names that ride alongside the build tree. The
 # offloader-side materialiser pulls these out of the tarball and
@@ -140,17 +137,12 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:
     is treated as a structural drift between the dashboard's
     inclusion lists and ESPHome's platform support) or when
     the artifact set exceeds :data:`FIRMWARE_MAX_TOTAL_BYTES`.
-    Two cap checks fire: the uncompressed walking sum (cheap,
-    lets us short-circuit before reading huge files), and a
-    final compressed-size check on the rendered tarball (the
-    offloader's :class:`BundleAssembler` caps on
-    ``ArtifactsStartFrameData.total_bytes``, the wire-side
-    length, so the receiver-side ceiling needs to match).
-    Compression usually shrinks the payload, so the
-    uncompressed gate fires first in practice; the
-    post-render check exists for the incompressible-data +
-    tar-header-overhead corner where ``len(tarball)`` could
-    technically exceed the uncompressed total. The caller
+    Two cap checks: a per-member walking sum inside the tar loop
+    (short-circuits when an individual file would already push
+    the total past the limit) plus a final compressed-size check
+    on the rendered tarball (the offloader's BundleAssembler caps
+    on ``ArtifactsStartFrameData.total_bytes``, the wire-side
+    length, so the two sides must agree). The caller
     (:meth:`ArtifactsDownloadSender.handle_download_artifacts`)
     catches both and surfaces a structured reject reason.
     """

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -167,8 +167,8 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:
         raise FileNotFoundError(msg)
 
     target_platform = (storage.target_platform or "").lower()
-    build_templates = build_files_for_platform(target_platform)
-    if not build_templates:
+    build_files = build_files_for_platform(target_platform)
+    if not build_files:
         msg = (
             f"no artifact_platforms module for target_platform="
             f"{storage.target_platform!r} (configuration={configuration!r})"
@@ -187,22 +187,22 @@ def pack_build_artifacts(configuration: str) -> PackedArtifacts:
 
     firmware_offset = _firmware_offset_for_platform(storage.target_platform or "")
 
-    # Build the file list: three platform-independent metadata
-    # members at the top, then every existing build-tree file
-    # from the platform's BUILD_FILES. Files that don't exist
-    # on disk are silently skipped (a build that didn't emit
-    # ``ota_data_initial.bin`` shouldn't fail the pack).
+    # Platform-independent metadata at the top, then every
+    # existing per-platform BUILD_FILES entry under
+    # .pioenvs/<name>/. Missing files are skipped (a build that
+    # didn't emit ``ota_data_initial.bin`` shouldn't fail).
     metadata_members: list[tuple[str, Path]] = [
         (STORAGE_MEMBER_NAME, storage_path),
         (IDEDATA_MEMBER_NAME, idedata_cache_path),
         (PLATFORMIO_INI_MEMBER_NAME, platformio_ini),
     ]
+    pioenvs_prefix = f".pioenvs/{storage.name}"
+    pioenvs_dir = build_path / ".pioenvs" / storage.name
     build_members: list[tuple[str, Path]] = []
-    for template in build_templates:
-        rel_path = template.format(name=storage.name)
-        abs_path = build_path / rel_path
+    for rel in build_files:
+        abs_path = pioenvs_dir / rel
         if abs_path.is_file():
-            build_members.append((rel_path, abs_path))
+            build_members.append((f"{pioenvs_prefix}/{rel}", abs_path))
 
     buf = io.BytesIO()
     total_uncompressed = 0

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -69,11 +69,13 @@ BUNDLE_MAX_TOTAL_BYTES = 4 * 1024 * 1024
 # pipeline ships the receiver's full build subtree (firmware
 # binaries + ``firmware.elf`` for picotool symbol resolution +
 # the StorageJSON / idedata / platformio.ini metadata). A real
-# ESP32-S3 build's ``firmware.elf`` alone runs ~22 MiB with
-# debug symbols, so the wire ceiling needs headroom above the
-# flashable image's size. 64 MiB is the bound; still finite so
-# a misbehaving receiver can't pin arbitrary memory.
-FIRMWARE_MAX_TOTAL_BYTES = 64 * 1024 * 1024
+# ESP32-S3 build's ``firmware.elf`` alone runs 22+ MiB with
+# debug symbols, and feature-heavy Apollo-style configs have
+# been observed pushing past 120 MiB once every flashable
+# image lands in the tarball. 256 MiB is the bound; finite
+# enough that a misbehaving receiver can't pin arbitrary
+# memory while leaving headroom for further firmware growth.
+FIRMWARE_MAX_TOTAL_BYTES = 256 * 1024 * 1024
 
 
 class BundleAssemblerErrorCode(StrEnum):

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -65,15 +65,15 @@ BUNDLE_CHUNK_SIZE_BYTES = 32 * 1024
 # a bundle. May be revisited based on production bundle sizes.
 BUNDLE_MAX_TOTAL_BYTES = 4 * 1024 * 1024
 
-# Hard cap on the assembled firmware binary. Typical
-# ESP32 firmware is 800 KiB - 1.5 MiB; ESP32-S3 with PSRAM
-# can reach ~4 MiB; future variants may grow further. 16 MiB
-# is well above the realistic ceiling but bounded enough that
-# a misbehaving receiver can't pin arbitrary memory pretending
-# to send firmware. Same buffer-size rationale as
-# :data:`BUNDLE_MAX_TOTAL_BYTES`, just with the larger cap
-# the firmware-binary direction needs.
-FIRMWARE_MAX_TOTAL_BYTES = 16 * 1024 * 1024
+# Hard cap on the assembled firmware tarball. The materialise
+# pipeline ships the receiver's full build subtree (firmware
+# binaries + ``firmware.elf`` for picotool symbol resolution +
+# the StorageJSON / idedata / platformio.ini metadata). A real
+# ESP32-S3 build's ``firmware.elf`` alone runs ~22 MiB with
+# debug symbols, so the wire ceiling needs headroom above the
+# flashable image's size. 64 MiB is the bound; still finite so
+# a misbehaving receiver can't pin arbitrary memory.
+FIRMWARE_MAX_TOTAL_BYTES = 64 * 1024 * 1024
 
 
 class BundleAssemblerErrorCode(StrEnum):

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -12,7 +12,6 @@ idedata cache (touched so ``_load_idedata``'s mtime gate hits).
 from __future__ import annotations
 
 import io
-import json
 import logging
 import os
 import re
@@ -20,7 +19,7 @@ import shutil
 import tarfile
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from esphome.storage_json import StorageJSON
 
@@ -29,6 +28,8 @@ from ..controllers.remote_build.artifacts_tarball import (
     PLATFORMIO_INI_MEMBER_NAME,
     STORAGE_MEMBER_NAME,
 )
+from .json import dumps_indent
+from .json import loads as json_loads
 from .storage_path import resolve_data_dir, resolve_idedata_path, resolve_storage_path
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,6 +47,13 @@ class MaterialiseError(RuntimeError):
     """Raised when a tarball can't be materialised into a usable build tree."""
 
 
+class _ExtractedTarball(NamedTuple):
+    storage_bytes: bytes
+    idedata_bytes: bytes
+    receiver_build_path: Path
+    build_path: Path
+
+
 def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
     """
     Stage *tarball* into offloader-local form.
@@ -56,36 +64,49 @@ def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
     Returns the staged build path; callers that just need the
     side-effects (the runner) can discard it.
     """
-    # storage.json + idedata.json are cache-side files; we
-    # rewrite their paths before write so they don't extract
-    # into the build tree.
+    extracted = _open_and_extract_build_tree(tarball, configuration)
+    _stage_offloader_storage(
+        configuration=configuration,
+        receiver_storage_bytes=extracted.storage_bytes,
+        receiver_build_path=extracted.receiver_build_path,
+        offloader_build_path=extracted.build_path,
+    )
+    cached_idedata_path = _stage_offloader_idedata(
+        configuration=configuration,
+        idedata_bytes=extracted.idedata_bytes,
+        device_name=extracted.build_path.name,
+        receiver_build_path=extracted.receiver_build_path,
+        offloader_build_path=extracted.build_path,
+    )
+    _force_idedata_cache_hit(
+        platformio_ini=extracted.build_path / PLATFORMIO_INI_MEMBER_NAME,
+        cached_idedata=cached_idedata_path,
+    )
+    return extracted.build_path
+
+
+def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _ExtractedTarball:
+    """Open *tarball*, validate the storage shape, wipe + extract into the offloader build dir.
+
+    storage.json + idedata.json are cache-side files; their
+    bytes are returned for the caller to rewrite before write
+    rather than extracted into the build tree.
+    """
     try:
-        tar_io = io.BytesIO(tarball)
-        with tarfile.open(fileobj=tar_io, mode="r:gz") as tar:
+        with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
             storage_bytes = _read_member_required(tar, STORAGE_MEMBER_NAME)
             idedata_bytes = _read_member_required(tar, IDEDATA_MEMBER_NAME)
             receiver_storage = _parse_storage_json(storage_bytes)
-            device_name = receiver_storage.get("name")
-            if not isinstance(device_name, str) or not device_name:
-                raise MaterialiseError("tarball storage.json missing required name field")
-            if not _SAFE_DEVICE_NAME_RE.fullmatch(device_name):
-                raise MaterialiseError(
-                    f"tarball storage.json name {device_name!r} not safe for a path segment"
-                )
-            receiver_build_path_str = receiver_storage.get("build_path")
-            if not isinstance(receiver_build_path_str, str):
-                raise MaterialiseError("tarball storage.json missing required build_path field")
-            receiver_build_path = Path(receiver_build_path_str)
+            device_name = _device_name_from_storage(receiver_storage)
+            receiver_build_path = _receiver_build_path_from_storage(receiver_storage)
 
-            data_dir = resolve_data_dir(configuration)
-            build_path = data_dir / "build" / device_name
+            build_path = resolve_data_dir(configuration) / "build" / device_name
             # Wipe before extract so a board swap on the same YAML
             # (esp32 → bk72xx) doesn't leave stale per-platform
             # artefacts that firmware/download could surface as
             # wrong bytes.
             shutil.rmtree(build_path, ignore_errors=True)
             build_path.mkdir(parents=True, exist_ok=True)
-
             _safe_extract_excluding(
                 tar,
                 build_path,
@@ -93,26 +114,32 @@ def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
             )
     except tarfile.TarError as err:
         raise MaterialiseError(f"tarball is malformed: {err}") from err
-
-    _stage_offloader_storage(
-        configuration=configuration,
-        receiver_storage_bytes=storage_bytes,
-        receiver_build_path=receiver_build_path,
-        offloader_build_path=build_path,
-    )
-    cached_idedata_path = _stage_offloader_idedata(
-        configuration=configuration,
+    return _ExtractedTarball(
+        storage_bytes=storage_bytes,
         idedata_bytes=idedata_bytes,
-        device_name=device_name,
         receiver_build_path=receiver_build_path,
-        offloader_build_path=build_path,
-    )
-    _force_idedata_cache_hit(
-        platformio_ini=build_path / PLATFORMIO_INI_MEMBER_NAME,
-        cached_idedata=cached_idedata_path,
+        build_path=build_path,
     )
 
-    return build_path
+
+def _device_name_from_storage(receiver_storage: dict[str, Any]) -> str:
+    """Pull and validate the device name from the shipped storage.json."""
+    device_name = receiver_storage.get("name")
+    if not isinstance(device_name, str) or not device_name:
+        raise MaterialiseError("tarball storage.json missing required name field")
+    if not _SAFE_DEVICE_NAME_RE.fullmatch(device_name):
+        raise MaterialiseError(
+            f"tarball storage.json name {device_name!r} not safe for a path segment"
+        )
+    return device_name
+
+
+def _receiver_build_path_from_storage(receiver_storage: dict[str, Any]) -> Path:
+    """Pull the receiver-absolute build_path from the shipped storage.json."""
+    receiver_build_path_str = receiver_storage.get("build_path")
+    if not isinstance(receiver_build_path_str, str):
+        raise MaterialiseError("tarball storage.json missing required build_path field")
+    return Path(receiver_build_path_str)
 
 
 def _read_member_required(tar: tarfile.TarFile, name: str) -> bytes:
@@ -151,7 +178,7 @@ def _safe_extract_excluding(tar: tarfile.TarFile, dest: Path, *, exclude: set[st
 def _parse_storage_json(payload: bytes) -> dict[str, Any]:
     """Parse the shipped storage.json into a dict for the pre-extract lookups."""
     try:
-        parsed = json.loads(payload)
+        parsed = json_loads(payload)
     except ValueError as err:
         raise MaterialiseError(f"tarball storage.json is not valid JSON: {err}") from err
     if not isinstance(parsed, dict):
@@ -194,51 +221,60 @@ def _stage_offloader_idedata(
     offloader_build_path: Path,
 ) -> Path:
     """Rewrite the receiver's idedata and save at the offloader's cache path."""
+    data = _parse_idedata_dict(idedata_bytes)
+    _remap_idedata_build_paths(data, receiver_build_path, offloader_build_path)
+    _remap_idedata_toolchain_path(data)
+
+    cached_path = resolve_idedata_path(configuration, name=device_name)
+    cached_path.parent.mkdir(parents=True, exist_ok=True)
+    cached_path.write_bytes(dumps_indent(data) + b"\n")
+    return cached_path
+
+
+def _parse_idedata_dict(payload: bytes) -> dict[str, Any]:
+    """Parse the shipped idedata.json or raise MaterialiseError."""
     try:
-        data = json.loads(idedata_bytes)
+        data = json_loads(payload)
     except ValueError as err:
         raise MaterialiseError(f"tarball idedata.json is not valid JSON: {err}") from err
     if not isinstance(data, dict):
         raise MaterialiseError("tarball idedata.json is not a JSON object")
+    return data
 
-    prog = data.get("prog_path")
-    if isinstance(prog, str):
-        data["prog_path"] = str(
-            _remap_to_offloader(Path(prog), receiver_build_path, offloader_build_path)
-        )
+
+def _remap_idedata_build_paths(
+    data: dict[str, Any],
+    receiver_build_path: Path,
+    offloader_build_path: Path,
+) -> None:
+    """Rewrite prog_path + extra.flash_images[*].path to the offloader's tree."""
+
+    def _remap(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        return str(_remap_to_offloader(Path(value), receiver_build_path, offloader_build_path))
+
+    if (prog := _remap(data.get("prog_path"))) is not None:
+        data["prog_path"] = prog
     extra = data.get("extra")
-    if isinstance(extra, dict):
-        flash_images = extra.get("flash_images")
-        if isinstance(flash_images, list):
-            for image in flash_images:
-                if not isinstance(image, dict):
-                    continue
-                path_str = image.get("path")
-                if isinstance(path_str, str):
-                    image["path"] = str(
-                        _remap_to_offloader(
-                            Path(path_str),
-                            receiver_build_path,
-                            offloader_build_path,
-                        )
-                    )
+    flash_images = extra.get("flash_images") if isinstance(extra, dict) else None
+    for image in flash_images or []:
+        if not isinstance(image, dict):
+            continue
+        if (remapped := _remap(image.get("path"))) is not None:
+            image["path"] = remapped
 
-    # Remap cc_path's PIO core prefix so RP2040 BOOTSEL's
-    # picotool lookup resolves on the offloader; drop the field
-    # if the shape isn't recognisable (picotool falls through to
-    # PATH).
+
+def _remap_idedata_toolchain_path(data: dict[str, Any]) -> None:
+    """Swap cc_path's PIO core prefix; drop if unrecognised (picotool falls back to PATH)."""
     cc_path = data.get("cc_path")
-    if isinstance(cc_path, str):
-        remapped = _remap_pio_toolchain_path(cc_path)
-        if remapped is None:
-            data.pop("cc_path", None)
-        else:
-            data["cc_path"] = remapped
-
-    cached_path = resolve_idedata_path(configuration, name=device_name)
-    cached_path.parent.mkdir(parents=True, exist_ok=True)
-    cached_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    return cached_path
+    if not isinstance(cc_path, str):
+        return
+    remapped = _remap_pio_toolchain_path(cc_path)
+    if remapped is None:
+        data.pop("cc_path", None)
+    else:
+        data["cc_path"] = remapped
 
 
 def _force_idedata_cache_hit(*, platformio_ini: Path, cached_idedata: Path) -> None:

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -30,6 +30,7 @@ from ..controllers.remote_build.artifacts_tarball import (
 )
 from .json import dumps_indent
 from .json import loads as json_loads
+from .peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
 from .storage_path import resolve_data_dir, resolve_idedata_path, resolve_storage_path
 
 _LOGGER = logging.getLogger(__name__)
@@ -114,6 +115,8 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             )
     except tarfile.TarError as err:
         raise MaterialiseError(f"tarball is malformed: {err}") from err
+    if not (build_path / PLATFORMIO_INI_MEMBER_NAME).is_file():
+        raise MaterialiseError(f"tarball missing required {PLATFORMIO_INI_MEMBER_NAME!r} member")
     return _ExtractedTarball(
         storage_bytes=storage_bytes,
         idedata_bytes=idedata_bytes,
@@ -143,26 +146,50 @@ def _receiver_build_path_from_storage(receiver_storage: dict[str, Any]) -> Path:
 
 
 def _read_member_required(tar: tarfile.TarFile, name: str) -> bytes:
-    """Return *name*'s bytes from *tar* or raise with a clear message."""
+    """Return *name*'s bytes from *tar* or raise with a clear message.
+
+    Caps the declared member size against
+    :data:`FIRMWARE_MAX_TOTAL_BYTES` before reading so a hostile
+    peer can't expand a tiny gzipped tarball into multi-GiB
+    memory by inflating a metadata-member header.
+    """
     try:
         member = tar.getmember(name)
     except KeyError as err:
         raise MaterialiseError(f"tarball missing required member: {name!r}") from err
     if not member.isfile():
         raise MaterialiseError(f"tarball member {name!r} is not a regular file")
+    _check_member_size(member, total_so_far=0)
     payload = tar.extractfile(member)
     if payload is None:  # ``isfile()`` already gates this; defence
         raise MaterialiseError(f"tarball member {name!r} unreadable")
     return payload.read()
 
 
+def _check_member_size(member: tarfile.TarInfo, *, total_so_far: int) -> None:
+    """Reject tar members whose declared size would breach the global cap."""
+    if member.size > FIRMWARE_MAX_TOTAL_BYTES:
+        raise MaterialiseError(
+            f"tarball member {member.name!r} declares size {member.size} "
+            f"exceeding FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
+        )
+    if total_so_far + member.size > FIRMWARE_MAX_TOTAL_BYTES:
+        raise MaterialiseError(
+            f"tarball cumulative size {total_so_far + member.size} "
+            f"exceeds FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
+        )
+
+
 def _safe_extract_excluding(tar: tarfile.TarFile, dest: Path, *, exclude: set[str]) -> None:
-    """Extract every member except *exclude*; reject any that escapes *dest*."""
+    """Extract every member except *exclude*; reject any that escapes *dest* or breaches the cap."""
     dest_resolved = dest.resolve()
     members_to_extract: list[tarfile.TarInfo] = []
+    total_bytes = 0
     for member in tar.getmembers():
         if member.name in exclude:
             continue
+        _check_member_size(member, total_so_far=total_bytes)
+        total_bytes += member.size
         member_path = (dest / member.name).resolve()
         try:
             member_path.relative_to(dest_resolved)

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -1,4 +1,5 @@
-"""Materialise a remote-build artifact tarball into the offloader's local build dir.
+"""
+Materialise a remote-build artifact tarball into the offloader's local build dir.
 
 After :func:`materialise_remote_artifacts` returns, the offloader's
 filesystem looks as if a local compile produced the build:
@@ -14,6 +15,8 @@ import io
 import json
 import logging
 import os
+import re
+import shutil
 import tarfile
 import time
 from pathlib import Path
@@ -31,16 +34,27 @@ from .storage_path import resolve_data_dir, resolve_idedata_path, resolve_storag
 _LOGGER = logging.getLogger(__name__)
 
 
+# Defence-in-depth gate on the receiver-supplied device name.
+# Pairing requires explicit operator approval so the wire isn't
+# fully untrusted, but the name flows straight into a Path join
+# (``<data_dir>/build/<name>/``) and a forged value like ``..``
+# would land the build tree outside the data dir.
+_SAFE_DEVICE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+
 class MaterialiseError(RuntimeError):
     """Raised when a tarball can't be materialised into a usable build tree."""
 
 
 def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
-    """Stage *tarball* into offloader-local form, returning the build path.
+    """
+    Stage *tarball* into offloader-local form.
 
     The build-dir ``<name>`` segment comes from the shipped
     ``storage.json``'s ``name`` field (not the YAML filename stem)
     so renamed devices key the same as esphome's CORE does.
+    Returns the staged build path; callers that just need the
+    side-effects (the runner) can discard it.
     """
     # storage.json + idedata.json are cache-side files; we
     # rewrite their paths before write so they don't extract
@@ -54,6 +68,10 @@ def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
             device_name = receiver_storage.get("name")
             if not isinstance(device_name, str) or not device_name:
                 raise MaterialiseError("tarball storage.json missing required name field")
+            if not _SAFE_DEVICE_NAME_RE.fullmatch(device_name):
+                raise MaterialiseError(
+                    f"tarball storage.json name {device_name!r} not safe for a path segment"
+                )
             receiver_build_path_str = receiver_storage.get("build_path")
             if not isinstance(receiver_build_path_str, str):
                 raise MaterialiseError("tarball storage.json missing required build_path field")
@@ -61,6 +79,11 @@ def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
 
             data_dir = resolve_data_dir(configuration)
             build_path = data_dir / "build" / device_name
+            # Wipe before extract so a board swap on the same YAML
+            # (esp32 → bk72xx) doesn't leave stale per-platform
+            # artefacts that firmware/download could surface as
+            # wrong bytes.
+            shutil.rmtree(build_path, ignore_errors=True)
             build_path.mkdir(parents=True, exist_ok=True)
 
             _safe_extract_excluding(

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -1,0 +1,261 @@
+"""Materialise a remote-build artifact tarball into the offloader's local build dir.
+
+After :func:`materialise_remote_artifacts` returns, the offloader's
+filesystem looks as if a local compile produced the build:
+``<data_dir>/build/<name>/`` carries the per-platform build tree,
+``<data_dir>/storage/<basename>.json`` is the rewritten StorageJSON
+sidecar, and ``<data_dir>/idedata/<name>.json`` is the rewritten
+idedata cache (touched so ``_load_idedata``'s mtime gate hits).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import tarfile
+import time
+from pathlib import Path
+from typing import Any
+
+from esphome.storage_json import StorageJSON
+
+from ..controllers.remote_build.artifacts_tarball import (
+    IDEDATA_MEMBER_NAME,
+    PLATFORMIO_INI_MEMBER_NAME,
+    STORAGE_MEMBER_NAME,
+)
+from .storage_path import resolve_data_dir, resolve_idedata_path, resolve_storage_path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MaterialiseError(RuntimeError):
+    """Raised when a tarball can't be materialised into a usable build tree."""
+
+
+def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
+    """Stage *tarball* into offloader-local form, returning the build path.
+
+    The build-dir ``<name>`` segment comes from the shipped
+    ``storage.json``'s ``name`` field (not the YAML filename stem)
+    so renamed devices key the same as esphome's CORE does.
+    """
+    # storage.json + idedata.json are cache-side files; we
+    # rewrite their paths before write so they don't extract
+    # into the build tree.
+    try:
+        tar_io = io.BytesIO(tarball)
+        with tarfile.open(fileobj=tar_io, mode="r:gz") as tar:
+            storage_bytes = _read_member_required(tar, STORAGE_MEMBER_NAME)
+            idedata_bytes = _read_member_required(tar, IDEDATA_MEMBER_NAME)
+            receiver_storage = _parse_storage_json(storage_bytes)
+            device_name = receiver_storage.get("name")
+            if not isinstance(device_name, str) or not device_name:
+                raise MaterialiseError("tarball storage.json missing required name field")
+            receiver_build_path_str = receiver_storage.get("build_path")
+            if not isinstance(receiver_build_path_str, str):
+                raise MaterialiseError("tarball storage.json missing required build_path field")
+            receiver_build_path = Path(receiver_build_path_str)
+
+            data_dir = resolve_data_dir(configuration)
+            build_path = data_dir / "build" / device_name
+            build_path.mkdir(parents=True, exist_ok=True)
+
+            _safe_extract_excluding(
+                tar,
+                build_path,
+                exclude={STORAGE_MEMBER_NAME, IDEDATA_MEMBER_NAME},
+            )
+    except tarfile.TarError as err:
+        raise MaterialiseError(f"tarball is malformed: {err}") from err
+
+    _stage_offloader_storage(
+        configuration=configuration,
+        receiver_storage_bytes=storage_bytes,
+        receiver_build_path=receiver_build_path,
+        offloader_build_path=build_path,
+    )
+    cached_idedata_path = _stage_offloader_idedata(
+        configuration=configuration,
+        idedata_bytes=idedata_bytes,
+        device_name=device_name,
+        receiver_build_path=receiver_build_path,
+        offloader_build_path=build_path,
+    )
+    _force_idedata_cache_hit(
+        platformio_ini=build_path / PLATFORMIO_INI_MEMBER_NAME,
+        cached_idedata=cached_idedata_path,
+    )
+
+    return build_path
+
+
+def _read_member_required(tar: tarfile.TarFile, name: str) -> bytes:
+    """Return *name*'s bytes from *tar* or raise with a clear message."""
+    try:
+        member = tar.getmember(name)
+    except KeyError as err:
+        raise MaterialiseError(f"tarball missing required member: {name!r}") from err
+    if not member.isfile():
+        raise MaterialiseError(f"tarball member {name!r} is not a regular file")
+    payload = tar.extractfile(member)
+    if payload is None:  # ``isfile()`` already gates this; defence
+        raise MaterialiseError(f"tarball member {name!r} unreadable")
+    return payload.read()
+
+
+def _safe_extract_excluding(tar: tarfile.TarFile, dest: Path, *, exclude: set[str]) -> None:
+    """Extract every member except *exclude*; reject any that escapes *dest*."""
+    dest_resolved = dest.resolve()
+    members_to_extract: list[tarfile.TarInfo] = []
+    for member in tar.getmembers():
+        if member.name in exclude:
+            continue
+        member_path = (dest / member.name).resolve()
+        try:
+            member_path.relative_to(dest_resolved)
+        except ValueError as err:
+            raise MaterialiseError(f"tarball member escapes destination: {member.name!r}") from err
+        members_to_extract.append(member)
+    # ``filter="data"`` is python 3.14's default-to-be: rejects
+    # symlinks / device nodes / setuid bits, mirrors the
+    # defensive intent of the per-member relative_to check above.
+    tar.extractall(dest, members=members_to_extract, filter="data")
+
+
+def _parse_storage_json(payload: bytes) -> dict[str, Any]:
+    """Parse the shipped storage.json into a dict for the pre-extract lookups."""
+    try:
+        parsed = json.loads(payload)
+    except ValueError as err:
+        raise MaterialiseError(f"tarball storage.json is not valid JSON: {err}") from err
+    if not isinstance(parsed, dict):
+        raise MaterialiseError("tarball storage.json is not a JSON object")
+    return parsed
+
+
+def _stage_offloader_storage(
+    *,
+    configuration: str,
+    receiver_storage_bytes: bytes,
+    receiver_build_path: Path,
+    offloader_build_path: Path,
+) -> None:
+    """Write the receiver's storage to the offloader's path, remap paths, save."""
+    storage_path = resolve_storage_path(configuration)
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    storage_path.write_bytes(receiver_storage_bytes)
+    storage = StorageJSON.load(storage_path)
+    if storage is None:
+        raise MaterialiseError(
+            f"StorageJSON.load returned None for the staged sidecar at {storage_path}"
+        )
+    if storage.firmware_bin_path is not None:
+        storage.firmware_bin_path = _remap_to_offloader(
+            Path(storage.firmware_bin_path),
+            receiver_build_path,
+            offloader_build_path,
+        )
+    storage.build_path = offloader_build_path
+    storage.save(storage_path)
+
+
+def _stage_offloader_idedata(
+    *,
+    configuration: str,
+    idedata_bytes: bytes,
+    device_name: str,
+    receiver_build_path: Path,
+    offloader_build_path: Path,
+) -> Path:
+    """Rewrite the receiver's idedata and save at the offloader's cache path."""
+    try:
+        data = json.loads(idedata_bytes)
+    except ValueError as err:
+        raise MaterialiseError(f"tarball idedata.json is not valid JSON: {err}") from err
+    if not isinstance(data, dict):
+        raise MaterialiseError("tarball idedata.json is not a JSON object")
+
+    prog = data.get("prog_path")
+    if isinstance(prog, str):
+        data["prog_path"] = str(
+            _remap_to_offloader(Path(prog), receiver_build_path, offloader_build_path)
+        )
+    extra = data.get("extra")
+    if isinstance(extra, dict):
+        flash_images = extra.get("flash_images")
+        if isinstance(flash_images, list):
+            for image in flash_images:
+                if not isinstance(image, dict):
+                    continue
+                path_str = image.get("path")
+                if isinstance(path_str, str):
+                    image["path"] = str(
+                        _remap_to_offloader(
+                            Path(path_str),
+                            receiver_build_path,
+                            offloader_build_path,
+                        )
+                    )
+
+    # Remap cc_path's PIO core prefix so RP2040 BOOTSEL's
+    # picotool lookup resolves on the offloader; drop the field
+    # if the shape isn't recognisable (picotool falls through to
+    # PATH).
+    cc_path = data.get("cc_path")
+    if isinstance(cc_path, str):
+        remapped = _remap_pio_toolchain_path(cc_path)
+        if remapped is None:
+            data.pop("cc_path", None)
+        else:
+            data["cc_path"] = remapped
+
+    cached_path = resolve_idedata_path(configuration, name=device_name)
+    cached_path.parent.mkdir(parents=True, exist_ok=True)
+    cached_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return cached_path
+
+
+def _force_idedata_cache_hit(*, platformio_ini: Path, cached_idedata: Path) -> None:
+    """Make platformio.ini.mtime < cached_idedata.mtime so _load_idedata's gate hits."""
+    if not platformio_ini.is_file() or not cached_idedata.is_file():
+        return
+    now = time.time()
+    os.utime(cached_idedata, (now, now))
+    os.utime(platformio_ini, (now - 1, now - 1))
+
+
+def _remap_to_offloader(
+    receiver_abs: Path,
+    receiver_build_path: Path,
+    offloader_build_path: Path,
+) -> Path:
+    """Translate *receiver_abs* under *receiver_build_path* to the offloader's tree.
+
+    Returns *receiver_abs* unchanged when it isn't actually under
+    *receiver_build_path* (cc_path-style absolute paths get
+    remapped via :func:`_remap_pio_toolchain_path` instead).
+    """
+    try:
+        relative = receiver_abs.relative_to(receiver_build_path)
+    except ValueError:
+        return receiver_abs
+    return offloader_build_path / relative
+
+
+def _remap_pio_toolchain_path(cc_path: str) -> str | None:
+    """Swap the receiver's ``<pio_core>/packages/...`` prefix for the offloader's.
+
+    Returns None when *cc_path* doesn't carry a ``packages``
+    segment; toolchain identifiers themselves are platform-stable
+    so the suffix carries verbatim.
+    """
+    parts = Path(cc_path).parts
+    try:
+        packages_idx = parts.index("packages")
+    except ValueError:
+        return None
+    offloader_core = Path(os.environ.get("PLATFORMIO_CORE_DIR", str(Path.home() / ".platformio")))
+    return str(offloader_core.joinpath(*parts[packages_idx:]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,9 @@ select = [
 # Discovery CLI: prints are the entire UX (mirrors aioesphomeapi-discover).
 "esphome_device_builder/discover.py" = ["T20"]
 "tests/*" = ["S105", "S106"] # hardcoded test credentials
+# Manual scripts: print is the UX, late imports gate optional setup,
+# subprocess + tempdir paths are part of the CLI contract.
+"tests/manual/*" = ["T20", "S108", "PLC0415"]
 # GitHub Action helpers: prints are CI-log diagnostics, lazy imports keep the
 # module importable for unit tests without PyGithub installed, and the temp
 # file path is a runner-controlled location not user input.

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -373,6 +373,50 @@ async def test_install_force_local_bypasses_scheduler(
 
 
 @pytest.mark.asyncio
+async def test_compile_force_local_bypasses_scheduler(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """``firmware/compile`` with ``force_local=True`` skips the remote-build route."""
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing()
+    _stub_remote_build(
+        controller,
+        pairings=[pairing],
+        open_pins=frozenset({_PIN}),
+        idle_pins=frozenset({_PIN}),
+    )
+    (tmp_path / "kitchen.yaml").write_text("")
+
+    job = await controller.compile(configuration="kitchen.yaml", force_local=True)
+
+    assert job.source is JobSource.LOCAL
+    assert job.source_pin_sha256 == ""
+
+
+@pytest.mark.asyncio
+async def test_compile_bulk_force_local_bypasses_scheduler(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """``firmware/compile_bulk`` with ``force_local=True`` keeps every job LOCAL."""
+    controller = firmware_controller_factory(with_queue=True)
+    pairing = _make_pairing()
+    _stub_remote_build(
+        controller,
+        pairings=[pairing],
+        open_pins=frozenset({_PIN}),
+        idle_pins=frozenset({_PIN}),
+    )
+    (tmp_path / "kitchen.yaml").write_text("")
+    (tmp_path / "garage.yaml").write_text("")
+
+    jobs = await controller.compile_bulk(
+        configurations=["kitchen.yaml", "garage.yaml"], force_local=True
+    )
+
+    assert [j.source for j in jobs] == [JobSource.LOCAL, JobSource.LOCAL]
+
+
+@pytest.mark.asyncio
 async def test_install_force_local_default_false_keeps_scheduler_behaviour(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -430,21 +430,16 @@ async def test_install_still_routes_remote_when_receiver_is_busy(
 
 
 @pytest.mark.asyncio
-async def test_install_forces_local_for_serial_port(
+async def test_install_serial_port_can_route_remote(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """
-    Serial ``port`` forces LOCAL regardless of the scheduler.
+    """Serial ports are eligible for REMOTE source routing.
 
-    The runner's REMOTE flash step uses ``esphome upload
-    --file`` which routes through
-    ``upload_using_esptool`` as a single ``FlashImage`` at
-    offset ``0x0``. That works for OTA / web_server pushes
-    but corrupts an ESP32 wired flash (needs bootloader /
-    partitions / OTA-data at their own offsets stitched
-    from ``idedata.extra.flash_images``). Until the runner
-    can stage the full multi-image set, serial REMOTE
-    installs stay LOCAL.
+    With the materialise-locally runner the offloader stages
+    the receiver's full build tree and spawns ``esphome upload
+    <yaml> --device <port>`` (no ``--file``). That handles
+    multi-image ESP32 wired flash cleanly via esphome's normal
+    per-platform dispatch.
     """
     controller = firmware_controller_factory(with_queue=True)
     pairing = _make_pairing()
@@ -458,7 +453,8 @@ async def test_install_forces_local_for_serial_port(
 
     job = await controller.install(configuration="kitchen.yaml", port="/dev/ttyUSB0")
 
-    assert job.source is JobSource.LOCAL
+    assert job.source is JobSource.REMOTE
+    assert job.source_pin_sha256 == _PIN
 
 
 @pytest.mark.asyncio
@@ -571,18 +567,10 @@ async def test_install_bulk_routes_each_config_through_the_scheduler(
 
 
 @pytest.mark.asyncio
-async def test_install_bulk_with_serial_port_forces_every_config_local(
+async def test_install_bulk_serial_port_routes_every_config_remote(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """
-    A serial-port bulk install routes every config to LOCAL.
-
-    Per-port gate is checked first; the scheduler isn't even
-    consulted when the port is serial. Pins the gate's order
-    so a future refactor that lifts the port check out of the
-    resolver doesn't silently send wired-flash jobs to a
-    remote receiver.
-    """
+    """Serial-port bulk install routes every config to REMOTE when a paired peer is open."""
     controller = firmware_controller_factory(with_queue=True)
     pairing = _make_pairing()
     _stub_remote_build(
@@ -598,4 +586,4 @@ async def test_install_bulk_with_serial_port_forces_every_config_local(
         configurations=["kitchen.yaml", "garage.yaml"], port="/dev/ttyUSB0"
     )
 
-    assert [j.source for j in jobs] == [JobSource.LOCAL, JobSource.LOCAL]
+    assert [j.source for j in jobs] == [JobSource.REMOTE, JobSource.REMOTE]

--- a/tests/controllers/firmware/test_queue_status.py
+++ b/tests/controllers/firmware/test_queue_status.py
@@ -249,7 +249,7 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
     if fn_name == "_finalize_success":
         remote_runner._finalize_success(controller, job)
     else:
-        remote_runner._fail_locally(controller, job, error="boom")
+        remote_runner._fail_locally(controller, job, reason="boom")
 
     assert captured == [(True, False, 0)]
     assert controller._current_job is None
@@ -259,6 +259,6 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
         # ``_fail_locally`` stamps ``job.error`` before
         # ``_finalize_terminal``; the JOB_FAILED listener that
         # rides the broadcast sees the populated field.
-        assert job.error == "boom"
+        assert job.error == "remote build: boom"
     else:
         assert job.error is None

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -489,6 +489,41 @@ async def test_remote_compile_plumbs_device_names_from_local_scanner(
 
 
 @pytest.mark.asyncio
+async def test_remote_compile_falls_through_when_no_device_matches(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """``submit_job`` ships empty names when the local scanner has no entry for the YAML."""
+    controller = firmware_controller_factory(with_terminate=True)
+    _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+
+    unrelated_device = MagicMock()
+    unrelated_device.configuration = "other.yaml"
+    unrelated_device.name = "other"
+    unrelated_device.friendly_name = "Other"
+    devices_stub = MagicMock()
+    devices_stub.get_devices.return_value = [unrelated_device]
+    controller._db.devices = devices_stub
+
+    job = _make_remote_job()
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    client.submit_job.assert_awaited_once_with(
+        job_id=job.job_id,
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=b"FAKEBUNDLE",
+        device_name="",
+        device_friendly_name="",
+    )
+
+
+@pytest.mark.asyncio
 async def test_remote_compile_progress_translates_to_local_progress_event(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -30,9 +30,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import remote_runner
-from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
-    UnpackArtifactsError,
-)
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
     DownloadArtifactsError,
     DownloadArtifactsResult,
@@ -41,6 +38,7 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.config_bundle import BundleBuildError
 from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.helpers.remote_artifacts_materialise import MaterialiseError
 from esphome_device_builder.models import (
     ErrorCode,
     EventType,
@@ -1423,17 +1421,10 @@ def _make_packed_artifacts(tarball: bytes = b"FAKE-TARBALL") -> DownloadArtifact
 
 
 @pytest.fixture
-def patch_extract_firmware(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
-    """Replace :func:`extract_firmware_bin` with a stub that returns canned bytes.
-
-    The real implementation parses a gzipped tarball; tests
-    don't care about the parse, only about the bytes that
-    end up at the staged path. Patching the symbol on
-    ``remote_runner`` (where the import landed) is the
-    standard "intercept at the call site" pattern.
-    """
-    stub = MagicMock(return_value=b"STAGED-FIRMWARE-BYTES")
-    monkeypatch.setattr(remote_runner, "extract_firmware_bin", stub)
+def patch_materialise(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stub ``materialise_remote_artifacts`` so the runner skips real I/O."""
+    stub = MagicMock(return_value=Path("/fake/staged/build/path"))
+    monkeypatch.setattr(remote_runner, "materialise_remote_artifacts", stub)
     return stub
 
 
@@ -1441,7 +1432,7 @@ def patch_extract_firmware(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
 async def test_remote_install_resets_progress_between_compile_and_upload(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
-    patch_extract_firmware: MagicMock,
+    patch_materialise: MagicMock,
 ) -> None:
     """
     The compile → upload seam fires ``JOB_PROGRESS{0}`` and clears ``job.progress``.
@@ -1489,7 +1480,7 @@ async def test_remote_install_resets_progress_between_compile_and_upload(
 async def test_remote_install_completes_after_local_upload_succeeds(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
-    patch_extract_firmware: MagicMock,
+    patch_materialise: MagicMock,
     tmp_path: Any,
 ) -> None:
     """
@@ -1521,14 +1512,14 @@ async def test_remote_install_completes_after_local_upload_succeeds(
     assert len(captured[EventType.JOB_COMPLETED]) == 1
     client.download_artifacts.assert_awaited_once_with(job_id=job.job_id)
     # ``firmware.bin`` was staged + ``esphome upload`` saw it.
-    patch_extract_firmware.assert_called_once()
+    patch_materialise.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_remote_install_local_upload_failure_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
-    patch_extract_firmware: MagicMock,
+    patch_materialise: MagicMock,
 ) -> None:
     """A non-zero ``esphome upload`` exit lands as JOB_FAILED with exit-code in error."""
     controller = firmware_controller_factory(with_terminate=True)
@@ -1576,18 +1567,12 @@ async def test_remote_install_download_artifacts_failure_fires_job_failed(
 
 
 @pytest.mark.asyncio
-async def test_remote_install_malformed_tarball_fires_job_failed(
+async def test_remote_install_materialise_failure_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    Tarball missing ``firmware.bin`` surfaces as JOB_FAILED with extract error.
-
-    Defensive — the receiver-side packer enforces the
-    layout, so a malformed tarball means an in-flight bug
-    or a misbehaving peer.
-    """
+    """Materialise failure (malformed tarball, missing member) lands as JOB_FAILED."""
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     client = _make_client()
@@ -1595,8 +1580,8 @@ async def test_remote_install_malformed_tarball_fires_job_failed(
     _wire_remote_build(controller, client=client)
     monkeypatch.setattr(
         remote_runner,
-        "extract_firmware_bin",
-        MagicMock(side_effect=UnpackArtifactsError("firmware.bin missing")),
+        "materialise_remote_artifacts",
+        MagicMock(side_effect=MaterialiseError("tarball missing required member: 'storage.json'")),
     )
     job = _make_remote_install_job()
 
@@ -1606,7 +1591,7 @@ async def test_remote_install_malformed_tarball_fires_job_failed(
     await asyncio.wait_for(runner, timeout=2.0)
 
     assert job.status == JobStatus.FAILED
-    assert job.error is not None and "firmware.bin missing" in job.error
+    assert job.error is not None and "materialise failed" in job.error
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
@@ -1614,7 +1599,7 @@ async def test_remote_install_malformed_tarball_fires_job_failed(
 async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
-    patch_extract_firmware: MagicMock,
+    patch_materialise: MagicMock,
 ) -> None:
     """
     User Stop during the ``esphome upload`` subprocess finalises as CANCELLED.
@@ -1677,7 +1662,7 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
 @pytest.mark.asyncio
 async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_terminates(
     firmware_controller_factory: FirmwareControllerFactory,
-    patch_extract_firmware: MagicMock,
+    patch_materialise: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
@@ -1718,19 +1703,15 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
     # regardless of the exit.
     _wire_upload_subprocess(controller, exit_code=0, stdout="ok\n")
 
-    # Patch ``Path.write_bytes`` so the executor hop that
-    # writes the staged firmware file flips
-    # ``_cancel_requested`` as a side effect. That puts the
-    # cancel into the gap between the pre-spawn check and
-    # the in-context-manager check.
-    original_write_bytes = Path.write_bytes
-
-    def _write_bytes_then_cancel(self: Path, data: bytes) -> int:
-        result = original_write_bytes(self, data)
+    # Flip ``_cancel_requested`` from inside ``_build_cache_args``,
+    # which runs after the pre-spawn check and before the
+    # subprocess spawn. The in-context-manager check fires
+    # post-spawn.
+    def _build_cache_args_then_cancel(_job: object) -> list[str]:
         controller._cancel_requested.add(job.job_id)
-        return result
+        return []
 
-    monkeypatch.setattr(Path, "write_bytes", _write_bytes_then_cancel)
+    controller._build_cache_args = _build_cache_args_then_cancel  # type: ignore[method-assign]
 
     await remote_runner._fetch_and_run_local_upload(controller=controller, job=job, client=client)
 
@@ -1746,7 +1727,7 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
 @pytest.mark.asyncio
 async def test_fetch_and_run_local_upload_cancel_pre_spawn_skips_subprocess(
     firmware_controller_factory: FirmwareControllerFactory,
-    patch_extract_firmware: MagicMock,
+    patch_materialise: MagicMock,
 ) -> None:
     """
     Cancel landing between extract + spawn skips the subprocess.
@@ -1786,14 +1767,14 @@ async def test_fetch_and_run_local_upload_cancel_pre_spawn_skips_subprocess(
     assert job.status == JobStatus.CANCELLED
     assert len(captured[EventType.JOB_CANCELLED]) == 1
     client.download_artifacts.assert_awaited_once()
-    patch_extract_firmware.assert_called_once()
+    patch_materialise.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_remote_upload_runs_the_same_local_flash_chain_as_install(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
-    patch_extract_firmware: MagicMock,
+    patch_materialise: MagicMock,
 ) -> None:
     """
     ``JobType.UPLOAD`` with REMOTE source follows the same artifact-fetch + flash chain.

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -588,7 +588,7 @@ async def test_remote_compile_failed_status_fires_job_failed(
     await asyncio.wait_for(runner, timeout=2.0)
 
     assert job.status == JobStatus.FAILED
-    assert job.error == "syntax error in YAML"
+    assert job.error == "remote build: syntax error in YAML"
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1611,6 +1611,54 @@ async def test_remote_install_materialise_failure_fires_job_failed(
 
 
 @pytest.mark.asyncio
+async def test_remote_install_materialise_oserror_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An OSError from materialise (disk full / permissions) lands as JOB_FAILED."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    monkeypatch.setattr(
+        remote_runner,
+        "materialise_remote_artifacts",
+        MagicMock(side_effect=OSError("ENOSPC: disk full")),
+    )
+    job = _make_remote_install_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
+    await _wait_until_dispatched(client)
+    _fire_state(controller, job_id=job.job_id, status="completed")
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "materialise IO error" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_run_local_upload_pre_spawn_cancel_finalises_locally(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Cancel landing after ``_fetch_and_materialise`` returns but before the spawn."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    job = _make_remote_install_job()
+    controller._cancel_requested.add(job.job_id)
+    controller._tracked_subprocess = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("subprocess should not have spawned")
+    )
+
+    await remote_runner._fetch_and_run_local_upload(controller=controller, job=job, client=client)
+
+    assert job.status == JobStatus.CANCELLED
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
+
+
+@pytest.mark.asyncio
 async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -372,6 +372,9 @@ async def test_remote_compile_translates_output_and_completes(
     assert len(captured[EventType.JOB_COMPLETED]) == 1
     assert captured[EventType.JOB_COMPLETED][0]["job"] is job
     assert captured[EventType.JOB_FAILED] == []
+    # COMPILE now goes through materialise so firmware/download
+    # serves the staged tree (#624).
+    client.download_artifacts.assert_awaited_once()
     client.submit_job.assert_awaited_once_with(
         job_id=job.job_id,
         configuration_filename="kitchen.yaml",

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -93,6 +93,10 @@ def _wire_remote_build(
     return remote_build, client
 
 
+def _make_packed_artifacts(tarball: bytes = b"FAKE-TARBALL") -> DownloadArtifactsResult:
+    return DownloadArtifactsResult(tarball=tarball, firmware_offset="0x10000")
+
+
 def _make_client(
     *,
     accepted: bool = True,
@@ -127,6 +131,12 @@ def _make_client(
         client.cancel_job = AsyncMock(side_effect=cancel_error)
     else:
         client.cancel_job = AsyncMock(return_value=cancel_return)
+    # Default so COMPILE / UPLOAD / INSTALL tests don't have to
+    # wire it per-test — the runner now goes through
+    # ``_fetch_and_materialise`` for every non-CLEAN COMPLETED
+    # job. Tests that want to inspect the call or simulate
+    # failure override this assignment.
+    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
     return client
 
 
@@ -1416,13 +1426,15 @@ def _wire_upload_subprocess(
     controller._build_cache_args = lambda _job: []
 
 
-def _make_packed_artifacts(tarball: bytes = b"FAKE-TARBALL") -> DownloadArtifactsResult:
-    return DownloadArtifactsResult(tarball=tarball, firmware_offset="0x10000")
-
-
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def patch_materialise(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """Stub ``materialise_remote_artifacts`` so the runner skips real I/O."""
+    """Autouse: stub ``materialise_remote_artifacts`` so the runner skips real I/O.
+
+    Every test in this file exercises the runner; the runner now
+    materialises for every non-CLEAN COMPLETED job. Autouse keeps
+    per-test signatures uncluttered; tests that want to inspect
+    or override the stub still request the fixture by name.
+    """
     stub = MagicMock(return_value=Path("/fake/staged/build/path"))
     monkeypatch.setattr(remote_runner, "materialise_remote_artifacts", stub)
     return stub
@@ -1725,45 +1737,28 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
 
 
 @pytest.mark.asyncio
-async def test_fetch_and_run_local_upload_cancel_pre_spawn_skips_subprocess(
+async def test_fetch_and_materialise_cancel_post_staging_finalises_locally(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_materialise: MagicMock,
 ) -> None:
-    """
-    Cancel landing between extract + spawn skips the subprocess.
+    """Cancel landing during the wire / extract executor hops finalises the job locally.
 
-    The wire round-trip (``download_artifacts``) and the
-    in-executor tarball extract have already happened by the
-    time the check fires — those couldn't be cancelled
-    cleanly anyway. The check guards the staging + spawn
-    phase: a cancel that arrived between the executor hop
-    and the spawn finalises the job locally without writing
-    the tmpdir or starting ``esphome upload``.
-
-    Unit-tested directly because the outer runner routes
-    most cancel races through ``_await_terminal``'s in-loop
-    check — this defensive gate is only reachable via the
-    helper's own entry. Pinning it here keeps the branch
-    alive against a future refactor that introduces an
-    ``await`` between ``_await_terminal`` and this helper.
+    download_artifacts + materialise happen first (they can't be
+    cleanly cancelled mid-flight); the post-staging cancel check
+    then routes through ``_finalize_cancelled`` and returns
+    ``False`` so the caller skips the spawn.
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     client = _make_client()
-    client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
-
-    # Track spawn attempts: ``_tracked_subprocess`` is an
-    # async context manager on the controller; a successful
-    # cancel-pre-spawn skip means it's never invoked.
-    controller._tracked_subprocess = MagicMock(  # type: ignore[method-assign]
-        side_effect=AssertionError("subprocess should not have spawned")
-    )
-
     job = _make_remote_install_job()
     controller._cancel_requested.add(job.job_id)
 
-    await remote_runner._fetch_and_run_local_upload(controller=controller, job=job, client=client)
+    proceed = await remote_runner._fetch_and_materialise(
+        controller=controller, job=job, client=client
+    )
 
+    assert proceed is False
     assert job.status == JobStatus.CANCELLED
     assert len(captured[EventType.JOB_CANCELLED]) == 1
     client.download_artifacts.assert_awaited_once()

--- a/tests/e2e/test_download_artifacts.py
+++ b/tests/e2e/test_download_artifacts.py
@@ -134,8 +134,10 @@ def _write_build_artifacts_on_disk(tmp_path: Path) -> dict[str, bytes]:
     real-disk bytes round-tripped through the wire envelope
     verbatim.
     """
-    build_dir = tmp_path / "build"
-    build_dir.mkdir(parents=True, exist_ok=True)
+    build_dir = tmp_path / ".esphome" / "build" / "kitchen"
+    pioenvs = build_dir / ".pioenvs" / "kitchen"
+    pioenvs.mkdir(parents=True, exist_ok=True)
+    (build_dir / "platformio.ini").write_bytes(b"[env:e2e]\nplatform = espressif32\n")
     images: dict[str, bytes] = {
         "firmware.bin": b"firmware-bin-bytes",
         "bootloader.bin": b"bootloader-bytes",
@@ -143,13 +145,14 @@ def _write_build_artifacts_on_disk(tmp_path: Path) -> dict[str, bytes]:
     }
     image_paths: dict[str, Path] = {}
     for name, payload in images.items():
-        path = build_dir / name
+        path = pioenvs / name
         path.write_bytes(payload)
         image_paths[name] = path
 
     write_storage_json(
         tmp_path,
         "kitchen.yaml",
+        build_path=build_dir,
         firmware_bin_path=image_paths["firmware.bin"],
         # Sidecar's ``target_platform`` drives
         # ``_firmware_offset_for_platform``; force esp32 so the

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -60,14 +60,19 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from esphome.core import CORE
+from esphome.storage_json import StorageJSON
 
 from esphome_device_builder.helpers.build_scheduler import (
     BuildPath,
     pick_build_path,
 )
+from esphome_device_builder.helpers.remote_artifacts_materialise import (
+    materialise_remote_artifacts,
+)
 from esphome_device_builder.helpers.remote_build_layout import (
     parse_from_configuration as parse_remote_build_path,
 )
+from esphome_device_builder.helpers.storage_path import resolve_storage_path
 from esphome_device_builder.models import (
     EventType,
     FirmwareJob,
@@ -467,6 +472,52 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
     assert len(paired_instances.receiver_closed) == 0
     assert len(paired_instances.offloader_opened) == opened_at_start[0]
     assert len(paired_instances.receiver_opened) == opened_at_start[1]
+
+
+@pytest.mark.asyncio
+async def test_remote_compile_materialises_for_local_firmware_download(
+    paired_instances: PairedInstances,
+    tmp_path: Path,
+) -> None:
+    """#624: compile remote → materialise → firmware/download reads staged bytes."""
+    await paired_instances.wait_until_session_opened()
+    created_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+
+    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    ack = await handle.client.submit_job(
+        job_id="off-compile-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=_build_real_bundle(),
+    )
+    assert ack["accepted"] is True
+    receiver_job = created_jobs[0]
+    images = _write_build_artifacts_on_disk(tmp_path, configuration=receiver_job.configuration)
+
+    paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=receiver_job))
+    paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=receiver_job))
+    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
+    state_changes.received.clear()
+    paired_instances.receiver_bus.fire(EventType.JOB_COMPLETED, JobLifecycleData(job=receiver_job))
+    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
+    receiver_job.status = JobStatus.COMPLETED
+
+    packed = await handle.client.download_artifacts(job_id="off-compile-1")
+    build_path = await asyncio.to_thread(
+        materialise_remote_artifacts, packed.tarball, "kitchen.yaml"
+    )
+    assert (build_path / ".pioenvs" / "kitchen" / "firmware.bin").is_file()
+
+    staged_storage = await asyncio.to_thread(StorageJSON.load, resolve_storage_path("kitchen.yaml"))
+    assert staged_storage is not None
+    assert staged_storage.firmware_bin_path is not None
+    download_dir = staged_storage.firmware_bin_path.parent
+    assert (download_dir / "firmware.bin").read_bytes() == images["firmware.bin"]
+    assert (download_dir / "bootloader.bin").read_bytes() == images["bootloader.bin"]
+    assert (download_dir / "partitions.bin").read_bytes() == images["partitions.bin"]
 
 
 def _drive_receiver_lifecycle(

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -487,12 +487,16 @@ async def test_remote_compile_materialises_for_local_firmware_download(
     )
 
     # Fail loud if the scheduler would have picked LOCAL — silent
-    # local fallback masks the whole point of this test.
-    queue_status = capture_events(
-        paired_instances.offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED
-    )
-    await asyncio.wait_for(queue_status.received.wait(), timeout=2.0)
+    # local fallback masks the whole point of this test. The
+    # receiver's queue_status push can land before or after the
+    # paired_instances fixture returns (event-vs-fixture race);
+    # poll the cache + scheduler decision instead of waiting on
+    # a one-shot event we might have missed.
+    deadline = asyncio.get_event_loop().time() + 2.0
     decision = pick_build_path(paired_instances.offloader.build_scheduler_snapshot())
+    while decision.path is not BuildPath.REMOTE and asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.02)
+        decision = pick_build_path(paired_instances.offloader.build_scheduler_snapshot())
     assert decision.path is BuildPath.REMOTE, (
         f"scheduler picked {decision.path} — expected REMOTE for the e2e to be meaningful"
     )

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -486,6 +486,17 @@ async def test_remote_compile_materialises_for_local_firmware_download(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
 
+    # Fail loud if the scheduler would have picked LOCAL — silent
+    # local fallback masks the whole point of this test.
+    queue_status = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED
+    )
+    await asyncio.wait_for(queue_status.received.wait(), timeout=2.0)
+    decision = pick_build_path(paired_instances.offloader.build_scheduler_snapshot())
+    assert decision.path is BuildPath.REMOTE, (
+        f"scheduler picked {decision.path} — expected REMOTE for the e2e to be meaningful"
+    )
+
     handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
     ack = await handle.client.submit_job(
         job_id="off-compile-1",

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -511,7 +511,10 @@ async def test_remote_compile_materialises_for_local_firmware_download(
     )
     assert (build_path / ".pioenvs" / "kitchen" / "firmware.bin").is_file()
 
-    staged_storage = await asyncio.to_thread(StorageJSON.load, resolve_storage_path("kitchen.yaml"))
+    def _load_staged() -> StorageJSON | None:
+        return StorageJSON.load(resolve_storage_path("kitchen.yaml"))
+
+    staged_storage = await asyncio.to_thread(_load_staged)
     assert staged_storage is not None
     assert staged_storage.firmware_bin_path is not None
     download_dir = staged_storage.firmware_bin_path.parent

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -192,8 +192,12 @@ def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dic
         "the helper is e2e-specific and not meant for bare-basename inputs"
     )
     data_dir = remote_build_path.data_dir(Path(CORE.data_dir))
-    build_dir = data_dir / "build" / remote_build_path.device_name
-    build_dir.mkdir(parents=True, exist_ok=True)
+    device_name = remote_build_path.device_name
+    build_dir = data_dir / "build" / device_name
+    pioenvs = build_dir / ".pioenvs" / device_name
+    pioenvs.mkdir(parents=True, exist_ok=True)
+    # platformio.ini is now part of the packer's required set.
+    (build_dir / "platformio.ini").write_bytes(b"[env:e2e]\nplatform = espressif32\n")
     images: dict[str, bytes] = {
         "firmware.bin": b"firmware-bin-bytes",
         "bootloader.bin": b"bootloader-bytes",
@@ -201,7 +205,7 @@ def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dic
     }
     image_paths: dict[str, Path] = {}
     for name, payload in images.items():
-        path = build_dir / name
+        path = pioenvs / name
         path.write_bytes(payload)
         image_paths[name] = path
 

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -1,0 +1,62 @@
+# Manual remote-firmware e2e scripts
+
+Two scripts that exercise the materialise-locally remote-firmware flow against
+a real `esphome` toolchain by pairing two in-process mock dashboards. **Not
+part of CI** — these are wet-test helpers for pre-release confidence.
+
+## Scripts
+
+### `run_mock_remote_e2e.py`
+
+Submits `firmware/install` on the offloader. The receiver runs a real
+`esphome compile`; the offloader materialises the artifacts and spawns a real
+`esphome upload` against the configured device.
+
+```sh
+python tests/manual/run_mock_remote_e2e.py \
+    --yaml apollo-r-pro-1-eth-5938e0.yaml \
+    --device OTA
+```
+
+For a wired (serial) install, pass `--device /dev/ttyUSB0` (or the platform
+equivalent). The apollo-r-pro-1-eth device that's been our wet-test target
+is safe to re-upload to as many times as needed.
+
+### `download_mock_remote_e2e.py`
+
+Submits `firmware/compile` on the offloader, then calls `firmware/download`
+to dump the staged binary to a local path. Proves the #624 download path
+end-to-end.
+
+```sh
+python tests/manual/download_mock_remote_e2e.py \
+    --yaml apollo-r-pro-1-eth-5938e0.yaml \
+    --out  /tmp/apollo-firmware.bin
+```
+
+Use `--file firmware.factory.bin` to download the factory image instead of
+the OTA binary; `--file firmware.uf2` for libretiny / RP2040.
+
+## Prerequisites
+
+- `esphome` installed in the active venv (the PIO toolchains install
+  themselves on first compile / upload, no separate setup needed).
+- A YAML the script can hand to `esphome compile`.
+
+Both scripts create a tempdir under cwd (or `--workdir`) and stand up the
+offloader + receiver dashboards there. The pairing handshake runs over a
+real Noise XX peer-link WS on a loopback port; no network access needed.
+
+## What they exercise
+
+- The full receiver-side compile pipeline (real `esphome compile` subprocess).
+- The wire round-trip (`submit_job` → fan-out → `download_artifacts`).
+- The offloader-side `materialise_remote_artifacts` against real
+  receiver-produced artifacts.
+- For `run_*`: the local `esphome upload <yaml> --device <port>` subprocess
+  the runner spawns against the staged tree.
+- For `download_*`: the dashboard's `firmware/download` endpoint reading
+  the staged StorageJSON sidecar.
+
+If a script returns non-zero, inspect the printed `job.error` and the
+streamed job output to find which side broke.

--- a/tests/manual/_mock_remote_e2e.py
+++ b/tests/manual/_mock_remote_e2e.py
@@ -92,6 +92,15 @@ async def paired_dashboards(
     if yaml_source is not None:
         target = offloader_dir / yaml_source.name
         target.write_bytes(yaml_source.read_bytes())
+        # Pull in ``secrets.yaml`` from the same directory so
+        # ``!secret`` references in the staged YAML resolve. Real
+        # device YAMLs almost always lean on this; without it the
+        # offloader's bundle step fails at config-read with
+        # "No such file: secrets.yaml" before ever talking to the
+        # receiver.
+        companion_secrets = yaml_source.parent / "secrets.yaml"
+        if companion_secrets.is_file():
+            (offloader_dir / "secrets.yaml").write_bytes(companion_secrets.read_bytes())
 
     offloader_settings = _make_settings(offloader_dir)
     receiver_settings = _make_settings(receiver_dir)

--- a/tests/manual/_mock_remote_e2e.py
+++ b/tests/manual/_mock_remote_e2e.py
@@ -1,0 +1,175 @@
+"""
+Shared helper for the manual remote-firmware e2e scripts.
+
+Stands up two ``DeviceBuilder`` instances in one process, pairs them via the
+production pairing flow over a real Noise XX peer-link WS, and yields handles
+to both. The receiver side runs a real :class:`FirmwareController` so
+``firmware/install`` / ``firmware/compile`` submitted on the offloader
+trigger a real ``esphome compile`` on the receiver side; the offloader's
+runner then materialises the receiver's artifacts back locally exactly like
+production.
+
+These scripts are *not* part of CI. They exist for wet-test confidence
+before each release. Run them manually against a real device.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from esphome.core import CORE
+
+from esphome_device_builder.api.ws import init_ws_app
+from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.controllers.remote_build.peer_link import (
+    PEER_LINK_PATH,
+    make_peer_link_handler,
+)
+from esphome_device_builder.device_builder import DeviceBuilder
+from esphome_device_builder.models import EventType
+
+
+@dataclass
+class MockPair:
+    """Handles for the offloader + receiver dashboards + pairing metadata."""
+
+    offloader: DeviceBuilder
+    receiver: DeviceBuilder
+    receiver_server: TestServer
+    pin_sha256: str
+    offloader_dashboard_id: str
+
+
+def _make_settings(config_dir: Path) -> DashboardSettings:
+    """Build a minimal ``DashboardSettings`` rooted at *config_dir*."""
+    settings = DashboardSettings()
+    settings.config_dir = config_dir
+    settings.absolute_config_dir = config_dir.resolve()
+    return settings
+
+
+@asynccontextmanager
+async def paired_dashboards(
+    *,
+    root_dir: Path,
+    yaml_source: Path | None = None,
+) -> AsyncIterator[MockPair]:
+    """Yield two paired ``DeviceBuilder`` instances under *root_dir*.
+
+    If *yaml_source* is given, copy it into the offloader's config dir
+    so ``firmware/install`` / ``firmware/compile`` calls have a YAML
+    to resolve. The receiver loads its own copy through the bundle the
+    offloader ships.
+
+    ``CORE.config_path`` is repointed at each side's sentinel during the
+    relevant phase; tests of the materialiser then resolve under that
+    side's data dir. The offloader's setup is what's active when the
+    context manager yields.
+    """
+    offloader_dir = root_dir / "offloader"
+    receiver_dir = root_dir / "receiver"
+    offloader_dir.mkdir(parents=True, exist_ok=True)
+    receiver_dir.mkdir(parents=True, exist_ok=True)
+
+    if yaml_source is not None:
+        target = offloader_dir / yaml_source.name
+        target.write_bytes(yaml_source.read_bytes())
+
+    offloader_settings = _make_settings(offloader_dir)
+    receiver_settings = _make_settings(receiver_dir)
+    offloader = DeviceBuilder(offloader_settings)
+    receiver = DeviceBuilder(receiver_settings)
+
+    # Pin CORE.config_path to the offloader sentinel — the
+    # offloader's materialise / firmware/download paths anchor
+    # on this. (The receiver-side compile subprocess sets
+    # ESPHOME_DATA_DIR explicitly so it doesn't depend on CORE.)
+    offloader_sentinel = offloader_dir / "___DASHBOARD_SENTINEL___.yaml"
+    CORE.config_path = offloader_sentinel
+
+    await receiver.start()
+    await offloader.start()
+    assert receiver.remote_build_receiver is not None
+    assert offloader.remote_build_offloader is not None
+
+    # Stand up the receiver's peer-link WS on a real loopback port.
+    app = web.Application()
+    init_ws_app(app)
+    handler = await make_peer_link_handler(receiver.remote_build_receiver, receiver_dir)
+    app.router.add_get(PEER_LINK_PATH, handler)
+    server = TestServer(app)
+    await server.start_server()
+    assert server.port is not None
+
+    # Pair via the production flow.
+    await receiver.remote_build_receiver.set_pairing_window(open=True, client="manual-script")
+    preview = await offloader.remote_build_offloader.preview_pair(
+        hostname="127.0.0.1", port=server.port
+    )
+    pin_sha256 = preview["pin_sha256"]
+    await offloader.remote_build_offloader.request_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+        pin_sha256=pin_sha256,
+        receiver_label="receiver",
+        offloader_label="offloader",
+    )
+    [pending_dashboard_id] = list(receiver.remote_build_receiver._pending_peers.keys())
+
+    pair_event = asyncio.Event()
+
+    def _on_pair_status(event: object) -> None:
+        pair_event.set()
+
+    offloader.bus.add_listener(EventType.OFFLOADER_PAIR_STATUS_CHANGED, _on_pair_status)
+    await receiver.remote_build_receiver.approve_peer(dashboard_id=pending_dashboard_id)
+    await asyncio.wait_for(pair_event.wait(), timeout=5.0)
+
+    pair = MockPair(
+        offloader=offloader,
+        receiver=receiver,
+        receiver_server=server,
+        pin_sha256=pin_sha256,
+        offloader_dashboard_id=pending_dashboard_id,
+    )
+    try:
+        yield pair
+    finally:
+        # Offloader first so its peer-link client sends a
+        # structured terminate before the receiver's WS unwinds.
+        await offloader.stop()
+        await receiver.stop()
+        await server.close()
+
+
+async def wait_for_job(
+    offloader: DeviceBuilder,
+    job_id: str,
+    *,
+    timeout: float = 600.0,
+) -> object:
+    """Wait until *job_id* lands a terminal state on the offloader bus."""
+    done = asyncio.Event()
+    terminal_event: list[object] = []
+
+    def _on_terminal(event: object) -> None:
+        data = getattr(event, "data", None)
+        if data is None:
+            return
+        job = data.get("job") if isinstance(data, dict) else None
+        if job is None or job.job_id != job_id:
+            return
+        terminal_event.append(data)
+        done.set()
+
+    for ev_type in (EventType.JOB_COMPLETED, EventType.JOB_FAILED, EventType.JOB_CANCELLED):
+        offloader.bus.add_listener(ev_type, _on_terminal)
+
+    await asyncio.wait_for(done.wait(), timeout=timeout)
+    return terminal_event[0]

--- a/tests/manual/_mock_remote_e2e.py
+++ b/tests/manual/_mock_remote_e2e.py
@@ -47,10 +47,17 @@ class MockPair:
 
 
 def _make_settings(config_dir: Path) -> DashboardSettings:
-    """Build a minimal ``DashboardSettings`` rooted at *config_dir*."""
+    """Build a minimal ``DashboardSettings`` rooted at *config_dir*.
+
+    Pins the dashboard ports to 0 (OS-assigned) so two paired mock
+    instances can coexist on a host that already runs a real
+    device-builder dashboard.
+    """
     settings = DashboardSettings()
     settings.config_dir = config_dir
     settings.absolute_config_dir = config_dir.resolve()
+    settings.port = 0
+    settings.remote_build_port = 0
     return settings
 
 
@@ -128,8 +135,21 @@ async def paired_dashboards(
         pair_event.set()
 
     offloader.bus.add_listener(EventType.OFFLOADER_PAIR_STATUS_CHANGED, _on_pair_status)
+
+    queue_status_event = asyncio.Event()
+
+    def _on_queue_status(event: object) -> None:
+        queue_status_event.set()
+
+    offloader.bus.add_listener(EventType.OFFLOADER_QUEUE_STATUS_CHANGED, _on_queue_status)
+
     await receiver.remote_build_receiver.approve_peer(dashboard_id=pending_dashboard_id)
     await asyncio.wait_for(pair_event.wait(), timeout=5.0)
+    # The scheduler needs the receiver's queue_status push before it
+    # treats the pairing as eligible for REMOTE. Without this wait,
+    # firmware.compile / install can race the push and silently
+    # fall back to source=LOCAL.
+    await asyncio.wait_for(queue_status_event.wait(), timeout=5.0)
 
     pair = MockPair(
         offloader=offloader,

--- a/tests/manual/_mock_remote_e2e.py
+++ b/tests/manual/_mock_remote_e2e.py
@@ -83,6 +83,11 @@ async def paired_dashboards(
     receiver_dir = root_dir / "receiver"
     offloader_dir.mkdir(parents=True, exist_ok=True)
     receiver_dir.mkdir(parents=True, exist_ok=True)
+    # ``/var/folders/...`` resolves to ``/private/var/folders/...`` on
+    # macOS; the receiver's ``relative_to`` against the extracted
+    # YAML path needs both sides to match, so canonicalise here.
+    offloader_dir = offloader_dir.resolve()
+    receiver_dir = receiver_dir.resolve()
 
     if yaml_source is not None:
         target = offloader_dir / yaml_source.name
@@ -105,51 +110,10 @@ async def paired_dashboards(
     assert receiver.remote_build_receiver is not None
     assert offloader.remote_build_offloader is not None
 
-    # Stand up the receiver's peer-link WS on a real loopback port.
-    app = web.Application()
-    init_ws_app(app)
-    handler = await make_peer_link_handler(receiver.remote_build_receiver, receiver_dir)
-    app.router.add_get(PEER_LINK_PATH, handler)
-    server = TestServer(app)
-    await server.start_server()
-    assert server.port is not None
-
-    # Pair via the production flow.
-    await receiver.remote_build_receiver.set_pairing_window(open=True, client="manual-script")
-    preview = await offloader.remote_build_offloader.preview_pair(
-        hostname="127.0.0.1", port=server.port
+    server = await _start_receiver_peer_link_server(receiver, receiver_dir)
+    pin_sha256, pending_dashboard_id = await _run_pair_flow(
+        offloader=offloader, receiver=receiver, server=server
     )
-    pin_sha256 = preview["pin_sha256"]
-    await offloader.remote_build_offloader.request_pair(
-        hostname="127.0.0.1",
-        port=server.port,
-        pin_sha256=pin_sha256,
-        receiver_label="receiver",
-        offloader_label="offloader",
-    )
-    [pending_dashboard_id] = list(receiver.remote_build_receiver._pending_peers.keys())
-
-    pair_event = asyncio.Event()
-
-    def _on_pair_status(event: object) -> None:
-        pair_event.set()
-
-    offloader.bus.add_listener(EventType.OFFLOADER_PAIR_STATUS_CHANGED, _on_pair_status)
-
-    queue_status_event = asyncio.Event()
-
-    def _on_queue_status(event: object) -> None:
-        queue_status_event.set()
-
-    offloader.bus.add_listener(EventType.OFFLOADER_QUEUE_STATUS_CHANGED, _on_queue_status)
-
-    await receiver.remote_build_receiver.approve_peer(dashboard_id=pending_dashboard_id)
-    await asyncio.wait_for(pair_event.wait(), timeout=5.0)
-    # The scheduler needs the receiver's queue_status push before it
-    # treats the pairing as eligible for REMOTE. Without this wait,
-    # firmware.compile / install can race the push and silently
-    # fall back to source=LOCAL.
-    await asyncio.wait_for(queue_status_event.wait(), timeout=5.0)
 
     pair = MockPair(
         offloader=offloader,
@@ -166,6 +130,66 @@ async def paired_dashboards(
         await offloader.stop()
         await receiver.stop()
         await server.close()
+
+
+async def _start_receiver_peer_link_server(
+    receiver: DeviceBuilder, receiver_dir: Path
+) -> TestServer:
+    """Stand up the receiver's peer-link WS on a real loopback port."""
+    app = web.Application()
+    init_ws_app(app)
+    assert receiver.remote_build_receiver is not None
+    handler = await make_peer_link_handler(receiver.remote_build_receiver, receiver_dir)
+    app.router.add_get(PEER_LINK_PATH, handler)
+    server = TestServer(app)
+    await server.start_server()
+    assert server.port is not None
+    return server
+
+
+async def _run_pair_flow(
+    *,
+    offloader: DeviceBuilder,
+    receiver: DeviceBuilder,
+    server: TestServer,
+) -> tuple[str, str]:
+    """Run the production pair handshake; return ``(pin_sha256, dashboard_id)``.
+
+    Also waits for the receiver's queue_status push so the
+    scheduler treats the pairing as REMOTE-eligible by the time
+    the caller submits a job.
+    """
+    assert receiver.remote_build_receiver is not None
+    assert offloader.remote_build_offloader is not None
+    assert server.port is not None
+
+    await receiver.remote_build_receiver.set_pairing_window(open=True, client="manual-script")
+    preview = await offloader.remote_build_offloader.preview_pair(
+        hostname="127.0.0.1", port=server.port
+    )
+    pin_sha256 = preview["pin_sha256"]
+    await offloader.remote_build_offloader.request_pair(
+        hostname="127.0.0.1",
+        port=server.port,
+        pin_sha256=pin_sha256,
+        receiver_label="receiver",
+        offloader_label="offloader",
+    )
+    [pending_dashboard_id] = list(receiver.remote_build_receiver._pending_peers.keys())
+
+    pair_event = asyncio.Event()
+    queue_status_event = asyncio.Event()
+    offloader.bus.add_listener(EventType.OFFLOADER_PAIR_STATUS_CHANGED, lambda _e: pair_event.set())
+    offloader.bus.add_listener(
+        EventType.OFFLOADER_QUEUE_STATUS_CHANGED, lambda _e: queue_status_event.set()
+    )
+
+    await receiver.remote_build_receiver.approve_peer(dashboard_id=pending_dashboard_id)
+    await asyncio.wait_for(pair_event.wait(), timeout=5.0)
+    # Scheduler needs the receiver's queue_status push before
+    # firmware.compile / install routes REMOTE.
+    await asyncio.wait_for(queue_status_event.wait(), timeout=5.0)
+    return pin_sha256, pending_dashboard_id
 
 
 async def wait_for_job(

--- a/tests/manual/download_mock_remote_e2e.py
+++ b/tests/manual/download_mock_remote_e2e.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+r"""
+Manual e2e: real firmware/compile + firmware/download through two paired mocks.
+
+Stands up an offloader + receiver, submits firmware/compile for the
+provided YAML. The receiver runs a real ``esphome compile``; on completion
+the offloader's runner pulls the tarball and materialises it. The script
+then calls ``firmware/download`` and writes the staged firmware binary to
+the requested output path.
+
+Usage::
+
+    python tests/manual/download_mock_remote_e2e.py \
+        --yaml /path/to/device.yaml \
+        --out  /tmp/device-firmware.bin \
+        [--file firmware.bin]
+
+Run from the repo root. Requires ``esphome`` on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import logging
+import sys
+from pathlib import Path
+
+from esphome_device_builder.models import EventType
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _mock_remote_e2e import paired_dashboards, wait_for_job
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yaml", required=True, type=Path, help="device YAML to compile")
+    parser.add_argument("--out", required=True, type=Path, help="where to write the binary")
+    parser.add_argument(
+        "--file",
+        default="firmware.bin",
+        help="binary basename: firmware.bin / firmware.uf2 / firmware.factory.bin",
+    )
+    parser.add_argument("--workdir", type=Path, help="run dir (default: tempdir under cwd)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    yaml_path = args.yaml.resolve()
+    out_path = args.out.resolve()
+    if not yaml_path.is_file():
+        print(f"YAML not found: {yaml_path}", file=sys.stderr)
+        return 2
+
+    if args.workdir is None:
+        import tempfile
+
+        workdir = Path(tempfile.mkdtemp(prefix="mock-remote-e2e-"))
+        print(f"Working under: {workdir}")
+    else:
+        workdir = args.workdir.resolve()
+
+    async with paired_dashboards(root_dir=workdir, yaml_source=yaml_path) as pair:
+        print(f"Paired pin_sha256={pair.pin_sha256}")
+
+        def _on_output(event: object) -> None:
+            data = getattr(event, "data", None)
+            if isinstance(data, dict) and (line := data.get("line")):
+                sys.stdout.write(line)
+                sys.stdout.flush()
+
+        pair.offloader.bus.add_listener(EventType.JOB_OUTPUT, _on_output)
+
+        job = await pair.offloader.firmware.compile(configuration=yaml_path.name)
+        print(f"Submitted compile job_id={job.job_id} source={job.source.value}")
+
+        terminal = await wait_for_job(pair.offloader, job.job_id)
+        status = terminal.get("job").status.value if isinstance(terminal, dict) else "?"
+        print(f"\nCompile terminal status: {status}")
+        if status != "completed":
+            if isinstance(terminal, dict):
+                job_obj = terminal.get("job")
+                if job_obj is not None and job_obj.error:
+                    print(f"job.error: {job_obj.error}")
+            return 1
+
+        # firmware/download reads the offloader-side StorageJSON sidecar
+        # that the materialiser just rewrote.
+        result = await pair.offloader.firmware.download(
+            configuration=yaml_path.name,
+            file=args.file,
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(base64.b64decode(result["data"]))
+        print(f"Wrote {result['size']} bytes to {out_path} ({result['filename']})")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/manual/download_mock_remote_e2e.py
+++ b/tests/manual/download_mock_remote_e2e.py
@@ -77,6 +77,11 @@ async def main() -> int:
 
         job = await pair.offloader.firmware.compile(configuration=yaml_path.name)
         print(f"Submitted compile job_id={job.job_id} source={job.source.value}")
+        if job.source.value != "remote":
+            raise RuntimeError(
+                f"scheduler picked source={job.source.value!r}; "
+                "the manual e2e requires the REMOTE path"
+            )
 
         terminal = await wait_for_job(pair.offloader, job.job_id)
         status = terminal.get("job").status.value if isinstance(terminal, dict) else "?"

--- a/tests/manual/run_mock_remote_e2e.py
+++ b/tests/manual/run_mock_remote_e2e.py
@@ -84,6 +84,14 @@ async def main() -> int:
             port=args.device,
         )
         print(f"Submitted install job_id={job.job_id} source={job.source.value}")
+        # Fail loud — the whole point of this script is exercising
+        # the REMOTE path. A silent local fallback would compile
+        # everything on the offloader and look like a green run.
+        if job.source.value != "remote":
+            raise RuntimeError(
+                f"scheduler picked source={job.source.value!r}; "
+                "the manual e2e requires the REMOTE path"
+            )
 
         terminal = await wait_for_job(pair.offloader, job.job_id)
         status = terminal.get("job").status.value if isinstance(terminal, dict) else "?"

--- a/tests/manual/run_mock_remote_e2e.py
+++ b/tests/manual/run_mock_remote_e2e.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+r"""
+Manual e2e: real firmware/install through two paired mock dashboards.
+
+Stands up an offloader + receiver, submits a firmware/install for the
+provided YAML against the provided device port. The offloader's runner
+sends the bundle to the receiver, which runs a real ``esphome compile``;
+on completion the offloader pulls the tarball back, materialises it, and
+spawns a real ``esphome upload`` against the configured device.
+
+Usage::
+
+    python tests/manual/run_mock_remote_e2e.py \
+        --yaml /path/to/device.yaml \
+        --device /dev/ttyUSB0
+        # or --device OTA for OTA installs
+
+Run from the repo root. Requires ``esphome`` on PATH (or installed in the
+active venv). The PIO toolchains install on first compile; no manual prep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+from esphome_device_builder.models import EventType
+
+# Add tests/ to sys.path so the shared helper imports as a sibling.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _mock_remote_e2e import paired_dashboards, wait_for_job
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yaml", required=True, type=Path, help="device YAML to install")
+    parser.add_argument(
+        "--device",
+        required=True,
+        help="install target: ``OTA`` or a serial path like ``/dev/ttyUSB0``",
+    )
+    parser.add_argument("--workdir", type=Path, help="run dir (default: tempdir under cwd)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    yaml_path = args.yaml.resolve()
+    if not yaml_path.is_file():
+        print(f"YAML not found: {yaml_path}", file=sys.stderr)
+        return 2
+
+    if args.workdir is None:
+        import tempfile
+
+        workdir = Path(tempfile.mkdtemp(prefix="mock-remote-e2e-"))
+        print(f"Working under: {workdir}")
+    else:
+        workdir = args.workdir.resolve()
+
+    async with paired_dashboards(root_dir=workdir, yaml_source=yaml_path) as pair:
+        print(f"Paired pin_sha256={pair.pin_sha256}")
+        print(f"Receiver dashboard_id={pair.offloader_dashboard_id}")
+
+        # Stream log lines as the receiver compiles + the offloader uploads.
+        def _on_output(event: object) -> None:
+            data = getattr(event, "data", None)
+            if isinstance(data, dict) and (line := data.get("line")):
+                sys.stdout.write(line)
+                sys.stdout.flush()
+
+        pair.offloader.bus.add_listener(EventType.JOB_OUTPUT, _on_output)
+
+        # Submit install via the offloader's firmware controller. The
+        # runner routes REMOTE because the scheduler sees the paired
+        # receiver as idle + APPROVED.
+        job = await pair.offloader.firmware.install(
+            configuration=yaml_path.name,
+            port=args.device,
+        )
+        print(f"Submitted install job_id={job.job_id} source={job.source.value}")
+
+        terminal = await wait_for_job(pair.offloader, job.job_id)
+        status = terminal.get("job").status.value if isinstance(terminal, dict) else "?"
+        print(f"\nJob terminal status: {status}")
+        if isinstance(terminal, dict):
+            job_obj = terminal.get("job")
+            if job_obj is not None and job_obj.error:
+                print(f"job.error: {job_obj.error}")
+        return 0 if status == "completed" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/manual/run_mock_remote_e2e.py
+++ b/tests/manual/run_mock_remote_e2e.py
@@ -65,7 +65,7 @@ async def main() -> int:
 
     async with paired_dashboards(root_dir=workdir, yaml_source=yaml_path) as pair:
         print(f"Paired pin_sha256={pair.pin_sha256}")
-        print(f"Receiver dashboard_id={pair.offloader_dashboard_id}")
+        print(f"Offloader dashboard_id (as tracked by receiver)={pair.offloader_dashboard_id}")
 
         # Stream log lines as the receiver compiles + the offloader uploads.
         def _on_output(event: object) -> None:

--- a/tests/test_artifact_platforms.py
+++ b/tests/test_artifact_platforms.py
@@ -72,16 +72,16 @@ def test_target_platform_values_are_unique() -> None:
         seen[key] = module.__name__
 
 
-def test_build_files_templates_format_with_name() -> None:
-    """Every BUILD_FILES entry must accept ``{name}`` substitution."""
+def test_build_files_entries_are_relative_paths() -> None:
+    """Every BUILD_FILES entry is a relative path under .pioenvs/<name>/."""
     for module in _public_platform_modules():
         for entry in module.BUILD_FILES:
-            try:
-                entry.format(name="kitchen")
-            except (KeyError, IndexError, ValueError) as err:  # pragma: no cover
-                raise AssertionError(
-                    f"{module.__name__} BUILD_FILES entry {entry!r} doesn't format: {err}"
-                ) from err
+            assert not entry.startswith("/"), (
+                f"{module.__name__} BUILD_FILES carries an absolute path: {entry!r}"
+            )
+            assert not entry.startswith(".pioenvs/"), (
+                f"{module.__name__} BUILD_FILES still has the .pioenvs/<name>/ prefix: {entry!r}"
+            )
 
 
 def test_libretiny_family_shares_build_files() -> None:
@@ -118,21 +118,19 @@ def test_lookup_returns_empty_for_unknown_platform() -> None:
 
 def test_esp32_includes_multi_image_bootloader_set() -> None:
     """ESP32 wired flash needs bootloader + partitions + ota_data + firmware."""
-    rendered = [f.format(name="kitchen") for f in esp32.BUILD_FILES]
-    assert ".pioenvs/kitchen/firmware.bin" in rendered
-    assert ".pioenvs/kitchen/bootloader.bin" in rendered
-    assert ".pioenvs/kitchen/partitions.bin" in rendered
-    assert ".pioenvs/kitchen/ota_data_initial.bin" in rendered
+    assert "firmware.bin" in esp32.BUILD_FILES
+    assert "bootloader.bin" in esp32.BUILD_FILES
+    assert "partitions.bin" in esp32.BUILD_FILES
+    assert "ota_data_initial.bin" in esp32.BUILD_FILES
 
 
 def test_libretiny_includes_uf2_and_bin() -> None:
     """Libretiny ships both .uf2 (UART/ltchiptool) and .bin (OTA)."""
-    rendered = [f.format(name="bw15") for f in build_files_for_platform("bk72xx")]
-    assert ".pioenvs/bw15/firmware.uf2" in rendered
-    assert ".pioenvs/bw15/firmware.bin" in rendered
+    files = build_files_for_platform("bk72xx")
+    assert "firmware.uf2" in files
+    assert "firmware.bin" in files
 
 
 def test_nrf52_includes_zephyr_app_update() -> None:
     """nrf52 component reads app_update.bin from .pioenvs/<name>/zephyr/."""
-    rendered = [f.format(name="locker") for f in build_files_for_platform("nrf52")]
-    assert ".pioenvs/locker/zephyr/app_update.bin" in rendered
+    assert "zephyr/app_update.bin" in build_files_for_platform("nrf52")

--- a/tests/test_artifact_platforms.py
+++ b/tests/test_artifact_platforms.py
@@ -102,6 +102,12 @@ def test_lookup_returns_empty_for_unknown_platform() -> None:
     assert build_files_for_platform("nonexistent_platform") == ()
 
 
+@pytest.mark.parametrize("variant", ["ESP32S3", "ESP32C3", "ESP32H2", "ESP32S2", "ESP32C6"])
+def test_esp32_chip_variants_fold_to_esp32_module(variant: str) -> None:
+    """Every ESP32 chip variant resolves to the esp32 BUILD_FILES tuple."""
+    assert build_files_for_platform(variant) is esp32.BUILD_FILES
+
+
 def test_esp32_includes_multi_image_bootloader_set() -> None:
     """ESP32 wired flash needs bootloader + partitions + ota_data + firmware."""
     rendered = [f.format(name="kitchen") for f in esp32.BUILD_FILES]

--- a/tests/test_artifact_platforms.py
+++ b/tests/test_artifact_platforms.py
@@ -92,24 +92,10 @@ def test_libretiny_family_shares_build_files() -> None:
     assert ln882x.BUILD_FILES is shared
 
 
-@pytest.mark.parametrize(
-    "lookup",
-    ["esp32", "ESP32", "Esp32", "esp32 ", " esp32"],
-)
+@pytest.mark.parametrize("lookup", ["esp32", "ESP32", "Esp32"])
 def test_lookup_is_case_insensitive_for_canonical_values(lookup: str) -> None:
-    """Upstream serialises ``target_platform.upper()`` so the registry must accept that.
-
-    The stripped form is also covered defensively; on-disk
-    sidecars come straight from ``StorageJSON`` and don't carry
-    leading/trailing whitespace, but a hand-edited sidecar
-    might. Strip + lowercase before lookup so the lookup behaves
-    the same regardless of canonicalisation drift.
-    """
-    result = build_files_for_platform(lookup.strip())
-    if lookup.strip().lower() == "esp32":
-        assert result, f"expected non-empty BUILD_FILES for {lookup!r}"
-    else:  # pragma: no cover - belt-and-braces
-        pass
+    """Upstream serialises ``target_platform.upper()`` so the registry must accept that."""
+    assert build_files_for_platform(lookup), f"expected non-empty BUILD_FILES for {lookup!r}"
 
 
 def test_lookup_returns_empty_for_unknown_platform() -> None:

--- a/tests/test_artifact_platforms.py
+++ b/tests/test_artifact_platforms.py
@@ -72,15 +72,15 @@ def test_target_platform_values_are_unique() -> None:
         seen[key] = module.__name__
 
 
-def test_build_files_entries_are_relative_paths() -> None:
-    """Every BUILD_FILES entry is a relative path under .pioenvs/<name>/."""
+def test_build_files_entries_are_build_relative_paths() -> None:
+    """Every BUILD_FILES entry is relative (joined against ``<build_path>/``)."""
     for module in _public_platform_modules():
         for entry in module.BUILD_FILES:
             assert not entry.startswith("/"), (
                 f"{module.__name__} BUILD_FILES carries an absolute path: {entry!r}"
             )
-            assert not entry.startswith(".pioenvs/"), (
-                f"{module.__name__} BUILD_FILES still has the .pioenvs/<name>/ prefix: {entry!r}"
+            assert entry.format(name="x"), (
+                f"{module.__name__} BUILD_FILES entry {entry!r} didn't format"
             )
 
 
@@ -104,19 +104,28 @@ def test_lookup_returns_empty_for_unknown_platform() -> None:
 
 def test_esp32_includes_multi_image_bootloader_set() -> None:
     """ESP32 wired flash needs bootloader + partitions + ota_data + firmware."""
-    assert "firmware.bin" in esp32.BUILD_FILES
-    assert "bootloader.bin" in esp32.BUILD_FILES
-    assert "partitions.bin" in esp32.BUILD_FILES
-    assert "ota_data_initial.bin" in esp32.BUILD_FILES
+    rendered = [f.format(name="kitchen") for f in esp32.BUILD_FILES]
+    assert ".pioenvs/kitchen/firmware.bin" in rendered
+    assert ".pioenvs/kitchen/bootloader.bin" in rendered
+    assert ".pioenvs/kitchen/partitions.bin" in rendered
+    assert ".pioenvs/kitchen/ota_data_initial.bin" in rendered
+
+
+def test_esp32_includes_factory_firmware_for_idf() -> None:
+    """ESP32 BUILD_FILES carries the factory firmware (download-factory path)."""
+    rendered = [f.format(name="kitchen") for f in esp32.BUILD_FILES]
+    assert ".pioenvs/kitchen/firmware.factory.bin" in rendered
+    assert "build/firmware.factory.bin" in rendered
 
 
 def test_libretiny_includes_uf2_and_bin() -> None:
     """Libretiny ships both .uf2 (UART/ltchiptool) and .bin (OTA)."""
-    files = build_files_for_platform("bk72xx")
-    assert "firmware.uf2" in files
-    assert "firmware.bin" in files
+    rendered = [f.format(name="bw15") for f in build_files_for_platform("bk72xx")]
+    assert ".pioenvs/bw15/firmware.uf2" in rendered
+    assert ".pioenvs/bw15/firmware.bin" in rendered
 
 
 def test_nrf52_includes_zephyr_app_update() -> None:
     """nrf52 component reads app_update.bin from .pioenvs/<name>/zephyr/."""
-    assert "zephyr/app_update.bin" in build_files_for_platform("nrf52")
+    rendered = [f.format(name="locker") for f in build_files_for_platform("nrf52")]
+    assert ".pioenvs/locker/zephyr/app_update.bin" in rendered

--- a/tests/test_artifact_platforms.py
+++ b/tests/test_artifact_platforms.py
@@ -1,0 +1,138 @@
+"""
+Registry-level coverage for the per-platform artifact module pack.
+
+Each ``controllers.remote_build.artifact_platforms.*`` module
+declares one platform's build-tree inclusion list; this test
+walks the registry without invoking the packer to assert the
+shape invariants the packer relies on.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pytest
+
+from esphome_device_builder.controllers.remote_build import artifact_platforms
+from esphome_device_builder.controllers.remote_build.artifact_platforms import (
+    _libretiny,
+    bk72xx,
+    build_files_for_platform,
+    esp32,
+    ln882x,
+    rtl87xx,
+)
+
+
+def _public_platform_modules() -> list:
+    """Yield every non-underscored module in the ``artifact_platforms`` package.
+
+    The registry's ``_PLATFORMS`` tuple is the canonical
+    enumeration, but walking the package directly lets the test
+    also catch a new module that's been added without a
+    corresponding import in ``__init__.py``.
+    """
+    modules = []
+    for module_info in pkgutil.iter_modules(artifact_platforms.__path__):
+        if module_info.name.startswith("_"):
+            continue
+        modules.append(
+            importlib.import_module(
+                f"esphome_device_builder.controllers.remote_build.artifact_platforms."
+                f"{module_info.name}"
+            )
+        )
+    return modules
+
+
+def test_every_module_exposes_target_platform_and_build_files() -> None:
+    modules = _public_platform_modules()
+    assert modules, "expected at least one platform module"
+    for module in modules:
+        assert isinstance(getattr(module, "TARGET_PLATFORM", None), str), (
+            f"{module.__name__} missing TARGET_PLATFORM"
+        )
+        build_files = getattr(module, "BUILD_FILES", None)
+        assert isinstance(build_files, tuple) and build_files, (
+            f"{module.__name__} missing or empty BUILD_FILES"
+        )
+        for entry in build_files:
+            assert isinstance(entry, str), (
+                f"{module.__name__} BUILD_FILES carries non-str: {entry!r}"
+            )
+
+
+def test_target_platform_values_are_unique() -> None:
+    seen: dict[str, str] = {}
+    for module in _public_platform_modules():
+        key = module.TARGET_PLATFORM.lower()
+        prior = seen.get(key)
+        assert prior is None, f"duplicate TARGET_PLATFORM {key!r}: {prior} and {module.__name__}"
+        seen[key] = module.__name__
+
+
+def test_build_files_templates_format_with_name() -> None:
+    """Every BUILD_FILES entry must accept ``{name}`` substitution."""
+    for module in _public_platform_modules():
+        for entry in module.BUILD_FILES:
+            try:
+                entry.format(name="kitchen")
+            except (KeyError, IndexError, ValueError) as err:  # pragma: no cover
+                raise AssertionError(
+                    f"{module.__name__} BUILD_FILES entry {entry!r} doesn't format: {err}"
+                ) from err
+
+
+def test_libretiny_family_shares_build_files() -> None:
+    """bk72xx / rtl87xx / ln882x re-export the shared libretiny tuple."""
+    shared = _libretiny.BUILD_FILES
+    assert bk72xx.BUILD_FILES is shared
+    assert rtl87xx.BUILD_FILES is shared
+    assert ln882x.BUILD_FILES is shared
+
+
+@pytest.mark.parametrize(
+    "lookup",
+    ["esp32", "ESP32", "Esp32", "esp32 ", " esp32"],
+)
+def test_lookup_is_case_insensitive_for_canonical_values(lookup: str) -> None:
+    """Upstream serialises ``target_platform.upper()`` so the registry must accept that.
+
+    The stripped form is also covered defensively; on-disk
+    sidecars come straight from ``StorageJSON`` and don't carry
+    leading/trailing whitespace, but a hand-edited sidecar
+    might. Strip + lowercase before lookup so the lookup behaves
+    the same regardless of canonicalisation drift.
+    """
+    result = build_files_for_platform(lookup.strip())
+    if lookup.strip().lower() == "esp32":
+        assert result, f"expected non-empty BUILD_FILES for {lookup!r}"
+    else:  # pragma: no cover - belt-and-braces
+        pass
+
+
+def test_lookup_returns_empty_for_unknown_platform() -> None:
+    assert build_files_for_platform("nonexistent_platform") == ()
+
+
+def test_esp32_includes_multi_image_bootloader_set() -> None:
+    """ESP32 wired flash needs bootloader + partitions + ota_data + firmware."""
+    rendered = [f.format(name="kitchen") for f in esp32.BUILD_FILES]
+    assert ".pioenvs/kitchen/firmware.bin" in rendered
+    assert ".pioenvs/kitchen/bootloader.bin" in rendered
+    assert ".pioenvs/kitchen/partitions.bin" in rendered
+    assert ".pioenvs/kitchen/ota_data_initial.bin" in rendered
+
+
+def test_libretiny_includes_uf2_and_bin() -> None:
+    """Libretiny ships both .uf2 (UART/ltchiptool) and .bin (OTA)."""
+    rendered = [f.format(name="bw15") for f in build_files_for_platform("bk72xx")]
+    assert ".pioenvs/bw15/firmware.uf2" in rendered
+    assert ".pioenvs/bw15/firmware.bin" in rendered
+
+
+def test_nrf52_includes_zephyr_app_update() -> None:
+    """nrf52 component reads app_update.bin from .pioenvs/<name>/zephyr/."""
+    rendered = [f.format(name="locker") for f in build_files_for_platform("nrf52")]
+    assert ".pioenvs/locker/zephyr/app_update.bin" in rendered

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -1,0 +1,445 @@
+"""
+Tests for the offloader-side materialiser.
+
+:func:`materialise_remote_artifacts` reads the receiver's
+tarball — produced by
+:func:`controllers.remote_build.artifacts_tarball.pack_build_artifacts` —
+and stages the build tree + sidecars at the offloader's
+canonical paths so ``esphome upload`` resolves cleanly.
+
+These tests build real tarballs through the production packer
+(rather than synthetic tarballs) so the wire-format contract
+between the two functions is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from esphome.core import CORE
+
+from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
+    IDEDATA_MEMBER_NAME,
+    STORAGE_MEMBER_NAME,
+    pack_build_artifacts,
+)
+from esphome_device_builder.helpers.remote_artifacts_materialise import (
+    MaterialiseError,
+    materialise_remote_artifacts,
+)
+from esphome_device_builder.helpers.storage_path import (
+    resolve_idedata_path,
+    resolve_storage_path,
+)
+from tests.test_remote_build_artifacts_download import _write_receiver_state
+
+
+def _pack_in_tmp(
+    receiver_root: Path,
+    *,
+    configuration: str = "kitchen.yaml",
+    **kwargs: object,
+) -> bytes:
+    """Build a receiver-side state under *receiver_root* and pack it.
+
+    Pins ``CORE.config_path`` to *receiver_root*'s sentinel so the
+    packer's path helpers resolve into the receiver tmp tree.
+    """
+    sentinel = receiver_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        _write_receiver_state(receiver_root, configuration=configuration, **kwargs)  # type: ignore[arg-type]
+        packed = pack_build_artifacts(configuration)
+    return packed.tarball
+
+
+def _materialise_in_tmp(
+    tarball: bytes,
+    offloader_root: Path,
+    *,
+    configuration: str = "kitchen.yaml",
+) -> Path:
+    """Materialise *tarball* into *offloader_root*'s .esphome subtree.
+
+    Pins ``CORE.config_path`` to *offloader_root*'s sentinel so
+    the materialiser's path helpers resolve into the offloader
+    tmp tree.
+    """
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        return materialise_remote_artifacts(tarball, configuration)
+
+
+# ---------------------------------------------------------------------------
+# Happy path: pack → materialise round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_materialise_stages_build_tree_and_sidecars(tmp_path: Path) -> None:
+    """Build tree, storage sidecar, and idedata cache all land at the offloader's paths."""
+    receiver_root = tmp_path / "receiver"
+    receiver_root.mkdir()
+    offloader_root = tmp_path / "offloader"
+    offloader_root.mkdir()
+
+    tarball = _pack_in_tmp(
+        receiver_root,
+        extras=[("bootloader.bin", "0x1000")],
+        extra_build_files={
+            ".pioenvs/kitchen/bootloader.bin": b"BOOT",
+            ".pioenvs/kitchen/firmware.elf": b"ELF",
+        },
+    )
+    build_path = _materialise_in_tmp(tarball, offloader_root)
+
+    assert build_path == offloader_root / ".esphome" / "build" / "kitchen"
+    assert (build_path / "platformio.ini").is_file()
+    assert (build_path / ".pioenvs" / "kitchen" / "firmware.bin").is_file()
+    assert (build_path / ".pioenvs" / "kitchen" / "bootloader.bin").is_file()
+    assert (build_path / ".pioenvs" / "kitchen" / "firmware.elf").is_file()
+    # Metadata members do NOT extract into the build tree —
+    # they go to the offloader's cache locations.
+    assert not (build_path / STORAGE_MEMBER_NAME).exists()
+    assert not (build_path / IDEDATA_MEMBER_NAME).exists()
+
+
+def test_materialise_storage_sidecar_carries_receiver_metadata(tmp_path: Path) -> None:
+    """Receiver's target_platform / framework / name flow through unchanged."""
+    receiver_root = tmp_path / "receiver"
+    receiver_root.mkdir()
+    offloader_root = tmp_path / "offloader"
+    offloader_root.mkdir()
+
+    tarball = _pack_in_tmp(receiver_root, target_platform="ESP32")
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        materialise_remote_artifacts(tarball, "kitchen.yaml")
+        storage_path = resolve_storage_path("kitchen.yaml")
+    data = json.loads(storage_path.read_text())
+
+    # Receiver's metadata flows through unchanged.
+    assert data["esp_platform"] == "ESP32"
+    assert data["framework"] == "arduino"
+    assert data["name"] == "kitchen"
+    # build_path + firmware_bin_path are remapped to the offloader's tree.
+    offloader_build_path = offloader_root / ".esphome" / "build" / "kitchen"
+    assert data["build_path"] == str(offloader_build_path)
+    assert data["firmware_bin_path"] == str(
+        offloader_build_path / ".pioenvs" / "kitchen" / "firmware.bin"
+    )
+
+
+def test_materialise_libretiny_storage_preserves_uf2_basename(tmp_path: Path) -> None:
+    """A libretiny build's firmware_bin_path round-trips as firmware.uf2, not firmware.bin.
+
+    The receiver-side StorageJSON carries the platform-correct
+    basename (esphome/core/__init__.py:778 returns ``firmware.uf2``
+    for libretiny); the materialiser remaps only the build-dir
+    prefix, leaving the basename untouched. Pins that the
+    materialiser doesn't accidentally hardcode firmware.bin.
+    """
+    receiver_root = tmp_path / "receiver"
+    receiver_root.mkdir()
+    offloader_root = tmp_path / "offloader"
+    offloader_root.mkdir()
+
+    sentinel = receiver_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        # Manually craft a receiver state where firmware_bin_path
+        # points at firmware.uf2 (mimicking libretiny's
+        # CORE.firmware_bin output).
+        _write_receiver_state(
+            receiver_root,
+            device_name="bw15",
+            target_platform="BK72XX",
+            extra_build_files={".pioenvs/bw15/firmware.uf2": b"UF2"},
+        )
+        # Override the storage sidecar's firmware_bin_path to .uf2.
+        storage_path = resolve_storage_path("kitchen.yaml")
+        data = json.loads(storage_path.read_text())
+        data["firmware_bin_path"] = str(
+            receiver_root / ".esphome" / "build" / "bw15" / ".pioenvs" / "bw15" / "firmware.uf2"
+        )
+        storage_path.write_text(json.dumps(data) + "\n")
+        packed = pack_build_artifacts("kitchen.yaml")
+
+    _materialise_in_tmp(packed.tarball, offloader_root)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        offloader_storage_path = resolve_storage_path("kitchen.yaml")
+    data = json.loads(offloader_storage_path.read_text())
+    assert data["firmware_bin_path"].endswith("/.pioenvs/bw15/firmware.uf2"), (
+        f"libretiny .uf2 should survive the round-trip, got {data['firmware_bin_path']!r}"
+    )
+
+
+def test_materialise_idedata_remaps_prog_path_and_flash_images(tmp_path: Path) -> None:
+    """Idedata's prog_path + extra.flash_images[*].path all remap to the offloader tree."""
+    receiver_root = tmp_path / "receiver"
+    receiver_root.mkdir()
+    offloader_root = tmp_path / "offloader"
+    offloader_root.mkdir()
+
+    tarball = _pack_in_tmp(
+        receiver_root,
+        extras=[("bootloader.bin", "0x1000"), ("partitions.bin", "0x8000")],
+        extra_build_files={
+            ".pioenvs/kitchen/bootloader.bin": b"BOOT",
+            ".pioenvs/kitchen/partitions.bin": b"PART",
+        },
+    )
+    _materialise_in_tmp(tarball, offloader_root)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        cached = resolve_idedata_path("kitchen.yaml", name="kitchen")
+    data = json.loads(cached.read_text())
+
+    offloader_build_path = offloader_root / ".esphome" / "build" / "kitchen"
+    pioenvs = offloader_build_path / ".pioenvs" / "kitchen"
+    assert data["prog_path"] == str(pioenvs / "firmware.elf")
+    paths = [entry["path"] for entry in data["extra"]["flash_images"]]
+    assert paths == [
+        str(pioenvs / "bootloader.bin"),
+        str(pioenvs / "partitions.bin"),
+    ]
+
+
+def test_materialise_idedata_remaps_cc_path_to_offloader_pio_core(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cc_path's PIO core prefix swaps to the offloader's PLATFORMIO_CORE_DIR."""
+    receiver_root = tmp_path / "receiver"
+    receiver_root.mkdir()
+    offloader_root = tmp_path / "offloader"
+    offloader_root.mkdir()
+    offloader_pio = tmp_path / "offloader_pio"
+    monkeypatch.setenv("PLATFORMIO_CORE_DIR", str(offloader_pio))
+
+    tarball = _pack_in_tmp(receiver_root)
+    _materialise_in_tmp(tarball, offloader_root)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        cached = resolve_idedata_path("kitchen.yaml", name="kitchen")
+    data = json.loads(cached.read_text())
+
+    # The receiver's cc_path was
+    #   /home/receiver/.platformio/packages/toolchain-xtensa32/bin/xtensa-esp32-elf-gcc
+    # The materialiser keys off "packages/" and prepends the
+    # offloader's PIO core dir.
+    assert data["cc_path"] == str(
+        offloader_pio / "packages" / "toolchain-xtensa32" / "bin" / "xtensa-esp32-elf-gcc"
+    )
+
+
+def test_materialise_idedata_drops_unparseable_cc_path(tmp_path: Path) -> None:
+    """cc_path without a 'packages/' segment is dropped from the staged idedata."""
+    receiver_root = tmp_path / "receiver"
+    receiver_root.mkdir()
+    offloader_root = tmp_path / "offloader"
+    offloader_root.mkdir()
+
+    sentinel = receiver_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        _write_receiver_state(receiver_root)
+        idedata_path = resolve_idedata_path("kitchen.yaml", name="kitchen")
+        data = json.loads(idedata_path.read_text())
+        data["cc_path"] = "/usr/bin/gcc"  # no packages/ segment
+        idedata_path.write_text(json.dumps(data) + "\n")
+        packed = pack_build_artifacts("kitchen.yaml")
+
+    _materialise_in_tmp(packed.tarball, offloader_root)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        cached = resolve_idedata_path("kitchen.yaml", name="kitchen")
+    data = json.loads(cached.read_text())
+    assert "cc_path" not in data
+
+
+def test_materialise_touches_mtimes_for_esphome_cache_hit(tmp_path: Path) -> None:
+    """platformio.ini.mtime ends up strictly older than the staged idedata's mtime.
+
+    Pins the contract that ``_load_idedata`` reads — the cache
+    check is ``platformio_ini.mtime >= cached.mtime``, so we
+    need the cached file to be newer to skip regeneration.
+    """
+    receiver_root = tmp_path / "receiver"
+    receiver_root.mkdir()
+    offloader_root = tmp_path / "offloader"
+    offloader_root.mkdir()
+
+    tarball = _pack_in_tmp(receiver_root)
+    build_path = _materialise_in_tmp(tarball, offloader_root)
+
+    platformio_ini = build_path / "platformio.ini"
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        cached = resolve_idedata_path("kitchen.yaml", name="kitchen")
+    assert platformio_ini.stat().st_mtime < cached.stat().st_mtime
+
+
+def test_materialise_idempotent_under_rerun(tmp_path: Path) -> None:
+    """Re-running materialise over an existing staged tree overwrites cleanly."""
+    receiver_root = tmp_path / "receiver"
+    receiver_root.mkdir()
+    offloader_root = tmp_path / "offloader"
+    offloader_root.mkdir()
+
+    tarball = _pack_in_tmp(receiver_root)
+    first = _materialise_in_tmp(tarball, offloader_root)
+    # Plant a stale file in the build tree before re-materialising
+    # to confirm extraction overwrites cleanly.
+    stale = first / ".pioenvs" / "kitchen" / "stale.bin"
+    stale.write_bytes(b"STALE")
+    second = _materialise_in_tmp(tarball, offloader_root)
+
+    assert first == second
+    # The materialised firmware.bin re-exists. (We don't assert on
+    # the stale file's removal — extract over existing files just
+    # rewrites the named members; leftover files aren't actively
+    # cleaned.)
+    assert (second / ".pioenvs" / "kitchen" / "firmware.bin").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+# Placeholder for a "build_path" field in synthetic tarballs that
+# the materialiser rejects before extraction.
+_FAKE_BUILD_PATH = "/fake/receiver/build/path"
+
+
+def test_materialise_rejects_missing_storage_member(tmp_path: Path) -> None:
+    """A tarball without storage.json raises MaterialiseError with a clear message."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"{}"))
+
+    with pytest.raises(MaterialiseError, match=r"missing required member: 'storage\.json'"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)
+
+
+def test_materialise_rejects_missing_idedata_member(tmp_path: Path) -> None:
+    """A tarball without idedata.json raises MaterialiseError."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        storage = json.dumps(
+            {"storage_version": 1, "name": "kitchen", "build_path": _FAKE_BUILD_PATH}
+        ).encode("utf-8")
+        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
+        info.size = len(storage)
+        tar.addfile(info, io.BytesIO(storage))
+
+    with pytest.raises(MaterialiseError, match=r"missing required member: 'idedata\.json'"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)
+
+
+def test_materialise_rejects_path_traversal(tmp_path: Path) -> None:
+    """Members that resolve outside the build dir raise before extraction."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        storage = json.dumps(
+            {"storage_version": 1, "name": "kitchen", "build_path": _FAKE_BUILD_PATH}
+        ).encode("utf-8")
+        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
+        info.size = len(storage)
+        tar.addfile(info, io.BytesIO(storage))
+
+        idedata = b"{}"
+        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
+        info.size = len(idedata)
+        tar.addfile(info, io.BytesIO(idedata))
+
+        # Member with a traversal-shaped path.
+        evil_payload = b"EVIL"
+        info = tarfile.TarInfo(name="../../../etc/passwd")
+        info.size = len(evil_payload)
+        tar.addfile(info, io.BytesIO(evil_payload))
+
+    with pytest.raises(MaterialiseError, match=r"escapes destination"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)
+
+
+def test_materialise_rejects_storage_missing_name(tmp_path: Path) -> None:
+    """storage.json without a 'name' field raises before extraction starts."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        storage = json.dumps({"storage_version": 1, "build_path": _FAKE_BUILD_PATH}).encode("utf-8")
+        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
+        info.size = len(storage)
+        tar.addfile(info, io.BytesIO(storage))
+        idedata = b"{}"
+        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
+        info.size = len(idedata)
+        tar.addfile(info, io.BytesIO(idedata))
+
+    with pytest.raises(MaterialiseError, match=r"missing required name field"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)
+
+
+def test_materialise_rejects_storage_missing_build_path(tmp_path: Path) -> None:
+    """storage.json without a 'build_path' field raises."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        storage = json.dumps({"storage_version": 1, "name": "kitchen"}).encode("utf-8")
+        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
+        info.size = len(storage)
+        tar.addfile(info, io.BytesIO(storage))
+        idedata = b"{}"
+        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
+        info.size = len(idedata)
+        tar.addfile(info, io.BytesIO(idedata))
+
+    with pytest.raises(MaterialiseError, match=r"missing required build_path field"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)
+
+
+def test_materialise_rejects_malformed_tarball(tmp_path: Path) -> None:
+    """Random bytes that aren't a gzipped tar surface as MaterialiseError."""
+    with pytest.raises(MaterialiseError, match=r"malformed"):
+        _materialise_in_tmp(b"definitely not a tarball", tmp_path)
+
+
+def test_materialise_rejects_non_json_storage(tmp_path: Path) -> None:
+    """storage.json that isn't parseable JSON raises MaterialiseError."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
+        info.size = 4
+        tar.addfile(info, io.BytesIO(b"{bad"))
+        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"{}"))
+
+    with pytest.raises(MaterialiseError, match=r"not valid JSON"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)
+
+
+def test_materialise_rejects_non_dict_idedata(tmp_path: Path) -> None:
+    """idedata.json that parses to a non-dict raises MaterialiseError."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        storage = json.dumps(
+            {"storage_version": 1, "name": "kitchen", "build_path": _FAKE_BUILD_PATH}
+        ).encode("utf-8")
+        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
+        info.size = len(storage)
+        tar.addfile(info, io.BytesIO(storage))
+        # idedata parses but isn't a dict.
+        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
+        info.size = 4
+        tar.addfile(info, io.BytesIO(b"null"))
+
+    with pytest.raises(MaterialiseError, match=r"is not a JSON object"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -174,7 +174,7 @@ def test_materialise_libretiny_storage_preserves_uf2_basename(tmp_path: Path) ->
     with patch.object(CORE, "config_path", sentinel):
         offloader_storage_path = resolve_storage_path("kitchen.yaml")
     data = json.loads(offloader_storage_path.read_text())
-    assert data["firmware_bin_path"].endswith("/.pioenvs/bw15/firmware.uf2"), (
+    assert Path(data["firmware_bin_path"]).parts[-3:] == (".pioenvs", "bw15", "firmware.uf2"), (
         f"libretiny .uf2 should survive the round-trip, got {data['firmware_bin_path']!r}"
     )
 

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -471,6 +471,38 @@ def test_materialise_rejects_cumulative_member_size(
         _materialise_in_tmp(tarball, tmp_path)
 
 
+def test_materialise_rejects_unreadable_storage_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Defensive guard: a regular-file member whose ``extractfile`` returns None raises."""
+    tarball = _synthetic_tarball()
+    real_extractfile = tarfile.TarFile.extractfile
+
+    def _stub_extractfile(self: tarfile.TarFile, member: object) -> object:
+        # Force None for the storage.json read; let other reads pass.
+        info = member if isinstance(member, tarfile.TarInfo) else self.getmember(str(member))
+        if info.name == STORAGE_MEMBER_NAME:
+            return None
+        return real_extractfile(self, member)
+
+    monkeypatch.setattr(tarfile.TarFile, "extractfile", _stub_extractfile)
+    with pytest.raises(MaterialiseError, match=r"unreadable"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
+def test_materialise_raises_when_storage_load_returns_none(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """A storage payload missing ``storage_version`` makes ``StorageJSON.load`` return None."""
+    _, offloader_root = paired_roots
+    # Drop storage_version so the early _parse_storage_json path still
+    # accepts name + build_path, but esphome.storage_json._load_impl
+    # raises KeyError and StorageJSON.load returns None.
+    tarball = _synthetic_tarball(storage={"name": "kitchen", "build_path": _FAKE_BUILD_PATH})
+    with pytest.raises(MaterialiseError, match=r"StorageJSON\.load returned None"):
+        _materialise_in_tmp(tarball, offloader_root)
+
+
 def test_materialise_idedata_skips_non_dict_flash_image_entry(
     paired_roots: tuple[Path, Path],
 ) -> None:

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -18,6 +18,7 @@ import io
 import json
 import tarfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -38,6 +39,11 @@ from esphome_device_builder.helpers.storage_path import (
 )
 from tests.test_remote_build_artifacts_download import _write_receiver_state
 
+_SENTINEL = object()
+# Placeholder ``build_path`` for synthetic tarballs the materialiser
+# rejects before extraction.
+_FAKE_BUILD_PATH = "/fake/receiver/build/path"
+
 
 def _pack_in_tmp(
     receiver_root: Path,
@@ -45,11 +51,7 @@ def _pack_in_tmp(
     configuration: str = "kitchen.yaml",
     **kwargs: object,
 ) -> bytes:
-    """Build a receiver-side state under *receiver_root* and pack it.
-
-    Pins ``CORE.config_path`` to *receiver_root*'s sentinel so the
-    packer's path helpers resolve into the receiver tmp tree.
-    """
+    """Build a receiver-side state under *receiver_root* and pack it."""
     sentinel = receiver_root / "___DASHBOARD_SENTINEL___.yaml"
     with patch.object(CORE, "config_path", sentinel):
         _write_receiver_state(receiver_root, configuration=configuration, **kwargs)  # type: ignore[arg-type]
@@ -63,15 +65,52 @@ def _materialise_in_tmp(
     *,
     configuration: str = "kitchen.yaml",
 ) -> Path:
-    """Materialise *tarball* into *offloader_root*'s .esphome subtree.
-
-    Pins ``CORE.config_path`` to *offloader_root*'s sentinel so
-    the materialiser's path helpers resolve into the offloader
-    tmp tree.
-    """
+    """Materialise *tarball* into *offloader_root*'s .esphome subtree."""
     sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
     with patch.object(CORE, "config_path", sentinel):
         return materialise_remote_artifacts(tarball, configuration)
+
+
+def _synthetic_tarball(
+    *,
+    storage: Any = _SENTINEL,
+    idedata: Any = _SENTINEL,
+    extra_members: list[tuple[str, bytes]] | None = None,
+) -> bytes:
+    """Build a minimal tarball for materialiser error-path tests.
+
+    ``storage`` / ``idedata`` accept dict (JSON-encoded), bytes
+    (raw — for malformed-JSON cases), or ``None`` (omit the
+    member). Default is a valid storage shape + ``{}`` idedata.
+    """
+    if storage is _SENTINEL:
+        storage = {"storage_version": 1, "name": "kitchen", "build_path": _FAKE_BUILD_PATH}
+    if idedata is _SENTINEL:
+        idedata = {}
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, value in ((STORAGE_MEMBER_NAME, storage), (IDEDATA_MEMBER_NAME, idedata)):
+            if value is None:
+                continue
+            payload = value if isinstance(value, bytes) else json.dumps(value).encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+        for member_name, member_payload in extra_members or []:
+            info = tarfile.TarInfo(name=member_name)
+            info.size = len(member_payload)
+            tar.addfile(info, io.BytesIO(member_payload))
+    return buf.getvalue()
+
+
+@pytest.fixture
+def paired_roots(tmp_path: Path) -> tuple[Path, Path]:
+    """Return ``(receiver_root, offloader_root)`` directories under tmp_path."""
+    receiver = tmp_path / "receiver"
+    receiver.mkdir()
+    offloader = tmp_path / "offloader"
+    offloader.mkdir()
+    return receiver, offloader
 
 
 # ---------------------------------------------------------------------------
@@ -79,13 +118,11 @@ def _materialise_in_tmp(
 # ---------------------------------------------------------------------------
 
 
-def test_materialise_stages_build_tree_and_sidecars(tmp_path: Path) -> None:
+def test_materialise_stages_build_tree_and_sidecars(
+    paired_roots: tuple[Path, Path],
+) -> None:
     """Build tree, storage sidecar, and idedata cache all land at the offloader's paths."""
-    receiver_root = tmp_path / "receiver"
-    receiver_root.mkdir()
-    offloader_root = tmp_path / "offloader"
-    offloader_root.mkdir()
-
+    receiver_root, offloader_root = paired_roots
     tarball = _pack_in_tmp(
         receiver_root,
         extras=[("bootloader.bin", "0x1000")],
@@ -107,13 +144,11 @@ def test_materialise_stages_build_tree_and_sidecars(tmp_path: Path) -> None:
     assert not (build_path / IDEDATA_MEMBER_NAME).exists()
 
 
-def test_materialise_storage_sidecar_carries_receiver_metadata(tmp_path: Path) -> None:
+def test_materialise_storage_sidecar_carries_receiver_metadata(
+    paired_roots: tuple[Path, Path],
+) -> None:
     """Receiver's target_platform / framework / name flow through unchanged."""
-    receiver_root = tmp_path / "receiver"
-    receiver_root.mkdir()
-    offloader_root = tmp_path / "offloader"
-    offloader_root.mkdir()
-
+    receiver_root, offloader_root = paired_roots
     tarball = _pack_in_tmp(receiver_root, target_platform="ESP32")
 
     sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
@@ -134,20 +169,11 @@ def test_materialise_storage_sidecar_carries_receiver_metadata(tmp_path: Path) -
     )
 
 
-def test_materialise_libretiny_storage_preserves_uf2_basename(tmp_path: Path) -> None:
-    """A libretiny build's firmware_bin_path round-trips as firmware.uf2, not firmware.bin.
-
-    The receiver-side StorageJSON carries the platform-correct
-    basename (esphome/core/__init__.py:778 returns ``firmware.uf2``
-    for libretiny); the materialiser remaps only the build-dir
-    prefix, leaving the basename untouched. Pins that the
-    materialiser doesn't accidentally hardcode firmware.bin.
-    """
-    receiver_root = tmp_path / "receiver"
-    receiver_root.mkdir()
-    offloader_root = tmp_path / "offloader"
-    offloader_root.mkdir()
-
+def test_materialise_libretiny_storage_preserves_uf2_basename(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """Libretiny build's firmware_bin_path round-trips as firmware.uf2, not firmware.bin."""
+    receiver_root, offloader_root = paired_roots
     sentinel = receiver_root / "___DASHBOARD_SENTINEL___.yaml"
     with patch.object(CORE, "config_path", sentinel):
         # Manually craft a receiver state where firmware_bin_path
@@ -179,13 +205,11 @@ def test_materialise_libretiny_storage_preserves_uf2_basename(tmp_path: Path) ->
     )
 
 
-def test_materialise_idedata_remaps_prog_path_and_flash_images(tmp_path: Path) -> None:
+def test_materialise_idedata_remaps_prog_path_and_flash_images(
+    paired_roots: tuple[Path, Path],
+) -> None:
     """Idedata's prog_path + extra.flash_images[*].path all remap to the offloader tree."""
-    receiver_root = tmp_path / "receiver"
-    receiver_root.mkdir()
-    offloader_root = tmp_path / "offloader"
-    offloader_root.mkdir()
-
+    receiver_root, offloader_root = paired_roots
     tarball = _pack_in_tmp(
         receiver_root,
         extras=[("bootloader.bin", "0x1000"), ("partitions.bin", "0x8000")],
@@ -212,13 +236,12 @@ def test_materialise_idedata_remaps_prog_path_and_flash_images(tmp_path: Path) -
 
 
 def test_materialise_idedata_remaps_cc_path_to_offloader_pio_core(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    paired_roots: tuple[Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """cc_path's PIO core prefix swaps to the offloader's PLATFORMIO_CORE_DIR."""
-    receiver_root = tmp_path / "receiver"
-    receiver_root.mkdir()
-    offloader_root = tmp_path / "offloader"
-    offloader_root.mkdir()
+    receiver_root, offloader_root = paired_roots
     offloader_pio = tmp_path / "offloader_pio"
     monkeypatch.setenv("PLATFORMIO_CORE_DIR", str(offloader_pio))
 
@@ -239,13 +262,11 @@ def test_materialise_idedata_remaps_cc_path_to_offloader_pio_core(
     )
 
 
-def test_materialise_idedata_drops_unparseable_cc_path(tmp_path: Path) -> None:
+def test_materialise_idedata_drops_unparseable_cc_path(
+    paired_roots: tuple[Path, Path],
+) -> None:
     """cc_path without a 'packages/' segment is dropped from the staged idedata."""
-    receiver_root = tmp_path / "receiver"
-    receiver_root.mkdir()
-    offloader_root = tmp_path / "offloader"
-    offloader_root.mkdir()
-
+    receiver_root, offloader_root = paired_roots
     sentinel = receiver_root / "___DASHBOARD_SENTINEL___.yaml"
     with patch.object(CORE, "config_path", sentinel):
         _write_receiver_state(receiver_root)
@@ -264,18 +285,11 @@ def test_materialise_idedata_drops_unparseable_cc_path(tmp_path: Path) -> None:
     assert "cc_path" not in data
 
 
-def test_materialise_touches_mtimes_for_esphome_cache_hit(tmp_path: Path) -> None:
-    """platformio.ini.mtime ends up strictly older than the staged idedata's mtime.
-
-    Pins the contract that ``_load_idedata`` reads — the cache
-    check is ``platformio_ini.mtime >= cached.mtime``, so we
-    need the cached file to be newer to skip regeneration.
-    """
-    receiver_root = tmp_path / "receiver"
-    receiver_root.mkdir()
-    offloader_root = tmp_path / "offloader"
-    offloader_root.mkdir()
-
+def test_materialise_touches_mtimes_for_esphome_cache_hit(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """platformio.ini.mtime ends up strictly older than the staged idedata's mtime."""
+    receiver_root, offloader_root = paired_roots
     tarball = _pack_in_tmp(receiver_root)
     build_path = _materialise_in_tmp(tarball, offloader_root)
 
@@ -286,141 +300,71 @@ def test_materialise_touches_mtimes_for_esphome_cache_hit(tmp_path: Path) -> Non
     assert platformio_ini.stat().st_mtime < cached.stat().st_mtime
 
 
-def test_materialise_idempotent_under_rerun(tmp_path: Path) -> None:
-    """Re-running materialise over an existing staged tree overwrites cleanly."""
-    receiver_root = tmp_path / "receiver"
-    receiver_root.mkdir()
-    offloader_root = tmp_path / "offloader"
-    offloader_root.mkdir()
-
+def test_materialise_idempotent_under_rerun(paired_roots: tuple[Path, Path]) -> None:
+    """Re-running materialise wipes stale files from the build dir."""
+    receiver_root, offloader_root = paired_roots
     tarball = _pack_in_tmp(receiver_root)
     first = _materialise_in_tmp(tarball, offloader_root)
-    # Plant a stale file in the build tree before re-materialising
-    # to confirm extraction overwrites cleanly.
+    # Plant a stale file the second materialise should clear.
     stale = first / ".pioenvs" / "kitchen" / "stale.bin"
     stale.write_bytes(b"STALE")
+
     second = _materialise_in_tmp(tarball, offloader_root)
 
     assert first == second
-    # The materialised firmware.bin re-exists. (We don't assert on
-    # the stale file's removal — extract over existing files just
-    # rewrites the named members; leftover files aren't actively
-    # cleaned.)
     assert (second / ".pioenvs" / "kitchen" / "firmware.bin").is_file()
+    assert not stale.exists(), "stale file should be cleared by the pre-extract rmtree"
 
 
 # ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------
 
-# Placeholder for a "build_path" field in synthetic tarballs that
-# the materialiser rejects before extraction.
-_FAKE_BUILD_PATH = "/fake/receiver/build/path"
-
 
 def test_materialise_rejects_missing_storage_member(tmp_path: Path) -> None:
     """A tarball without storage.json raises MaterialiseError with a clear message."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
-        info.size = 2
-        tar.addfile(info, io.BytesIO(b"{}"))
-
+    tarball = _synthetic_tarball(storage=None)
     with pytest.raises(MaterialiseError, match=r"missing required member: 'storage\.json'"):
-        _materialise_in_tmp(buf.getvalue(), tmp_path)
+        _materialise_in_tmp(tarball, tmp_path)
 
 
 def test_materialise_rejects_missing_idedata_member(tmp_path: Path) -> None:
     """A tarball without idedata.json raises MaterialiseError."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        storage = json.dumps(
-            {"storage_version": 1, "name": "kitchen", "build_path": _FAKE_BUILD_PATH}
-        ).encode("utf-8")
-        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
-        info.size = len(storage)
-        tar.addfile(info, io.BytesIO(storage))
-
+    tarball = _synthetic_tarball(idedata=None)
     with pytest.raises(MaterialiseError, match=r"missing required member: 'idedata\.json'"):
-        _materialise_in_tmp(buf.getvalue(), tmp_path)
+        _materialise_in_tmp(tarball, tmp_path)
 
 
 def test_materialise_rejects_path_traversal(tmp_path: Path) -> None:
     """Members that resolve outside the build dir raise before extraction."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        storage = json.dumps(
-            {"storage_version": 1, "name": "kitchen", "build_path": _FAKE_BUILD_PATH}
-        ).encode("utf-8")
-        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
-        info.size = len(storage)
-        tar.addfile(info, io.BytesIO(storage))
-
-        idedata = b"{}"
-        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
-        info.size = len(idedata)
-        tar.addfile(info, io.BytesIO(idedata))
-
-        # Member with a traversal-shaped path.
-        evil_payload = b"EVIL"
-        info = tarfile.TarInfo(name="../../../etc/passwd")
-        info.size = len(evil_payload)
-        tar.addfile(info, io.BytesIO(evil_payload))
-
+    tarball = _synthetic_tarball(extra_members=[("../../../etc/passwd", b"EVIL")])
     with pytest.raises(MaterialiseError, match=r"escapes destination"):
-        _materialise_in_tmp(buf.getvalue(), tmp_path)
+        _materialise_in_tmp(tarball, tmp_path)
 
 
 def test_materialise_rejects_traversal_in_storage_name(tmp_path: Path) -> None:
     """A storage.json ``name`` carrying path-separator chars is rejected."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        storage = json.dumps(
-            {"storage_version": 1, "name": "../sneaky", "build_path": _FAKE_BUILD_PATH}
-        ).encode("utf-8")
-        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
-        info.size = len(storage)
-        tar.addfile(info, io.BytesIO(storage))
-        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
-        info.size = 2
-        tar.addfile(info, io.BytesIO(b"{}"))
-
+    tarball = _synthetic_tarball(
+        storage={"storage_version": 1, "name": "../sneaky", "build_path": _FAKE_BUILD_PATH},
+    )
     with pytest.raises(MaterialiseError, match=r"not safe for a path segment"):
-        _materialise_in_tmp(buf.getvalue(), tmp_path)
+        _materialise_in_tmp(tarball, tmp_path)
 
 
 def test_materialise_rejects_storage_missing_name(tmp_path: Path) -> None:
     """storage.json without a 'name' field raises before extraction starts."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        storage = json.dumps({"storage_version": 1, "build_path": _FAKE_BUILD_PATH}).encode("utf-8")
-        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
-        info.size = len(storage)
-        tar.addfile(info, io.BytesIO(storage))
-        idedata = b"{}"
-        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
-        info.size = len(idedata)
-        tar.addfile(info, io.BytesIO(idedata))
-
+    tarball = _synthetic_tarball(
+        storage={"storage_version": 1, "build_path": _FAKE_BUILD_PATH},
+    )
     with pytest.raises(MaterialiseError, match=r"missing required name field"):
-        _materialise_in_tmp(buf.getvalue(), tmp_path)
+        _materialise_in_tmp(tarball, tmp_path)
 
 
 def test_materialise_rejects_storage_missing_build_path(tmp_path: Path) -> None:
     """storage.json without a 'build_path' field raises."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        storage = json.dumps({"storage_version": 1, "name": "kitchen"}).encode("utf-8")
-        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
-        info.size = len(storage)
-        tar.addfile(info, io.BytesIO(storage))
-        idedata = b"{}"
-        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
-        info.size = len(idedata)
-        tar.addfile(info, io.BytesIO(idedata))
-
+    tarball = _synthetic_tarball(storage={"storage_version": 1, "name": "kitchen"})
     with pytest.raises(MaterialiseError, match=r"missing required build_path field"):
-        _materialise_in_tmp(buf.getvalue(), tmp_path)
+        _materialise_in_tmp(tarball, tmp_path)
 
 
 def test_materialise_rejects_malformed_tarball(tmp_path: Path) -> None:
@@ -431,33 +375,13 @@ def test_materialise_rejects_malformed_tarball(tmp_path: Path) -> None:
 
 def test_materialise_rejects_non_json_storage(tmp_path: Path) -> None:
     """storage.json that isn't parseable JSON raises MaterialiseError."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
-        info.size = 4
-        tar.addfile(info, io.BytesIO(b"{bad"))
-        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
-        info.size = 2
-        tar.addfile(info, io.BytesIO(b"{}"))
-
+    tarball = _synthetic_tarball(storage=b"{bad")
     with pytest.raises(MaterialiseError, match=r"not valid JSON"):
-        _materialise_in_tmp(buf.getvalue(), tmp_path)
+        _materialise_in_tmp(tarball, tmp_path)
 
 
 def test_materialise_rejects_non_dict_idedata(tmp_path: Path) -> None:
     """idedata.json that parses to a non-dict raises MaterialiseError."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        storage = json.dumps(
-            {"storage_version": 1, "name": "kitchen", "build_path": _FAKE_BUILD_PATH}
-        ).encode("utf-8")
-        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
-        info.size = len(storage)
-        tar.addfile(info, io.BytesIO(storage))
-        # idedata parses but isn't a dict.
-        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
-        info.size = 4
-        tar.addfile(info, io.BytesIO(b"null"))
-
+    tarball = _synthetic_tarball(idedata=b"null")
     with pytest.raises(MaterialiseError, match=r"is not a JSON object"):
-        _materialise_in_tmp(buf.getvalue(), tmp_path)
+        _materialise_in_tmp(tarball, tmp_path)

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -32,6 +32,8 @@ from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
 )
 from esphome_device_builder.helpers.remote_artifacts_materialise import (
     MaterialiseError,
+    _force_idedata_cache_hit,
+    _remap_to_offloader,
     materialise_remote_artifacts,
 )
 from esphome_device_builder.helpers.storage_path import (
@@ -406,8 +408,103 @@ def test_materialise_rejects_oversized_member(
         _materialise_in_tmp(tarball, tmp_path)
 
 
+def test_materialise_rejects_non_regular_storage_member(tmp_path: Path) -> None:
+    """A storage.json entry that's a symlink (not a regular file) is rejected."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../../etc/passwd"
+        tar.addfile(info)
+    with pytest.raises(MaterialiseError, match=r"not a regular file"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)
+
+
+def test_materialise_rejects_non_dict_storage(tmp_path: Path) -> None:
+    """storage.json that parses to a non-dict (e.g. ``null``) raises."""
+    tarball = _synthetic_tarball(storage=b"null")
+    with pytest.raises(MaterialiseError, match=r"is not a JSON object"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
+def test_materialise_rejects_non_json_idedata(tmp_path: Path) -> None:
+    """idedata.json that isn't parseable JSON raises."""
+    tarball = _synthetic_tarball(idedata=b"{not-json")
+    with pytest.raises(MaterialiseError, match=r"idedata.*not valid JSON"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
 def test_materialise_rejects_non_dict_idedata(tmp_path: Path) -> None:
     """idedata.json that parses to a non-dict raises MaterialiseError."""
     tarball = _synthetic_tarball(idedata=b"null")
     with pytest.raises(MaterialiseError, match=r"is not a JSON object"):
         _materialise_in_tmp(tarball, tmp_path)
+
+
+def test_remap_to_offloader_returns_input_when_not_under_build_path(tmp_path: Path) -> None:
+    """An absolute path that isn't under receiver_build_path passes through unchanged."""
+    receiver_build = tmp_path / "receiver_build"
+    offloader_build = tmp_path / "offloader_build"
+    outside = Path("/totally/unrelated/path.bin")
+    result = _remap_to_offloader(outside, receiver_build, offloader_build)
+    assert result == outside
+
+
+def test_materialise_rejects_cumulative_member_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two extract-side members whose sum breaches the cap raise on the second."""
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.remote_artifacts_materialise.FIRMWARE_MAX_TOTAL_BYTES",
+        500,
+    )
+    # storage / idedata read via _read_member_required (single-member
+    # cap only). The cumulative gate fires in _safe_extract_excluding
+    # across build-tree members; ship two that exceed the cap together.
+    tarball = _synthetic_tarball(
+        extra_members=[
+            (".pioenvs/kitchen/firmware.bin", b"x" * 300),
+            (".pioenvs/kitchen/firmware.elf", b"y" * 300),
+        ]
+    )
+    with pytest.raises(MaterialiseError, match=r"cumulative size"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
+def test_materialise_idedata_skips_non_dict_flash_image_entry(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """A non-dict entry in idedata.extra.flash_images is silently skipped."""
+    receiver_root, offloader_root = paired_roots
+    sentinel = receiver_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        _write_receiver_state(receiver_root)
+        # Inject a malformed flash_images entry alongside a valid one.
+        idedata_path = resolve_idedata_path("kitchen.yaml", name="kitchen")
+        data = json.loads(idedata_path.read_text())
+        data.setdefault("extra", {})["flash_images"] = [
+            "not-a-dict",
+            {"path": "/fake/receiver/build/firmware.bin"},
+        ]
+        idedata_path.write_text(json.dumps(data) + "\n")
+        packed = pack_build_artifacts("kitchen.yaml")
+
+    _materialise_in_tmp(packed.tarball, offloader_root)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        cached = resolve_idedata_path("kitchen.yaml", name="kitchen")
+    data = json.loads(cached.read_text())
+    # The non-dict survives untouched; the dict entry got remapped.
+    flash_images = data["extra"]["flash_images"]
+    assert flash_images[0] == "not-a-dict"
+    assert isinstance(flash_images[1], dict)
+
+
+def test_force_idedata_cache_hit_noop_when_files_missing(tmp_path: Path) -> None:
+    """``_force_idedata_cache_hit`` returns early when either side doesn't exist."""
+    # Neither file exists; helper must not raise.
+    _force_idedata_cache_hit(
+        platformio_ini=tmp_path / "missing.ini",
+        cached_idedata=tmp_path / "missing.json",
+    )

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -26,6 +26,7 @@ from esphome.core import CORE
 
 from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     IDEDATA_MEMBER_NAME,
+    PLATFORMIO_INI_MEMBER_NAME,
     STORAGE_MEMBER_NAME,
     pack_build_artifacts,
 )
@@ -75,28 +76,33 @@ def _synthetic_tarball(
     *,
     storage: Any = _SENTINEL,
     idedata: Any = _SENTINEL,
+    platformio_ini: bytes | None = b"[env:e2e]\n",
     extra_members: list[tuple[str, bytes]] | None = None,
 ) -> bytes:
     """Build a minimal tarball for materialiser error-path tests.
 
     ``storage`` / ``idedata`` accept dict (JSON-encoded), bytes
     (raw — for malformed-JSON cases), or ``None`` (omit the
-    member). Default is a valid storage shape + ``{}`` idedata.
+    member). ``platformio_ini`` accepts bytes or ``None`` (omit).
+    Default is a valid storage shape + ``{}`` idedata + a
+    minimal platformio.ini stub.
     """
     if storage is _SENTINEL:
         storage = {"storage_version": 1, "name": "kitchen", "build_path": _FAKE_BUILD_PATH}
     if idedata is _SENTINEL:
         idedata = {}
+    members: list[tuple[str, bytes]] = []
+    for name, value in ((STORAGE_MEMBER_NAME, storage), (IDEDATA_MEMBER_NAME, idedata)):
+        if value is None:
+            continue
+        payload = value if isinstance(value, bytes) else json.dumps(value).encode("utf-8")
+        members.append((name, payload))
+    if platformio_ini is not None:
+        members.append((PLATFORMIO_INI_MEMBER_NAME, platformio_ini))
+    members.extend(extra_members or [])
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        for name, value in ((STORAGE_MEMBER_NAME, storage), (IDEDATA_MEMBER_NAME, idedata)):
-            if value is None:
-                continue
-            payload = value if isinstance(value, bytes) else json.dumps(value).encode("utf-8")
-            info = tarfile.TarInfo(name=name)
-            info.size = len(payload)
-            tar.addfile(info, io.BytesIO(payload))
-        for member_name, member_payload in extra_members or []:
+        for member_name, member_payload in members:
             info = tarfile.TarInfo(name=member_name)
             info.size = len(member_payload)
             tar.addfile(info, io.BytesIO(member_payload))
@@ -377,6 +383,26 @@ def test_materialise_rejects_non_json_storage(tmp_path: Path) -> None:
     """storage.json that isn't parseable JSON raises MaterialiseError."""
     tarball = _synthetic_tarball(storage=b"{bad")
     with pytest.raises(MaterialiseError, match=r"not valid JSON"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
+def test_materialise_rejects_missing_platformio_ini(tmp_path: Path) -> None:
+    """A tarball without platformio.ini raises MaterialiseError post-extract."""
+    tarball = _synthetic_tarball(platformio_ini=None)
+    with pytest.raises(MaterialiseError, match=r"missing required 'platformio\.ini'"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
+def test_materialise_rejects_oversized_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A member declaring more bytes than the cap is rejected as a decompression-bomb defence."""
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.remote_artifacts_materialise.FIRMWARE_MAX_TOTAL_BYTES",
+        16,
+    )
+    tarball = _synthetic_tarball()
+    with pytest.raises(MaterialiseError, match=r"FIRMWARE_MAX_TOTAL_BYTES"):
         _materialise_in_tmp(tarball, tmp_path)
 
 

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -371,6 +371,24 @@ def test_materialise_rejects_path_traversal(tmp_path: Path) -> None:
         _materialise_in_tmp(buf.getvalue(), tmp_path)
 
 
+def test_materialise_rejects_traversal_in_storage_name(tmp_path: Path) -> None:
+    """A storage.json ``name`` carrying path-separator chars is rejected."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        storage = json.dumps(
+            {"storage_version": 1, "name": "../sneaky", "build_path": _FAKE_BUILD_PATH}
+        ).encode("utf-8")
+        info = tarfile.TarInfo(name=STORAGE_MEMBER_NAME)
+        info.size = len(storage)
+        tar.addfile(info, io.BytesIO(storage))
+        info = tarfile.TarInfo(name=IDEDATA_MEMBER_NAME)
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"{}"))
+
+    with pytest.raises(MaterialiseError, match=r"not safe for a path segment"):
+        _materialise_in_tmp(buf.getvalue(), tmp_path)
+
+
 def test_materialise_rejects_storage_missing_name(tmp_path: Path) -> None:
     """storage.json without a 'name' field raises before extraction starts."""
     buf = io.BytesIO()

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -547,6 +547,46 @@ def test_pack_build_artifacts_raises_when_platformio_ini_missing(tmp_path: Path)
         pack_build_artifacts("kitchen.yaml")
 
 
+def test_pack_build_artifacts_rejects_firmware_bin_outside_build_files(
+    tmp_path: Path,
+) -> None:
+    """A firmware_bin_path not covered by BUILD_FILES raises ``RuntimeError``.
+
+    Defence-in-depth against a future esphome bump moving
+    firmware_bin_path somewhere a platform module doesn't list:
+    we want a clean reject rather than a half-shipped tarball
+    the offloader stages without the firmware binary.
+    """
+    state = _write_receiver_state(tmp_path)
+    # Point firmware_bin_path at a path that isn't covered by
+    # esp32's BUILD_FILES tuple (no platform ships a top-level
+    # ``custom_firmware.bin``).
+    custom_path = state["build_path"] / "custom_firmware.bin"
+    custom_path.write_bytes(b"CUSTOM")
+    storage_data = json.loads(state["storage_path"].read_text())
+    storage_data["firmware_bin_path"] = str(custom_path)
+    state["storage_path"].write_text(json.dumps(storage_data) + "\n")
+
+    with pytest.raises(RuntimeError, match=r"not covered by BUILD_FILES"):
+        pack_build_artifacts("kitchen.yaml")
+
+
+def test_pack_build_artifacts_rejects_firmware_bin_outside_build_path(
+    tmp_path: Path,
+) -> None:
+    """A firmware_bin_path that escapes the build dir raises ``RuntimeError``."""
+    state = _write_receiver_state(tmp_path)
+    escapee = tmp_path / "outside" / "firmware.bin"
+    escapee.parent.mkdir()
+    escapee.write_bytes(b"OUTSIDE")
+    storage_data = json.loads(state["storage_path"].read_text())
+    storage_data["firmware_bin_path"] = str(escapee)
+    state["storage_path"].write_text(json.dumps(storage_data) + "\n")
+
+    with pytest.raises(RuntimeError, match=r"not under build_path"):
+        pack_build_artifacts("kitchen.yaml")
+
+
 def test_pack_build_artifacts_rejects_oversized_uncompressed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -38,6 +38,7 @@ from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     STORAGE_MEMBER_NAME,
     PackedArtifacts,
     UnpackArtifactsError,
+    _download_type_files,
     pack_build_artifacts,
     read_artifacts_tarball,
     unpack_artifacts_response,
@@ -521,6 +522,39 @@ def test_pack_build_artifacts_rejects_unknown_target_platform(tmp_path: Path) ->
         pack_build_artifacts("kitchen.yaml")
 
 
+def test_pack_build_artifacts_raises_when_firmware_bin_path_unset(tmp_path: Path) -> None:
+    """StorageJSON with ``firmware_bin_path=None`` raises FileNotFoundError."""
+    state = _write_receiver_state(tmp_path)
+    data = json.loads(state["storage_path"].read_text())
+    data["firmware_bin_path"] = None
+    state["storage_path"].write_text(json.dumps(data) + "\n")
+
+    with pytest.raises(FileNotFoundError, match=r"firmware_bin_path unset"):
+        pack_build_artifacts("kitchen.yaml")
+
+
+def test_pack_build_artifacts_raises_when_build_path_unset(tmp_path: Path) -> None:
+    """StorageJSON with ``build_path=None`` raises FileNotFoundError."""
+    state = _write_receiver_state(tmp_path)
+    data = json.loads(state["storage_path"].read_text())
+    data["build_path"] = None
+    state["storage_path"].write_text(json.dumps(data) + "\n")
+
+    with pytest.raises(FileNotFoundError, match=r"build_path unset"):
+        pack_build_artifacts("kitchen.yaml")
+
+
+def test_pack_build_artifacts_raises_when_name_empty(tmp_path: Path) -> None:
+    """StorageJSON with an empty ``name`` raises FileNotFoundError."""
+    state = _write_receiver_state(tmp_path)
+    data = json.loads(state["storage_path"].read_text())
+    data["name"] = ""
+    state["storage_path"].write_text(json.dumps(data) + "\n")
+
+    with pytest.raises(FileNotFoundError, match=r"name unset / non-string"):
+        pack_build_artifacts("kitchen.yaml")
+
+
 def test_pack_build_artifacts_raises_when_storage_missing(tmp_path: Path) -> None:
     """No StorageJSON sidecar on disk → FileNotFoundError (mapped to build_dir_missing)."""
     # Don't call _write_receiver_state — the storage sidecar
@@ -545,6 +579,51 @@ def test_pack_build_artifacts_raises_when_platformio_ini_missing(tmp_path: Path)
 
     with pytest.raises(FileNotFoundError, match=r"platformio\.ini missing"):
         pack_build_artifacts("kitchen.yaml")
+
+
+def test_pack_build_artifacts_includes_get_download_types_files(tmp_path: Path) -> None:
+    """``get_download_types`` files (firmware.factory.bin etc.) ride in the tarball."""
+    _write_receiver_state(
+        tmp_path,
+        extra_build_files={
+            ".pioenvs/kitchen/firmware.factory.bin": b"FACTORY",
+            ".pioenvs/kitchen/firmware.ota.bin": b"OTA",
+        },
+    )
+
+    packed = pack_build_artifacts("kitchen.yaml")
+
+    names = _tar_member_names(packed.tarball)
+    assert ".pioenvs/kitchen/firmware.factory.bin" in names
+    assert ".pioenvs/kitchen/firmware.ota.bin" in names
+
+
+def test_download_type_files_empty_for_unknown_component() -> None:
+    """``_download_type_files`` returns ``[]`` when the platform has no mapped component."""
+    fake_storage = MagicMock()
+    fake_storage.target_platform = None
+    assert _download_type_files(fake_storage) == []
+
+
+def test_pack_build_artifacts_logs_download_types_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """If ``get_download_types`` raises, we log the traceback and ship without those files."""
+    _write_receiver_state(tmp_path)
+
+    def _raise(_storage: object) -> object:
+        raise RuntimeError("simulated component breakage")
+
+    import esphome.components.esp32  # noqa: PLC0415
+
+    monkeypatch.setattr(esphome.components.esp32, "get_download_types", _raise)
+
+    with caplog.at_level("ERROR"):
+        packed = pack_build_artifacts("kitchen.yaml")
+
+    assert packed.tarball  # pack succeeded with the static BUILD_FILES set
+    assert any("Could not determine download types" in r.message for r in caplog.records)
+    assert any(r.exc_info is not None for r in caplog.records)
 
 
 def test_pack_build_artifacts_rejects_firmware_bin_outside_build_files(
@@ -950,6 +1029,43 @@ def test_read_artifacts_tarball_rejects_cumulative_size_over_cap(
 
     with pytest.raises(UnpackArtifactsError, match="cumulative size"):
         read_artifacts_tarball(tarball)
+
+
+def test_read_artifacts_tarball_rejects_per_member_size_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single member declaring more bytes than the cap is rejected."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball."
+        "FIRMWARE_MAX_TOTAL_BYTES",
+        128,
+    )
+    tarball = _build_minimal_tarball(
+        {"idedata.json": b'{"extra": {}}', "firmware.bin": b"x" * 200},
+    )
+
+    with pytest.raises(UnpackArtifactsError, match=r"exceeding FIRMWARE_MAX_TOTAL_BYTES"):
+        read_artifacts_tarball(tarball)
+
+
+def test_read_artifacts_tarball_rejects_duplicate_basename() -> None:
+    """Two tarball members sharing the same basename surface as UnpackArtifactsError."""
+    idedata_bytes = json.dumps({"extra": {"flash_images": []}}).encode("utf-8")
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name="idedata.json")
+        info.size = len(idedata_bytes)
+        tar.addfile(info, io.BytesIO(idedata_bytes))
+        firm = b"FIRM"
+        info = tarfile.TarInfo(name=".pioenvs/a/firmware.bin")
+        info.size = len(firm)
+        tar.addfile(info, io.BytesIO(firm))
+        info = tarfile.TarInfo(name=".pioenvs/b/firmware.bin")
+        info.size = len(firm)
+        tar.addfile(info, io.BytesIO(firm))
+
+    with pytest.raises(UnpackArtifactsError, match=r"duplicate basename"):
+        read_artifacts_tarball(buf.getvalue())
 
 
 def test_read_artifacts_tarball_surfaces_malformed_tarball_as_unpack_error() -> None:

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -33,9 +33,11 @@ from esphome_device_builder.controllers.remote_build.artifacts_download import (
     ArtifactsDownloadSender,
 )
 from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
+    IDEDATA_MEMBER_NAME,
+    PLATFORMIO_INI_MEMBER_NAME,
+    STORAGE_MEMBER_NAME,
     PackedArtifacts,
     UnpackArtifactsError,
-    extract_firmware_bin,
     pack_build_artifacts,
     read_artifacts_tarball,
     unpack_artifacts_response,
@@ -43,12 +45,11 @@ from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
     DownloadArtifactsResult,
 )
-from esphome_device_builder.helpers.build_artifacts import (
-    BuildArtifacts,
-    FlashArtifact,
-    load_build_artifacts,
+from esphome_device_builder.helpers.build_artifacts import load_build_artifacts
+from esphome_device_builder.helpers.storage_path import (
+    resolve_idedata_path,
+    resolve_storage_path,
 )
-from esphome_device_builder.helpers.peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
 from esphome_device_builder.models import (
     DownloadArtifactsFrameData,
     JobStatus,
@@ -329,123 +330,236 @@ async def test_download_artifacts_clears_inflight_on_reject(
 # ---------------------------------------------------------------------------
 
 
-def _make_build_artifacts(
+def _write_receiver_state(
     tmp_path: Path,
     *,
-    extra_offsets: list[tuple[str, str]] | None = None,
-) -> BuildArtifacts:
-    """Build a synthetic :class:`BuildArtifacts` on disk for round-trip tests.
+    configuration: str = "kitchen.yaml",
+    device_name: str = "kitchen",
+    target_platform: str = "ESP32",
+    extras: list[tuple[str, str]] | None = None,
+    extra_build_files: dict[str, bytes] | None = None,
+) -> dict[str, Path]:
+    """Lay down a minimal receiver-side build state on disk.
 
-    *extra_offsets* is a list of ``(basename, offset_hex)`` for
-    additional flash images (bootloader / partitions /
-    ota_data_initial). The matching idedata.json carries these
-    under ``extra.flash_images`` with absolute receiver-side
-    paths so the unpack can prove the basename rewrite.
+    Writes:
+
+    * ``<data_dir>/build/<device_name>/platformio.ini``
+    * ``<data_dir>/build/<device_name>/.pioenvs/<device_name>/firmware.bin``
+    * Any additional build-tree files in *extra_build_files*
+      (keys are paths relative to ``<build_path>/``).
+    * ``<data_dir>/storage/<basename>.json`` with the JSON
+      fields the new packer reads via ``StorageJSON.load``.
+    * ``<data_dir>/idedata/<device_name>.json`` with an
+      ``extra.flash_images`` entry per *extras*
+      (``(basename, offset_hex)``); receiver-absolute paths
+      under ``.pioenvs/<device_name>/<basename>`` so the
+      WS-adapter rewrite to basenames is observable.
+
+    Returns the key paths so individual tests can mutate them
+    (e.g. drop ``platformio.ini`` to drive the missing-file
+    branch).
+
+    Side-effects ``CORE.config_path`` so the dashboard's
+    ``resolve_storage_path`` / ``resolve_idedata_path`` /
+    ``resolve_data_dir`` all anchor on *tmp_path*'s ``.esphome``
+    subtree. The autouse ``_core_config_path_in_tmp`` fixture
+    already pins this, so we just rely on its anchor here.
     """
-    extras = extra_offsets or []
-    firmware_path = tmp_path / "firmware.bin"
-    firmware_path.write_bytes(b"FIRMWARE")
-    flash_images = [FlashArtifact(path=firmware_path, offset="0x10000")]
-    extra_entries: list[dict[str, str]] = []
-    for name, offset in extras:
-        path = tmp_path / name
-        path.write_bytes(name.encode("ascii"))
-        flash_images.append(FlashArtifact(path=path, offset=offset))
-        extra_entries.append({"path": str(path), "offset": offset})
-    idedata_payload = {"extra": {"flash_images": extra_entries}}
-    idedata_bytes = json.dumps(idedata_payload).encode("utf-8")
-    return BuildArtifacts(flash_images=flash_images, idedata_bytes=idedata_bytes)
+    data_dir = tmp_path / ".esphome"
+    build_path = data_dir / "build" / device_name
+    pioenvs = build_path / ".pioenvs" / device_name
+    pioenvs.mkdir(parents=True, exist_ok=True)
+    (build_path / "platformio.ini").write_bytes(b"[env:kitchen]\nplatform = espressif32\n")
+    firmware_bin = pioenvs / "firmware.bin"
+    firmware_bin.write_bytes(b"FIRMWARE")
 
+    extra_paths: list[dict[str, str]] = []
+    for basename, offset in extras or []:
+        path = pioenvs / basename
+        path.write_bytes(basename.encode("ascii"))
+        extra_paths.append({"path": str(path), "offset": offset})
 
-def test_pack_build_artifacts_layout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tarball contains ``idedata.json`` first, then every flash image, flat."""
-    artifacts = _make_build_artifacts(
-        tmp_path,
-        extra_offsets=[("bootloader.bin", "0x1000"), ("partitions.bin", "0x8000")],
+    for rel_path, payload in (extra_build_files or {}).items():
+        abs_path = build_path / rel_path
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_path.write_bytes(payload)
+
+    storage_path = resolve_storage_path(configuration)
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    storage_path.write_text(
+        json.dumps(
+            {
+                "storage_version": 1,
+                "name": device_name,
+                "esp_platform": target_platform,
+                "build_path": str(build_path),
+                "firmware_bin_path": str(firmware_bin),
+                "loaded_integrations": [],
+                "loaded_platforms": [],
+                "no_mdns": False,
+                "framework": "arduino",
+                "core_platform": target_platform.lower(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
     )
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
-        lambda _config: artifacts,
+
+    idedata_path = resolve_idedata_path(configuration, name=device_name)
+    idedata_path.parent.mkdir(parents=True, exist_ok=True)
+    idedata_path.write_text(
+        json.dumps(
+            {
+                "prog_path": str(pioenvs / "firmware.elf"),
+                "cc_path": (
+                    "/home/receiver/.platformio/packages/toolchain-xtensa32"
+                    "/bin/xtensa-esp32-elf-gcc"
+                ),
+                "extra": {"flash_images": extra_paths},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "build_path": build_path,
+        "firmware_bin": firmware_bin,
+        "storage_path": storage_path,
+        "idedata_path": idedata_path,
+        "platformio_ini": build_path / "platformio.ini",
+    }
+
+
+def _tar_member_names(tarball: bytes) -> list[str]:
+    with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
+        return tar.getnames()
+
+
+def test_pack_build_artifacts_ships_metadata_and_per_platform_build_tree(
+    tmp_path: Path,
+) -> None:
+    """Tarball carries storage.json + idedata.json + platformio.ini at root, then BUILD_FILES."""
+    state = _write_receiver_state(
+        tmp_path,
+        extras=[("bootloader.bin", "0x1000"), ("partitions.bin", "0x8000")],
+        extra_build_files={
+            ".pioenvs/kitchen/firmware.elf": b"ELF",
+            ".pioenvs/kitchen/bootloader.bin": b"BOOT",
+            ".pioenvs/kitchen/partitions.bin": b"PART",
+            ".pioenvs/kitchen/ota_data_initial.bin": b"OTA",
+        },
     )
 
     packed = pack_build_artifacts("kitchen.yaml")
 
     assert packed.firmware_offset == "0x10000"
-    with tarfile.open(fileobj=io.BytesIO(packed.tarball), mode="r:gz") as tar:
-        names = tar.getnames()
-    assert names == ["idedata.json", "firmware.bin", "bootloader.bin", "partitions.bin"]
+    names = _tar_member_names(packed.tarball)
+    # Three metadata members at the top, in deterministic order.
+    assert names[:3] == [
+        STORAGE_MEMBER_NAME,
+        IDEDATA_MEMBER_NAME,
+        PLATFORMIO_INI_MEMBER_NAME,
+    ]
+    # The ESP32 BUILD_FILES list resolved at pack time.
+    assert ".pioenvs/kitchen/firmware.bin" in names
+    assert ".pioenvs/kitchen/firmware.elf" in names
+    assert ".pioenvs/kitchen/bootloader.bin" in names
+    assert ".pioenvs/kitchen/partitions.bin" in names
+    assert ".pioenvs/kitchen/ota_data_initial.bin" in names
+    # Nothing else snuck into the tarball.
+    assert state["build_path"].is_dir()  # tmp dir still around
 
 
-def test_pack_build_artifacts_rejects_oversized_idedata(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Idedata.json alone exceeding ``FIRMWARE_MAX_TOTAL_BYTES`` raises ``RuntimeError``."""
-    firmware_path = tmp_path / "firmware.bin"
-    firmware_path.write_bytes(b"FW")
-    artifacts = BuildArtifacts(
-        flash_images=[FlashArtifact(path=firmware_path, offset="0x10000")],
-        idedata_bytes=b"x" * (FIRMWARE_MAX_TOTAL_BYTES + 1),
+def test_pack_build_artifacts_skips_missing_build_files(tmp_path: Path) -> None:
+    """Per-platform BUILD_FILES entries that don't exist on disk are silently skipped.
+
+    The packer pre-declares every file the platform might
+    emit (e.g. ESP32 lists ``ota_data_initial.bin``) but a
+    given build doesn't always emit each one. Skipping them
+    is intentional — the missing-file branch is platform
+    behaviour, not a packer error.
+    """
+    _write_receiver_state(tmp_path)  # only firmware.bin under .pioenvs/
+
+    packed = pack_build_artifacts("kitchen.yaml")
+
+    names = _tar_member_names(packed.tarball)
+    assert ".pioenvs/kitchen/firmware.bin" in names
+    # firmware.elf / bootloader.bin / etc were never written, so they're absent.
+    assert ".pioenvs/kitchen/firmware.elf" not in names
+    assert ".pioenvs/kitchen/bootloader.bin" not in names
+
+
+def test_pack_build_artifacts_libretiny_ships_uf2(tmp_path: Path) -> None:
+    """Libretiny BUILD_FILES is resolved from the registry (.uf2 + .bin + .elf)."""
+    _write_receiver_state(
+        tmp_path,
+        device_name="bw15",
+        target_platform="BK72XX",
+        extra_build_files={
+            ".pioenvs/bw15/firmware.uf2": b"UF2",
+            ".pioenvs/bw15/firmware.elf": b"ELF",
+        },
     )
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
-        lambda _config: artifacts,
-    )
 
-    with pytest.raises(RuntimeError, match=r"already exceeds FIRMWARE_MAX_TOTAL_BYTES"):
+    packed = pack_build_artifacts("kitchen.yaml")
+
+    # ESP32 prefix → 0x10000; libretiny falls through to 0x0.
+    assert packed.firmware_offset == "0x0"
+    names = _tar_member_names(packed.tarball)
+    assert ".pioenvs/bw15/firmware.uf2" in names
+    assert ".pioenvs/bw15/firmware.bin" in names
+    assert ".pioenvs/bw15/firmware.elf" in names
+
+
+def test_pack_build_artifacts_rejects_unknown_target_platform(tmp_path: Path) -> None:
+    """A target_platform without an artifact_platforms module raises RuntimeError."""
+    _write_receiver_state(tmp_path, target_platform="ABSURDIAN-X1")
+
+    with pytest.raises(RuntimeError, match=r"no artifact_platforms module"):
         pack_build_artifacts("kitchen.yaml")
 
 
-def test_pack_build_artifacts_rejects_oversized_compressed(
+def test_pack_build_artifacts_raises_when_storage_missing(tmp_path: Path) -> None:
+    """No StorageJSON sidecar on disk → FileNotFoundError (mapped to build_dir_missing)."""
+    # Don't call _write_receiver_state — the storage sidecar
+    # never gets written.
+    with pytest.raises(FileNotFoundError, match="StorageJSON sidecar missing"):
+        pack_build_artifacts("kitchen.yaml")
+
+
+def test_pack_build_artifacts_raises_when_idedata_missing(tmp_path: Path) -> None:
+    """No cached idedata.json → FileNotFoundError."""
+    state = _write_receiver_state(tmp_path)
+    state["idedata_path"].unlink()
+
+    with pytest.raises(FileNotFoundError, match="idedata cache missing"):
+        pack_build_artifacts("kitchen.yaml")
+
+
+def test_pack_build_artifacts_raises_when_platformio_ini_missing(tmp_path: Path) -> None:
+    """No platformio.ini → FileNotFoundError."""
+    state = _write_receiver_state(tmp_path)
+    state["platformio_ini"].unlink()
+
+    with pytest.raises(FileNotFoundError, match=r"platformio\.ini missing"):
+        pack_build_artifacts("kitchen.yaml")
+
+
+def test_pack_build_artifacts_rejects_oversized_uncompressed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Tarball that lands oversized after pack raises ``RuntimeError``.
-
-    Pins the post-render cap that catches the
-    incompressible-data + tar-header-overhead corner where
-    the uncompressed walking sum slips under the limit but
-    ``len(tarball)`` exceeds it. Constructs the corner case
-    with a synthetic ``BuildArtifacts`` whose uncompressed
-    total is tiny (passing the walking gates) but whose tar
-    headers + gzip framing inflate ``len(tarball)`` past a
-    monkey-patched cap.
-    """
-    firmware_path = tmp_path / "firmware.bin"
-    firmware_path.write_bytes(b"")  # 0 bytes — uncompressed walks pass with any cap >= 2
-    artifacts = BuildArtifacts(
-        flash_images=[FlashArtifact(path=firmware_path, offset="0x10000")],
-        idedata_bytes=b"{}",  # 2 bytes
-    )
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
-        lambda _config: artifacts,
-    )
-    # Cap=10 lets uncompressed total (2 bytes idedata + 0
-    # bytes firmware) clear the two walking gates but the
-    # rendered tarball — gzip envelope (~20B) + two tar
-    # headers (1024B compressed to ~30B) — easily exceeds.
+    """Uncompressed walking sum exceeding the cap raises ``RuntimeError``."""
+    _write_receiver_state(tmp_path)
+    # Cap to a small value so the uncompressed walk trips on
+    # the first few members (storage.json + idedata.json
+    # together are well over 128 bytes once we serialise
+    # them).
     monkeypatch.setattr(
         "esphome_device_builder.controllers.remote_build.artifacts_tarball."
         "FIRMWARE_MAX_TOTAL_BYTES",
-        10,
-    )
-
-    with pytest.raises(RuntimeError, match=r"on the wire"):
-        pack_build_artifacts("kitchen.yaml")
-
-
-def test_pack_build_artifacts_rejects_oversized_cumulative(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Cumulative artifact bytes exceeding the cap raises ``RuntimeError``."""
-    firmware_path = tmp_path / "firmware.bin"
-    firmware_path.write_bytes(b"x" * (FIRMWARE_MAX_TOTAL_BYTES + 1))
-    artifacts = BuildArtifacts(
-        flash_images=[FlashArtifact(path=firmware_path, offset="0x10000")],
-        idedata_bytes=b"{}",
-    )
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
-        lambda _config: artifacts,
+        16,
     )
 
     with pytest.raises(RuntimeError, match=r"would exceed FIRMWARE_MAX_TOTAL_BYTES"):
@@ -462,46 +576,16 @@ def test_artifacts_download_sender_discard_session_clears_inflight() -> None:
     assert "alpha" not in sender._inflight
 
 
-def test_pack_build_artifacts_rejects_duplicate_basename(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Two extras with the same basename trigger a ``RuntimeError``."""
-    firmware_path = tmp_path / "firmware.bin"
-    firmware_path.write_bytes(b"FW")
-    extra_a = tmp_path / "a" / "img.bin"
-    extra_a.parent.mkdir()
-    extra_a.write_bytes(b"A")
-    extra_b = tmp_path / "b" / "img.bin"
-    extra_b.parent.mkdir()
-    extra_b.write_bytes(b"B")
-    artifacts = BuildArtifacts(
-        flash_images=[
-            FlashArtifact(path=firmware_path, offset="0x10000"),
-            FlashArtifact(path=extra_a, offset="0x1000"),
-            FlashArtifact(path=extra_b, offset="0x8000"),
-        ],
-        idedata_bytes=b"{}",
-    )
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
-        lambda _config: artifacts,
-    )
-
-    with pytest.raises(RuntimeError, match="duplicate flash image basename"):
-        pack_build_artifacts("kitchen.yaml")
-
-
-def test_unpack_artifacts_response_round_trip(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_unpack_artifacts_response_round_trip(tmp_path: Path) -> None:
     """Pack → unpack returns the same flash bytes + rewrites idedata paths to basenames."""
-    artifacts = _make_build_artifacts(
+    _write_receiver_state(
         tmp_path,
-        extra_offsets=[("bootloader.bin", "0x1000"), ("ota_data_initial.bin", "0xe000")],
-    )
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_tarball.load_build_artifacts",
-        lambda _config: artifacts,
+        extras=[("bootloader.bin", "0x1000"), ("ota_data_initial.bin", "0xe000")],
+        extra_build_files={
+            ".pioenvs/kitchen/firmware.elf": b"ELF",
+            ".pioenvs/kitchen/bootloader.bin": b"BOOT",
+            ".pioenvs/kitchen/ota_data_initial.bin": b"OTA",
+        },
     )
 
     packed = pack_build_artifacts("kitchen.yaml")
@@ -520,6 +604,25 @@ def test_unpack_artifacts_response_round_trip(
     rewritten_paths = [entry["path"] for entry in response["idedata"]["extra"]["flash_images"]]
     assert rewritten_paths == ["bootloader.bin", "ota_data_initial.bin"]
     assert response["total_bytes"] == sum(image["size"] for image in response["images"])
+
+
+def test_unpack_artifacts_response_ignores_metadata_and_aux_members(tmp_path: Path) -> None:
+    """storage.json / platformio.ini / firmware.elf are filtered from the images set."""
+    _write_receiver_state(
+        tmp_path,
+        extra_build_files={".pioenvs/kitchen/firmware.elf": b"ELF"},
+    )
+
+    packed = pack_build_artifacts("kitchen.yaml")
+    response = unpack_artifacts_response(
+        DownloadArtifactsResult(tarball=packed.tarball, firmware_offset="0x10000"),
+        job_id="j",
+    )
+
+    image_names = [image["name"] for image in response["images"]]
+    # Only flash images (per idedata.extra.flash_images) plus firmware.bin appear.
+    # storage.json / platformio.ini / firmware.elf are absent.
+    assert image_names == ["firmware.bin"]
 
 
 def test_unpack_artifacts_response_missing_idedata_raises() -> None:
@@ -553,8 +656,18 @@ def test_unpack_artifacts_response_missing_firmware_raises() -> None:
         )
 
 
-def test_unpack_artifacts_response_unreferenced_file_raises() -> None:
-    """An extra file in the tarball not referenced by idedata raises."""
+def test_unpack_artifacts_response_ignores_unreferenced_aux_files() -> None:
+    """Aux files in the tarball that aren't in idedata.extra.flash_images are silently ignored.
+
+    The materialise-locally wire format legitimately ships
+    per-platform aux files (``firmware.elf`` for picotool
+    symbol resolution, ``firmware.uf2`` for libretiny/RP2040
+    ltchiptool flashing) that aren't in
+    ``idedata.extra.flash_images``. The WS-adapter
+    surfaces only the flash-image subset to the frontend;
+    leftovers in the basename map are dropped without
+    raising.
+    """
     idedata_bytes = json.dumps({"extra": {"flash_images": []}}).encode("utf-8")
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
@@ -564,15 +677,17 @@ def test_unpack_artifacts_response_unreferenced_file_raises() -> None:
         firmware_info = tarfile.TarInfo(name="firmware.bin")
         firmware_info.size = 4
         tar.addfile(firmware_info, io.BytesIO(b"FIRM"))
-        stray_info = tarfile.TarInfo(name="stray.bin")
+        stray_info = tarfile.TarInfo(name="firmware.elf")
         stray_info.size = 1
         tar.addfile(stray_info, io.BytesIO(b"X"))
 
-    with pytest.raises(UnpackArtifactsError, match="unexpected files not referenced"):
-        unpack_artifacts_response(
-            DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x0"),
-            job_id="j",
-        )
+    response = unpack_artifacts_response(
+        DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x10000"),
+        job_id="j",
+    )
+
+    # Only the manifest-referenced flash images surface; firmware.elf is dropped.
+    assert [image["name"] for image in response["images"]] == ["firmware.bin"]
 
 
 def test_unpack_artifacts_response_invalid_idedata_json_raises() -> None:
@@ -753,12 +868,12 @@ def test_load_build_artifacts_rejects_non_dict_idedata(
 
 
 # ---------------------------------------------------------------------------
-# extract_firmware_bin — runner-side single-image extractor
+# read_artifacts_tarball — cumulative size cap (decompression-bomb defence)
 # ---------------------------------------------------------------------------
 
 
 def _build_minimal_tarball(members: dict[str, bytes]) -> bytes:
-    """Build a gzipped tarball with *members* (basename → bytes)."""
+    """Build a gzipped tarball with *members* (full name → bytes)."""
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         for name, payload in members.items():
@@ -766,106 +881,6 @@ def _build_minimal_tarball(members: dict[str, bytes]) -> bytes:
             info.size = len(payload)
             tar.addfile(info, io.BytesIO(payload))
     return buf.getvalue()
-
-
-def test_extract_firmware_bin_returns_firmware_bytes() -> None:
-    """The happy path: a tarball with ``firmware.bin`` returns its payload."""
-    expected = b"\xe9\x08\x02\x20RUNTIME-FIRMWARE-BYTES"
-    tarball = _build_minimal_tarball(
-        {"idedata.json": b"{}", "firmware.bin": expected, "extra.bin": b"x"},
-    )
-
-    assert extract_firmware_bin(tarball) == expected
-
-
-def test_extract_firmware_bin_raises_when_firmware_missing() -> None:
-    """No ``firmware.bin`` in the tarball → ``UnpackArtifactsError``."""
-    tarball = _build_minimal_tarball(
-        {"idedata.json": b"{}", "bootloader.bin": b"boot"},
-    )
-
-    with pytest.raises(UnpackArtifactsError, match=r"firmware\.bin missing"):
-        extract_firmware_bin(tarball)
-
-
-def test_extract_firmware_bin_raises_when_firmware_is_a_directory() -> None:
-    """
-    A directory entry named ``firmware.bin`` surfaces as ``UnpackArtifactsError``.
-
-    Defensive — the receiver-side packer never writes a
-    directory, so this is a wire-shape-drift / hostile-peer
-    case. ``isfile()`` rejects non-regular members before we
-    read any bytes.
-    """
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        info = tarfile.TarInfo(name="firmware.bin")
-        info.type = tarfile.DIRTYPE
-        tar.addfile(info)
-    tarball = buf.getvalue()
-
-    with pytest.raises(UnpackArtifactsError, match="not a regular file"):
-        extract_firmware_bin(tarball)
-
-
-def test_extract_firmware_bin_raises_when_firmware_is_a_symlink() -> None:
-    """
-    A symlink entry named ``firmware.bin`` surfaces as ``UnpackArtifactsError``.
-
-    Defence against a hostile peer: ``tarfile.extractfile()``
-    follows symlinks transparently and returns a readable
-    stream pointing at whatever the link target resolves to
-    on the receiver's filesystem. An ``is None`` guard alone
-    would let the bytes through; the explicit
-    ``member.isfile()`` check rejects every non-regular type
-    before the read.
-    """
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        info = tarfile.TarInfo(name="firmware.bin")
-        info.type = tarfile.SYMTYPE
-        info.linkname = "../../../etc/passwd"
-        tar.addfile(info)
-    tarball = buf.getvalue()
-
-    with pytest.raises(UnpackArtifactsError, match="not a regular file"):
-        extract_firmware_bin(tarball)
-
-
-def test_extract_firmware_bin_raises_on_malformed_tarball() -> None:
-    """A non-gzipped / non-tar payload surfaces as ``UnpackArtifactsError``."""
-    with pytest.raises(UnpackArtifactsError, match="malformed tarball"):
-        extract_firmware_bin(b"this is not a gzipped tarball")
-
-
-def test_extract_firmware_bin_rejects_oversized_member() -> None:
-    """
-    A tarball declaring a firmware.bin larger than the cap fails fast.
-
-    Decompression-bomb defence: gzip can shrink huge zero-
-    filled / sparse data to a tiny on-the-wire payload. The
-    header-size gate trips before ``extractfile`` reads a
-    single byte.
-    """
-    # Build a tarball whose header declares a huge size but
-    # whose actual payload is tiny — mimic the
-    # "decompression-bomb" shape: a TarInfo with an inflated
-    # ``size`` field followed by the matching payload.
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        oversized_payload = b"\x00" * (FIRMWARE_MAX_TOTAL_BYTES + 1)
-        info = tarfile.TarInfo(name="firmware.bin")
-        info.size = len(oversized_payload)
-        tar.addfile(info, io.BytesIO(oversized_payload))
-    tarball = buf.getvalue()
-
-    with pytest.raises(UnpackArtifactsError, match="exceeding FIRMWARE_MAX_TOTAL_BYTES"):
-        extract_firmware_bin(tarball)
-
-
-# ---------------------------------------------------------------------------
-# read_artifacts_tarball — cumulative size cap (decompression-bomb defence)
-# ---------------------------------------------------------------------------
 
 
 def test_read_artifacts_tarball_rejects_cumulative_size_over_cap(


### PR DESCRIPTION
# What does this implement/fix?

Replaces the flat-tarball + `esphome upload --file` flow with build-tree materialisation on the offloader.

The receiver-side packer ships the per-platform build files plus `storage.json` / `idedata.json` / `platformio.ini` at fixed top-level wire names. A new offloader-side helper, `materialise_remote_artifacts`, stages everything at esphome's canonical paths (`<data_dir>/build/<name>/`, `<data_dir>/storage/<basename>.json`, `<data_dir>/idedata/<name>.json`) and rewrites receiver-absolute paths to offloader-local. After it returns, `esphome upload <yaml> --device <port>` resolves through esphome's normal per-platform dispatch — no `--file`, no per-platform code in this repo or upstream.

Consequences for the dashboard:

* **Serial-port installs no longer force LOCAL.** The runner stages the full multi-image set (bootloader / partitions / ota_data_initial / firmware) so esptool sees the same offsets a local compile would have produced; libretiny / RP2040 serial spawn `pio run -t upload -t nobuild` against the staged tree.
* **`firmware/compile` + `firmware/compile_bulk` route through `_resolve_install_source`.** A paired receiver compiles the binary and the offloader materialises it; `firmware/download` then serves from the staged StorageJSON sidecar.
* **Idedata regeneration is skipped on first install.** The materialiser writes the rewritten cache at `<data_dir>/idedata/<name>.json` (the file `_load_idedata` actually reads, not PIO's internal `.pioenvs/<name>/idedata.json`) and touches mtimes so the staleness gate hits. `cc_path`'s PIO core prefix is remapped via `PLATFORMIO_CORE_DIR` so RP2040 BOOTSEL's picotool lookup resolves on the offloader.

New `artifact_platforms/` registry: one module per platform (esp32, esp8266, rp2040, bk72xx, rtl87xx, ln882x, nrf52) declares the `BUILD_FILES` to ship. Adding a new platform = one new module + one import line. The libretiny variants share an internal `_libretiny.py` for the common tuple.

**Breaking wire-format change** for offloader/receiver pairs already on the prior format. The feature shipped this week; both sides need to upgrade together. No back-compat shims.

**Related issue or feature (if applicable):**

- Closes #570 — stage multi-image set so serial REMOTE installs compile remotely too
- Closes #624 — route `firmware/compile` (and Download firmware binary) through paired build server
- Closes #572 — upstream `esphome upload --prebuilt-dir` tracker; obsoleted by the dashboard-side materialise step (no upstream change needed)
- Replaces esphome/esphome#16348 (closed) — the `esphome upload --prebuilt-dir` approach pushed per-platform flash dispatch knowledge into ESPHome that already lives there.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

The `remote_build/download_artifacts` WS response shape is unchanged — `{job_id, idedata, images, total_bytes}` with basename-keyed images. The WS adapter's unpacker now filters the new metadata members and keys binaries by basename so the Web Serial flasher consumes the new tarball layout transparently.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
