### PR TITLE
Trim build_size.py prose (382 → 262 lines)

### DIFF
--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -1,23 +1,16 @@
-"""Cached, mtime-gated walk of a device's per-build artifact directory.
+"""
+Cached, mtime-gated walk of a device's per-build artifact directory.
 
-ESPHome compiles produce a meaty ``.esphome/build/<device>/`` tree —
-PlatformIO checkouts, framework toolchain output, intermediate ``.o``
-files, the linked binaries. A typical board lands at 50-250 MB, with
-heavier configs (BLE-tracker fleets, multi-bus designs) easily past a
-gigabyte. The dashboard surfaces this size in the per-device drawer
-and as a hidden-by-default table column so a user planning a clean-up
-can see at a glance which devices are eating disk.
+ESPHome compiles produce a meaty ``.esphome/build/<device>/``
+tree (50-250 MB typical, multi-gigabyte for heavy configs). The
+dashboard surfaces this size in the per-device drawer; the walk
+itself is heavy I/O. We cache the computed total in the
+per-device metadata sidecar keyed off a *freshness pair*:
+``(dir_mtime, build_info_mtime)``. Either side moving counts
+as stale.
 
-The walk itself is heavy + I/O-bound — every entry under the tree
-needs an ``stat()`` to get its size, and a fleet with dozens of
-devices would otherwise burn measurable time on every dashboard
-load. We cache the computed total in the per-device metadata sidecar
-keyed off a *freshness pair*: ``(dir_mtime, build_info_mtime)``.
-Either side moving counts as stale; both halves are needed because
-each catches a class of changes the other misses.
-
-Empirical matrix (Python 3.12, macOS APFS) — which signal moves
-under each write pattern that ESPHome / PlatformIO actually use::
+Both halves are needed — empirical matrix (Python 3.12,
+macOS APFS) for the write patterns ESPHome / PlatformIO use::
 
     case                      | dir       | firmware  | sibling
     --------------------------+-----------+-----------+----------
@@ -29,23 +22,17 @@ under each write pattern that ESPHome / PlatformIO actually use::
     write_file_if_changed=    | unchanged | unchanged | unchanged
     write_file_if_changed≠    | unchanged | unchanged | MOVED
 
-``write_file_if_changed`` (used by ``esphome/writer.py`` for
-``build_info.json``, ``main.cpp``, etc.) deliberately skips the
-write when content is identical — so a no-op recompile is correctly
-a no-op for the cache too. When the compile *does* produce
-different output, ``write_file_if_changed`` truncates-and-writes,
-which moves the file's own mtime (caught by ``build_info_mtime``)
-but leaves the parent dir's mtime alone. PlatformIO's intermediate
-work churns siblings, which moves the parent dir's mtime
-(caught by ``dir_mtime``) but leaves ``build_info.json`` alone.
-Tracking both gives full coverage; tracking either alone has
-real holes.
+``write_file_if_changed`` (ESPHome's writer) skips identical
+content, so a no-op recompile is a no-op for the cache too.
+When the compile produces different output, ``build_info.json``
+itself moves (caught by ``build_info_mtime``) but the parent
+dir's mtime doesn't (PlatformIO sibling churn is what moves
+that — caught by ``dir_mtime``).
 
-The build path itself comes from the device's ``StorageJSON``
-sidecar (written by ESPHome at compile time), via
-``resolve_build_dir``. Devices that haven't been compiled yet —
-fresh adoption / wizard / on-disk YAML drop — return ``None``;
-callers treat that the same as "no cached value, total = 0".
+The build path comes from each device's ``StorageJSON``
+sidecar via :func:`resolve_build_dir`. Devices that haven't
+been compiled return ``None`` — callers treat that as "no
+cached value, total = 0".
 """
 
 from __future__ import annotations
@@ -69,9 +56,8 @@ class BuildDirSignal:
 
     ``dir_mtime`` and ``info_mtime`` are whole-second
     ``int(stat.st_mtime)`` values; ``0`` means that path is
-    missing. Each catches a class of changes the other misses
-    (see the module docstring's empirical matrix), so the cache
-    treats inequality on either half as "stale".
+    missing. The cache treats inequality on either half as
+    stale (see the module docstring's empirical matrix).
     """
 
     dir_mtime: int
@@ -80,12 +66,7 @@ class BuildDirSignal:
 
 @dataclass(frozen=True, slots=True)
 class BuildSizeRefreshResult:
-    """The persisted triple after a successful walk: size + freshness pair.
-
-    ``size_bytes`` is the recursive-walk sum;
-    ``signal`` is the freshness pair captured at walk time, used
-    to short-circuit the next call when the dir hasn't moved.
-    """
+    """The persisted triple after a successful walk: size + freshness pair."""
 
     size_bytes: int
     signal: BuildDirSignal
@@ -95,19 +76,16 @@ def resolve_build_dir(filename: str) -> Path | None:
     """
     Return the per-device build directory path, or ``None`` if unknown.
 
-    Reads the canonical ``build_path`` off the device's StorageJSON
-    sidecar — the same path ``shutil.rmtree``'d by the archive /
-    delete flow's ``_wipe_device_build_dir``. ``None`` covers two
-    cases: no StorageJSON yet (device hasn't been compiled) and an
-    older StorageJSON whose ``build_path`` was never populated.
-    Both legitimately mean "we have no build artifacts to size."
+    Reads ``build_path`` off the device's StorageJSON sidecar.
+    ``None`` covers both "no StorageJSON" (never compiled) and
+    "older StorageJSON with no build_path" — both legitimately
+    mean "no build artifacts to size."
     """
     try:
         storage = StorageJSON.load(resolve_storage_path(filename))
     except Exception:
-        # ``StorageJSON.load`` returns ``None`` on a missing file
-        # but raises on a corrupt one; treat both as "no build
-        # artifacts on disk."
+        # StorageJSON.load returns None on missing-file but
+        # raises on a corrupt one; treat both as "no artifacts."
         _LOGGER.debug("StorageJSON load failed for %s", filename, exc_info=True)
         return None
     if storage is None or not storage.build_path:
@@ -116,31 +94,7 @@ def resolve_build_dir(filename: str) -> Path | None:
 
 
 def get_build_dir_signal(build_dir: Path) -> BuildDirSignal:
-    """
-    Return the :class:`BuildDirSignal` freshness pair for *build_dir*.
-
-    Both stats are whole-second ints; ``0`` means that path is
-    missing. Tracking *both* because each catches a class of
-    changes the other misses — empirically verified:
-
-    - **Dir mtime** moves on entry-set churn (sibling add /
-      remove / rename, atomic-replace via ``os.replace``). Misses
-      truncate-overwrites of an existing file (no entry change).
-
-    - **build_info.json mtime** moves on every real ESPHome
-      recompile because :func:`esphome.writer.write_file_if_changed`
-      rewrites it with the new ``config_hash`` / ``esphome_version``.
-      Misses PlatformIO's intermediate sibling churn (since
-      ``build_info.json`` itself isn't touched on those passes).
-
-    Either side moving means "something real happened," so the
-    cache compares both halves of the pair and treats inequality
-    on either as stale. ``build_info.json`` is the *preferred*
-    signal — it's the one ESPHome guarantees to write per
-    successful compile / ``--only-generate`` — but a missing
-    file (``mtime == 0``) just means we lean on the dir mtime
-    half until ESPHome catches up.
-    """
+    """Return the :class:`BuildDirSignal` freshness pair for *build_dir*."""
     return BuildDirSignal(
         dir_mtime=get_build_dir_mtime(build_dir),
         info_mtime=get_build_dir_mtime(build_dir / "build_info.json"),
@@ -151,36 +105,19 @@ def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
     """
     Cheap fleet-wide stat: return the subset whose freshness pair moved.
 
-    Run this in one executor job ahead of the heavy walk so the
-    thread-pool round-trip overhead stays at a single hop for the
-    "is anything actually out of date?" question — if the answer
-    is "nothing", we never have to schedule a walk job at all.
-
-    For each *filename*, resolves the build dir via
-    ``StorageJSON`` and stats the
-    ``(dir_mtime, build_info_mtime)`` pair in whole seconds, then
-    compares against the cached pair in the sidecar. The
-    filenames where *either* current ≠ cached are returned in the
-    same order the caller passed them — including the
-    ``current = (0, 0)`` but cached non-zero case, where the
-    build dir vanished after the last walk and the worker still
-    needs to clear the stale cached values. Devices with no
-    StorageJSON / no ``build_path`` are silently skipped —
-    pre-first-compile devices have nothing to walk in the first
-    place, so there's no cache state to clear either.
-
-    Used at startup to catch CLI-driven compiles that ran while
-    the dashboard wasn't watching, plus any other fleet-refresh
-    trigger; the per-device hot path
-    (``refresh_build_size_if_stale``) covers a single device on
-    demand.
+    Run in one executor job ahead of the heavy walk so the
+    "is anything actually out of date?" question pays one
+    thread-pool hop for the whole fleet. Returns the filenames
+    where current ≠ cached, in the caller's input order —
+    including the ``current = (0, 0)`` + cached non-zero case
+    (build dir vanished after the last walk and the cache still
+    needs clearing). Devices with no StorageJSON / no
+    ``build_path`` are skipped silently.
     """
     stale: list[str] = []
-    # Load the metadata file once for the whole sweep — the
-    # per-device entries live in a single JSON blob, and
-    # ``get_device_metadata`` would re-parse it from disk N times
-    # in the loop otherwise. The fleet sweep is the cheap-cost
-    # path the cache exists to keep cheap; one read is correct.
+    # Load metadata once for the whole sweep — the per-device
+    # entries live in one JSON blob and ``get_device_metadata``
+    # would re-parse it from disk N times in the loop.
     full_metadata = _load_full_metadata(config_dir)
     for filename in filenames:
         build_dir = resolve_build_dir(filename)
@@ -192,35 +129,23 @@ def find_stale_build_dirs(config_dir: Path, filenames: list[str]) -> list[str]:
             dir_mtime=coerce_sidecar_int(entry.get("build_size_dir_mtime")),
             info_mtime=coerce_sidecar_int(entry.get("build_size_info_mtime")),
         )
-        # Equality covers every case correctly: dir-gone +
-        # cache-empty short-circuits ((0, 0) == (0, 0)),
-        # dir-gone + cache-populated falls through to walk
-        # (which clears), dir-present + cache-stale falls
-        # through to walk. We *don't* short-circuit on
-        # "current is empty" — that case used to be skipped
-        # but it leaked stale non-zero cache state forever
-        # when a user manually wiped a build dir.
+        # Equality covers every case: dir-gone + cache-empty
+        # short-circuits, dir-gone + cache-populated falls
+        # through to walk (which clears), dir-present +
+        # cache-stale falls through to walk. Don't
+        # short-circuit on "current empty" — it leaked stale
+        # non-zero cache state when a user manually wiped a
+        # build dir.
         if current != cached:
             stale.append(filename)
     return stale
 
 
 def _load_full_metadata(config_dir: Path) -> dict[str, dict]:
-    """Read the per-device metadata file once. Returns ``{}`` on any error.
-
-    Used by :func:`find_stale_build_dirs` to amortize the JSON
-    parse across an N-device fleet sweep into a single read.
-    The format is a plain dict-of-dicts keyed on the device's
-    YAML filename; missing entries / wrong shapes return ``{}``
-    so callers can treat them as "no cached data."
-    """
-    # Local import flags this as an intentional reach into
-    # ``controllers.config``'s underscore-prefixed surface (so a
-    # future grep for ``_load_metadata`` finds the call site
-    # alongside the explanation). Module-level ``controllers.config``
-    # is already imported above for the public helpers, so this
-    # isn't a layering boundary — just a "yes, we know we're
-    # touching the private one, here's why" marker.
+    """Read the per-device metadata file once; ``{}`` on any error."""
+    # Local import is intentional reach into the underscore
+    # surface — a grep for ``_load_metadata`` finds the call
+    # site alongside the explanation.
     from ..controllers.config import _load_metadata  # noqa: PLC0415
 
     try:
@@ -237,26 +162,13 @@ def refresh_build_size_if_stale(
     """
     Refresh the cached size when the build dir's freshness pair moved.
 
-    Bundles the whole refresh into one synchronous unit so callers
-    can hand it to a single ``run_in_executor`` rather than
-    chaining four separate executor hops (sidecar-read / resolve /
-    stat / walk / sidecar-write). Returns ``None`` when the
-    cached pair was already fresh — the steady-state
-    dashboard-poll path, where we want to skip every executor
-    handoff we can. When stale, returns the freshly-persisted
-    :class:`BuildSizeRefreshResult` (size + freshness pair); the
-    caller uses the non-None return as the signal to reload /
-    fire ``DEVICE_UPDATED``.
-
-    Sequencing is cheap-first-then-heavy:
-    ``get_device_metadata`` → JSON read on a small file,
-    ``resolve_build_dir`` → small StorageJSON read,
-    ``get_build_dir_signal`` → two ``stat()`` calls,
-    ``compute_build_dir_size`` → the recursive walk we're trying
-    to avoid. The walk only runs when *either* half of the
-    freshness pair moved; the dashboard-restart cold path takes
-    the walk once per device and every subsequent poll
-    short-circuits on the cached pair match.
+    One synchronous unit (sidecar-read → resolve → stat →
+    walk → sidecar-write) so callers hand it to a single
+    ``run_in_executor`` rather than chaining four hops.
+    Returns ``None`` on cache-hit (the steady-state poll path).
+    On miss, returns the freshly-persisted triple — the
+    non-None return signals the caller to fire
+    ``DEVICE_UPDATED``.
     """
     build_dir = resolve_build_dir(filename)
     if build_dir is None:
@@ -267,15 +179,11 @@ def refresh_build_size_if_stale(
         dir_mtime=coerce_sidecar_int(md.get("build_size_dir_mtime")),
         info_mtime=coerce_sidecar_int(md.get("build_size_info_mtime")),
     )
-    # Pure equality check across the whole pair. Crucially this
-    # short-circuits the "build dir is missing AND we never had
-    # one cached" case (signal(0, 0) == signal(0, 0) → fresh →
-    # return None); without that we'd walk the missing path on
-    # every poll and ``set_device_metadata`` would re-clear
-    # three fields that are already absent, with the non-None
-    # return retriggering a scanner.reload each time. The "dir
-    # vanished but cache was populated" case still falls through
-    # to walk so the cache gets cleared exactly once.
+    # Pure equality across the whole pair. Crucially this
+    # short-circuits "build dir is missing AND we never had
+    # one cached" ((0, 0) == (0, 0) → None); without that we'd
+    # walk the missing path on every poll and retrigger a
+    # scanner reload on each non-None return.
     if current == cached:
         return None
     size = compute_build_dir_size(build_dir)
@@ -292,17 +200,13 @@ def refresh_build_size_if_stale(
 def coerce_sidecar_int(value: object) -> int:
     """Coerce a cached sidecar value to ``int``; ``0`` on any failure.
 
-    Same defensive shape ``_resolve_device_metadata`` uses for the
-    cached size — a hand-edited or partially-written sidecar
-    could land here with a non-numeric value (``None``, an
-    object, a decimal-string like ``"12.7"``). Falling back to
-    ``0`` matches the "never walked" sentinel and lets the next
-    refresh repopulate from the build dir.
+    A hand-edited or partially-written sidecar can land here
+    with a non-numeric value; falling back to ``0`` matches the
+    "never walked" sentinel and the next refresh repopulates.
     """
-    # Narrow before ``int(...)`` so mypy can resolve the overload —
-    # JSON-decoded sidecars realistically carry only these scalar
-    # shapes; lists / dicts / arbitrary objects fall straight to
-    # the ``0`` sentinel without an exception round-trip.
+    # Narrow before ``int(...)`` so mypy can resolve the
+    # overload — lists / dicts fall straight to the sentinel
+    # without an exception round-trip.
     if not isinstance(value, (int, float, str, bytes)):
         return 0
     try:
@@ -313,29 +217,16 @@ def coerce_sidecar_int(value: object) -> int:
 
 def get_build_dir_mtime(path: Path) -> int:
     """
-    Stat *path*'s mtime in whole seconds. ``0`` when the path is missing.
+    Stat *path*'s mtime in whole seconds. ``0`` when missing.
 
-    Used for both halves of the freshness pair —
-    :func:`get_build_dir_signal` calls it on the build dir
-    itself (entry-set churn) and on ``build_info.json``
-    (ESPHome's per-recompile rewrite). Same cross-filesystem
-    rationale either way.
-
-    We deliberately truncate to whole seconds rather than carrying
-    ``st_mtime``'s native float precision: filesystems that don't
-    support sub-second mtimes (FAT32 on a USB-mounted backup, some
-    NFS / CIFS shares, older ext3) round to the nearest second on
-    write. A cached fractional value from one filesystem would
-    then never compare equal to the truncated re-stat after a
-    cross-mount move, so the dashboard would walk the tree on
-    every poll. Whole seconds give us the cross-filesystem safety
-    at the cost of one false-negative re-walk per second of clock
-    drift around a real change — entirely fine for a heavy-I/O
-    cache primarily meant to skip steady-state polls.
-
-    Returning ``0`` for a missing path short-circuits the cache
-    (any non-zero cached mtime wouldn't match) and naturally
-    drives the cached size back to zero on the next refresh.
+    Truncated to whole seconds (not the float ``st_mtime``)
+    for cross-filesystem safety: FAT32 / older NFS / CIFS round
+    to the nearest second on write, so a cached fractional
+    value from one filesystem would never compare equal to the
+    truncated re-stat after a cross-mount move and the
+    dashboard would walk the tree on every poll. Cost is one
+    false-negative re-walk per second of clock drift around a
+    real change.
     """
     try:
         return int(path.stat().st_mtime)
@@ -347,36 +238,25 @@ def compute_build_dir_size(build_dir: Path) -> int:
     """
     Sum every regular-file size under *build_dir*, recursive.
 
-    Heavy + I/O-bound — caller is responsible for gating this
-    behind an mtime check (``get_build_dir_mtime`` above) and for
-    running it off the event loop (e.g. via
-    ``asyncio.to_thread``). Returns ``0`` when the dir is missing
-    or empty. Per-entry ``OSError`` (e.g. a vanishing file mid-
-    walk during a concurrent compile) is swallowed so the total
-    reflects what we could see rather than failing the whole
-    operation.
+    Heavy + I/O-bound — caller is responsible for gating
+    behind the mtime check and for running off the event loop.
+    Returns ``0`` when the dir is missing or empty. Per-entry
+    ``OSError`` (vanishing files during a concurrent compile)
+    is swallowed so the total reflects what we could see.
 
-    Walks via ``os.walk()`` rather than ``Path.rglob`` — the
-    former delegates to ``os.scandir()`` since Python 3.5, which
-    gets cached ``d_type`` from ``readdir()`` so we don't pay a
-    syscall just to know "is this a file or a dir". ``rglob``
-    allocates a ``Path`` per entry and re-stats for ``is_file()``,
-    which roughly doubles the syscall count on big build trees
-    (PlatformIO checkouts can be 10k+ files).
+    Walks via :func:`os.walk` rather than :meth:`Path.rglob` —
+    ``os.walk`` delegates to :func:`os.scandir` which carries
+    cached ``d_type`` from ``readdir()``, halving the syscall
+    count vs ``rglob`` on 10k-file PlatformIO trees.
     """
     total = 0
     # ``onerror`` swallows top-level failures (missing dir,
-    # permission denied at root). Per-file ``getsize`` errors
-    # are caught individually below so a vanishing file mid-walk
-    # doesn't kill the whole operation.
+    # permission denied at root). Per-file errors are caught
+    # below.
     for dirpath, _dirnames, filenames in os.walk(build_dir, onerror=lambda _e: None):
         for filename in filenames:
             try:
                 total += os.path.getsize(os.path.join(dirpath, filename))
             except OSError:
-                # File vanished mid-walk (concurrent compile
-                # cleanup, symlink target removed, …). Skip and
-                # keep going — a partial total is better than
-                # no total.
                 continue
     return total


### PR DESCRIPTION
# What does this implement/fix?

`helpers/build_size.py` had multi-paragraph docstrings on
every helper that mostly paraphrased the surrounding code.

**382 → 262 lines** (−120), zero functional change. Ratio
**2.36 → 1.26**.

## What was cut

* Module docstring: kept the empirical
  ``(dir_mtime, build_info_mtime)`` matrix (load-bearing
  reason both halves are needed). Trimmed the prose around it
  by half.
* Per-method docstrings: collapsed each to the one non-obvious
  correctness invariant — the (0, 0) == (0, 0) short-circuit
  in `refresh_build_size_if_stale`, the
  don't-short-circuit-on-empty-current invariant in
  `find_stale_build_dirs`, the cross-filesystem whole-second
  truncation rationale in `get_build_dir_mtime`, the
  `os.walk`-vs-`rglob` syscall-count rationale in
  `compute_build_dir_size`.
* `get_build_dir_signal` lost its 25-line restatement of the
  module-level matrix.
* `coerce_sidecar_int` lost the 8-line preamble for a 5-line
  function.

3178 tests pass; ruff + mypy clean.

**Related issue or feature (if applicable):**

- Follow-up to #649. Final file in the prose-trim sweep over
  the worst prose-to-code ratios in the repo.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
