### PR TITLE
Cover post-render wire-size guard in remote build artifact packer

### DIFF
--- a/tests/e2e/test_download_artifacts.py
+++ b/tests/e2e/test_download_artifacts.py
@@ -312,29 +312,32 @@ async def test_download_artifacts_pack_oversize_surfaces_unavailable(
 ) -> None:
     """Receiver-side ``RuntimeError`` from the packer rejects ``pack_failed`` → UNAVAILABLE.
 
-    Pins the soft-reject round-trip for the wire-size guard in
-    :func:`pack_build_artifacts._render_tarball`: when the
-    gzipped tarball would exceed
-    :data:`FIRMWARE_MAX_TOTAL_BYTES`, the packer raises
-    ``RuntimeError``; the receiver-side
+    Pins the soft-reject wire-surface mapping for any
+    ``RuntimeError`` raised by
+    :func:`pack_build_artifacts <controllers.remote_build.artifacts_tarball.pack_build_artifacts>`:
+    the receiver-side
     :meth:`ArtifactsDownloadSender.handle_download_artifacts`
     catches anything except ``FileNotFoundError`` and replies
     with a single ``artifacts_end{accepted: false, reason:
-    "pack_failed"}`` frame. The offloader-side WS layer maps
+    "pack_failed"}`` frame; the offloader-side WS layer maps
     that reason to :attr:`ErrorCode.UNAVAILABLE` via
-    :data:`_DOWNLOAD_ARTIFACTS_REASON_TO_ERROR_CODE`, so the
-    user sees a "remote build artifacts unavailable" surface
-    rather than a stack-trace toast.
+    :data:`_DOWNLOAD_ARTIFACTS_REASON_TO_ERROR_CODE`. The
+    end-to-end contract is the same regardless of which size
+    branch in
+    :func:`_render_tarball <controllers.remote_build.artifacts_tarball._render_tarball>`
+    fires; capping :data:`FIRMWARE_MAX_TOTAL_BYTES` to 10
+    triggers the per-member uncompressed pre-check with the
+    e2e fixture payloads. The unit test
+    ``test_render_tarball_rejects_oversized_on_the_wire`` pins
+    the post-render guard specifically.
     """
     await paired_instances.wait_until_session_opened()
     job = _seed_firmware_job(paired_instances)
     _write_build_artifacts_on_disk(tmp_path)
-    # Force the post-render wire-size guard by capping below
-    # the rendered tarball. With the e2e fixture's tiny test
-    # payloads the gzipped tarball is well over 10 bytes; the
-    # per-member uncompressed pre-check would also trip here,
-    # but either branch surfaces the same ``pack_failed``
-    # reason — the user-visible contract is identical.
+    # Cap below the smallest fixture file so the per-member
+    # uncompressed pre-check trips inside the packer. The wire
+    # shape we pin here (``pack_failed`` → UNAVAILABLE) is the
+    # same for any RuntimeError the packer raises.
     monkeypatch.setattr(
         "esphome_device_builder.controllers.remote_build.artifacts_tarball."
         "FIRMWARE_MAX_TOTAL_BYTES",

--- a/tests/e2e/test_download_artifacts.py
+++ b/tests/e2e/test_download_artifacts.py
@@ -302,3 +302,49 @@ async def test_download_artifacts_job_not_completed_surfaces_precondition_failed
         )
 
     assert exc_info.value.code == ErrorCode.PRECONDITION_FAILED
+
+
+@pytest.mark.asyncio
+async def test_download_artifacts_pack_oversize_surfaces_unavailable(
+    paired_instances: PairedInstances,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Receiver-side ``RuntimeError`` from the packer rejects ``pack_failed`` → UNAVAILABLE.
+
+    Pins the soft-reject round-trip for the wire-size guard in
+    :func:`pack_build_artifacts._render_tarball`: when the
+    gzipped tarball would exceed
+    :data:`FIRMWARE_MAX_TOTAL_BYTES`, the packer raises
+    ``RuntimeError``; the receiver-side
+    :meth:`ArtifactsDownloadSender.handle_download_artifacts`
+    catches anything except ``FileNotFoundError`` and replies
+    with a single ``artifacts_end{accepted: false, reason:
+    "pack_failed"}`` frame. The offloader-side WS layer maps
+    that reason to :attr:`ErrorCode.UNAVAILABLE` via
+    :data:`_DOWNLOAD_ARTIFACTS_REASON_TO_ERROR_CODE`, so the
+    user sees a "remote build artifacts unavailable" surface
+    rather than a stack-trace toast.
+    """
+    await paired_instances.wait_until_session_opened()
+    job = _seed_firmware_job(paired_instances)
+    _write_build_artifacts_on_disk(tmp_path)
+    # Force the post-render wire-size guard by capping below
+    # the rendered tarball. With the e2e fixture's tiny test
+    # payloads the gzipped tarball is well over 10 bytes; the
+    # per-member uncompressed pre-check would also trip here,
+    # but either branch surfaces the same ``pack_failed``
+    # reason — the user-visible contract is identical.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball."
+        "FIRMWARE_MAX_TOTAL_BYTES",
+        10,
+    )
+
+    with pytest.raises(CommandError) as exc_info:
+        await paired_instances.offloader.download_artifacts(
+            pin_sha256=paired_instances.pin_sha256,
+            job_id=job.remote_job_id,
+        )
+
+    assert exc_info.value.code == ErrorCode.UNAVAILABLE

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -39,6 +39,7 @@ from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     PackedArtifacts,
     UnpackArtifactsError,
     _download_type_files,
+    _render_tarball,
     pack_build_artifacts,
     read_artifacts_tarball,
     unpack_artifacts_response,
@@ -683,6 +684,31 @@ def test_pack_build_artifacts_rejects_oversized_uncompressed(
 
     with pytest.raises(RuntimeError, match=r"would exceed FIRMWARE_MAX_TOTAL_BYTES"):
         pack_build_artifacts("kitchen.yaml")
+
+
+def test_render_tarball_rejects_oversized_on_the_wire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Gzipped tarball larger than the cap raises the post-render ``on the wire`` guard.
+
+    The per-member uncompressed pre-check is the first gate;
+    the post-render wire-size cap is the second gate, defending
+    against the case where the gzipped output is *larger* than
+    the uncompressed file contents (tar headers + gzip framing
+    add ~80 bytes minimum, easily exceeding tiny payloads).
+    Use a 1-byte file so the loop sees ``0 + 1 > cap`` is false
+    while the rendered tarball trips the post-check.
+    """
+    payload = tmp_path / "tiny.bin"
+    payload.write_bytes(b"X")
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.artifacts_tarball."
+        "FIRMWARE_MAX_TOTAL_BYTES",
+        10,
+    )
+
+    with pytest.raises(RuntimeError, match=r"would exceed FIRMWARE_MAX_TOTAL_BYTES on the wire"):
+        _render_tarball([("tiny.bin", payload)], configuration="kitchen.yaml")
 
 
 def test_artifacts_download_sender_discard_session_clears_inflight() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adds coverage for the post-render wire-size guard in
`controllers/remote_build/artifacts_tarball._render_tarball`
that Codecov flagged on #641. The guard catches the (rare)
case where the gzipped tarball is *larger* than its
uncompressed file contents: tar headers (512 bytes per file)
plus gzip framing easily exceed a tiny payload's bytes, so
the per-member uncompressed pre-check passes but the
final-bytes-on-the-wire cap is the only thing that stops the
packer from handing back something the BundleAssembler
already won't accept.

Two tests cover it:

* **Unit** — `test_render_tarball_rejects_oversized_on_the_wire`
  calls the helper directly with a 1-byte file and a cap of
  10, so the loop's `0 + 1 > 10` is false and the post-render
  guard is the only branch that can fire.
* **End-to-end** — `test_download_artifacts_pack_oversize_surfaces_unavailable`
  pins the wire surface: receiver-side packer raises
  `RuntimeError` → receiver's `ArtifactsDownloadSender` sends
  `artifacts_end{accepted: false, reason: "pack_failed"}` →
  offloader's WS layer maps the reason to
  `ErrorCode.UNAVAILABLE` via
  `_DOWNLOAD_ARTIFACTS_REASON_TO_ERROR_CODE`. A regression
  that swapped the reject reason or dropped the mapping would
  surface here as the wrong `ErrorCode`.

After: `artifacts_tarball.py` at 100% line coverage.

**Related issue or feature (if applicable):**

- follow-up to #641

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
