### PR TITLE
Speed up single-instance contention tests

### DIFF
--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -14,12 +14,8 @@ These tests pin three contracts:
    ``lock_format_version``, ``device_builder_version``, and
    ``start_ts`` — operators / future dashboards reading the file
    must see a stable shape.
-2. **Second start contends** and gets ``exit_code = 1``, with the
-   running PID surfaced on stderr so the operator knows what
-   they're stepping on. Driven from a background thread that
-   opens its own fd — flock treats separate fds as independent
-   locks even in the same process (Linux + BSD flock), which
-   reproduces a cross-PID holder without paying spawn cost.
+2. **Second start contends** and gets ``exit_code = 1``, with
+   the running PID surfaced on stderr.
 3. **A stale lock file is harmless** — the next start re-acquires
    cleanly, so a previous crash doesn't permanently lock the user
    out.
@@ -63,15 +59,7 @@ _REQUIRES_FCNTL = pytest.mark.skipif(
 
 @contextmanager
 def _lock_held_by_thread(config_dir: Path) -> Generator[None]:
-    """
-    Hold the single-instance lock from a background thread.
-
-    flock on separate fds within one process is treated as
-    independent locks (Linux + BSD flock), so a thread that
-    enters ``ensure_single_execution`` blocks any subsequent
-    same-process acquire — exactly the contention shape the
-    cross-PID subprocess used to produce, minus the spawn cost.
-    """
+    """Hold the single-instance lock from a background thread."""
     started = threading.Event()
     release = threading.Event()
 
@@ -91,8 +79,6 @@ def _lock_held_by_thread(config_dir: Path) -> Generator[None]:
     finally:
         release.set()
         thread.join(timeout=5.0)
-        # Surface a stuck thread instead of letting the next test
-        # inherit a live lock holder.
         assert not thread.is_alive(), "lock-holder thread did not exit after release"
 
 
@@ -170,17 +156,7 @@ def test_windows_no_op_yields_success_without_touching_disk(
 def test_contention_with_running_instance_returns_exit_code_1(
     tmp_path: Path, capfd: pytest.CaptureFixture[str]
 ) -> None:
-    """
-    A second start while the lock is held surfaces ``exit_code=1``.
-
-    Drives the contention from a background thread that opens
-    its own fd to the lock file — flock treats separate fds as
-    separate locks even within one process, which is the same
-    shape a cross-PID holder would produce, minus the spawn
-    cost. The dashboard writes its own PID into the lock file,
-    so the diagnostic-PID assertion holds against
-    ``os.getpid()``.
-    """
+    """A second start while the lock is held surfaces ``exit_code=1``."""
     with _lock_held_by_thread(tmp_path):
         capfd.readouterr()
 

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -16,10 +16,10 @@ These tests pin three contracts:
    must see a stable shape.
 2. **Second start contends** and gets ``exit_code = 1``, with the
    running PID surfaced on stderr so the operator knows what
-   they're stepping on. Driven via ``multiprocessing.Process`` so
-   the contention is real (cross-process flock); a same-process
-   re-acquire would falsely succeed because flock is reentrant on
-   the same fd.
+   they're stepping on. Driven from a background thread that
+   opens its own fd — flock treats separate fds as independent
+   locks even in the same process (Linux + BSD flock), which
+   reproduces a cross-PID holder without paying spawn cost.
 3. **A stale lock file is harmless** — the next start re-acquires
    cleanly, so a previous crash doesn't permanently lock the user
    out.
@@ -32,10 +32,9 @@ issue #451's "best-effort or skip entirely" Windows allowance).
 from __future__ import annotations
 
 import json
-import multiprocessing as mp
 import os
 import sys
-import time
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -62,65 +61,35 @@ _REQUIRES_FCNTL = pytest.mark.skipif(
 )
 
 
-def _hold_lock(
-    config_dir: str,
-    started: mp.synchronize.Event,
-    release: mp.synchronize.Event,
-) -> None:
-    """
-    Subprocess body: acquire the lock and wait for the parent's signal.
-
-    Used by the contention test — runs in a spawned subprocess
-    (via ``mp.get_context("spawn")``) so the flock is held by a
-    *different* PID than the test runner. Signals via ``started``
-    once the lock is held, then blocks on ``release`` to keep
-    the lock alive until the parent has finished its own
-    (failing) acquisition attempt.
-    """
-    with ensure_single_execution(Path(config_dir)) as lock:
-        if lock.exit_code is not None:
-            # Shouldn't happen — we're the first acquirer.
-            return
-        started.set()
-        release.wait(timeout=10.0)
-
-
 @contextmanager
-def _lock_held_by_subprocess(
-    config_dir: Path,
-) -> Generator[mp.process.BaseProcess]:
-    """
-    Spawn a subprocess that holds the lock for the duration of the ``with``.
+def _lock_held_by_thread(config_dir: Path) -> Generator[None]:
+    """Hold the single-instance lock from a background thread.
 
-    Yields the running ``Process`` (so the test body can read
-    ``holder.pid`` for diagnostic-output assertions) and tears
-    everything down on exit: signals the child to release, waits
-    for a clean join, and force-terminates if it didn't exit
-    promptly. Used by both contention tests so the
-    spawn / Event coordination / cleanup boilerplate lives in
-    exactly one place.
+    flock on separate fds within one process is treated as
+    independent locks (Linux + BSD flock), so a thread that
+    enters ``ensure_single_execution`` blocks any subsequent
+    same-process acquire — exactly the contention shape the
+    cross-PID subprocess used to produce, minus the spawn cost.
     """
-    ctx = mp.get_context("spawn")
-    started = ctx.Event()
-    release = ctx.Event()
-    holder = ctx.Process(
-        target=_hold_lock,
-        args=(str(config_dir), started, release),
-    )
-    holder.start()
+    started = threading.Event()
+    release = threading.Event()
+
+    def _hold() -> None:
+        with ensure_single_execution(config_dir) as lock:
+            if lock.exit_code is not None:
+                return  # acquisition unexpectedly failed; let started timeout
+            started.set()
+            release.wait(timeout=10.0)
+
+    thread = threading.Thread(target=_hold, daemon=True)
+    thread.start()
     try:
-        # Wait for the child to actually acquire — without this
-        # the parent might race ahead and acquire first, defeating
-        # the test's premise.
         if not started.wait(timeout=5.0):
-            raise RuntimeError("subprocess did not acquire lock in time")
-        yield holder
+            raise RuntimeError("background thread did not acquire lock in time")
+        yield
     finally:
         release.set()
-        holder.join(timeout=5.0)
-        if holder.is_alive():
-            holder.terminate()
-            holder.join(timeout=2.0)
+        thread.join(timeout=5.0)
 
 
 @_REQUIRES_FCNTL
@@ -198,17 +167,17 @@ def test_contention_with_running_instance_returns_exit_code_1(
     tmp_path: Path, capfd: pytest.CaptureFixture[str]
 ) -> None:
     """
-    A second start while the lock is held by another PID surfaces ``exit_code=1``.
+    A second start while the lock is held surfaces ``exit_code=1``.
 
-    Drives the contention via ``multiprocessing.Process`` so the
-    flock is genuinely held by a different PID — same-process
-    flock is reentrant on the same fd and would falsely succeed.
-    Captures stderr to confirm the operator-facing diagnostic
-    output names the running PID.
+    Drives the contention from a background thread that opens
+    its own fd to the lock file — flock treats separate fds as
+    separate locks even within one process, which is the same
+    shape a cross-PID holder would produce, minus the spawn
+    cost. The dashboard writes its own PID into the lock file,
+    so the diagnostic-PID assertion holds against
+    ``os.getpid()``.
     """
-    with _lock_held_by_subprocess(tmp_path) as holder:
-        # Drain anything the child wrote to stderr before we check
-        # the parent's contention output.
+    with _lock_held_by_thread(tmp_path):
         capfd.readouterr()
 
         with ensure_single_execution(tmp_path) as lock:
@@ -218,7 +187,7 @@ def test_contention_with_running_instance_returns_exit_code_1(
         assert "Another device-builder is already running" in captured.err
         # Surfaces the running PID so operators can ``kill`` or
         # ``ps`` it; this is the headline UX win.
-        assert f"PID: {holder.pid}" in captured.err
+        assert f"PID: {os.getpid()}" in captured.err
         assert str(tmp_path) in captured.err
 
 
@@ -238,11 +207,9 @@ def test_contention_handles_unreadable_lock_file_gracefully(
     holder has flushed its diagnostic record so the parent's
     read sees the garbage, not the holder's clean JSON.
     """
-    with _lock_held_by_subprocess(tmp_path):
-        # Wait briefly so the holder's flush lands before we
-        # overwrite — we want our garbage in the file when the
-        # parent reads on contention.
-        time.sleep(0.05)
+    with _lock_held_by_thread(tmp_path):
+        # ``_write_lock_info`` flushes before the started-signal
+        # fires, so the lock file is already on disk by now.
         (tmp_path / _LOCK_FILE_NAME).write_text("not valid json {{{")
 
         capfd.readouterr()

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -63,7 +63,8 @@ _REQUIRES_FCNTL = pytest.mark.skipif(
 
 @contextmanager
 def _lock_held_by_thread(config_dir: Path) -> Generator[None]:
-    """Hold the single-instance lock from a background thread.
+    """
+    Hold the single-instance lock from a background thread.
 
     flock on separate fds within one process is treated as
     independent locks (Linux + BSD flock), so a thread that
@@ -90,6 +91,9 @@ def _lock_held_by_thread(config_dir: Path) -> Generator[None]:
     finally:
         release.set()
         thread.join(timeout=5.0)
+        # Surface a stuck thread instead of letting the next test
+        # inherit a live lock holder.
+        assert not thread.is_alive(), "lock-holder thread did not exit after release"
 
 
 @_REQUIRES_FCNTL


### PR DESCRIPTION
# What does this implement/fix?

Two tests in `tests/test_single_instance.py` had been sitting
on pytest's slowest-10 list at ~1 s each:

```
1.19s test_contention_handles_unreadable_lock_file_gracefully
1.01s test_contention_with_running_instance_returns_exit_code_1
```

Both spawned a fresh Python interpreter via
`multiprocessing.Process(spawn)` so the lock holder ran in a
different PID. The cold-spawn cost was the entire runtime.

Replace the subprocess with a background thread that opens
its own fd to the lock file. `flock(2)` treats separate
"open file descriptions" as independent locks even within
one process (Linux + BSD flock), so a thread-held lock
blocks a same-process acquire exactly the way a separate
PID would. Same contention shape, same diagnostic output —
the dashboard writes its own PID into the lock file, so the
assertion just becomes `f"PID: {os.getpid()}"` instead of
`f"PID: {holder.pid}"`.

## Results

Whole file now runs in 0.09 s end-to-end on macOS; both
slow tests drop below the 5 ms display threshold.

## What this PR does *not* do

- The cross-process semantics of the dashboard's lock are
  unchanged; only the test plumbing moved off
  multiprocessing.
- The `_REQUIRES_FCNTL` skip on Windows stays — same
  reason as before (no `fcntl`).

**Related issue or feature (if applicable):**

- Test-runtime cleanup; not user-visible.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
