### PR TITLE
Switch port classification to esphome.upload_targets

### DIFF
--- a/esphome_device_builder/controllers/firmware/_upload_targets_fallback.py
+++ b/esphome_device_builder/controllers/firmware/_upload_targets_fallback.py
@@ -1,0 +1,32 @@
+"""Local mirror of ``esphome.upload_targets`` for older esphome installs.
+
+Delete this module (and the ``try``/``except`` in
+:mod:`.helpers`) once the ``esphome`` dependency floor is past the
+release that ships ``esphome.upload_targets`` (PR
+esphome/esphome#16346, merged 2026-05-11).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class PortType(StrEnum):
+    SERIAL = "SERIAL"
+    NETWORK = "NETWORK"
+    MQTT = "MQTT"
+    MQTTIP = "MQTTIP"
+    BOOTSEL = "BOOTSEL"
+
+
+def get_port_type(port: str) -> PortType:
+    """Classify a user-supplied ``--device`` string."""
+    if port == "BOOTSEL":
+        return PortType.BOOTSEL
+    if port.startswith("/") or port.startswith("COM"):
+        return PortType.SERIAL
+    if port == "MQTT":
+        return PortType.MQTT
+    if port == "MQTTIP":
+        return PortType.MQTTIP
+    return PortType.NETWORK

--- a/esphome_device_builder/controllers/firmware/_upload_targets_fallback.py
+++ b/esphome_device_builder/controllers/firmware/_upload_targets_fallback.py
@@ -1,10 +1,7 @@
-"""Local mirror of ``esphome.upload_targets`` for older esphome installs.
+"""Local mirror of ``esphome.upload_targets`` for older esphome installs."""
 
-Delete this module (and the ``try``/``except`` in
-:mod:`.helpers`) once the ``esphome`` dependency floor is past the
-release that ships ``esphome.upload_targets`` (PR
-esphome/esphome#16346, merged 2026-05-11).
-"""
+# TODO: remove after the esphome dep floor is past the release that ships
+# ``esphome.upload_targets``.
 
 from __future__ import annotations
 

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -40,9 +40,10 @@ from .constants import (
 )
 
 try:
-    # esphome ≥ release that ships esphome/esphome#16346.
     from esphome.upload_targets import PortType, get_port_type
-except ImportError:
+except ModuleNotFoundError as exc:
+    if exc.name != "esphome.upload_targets":
+        raise
     from ._upload_targets_fallback import PortType, get_port_type
 
 if TYPE_CHECKING:

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -39,6 +39,12 @@ from .constants import (
     _PROGRESS_PATTERNS,
 )
 
+try:
+    # esphome ≥ release that ships esphome/esphome#16346.
+    from esphome.upload_targets import PortType, get_port_type
+except ImportError:
+    from ._upload_targets_fallback import PortType, get_port_type
+
 if TYPE_CHECKING:
     from ...helpers.event_bus import EventBus
 
@@ -188,73 +194,11 @@ def _parse_progress(line: str) -> int | None:
     return None
 
 
-def _is_serial_port(port: str) -> bool:
-    """
-    Return True if *port* looks like a serial-device path.
-
-    Shared between :func:`_validate_port`'s accept rules and
-    the remote-install gate that forces serial targets to the
-    LOCAL path. ``esphome.__main__.get_port_type`` is the
-    upstream equivalent, but it lives in ``__main__`` — not a
-    stable public surface to import from. Owning our own
-    classifier keeps the dashboard pinned to its own rules
-    rather than tracking an unversioned upstream private.
-
-    Tracked at esphome/device-builder#562 — once we land an
-    upstream PR that re-exports ``get_port_type`` /
-    ``PortType`` from a non-``__main__`` module and bump the
-    esphome dependency floor past it, this helper collapses
-    to a thin re-export of the upstream call.
-
-    Adding a new serial-path marker updates both
-    :func:`_validate_port` (the WS validator) and the
-    remote-install gate together — keep them in lockstep.
-    """
-    return (
-        port.startswith("/")
-        or port.startswith("COM")
-        or any(marker in port for marker in ("ttyUSB", "ttyACM", "cu.", "tty."))
-    )
-
-
 def _validate_port(port: str) -> None:
-    """Sanity-check the user-supplied ``--device`` value.
-
-    The esphome CLI accepts arbitrary strings for ``--device`` and
-    treats them as one of: the literal ``"OTA"`` (let the CLI
-    resolve the configured host), a serial path, or a network host
-    (IPv4 / IPv6 / ``.local`` hostname). Without an upfront check
-    a typo'd IP would queue, run a compile, and only fail at the
-    flash step with a CLI error buried in the job output. Validate
-    early so the WS layer can return a clean ``INVALID_ARGS``.
-
-    The check is deliberately permissive — any of these shapes is
-    accepted:
-
-    * Empty string (``upload`` default — CLI auto-detects)
-    * The literal ``"OTA"``
-    * A serial path: starts with ``/``, ``COM`` (Windows), or
-      contains ``ttyUSB`` / ``ttyACM`` / ``cu.``
-    * A valid IPv4 or IPv6 address
-    * A hostname (``[a-z0-9-]+`` per label, optional ``.local``
-      suffix, optional FQDN trailing dot) — covers
-      ``device-name.local``, ``device.example.com.``, and bare
-      hostnames
-
-    Anything else (random punctuation, IPv4 with extra dots, etc.)
-    raises ``CommandError(INVALID_ARGS)``. Coordinated frontend
-    forms can pre-filter to the same shape.
-
-    Error messages use neutral "device target" wording — this
-    helper is shared across ``firmware/upload``, ``firmware/install``,
-    and ``firmware/install_bulk``, and the message is surfaced
-    verbatim over WS, so naming a single command in the error
-    would mislead callers of the others.
-    """
+    """Accept ``""`` / ``"OTA"`` / SERIAL / IPv4-6 / hostname; raise ``INVALID_ARGS`` otherwise."""
     if not port or port == "OTA":
         return
-    # Serial paths.
-    if _is_serial_port(port):
+    if get_port_type(port) is PortType.SERIAL:
         return
     # IP-shaped input must parse as a valid IP. Doing this check
     # *before* the hostname check rejects truncated / malformed

--- a/tests/controllers/firmware/test_install_to_specific_address.py
+++ b/tests/controllers/firmware/test_install_to_specific_address.py
@@ -26,7 +26,6 @@ from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware.helpers import (
     PortType,
     _validate_port,
-    get_port_type,
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, FirmwareJob, JobType
@@ -116,14 +115,23 @@ def test_validate_port_rejects_typos(port: str) -> None:
     assert "install target" not in exc.value.message
 
 
-def test_validator_routes_serial_through_upstream_classifier() -> None:
-    """``_validate_port`` uses ``get_port_type`` for the SERIAL accept branch."""
-    assert get_port_type("/dev/ttyUSB0") is PortType.SERIAL
-    assert get_port_type("COM3") is PortType.SERIAL
-    # Stricter than the previous local classifier — bare names without
-    # a ``/`` or ``COM`` prefix classify as NETWORK and fall through to
-    # the hostname/IP check.
-    assert get_port_type("ttyUSB0") is PortType.NETWORK
+def test_validate_port_consults_get_port_type_for_serial_accept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_validate_port`` accepts via ``get_port_type(port) is PortType.SERIAL``."""
+    calls: list[str] = []
+
+    def fake(port: str) -> PortType:
+        calls.append(port)
+        return PortType.SERIAL
+
+    monkeypatch.setattr("esphome_device_builder.controllers.firmware.helpers.get_port_type", fake)
+
+    # An input the hostname/IP regex would reject — proves the SERIAL
+    # short-circuit was taken before the fallthrough branches ran.
+    _validate_port("not a valid hostname OR an IP")
+
+    assert calls == ["not a valid hostname OR an IP"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_install_to_specific_address.py
+++ b/tests/controllers/firmware/test_install_to_specific_address.py
@@ -23,7 +23,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware.helpers import _validate_port
+from esphome_device_builder.controllers.firmware.helpers import (
+    PortType,
+    _validate_port,
+    get_port_type,
+)
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, FirmwareJob, JobType
 
@@ -110,6 +114,16 @@ def test_validate_port_rejects_typos(port: str) -> None:
     # verbatim over WS to whichever command the user actually ran.
     assert "device target" in exc.value.message
     assert "install target" not in exc.value.message
+
+
+def test_validator_routes_serial_through_upstream_classifier() -> None:
+    """``_validate_port`` uses ``get_port_type`` for the SERIAL accept branch."""
+    assert get_port_type("/dev/ttyUSB0") is PortType.SERIAL
+    assert get_port_type("COM3") is PortType.SERIAL
+    # Stricter than the previous local classifier — bare names without
+    # a ``/`` or ``COM`` prefix classify as NETWORK and fall through to
+    # the hostname/IP check.
+    assert get_port_type("ttyUSB0") is PortType.NETWORK
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_upload_targets_fallback.py
+++ b/tests/controllers/firmware/test_upload_targets_fallback.py
@@ -1,9 +1,6 @@
-"""Contract pin for the local ``esphome.upload_targets`` fallback.
+"""Contract pin for the local ``esphome.upload_targets`` fallback."""
 
-Delete this file when ``_upload_targets_fallback`` itself is
-deleted (after the ``esphome`` dep floor is past the release that
-ships ``esphome.upload_targets``).
-"""
+# TODO: delete with _upload_targets_fallback.
 
 from __future__ import annotations
 

--- a/tests/controllers/firmware/test_upload_targets_fallback.py
+++ b/tests/controllers/firmware/test_upload_targets_fallback.py
@@ -1,0 +1,32 @@
+"""Contract pin for the local ``esphome.upload_targets`` fallback.
+
+Delete this file when ``_upload_targets_fallback`` itself is
+deleted (after the ``esphome`` dep floor is past the release that
+ships ``esphome.upload_targets``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.controllers.firmware._upload_targets_fallback import (
+    PortType,
+    get_port_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("port", "expected"),
+    [
+        ("BOOTSEL", PortType.BOOTSEL),
+        ("MQTT", PortType.MQTT),
+        ("MQTTIP", PortType.MQTTIP),
+        ("/dev/ttyUSB0", PortType.SERIAL),
+        ("COM3", PortType.SERIAL),
+        ("kitchen.local", PortType.NETWORK),
+        ("192.168.1.42", PortType.NETWORK),
+        ("ttyUSB0", PortType.NETWORK),  # bare name — no ``/`` or ``COM`` prefix
+    ],
+)
+def test_get_port_type(port: str, expected: PortType) -> None:
+    assert get_port_type(port) is expected


### PR DESCRIPTION
# What does this implement/fix?

esphome/esphome#16346 (merged 2026-05-11, awaiting a tagged release) promoted `get_port_type` / `PortType` out of `esphome.__main__` and into a new stable `esphome.upload_targets` module. The dashboard previously kept its own classifier (`_is_serial_port`) precisely because `esphome.__main__` is a CLI entrypoint, not a stable import path. Now there's a stable surface; switch to it.

## Change

- Import shim in `controllers/firmware/helpers.py`:
  ```python
  try:
      from esphome.upload_targets import PortType, get_port_type
  except ImportError:
      from ._upload_targets_fallback import PortType, get_port_type
  ```
- New `controllers/firmware/_upload_targets_fallback.py` — byte-for-byte mirror of the upstream module, used on esphome installs that pre-date the upstream module landing in a tagged release. Marked for deletion (along with `tests/controllers/firmware/test_upload_targets_fallback.py`) once the `esphome` dep floor is past that release — the conditional import collapses to an unconditional one.
- `_validate_port` routes the SERIAL accept branch through `get_port_type(port) is PortType.SERIAL`. The local `_is_serial_port` helper is deleted.
- Tests pin `get_port_type`'s full contract (the five `PortType` members) against the fallback so a drift in the upstream module is visible the moment we switch back to it.

## Behaviour change

The previous local classifier accepted a *permissive* set of serial markers (`/`, `COM`, or any of `ttyUSB` / `ttyACM` / `cu.` / `tty.` as a substring). Upstream's `get_port_type` is *strict*: SERIAL requires a leading `/` or `COM`. Issue #563 listed (a) restrict the validator to upstream's rules, (b) push a permissive PR upstream, (c) keep the permissive validator as a separate layer — and deferred the choice.

This PR picks (a). Concrete impact:

- Every documented validator-test case (`tests/controllers/firmware/test_install_to_specific_address.py`) already uses `/dev/...` or `COM` prefixes and still classifies as SERIAL — no test churn.
- A user typing a bare name without a path prefix (`ttyUSB0`, `cu.usbserial-1410`) used to be accepted by the validator as SERIAL; now it falls through to the hostname regex (which matches it) and is accepted as a hostname. The CLI will reject the unresolvable target at flash time — the same failure mode any other typo'd target hits today. Frontend pickers always send the full `/dev/...` path, so this only affects users hand-typing the bare name.

If keeping the permissive markers is preferred, the alternative is to land (c) — keep `_is_serial_port` for the validator-only accept branch and use `get_port_type` for future routing decisions. Happy to switch shape if a reviewer prefers it.

**Related issue or feature (if applicable):**

- closes #563
- upstream: esphome/esphome#16346
- parent: #562

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

WS contract unchanged. The validator's accept-set is slightly narrower for hand-typed bare serial names; frontend pickers send the full `/dev/...` path, so no coordinated change is required.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
