### PR TITLE
Strip remaining planning-doc phase tags missed by #610

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -504,10 +504,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         peer-link-connected, the resulting job carries
         ``source=REMOTE`` + ``source_pin_sha256=<pin>`` +
         ``source_label=<receiver_label>`` so the source-routed
-        runner (7a-2b) dispatches the compile to that receiver
-        and stages the resulting artifacts back for the local
-        flash step. Otherwise the job stays ``source=LOCAL``
-        and runs through the existing in-process subprocess
+        runner dispatches the compile to that receiver and stages
+        the resulting artifacts back for the local flash step.
+        Otherwise the job stays ``source=LOCAL`` and runs through
+        the existing in-process subprocess
         pipeline. Silent fallback by design — the user doesn't
         choose a build location; the scheduler routes
         transparently.
@@ -1840,10 +1840,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         friendly name).
 
         ``source`` / ``source_pin_sha256`` / ``source_label`` are
-        the offloader-side dispatch-origin fields (7a-2a):
-        ``LOCAL`` for jobs the offloader compiles itself, ``REMOTE``
-        for jobs the offloader dispatches to a paired receiver via
-        the source-routed runner (7a-2b). ``source_pin_sha256``
+        the offloader-side dispatch-origin fields: ``LOCAL`` for
+        jobs the offloader compiles itself, ``REMOTE`` for jobs
+        the offloader dispatches to a paired receiver via the
+        source-routed runner. ``source_pin_sha256``
         identifies the receiver; ``source_label`` is the display
         name. Defaults make every existing call site continue to
         produce LOCAL jobs.

--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -92,7 +92,7 @@ _LOGGER = logging.getLogger(__name__)
 # Reject reason codes carried on
 # :class:`ArtifactsEndFrameData.reason` when ``accepted=False``.
 # Same idiom as :data:`controllers.remote_build.submit_job._REASON_*` —
-# the offloader-side submitter (6b) maps these to user-facing
+# the offloader-side submitter maps these to user-facing
 # error messages. Only soft-rejects appear here; protocol
 # violations (malformed frame shape) skip the ``artifacts_end``
 # path entirely and terminate the session with

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1,7 +1,7 @@
 """
 Tests for the source-routed firmware runner branch.
 
-Exercises ``FirmwareController._execute_remote_job`` (7a-2b)
+Exercises ``FirmwareController._execute_remote_job``
 end-to-end against a real :class:`EventBus`. The test scaffolding
 substitutes the bundle build + peer-link client surfaces with
 :class:`AsyncMock` shims so the runner's wire-event translation

--- a/tests/controllers/firmware/test_traversal_validation.py
+++ b/tests/controllers/firmware/test_traversal_validation.py
@@ -83,8 +83,8 @@ async def test_validate_configurations_boundary_raises_on_bad_entry(
     Bulk handlers reject the whole batch on bad input rather than
     silently dropping the offending entry — a typo in one of N
     configurations is something the caller wants to know about,
-    not have masked by partial success. Rename-lock conflicts in
-    phase 2 stay skip-and-continue (transient state, not bad
+    not have masked by partial success. Rename-lock conflicts at
+    enqueue time stay skip-and-continue (transient state, not bad
     input).
     """
     controller = firmware_controller_factory()


### PR DESCRIPTION
# What does this implement/fix?

Follow-up sweep to #610 ("Strip planning-doc phase tags from code
comments and docstrings"). Five `(7a-2a)` / `(7a-2b)` / `(6b)` /
`phase 2` references slipped past the original sweep — visible at
the time #610 landed but un-grepped because the regex didn't catch
them. The remote-build feature shipped end-to-end (#106 closed); a
maintainer reading the running code shouldn't have to translate
planning-doc slice labels to make sense of it.

### What's removed

- `esphome_device_builder/controllers/firmware/controller.py` — two `(7a-2b)` references and one `(7a-2a)` in the docstring describing the source-routed runner / dispatch-origin fields.
- `esphome_device_builder/controllers/remote_build/artifacts_download.py` — one `(6b)` in the reject-reason-codes comment.
- `tests/controllers/firmware/test_remote_runner.py` — `(7a-2b)` in the module docstring.
- `tests/controllers/firmware/test_traversal_validation.py` — `phase 2` in the bulk-validator docstring; replaced with "at enqueue time" which is what that slice referred to.

The legitimate runtime "phase" wording (the cancellation phase in `firmware/controller.py` at lines 1465 / 1478) stays — those describe the actual runner-phase concept, not planning-doc shorthand.

### Verified

- `grep -rnE "phase [0-9][a-z]?(-[0-9][a-z]?)?|\([0-9][a-z]-[0-9][a-z]?\)|\([0-9][a-z]\)"` across `esphome_device_builder/` + `tests/` Python files → only the runtime "phase" hits in firmware/controller.py + an unrelated `(1h)` time-unit literal in `test_remote_build_controller.py` remain.
- `pytest tests/controllers/firmware/test_remote_runner.py tests/controllers/firmware/test_traversal_validation.py` → 51 passed.

**Related issue or feature (if applicable):**

- follow-up to #610; no behavioural change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
