### PR TITLE
Tighten api_key.py docstrings and comments

### DIFF
--- a/esphome_device_builder/controllers/devices/api_key.py
+++ b/esphome_device_builder/controllers/devices/api_key.py
@@ -18,15 +18,14 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def get_api_key(controller: DevicesController, configuration: str) -> dict[str, str]:
-    """Return the resolved Native API encryption key for *configuration*.
+    """
+    Return the resolved Native API encryption key for *configuration*.
 
-    Tries the in-process YAML loader first; on miss falls back to
-    ``esphome config --show-secrets`` to cover configs whose key
-    is constructed by an ESPHome preprocessor feature the
-    in-process loader doesn't reproduce (Jinja-templated
-    ``packages``, issue #437). Returns ``{"key": ""}`` when both
-    paths fail; the caller treats that as the "open the editor
-    and check" signal.
+    Tries the in-process YAML loader first, then falls back to
+    ``esphome config --show-secrets`` for configs whose key is
+    constructed by Jinja-templated ``packages`` (issue #437).
+    Returns ``{"key": ""}`` when both paths fail; the caller
+    treats that as the "open the editor and check" signal.
     """
     path = controller._db.settings.rel_path(configuration)
     loop = asyncio.get_running_loop()
@@ -39,17 +38,16 @@ async def get_api_key(controller: DevicesController, configuration: str) -> dict
 
 
 async def resolve_via_esphome_config(controller: DevicesController, configuration: str) -> str:
-    r"""Subprocess fallback for :func:`get_api_key`.
+    r"""
+    Subprocess fallback for :func:`get_api_key`.
 
     ``--show-secrets`` is required: without it ESPHome wraps each
     secret value in the ANSI conceal SGR (``\x1b[8m...\x1b[28m``)
     and ``yaml.safe_load`` would treat the wrapped string as the
-    key. Returns ``""`` on every failure (no esphome cmd,
-    subprocess error, non-zero exit, unparsable stdout, missing
-    api / encryption block).
+    key. Returns ``""`` on every failure path.
     """
-    # Bypass-init test controllers don't set ``_esphome_cmd``;
-    # production always does in ``start()``.
+    # Defensive ``getattr``: bypass-init test controllers skip
+    # ``__init__`` (which is what creates the attribute).
     esphome_cmd: list[str] | None = getattr(controller, "_esphome_cmd", None)
     if not esphome_cmd:
         return ""

--- a/esphome_device_builder/controllers/devices/api_key.py
+++ b/esphome_device_builder/controllers/devices/api_key.py
@@ -18,33 +18,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def get_api_key(controller: DevicesController, configuration: str) -> dict[str, str]:
-    r"""
-    Return the resolved Native API encryption key for *configuration*.
+    """Return the resolved Native API encryption key for *configuration*.
 
-    Two-stage resolution:
-
-    1. Fast path — ``yaml_util.load_yaml`` + package merge in-process.
-       Resolves ``!secret`` / ``!include`` / packages the same way
-       the rest of the dashboard does. Covers the common case
-       (key directly in YAML or behind a ``!secret`` reference)
-       with no subprocess overhead.
-
-    2. Slow path — ``esphome --dashboard config <file> --show-secrets``
-       subprocess. Falls back here when the fast path returns ``""``,
-       which happens for configs whose key is constructed by an
-       ESPHome preprocessor feature the dashboard's loader doesn't
-       reproduce. The canonical example is Jinja-templated
-       packages (``api: |\\n  # set ns = ... ${ns.cfg}``) — issue
-       #437. ESPHome's full pipeline runs the Jinja step before
-       YAML parsing, so its ``config`` subcommand emits a
-       fully-resolved YAML on stdout that we parse to pull the
-       key out. Slow (~1s subprocess) but only on click, not per
-       scan, and only when the fast path fails.
-
-    ``{"key": "<base64 32-byte>"}`` on success; ``{"key": ""}`` when
-    both paths fail (no ``api:`` block, no ``encryption`` key, YAML
-    loading fails, or the subprocess errors out). Callers treat
-    the empty value as the "open the editor and check" signal.
+    Tries the in-process YAML loader first; on miss falls back to
+    ``esphome config --show-secrets`` to cover configs whose key
+    is constructed by an ESPHome preprocessor feature the
+    in-process loader doesn't reproduce (Jinja-templated
+    ``packages``, issue #437). Returns ``{"key": ""}`` when both
+    paths fail; the caller treats that as the "open the editor
+    and check" signal.
     """
     path = controller._db.settings.rel_path(configuration)
     loop = asyncio.get_running_loop()
@@ -52,41 +34,22 @@ async def get_api_key(controller: DevicesController, configuration: str) -> dict
     key = get_api_encryption_key(config)
     if key:
         return {"key": key}
-    # Fast path missed — subprocess to ESPHome's full
-    # ``config`` pipeline (which runs the Jinja preprocessor
-    # over packages) and parse its resolved-YAML output.
     key = await resolve_via_esphome_config(controller, configuration)
     return {"key": key}
 
 
 async def resolve_via_esphome_config(controller: DevicesController, configuration: str) -> str:
-    r"""
-    Subprocess fallback for ``get_api_key``.
+    r"""Subprocess fallback for :func:`get_api_key`.
 
-    Runs ``esphome --dashboard config <path> --show-secrets``,
-    captures stdout, parses it as YAML, and returns
-    ``api.encryption.key`` if present. ``--show-secrets`` is
-    required: without it, ``esphome config`` wraps each
-    ``key`` value in the ANSI conceal SGR (``\\x1b[8m...\\x1b[28m``)
+    ``--show-secrets`` is required: without it ESPHome wraps each
+    secret value in the ANSI conceal SGR (``\x1b[8m...\x1b[28m``)
     and ``yaml.safe_load`` would treat the wrapped string as the
-    key value. The wire form ESPHome emits when secrets are
-    shown is the literal base64 we want.
-
-    Returns ``""`` on any failure path: subprocess startup
-    failure (``controller._esphome_cmd`` empty / unreachable),
-    non-zero exit (config didn't validate), stdout that doesn't
-    parse as YAML, missing api / encryption block. The caller
-    rolls all of these into the documented "open the editor and
-    check" signal — there's no actionable distinction between
-    "config invalid" and "no encryption" at the API surface.
+    key. Returns ``""`` on every failure (no esphome cmd,
+    subprocess error, non-zero exit, unparsable stdout, missing
+    api / encryption block).
     """
-    # Defensive ``getattr``: bypass-init controllers used by
-    # tests that don't go through ``start()`` (the
-    # ``make_controller`` factory in
-    # ``tests/controllers/devices/conftest.py``) don't set
-    # ``_esphome_cmd`` unless explicitly told to. Production
-    # always sets it in ``start()`` so the attribute is
-    # guaranteed there.
+    # Bypass-init test controllers don't set ``_esphome_cmd``;
+    # production always does in ``start()``.
     esphome_cmd: list[str] | None = getattr(controller, "_esphome_cmd", None)
     if not esphome_cmd:
         return ""
@@ -112,13 +75,10 @@ async def resolve_via_esphome_config(controller: DevicesController, configuratio
     try:
         resolved = yaml.safe_load(stdout_bytes.decode("utf-8", errors="replace"))
     except yaml.YAMLError as exc:
-        # ``str(yaml.YAMLError)`` includes context lines from
-        # the input, which were emitted with ``--show-secrets``
-        # and therefore carry the resolved Wi-Fi password,
-        # API key, etc. verbatim. Log only the exception class
-        # name so a malformed-output failure surfaces in debug
-        # logs without leaking those secrets into the operator's
-        # log scrape / support bundle.
+        # Log the exception class only; ``str(yaml.YAMLError)``
+        # includes context lines from the ``--show-secrets``
+        # output, which carry resolved Wi-Fi passwords / API
+        # keys verbatim and would leak into log scrapes.
         _LOGGER.debug(
             "esphome config output for %s did not parse as YAML (%s)",
             configuration,


### PR DESCRIPTION
# What does this implement/fix?

Style cleanup pass on `controllers/devices/api_key.py` (landed in #672) to bring the docstrings and inline comments into line with the conventions the sibling submodules follow. No behaviour change.

Specifically:

- **`get_api_key` docstring** collapsed from a numbered two-stage framing to three sentences. Kept the load-bearing why (Jinja-templated `packages`, issue #437) and the empty-key sentinel contract that callers depend on.
- **`resolve_via_esphome_config` docstring** trimmed. The `--show-secrets` ANSI-conceal-SGR rationale stays since that is genuinely non-obvious; the failure-path enumeration collapses to one sentence.
- **Defensive `getattr` comment** on `_esphome_cmd` shrunk to one line; the bypass-init test factory rationale is the load-bearing bit, the rest paraphrased the call site.
- **Inline "fast path missed" comment** dropped; the call line immediately below is self-describing.
- **`yaml.YAMLError` redaction comment** kept (real security rationale: avoid leaking resolved secrets into log scrapes) but tightened to four lines.
- **Em-dashes** replaced with semicolons / commas.

`api_key.py` drops 130 → 90 lines (most of that is removed comment churn). 3206 tests pass.

**Related issue or feature (if applicable):**

- follow-up to #672

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
