### PR TITLE
Match CLAUDE.md docstring convention in _task_controller_base.py

### DIFF
--- a/esphome_device_builder/controllers/_task_controller_base.py
+++ b/esphome_device_builder/controllers/_task_controller_base.py
@@ -1,9 +1,11 @@
-"""Base class for controllers that schedule fire-and-forget background work.
+"""
+Base class for controllers that schedule fire-and-forget background work.
 
 The event loop keeps only a weak ref to each
-:class:`~asyncio.Task`; an unreferenced task can be GC'd mid-await.
-:class:`TaskControllerBase` provides the strong-ref set + schedule
-helper so subclasses don't repeat the idiom inline.
+:class:`~asyncio.Task`; an unreferenced task can be GC'd
+mid-await. :class:`TaskControllerBase` provides the strong-ref
+set + schedule helper so subclasses don't repeat the idiom
+inline.
 """
 
 from __future__ import annotations
@@ -14,7 +16,8 @@ from typing import Any
 
 
 class TaskControllerBase:
-    """Base for controllers that schedule fire-and-forget tasks.
+    """
+    Base for controllers that schedule fire-and-forget tasks.
 
     Subclasses call ``super().__init__()`` to initialise
     :attr:`_tasks`, then schedule via ``self._track_task(coro)``.


### PR DESCRIPTION
# What does this implement/fix?

Copilot flagged on #640 that the module + class docstrings in
`_task_controller_base.py` start their content on the same
line as the opening `"""`, but CLAUDE.md's docstring section
specifies that multi-line docstring content goes on the line
*after* the opening quotes. Reformat to match.

Single-file diff, +8/-5 lines, zero functional change.

**Related issue or feature (if applicable):**

- Follow-up to #640 (which had already merged when the
  Copilot review landed).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
