### PR TITLE
Tighten devices-split docstrings and comments

### DIFF
--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -210,13 +210,6 @@ def sync_deployed_hash_after_flash(controller: DevicesController, configuration:
 async def persist_storage_version_async(
     controller: DevicesController, configuration: str, version: str
 ) -> None:
-    """Update ``StorageJSON.esphome_version`` on disk if it differs.
-
-    The sync write is dispatched to a thread so the controller's
-    event loop isn't blocked on disk I/O. The controller's
-    ``_persist_storage_version`` static method is the actual
-    writer — kept as a static on the class so tests can call it
-    via ``DevicesController._persist_storage_version(...)``.
-    """
+    """Update ``StorageJSON.esphome_version`` on disk if it differs."""
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, controller._persist_storage_version, configuration, version)

--- a/esphome_device_builder/controllers/devices/reachability.py
+++ b/esphome_device_builder/controllers/devices/reachability.py
@@ -125,7 +125,8 @@ async def subscribe(
 
 
 async def refresh_loop(controller: DevicesController, device_name: str) -> None:
-    """Schedule mDNS refreshes off the cached A record's expiry.
+    """
+    Schedule mDNS refreshes off the cached A record's expiry.
 
     Quiet when active source is ping (the regular sweep already
     runs every 60s) or MQTT (the discover-publish loop already

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -18,11 +18,10 @@ keep the spawn rate bounded:
   ``expected_config_hash`` write.
 
 Three sets + one lock live on the controller (``_regenerate_pending``,
-``_regenerate_failed``, ``_regenerate_lock``). The functions here
+``_regenerate_failed``, ``_regenerate_lock``); the functions here
 reach in via the ``controller`` arg rather than holding their own
-state — ``_on_scan_change`` (in monitor_callbacks) reads
-``_regenerate_failed.discard()`` too, so the state is shared
-across modules and stays controller-owned.
+state, so the scan-change callback can clear ``_regenerate_failed``
+when a YAML edit invalidates the marker.
 """
 
 from __future__ import annotations
@@ -107,15 +106,9 @@ def schedule(controller: DevicesController, configuration: str) -> None:
         # changed since; rerunning would produce the same error.
         return
 
-    # Mark synchronously so two same-tick ``schedule()`` calls
-    # don't both pass the dedupe check above (the coroutine
-    # body that used to do the add only runs after the loop
-    # yields, leaving a race window where a second call would
-    # queue a duplicate task; the lock further down serialises
-    # the subprocess but both runs would still pay the
-    # failure-stamp read + reload). Discard in ``_run``'s
-    # finally below so a single in-flight regen still clears
-    # cleanly.
+    # Mark synchronously so a second same-tick call sees the
+    # marker before the coroutine yields. ``_run``'s finally
+    # discards on completion.
     controller._regenerate_pending.add(configuration)
     controller._db.create_background_task(_run(controller, configuration))
 
@@ -155,7 +148,8 @@ async def _run(controller: DevicesController, configuration: str) -> None:
 
 
 async def spawn_only_generate(controller: DevicesController, configuration: str) -> bool:
-    """Run ``esphome compile --only-generate`` once. Return True iff exit-0.
+    """
+    Run ``esphome compile --only-generate`` once. Return True iff exit-0.
 
     Both failure modes (spawn raised, or the subprocess exited
     non-zero) get logged at debug and produce ``False`` so the
@@ -188,7 +182,8 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
 
 
 async def already_failed_recently_async(controller: DevicesController, configuration: str) -> bool:
-    """Return True iff the persisted failure stamp is unchanged-and-fresh.
+    """
+    Return True iff the persisted failure stamp is unchanged-and-fresh.
 
     Both halves have to hold for the guard to fire:
 
@@ -240,7 +235,8 @@ async def already_failed_recently_async(controller: DevicesController, configura
 
 
 async def stamp_failure(controller: DevicesController, configuration: str) -> None:
-    """Persist the cross-restart "we already tried, gave up" marker — one executor hop.
+    """
+    Persist the cross-restart "we already tried, gave up" marker — one executor hop.
 
     Combines the YAML ``stat()`` and the sidecar write into a
     single closure handed to ``run_in_executor``. The earlier
@@ -271,7 +267,8 @@ async def stamp_failure(controller: DevicesController, configuration: str) -> No
 
 
 async def finalize_success(controller: DevicesController, configuration: str) -> None:
-    """Read the post-only-generate hash and clear the failure stamp — one executor hop.
+    """
+    Read the post-only-generate hash and clear the failure stamp — one executor hop.
 
     Used to be three separate awaits — read ``build_info.json``,
     write the hash, write the cleared regen stamp — totalling

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -284,7 +284,7 @@ async def test_regenerate_dedupes_same_tick_calls(
     make_controller: MakeControllerFactory,
 ) -> None:
     """
-    Two ``schedule_storage_regenerate`` calls in the same tick → one task.
+    Two ``_schedule_storage_regenerate`` calls in the same tick → one task.
 
     Pins the pre-yield window the in-flight test below can't
     reach; the second sync call has to see

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -283,17 +283,13 @@ async def test_regenerate_dedupes_same_tick_calls(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """Two ``schedule_storage_regenerate`` calls in the same tick → one task.
+    """
+    Two ``schedule_storage_regenerate`` calls in the same tick → one task.
 
-    Pins the same-tick race the in-flight test below can't reach.
-    Before the fix, ``_regenerate_pending`` was only populated
-    inside the spawned coroutine; back-to-back sync calls landed
-    before the loop ran the body, so both saw an empty pending
-    set and queued duplicate tasks (the lock further down then
-    serialised the subprocess but each task still paid the
-    failure-stamp read + post-success reload). With the sync
-    ``.add()`` in ``schedule`` the second call's dedupe check
-    fires immediately and only the first call queues a task.
+    Pins the pre-yield window the in-flight test below can't
+    reach; the second sync call has to see
+    ``_regenerate_pending`` populated before the spawned
+    coroutine runs.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
 


### PR DESCRIPTION
# What does this implement/fix?

Docstring and comment cleanup for the devices-split landed in #663 and the same-tick race fix in #665, against the conventions in `CLAUDE.md` ("Code style — Docstrings / Comments") and the no-old-codepath-references guidance.

- `storage_regen.py`: removed the forward-reference in the top-of-file docstring to a `monitor_callbacks` module that doesn't exist yet (the scan-change callback is still on the controller; that extraction was deferred to a follow-up). Tightened the comment that justifies the sync `.add()` in `schedule()` so it explains the contract instead of paraphrasing the diff. Moved multi-line docstring summaries onto the line after the opening `"""` (the convention).
- `firmware_sync.py`: reverted `persist_storage_version_async` to the one-line docstring it had before the extraction; the multi-line expansion I added was a paraphrase of obvious code at the call site.
- `reachability.py`: same docstring-shape fix on `refresh_loop`.
- `test_regenerate_dedupes_same_tick_calls`: dropped the "before the fix" framing (which rots once #665 ages out of recent memory) and tightened the body to two sentences.

**Related issue or feature (if applicable):**

- follow-up to #663 and #665

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
