### PR TITLE
Dedupe same-tick storage-regen schedule calls synchronously

### DIFF
--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -107,11 +107,20 @@ def schedule(controller: DevicesController, configuration: str) -> None:
         # changed since; rerunning would produce the same error.
         return
 
+    # Mark synchronously so two same-tick ``schedule()`` calls
+    # don't both pass the dedupe check above (the coroutine
+    # body that used to do the add only runs after the loop
+    # yields, leaving a race window where a second call would
+    # queue a duplicate task; the lock further down serialises
+    # the subprocess but both runs would still pay the
+    # failure-stamp read + reload). Discard in ``_run``'s
+    # finally below so a single in-flight regen still clears
+    # cleanly.
+    controller._regenerate_pending.add(configuration)
     controller._db.create_background_task(_run(controller, configuration))
 
 
 async def _run(controller: DevicesController, configuration: str) -> None:
-    controller._regenerate_pending.add(configuration)
     try:
         # Cross-restart skip: the previous backend persisted
         # the YAML's mtime + wall-clock when the regen

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -278,6 +278,53 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
 
 
 @pytest.mark.asyncio
+async def test_regenerate_dedupes_same_tick_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Two ``schedule_storage_regenerate`` calls in the same tick → one task.
+
+    Pins the same-tick race the in-flight test below can't reach.
+    Before the fix, ``_regenerate_pending`` was only populated
+    inside the spawned coroutine; back-to-back sync calls landed
+    before the loop ran the body, so both saw an empty pending
+    set and queued duplicate tasks (the lock further down then
+    serialised the subprocess but each task still paid the
+    failure-stamp read + post-success reload). With the sync
+    ``.add()`` in ``schedule`` the second call's dedupe check
+    fires immediately and only the first call queues a task.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+    monkeypatch.setattr(
+        DevicesController,
+        "_finalize_regen_success",
+        AsyncMock(),
+    )
+
+    # Two synchronous calls — no ``await`` between them, so the
+    # spawned coroutine hasn't had a chance to run.
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    controller._schedule_storage_regenerate("kitchen.yaml")
+
+    assert len(controller._spawned_tasks) == 1  # type: ignore[attr-defined]
+    # Sync ``.add()`` in ``schedule`` is the load-bearing piece —
+    # without it the second call wouldn't see the marker yet.
+    assert controller._regenerate_pending == {"kitchen.yaml"}
+
+    await _drain(controller)
+    assert controller._regenerate_pending == set()
+
+
+@pytest.mark.asyncio
 async def test_regenerate_pending_blocks_in_flight_dupe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# What does this implement/fix?

Fixes a same-tick race in `storage_regen.schedule()` (formerly `DevicesController._schedule_storage_regenerate`). The sync dedupe guard reads `_regenerate_pending`, but the matching `.add()` lived inside the spawned `_run()` coroutine — so two synchronous `schedule()` calls back-to-back both passed the empty-set check before either coroutine ran, queued two background tasks, and (after the lock further down serialised the subprocess) each paid the failure-stamp read + post-success reload. Caller-visible symptom: a tight loop of YAML saves on the same device double-fires `_scanner.reload(configuration)` and the `DEVICE_UPDATED` event the frontend keys off.

The fix moves the `.add()` up into the sync `schedule()` body, after the dedupe checks but before `create_background_task`. The second same-tick call now sees the marker immediately and short-circuits. The `discard` in `_run`'s `finally` block still runs, so single in-flight regens clear cleanly when the coroutine finishes.

Adds `test_regenerate_dedupes_same_tick_calls` next to the existing in-flight test in `test_storage_regenerate_e2e.py`. The existing `test_regenerate_pending_blocks_in_flight_dupe` only covers the case where the first coroutine has already run far enough to set the marker (`in_flight.set()` after the spawn entered); the new test pins the pre-yield window the old shape couldn't catch. Verified the new test fails on `main` (`AssertionError: assert 2 == 1`) and passes with this change.

Spotted by Copilot during review of #663 (`refactor` PR); the issue was pre-existing and survived the 1:1 extraction, so the fix lands here as its own behaviour-change PR.

**Related issue or feature (if applicable):**

- follow-up to #663

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
