### PR TITLE
Accept a network interface name for --host / --ingress-host / --remote-build-host

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -285,6 +285,10 @@ Both gates apply only to requests that carry an `Origin` header. Browsers always
 
 Match is case-insensitive and port-tolerant: `dashboard.example.com` accepts `Dashboard.Example.com:8443`. IPv6 may be entered with or without brackets (`::1` and `[::1]` both work). Use `*` as the only entry to opt out of the Host restriction while still permitting cross-origin handshakes (handy when the Host varies per request).
 
+### Binding to a network interface name
+
+`--host`, `--ingress-host`, and `--remote-build-host` each accept either an IP literal (the usual `0.0.0.0` / `127.0.0.1` / a specific LAN IP) or a **local network interface name** (`eth0`, `wlan0`, `lo`, …). When the value matches an interface present on the host, the bind expands to every IPv4 / IPv6 address currently assigned to that interface.
+
 ## Discovery (mDNS)
 
 Two mDNS surfaces ride the same `AsyncEsphomeZeroconf` instance the device state monitor already owns. Sharing one Zeroconf singleton matters: opening a second responder fights for the same multicast socket and silently drops half the packets.

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -123,7 +123,7 @@ def main() -> None:
         default=DEFAULT_HOST,
         help=(
             "Host/IP to bind to. Accepts an IP literal, a hostname, or a "
-            "local network interface name (e.g. ``eth0``) — the latter "
+            "local network interface name (e.g. 'eth0'); an interface name "
             "binds to every IPv4 / IPv6 address currently assigned to "
             "that interface. Useful in Docker host-network mode where "
             "the container's LAN IP isn't known in advance"
@@ -156,7 +156,7 @@ def main() -> None:
         help=(
             "Bind address for the HA Ingress site (defaults to all interfaces "
             "inside the addon container). Accepts an IP literal or a local "
-            "network interface name (e.g. ``eth0``)"
+            "network interface name (e.g. 'eth0')"
         ),
     )
     parser.add_argument(
@@ -186,14 +186,14 @@ def main() -> None:
         help=(
             "Bind address for the remote-build peer-link receiver. "
             "Defaults to 0.0.0.0 (all interfaces) so paired peers on "
-            "the LAN can reach the receiver — the peer-link's "
+            "the LAN can reach the receiver; the peer-link's "
             "security is Noise + pre-shared pin, independent of bind "
             "address. Override (e.g. 127.0.0.1) only if you want to "
             "restrict the receiver to a specific interface. Accepts an "
             "IP literal or a local network interface name (e.g. "
-            "``eth0``) — the latter binds to every IPv4 / IPv6 address "
-            "currently assigned to that interface. Falls back to "
-            "$ESPHOME_REMOTE_BUILD_HOST when unset. Only bound when "
+            "'eth0'); an interface name binds to every IPv4 / IPv6 "
+            "address currently assigned to that interface. Falls back "
+            "to $ESPHOME_REMOTE_BUILD_HOST when unset. Only bound when "
             "remote-build is enabled in Settings"
         ),
     )

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -118,7 +118,17 @@ def main() -> None:
         help="Path to the ESPHome configuration directory",
     )
     parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="HTTP port to listen on")
-    parser.add_argument("--host", default=DEFAULT_HOST, help="Host/IP to bind to")
+    parser.add_argument(
+        "--host",
+        default=DEFAULT_HOST,
+        help=(
+            "Host/IP to bind to. Accepts an IP literal, a hostname, or a "
+            "local network interface name (e.g. ``eth0``) — the latter "
+            "binds to every IPv4 / IPv6 address currently assigned to "
+            "that interface. Useful in Docker host-network mode where "
+            "the container's LAN IP isn't known in advance"
+        ),
+    )
     parser.add_argument(
         "--username",
         default="",
@@ -145,7 +155,8 @@ def main() -> None:
         default="",
         help=(
             "Bind address for the HA Ingress site (defaults to all interfaces "
-            "inside the addon container)"
+            "inside the addon container). Accepts an IP literal or a local "
+            "network interface name (e.g. ``eth0``)"
         ),
     )
     parser.add_argument(
@@ -178,9 +189,12 @@ def main() -> None:
             "the LAN can reach the receiver — the peer-link's "
             "security is Noise + pre-shared pin, independent of bind "
             "address. Override (e.g. 127.0.0.1) only if you want to "
-            "restrict the receiver to a specific interface. Falls "
-            "back to $ESPHOME_REMOTE_BUILD_HOST when unset. Only "
-            "bound when remote-build is enabled in Settings"
+            "restrict the receiver to a specific interface. Accepts an "
+            "IP literal or a local network interface name (e.g. "
+            "``eth0``) — the latter binds to every IPv4 / IPv6 address "
+            "currently assigned to that interface. Falls back to "
+            "$ESPHOME_REMOTE_BUILD_HOST when unset. Only bound when "
+            "remote-build is enabled in Settings"
         ),
     )
     parser.add_argument(

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -91,7 +91,10 @@ class DashboardSettings:
     # ``127.0.0.1`` (desktop app loopback security model) while the
     # peer-link still needs to be LAN-reachable. Operators who want
     # to lock the receiver to a specific NIC can override via
-    # ``--remote-build-host`` / ``$ESPHOME_REMOTE_BUILD_HOST``.
+    # ``--remote-build-host`` / ``$ESPHOME_REMOTE_BUILD_HOST``. Accepts
+    # an IP literal or a local interface name (e.g. ``eth0``); the
+    # latter is resolved at bind time to every IPv4 / IPv6 address
+    # on the interface (see :func:`helpers.network_interfaces.resolve_bind_host`).
     remote_build_host: str = "0.0.0.0"
     # In dev mode the SPA shell is served with ``Cache-Control: no-cache``
     # so a re-deployed wheel isn't masked by a browser-cached

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -1091,6 +1091,24 @@ class DeviceBuilder:
         assert loop is not None  # caller-checked
         assert self.remote_build_receiver is not None  # caller-checked
 
+        # Validation runs before any resources are acquired: each
+        # ``TCPSite(port=0)`` would get its own OS-assigned port,
+        # but only one port can be carried in the mDNS
+        # ``remote_build_port`` TXT field. Reusing the first site's
+        # port for subsequent binds isn't safe either — the OS
+        # doesn't guarantee it's free on the second adapter. Fail
+        # loud here so the caller's fail-soft handler logs and the
+        # dashboard keeps running without a receiver listener.
+        configured_port = self.settings.remote_build_port
+        hosts = resolve_bind_host(self.settings.remote_build_host)
+        if configured_port == 0 and len(hosts) > 1:
+            raise RuntimeError(
+                "Refusing to bind: --remote-build-port 0 (ephemeral) is "
+                "incompatible with --remote-build-host resolving to "
+                f"multiple addresses ({hosts!r}). Pick a fixed port, or "
+                "pass a single IP literal."
+            )
+
         runner: web.AppRunner | None = None
         try:
             identity = await self.peer_link_identity_store.async_load()
@@ -1106,7 +1124,6 @@ class DeviceBuilder:
 
             runner = web.AppRunner(app)
             await runner.setup()
-            configured_port = self.settings.remote_build_port
             # ``reuse_address=True`` is the asyncio default on POSIX
             # but defaults to False on Windows; pin it explicitly so
             # the rotation rebuild path
@@ -1115,23 +1132,6 @@ class DeviceBuilder:
             # (default 6055) cross-platform. The ephemeral-port test
             # path masks this risk because the OS picks a fresh port
             # each rebuild; production deploys with a fixed port.
-            hosts = resolve_bind_host(self.settings.remote_build_host)
-            # Ephemeral port + multi-host fan-out is refused: each
-            # ``TCPSite(port=0)`` would get its own OS-assigned port,
-            # but only one port can be carried in the mDNS
-            # ``remote_build_port`` TXT field. Reusing the first
-            # site's port for subsequent binds isn't safe either —
-            # the OS doesn't guarantee it's free on the second
-            # adapter. Fail loud at startup; the operator picks an
-            # IP literal or a fixed port (Copilot review on PR
-            # #674).
-            if configured_port == 0 and len(hosts) > 1:
-                raise RuntimeError(
-                    "Refusing to bind: --remote-build-port 0 (ephemeral) is "
-                    "incompatible with --remote-build-host resolving to "
-                    f"multiple addresses ({hosts!r}). Pick a fixed port, or "
-                    "pass a single IP literal."
-                )
             for host in hosts:
                 site = web.TCPSite(
                     runner,

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -50,7 +50,7 @@ from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.dashboard_identity import get_or_create_identity as get_or_create_dashboard_identity
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware
-from .helpers.network_interfaces import resolve_bind_host
+from .helpers.network_interfaces import ensure_single_host_for_ephemeral_port, resolve_bind_host
 from .helpers.peer_link_identity import PeerLinkIdentityStore
 from .helpers.subscriber_presence import SubscriberPresence
 from .models import EventType
@@ -766,18 +766,30 @@ class DeviceBuilder:
 
     async def _start_ingress_site(self, _: web.Application) -> None:
         """Start the trusted HA Ingress TCP site alongside the public site."""
+        hosts = resolve_bind_host(self.settings.ingress_host or "0.0.0.0")
+        ensure_single_host_for_ephemeral_port(hosts, self.settings.ingress_port, "--ingress-port")
         ingress_app = self.create_app(trusted=True, with_lifecycle=False)
         runner = web.AppRunner(ingress_app)
         await runner.setup()
-        hosts = resolve_bind_host(self.settings.ingress_host or "0.0.0.0")
-        for host in hosts:
-            site = web.TCPSite(runner, host, self.settings.ingress_port)
-            await site.start()
-            _LOGGER.info(
-                "Ingress site listening on %s:%d (trusted, bypasses auth)",
-                host,
-                self.settings.ingress_port,
-            )
+        # Partial-bind cleanup: a multi-host expansion can succeed
+        # on host[0] and fail on host[1]; without this guard the
+        # runner (still owning the host[0] socket) would go out of
+        # scope before ``self._ingress_runner`` is assigned, so
+        # ``_stop_ingress_site`` would see ``None`` and leak the
+        # bound port until process exit.
+        try:
+            for host in hosts:
+                site = web.TCPSite(runner, host, self.settings.ingress_port)
+                await site.start()
+                _LOGGER.info(
+                    "Ingress site listening on %s:%d (trusted, bypasses auth)",
+                    host,
+                    self.settings.ingress_port,
+                )
+        except Exception:
+            with contextlib.suppress(Exception):
+                await runner.cleanup()
+            raise
         self._ingress_runner = runner
 
     async def _stop_ingress_site(self, _: web.Application) -> None:
@@ -1091,23 +1103,13 @@ class DeviceBuilder:
         assert loop is not None  # caller-checked
         assert self.remote_build_receiver is not None  # caller-checked
 
-        # Validation runs before any resources are acquired: each
-        # ``TCPSite(port=0)`` would get its own OS-assigned port,
-        # but only one port can be carried in the mDNS
-        # ``remote_build_port`` TXT field. Reusing the first site's
-        # port for subsequent binds isn't safe either — the OS
-        # doesn't guarantee it's free on the second adapter. Fail
-        # loud here so the caller's fail-soft handler logs and the
-        # dashboard keeps running without a receiver listener.
+        # Validate before acquiring resources so the caller's
+        # fail-soft handler logs cleanly. The mDNS ``remote_build_port``
+        # TXT field only carries one port, so a multi-host expansion
+        # combined with an ephemeral port has no safe answer.
         configured_port = self.settings.remote_build_port
         hosts = resolve_bind_host(self.settings.remote_build_host)
-        if configured_port == 0 and len(hosts) > 1:
-            raise RuntimeError(
-                "Refusing to bind: --remote-build-port 0 (ephemeral) is "
-                "incompatible with --remote-build-host resolving to "
-                f"multiple addresses ({hosts!r}). Pick a fixed port, or "
-                "pass a single IP literal."
-            )
+        ensure_single_host_for_ephemeral_port(hosts, configured_port, "--remote-build-port")
 
         runner: web.AppRunner | None = None
         try:

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -50,6 +50,7 @@ from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.dashboard_identity import get_or_create_identity as get_or_create_dashboard_identity
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware
+from .helpers.network_interfaces import resolve_bind_host
 from .helpers.peer_link_identity import PeerLinkIdentityStore
 from .helpers.subscriber_presence import SubscriberPresence
 from .models import EventType
@@ -768,15 +769,16 @@ class DeviceBuilder:
         ingress_app = self.create_app(trusted=True, with_lifecycle=False)
         runner = web.AppRunner(ingress_app)
         await runner.setup()
-        host = self.settings.ingress_host or "0.0.0.0"
-        site = web.TCPSite(runner, host, self.settings.ingress_port)
-        await site.start()
+        hosts = resolve_bind_host(self.settings.ingress_host or "0.0.0.0")
+        for host in hosts:
+            site = web.TCPSite(runner, host, self.settings.ingress_port)
+            await site.start()
+            _LOGGER.info(
+                "Ingress site listening on %s:%d (trusted, bypasses auth)",
+                host,
+                self.settings.ingress_port,
+            )
         self._ingress_runner = runner
-        _LOGGER.info(
-            "Ingress site listening on %s:%d (trusted, bypasses auth)",
-            host,
-            self.settings.ingress_port,
-        )
 
     async def _stop_ingress_site(self, _: web.Application) -> None:
         if self._ingress_runner is not None:
@@ -1113,13 +1115,14 @@ class DeviceBuilder:
             # (default 6055) cross-platform. The ephemeral-port test
             # path masks this risk because the OS picks a fresh port
             # each rebuild; production deploys with a fixed port.
-            site = web.TCPSite(
-                runner,
-                self.settings.remote_build_host,
-                configured_port,
-                reuse_address=True,
-            )
-            await site.start()
+            for host in resolve_bind_host(self.settings.remote_build_host):
+                site = web.TCPSite(
+                    runner,
+                    host,
+                    configured_port,
+                    reuse_address=True,
+                )
+                await site.start()
         except Exception:
             if runner is not None:
                 with contextlib.suppress(Exception):
@@ -1191,7 +1194,7 @@ class DeviceBuilder:
             app = self.create_app(trusted=True, with_ingress_site=False)
             web.run_app(
                 app,
-                host=settings.ingress_host or "0.0.0.0",
+                host=resolve_bind_host(settings.ingress_host or "0.0.0.0"),
                 port=settings.ingress_port,
                 shutdown_timeout=_SHUTDOWN_TIMEOUT_SECONDS,
             )
@@ -1199,7 +1202,7 @@ class DeviceBuilder:
         app = self.create_app()
         web.run_app(
             app,
-            host=settings.host,
+            host=resolve_bind_host(settings.host),
             port=settings.port,
             shutdown_timeout=_SHUTDOWN_TIMEOUT_SECONDS,
         )

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -1115,7 +1115,24 @@ class DeviceBuilder:
             # (default 6055) cross-platform. The ephemeral-port test
             # path masks this risk because the OS picks a fresh port
             # each rebuild; production deploys with a fixed port.
-            for host in resolve_bind_host(self.settings.remote_build_host):
+            hosts = resolve_bind_host(self.settings.remote_build_host)
+            # Ephemeral port + multi-host fan-out is refused: each
+            # ``TCPSite(port=0)`` would get its own OS-assigned port,
+            # but only one port can be carried in the mDNS
+            # ``remote_build_port`` TXT field. Reusing the first
+            # site's port for subsequent binds isn't safe either —
+            # the OS doesn't guarantee it's free on the second
+            # adapter. Fail loud at startup; the operator picks an
+            # IP literal or a fixed port (Copilot review on PR
+            # #674).
+            if configured_port == 0 and len(hosts) > 1:
+                raise RuntimeError(
+                    "Refusing to bind: --remote-build-port 0 (ephemeral) is "
+                    "incompatible with --remote-build-host resolving to "
+                    f"multiple addresses ({hosts!r}). Pick a fixed port, or "
+                    "pass a single IP literal."
+                )
+            for host in hosts:
                 site = web.TCPSite(
                     runner,
                     host,

--- a/esphome_device_builder/helpers/network_interfaces.py
+++ b/esphome_device_builder/helpers/network_interfaces.py
@@ -14,9 +14,7 @@ for the legacy Tornado dashboard.
 
 from __future__ import annotations
 
-import socket
-
-import psutil
+import ifaddr
 
 
 def resolve_bind_host(host: str) -> list[str]:
@@ -25,23 +23,21 @@ def resolve_bind_host(host: str) -> list[str]:
 
     Raises :class:`OSError` when *host* names an interface with no bindable address.
     """
-    addrs = psutil.net_if_addrs().get(host)
-    if addrs is None:
+    adapter = next(
+        (a for a in ifaddr.get_adapters() if host in (a.name, a.nice_name)),
+        None,
+    )
+    if adapter is None:
         return [host]
 
     out: list[str] = []
-    for addr in addrs:
-        if addr.family == socket.AF_INET:
-            out.append(addr.address)
-        elif addr.family == socket.AF_INET6:
-            address = addr.address
-            # Link-local IPv6 (fe80::/10) is per-interface; the
-            # kernel needs a zone identifier to disambiguate which
-            # interface to send through. psutil sometimes already
-            # carries one (``fe80::1%eth0``) on some platforms; skip
-            # when present.
-            if address.lower().startswith("fe80:") and "%" not in address:
-                address = f"{address}%{socket.if_nametoindex(host)}"
+    for ip in adapter.ips:
+        if ip.is_IPv4:
+            out.append(str(ip.ip))
+        elif ip.is_IPv6:
+            address, _flowinfo, scope_id = ip.ip
+            if scope_id:
+                address = f"{address}%{scope_id}"
             out.append(address)
 
     if not out:

--- a/esphome_device_builder/helpers/network_interfaces.py
+++ b/esphome_device_builder/helpers/network_interfaces.py
@@ -23,21 +23,7 @@ caller that hits a hot path should route through
 
 from __future__ import annotations
 
-import logging
-
 import ifaddr
-
-_LOGGER = logging.getLogger(__name__)
-
-
-_WELL_KNOWN_HOSTNAMES = frozenset({"localhost"})
-
-
-def _looks_like_interface_name(host: str) -> bool:
-    """Return True when *host* is shaped like a NIC name (no dots, no colons)."""
-    if not host or host in _WELL_KNOWN_HOSTNAMES:
-        return False
-    return "." not in host and ":" not in host
 
 
 def resolve_bind_host(host: str) -> list[str]:
@@ -51,18 +37,6 @@ def resolve_bind_host(host: str) -> list[str]:
         None,
     )
     if adapter is None:
-        if _looks_like_interface_name(host):
-            # Plausible NIC-shaped string that didn't match any
-            # adapter — almost certainly a typo (``eth01`` vs
-            # ``eth0``). The bind below will surface ``gaierror``
-            # which is opaque; log up front so the operator sees
-            # what happened.
-            _LOGGER.warning(
-                "Host %r did not match any local network interface; "
-                "treating as a literal hostname. Run ``ip link`` (or "
-                "``ipconfig``) to confirm the interface name.",
-                host,
-            )
         return [host]
 
     out: list[str] = []

--- a/esphome_device_builder/helpers/network_interfaces.py
+++ b/esphome_device_builder/helpers/network_interfaces.py
@@ -1,25 +1,48 @@
 """Resolve a NIC name into the IP addresses to bind to.
 
 When ``--host`` (or ``--ingress-host`` / ``--remote-build-host``)
-is given an interface name like ``eth0`` instead of an IP, we want
+is given an interface name like 'eth0' instead of an IP, we want
 to bind the listener to every IPv4 / IPv6 address the kernel has
 assigned to that interface. Useful inside Docker host-network mode
-on a multi-homed host where the LAN IP isn't known in advance —
+on a multi-homed host where the LAN IP isn't known in advance;
 the operator points at the interface, the listener follows
 whatever addresses it currently carries.
 
 Inspired by esphome/esphome#15485, which solved the same problem
 for the legacy Tornado dashboard.
+
+The resolution is one-shot at startup. ``ifaddr.get_adapters``
+is blocking I/O (reads /proc/net on Linux, calls
+``GetAdaptersAddresses`` on Windows), but callers run it
+synchronously off the event loop in startup paths only; a
+one-shot syscall scan during bind is acceptable. Any new async
+caller that hits a hot path should route through
+``loop.run_in_executor`` to match the convention in
+``dashboard_advertise.py``.
 """
 
 from __future__ import annotations
 
+import logging
+
 import ifaddr
+
+_LOGGER = logging.getLogger(__name__)
+
+
+_WELL_KNOWN_HOSTNAMES = frozenset({"localhost"})
+
+
+def _looks_like_interface_name(host: str) -> bool:
+    """Return True when *host* is shaped like a NIC name (no dots, no colons)."""
+    if not host or host in _WELL_KNOWN_HOSTNAMES:
+        return False
+    return "." not in host and ":" not in host
 
 
 def resolve_bind_host(host: str) -> list[str]:
     """
-    Return the bind targets for *host* — verbatim, or the NIC's IPs.
+    Return the bind targets for *host* (verbatim, or the NIC's IPs).
 
     Raises :class:`OSError` when *host* names an interface with no bindable address.
     """
@@ -28,6 +51,18 @@ def resolve_bind_host(host: str) -> list[str]:
         None,
     )
     if adapter is None:
+        if _looks_like_interface_name(host):
+            # Plausible NIC-shaped string that didn't match any
+            # adapter — almost certainly a typo (``eth01`` vs
+            # ``eth0``). The bind below will surface ``gaierror``
+            # which is opaque; log up front so the operator sees
+            # what happened.
+            _LOGGER.warning(
+                "Host %r did not match any local network interface; "
+                "treating as a literal hostname. Run ``ip link`` (or "
+                "``ipconfig``) to confirm the interface name.",
+                host,
+            )
         return [host]
 
     out: list[str] = []
@@ -48,3 +83,21 @@ def resolve_bind_host(host: str) -> list[str]:
         )
 
     return out
+
+
+def ensure_single_host_for_ephemeral_port(hosts: list[str], port: int, flag: str) -> None:
+    """
+    Refuse ephemeral-port (port=0) bind when *hosts* expands to more than one address.
+
+    Each ``TCPSite(port=0)`` gets its own OS-assigned port, but
+    callers that advertise the bound port elsewhere (e.g. the
+    mDNS ``remote_build_port`` TXT) only carry one. Reusing the
+    first site's port for subsequent binds isn't safe either,
+    the OS doesn't guarantee it's free on the second adapter.
+    """
+    if port == 0 and len(hosts) > 1:
+        raise RuntimeError(
+            f"Refusing to bind: {flag} 0 (ephemeral) is incompatible "
+            f"with the host argument resolving to multiple addresses "
+            f"({hosts!r}). Pick a fixed port, or pass a single IP literal."
+        )

--- a/esphome_device_builder/helpers/network_interfaces.py
+++ b/esphome_device_builder/helpers/network_interfaces.py
@@ -1,0 +1,54 @@
+"""Resolve a NIC name into the IP addresses to bind to.
+
+When ``--host`` (or ``--ingress-host`` / ``--remote-build-host``)
+is given an interface name like ``eth0`` instead of an IP, we want
+to bind the listener to every IPv4 / IPv6 address the kernel has
+assigned to that interface. Useful inside Docker host-network mode
+on a multi-homed host where the LAN IP isn't known in advance —
+the operator points at the interface, the listener follows
+whatever addresses it currently carries.
+
+Inspired by esphome/esphome#15485, which solved the same problem
+for the legacy Tornado dashboard.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import psutil
+
+
+def resolve_bind_host(host: str) -> list[str]:
+    """
+    Return the bind targets for *host* — verbatim, or the NIC's IPs.
+
+    Raises :class:`OSError` when *host* names an interface with no bindable address.
+    """
+    addrs = psutil.net_if_addrs().get(host)
+    if addrs is None:
+        return [host]
+
+    out: list[str] = []
+    for addr in addrs:
+        if addr.family == socket.AF_INET:
+            out.append(addr.address)
+        elif addr.family == socket.AF_INET6:
+            address = addr.address
+            # Link-local IPv6 (fe80::/10) is per-interface; the
+            # kernel needs a zone identifier to disambiguate which
+            # interface to send through. psutil sometimes already
+            # carries one (``fe80::1%eth0``) on some platforms; skip
+            # when present.
+            if address.lower().startswith("fe80:") and "%" not in address:
+                address = f"{address}%{socket.if_nametoindex(host)}"
+            out.append(address)
+
+    if not out:
+        raise OSError(
+            f"Network interface {host!r} has no bindable IPv4/IPv6 address; "
+            "refusing to start. Bring the interface up, assign an address, "
+            "or pass an IP literal instead."
+        )
+
+    return out

--- a/esphome_device_builder/helpers/network_interfaces.py
+++ b/esphome_device_builder/helpers/network_interfaces.py
@@ -32,13 +32,13 @@ def resolve_bind_host(host: str) -> list[str]:
 
     out: list[str] = []
     for ip in adapter.ips:
-        if ip.is_IPv4:
-            out.append(str(ip.ip))
-        elif ip.is_IPv6:
-            address, _flowinfo, scope_id = ip.ip
-            if scope_id:
-                address = f"{address}%{scope_id}"
-            out.append(address)
+        match ip.ip:
+            case str() as address:
+                out.append(address)
+            case (address, _flowinfo, scope_id):
+                if scope_id:
+                    address = f"{address}%{scope_id}"
+                out.append(address)
 
     if not out:
         raise OSError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "cryptography>=42.0.2",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
+  "psutil>=5.9.0",
   "pyyaml>=6.0",
   # ESPHome already ships ruamel.yaml as a transitive dependency,
   # but the automations editor's parse / upsert path imports it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ dependencies = [
   "aiohttp-asyncmdnsresolver>=0.1.1",
   "colorlog>=6.8.0",
   "cryptography>=42.0.2",
+  "ifaddr>=0.2.0",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
-  "psutil>=5.9.0",
   "pyyaml>=6.0",
   # ESPHome already ships ruamel.yaml as a transitive dependency,
   # but the automations editor's parse / upsert path imports it

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -21,6 +21,7 @@ import builtins
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from aiohttp import web
 
 from esphome_device_builder.device_builder import DeviceBuilder
 
@@ -210,6 +211,71 @@ async def test_start_and_stop_ingress_site_lifecycle(make_settings: MakeSettings
 
     # And shutting it down releases the bind.
     await db._stop_ingress_site(fake_app)  # type: ignore[arg-type]
+    assert db._ingress_runner is None
+
+
+async def test_start_ingress_site_cleans_up_runner_on_partial_bind_failure(
+    make_settings: MakeSettingsFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial multi-host bind failure releases the half-bound runner."""
+    db = _make_db(make_settings, on_ha_addon=True, using_password=True)
+    db.settings.ingress_port = 6053  # fixed port; multi-host expansion is allowed
+
+    monkeypatch.setattr(
+        "esphome_device_builder.device_builder.resolve_bind_host",
+        lambda _: ["127.0.0.1", "127.0.0.1"],
+    )
+
+    real_start = web.TCPSite.start
+    calls: list[web.TCPSite] = []
+
+    async def flaky_start(self: web.TCPSite) -> None:
+        calls.append(self)
+        if len(calls) == 1:
+            await real_start(self)
+            return
+        raise OSError("simulated second-bind failure")
+
+    cleanup_calls: list[web.AppRunner] = []
+    real_cleanup = web.AppRunner.cleanup
+
+    async def tracking_cleanup(self: web.AppRunner) -> None:
+        cleanup_calls.append(self)
+        await real_cleanup(self)
+
+    monkeypatch.setattr(web.TCPSite, "start", flaky_start)
+    monkeypatch.setattr(web.AppRunner, "cleanup", tracking_cleanup)
+
+    fake_app: object = object()
+    with pytest.raises(OSError, match="simulated second-bind failure"):
+        await db._start_ingress_site(fake_app)  # type: ignore[arg-type]
+
+    # Runner attribute never assigned; the half-bound runner was
+    # cleaned up inline so ``_stop_ingress_site`` doesn't get a
+    # chance to see it.
+    assert db._ingress_runner is None
+    assert len(calls) == 2, "expected the second bind to be attempted"
+    assert len(cleanup_calls) == 1, "expected the half-bound runner to be cleaned up"
+
+
+async def test_start_ingress_site_refuses_port_zero_with_multi_host(
+    make_settings: MakeSettingsFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--ingress-port 0`` paired with a multi-address NIC refuses to bind."""
+    db = _make_db(make_settings, on_ha_addon=True, using_password=True)
+    db.settings.ingress_port = 0
+
+    monkeypatch.setattr(
+        "esphome_device_builder.device_builder.resolve_bind_host",
+        lambda _: ["192.168.1.10", "192.168.1.11"],
+    )
+
+    fake_app: object = object()
+    with pytest.raises(RuntimeError, match=r"--ingress-port 0 .* multiple addresses"):
+        await db._start_ingress_site(fake_app)  # type: ignore[arg-type]
+
     assert db._ingress_runner is None
 
 

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -72,7 +72,7 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(
 
     captured: dict[str, object] = {}
 
-    def fake_run_app(app, *, host: str, port: int, **_: object) -> None:
+    def fake_run_app(app, *, host: list[str], port: int, **_: object) -> None:
         captured["host"] = host
         captured["port"] = port
         captured["trusted"] = bool(app.get("trusted_site"))
@@ -86,7 +86,10 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(
 
     # Only the ingress site got bound — public port was suppressed.
     assert captured["port"] == 6053  # ingress_port
-    assert captured["host"] == "0.0.0.0"  # ingress_host fallback
+    # ``host`` is now always a list — ``resolve_bind_host`` wraps
+    # literals in a singleton so the bind code can fan out
+    # uniformly when the operator passes an interface name.
+    assert captured["host"] == ["0.0.0.0"]  # ingress_host fallback
     assert captured["trusted"] is True  # trusted=True (auth bypass)
 
     # The single create_app call was for the trusted ingress, with
@@ -146,7 +149,7 @@ def test_ha_addon_with_password_binds_public_site_normally(
 
     captured: dict[str, object] = {}
 
-    def fake_run_app(app, *, host: str, port: int, **_: object) -> None:
+    def fake_run_app(app, *, host: list[str], port: int, **_: object) -> None:
         captured["host"] = host
         captured["port"] = port
         captured["trusted"] = bool(app.get("trusted_site"))
@@ -156,7 +159,7 @@ def test_ha_addon_with_password_binds_public_site_normally(
 
     # Public port bound (auth gates it via using_password).
     assert captured["port"] == 6052
-    assert captured["host"] == "0.0.0.0"
+    assert captured["host"] == ["0.0.0.0"]
     assert captured["trusted"] is False
 
 
@@ -171,7 +174,7 @@ def test_non_ha_addon_binds_public_site_normally(make_settings: MakeSettingsFact
 
     captured: dict[str, object] = {}
 
-    def fake_run_app(app, *, host: str, port: int, **_: object) -> None:
+    def fake_run_app(app, *, host: list[str], port: int, **_: object) -> None:
         captured["host"] = host
         captured["port"] = port
 
@@ -181,7 +184,7 @@ def test_non_ha_addon_binds_public_site_normally(make_settings: MakeSettingsFact
     # Public port bound — non-add-on deployments get the legacy
     # default of "no auth required, user opts in via PASSWORD".
     assert captured["port"] == 6052
-    assert captured["host"] == "0.0.0.0"
+    assert captured["host"] == ["0.0.0.0"]
 
 
 async def test_start_and_stop_ingress_site_lifecycle(make_settings: MakeSettingsFactory) -> None:

--- a/tests/test_network_interfaces.py
+++ b/tests/test_network_interfaces.py
@@ -2,14 +2,13 @@
 
 Pins the contract: an IP literal or hostname is returned
 unchanged; a known interface name expands to its IPv4 + IPv6
-addresses (link-local IPv6 gets a zone-index suffix); a known
-interface with no bindable address raises ``OSError`` rather
-than silently falling through to a bind on nothing.
+addresses (link-local IPv6 gets the kernel-reported zone suffix);
+a known interface with no bindable address raises ``OSError``
+rather than silently falling through to a bind on nothing.
 """
 
 from __future__ import annotations
 
-import socket
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -18,17 +17,36 @@ import pytest
 from esphome_device_builder.helpers.network_interfaces import resolve_bind_host
 
 
-def _addr(family: int, address: str) -> SimpleNamespace:
-    """Psutil ``snicaddr``-shaped stub (only the fields we read)."""
-    return SimpleNamespace(family=family, address=address)
+def _ipv4(address: str) -> SimpleNamespace:
+    """Ifaddr ``IP``-shaped stub for an IPv4 address."""
+    return SimpleNamespace(ip=address, is_IPv4=True, is_IPv6=False, network_prefix=24)
+
+
+def _ipv6(address: str, scope_id: int = 0) -> SimpleNamespace:
+    """Ifaddr ``IP``-shaped stub for an IPv6 address (tuple form: addr, flowinfo, scope_id)."""
+    return SimpleNamespace(
+        ip=(address, 0, scope_id),
+        is_IPv4=False,
+        is_IPv6=True,
+        network_prefix=64,
+    )
+
+
+def _adapter(name: str, *, index: int = 1, ips: list[SimpleNamespace]) -> SimpleNamespace:
+    """Ifaddr ``Adapter``-shaped stub (only the fields we read)."""
+    return SimpleNamespace(name=name, nice_name=name, index=index, ips=ips)
+
+
+def _patch_adapters(*adapters: SimpleNamespace) -> object:
+    return patch(
+        "esphome_device_builder.helpers.network_interfaces.ifaddr.get_adapters",
+        return_value=list(adapters),
+    )
 
 
 def test_unknown_interface_returns_literal_as_singleton() -> None:
     """A literal IP / hostname is wrapped in a single-element list."""
-    with patch(
-        "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
-        return_value={"eth0": [_addr(socket.AF_INET, "192.168.1.10")]},
-    ):
+    with _patch_adapters(_adapter("eth0", ips=[_ipv4("192.168.1.10")])):
         assert resolve_bind_host("127.0.0.1") == ["127.0.0.1"]
         assert resolve_bind_host("0.0.0.0") == ["0.0.0.0"]
         assert resolve_bind_host("dashboard.lan") == ["dashboard.lan"]
@@ -36,79 +54,30 @@ def test_unknown_interface_returns_literal_as_singleton() -> None:
 
 def test_ipv4_interface_expands() -> None:
     """Interface name → its IPv4 address list."""
-    with patch(
-        "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
-        return_value={
-            "eth0": [
-                _addr(socket.AF_INET, "192.168.1.10"),
-                _addr(socket.AF_INET, "10.0.0.5"),
-            ],
-        },
+    with _patch_adapters(
+        _adapter("eth0", ips=[_ipv4("192.168.1.10"), _ipv4("10.0.0.5")]),
     ):
         assert resolve_bind_host("eth0") == ["192.168.1.10", "10.0.0.5"]
 
 
-def test_ipv6_link_local_gets_zone_suffix() -> None:
-    """``fe80::/10`` addresses get ``%<ifindex>`` so the bind picks the scope."""
-    with (
-        patch(
-            "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
-            return_value={
-                "eth0": [
-                    _addr(socket.AF_INET, "192.168.1.10"),
-                    _addr(socket.AF_INET6, "fe80::1"),
-                    _addr(socket.AF_INET6, "2001:db8::1"),
-                ],
-            },
-        ),
-        patch(
-            "esphome_device_builder.helpers.network_interfaces.socket.if_nametoindex",
-            return_value=2,
-        ) as if_nametoindex,
-    ):
-        resolved = resolve_bind_host("eth0")
-    assert resolved == ["192.168.1.10", "fe80::1%2", "2001:db8::1"]
-    if_nametoindex.assert_called_once_with("eth0")
-
-
-def test_ipv6_link_local_with_existing_zone_is_passed_through() -> None:
-    """A ``%`` already present means psutil included the zone — don't re-suffix."""
-    with (
-        patch(
-            "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
-            return_value={"eth0": [_addr(socket.AF_INET6, "fe80::1%eth0")]},
-        ),
-        patch(
-            "esphome_device_builder.helpers.network_interfaces.socket.if_nametoindex",
-        ) as if_nametoindex,
-    ):
-        assert resolve_bind_host("eth0") == ["fe80::1%eth0"]
-    if_nametoindex.assert_not_called()
-
-
-def test_link_layer_addresses_are_skipped() -> None:
-    """MAC / AF_PACKET entries are dropped — only IPv4/IPv6 can be bound."""
-    af_packet = getattr(socket, "AF_PACKET", -1)
-    with patch(
-        "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
-        return_value={
-            "eth0": [
-                _addr(af_packet, "aa:bb:cc:dd:ee:ff"),
-                _addr(socket.AF_INET, "192.168.1.10"),
+def test_ipv6_addresses_carry_their_scope_id() -> None:
+    """A non-zero scope_id from the kernel tuple is suffixed; zero is left bare."""
+    with _patch_adapters(
+        _adapter(
+            "eth0",
+            ips=[
+                _ipv6("fe80::1", scope_id=2),
+                _ipv6("2001:db8::1", scope_id=0),
             ],
-        },
+        ),
     ):
-        assert resolve_bind_host("eth0") == ["192.168.1.10"]
+        assert resolve_bind_host("eth0") == ["fe80::1%2", "2001:db8::1"]
 
 
 def test_interface_without_ip_raises() -> None:
     """A known interface that carries no IPv4/IPv6 refuses to start."""
-    af_packet = getattr(socket, "AF_PACKET", -1)
     with (
-        patch(
-            "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
-            return_value={"eth0": [_addr(af_packet, "aa:bb:cc:dd:ee:ff")]},
-        ),
+        _patch_adapters(_adapter("eth0", ips=[])),
         pytest.raises(OSError, match="no bindable IPv4/IPv6"),
     ):
         resolve_bind_host("eth0")

--- a/tests/test_network_interfaces.py
+++ b/tests/test_network_interfaces.py
@@ -1,0 +1,114 @@
+"""Tests for :func:`helpers.network_interfaces.resolve_bind_host`.
+
+Pins the contract: an IP literal or hostname is returned
+unchanged; a known interface name expands to its IPv4 + IPv6
+addresses (link-local IPv6 gets a zone-index suffix); a known
+interface with no bindable address raises ``OSError`` rather
+than silently falling through to a bind on nothing.
+"""
+
+from __future__ import annotations
+
+import socket
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder.helpers.network_interfaces import resolve_bind_host
+
+
+def _addr(family: int, address: str) -> SimpleNamespace:
+    """Psutil ``snicaddr``-shaped stub (only the fields we read)."""
+    return SimpleNamespace(family=family, address=address)
+
+
+def test_unknown_interface_returns_literal_as_singleton() -> None:
+    """A literal IP / hostname is wrapped in a single-element list."""
+    with patch(
+        "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
+        return_value={"eth0": [_addr(socket.AF_INET, "192.168.1.10")]},
+    ):
+        assert resolve_bind_host("127.0.0.1") == ["127.0.0.1"]
+        assert resolve_bind_host("0.0.0.0") == ["0.0.0.0"]
+        assert resolve_bind_host("dashboard.lan") == ["dashboard.lan"]
+
+
+def test_ipv4_interface_expands() -> None:
+    """Interface name → its IPv4 address list."""
+    with patch(
+        "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
+        return_value={
+            "eth0": [
+                _addr(socket.AF_INET, "192.168.1.10"),
+                _addr(socket.AF_INET, "10.0.0.5"),
+            ],
+        },
+    ):
+        assert resolve_bind_host("eth0") == ["192.168.1.10", "10.0.0.5"]
+
+
+def test_ipv6_link_local_gets_zone_suffix() -> None:
+    """``fe80::/10`` addresses get ``%<ifindex>`` so the bind picks the scope."""
+    with (
+        patch(
+            "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
+            return_value={
+                "eth0": [
+                    _addr(socket.AF_INET, "192.168.1.10"),
+                    _addr(socket.AF_INET6, "fe80::1"),
+                    _addr(socket.AF_INET6, "2001:db8::1"),
+                ],
+            },
+        ),
+        patch(
+            "esphome_device_builder.helpers.network_interfaces.socket.if_nametoindex",
+            return_value=2,
+        ) as if_nametoindex,
+    ):
+        resolved = resolve_bind_host("eth0")
+    assert resolved == ["192.168.1.10", "fe80::1%2", "2001:db8::1"]
+    if_nametoindex.assert_called_once_with("eth0")
+
+
+def test_ipv6_link_local_with_existing_zone_is_passed_through() -> None:
+    """A ``%`` already present means psutil included the zone — don't re-suffix."""
+    with (
+        patch(
+            "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
+            return_value={"eth0": [_addr(socket.AF_INET6, "fe80::1%eth0")]},
+        ),
+        patch(
+            "esphome_device_builder.helpers.network_interfaces.socket.if_nametoindex",
+        ) as if_nametoindex,
+    ):
+        assert resolve_bind_host("eth0") == ["fe80::1%eth0"]
+    if_nametoindex.assert_not_called()
+
+
+def test_link_layer_addresses_are_skipped() -> None:
+    """MAC / AF_PACKET entries are dropped — only IPv4/IPv6 can be bound."""
+    af_packet = getattr(socket, "AF_PACKET", -1)
+    with patch(
+        "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
+        return_value={
+            "eth0": [
+                _addr(af_packet, "aa:bb:cc:dd:ee:ff"),
+                _addr(socket.AF_INET, "192.168.1.10"),
+            ],
+        },
+    ):
+        assert resolve_bind_host("eth0") == ["192.168.1.10"]
+
+
+def test_interface_without_ip_raises() -> None:
+    """A known interface that carries no IPv4/IPv6 refuses to start."""
+    af_packet = getattr(socket, "AF_PACKET", -1)
+    with (
+        patch(
+            "esphome_device_builder.helpers.network_interfaces.psutil.net_if_addrs",
+            return_value={"eth0": [_addr(af_packet, "aa:bb:cc:dd:ee:ff")]},
+        ),
+        pytest.raises(OSError, match="no bindable IPv4/IPv6"),
+    ):
+        resolve_bind_host("eth0")

--- a/tests/test_remote_build_listener.py
+++ b/tests/test_remote_build_listener.py
@@ -196,6 +196,57 @@ async def test_maybe_start_remote_build_site_fails_soft_on_bind_error(
 
 
 @pytest.mark.asyncio
+async def test_maybe_start_remote_build_site_refuses_port_zero_with_multi_host(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Ephemeral port + interface name resolving to >1 address refuses to bind.
+
+    Each ``TCPSite(port=0)`` would get a different OS-assigned
+    port, but only one port can be carried in the mDNS
+    ``remote_build_port`` TXT field. Refuses loudly at bind time;
+    the dashboard keeps running without a receiver listener.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as txn:
+            txn.enabled = True
+
+    await loop.run_in_executor(None, _enable)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.device_builder.resolve_bind_host",
+        lambda _: ["192.168.1.10", "192.168.1.11"],
+    )
+
+    settings = DashboardSettings(config_dir=tmp_path)
+    settings.remote_build_host = "eth0"
+    settings.remote_build_port = 0
+    db = DeviceBuilder(settings)
+    db.loop = loop
+    db.remote_build_receiver = MagicMock()
+    db.remote_build_receiver._db.settings.config_dir = tmp_path
+
+    with caplog.at_level("ERROR", logger="esphome_device_builder.device_builder"):
+        await db._maybe_start_remote_build_site()
+
+    assert db._remote_build_runner is None
+    # The fail-soft handler logs via ``logger.exception`` — the
+    # RuntimeError text lives on the captured ``exc_info``, not the
+    # main message. Check both so a refactor that swaps the log
+    # call shape (or drops the exc_info) still gets caught.
+    refusal_logged = any(
+        rec.exc_info is not None
+        and "incompatible with --remote-build-host resolving to multiple" in str(rec.exc_info[1])
+        for rec in caplog.records
+    )
+    assert refusal_logged, "expected the operator-facing refusal on the fail-soft log's exc_info"
+
+
+@pytest.mark.asyncio
 async def test_strip_server_header_middleware_overrides_to_empty(tmp_path: Path) -> None:
     """
     The Server header is overridden to empty string.

--- a/tests/test_remote_build_listener.py
+++ b/tests/test_remote_build_listener.py
@@ -240,7 +240,8 @@ async def test_maybe_start_remote_build_site_refuses_port_zero_with_multi_host(
     # call shape (or drops the exc_info) still gets caught.
     refusal_logged = any(
         rec.exc_info is not None
-        and "incompatible with --remote-build-host resolving to multiple" in str(rec.exc_info[1])
+        and "--remote-build-port 0 (ephemeral) is incompatible" in str(rec.exc_info[1])
+        and "multiple addresses" in str(rec.exc_info[1])
         for rec in caplog.records
     )
     assert refusal_logged, "expected the operator-facing refusal on the fail-soft log's exc_info"


### PR DESCRIPTION
# What does this implement/fix?

Accept a **local network interface name** (e.g. `eth0`, `wlan0`, `lo`) as the value of `--host`, `--ingress-host`, and `--remote-build-host`. When the value matches an interface present on the host, the bind expands at bind time to every IPv4 / IPv6 address currently assigned to that interface; IPv6 link-local entries (`fe80::/10`) get the interface zone-index suffixed so the kernel picks the right scope. IP literals and hostnames fall through verbatim (existing behaviour).

Aimed at deployments where the IP isn't predictable at launch time: host-network Docker containers, DHCP-assigned LAN IPs, macvlan / ipvlan attachments. Mirrors the legacy ESPHome dashboard's approach in esphome/esphome#15485.

**Related issue or feature (if applicable):**

- inspired by esphome/esphome#15485 & https://github.com/matter-js/matterjs-server/pull/480

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
