### PR TITLE
Default devices/logs port to OTA so empty port doesn't EOF the CLI

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -114,7 +114,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `devices/import` | `{name, project_name?, package_import_url?, ...}` | `dict` | Import/adopt discovered device |
 | `devices/ignore` | `{name, ignore?}` | — | Toggle device visibility |
 | `devices/validate` | `{configuration}` | Streaming | Validate YAML config |
-| `devices/logs` | `{configuration, port?}` | Streaming | Stream live device logs |
+| `devices/logs` | `{configuration, port?: "OTA" \| serial, no_states?: bool}` | Streaming | Stream live device logs. `port` defaults to `"OTA"` (empty string is treated the same) — without a default, `esphome logs` falls into an interactive port-choice prompt when multiple targets are visible and the stdin-less subprocess crashes with `EOFError`. |
 
 `Device.state`: `DeviceState` — `unknown`, `online`, or `offline` (discovered via mDNS + ping).
 `Device.has_pending_changes`: `true` = config changed since last compile, `false` = up to date, `null` = never compiled.

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -2130,26 +2130,18 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         """
         Stream live device logs. Per-connection, not queued.
 
-        ``port`` is forwarded to ``esphome logs`` as ``--device``;
-        when the caller omits it (or passes the empty string) we
-        default to ``OTA`` to match the legacy dashboard's
-        always-supply-a-target shape and ``firmware/install``'s
-        default. Without that default the CLI sees multiple options
-        (multiple serial ports + the OTA endpoint), falls into an
-        interactive ``input()`` prompt for the port choice, and
-        crashes with ``EOFError`` because our subprocess has no
-        stdin attached — the symptom in issue #636 after a
-        Stop → Start of the log stream from a "this computer"
-        (browser-serial) install, where the frontend leaves
-        ``port`` empty.
-
-        ``no_states`` passes ``--no-states`` through to ``esphome logs``
-        so component state-publish lines (sensor / binary_sensor /
-        switch / cover / climate ...) are suppressed at the source.
-        Mirrors the legacy dashboard's "Show entity state changes"
-        toggle.
+        ``port`` is forwarded to ``esphome logs`` as ``--device``
+        and defaults to ``OTA`` when missing or empty. ``no_states``
+        passes ``--no-states`` through so component state-publish
+        lines (sensor / binary_sensor / switch / cover / climate ...)
+        are suppressed at the source — mirrors the legacy
+        dashboard's "Show entity state changes" toggle.
         """
         config_path = str(self._db.settings.rel_path(configuration))
+        # Always pass --device. Without one, ``esphome logs`` enters
+        # an interactive port-choice prompt when multiple targets
+        # are visible (serial + OTA); the stdin-less subprocess
+        # then crashes with EOFError. (#636)
         cmd = [
             *self._esphome_cmd,
             "--dashboard",

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -2130,6 +2130,19 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         """
         Stream live device logs. Per-connection, not queued.
 
+        ``port`` is forwarded to ``esphome logs`` as ``--device``;
+        when the caller omits it (or passes the empty string) we
+        default to ``OTA`` to match the legacy dashboard's
+        always-supply-a-target shape and ``firmware/install``'s
+        default. Without that default the CLI sees multiple options
+        (multiple serial ports + the OTA endpoint), falls into an
+        interactive ``input()`` prompt for the port choice, and
+        crashes with ``EOFError`` because our subprocess has no
+        stdin attached — the symptom in issue #636 after a
+        Stop → Start of the log stream from a "this computer"
+        (browser-serial) install, where the frontend leaves
+        ``port`` empty.
+
         ``no_states`` passes ``--no-states`` through to ``esphome logs``
         so component state-publish lines (sensor / binary_sensor /
         switch / cover / climate ...) are suppressed at the source.
@@ -2137,9 +2150,14 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         toggle.
         """
         config_path = str(self._db.settings.rel_path(configuration))
-        cmd = [*self._esphome_cmd, "--dashboard", "logs", config_path]
-        if port:
-            cmd.extend(["--device", port])
+        cmd = [
+            *self._esphome_cmd,
+            "--dashboard",
+            "logs",
+            config_path,
+            "--device",
+            port or "OTA",
+        ]
         if no_states:
             cmd.append("--no-states")
         await self._stream_subprocess(cmd, client, message_id)

--- a/tests/controllers/devices/test_stream_cancel.py
+++ b/tests/controllers/devices/test_stream_cancel.py
@@ -255,10 +255,20 @@ async def test_stream_logs_command_includes_dashboard_flag(
     assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA"]]
 
 
-async def test_stream_logs_command_without_port_omits_device_arg(
+async def test_stream_logs_command_without_port_defaults_to_ota(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """No port given → no ``--device`` arg, ``--dashboard`` still present."""
+    """No port given → ``--device OTA`` (don't let esphome fall into an interactive prompt).
+
+    Regression guard for #636 — the frontend's browser-serial log
+    dialog leaves ``port`` empty after a Stop → Start cycle, and
+    without a default the CLI saw multiple options
+    (``/dev/ttyACM0`` + ``/dev/ttyUSB0`` + OTA) and tried to
+    ``input()`` for the port choice. Our subprocess has no stdin
+    attached, so that crashed with ``EOFError``. Defaulting to OTA
+    mirrors the legacy dashboard's always-supply-a-target shape
+    and ``firmware/install``'s default.
+    """
     ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
@@ -269,7 +279,26 @@ async def test_stream_logs_command_without_port_omits_device_arg(
 
     await ctrl.stream_logs(configuration="kitchen.yaml", client=MagicMock(), message_id="m2")
 
-    assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml"]]
+    assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA"]]
+
+
+async def test_stream_logs_command_empty_port_defaults_to_ota(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Explicit empty-string port behaves the same as no port — defaults to OTA."""
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(
+        configuration="kitchen.yaml", port="", client=MagicMock(), message_id="m2e"
+    )
+
+    assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA"]]
 
 
 async def test_stream_logs_command_appends_no_states_when_requested(
@@ -300,7 +329,7 @@ async def test_stream_logs_command_appends_no_states_when_requested(
 async def test_stream_logs_command_no_states_without_port(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """``no_states=True`` and no ``port`` → ``--no-states`` lands without ``--device``."""
+    """``no_states=True`` and no ``port`` → ``--no-states`` after the OTA default."""
     ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 
@@ -316,7 +345,9 @@ async def test_stream_logs_command_no_states_without_port(
         message_id="m2-ns",
     )
 
-    assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--no-states"]]
+    assert captured == [
+        ["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA", "--no-states"]
+    ]
 
 
 async def test_stream_logs_command_omits_no_states_by_default(

--- a/tests/controllers/devices/test_stream_cancel.py
+++ b/tests/controllers/devices/test_stream_cancel.py
@@ -258,17 +258,7 @@ async def test_stream_logs_command_includes_dashboard_flag(
 async def test_stream_logs_command_without_port_defaults_to_ota(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """No port given → ``--device OTA`` (don't let esphome fall into an interactive prompt).
-
-    Regression guard for #636 — the frontend's browser-serial log
-    dialog leaves ``port`` empty after a Stop → Start cycle, and
-    without a default the CLI saw multiple options
-    (``/dev/ttyACM0`` + ``/dev/ttyUSB0`` + OTA) and tried to
-    ``input()`` for the port choice. Our subprocess has no stdin
-    attached, so that crashed with ``EOFError``. Defaulting to OTA
-    mirrors the legacy dashboard's always-supply-a-target shape
-    and ``firmware/install``'s default.
-    """
+    """No port given → ``--device OTA`` (regression guard for #636)."""
     ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
     captured: list[list[str]] = []
 


### PR DESCRIPTION
# What does this implement/fix?

When the frontend's browser-serial log dialog is opened "passively" during a "this computer" install, the dialog sets `_port = ""` and streams logs straight from the Web Serial connection. Clicking **Stop** then **Start** calls `api.logs(configuration, "")` — empty `port`. The backend's `devices/logs` handler was building `esphome --dashboard logs <yaml>` with no `--device` in that case. With multiple options visible (one or more `/dev/tty*` + the OTA endpoint) the ESPHome CLI fell into an interactive `input("(number): ")` prompt, and our subprocess has no stdin attached, so it died with the traceback in #636:

```
File "/esphome/esphome/__main__.py", line 168, in choose_prompt
    opt = input("(number): ")
EOFError: EOF when reading a line
```

Default the missing/empty `port` to `"OTA"` so we always pass a target on the command line. This matches:

- The legacy dashboard's `EsphomePortCommandWebSocket`, which read `port = json_message["port"]` as a required field — the legacy frontend never sent an empty port.
- `firmware/install`'s existing `"OTA"` default.

Devices that aren't network-reachable now surface a clean OTA-connect error instead of the `EOFError` traceback; serial users keep working by passing the port explicitly. A full frontend-side fix (carrying the right `port` through Stop → Start for the browser-serial flow) can land later without depending on this server-side guard.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/636

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

The wire contract is unchanged — `port` is still an optional field on `devices/logs`. A separate frontend follow-up to carry the right port through Stop → Start of the browser-serial log dialog is desirable but not required to fix the EOF crash users see today.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
