### PR TITLE
Fan out job_state_changed{queued} for cross-offloader wait UX

### DIFF
--- a/esphome_device_builder/controllers/remote_build/job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build/job_fanout.py
@@ -14,14 +14,13 @@ back to the submitting offloader over the same session.
 
 Wiring:
 
-* Lifecycle events ``JOB_STARTED`` / ``JOB_COMPLETED`` /
-  ``JOB_FAILED`` / ``JOB_CANCELLED`` map 1:1 to
-  ``job_state_changed`` frames with ``status`` = ``running`` /
-  ``completed`` / ``failed`` / ``cancelled``. ``JOB_QUEUED``
-  doesn't fan out — the ``submit_job_ack`` already tells the
-  offloader the job is queued, so a redundant
-  ``job_state_changed{queued}`` frame would race the ack and
-  add wire noise without adding signal.
+* Lifecycle events ``JOB_QUEUED`` / ``JOB_STARTED`` /
+  ``JOB_COMPLETED`` / ``JOB_FAILED`` / ``JOB_CANCELLED`` map 1:1
+  to ``job_state_changed`` frames with ``status`` = ``queued`` /
+  ``running`` / ``completed`` / ``failed`` / ``cancelled``. The
+  ``queued`` fan-out is what drives the offloader's "waiting in
+  line" screen when the receiver is busy with another
+  offloader's job.
 * ``JOB_OUTPUT`` maps to ``job_output{stream, line}``. High-
   rate during an active build (one per line of compiler /
   linker output); the channel's per-frame Noise AEAD overhead
@@ -65,12 +64,11 @@ _LOGGER = logging.getLogger(__name__)
 # ``JobStateChangedFrameData.status`` value. The receiver
 # fires the bus event from the firmware queue's existing
 # transitions; this map turns each into the typed frame's
-# enum string. ``JOB_QUEUED`` is intentionally absent — the
-# ``submit_job_ack`` already tells the offloader the job is
-# queued (see module docstring).
+# enum string.
 _JobStatusLiteral = Literal["queued", "running", "completed", "failed", "cancelled"]
 
 _LIFECYCLE_EVENT_TO_STATUS: dict[EventType, _JobStatusLiteral] = {
+    EventType.JOB_QUEUED: "queued",
     EventType.JOB_STARTED: "running",
     EventType.JOB_COMPLETED: "completed",
     EventType.JOB_FAILED: "failed",
@@ -125,12 +123,13 @@ class JobFanout:
         bus = self._controller._db.bus
         if bus is None:
             return
-        # JOB_QUEUED populates the cache but doesn't fan out (see
-        # module docstring on the deliberate skip — the
-        # ``submit_job_ack`` already signals queued, and a frame
-        # firing here would race the ack).
+        # JOB_QUEUED has a dedicated handler so the cache
+        # populate runs before the fan-out (listener order on
+        # the bus is not defined).
         self._listeners.callback(bus.add_listener(EventType.JOB_QUEUED, self._on_queued))
         for event_type in _LIFECYCLE_EVENT_TO_STATUS:
+            if event_type is EventType.JOB_QUEUED:
+                continue
             self._listeners.callback(bus.add_listener(event_type, self._on_lifecycle))
         self._listeners.callback(bus.add_listener(EventType.JOB_OUTPUT, self._on_output))
 
@@ -172,26 +171,12 @@ class JobFanout:
         return None
 
     def _on_queued(self, event: Event[JobLifecycleData]) -> None:
-        """Cache the remote-peer correlation for *job* if it has one.
+        """Cache the remote-peer correlation for *job* and fan out ``queued``.
 
-        JOB_QUEUED fires from :meth:`FirmwareController._enqueue`
-        immediately after the job lands in the queue — before any
-        JOB_STARTED / JOB_OUTPUT / terminal event. Populating
-        :attr:`_remote_jobs` here means subsequent listeners
-        (especially :meth:`_on_output`, which fires per line of
-        output) can do an O(1) sync lookup against state this
-        module owns rather than reaching back into the firmware
-        controller's job map.
-
-        Local-only jobs (``remote_peer`` empty) don't go in the
-        cache — saves a per-line dict miss on the busy path.
-        Jobs with ``remote_peer`` set but ``remote_job_id``
-        empty are flagged at debug — the cache miss would be
-        silent on every later lifecycle / output event,
-        making the missing correlation hard to find. The
-        likely shape is a persisted job from before
-        ``remote_job_id`` existed, or a future call site
-        forgetting to pass it through ``_create_job``.
+        The ``queued`` frame drives the offloader's "waiting in
+        line" screen when the receiver is busy with another
+        offloader's job. Local-only jobs and jobs missing
+        ``remote_job_id`` are skipped.
         """
         job = event.data["job"]
         if not job.remote_peer:
@@ -205,6 +190,14 @@ class JobFanout:
             )
             return
         self._remote_jobs[job.job_id] = (job.remote_peer, job.remote_job_id)
+        self._dispatch_state_changed(
+            remote_peer=job.remote_peer,
+            remote_job_id=job.remote_job_id,
+            status="queued",
+            error_message="",
+            log_label="JOB_QUEUED",
+            log_job_id=job.job_id,
+        )
 
     def _on_lifecycle(self, event: Event[JobLifecycleData]) -> None:
         """Forward a lifecycle transition to the submitting session, best-effort.
@@ -231,21 +224,41 @@ class JobFanout:
         if entry is None:
             return
         remote_peer, remote_job_id = entry
-        session = self._controller._peer_link_sessions.get(remote_peer)
-        if session is None:
-            _LOGGER.debug(
-                "%s for remote peer %s (job %s): no active session; dropping fan-out",
-                event.event_type.value,
-                remote_peer,
-                job.job_id,
-            )
-            return
         status = _LIFECYCLE_EVENT_TO_STATUS[event.event_type]
         # ``error_message`` is the empty string on non-terminal
         # paths; populate from ``FirmwareJob.error`` on
         # ``failed`` / ``cancelled`` so the offloader has a
         # one-liner to surface without parsing the full output.
         error_message = job.error if status in {"failed", "cancelled"} and job.error else ""
+        self._dispatch_state_changed(
+            remote_peer=remote_peer,
+            remote_job_id=remote_job_id,
+            status=status,
+            error_message=error_message,
+            log_label=event.event_type.value,
+            log_job_id=job.job_id,
+        )
+
+    def _dispatch_state_changed(
+        self,
+        *,
+        remote_peer: str,
+        remote_job_id: str,
+        status: _JobStatusLiteral,
+        error_message: str,
+        log_label: str,
+        log_job_id: str,
+    ) -> None:
+        """Send a ``job_state_changed`` frame to *remote_peer*'s session, best-effort."""
+        session = self._controller._peer_link_sessions.get(remote_peer)
+        if session is None:
+            _LOGGER.debug(
+                "%s for remote peer %s (job %s): no active session; dropping fan-out",
+                log_label,
+                remote_peer,
+                log_job_id,
+            )
+            return
         self._dispatch(
             session,
             JobStateChangedFrameData(

--- a/esphome_device_builder/controllers/remote_build/job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build/job_fanout.py
@@ -195,7 +195,7 @@ class JobFanout:
             remote_job_id=job.remote_job_id,
             status="queued",
             error_message="",
-            log_label="JOB_QUEUED",
+            log_label=event.event_type.value,
             log_job_id=job.job_id,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,15 @@ class _CapturedEvents(list[dict]):
         super().append(item)
         self.received.set()
 
+    async def wait_for_status(self, status: str, *, timeout: float = 2.0) -> dict:
+        """Return the first captured event whose ``status`` matches *status*."""
+        while True:
+            for entry in self:
+                if entry.get("status") == status:
+                    return entry
+            self.received.clear()
+            await asyncio.wait_for(self.received.wait(), timeout=timeout)
+
 
 def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:
     """Subscribe to *event_type* on *bus* and return a list captured-as-they-fire.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,13 +177,22 @@ class _CapturedEvents(list[dict]):
         self.received.set()
 
     async def wait_for_status(self, status: str, *, timeout: float = 2.0) -> dict:
-        """Return the first captured event whose ``status`` matches *status*."""
-        while True:
-            for entry in self:
-                if entry.get("status") == status:
-                    return entry
-            self.received.clear()
-            await asyncio.wait_for(self.received.wait(), timeout=timeout)
+        """Return the first captured event whose ``status`` matches *status*.
+
+        The *timeout* bounds the total wait, not each loop iteration,
+        so a stream of non-matching events can't push the deadline
+        forward indefinitely.
+        """
+
+        async def _poll() -> dict:
+            while True:
+                for entry in self:
+                    if entry.get("status") == status:
+                        return entry
+                self.received.clear()
+                await self.received.wait()
+
+        return await asyncio.wait_for(_poll(), timeout=timeout)
 
 
 def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -365,11 +365,10 @@ async def make_and_seed_remote_peer_job(
 
     :class:`JobFanout._on_lifecycle` is a sync bus listener that
     looks up the correlation in :attr:`JobFanout._remote_jobs`,
-    populated only by ``JOB_QUEUED`` (the fan-out deliberately
-    skips the queued frame itself; see
-    ``test_submit_job_fanout.py``'s module docstring on why a
-    redundant ``job_state_changed{queued}`` would race the
-    submit ack).
+    populated by ``JOB_QUEUED``. The queued event itself also
+    fans out a ``job_state_changed{queued}`` frame to the
+    submitting offloader so the cross-offloader "waiting in
+    line" screen has its trigger.
     """
     job = make_remote_peer_job(remote_peer=instances.offloader_dashboard_id, error=error)
     instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))

--- a/tests/e2e/test_cancel_job.py
+++ b/tests/e2e/test_cancel_job.py
@@ -174,10 +174,11 @@ async def test_offloader_cancel_job_full_round_trip_to_state_changed(
     # stub didn't fire on its own.
     paired_instances.receiver_bus.fire(EventType.JOB_CANCELLED, JobLifecycleData(job=job))
 
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
-    payload = state_changes[-1]
+    # The queued frame from ``make_and_seed_remote_peer_job``
+    # may still be on the wire here; poll for the cancelled
+    # transition rather than asserting it's the only entry.
+    payload = await state_changes.wait_for_status("cancelled")
     assert payload["job_id"] == job.remote_job_id
-    assert payload["status"] == "cancelled"
     assert payload["pin_sha256"] == paired_instances.pin_sha256
 
 

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -342,12 +342,12 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
 
     * ``submit_job_ack{accepted: true}`` flows back; the
       receiver's recorded job carries the correlation fields.
-    * Two ``OFFLOADER_JOB_STATE_CHANGED`` events landed
-      (``running`` then ``completed``), both echoing the
-      offloader-supplied ``job_id`` and the live ``pin_sha256``
-      from the harness's handshake — the fan-out preserves the
-      offloader's tag rather than leaking the receiver's local
-      id.
+    * ``OFFLOADER_JOB_STATE_CHANGED`` events land for the
+      ``running`` then ``completed`` transitions (a leading
+      ``queued`` from JOB_QUEUED may precede them; this test
+      polls for the named statuses rather than asserting count).
+      Both echo the offloader-supplied ``job_id`` and the live
+      ``pin_sha256`` from the harness's handshake.
     * ``download_artifacts`` returns the StorageJSON +
       ``idedata`` + base64-enveloped image bytes the receiver
       packed; the artifact set survives the round-trip on the
@@ -406,23 +406,13 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
     # the deterministic sync point.
     paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=receiver_job))
     paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=receiver_job))
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
-    running_payload = state_changes[-1]
+    running_payload = await state_changes.wait_for_status("running")
     assert running_payload["job_id"] == "off-job-1"
-    assert running_payload["status"] == "running"
     assert running_payload["pin_sha256"] == paired_instances.pin_sha256
 
-    # Re-arm the captured event for the next deterministic wait
-    # — the helper's ``received`` event stays set after the
-    # first deliver, so a second wait_for would return
-    # immediately on the old payload without checking that
-    # JOB_COMPLETED actually fanned out.
-    state_changes.received.clear()
     paired_instances.receiver_bus.fire(EventType.JOB_COMPLETED, JobLifecycleData(job=receiver_job))
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
-    completed_payload = state_changes[-1]
+    completed_payload = await state_changes.wait_for_status("completed")
     assert completed_payload["job_id"] == "off-job-1"
-    assert completed_payload["status"] == "completed"
     assert completed_payload["pin_sha256"] == paired_instances.pin_sha256
 
     # 5. Flip the recorded receiver-side job to COMPLETED so
@@ -514,10 +504,9 @@ async def test_remote_compile_materialises_for_local_firmware_download(
 
     paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=receiver_job))
     paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=receiver_job))
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
-    state_changes.received.clear()
+    await state_changes.wait_for_status("running")
     paired_instances.receiver_bus.fire(EventType.JOB_COMPLETED, JobLifecycleData(job=receiver_job))
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
+    await state_changes.wait_for_status("completed")
     receiver_job.status = JobStatus.COMPLETED
 
     packed = await handle.client.download_artifacts(job_id="off-compile-1")
@@ -809,24 +798,14 @@ async def test_remote_clean_round_trip_lands_clean_job_and_fans_state_back(
     # compile / install.
     _drive_receiver_lifecycle(paired_instances, receiver_job, terminal=EventType.JOB_COMPLETED)
 
-    # Two state changes land on the offloader's bus: running then
-    # completed, both carrying the offloader-supplied ``job_id`` and
-    # the live pin_sha256. JOB_QUEUED doesn't produce a state-change
-    # fan-out (the fan-out fires from JOB_STARTED onward); two
-    # events is the right count. Poll until both have arrived rather
-    # than ``wait_for(received)`` once — the latter wakes on the
-    # first event, races the second one, and would flake on a
-    # slower CPU.
-    async def _wait_for_two_events() -> None:
-        while len(state_changes) < 2:
-            state_changes.received.clear()
-            if len(state_changes) >= 2:
-                return
-            await state_changes.received.wait()
-
-    await asyncio.wait_for(_wait_for_two_events(), timeout=2.0)
-    assert len(state_changes) >= 2
+    # Three state changes land on the offloader's bus: queued,
+    # running, completed; each carries the offloader-supplied
+    # ``job_id`` and the live pin_sha256. Poll for the terminal
+    # one and then check every captured entry rather than racing
+    # ``wait_for(received)`` against the lifecycle.
+    await state_changes.wait_for_status("completed")
     statuses = [payload["status"] for payload in state_changes]
+    assert "queued" in statuses
     assert "running" in statuses
     assert "completed" in statuses
     for payload in state_changes:

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -50,7 +50,6 @@ covered separately by tests on :func:`build_yaml_bundle`.
 
 from __future__ import annotations
 
-import asyncio
 import io
 import json
 import tarfile
@@ -300,10 +299,11 @@ async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
     assert job.job_id in paired_instances.receiver._job_fanout._remote_jobs
     paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
 
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
-    payload = state_changes[-1]
+    # JOB_QUEUED now fans out as ``queued`` ahead of ``running``;
+    # poll for the running transition rather than asserting on
+    # whichever frame raced to the bus first.
+    payload = await state_changes.wait_for_status("running")
     assert payload["job_id"] == "off-job-1"  # offloader's tag echoed back
-    assert payload["status"] == "running"
     assert payload["pin_sha256"] == paired_instances.pin_sha256
 
 

--- a/tests/e2e/test_submit_job_fanout.py
+++ b/tests/e2e/test_submit_job_fanout.py
@@ -85,24 +85,25 @@ async def test_remote_peer_job_lifecycle_fans_out_to_offloader_bus(
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
+    # ``make_and_seed_remote_peer_job`` fires JOB_QUEUED on the
+    # receiver, which fans out a queued frame the offloader sees
+    # before the running one. Poll until both lifecycle frames
+    # have landed so the lifecycle assertion below is order-
+    # independent against the wire round-trip.
     job = await make_and_seed_remote_peer_job(paired_instances)
-
-    # Drive the lifecycle event the fan-out actually fires for.
     paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
 
-    # Wait for the wire round-trip — frame send is scheduled as
-    # a background task, frame decrypt + dispatch happens on the
-    # offloader's receive loop on its own task. The capture
-    # ``Event`` flips when the OFFLOADER_JOB_STATE_CHANGED fires.
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
-    assert len(state_changes) == 1
-    payload = state_changes[-1]
-    assert payload["job_id"] == "off-job-1"  # offloader's tag echoed back
-    assert payload["status"] == "running"
-    assert payload["error_message"] == ""
-    assert payload["pin_sha256"] == paired_instances.pin_sha256
-    assert payload["receiver_hostname"] == "127.0.0.1"
-    assert payload["receiver_port"] == paired_instances.receiver_server.port
+    queued = await state_changes.wait_for_status("queued")
+    running = await state_changes.wait_for_status("running")
+
+    assert queued["job_id"] == "off-job-1"
+    assert queued["error_message"] == ""
+
+    assert running["job_id"] == "off-job-1"  # offloader's tag echoed back
+    assert running["error_message"] == ""
+    assert running["pin_sha256"] == paired_instances.pin_sha256
+    assert running["receiver_hostname"] == "127.0.0.1"
+    assert running["receiver_port"] == paired_instances.receiver_server.port
 
 
 @pytest.mark.asyncio
@@ -127,9 +128,7 @@ async def test_remote_peer_terminal_failure_carries_error_message(
 
     paired_instances.receiver_bus.fire(EventType.JOB_FAILED, JobLifecycleData(job=job))
 
-    await asyncio.wait_for(state_changes.received.wait(), timeout=2.0)
-    payload = state_changes[-1]
-    assert payload["status"] == "failed"
+    payload = await state_changes.wait_for_status("failed")
     assert payload["error_message"] == "esphome compile failed: undefined reference"
 
 

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -135,6 +135,7 @@ async def test_lifecycle_event_fans_out_as_job_state_changed(
     fanout.start()
     job = _make_remote_job(status=status_field)
     _seed_via_queued(bus, job)
+    await _drain_background(controller)  # flush the queued frame's fan-out
     session.send_app_frame.reset_mock()
 
     bus.fire(event_type, {"job": job})
@@ -158,6 +159,7 @@ async def test_failed_event_carries_error_message() -> None:
     fanout.start()
     job = _make_remote_job(status=JobStatus.FAILED, error="compile failed: bad pin")
     _seed_via_queued(bus, job)
+    await _drain_background(controller)  # flush the queued frame's fan-out
     session.send_app_frame.reset_mock()
 
     bus.fire(EventType.JOB_FAILED, {"job": job})
@@ -210,18 +212,15 @@ async def test_lifecycle_skips_when_session_gone() -> None:
 
 
 @pytest.mark.asyncio
-async def test_job_queued_caches_correlation_but_does_not_fan_out() -> None:
-    """``JOB_QUEUED`` populates the fan-out cache but doesn't send a wire frame.
+async def test_job_queued_caches_correlation_and_fans_out_queued_frame() -> None:
+    """``JOB_QUEUED`` populates the cache AND fans out a ``queued`` wire frame.
 
-    Pins two contracts: (1) the ``submit_job_ack`` response
-    carries the queued signal implicitly, and a redundant
-    ``job_state_changed{queued}`` frame would race the ack and
-    add wire noise without adding signal; (2) the cache
-    population path itself runs so subsequent JOB_STARTED /
-    JOB_OUTPUT events can dispatch.
+    The ``queued`` fan-out is what drives the offloader's
+    "waiting in line" screen when the receiver is busy with
+    another offloader's job.
     """
     bus = EventBus()
-    session = _make_session()
+    session = _make_session(dashboard_id="alpha")
     controller = _make_controller(bus=bus, sessions={"alpha": session})
     fanout = JobFanout(controller)
     fanout.start()
@@ -230,7 +229,12 @@ async def test_job_queued_caches_correlation_but_does_not_fan_out() -> None:
     bus.fire(EventType.JOB_QUEUED, {"job": job})
     await _drain_background(controller)
 
-    session.send_app_frame.assert_not_called()
+    session.send_app_frame.assert_awaited_once()
+    frame = session.send_app_frame.call_args.args[0]
+    assert frame["type"] == "job_state_changed"
+    assert frame["job_id"] == "wire-job"
+    assert frame["status"] == "queued"
+    assert frame["error_message"] == ""
     # Cache populated — the JOB_STARTED that lands next will
     # find its correlation tuple.
     assert fanout._remote_jobs == {job.job_id: ("alpha", "wire-job")}
@@ -315,6 +319,7 @@ async def test_job_output_fans_out_as_job_output_frame() -> None:
     fanout = JobFanout(controller)
     fanout.start()
     _seed_via_queued(bus, job)
+    await _drain_background(controller)  # flush the queued frame's fan-out
     session.send_app_frame.reset_mock()
 
     bus.fire(EventType.JOB_OUTPUT, {"job_id": "local-1", "line": "Compiling .pioenvs/...\n"})


### PR DESCRIPTION
# What does this implement/fix?

When two offloaders submit jobs to the same receiver, the second offloader's install dialog sits blank instead of showing the "Waiting in queue" screen.

The receiver was deliberately skipping `job_state_changed{queued}` fan-out (the rationale being that `submit_job_ack` already implied queued). That's fine in the single-offloader case where the offloader's local firmware queue carries the predecessor and drives the wait UI. With two offloaders, the predecessor lives on a different offloader's queue, so the local view has nothing to render against; the explicit `queued` frame is the only signal the second offloader can use.

Receiver-side `JOB_QUEUED` now fans out `job_state_changed{queued}` to the submitting peer, alongside the existing cache-populate step. The wire format already accepted `queued` as a valid status; the offloader's dispatcher already upserts on `queued`. Frontend companion PR esphome/device-builder-frontend#314 wires the install dialog's overlay to this new signal.

**Related issue or feature (if applicable):**

- fixes none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#314

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

