### PR TITLE
Ship build_info.json in the remote-build artifacts tarball

### DIFF
--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -78,8 +78,16 @@ _LOGGER = logging.getLogger(__name__)
 STORAGE_MEMBER_NAME = "storage.json"
 IDEDATA_MEMBER_NAME = "idedata.json"
 PLATFORMIO_INI_MEMBER_NAME = "platformio.ini"
+# Read by the offloader's ``read_build_info_hash`` to populate
+# ``expected_config_hash`` post-build (see #654).
+BUILD_INFO_MEMBER_NAME = "build_info.json"
 _METADATA_MEMBERS: frozenset[str] = frozenset(
-    {STORAGE_MEMBER_NAME, IDEDATA_MEMBER_NAME, PLATFORMIO_INI_MEMBER_NAME}
+    {
+        STORAGE_MEMBER_NAME,
+        IDEDATA_MEMBER_NAME,
+        PLATFORMIO_INI_MEMBER_NAME,
+        BUILD_INFO_MEMBER_NAME,
+    }
 )
 
 
@@ -175,11 +183,14 @@ def _collect_pack_members(
         msg = f"platformio.ini missing for {configuration}: {platformio_ini}"
         raise FileNotFoundError(msg)
 
+    build_info_path = build_path / BUILD_INFO_MEMBER_NAME
     members: list[tuple[str, Path]] = [
         (STORAGE_MEMBER_NAME, storage_path),
         (IDEDATA_MEMBER_NAME, idedata_cache_path),
         (PLATFORMIO_INI_MEMBER_NAME, platformio_ini),
     ]
+    if build_info_path.is_file():
+        members.append((BUILD_INFO_MEMBER_NAME, build_info_path))
     # Dedupe by basename, not full path: the WS-unpack adapter
     # keys flash images by basename, so a build emitting both
     # ``.pioenvs/<name>/firmware.factory.bin`` and

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -18,13 +18,17 @@ Tarball layout (materialise-locally wire format):
     storage.json     # receiver's <data_dir>/storage/<basename>.json
     idedata.json     # receiver's <data_dir>/idedata/<name>.json (esphome's cache copy)
     platformio.ini   # receiver's <build_path>/platformio.ini
+    build_info.json  # receiver's <build_path>/build_info.json (optional; #654)
     <per-platform build-tree files>  # see artifact_platforms/*.py
 
-The three metadata members at the top of the tarball are
-platform-independent — every build ships them. The
-:mod:`controllers.remote_build.artifact_platforms` registry
-drives which build-tree files travel alongside them; see the
-per-platform modules for the exact paths each platform ships.
+The metadata members at the top of the tarball are
+platform-independent — every build ships them
+(``build_info.json`` is optional: skipped when the receiver's
+build tree predates ESPHome's ``build_info.json`` write
+hook). The :mod:`controllers.remote_build.artifact_platforms`
+registry drives which build-tree files travel alongside them;
+see the per-platform modules for the exact paths each platform
+ships.
 
 The offloader-side materialiser
 (:func:`helpers.remote_artifacts_materialise.materialise_remote_artifacts`)

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -62,6 +62,9 @@ import pytest
 from esphome.core import CORE
 from esphome.storage_json import StorageJSON
 
+from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
+    BUILD_INFO_MEMBER_NAME,
+)
 from esphome_device_builder.helpers.build_scheduler import (
     BuildPath,
     pick_build_path,
@@ -216,7 +219,7 @@ def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dic
         image_paths[name] = path
 
     # Mirrors ESPHome's post-codegen build_info.json (#654).
-    (build_dir / "build_info.json").write_text(
+    (build_dir / BUILD_INFO_MEMBER_NAME).write_text(
         json.dumps({"config_hash": 0x5A94A12D}), encoding="utf-8"
     )
 
@@ -533,9 +536,10 @@ async def test_remote_compile_materialises_for_local_firmware_download(
     assert (download_dir / "partitions.bin").read_bytes() == images["partitions.bin"]
 
     # #654: read_build_info_hash resolves post-materialise.
-    assert (build_path / "build_info.json").is_file()
+    assert (build_path / BUILD_INFO_MEMBER_NAME).is_file()
     yaml_path = Path(CORE.config_path).parent / "kitchen.yaml"
-    assert read_build_info_hash(yaml_path) == "5a94a12d"
+    hex_hash = await asyncio.to_thread(read_build_info_hash, yaml_path)
+    assert hex_hash == "5a94a12d"
 
 
 def _drive_receiver_lifecycle(

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -66,6 +66,7 @@ from esphome_device_builder.helpers.build_scheduler import (
     BuildPath,
     pick_build_path,
 )
+from esphome_device_builder.helpers.config_hash import read_build_info_hash
 from esphome_device_builder.helpers.remote_artifacts_materialise import (
     materialise_remote_artifacts,
 )
@@ -213,6 +214,11 @@ def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dic
         path = pioenvs / name
         path.write_bytes(payload)
         image_paths[name] = path
+
+    # Mirrors ESPHome's post-codegen build_info.json (#654).
+    (build_dir / "build_info.json").write_text(
+        json.dumps({"config_hash": 0x5A94A12D}), encoding="utf-8"
+    )
 
     # The receiver-side compile writes
     # ``<data_dir>/storage/<basename>.json`` (esphome's
@@ -525,6 +531,11 @@ async def test_remote_compile_materialises_for_local_firmware_download(
     assert (download_dir / "firmware.bin").read_bytes() == images["firmware.bin"]
     assert (download_dir / "bootloader.bin").read_bytes() == images["bootloader.bin"]
     assert (download_dir / "partitions.bin").read_bytes() == images["partitions.bin"]
+
+    # #654: read_build_info_hash resolves post-materialise.
+    assert (build_path / "build_info.json").is_file()
+    yaml_path = Path(CORE.config_path).parent / "kitchen.yaml"
+    assert read_build_info_hash(yaml_path) == "5a94a12d"
 
 
 def _drive_receiver_lifecycle(

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -25,6 +25,7 @@ import pytest
 from esphome.core import CORE
 
 from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
+    BUILD_INFO_MEMBER_NAME,
     IDEDATA_MEMBER_NAME,
     PLATFORMIO_INI_MEMBER_NAME,
     STORAGE_MEMBER_NAME,
@@ -162,12 +163,12 @@ def test_materialise_lands_build_info_json_for_hash_lookup(
     tarball = _pack_in_tmp(
         receiver_root,
         extra_build_files={
-            "build_info.json": f'{{"config_hash": {config_hash_int}}}\n'.encode(),
+            BUILD_INFO_MEMBER_NAME: f'{{"config_hash": {config_hash_int}}}\n'.encode(),
         },
     )
     build_path = _materialise_in_tmp(tarball, offloader_root)
 
-    staged = build_path / "build_info.json"
+    staged = build_path / BUILD_INFO_MEMBER_NAME
     assert staged.is_file()
     assert json.loads(staged.read_text())["config_hash"] == config_hash_int
 
@@ -184,7 +185,7 @@ def test_materialise_handles_missing_build_info_json(
     receiver_root, offloader_root = paired_roots
     tarball = _pack_in_tmp(receiver_root)
     build_path = _materialise_in_tmp(tarball, offloader_root)
-    assert not (build_path / "build_info.json").exists()
+    assert not (build_path / BUILD_INFO_MEMBER_NAME).exists()
 
 
 def test_materialise_storage_sidecar_carries_receiver_metadata(

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -30,6 +30,7 @@ from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     STORAGE_MEMBER_NAME,
     pack_build_artifacts,
 )
+from esphome_device_builder.helpers.config_hash import read_build_info_hash
 from esphome_device_builder.helpers.remote_artifacts_materialise import (
     MaterialiseError,
     _force_idedata_cache_hit,
@@ -150,6 +151,40 @@ def test_materialise_stages_build_tree_and_sidecars(
     # they go to the offloader's cache locations.
     assert not (build_path / STORAGE_MEMBER_NAME).exists()
     assert not (build_path / IDEDATA_MEMBER_NAME).exists()
+
+
+def test_materialise_lands_build_info_json_for_hash_lookup(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """#654: build_info.json round-trips so ``read_build_info_hash`` resolves."""
+    receiver_root, offloader_root = paired_roots
+    config_hash_int = 0x5A94A12D
+    tarball = _pack_in_tmp(
+        receiver_root,
+        extra_build_files={
+            "build_info.json": f'{{"config_hash": {config_hash_int}}}\n'.encode(),
+        },
+    )
+    build_path = _materialise_in_tmp(tarball, offloader_root)
+
+    staged = build_path / "build_info.json"
+    assert staged.is_file()
+    assert json.loads(staged.read_text())["config_hash"] == config_hash_int
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        yaml_path = offloader_root / "kitchen.yaml"
+        assert read_build_info_hash(yaml_path) == "5a94a12d"
+
+
+def test_materialise_handles_missing_build_info_json(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """Receiver without build_info.json: materialise completes, no file staged."""
+    receiver_root, offloader_root = paired_roots
+    tarball = _pack_in_tmp(receiver_root)
+    build_path = _materialise_in_tmp(tarball, offloader_root)
+    assert not (build_path / "build_info.json").exists()
 
 
 def test_materialise_storage_sidecar_carries_receiver_metadata(


### PR DESCRIPTION
# What does this implement/fix?

Closes #654.

After a remote install completes, the offloader-side
`_persist_expected_config_hash` calls `read_build_info_hash`
to populate `expected_config_hash` so
`compute_has_pending_changes` can compare it against the
device's mDNS-broadcast `deployed_config_hash`. ESPHome
writes `build_info.json` to `<build_path>/build_info.json`
on every successful compile, but `materialise_remote_artifacts`
wasn't shipping the file — the offloader's build tree had
every flash binary plus the storage / idedata sidecars but
no `build_info.json`. So the post-build hash refresh
silently missed (`read_build_info_hash` returned `None`,
the warning the issue quotes fired), the device's
`expected_config_hash` stayed at the previous value, and
`compute_has_pending_changes` flipped the orange "Modified"
dot for every remote build until a real local build
rewrote the sidecar.

## What lands

* `artifacts_tarball.py` — new `BUILD_INFO_MEMBER_NAME`
  constant; the packer includes
  `<build_path>/build_info.json` as a top-level tarball
  member alongside `platformio.ini` when the receiver has
  one (skipped if absent — keeps legacy receivers
  working). Added to `_METADATA_MEMBERS` so the
  WS-unpack walk doesn't try to treat it as a flash image.
* Two materialise tests: one for the happy-path round-trip
  (verifies `read_build_info_hash` resolves to the
  receiver-baked hex after extract), one for the
  legacy-receiver case (no `build_info.json` ⇒ materialise
  still completes cleanly, just no hash to read).

## Why ship it as a top-level member

Same shape as `platformio.ini`: lives at
`<build_path>/build_info.json` on the receiver, lands at
`<build_path>/build_info.json` on the offloader after
`_safe_extract_excluding`. No materialise-side change
needed; the offloader-side cache helpers already look in
the right place.

**Related issue or feature (if applicable):**

- closes #654

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
