### PR TITLE
Forward --mdns/--dns-address-cache args to devices/logs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -114,7 +114,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `devices/import` | `{name, project_name?, package_import_url?, ...}` | `dict` | Import/adopt discovered device |
 | `devices/ignore` | `{name, ignore?}` | — | Toggle device visibility |
 | `devices/validate` | `{configuration}` | Streaming | Validate YAML config |
-| `devices/logs` | `{configuration, port?: "OTA" \| serial, no_states?: bool}` | Streaming | Stream live device logs. `port` defaults to `"OTA"` (empty string is treated the same) — without a default, `esphome logs` falls into an interactive port-choice prompt when multiple targets are visible and the stdin-less subprocess crashes with `EOFError`. |
+| `devices/logs` | `{configuration, port?: "OTA" \| serial, no_states?: bool}` | Streaming | Stream live device logs. `port` defaults to `"OTA"` (empty string is treated the same) — without a default, `esphome logs` falls into an interactive port-choice prompt when multiple targets are visible and the stdin-less subprocess crashes with `EOFError`. When `port` resolves to `"OTA"` the dashboard forwards its mDNS / DNS cache as `--mdns-address-cache` / `--dns-address-cache` so the CLI doesn't redo resolution the dashboard already has (legacy-dashboard parity with `build_cache_arguments`). |
 
 `Device.state`: `DeviceState` — `unknown`, `online`, or `offline` (discovered via mDNS + ping).
 `Device.has_pending_changes`: `true` = config changed since last compile, `false` = up to date, `null` = never compiled.

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -338,16 +338,7 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         return _build_address_cache_args(device, self._state_monitor)
 
     def get_ota_address_cache_args(self, configuration: str, port: str) -> list[str]:
-        """
-        Return cache args iff *port* is exactly ``"OTA"``; empty otherwise.
-
-        Serial targets get no cache args — the flags are no-ops for
-        ``--device /dev/tty*``. Callers that default a missing port
-        to OTA (``stream_logs``, ``firmware/install``) must normalise
-        before calling; the strict check keeps ``firmware/upload``'s
-        ``port=""`` auto-detect path from picking up cache args it
-        wasn't getting before.
-        """
+        """Return ``--mdns/--dns-address-cache`` args when ``port == "OTA"``; empty otherwise."""
         if port != "OTA":
             return []
         return self.get_address_cache_args(configuration)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -337,9 +337,9 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
             return []
         return _build_address_cache_args(device, self._state_monitor)
 
-    def get_ota_address_cache_args(self, configuration: str, port: str) -> list[str]:
-        """Return ``--mdns/--dns-address-cache`` args when ``port == "OTA"``; empty otherwise."""
-        if port != "OTA":
+    def get_ota_address_cache_args(self, configuration: str, port: str | None) -> list[str]:
+        """Return cache args when ``port == "OTA"`` (or ``None`` for always-OTA flows)."""
+        if port is not None and port != "OTA":
             return []
         return self.get_address_cache_args(configuration)
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -337,6 +337,21 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
             return []
         return _build_address_cache_args(device, self._state_monitor)
 
+    def get_ota_address_cache_args(self, configuration: str, port: str) -> list[str]:
+        """
+        Return cache args iff *port* is exactly ``"OTA"``; empty otherwise.
+
+        Serial targets get no cache args — the flags are no-ops for
+        ``--device /dev/tty*``. Callers that default a missing port
+        to OTA (``stream_logs``, ``firmware/install``) must normalise
+        before calling; the strict check keeps ``firmware/upload``'s
+        ``port=""`` auto-detect path from picking up cache args it
+        wasn't getting before.
+        """
+        if port != "OTA":
+            return []
+        return self.get_address_cache_args(configuration)
+
     # ------------------------------------------------------------------
     # API commands — listing
     # ------------------------------------------------------------------
@@ -2142,13 +2157,20 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         # an interactive port-choice prompt when multiple targets
         # are visible (serial + OTA); the stdin-less subprocess
         # then crashes with EOFError. (#636)
+        resolved_port = port or "OTA"
+        # Cache args must come before the subcommand — esphome parses
+        # ``--mdns/--dns-address-cache`` on the top-level parser, not
+        # ``logs``'s. Skip the round-trip the legacy dashboard already
+        # avoided.
+        cache_args = self.get_ota_address_cache_args(configuration, resolved_port)
         cmd = [
             *self._esphome_cmd,
             "--dashboard",
+            *cache_args,
             "logs",
             config_path,
             "--device",
-            port or "OTA",
+            resolved_port,
         ]
         if no_states:
             cmd.append("--no-states")

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -117,6 +117,11 @@ _PRIMARY_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL}
 )
 
+# Job types eligible for ``--mdns/--dns-address-cache`` forwarding.
+_OTA_ADDRESS_CACHE_JOB_TYPES: frozenset[JobType] = frozenset(
+    {JobType.UPLOAD, JobType.INSTALL, JobType.RENAME}
+)
+
 # Per-job output cap for retained terminal jobs. Compile output for a
 # successful build runs ~3-10k lines; the head is mostly toolchain
 # noise that's rarely useful once the build finished. Trim

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -58,6 +58,7 @@ from .constants import (
     _JOBS_KEY,
     _MAX_AUX_TERMINAL_JOBS,
     _MAX_PRIMARY_TERMINAL_JOBS,
+    _OTA_ADDRESS_CACHE_JOB_TYPES,
     _PRIMARY_JOB_TYPES,
     ESPHOME_SUBPROCESS_ENV,
 )
@@ -1718,18 +1719,13 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     def _build_cache_args(self, job: FirmwareJob) -> list[str]:
         """Return ``--mdns/--dns-address-cache`` args for *job*, or empty."""
-        # Only OTA uploads benefit — serial flashes don't talk to the
-        # device's network address at all. ``rename`` does an internal
-        # OTA install via ``esphome run`` against the *old* address, so
-        # the same cache shortcut applies regardless of ``job.port``.
-        if (
-            job.job_type not in (JobType.UPLOAD, JobType.INSTALL, JobType.RENAME)
-            or self._db.devices is None
-        ):
+        if job.job_type not in _OTA_ADDRESS_CACHE_JOB_TYPES or self._db.devices is None:
             return []
-        if job.job_type == JobType.RENAME:
-            return self._db.devices.get_address_cache_args(job.configuration)
-        return self._db.devices.get_ota_address_cache_args(job.configuration, job.port)
+        # ``rename``'s ``port`` is the post-rename re-install target;
+        # the inner ``esphome run`` against the *old* address is
+        # always OTA, so skip the gate with ``None``.
+        port: str | None = None if job.job_type == JobType.RENAME else job.port
+        return self._db.devices.get_ota_address_cache_args(job.configuration, port)
 
     # ------------------------------------------------------------------
     # Internals — job management

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1722,9 +1722,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         # device's network address at all. ``rename`` does an internal
         # OTA install via ``esphome run`` against the *old* address, so
         # the same cache shortcut applies regardless of ``job.port``.
-        if job.job_type not in (JobType.UPLOAD, JobType.INSTALL, JobType.RENAME):
-            return []
-        if self._db.devices is None:
+        if (
+            job.job_type not in (JobType.UPLOAD, JobType.INSTALL, JobType.RENAME)
+            or self._db.devices is None
+        ):
             return []
         if job.job_type == JobType.RENAME:
             return self._db.devices.get_address_cache_args(job.configuration)

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1721,14 +1721,14 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         # Only OTA uploads benefit — serial flashes don't talk to the
         # device's network address at all. ``rename`` does an internal
         # OTA install via ``esphome run`` against the *old* address, so
-        # the same cache shortcut applies.
+        # the same cache shortcut applies regardless of ``job.port``.
         if job.job_type not in (JobType.UPLOAD, JobType.INSTALL, JobType.RENAME):
-            return []
-        if job.job_type != JobType.RENAME and job.port != "OTA":
             return []
         if self._db.devices is None:
             return []
-        return self._db.devices.get_address_cache_args(job.configuration)
+        if job.job_type == JobType.RENAME:
+            return self._db.devices.get_address_cache_args(job.configuration)
+        return self._db.devices.get_ota_address_cache_args(job.configuration, job.port)
 
     # ------------------------------------------------------------------
     # Internals — job management

--- a/tests/controllers/devices/test_stream_cancel.py
+++ b/tests/controllers/devices/test_stream_cancel.py
@@ -362,6 +362,113 @@ async def test_stream_logs_command_omits_no_states_by_default(
     assert captured == [["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "OTA"]]
 
 
+async def test_stream_logs_splices_cache_args_for_ota(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """OTA port → ``--mdns/--dns-address-cache`` lands between ``--dashboard`` and ``logs``.
+
+    The cache flags are parsed on esphome's top-level parser, not
+    ``logs``'s — landing them after the subcommand triggers
+    ``unrecognized arguments``.
+    """
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
+    cache = ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+    ctrl.get_ota_address_cache_args = lambda _configuration, _port: cache  # type: ignore[method-assign]
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(
+        configuration="kitchen.yaml",
+        port="OTA",
+        client=MagicMock(),
+        message_id="m-cache",
+    )
+
+    assert captured == [
+        [
+            "esphome",
+            "--dashboard",
+            "--mdns-address-cache",
+            "kitchen.local=192.168.1.50",
+            "logs",
+            "kitchen.yaml",
+            "--device",
+            "OTA",
+        ]
+    ]
+
+
+async def test_stream_logs_splices_cache_args_when_port_defaults_to_ota(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Empty port resolves to OTA *before* the cache-args lookup, so cache args still land."""
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
+    cache = ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+    seen_ports: list[str] = []
+
+    def fake_get(configuration: str, port: str) -> list[str]:
+        seen_ports.append(port)
+        return cache if port == "OTA" else []
+
+    ctrl.get_ota_address_cache_args = fake_get  # type: ignore[method-assign]
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(
+        configuration="kitchen.yaml", client=MagicMock(), message_id="m-defcache"
+    )
+
+    assert seen_ports == ["OTA"]
+    assert captured == [
+        [
+            "esphome",
+            "--dashboard",
+            "--mdns-address-cache",
+            "kitchen.local=192.168.1.50",
+            "logs",
+            "kitchen.yaml",
+            "--device",
+            "OTA",
+        ]
+    ]
+
+
+async def test_stream_logs_no_cache_args_for_serial_port(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Serial target → no cache args even if a cached IP exists.
+
+    ``--mdns/--dns-address-cache`` are no-ops for ``--device /dev/tty*``;
+    forwarding them would just be noise on the argv.
+    """
+    ctrl = _make_controller_with_settings(make_controller, tmp_path, ["esphome"])
+    captured: list[list[str]] = []
+
+    async def fake_stream(cmd: list[str], _client: Any, _mid: str, **_kwargs: Any) -> None:
+        captured.append(cmd)
+
+    ctrl._stream_subprocess = fake_stream  # type: ignore[method-assign]
+
+    await ctrl.stream_logs(
+        configuration="kitchen.yaml",
+        port="/dev/ttyUSB0",
+        client=MagicMock(),
+        message_id="m-serial",
+    )
+
+    assert captured == [
+        ["esphome", "--dashboard", "logs", "kitchen.yaml", "--device", "/dev/ttyUSB0"]
+    ]
+
+
 async def test_validate_config_command_includes_dashboard_flag(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -246,16 +246,20 @@ def test_get_ota_address_cache_args_empty_for_serial_port() -> None:
 
 
 def test_get_ota_address_cache_args_empty_for_missing_port() -> None:
-    """Empty string is *not* treated as OTA — callers must normalise first.
-
-    ``firmware/upload`` defaults to ``port=""`` and historically did
-    not forward cache args; the helper preserves that behaviour. The
-    ``stream_logs`` caller normalises ``port or "OTA"`` before passing
-    in (matching its ``--device`` default).
-    """
+    """Empty string is *not* treated as OTA — callers must normalise first."""
     controller = _devices_controller_with(_device())
 
     assert controller.get_ota_address_cache_args("kitchen.yaml", "") == []
+
+
+def test_get_ota_address_cache_args_none_is_always_ota() -> None:
+    """``port=None`` skips the OTA gate — for always-OTA flows like ``rename``."""
+    controller = _devices_controller_with(_device())
+
+    assert controller.get_ota_address_cache_args("kitchen.yaml", None) == [
+        "--mdns-address-cache",
+        "kitchen.local=192.168.1.50",
+    ]
 
 
 # ----------------------------------------------------------------------
@@ -311,22 +315,18 @@ def test_cache_args_no_devices_controller() -> None:
     assert controller._build_cache_args(job) == []
 
 
-def test_cache_args_rename_always_uses_cache_regardless_of_port() -> None:
-    """``rename`` runs an internal OTA install against the *old* address.
+def test_cache_args_rename_passes_none_port_to_skip_gate() -> None:
+    """``rename`` calls the helper with ``port=None`` (always-OTA marker).
 
-    ``job.port`` on a rename row isn't a target — it's the value the
-    user picked for the post-rename re-install. The address-cache
-    shortcut applies to the inner OTA either way, so the rename
-    branch goes through ``get_address_cache_args`` directly and
-    bypasses the strict ``port == "OTA"`` gate that the
-    upload / install branches go through.
+    The user-supplied ``job.port`` is the post-rename re-install
+    target — irrelevant to the inner ``esphome run`` against the
+    old address, which is always OTA.
     """
     cache = ["--mdns-address-cache", "k.local=1.2.3.4"]
     devices = MagicMock()
-    devices.get_address_cache_args.return_value = cache
-    # Side-effect deliberately returns [] so we'd notice if the
-    # rename branch leaked into the OTA-gated helper.
-    devices.get_ota_address_cache_args.side_effect = lambda *_args, **_kwargs: []
+    devices.get_ota_address_cache_args.side_effect = lambda _configuration, port: (
+        cache if port in (None, "OTA") else []
+    )
     controller = _firmware_controller_with(devices)
 
     job = FirmwareJob(
@@ -336,8 +336,7 @@ def test_cache_args_rename_always_uses_cache_regardless_of_port() -> None:
         port="/dev/ttyUSB0",
     )
     assert controller._build_cache_args(job) == cache
-    devices.get_address_cache_args.assert_called_once_with("kitchen.yaml")
-    devices.get_ota_address_cache_args.assert_not_called()
+    devices.get_ota_address_cache_args.assert_called_once_with("kitchen.yaml", None)
 
 
 def test_command_places_cache_args_before_subcommand() -> None:

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -228,6 +228,36 @@ def test_get_address_cache_args_unknown_configuration_returns_empty() -> None:
     assert args == []
 
 
+def test_get_ota_address_cache_args_returns_cache_for_ota_port() -> None:
+    """Strict ``port == "OTA"`` → delegate to ``get_address_cache_args``."""
+    controller = _devices_controller_with(_device())
+
+    assert controller.get_ota_address_cache_args("kitchen.yaml", "OTA") == [
+        "--mdns-address-cache",
+        "kitchen.local=192.168.1.50",
+    ]
+
+
+def test_get_ota_address_cache_args_empty_for_serial_port() -> None:
+    """``--device /dev/tty*`` doesn't consult the address cache."""
+    controller = _devices_controller_with(_device())
+
+    assert controller.get_ota_address_cache_args("kitchen.yaml", "/dev/ttyUSB0") == []
+
+
+def test_get_ota_address_cache_args_empty_for_missing_port() -> None:
+    """Empty string is *not* treated as OTA — callers must normalise first.
+
+    ``firmware/upload`` defaults to ``port=""`` and historically did
+    not forward cache args; the helper preserves that behaviour. The
+    ``stream_logs`` caller normalises ``port or "OTA"`` before passing
+    in (matching its ``--device`` default).
+    """
+    controller = _devices_controller_with(_device())
+
+    assert controller.get_ota_address_cache_args("kitchen.yaml", "") == []
+
+
 # ----------------------------------------------------------------------
 # FirmwareController._build_cache_args / _build_command
 # ----------------------------------------------------------------------
@@ -243,8 +273,12 @@ def _firmware_controller_with(devices_controller: Any) -> FirmwareController:
 
 def test_cache_args_only_for_ota_upload_install() -> None:
     """Compile / clean / serial-port jobs don't get cache args."""
+    cache = ["--mdns-address-cache", "k.local=1.2.3.4"]
     devices = MagicMock()
-    devices.get_address_cache_args.return_value = ["--mdns-address-cache", "k.local=1.2.3.4"]
+    devices.get_address_cache_args.return_value = cache
+    devices.get_ota_address_cache_args.side_effect = lambda _configuration, port: (
+        cache if port == "OTA" else []
+    )
     controller = _firmware_controller_with(devices)
 
     # Compile: no port, irrelevant
@@ -265,7 +299,7 @@ def test_cache_args_only_for_ota_upload_install() -> None:
     job = FirmwareJob(
         job_id="4", configuration="kitchen.yaml", job_type=JobType.INSTALL, port="OTA"
     )
-    assert controller._build_cache_args(job) == ["--mdns-address-cache", "k.local=1.2.3.4"]
+    assert controller._build_cache_args(job) == cache
 
 
 def test_cache_args_no_devices_controller() -> None:

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -311,6 +311,35 @@ def test_cache_args_no_devices_controller() -> None:
     assert controller._build_cache_args(job) == []
 
 
+def test_cache_args_rename_always_uses_cache_regardless_of_port() -> None:
+    """``rename`` runs an internal OTA install against the *old* address.
+
+    ``job.port`` on a rename row isn't a target — it's the value the
+    user picked for the post-rename re-install. The address-cache
+    shortcut applies to the inner OTA either way, so the rename
+    branch goes through ``get_address_cache_args`` directly and
+    bypasses the strict ``port == "OTA"`` gate that the
+    upload / install branches go through.
+    """
+    cache = ["--mdns-address-cache", "k.local=1.2.3.4"]
+    devices = MagicMock()
+    devices.get_address_cache_args.return_value = cache
+    # Side-effect deliberately returns [] so we'd notice if the
+    # rename branch leaked into the OTA-gated helper.
+    devices.get_ota_address_cache_args.side_effect = lambda *_args, **_kwargs: []
+    controller = _firmware_controller_with(devices)
+
+    job = FirmwareJob(
+        job_id="rename-1",
+        configuration="kitchen.yaml",
+        job_type=JobType.RENAME,
+        port="/dev/ttyUSB0",
+    )
+    assert controller._build_cache_args(job) == cache
+    devices.get_address_cache_args.assert_called_once_with("kitchen.yaml")
+    devices.get_ota_address_cache_args.assert_not_called()
+
+
 def test_command_places_cache_args_before_subcommand() -> None:
     """Esphome CLI parses ``--mdns-address-cache`` on the *top-level* parser.
 

--- a/tests/controllers/firmware/test_install_to_specific_address.py
+++ b/tests/controllers/firmware/test_install_to_specific_address.py
@@ -206,11 +206,12 @@ def test_install_ota_default_keeps_cache_args() -> None:
     cache args and verifies they pass through to the command.
     """
     controller = _controller()
+    cache = ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
     controller._db.devices = MagicMock()
-    controller._db.devices.get_address_cache_args.return_value = [
-        "--mdns-address-cache",
-        "kitchen.local=192.168.1.50",
-    ]
+    controller._db.devices.get_address_cache_args.return_value = cache
+    controller._db.devices.get_ota_address_cache_args.side_effect = lambda _configuration, port: (
+        cache if port == "OTA" else []
+    )
     job = FirmwareJob(
         job_id="install-2",
         configuration="kitchen.yaml",
@@ -221,5 +222,5 @@ def test_install_ota_default_keeps_cache_args() -> None:
     cache_args = controller._build_cache_args(job)
     cmd = controller._build_command(JobType.INSTALL, "kitchen.yaml", "OTA", cache_args)
 
-    assert cache_args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+    assert cache_args == cache
     assert "--mdns-address-cache" in cmd

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -132,14 +132,16 @@ class _StubDevices:
     ``_verify_chip`` no longer reads from the devices controller —
     chip variant comes from ``StorageJSON`` directly — but the
     runner's ``_build_cache_args`` still calls
-    ``get_address_cache_args`` on the install/upload paths.
-    Returning ``[]`` for the address-cache args keeps the build
-    command shape minimal (``--mdns-address-cache`` / ``--dns-
-    address-cache`` skipped) — orthogonal to the chip-id branches
-    these tests exercise.
+    ``get_address_cache_args`` / ``get_ota_address_cache_args`` on
+    the install/upload/rename paths. Returning ``[]`` for both
+    keeps the build command shape minimal — orthogonal to the
+    chip-id branches these tests exercise.
     """
 
     def get_address_cache_args(self, _configuration: str) -> list[str]:
+        return []
+
+    def get_ota_address_cache_args(self, _configuration: str, _port: str) -> list[str]:
         return []
 
 


### PR DESCRIPTION
# What does this implement/fix?

The legacy ESPHome dashboard's `EsphomePortCommandWebSocket.build_device_command` forwarded `build_cache_arguments(...)` for every OTA-targeted CLI invocation, so `esphome logs` / `esphome run` / `esphome upload` could short-circuit mDNS / DNS resolution the dashboard already had cached. #18 ported that hand-off into the new backend for the firmware-job path (`firmware/upload`, `firmware/install`, `firmware/rename`); this PR extends the same hand-off to `devices/logs`, which was the one OTA-targeted command still missing it. Every OTA log-stream start paid an avoidable DNS / mDNS round-trip — what made "start logs" feel sluggish on a freshly flashed device.

## Change

Reuses #18's existing plumbing verbatim — `_build_address_cache_args` (helpers) and `DevicesController.get_address_cache_args` (integration gate on `api` / `web_server`). The only new logic is one thin wrapper that pulls the inline `port != "OTA"` gate out of the firmware controller so the logs path can share it:

- New `DevicesController.get_ota_address_cache_args(configuration, port)` — strict `port == "OTA"` gate over the existing `get_address_cache_args`. Replaces the inline check that lived in `FirmwareController._build_cache_args` since #18.
- `DevicesController.stream_logs` normalises `port or "OTA"` once, looks up cache args through the new helper, and splices them between `--dashboard` and the `logs` subcommand. (The cache flags are parsed on esphome's top-level parser, not `logs`'s — landing them after the subcommand triggers `unrecognized arguments`.)
- `FirmwareController._build_cache_args` delegates to the new helper for UPLOAD / INSTALL; RENAME keeps its always-OTA path. Behaviour-preserving — the inline `job.port != "OTA"` short-circuit becomes the strict check inside the helper.
- Tests pin the new splice (`stream_logs` cases: OTA / empty → OTA default / serial; unit test on the helper itself for the three port shapes) and update the existing firmware mocks to expose the new method.
- `docs/API.md` documents the cache forwarding under `devices/logs` matching the firmware-row note.

After this lands there is exactly one cache-args-for-OTA path (`get_ota_address_cache_args`) and one underlying builder (`_build_address_cache_args`), shared by both the firmware and logs call sites.

**Related issue or feature (if applicable):**

- builds on #18 (firmware-path forwarding); extends the parity to `devices/logs`
- restores legacy-dashboard parity (`build_cache_arguments` in `esphome/dashboard/web_server.py:341` upstream)
- gap exposed while fixing #636

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

`devices/logs`' wire shape is unchanged. The frontend keeps passing `{configuration, port?, no_states?}` exactly as before; this PR only changes what the backend hands to the `esphome` CLI.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
