### PR TITLE
Hold the unreachable-receiver port bound for the test (deflake)

### DIFF
--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -22,8 +22,8 @@ import hashlib
 import io
 import secrets
 import tarfile
-from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator
+from contextlib import asynccontextmanager, closing
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -31,7 +31,7 @@ from unittest.mock import MagicMock
 import aiohttp
 import pytest
 from aiohttp import WSMessage, WSMsgType, web
-from aiohttp.test_utils import TestServer
+from aiohttp.test_utils import TestServer, get_unused_port_socket
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from noise.exceptions import NoiseInvalidMessage
 
@@ -104,6 +104,13 @@ from .conftest import (
     make_remote_build_controller,
 )
 from .conftest import RemoteBuildTestHandles as RemoteBuildController
+
+
+@pytest.fixture
+def bound_unused_tcp_port() -> Iterator[int]:
+    """Yield a 127.0.0.1 port held bound (no ``listen``) for the test — no TOCTOU race."""
+    with closing(get_unused_port_socket("127.0.0.1")) as sock:
+        yield sock.getsockname()[1]
 
 
 def _make_controller(*, config_dir: Path) -> RemoteBuildController:
@@ -201,14 +208,14 @@ async def test_preview_pair_does_not_persist_state_on_receiver(
 @pytest.mark.asyncio
 async def test_preview_pair_connection_refused_raises_client_error(
     tmp_path: Path,
-    unused_tcp_port: int,
+    bound_unused_tcp_port: int,
 ) -> None:
     """Connecting to a closed port raises :class:`PeerLinkClientError`."""
     initiator_priv = secrets.token_bytes(32)
     with pytest.raises(PeerLinkClientError, match="failed"):
         await preview_pair(
             hostname="127.0.0.1",
-            port=unused_tcp_port,
+            port=bound_unused_tcp_port,
             identity_priv=initiator_priv,
         )
 
@@ -738,7 +745,7 @@ async def test_controller_preview_pair_returns_receiver_pin(
 @pytest.mark.asyncio
 async def test_controller_preview_pair_unavailable_on_unreachable_receiver(
     offloader_controller_dir: Path,
-    unused_tcp_port: int,
+    bound_unused_tcp_port: int,
 ) -> None:
     """Receiver unreachable → CommandError(UNAVAILABLE)."""
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -747,7 +754,7 @@ async def test_controller_preview_pair_unavailable_on_unreachable_receiver(
     with pytest.raises(CommandError) as exc:
         await offloader.preview_pair(
             hostname="127.0.0.1",
-            port=unused_tcp_port,
+            port=bound_unused_tcp_port,
         )
     assert exc.value.code == ErrorCode.UNAVAILABLE
 
@@ -839,7 +846,7 @@ async def test_controller_request_pair_closed_window_raises_no_pairing_window(
 @pytest.mark.asyncio
 async def test_controller_request_pair_unavailable_on_unreachable_receiver(
     offloader_controller_dir: Path,
-    unused_tcp_port: int,
+    bound_unused_tcp_port: int,
 ) -> None:
     """Receiver unreachable → CommandError(UNAVAILABLE)."""
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -848,7 +855,7 @@ async def test_controller_request_pair_unavailable_on_unreachable_receiver(
     with pytest.raises(CommandError) as exc:
         await offloader.request_pair(
             hostname="127.0.0.1",
-            port=unused_tcp_port,
+            port=bound_unused_tcp_port,
             pin_sha256="a" * 64,
             receiver_label="my-receiver",
             offloader_label="my-builder",


### PR DESCRIPTION
# What does this implement/fix?

`pytest-asyncio`'s stock `unused_tcp_port` fixture binds a socket, reads the port, then **closes** before yielding the int. Between that close and the test's connect, the kernel can hand the same port to another process — and the test's "unreachable receiver" assertion flips green because the connection now succeeds against whatever happened to grab the port. Hit on CI as [`test_controller_preview_pair_unavailable_on_unreachable_receiver` failing with `DID NOT RAISE`](https://github.com/esphome/device-builder/actions/runs/25752783602/job/75633234096).

Three tests in `test_remote_build_peer_link_client.py` use that fixture for the same assertion shape:

- `test_preview_pair_connection_refused_raises_client_error`
- `test_controller_preview_pair_unavailable_on_unreachable_receiver`
- `test_controller_request_pair_unavailable_on_unreachable_receiver`

Switch them to a local `bound_unused_tcp_port` fixture that uses `aiohttp.test_utils.get_unused_port_socket` to bind a `SOCK_STREAM` socket (without `listen`), hold it open across the test, and yield `getsockname()[1]`. The kernel keeps the reservation, so nothing else can bind the port — the TOCTOU window is gone. On Linux (CI) the bound-without-listen socket replies with RST → immediate `ConnectionRefusedError`. On macOS the kernel silently drops the SYN and the peer-link client's 10 s `aiohttp.ClientTimeout` fires — same `PeerLinkClientError` surface, just slower locally.

**Related issue or feature (if applicable):**

- deflakes CI run https://github.com/esphome/device-builder/actions/runs/25752783602 (surfaced from PR #664)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

Test-only change.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
