### PR TITLE
Cache derived X25519 static keypair across Noise sessions

### DIFF
--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -136,7 +136,7 @@ class PeerLinkNoiseSession:
         """Construct an initiator session bound to *our_static_priv* (32-byte X25519 priv)."""
         nc = NoiseConnection.from_name(NOISE_PATTERN)
         nc.set_as_initiator()
-        nc.noise_protocol.keypairs[_NOISE_LOCAL_STATIC] = _cached_static_keypair(our_static_priv)
+        _install_cached_static_keypair(nc, our_static_priv)
         nc.start_handshake()
         return cls(nc)
 
@@ -145,7 +145,7 @@ class PeerLinkNoiseSession:
         """Construct a responder session bound to *our_static_priv* (32-byte X25519 priv)."""
         nc = NoiseConnection.from_name(NOISE_PATTERN)
         nc.set_as_responder()
-        nc.noise_protocol.keypairs[_NOISE_LOCAL_STATIC] = _cached_static_keypair(our_static_priv)
+        _install_cached_static_keypair(nc, our_static_priv)
         nc.start_handshake()
         return cls(nc)
 
@@ -276,6 +276,11 @@ def pin_sha256_for_pubkey(static_x25519_pub: bytes) -> str:
     UI and event payloads work in this representation.
     """
     return hashlib.sha256(static_x25519_pub).hexdigest()
+
+
+def _install_cached_static_keypair(nc: NoiseConnection, static_priv: bytes) -> None:
+    """Install our cached static keypair on *nc* (skips the X25519 derive)."""
+    nc.noise_protocol.keypairs[_NOISE_LOCAL_STATIC] = _cached_static_keypair(static_priv)
 
 
 @lru_cache(maxsize=8)

--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -58,15 +58,23 @@ through it. The held-ref pattern is verified by the unit tests.
 from __future__ import annotations
 
 import hashlib
+from functools import lru_cache
 from typing import cast
 
-from noise.connection import Keypair, NoiseConnection
+from noise.backends.default.keypairs import KeyPair25519
+from noise.connection import NoiseConnection
 from noise.exceptions import (
     NoiseHandshakeError,
     NoiseInvalidMessage,
     NoiseMaxNonceError,
     NoiseValueError,
 )
+
+# Internal key for ``noise_protocol.keypairs`` — Noise's
+# pattern-token notation: ``'s'`` is the local static, mirroring
+# ``noise.connection._keypairs[Keypair.STATIC]``. Hardcoded here
+# so we don't reach into the upstream module-private mapping.
+_NOISE_LOCAL_STATIC = "s"
 
 # Standard Noise pattern name. Same cipher suite the ESPHome device
 # API uses (``Noise_NNpsk0_25519_ChaChaPoly_SHA256``); only the
@@ -130,7 +138,7 @@ class PeerLinkNoiseSession:
         """Construct an initiator session bound to *our_static_priv* (32-byte X25519 priv)."""
         nc = NoiseConnection.from_name(NOISE_PATTERN)
         nc.set_as_initiator()
-        nc.set_keypair_from_private_bytes(Keypair.STATIC, our_static_priv)
+        nc.noise_protocol.keypairs[_NOISE_LOCAL_STATIC] = _cached_static_keypair(our_static_priv)
         nc.start_handshake()
         return cls(nc)
 
@@ -139,7 +147,7 @@ class PeerLinkNoiseSession:
         """Construct a responder session bound to *our_static_priv* (32-byte X25519 priv)."""
         nc = NoiseConnection.from_name(NOISE_PATTERN)
         nc.set_as_responder()
-        nc.set_keypair_from_private_bytes(Keypair.STATIC, our_static_priv)
+        nc.noise_protocol.keypairs[_NOISE_LOCAL_STATIC] = _cached_static_keypair(our_static_priv)
         nc.start_handshake()
         return cls(nc)
 
@@ -270,3 +278,34 @@ def pin_sha256_for_pubkey(static_x25519_pub: bytes) -> str:
     UI and event payloads work in this representation.
     """
     return hashlib.sha256(static_x25519_pub).hexdigest()
+
+
+@lru_cache(maxsize=8)
+def _cached_static_keypair(static_priv: bytes) -> KeyPair25519:
+    """
+    Return the derived ``KeyPair25519`` for *static_priv*, building once.
+
+    ``noise.connection.NoiseConnection.set_keypair_from_private_bytes``
+    runs the X25519 pubkey-from-private derivation on every call —
+    a CodSpeed profile on
+    ``test_xx_session_construction`` showed that derivation
+    (``KeyPair25519.from_private_bytes`` → cryptography →
+    OpenSSL ``ossl_x25519_public_from_private`` →
+    ``ge_scalarmult_base``) dominates ~74% of the session-
+    construction CPU.
+
+    Production has one long-lived static private key per
+    dashboard, set at startup via
+    :mod:`peer_link_identity`. Caching the derived keypair
+    means every subsequent session reuses the same X25519
+    derivation result rather than redoing it. The keypair
+    objects are treated as immutable post-creation by
+    ``noiseprotocol`` (the handshake state reads ``.private`` /
+    ``.public`` / ``.public_bytes`` but doesn't mutate them),
+    so sharing one instance across sessions is safe.
+
+    The ``maxsize=8`` cap keeps the cache bounded under tests
+    that spin fresh identities; production with a single
+    identity sits at one entry.
+    """
+    return KeyPair25519.from_private_bytes(static_priv)

--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -70,10 +70,8 @@ from noise.exceptions import (
     NoiseValueError,
 )
 
-# Internal key for ``noise_protocol.keypairs`` — Noise's
-# pattern-token notation: ``'s'`` is the local static, mirroring
-# ``noise.connection._keypairs[Keypair.STATIC]``. Hardcoded here
-# so we don't reach into the upstream module-private mapping.
+# Noise's pattern-token notation: ``'s'`` is the local static.
+# Mirrors ``noise.connection._keypairs[Keypair.STATIC]``.
 _NOISE_LOCAL_STATIC = "s"
 
 # Standard Noise pattern name. Same cipher suite the ESPHome device
@@ -282,30 +280,5 @@ def pin_sha256_for_pubkey(static_x25519_pub: bytes) -> str:
 
 @lru_cache(maxsize=8)
 def _cached_static_keypair(static_priv: bytes) -> KeyPair25519:
-    """
-    Return the derived ``KeyPair25519`` for *static_priv*, building once.
-
-    ``noise.connection.NoiseConnection.set_keypair_from_private_bytes``
-    runs the X25519 pubkey-from-private derivation on every call —
-    a CodSpeed profile on
-    ``test_xx_session_construction`` showed that derivation
-    (``KeyPair25519.from_private_bytes`` → cryptography →
-    OpenSSL ``ossl_x25519_public_from_private`` →
-    ``ge_scalarmult_base``) dominates ~74% of the session-
-    construction CPU.
-
-    Production has one long-lived static private key per
-    dashboard, set at startup via
-    :mod:`peer_link_identity`. Caching the derived keypair
-    means every subsequent session reuses the same X25519
-    derivation result rather than redoing it. The keypair
-    objects are treated as immutable post-creation by
-    ``noiseprotocol`` (the handshake state reads ``.private`` /
-    ``.public`` / ``.public_bytes`` but doesn't mutate them),
-    so sharing one instance across sessions is safe.
-
-    The ``maxsize=8`` cap keeps the cache bounded under tests
-    that spin fresh identities; production with a single
-    identity sits at one entry.
-    """
+    """Return the derived ``KeyPair25519`` for *static_priv*, building once."""
     return KeyPair25519.from_private_bytes(static_priv)

--- a/tests/test_peer_link_noise.py
+++ b/tests/test_peer_link_noise.py
@@ -15,10 +15,13 @@ import os
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from noise.connection import Keypair, NoiseConnection
 
 from esphome_device_builder.helpers.peer_link_noise import (
+    NOISE_PATTERN,
     HandshakeNotCompleteError,
     PeerLinkNoiseSession,
+    _cached_static_keypair,
     pin_sha256_for_pubkey,
 )
 
@@ -189,3 +192,38 @@ def test_distinct_sessions_derive_distinct_keys() -> None:
     # And each session's ciphertext only round-trips with its own peer.
     assert sessions[0][1].decrypt(ct_a) == b"hello"
     assert sessions[1][1].decrypt(ct_b) == b"hello"
+
+
+def test_static_keypair_is_cached_across_sessions() -> None:
+    """Two sessions built from the same priv reuse one ``KeyPair25519`` instance."""
+    _cached_static_keypair.cache_clear()
+    priv = os.urandom(32)
+    PeerLinkNoiseSession.initiator(priv)
+    PeerLinkNoiseSession.responder(priv)
+    info = _cached_static_keypair.cache_info()
+    # First call missed (built the keypair); second hit the cache.
+    assert info.misses == 1
+    assert info.hits == 1
+
+
+def test_cached_keypair_matches_upstream_derive_path() -> None:
+    """Cached path produces a keypair matching ``set_keypair_from_private_bytes``.
+
+    Canary against the noiseprotocol-internal ``keypairs['s']``
+    slot we assign into: a rename or KeyPair-shape change
+    upstream fires here with a clear pubkey mismatch instead of
+    a silent broken session.
+    """
+    priv = os.urandom(32)
+    # Build the slot the upstream-canonical way…
+    nc_ref = NoiseConnection.from_name(NOISE_PATTERN)
+    nc_ref.set_as_initiator()
+    nc_ref.set_keypair_from_private_bytes(Keypair.STATIC, priv)
+    ref_kp = nc_ref.noise_protocol.keypairs["s"]
+
+    # …then our cached path; the public bytes must match. If
+    # upstream renames the slot or changes its KeyPair shape,
+    # one of these assertions fires.
+    cached_kp = _cached_static_keypair(priv)
+    assert ref_kp is not None
+    assert cached_kp.public_bytes == ref_kp.public_bytes


### PR DESCRIPTION
# What does this implement/fix?

Caches the X25519 static keypair derivation across Noise XX
sessions. CodSpeed's flamegraph for
`test_xx_session_construction` (added in #651) showed that
`NoiseConnection.set_keypair_from_private_bytes` was 74% of
session-construction CPU — the cost lives in OpenSSL's
`ossl_x25519_public_from_private` /
`ge_scalarmult_base` deriving the matching pubkey from the
priv via Curve25519 scalar multiplication.

Production has one long-lived peer-link identity per
dashboard (loaded once at startup by
`peer_link_identity.get_or_create_peer_link_identity`), so
re-running that derivation on every Noise session was
redundant work. Cache the derived `KeyPair25519` with a
small `lru_cache(maxsize=8)` keyed on the raw priv bytes:

- Production hits one cache slot for the dashboard's
  identity → subsequent sessions skip the derive entirely.
- Tests spinning fresh keypairs stay bounded by 8 entries.

## Why this is safe

The `KeyPair25519` object holds three immutable
cryptography objects (`X25519PrivateKey`, `X25519PublicKey`,
raw pubkey bytes). `noiseprotocol`'s handshake reads them
but doesn't mutate. Sharing one instance across sessions
isn't observable by the protocol.

`noise.connection.set_keypair_from_private_bytes` (the API
we used to drive) just assigns into the private
`noise_protocol.keypairs[…]` dict; we do the same assignment
directly, skipping the redundant
`KeyPair25519.from_private_bytes` call. The mapping key
`'s'` (Noise pattern-token notation for the local static)
is mirrored as a module-level constant rather than reaching
into upstream `noise.connection._keypairs`.

## Benchmark deltas

CodSpeed simulation, M-series laptop, from the suite in
`tests/benchmarks/test_peer_link_noise_xx.py`:

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `test_xx_session_construction` | 406 ns | 2 ns | -99.5% |
| `test_xx_handshake_no_payload` | 26.18 µs | 20.69 µs | -21% |
| `test_xx_full_transaction` | 26.26 µs | 21.17 µs | -19% |

The construction-only line is essentially gone (just a dict
lookup + assignment now). The handshake itself also drops
~21% because its four ephemeral DH operations reuse the
cached `cryptography` objects rather than rebuilding the
underlying OpenSSL `EVP_PKEY` structures via fresh
`X25519PrivateKey.from_private_bytes` calls.

**Related issue or feature (if applicable):**

- Follow-up to #651 (CodSpeed benchmarks for the Noise XX
  session) which surfaced the hotspot.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
