### PR TITLE
Split DevicesController: extract API encryption-key resolver

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -9,6 +9,9 @@ resolving after the subpackage split. Submodules:
 - ``helpers`` — pure free functions (``_remove_device_sidecars``,
   ``_apply_featured_presets``, ``_build_address_cache_args``,
   ``friendly_name_slugify`` re-export).
+- ``api_key`` — Native API encryption-key resolver
+  (in-process YAML loader fast path + ``esphome config``
+  subprocess fallback).
 - ``archive`` — archive / unarchive / delete helpers + the
   bulk-fan-out runner.
 - ``firmware_sync`` — firmware-job → device-state sync helpers

--- a/esphome_device_builder/controllers/devices/api_key.py
+++ b/esphome_device_builder/controllers/devices/api_key.py
@@ -1,0 +1,128 @@
+"""Native API encryption-key resolution for the devices controller."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+import yaml
+
+from ...helpers.device_yaml import get_api_encryption_key, load_device_yaml
+from ...helpers.subprocess import create_subprocess_exec
+
+if TYPE_CHECKING:
+    from .controller import DevicesController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def get_api_key(controller: DevicesController, configuration: str) -> dict[str, str]:
+    r"""
+    Return the resolved Native API encryption key for *configuration*.
+
+    Two-stage resolution:
+
+    1. Fast path — ``yaml_util.load_yaml`` + package merge in-process.
+       Resolves ``!secret`` / ``!include`` / packages the same way
+       the rest of the dashboard does. Covers the common case
+       (key directly in YAML or behind a ``!secret`` reference)
+       with no subprocess overhead.
+
+    2. Slow path — ``esphome --dashboard config <file> --show-secrets``
+       subprocess. Falls back here when the fast path returns ``""``,
+       which happens for configs whose key is constructed by an
+       ESPHome preprocessor feature the dashboard's loader doesn't
+       reproduce. The canonical example is Jinja-templated
+       packages (``api: |\\n  # set ns = ... ${ns.cfg}``) — issue
+       #437. ESPHome's full pipeline runs the Jinja step before
+       YAML parsing, so its ``config`` subcommand emits a
+       fully-resolved YAML on stdout that we parse to pull the
+       key out. Slow (~1s subprocess) but only on click, not per
+       scan, and only when the fast path fails.
+
+    ``{"key": "<base64 32-byte>"}`` on success; ``{"key": ""}`` when
+    both paths fail (no ``api:`` block, no ``encryption`` key, YAML
+    loading fails, or the subprocess errors out). Callers treat
+    the empty value as the "open the editor and check" signal.
+    """
+    path = controller._db.settings.rel_path(configuration)
+    loop = asyncio.get_running_loop()
+    config = await loop.run_in_executor(None, load_device_yaml, path)
+    key = get_api_encryption_key(config)
+    if key:
+        return {"key": key}
+    # Fast path missed — subprocess to ESPHome's full
+    # ``config`` pipeline (which runs the Jinja preprocessor
+    # over packages) and parse its resolved-YAML output.
+    key = await resolve_via_esphome_config(controller, configuration)
+    return {"key": key}
+
+
+async def resolve_via_esphome_config(controller: DevicesController, configuration: str) -> str:
+    r"""
+    Subprocess fallback for ``get_api_key``.
+
+    Runs ``esphome --dashboard config <path> --show-secrets``,
+    captures stdout, parses it as YAML, and returns
+    ``api.encryption.key`` if present. ``--show-secrets`` is
+    required: without it, ``esphome config`` wraps each
+    ``key`` value in the ANSI conceal SGR (``\\x1b[8m...\\x1b[28m``)
+    and ``yaml.safe_load`` would treat the wrapped string as the
+    key value. The wire form ESPHome emits when secrets are
+    shown is the literal base64 we want.
+
+    Returns ``""`` on any failure path: subprocess startup
+    failure (``controller._esphome_cmd`` empty / unreachable),
+    non-zero exit (config didn't validate), stdout that doesn't
+    parse as YAML, missing api / encryption block. The caller
+    rolls all of these into the documented "open the editor and
+    check" signal — there's no actionable distinction between
+    "config invalid" and "no encryption" at the API surface.
+    """
+    # Defensive ``getattr``: bypass-init controllers used by
+    # tests that don't go through ``start()`` (the
+    # ``make_controller`` factory in
+    # ``tests/controllers/devices/conftest.py``) don't set
+    # ``_esphome_cmd`` unless explicitly told to. Production
+    # always sets it in ``start()`` so the attribute is
+    # guaranteed there.
+    esphome_cmd: list[str] | None = getattr(controller, "_esphome_cmd", None)
+    if not esphome_cmd:
+        return ""
+    config_path = str(controller._db.settings.rel_path(configuration))
+    cmd = [*esphome_cmd, "--dashboard", "config", config_path, "--show-secrets"]
+    try:
+        proc = await create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout_bytes, _ = await proc.communicate()
+    except OSError as exc:
+        _LOGGER.debug("esphome config subprocess failed for %s: %s", configuration, exc)
+        return ""
+    if proc.returncode != 0:
+        _LOGGER.debug(
+            "esphome config returned %s for %s; key extraction skipped",
+            proc.returncode,
+            configuration,
+        )
+        return ""
+    try:
+        resolved = yaml.safe_load(stdout_bytes.decode("utf-8", errors="replace"))
+    except yaml.YAMLError as exc:
+        # ``str(yaml.YAMLError)`` includes context lines from
+        # the input, which were emitted with ``--show-secrets``
+        # and therefore carry the resolved Wi-Fi password,
+        # API key, etc. verbatim. Log only the exception class
+        # name so a malformed-output failure surfaces in debug
+        # logs without leaking those secrets into the operator's
+        # log scrape / support bundle.
+        _LOGGER.debug(
+            "esphome config output for %s did not parse as YAML (%s)",
+            configuration,
+            type(exc).__name__,
+        )
+        return ""
+    return get_api_encryption_key(resolved)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -16,7 +16,6 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-import yaml
 from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON
 from esphome.zeroconf import AsyncEsphomeZeroconf
@@ -28,8 +27,6 @@ from ...helpers.device_yaml import (
     configuration_stem,
     generate_device_yaml,
     generate_minimal_stub_yaml,
-    get_api_encryption_key,
-    load_device_yaml,
     parse_esphome_meta,
     parse_platform_from_yaml,
 )
@@ -74,7 +71,7 @@ from ..config import (
     set_device_metadata,
 )
 from ..firmware.helpers import _find_esphome_cmd
-from . import archive, firmware_sync, importable, reachability, storage_regen
+from . import api_key, archive, firmware_sync, importable, reachability, storage_regen
 from ._yaml_search import (
     DEFAULT_CONTEXT_LINES,
     MAX_CONTEXT_LINES,
@@ -1471,113 +1468,11 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
 
     @api_command("devices/get_api_key")
     async def get_api_key(self, *, configuration: str, **kwargs: Any) -> dict[str, str]:
-        r"""
-        Return the resolved Native API encryption key for *configuration*.
-
-        Two-stage resolution:
-
-        1. Fast path — ``yaml_util.load_yaml`` + package merge in-process.
-           Resolves ``!secret`` / ``!include`` / packages the same way
-           the rest of the dashboard does. Covers the common case
-           (key directly in YAML or behind a ``!secret`` reference)
-           with no subprocess overhead.
-
-        2. Slow path — ``esphome --dashboard config <file> --show-secrets``
-           subprocess. Falls back here when the fast path returns ``""``,
-           which happens for configs whose key is constructed by an
-           ESPHome preprocessor feature the dashboard's loader doesn't
-           reproduce. The canonical example is Jinja-templated
-           packages (``api: |\\n  # set ns = ... ${ns.cfg}``) — issue
-           #437. ESPHome's full pipeline runs the Jinja step before
-           YAML parsing, so its ``config`` subcommand emits a
-           fully-resolved YAML on stdout that we parse to pull the
-           key out. Slow (~1s subprocess) but only on click, not per
-           scan, and only when the fast path fails.
-
-        ``{"key": "<base64 32-byte>"}`` on success; ``{"key": ""}`` when
-        both paths fail (no ``api:`` block, no ``encryption`` key, YAML
-        loading fails, or the subprocess errors out). Callers treat
-        the empty value as the "open the editor and check" signal.
-        """
-        path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        config = await loop.run_in_executor(None, load_device_yaml, path)
-        key = get_api_encryption_key(config)
-        if key:
-            return {"key": key}
-        # Fast path missed — subprocess to ESPHome's full
-        # ``config`` pipeline (which runs the Jinja preprocessor
-        # over packages) and parse its resolved-YAML output.
-        key = await self._resolve_api_key_via_esphome_config(configuration)
-        return {"key": key}
+        """Return the resolved Native API encryption key for *configuration*."""
+        return await api_key.get_api_key(self, configuration)
 
     async def _resolve_api_key_via_esphome_config(self, configuration: str) -> str:
-        r"""
-        Subprocess fallback for ``get_api_key``.
-
-        Runs ``esphome --dashboard config <path> --show-secrets``,
-        captures stdout, parses it as YAML, and returns
-        ``api.encryption.key`` if present. ``--show-secrets`` is
-        required: without it, ``esphome config`` wraps each
-        ``key`` value in the ANSI conceal SGR (``\\x1b[8m...\\x1b[28m``)
-        and ``yaml.safe_load`` would treat the wrapped string as the
-        key value. The wire form ESPHome emits when secrets are
-        shown is the literal base64 we want.
-
-        Returns ``""`` on any failure path: subprocess startup
-        failure (``self._esphome_cmd`` empty / unreachable),
-        non-zero exit (config didn't validate), stdout that doesn't
-        parse as YAML, missing api / encryption block. The caller
-        rolls all of these into the documented "open the editor and
-        check" signal — there's no actionable distinction between
-        "config invalid" and "no encryption" at the API surface.
-        """
-        # Defensive ``getattr``: bypass-init controllers used by
-        # tests that don't go through ``start()`` (the
-        # ``make_controller`` factory in
-        # ``tests/controllers/devices/conftest.py``) don't set
-        # ``_esphome_cmd`` unless explicitly told to. Production
-        # always sets it in ``start()`` so the attribute is
-        # guaranteed there.
-        esphome_cmd: list[str] | None = getattr(self, "_esphome_cmd", None)
-        if not esphome_cmd:
-            return ""
-        config_path = str(self._db.settings.rel_path(configuration))
-        cmd = [*esphome_cmd, "--dashboard", "config", config_path, "--show-secrets"]
-        try:
-            proc = await create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            stdout_bytes, _ = await proc.communicate()
-        except OSError as exc:
-            _LOGGER.debug("esphome config subprocess failed for %s: %s", configuration, exc)
-            return ""
-        if proc.returncode != 0:
-            _LOGGER.debug(
-                "esphome config returned %s for %s; key extraction skipped",
-                proc.returncode,
-                configuration,
-            )
-            return ""
-        try:
-            resolved = yaml.safe_load(stdout_bytes.decode("utf-8", errors="replace"))
-        except yaml.YAMLError as exc:
-            # ``str(yaml.YAMLError)`` includes context lines from
-            # the input, which were emitted with ``--show-secrets``
-            # and therefore carry the resolved Wi-Fi password,
-            # API key, etc. verbatim. Log only the exception class
-            # name so a malformed-output failure surfaces in debug
-            # logs without leaking those secrets into the operator's
-            # log scrape / support bundle.
-            _LOGGER.debug(
-                "esphome config output for %s did not parse as YAML (%s)",
-                configuration,
-                type(exc).__name__,
-            )
-            return ""
-        return get_api_encryption_key(resolved)
+        return await api_key.resolve_via_esphome_config(self, configuration)
 
     @api_command("devices/add_component")
     async def add_component(

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -32,7 +32,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import esphome_device_builder.controllers.devices.controller as ctrl_mod
+import esphome_device_builder.controllers.devices.api_key as api_key_mod
 from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices.controller import StorageJSON
 from esphome_device_builder.helpers.event_bus import Event
@@ -333,7 +333,7 @@ async def test_get_api_key_falls_back_to_esphome_config_subprocess(
         return fake_proc
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(ctrl_mod, "create_subprocess_exec", _fake_create_subprocess)
+        mp.setattr(api_key_mod, "create_subprocess_exec", _fake_create_subprocess)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": "ZGFzaGJvYXJkLWtleS1mcm9tLWVzcGhvbWUtY29uZmln"}
@@ -367,7 +367,7 @@ async def test_get_api_key_subprocess_returns_empty_on_nonzero_exit(
         return fake_proc
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(ctrl_mod, "create_subprocess_exec", _fake_create_subprocess)
+        mp.setattr(api_key_mod, "create_subprocess_exec", _fake_create_subprocess)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}
@@ -399,7 +399,7 @@ async def test_get_api_key_subprocess_returns_empty_on_unparsable_yaml(
         return fake_proc
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(ctrl_mod, "create_subprocess_exec", _fake_create_subprocess)
+        mp.setattr(api_key_mod, "create_subprocess_exec", _fake_create_subprocess)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}
@@ -427,7 +427,7 @@ async def test_get_api_key_subprocess_returns_empty_on_oserror(
         raise OSError("simulated subprocess startup failure")
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(ctrl_mod, "create_subprocess_exec", _boom)
+        mp.setattr(api_key_mod, "create_subprocess_exec", _boom)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}
@@ -453,7 +453,7 @@ async def test_get_api_key_skips_subprocess_when_fast_path_finds_key(
     spawn_spy = AsyncMock()
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(ctrl_mod, "create_subprocess_exec", spawn_spy)
+        mp.setattr(api_key_mod, "create_subprocess_exec", spawn_spy)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": "a/c+inline-key=="}
@@ -485,7 +485,7 @@ async def test_get_api_key_fallback_skipped_when_esphome_cmd_unset(
     spawn_spy = AsyncMock()
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(ctrl_mod, "create_subprocess_exec", spawn_spy)
+        mp.setattr(api_key_mod, "create_subprocess_exec", spawn_spy)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}


### PR DESCRIPTION
# What does this implement/fix?

Continues the `controllers/devices/controller.py` size reduction (2412 → 2310 lines) by extracting the Native API encryption-key resolver into a sibling `api_key.py` module. Same shape as the prior splits in #663 / #667 / #670: free functions take `controller` as the first arg; the controller keeps thin bound-method delegates so WS dispatch and tests that reach in by attribute name continue to resolve.

`api_key.py` hosts the bodies of:

- `get_api_key` (the `devices/get_api_key` WS command) — the two-stage resolver: in-process YAML loader fast path, then the `esphome config --show-secrets` subprocess fallback for Jinja-templated package configs (issue #437).
- `resolve_via_esphome_config` — the subprocess fallback, formerly the private `_resolve_api_key_via_esphome_config` method.

Test patches that targeted `controller.create_subprocess_exec` inside the `get_api_key` flow are re-pointed at `api_key_mod` (six `mp.setattr` sites in `test_branches_coverage.py`). The sibling `_stream_subprocess` test in the same file keeps its patch pointed at `controller` because `_stream_subprocess` itself stays there.

3206 tests pass; pure refactor.

**Related issue or feature (if applicable):**

- follow-up to #670

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
