### PR TITLE
[remote-build] Ship validated-config cache so local upload/logs skip read_config

### DIFF
--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -64,7 +64,11 @@ from esphome.storage_json import StorageJSON
 from ...helpers.build_artifacts import _firmware_offset_for_platform
 from ...helpers.json import loads as json_loads
 from ...helpers.peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
-from ...helpers.storage_path import resolve_idedata_path, resolve_storage_path
+from ...helpers.storage_path import (
+    resolve_compiled_config_path,
+    resolve_idedata_path,
+    resolve_storage_path,
+)
 from .artifact_platforms import build_files_for_platform
 
 if TYPE_CHECKING:
@@ -85,14 +89,31 @@ PLATFORMIO_INI_MEMBER_NAME = "platformio.ini"
 # Read by the offloader's ``read_build_info_hash`` to populate
 # ``expected_config_hash`` post-build (see #654).
 BUILD_INFO_MEMBER_NAME = "build_info.json"
+# Receiver-side esphome >= 2026.6.0 dumps the validated config alongside
+# the StorageJSON sidecar; reusing it on the offloader lets `esphome
+# upload` / `esphome logs` skip the full `read_config()` pipeline. Optional
+# member: skipped when the receiver predates the cache.
+VALIDATED_YAML_MEMBER_NAME = "validated.yaml"
 _METADATA_MEMBERS: frozenset[str] = frozenset(
     {
         STORAGE_MEMBER_NAME,
         IDEDATA_MEMBER_NAME,
         PLATFORMIO_INI_MEMBER_NAME,
         BUILD_INFO_MEMBER_NAME,
+        VALIDATED_YAML_MEMBER_NAME,
     }
 )
+
+# esphome's `update_storage_json` writes the validated-config cache and
+# the StorageJSON sidecar inside the same call, so a same-compile pair
+# of mtimes lands within milliseconds. A downgrade to an esphome version
+# that doesn't write the cache leaves the previous cache lingering with
+# its mtime stuck on the older compile while the storage.json gets
+# rewritten by every new compile. Reject anything older than the
+# sidecar by more than this many seconds -- generous enough to cover
+# `clean_build` + `clean_cmake_cache` running between the two writes,
+# tight enough to never accept a cache from a prior compile cycle.
+_VALIDATED_YAML_STALE_THRESHOLD_S = 60.0
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +209,7 @@ def _collect_pack_members(
         raise FileNotFoundError(msg)
 
     build_info_path = build_path / BUILD_INFO_MEMBER_NAME
+    validated_yaml_path = resolve_compiled_config_path(configuration)
     members: list[tuple[str, Path]] = [
         (STORAGE_MEMBER_NAME, storage_path),
         (IDEDATA_MEMBER_NAME, idedata_cache_path),
@@ -195,6 +217,8 @@ def _collect_pack_members(
     ]
     if build_info_path.is_file():
         members.append((BUILD_INFO_MEMBER_NAME, build_info_path))
+    if _validated_yaml_is_fresh(validated_yaml_path, storage_path):
+        members.append((VALIDATED_YAML_MEMBER_NAME, validated_yaml_path))
     # Dedupe by basename, not full path: the WS-unpack adapter
     # keys flash images by basename, so a build emitting both
     # ``.pioenvs/<name>/firmware.factory.bin`` and
@@ -235,6 +259,23 @@ def _collect_pack_members(
         )
         raise RuntimeError(msg)
     return members
+
+
+def _validated_yaml_is_fresh(validated_yaml: Path, storage_json: Path) -> bool:
+    """Test that *validated_yaml* was written by the same compile as *storage_json*.
+
+    esphome >= 2026.6 writes both inside one ``update_storage_json``
+    call. If the receiver later downgrades to an esphome that doesn't
+    write the cache, the old cache stays on disk while the sidecar
+    gets rewritten by every new compile -- detected here by the
+    sidecar pulling ahead of the cache.
+    """
+    try:
+        storage_mtime = storage_json.stat().st_mtime
+        validated_mtime = validated_yaml.stat().st_mtime
+    except OSError:
+        return False
+    return storage_mtime - validated_mtime <= _VALIDATED_YAML_STALE_THRESHOLD_S
 
 
 def _download_type_files(storage: StorageJSON) -> list[str]:

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -19,6 +19,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tarfile
 import time
 from pathlib import Path
@@ -112,9 +113,19 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
     """
     try:
         with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
-            storage_bytes = _read_member_required(tar, STORAGE_MEMBER_NAME)
-            idedata_bytes = _read_member_required(tar, IDEDATA_MEMBER_NAME)
-            validated_yaml_bytes = _read_member_optional(tar, VALIDATED_YAML_MEMBER_NAME)
+            # Thread one running total across every metadata read and
+            # the build-tree extract so the global FIRMWARE_MAX_TOTAL_BYTES
+            # cap holds for the whole tarball, not per-member.
+            total_bytes = 0
+            storage_bytes, total_bytes = _read_member_required(
+                tar, STORAGE_MEMBER_NAME, total_so_far=total_bytes
+            )
+            idedata_bytes, total_bytes = _read_member_required(
+                tar, IDEDATA_MEMBER_NAME, total_so_far=total_bytes
+            )
+            validated_yaml_bytes, total_bytes = _read_member_optional(
+                tar, VALIDATED_YAML_MEMBER_NAME, total_so_far=total_bytes
+            )
             receiver_storage = _parse_storage_json(storage_bytes)
             device_name = _device_name_from_storage(receiver_storage)
             receiver_build_path = _receiver_build_path_from_storage(receiver_storage)
@@ -134,6 +145,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
                     IDEDATA_MEMBER_NAME,
                     VALIDATED_YAML_MEMBER_NAME,
                 },
+                initial_total_bytes=total_bytes,
             )
     except tarfile.TarError as err:
         raise MaterialiseError(f"tarball is malformed: {err}") from err
@@ -168,28 +180,37 @@ def _receiver_build_path_from_storage(receiver_storage: dict[str, Any]) -> Path:
     return Path(receiver_build_path_str)
 
 
-def _read_member_optional(tar: tarfile.TarFile, name: str) -> bytes | None:
-    """Return *name*'s bytes or None when absent. Same size cap as required."""
+def _read_member_optional(
+    tar: tarfile.TarFile, name: str, *, total_so_far: int = 0
+) -> tuple[bytes | None, int]:
+    """Read *name* if present. Returns ``(payload-or-None, running total)``."""
     try:
         member = tar.getmember(name)
     except KeyError:
-        return None
+        return None, total_so_far
     if not member.isfile():
         raise MaterialiseError(f"tarball member {name!r} is not a regular file")
-    _check_member_size(member, total_so_far=0)
+    _check_member_size(member, total_so_far=total_so_far)
     payload = tar.extractfile(member)
     if payload is None:
         raise MaterialiseError(f"tarball member {name!r} unreadable")
-    return payload.read()
+    return payload.read(), total_so_far + member.size
 
 
-def _read_member_required(tar: tarfile.TarFile, name: str) -> bytes:
-    """Return *name*'s bytes from *tar* or raise with a clear message.
+def _read_member_required(
+    tar: tarfile.TarFile, name: str, *, total_so_far: int = 0
+) -> tuple[bytes, int]:
+    """Read *name* or raise. Returns ``(payload, running total)``.
 
     Caps the declared member size against
     :data:`FIRMWARE_MAX_TOTAL_BYTES` before reading so a hostile
     peer can't expand a tiny gzipped tarball into multi-GiB
-    memory by inflating a metadata-member header.
+    memory by inflating a metadata-member header. *total_so_far*
+    threads the running cumulative-size accounting from the
+    caller; the cap is checked against
+    ``total_so_far + member.size`` so successive metadata reads
+    can't each fit under the cap individually while collectively
+    breaching it.
     """
     try:
         member = tar.getmember(name)
@@ -197,11 +218,11 @@ def _read_member_required(tar: tarfile.TarFile, name: str) -> bytes:
         raise MaterialiseError(f"tarball missing required member: {name!r}") from err
     if not member.isfile():
         raise MaterialiseError(f"tarball member {name!r} is not a regular file")
-    _check_member_size(member, total_so_far=0)
+    _check_member_size(member, total_so_far=total_so_far)
     payload = tar.extractfile(member)
     if payload is None:  # ``isfile()`` already gates this; defence
         raise MaterialiseError(f"tarball member {name!r} unreadable")
-    return payload.read()
+    return payload.read(), total_so_far + member.size
 
 
 def _check_member_size(member: tarfile.TarInfo, *, total_so_far: int) -> None:
@@ -218,11 +239,23 @@ def _check_member_size(member: tarfile.TarInfo, *, total_so_far: int) -> None:
         )
 
 
-def _safe_extract_excluding(tar: tarfile.TarFile, dest: Path, *, exclude: set[str]) -> None:
-    """Extract every member except *exclude*; reject any that escapes *dest* or breaches the cap."""
+def _safe_extract_excluding(
+    tar: tarfile.TarFile,
+    dest: Path,
+    *,
+    exclude: set[str],
+    initial_total_bytes: int = 0,
+) -> None:
+    """Extract every member except *exclude*; reject any that escapes *dest* or breaches the cap.
+
+    *initial_total_bytes* lets the caller seed the cumulative-size
+    counter with bytes already read out of the tarball (the metadata
+    members) so the cap applies across the whole archive, not just
+    the build-tree members.
+    """
     dest_resolved = dest.resolve()
     members_to_extract: list[tarfile.TarInfo] = []
-    total_bytes = 0
+    total_bytes = initial_total_bytes
     for member in tar.getmembers():
         if member.name in exclude:
             continue
@@ -356,8 +389,17 @@ def _stage_offloader_validated_yaml(
     """
     path = resolve_compiled_config_path(configuration)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(payload)
-    os.chmod(path, 0o600)
+    # Open with 0600 at creation time so the file is never momentarily
+    # readable at the process umask between write_bytes() and chmod().
+    # O_CREAT honours an existing inode's mode bits, so tighten with
+    # an explicit chmod afterwards too (no-op on Windows).
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, payload)
+    finally:
+        os.close(fd)
+    if sys.platform != "win32":
+        os.chmod(path, 0o600)
     now = time.time()
     os.utime(path, (now, now))
 

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -392,8 +392,11 @@ def _stage_offloader_validated_yaml(
     # Open with 0600 at creation time so the file is never momentarily
     # readable at the process umask between write_bytes() and chmod().
     # O_CREAT honours an existing inode's mode bits, so tighten with
-    # an explicit chmod afterwards too (no-op on Windows).
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    # an explicit chmod afterwards too (no-op on Windows). O_BINARY
+    # only exists on Windows where it disables the CRLF translation
+    # that would otherwise corrupt the YAML bytes.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_BINARY", 0)
+    fd = os.open(path, flags, 0o600)
     try:
         os.write(fd, payload)
     finally:

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -5,8 +5,11 @@ After :func:`materialise_remote_artifacts` returns, the offloader's
 filesystem looks as if a local compile produced the build:
 ``<data_dir>/build/<name>/`` carries the per-platform build tree,
 ``<data_dir>/storage/<basename>.json`` is the rewritten StorageJSON
-sidecar, and ``<data_dir>/idedata/<name>.json`` is the rewritten
-idedata cache (touched so ``_load_idedata``'s mtime gate hits).
+sidecar, ``<data_dir>/idedata/<name>.json`` is the rewritten idedata
+cache (touched so ``_load_idedata``'s mtime gate hits), and -- when
+the receiver-side esphome shipped one -- ``<basename>.validated.yaml``
+sits next to the JSON sidecar so the next local ``esphome upload`` /
+``esphome logs`` skips ``read_config()`` via esphome's fast path.
 """
 
 from __future__ import annotations
@@ -27,11 +30,17 @@ from ..controllers.remote_build.artifacts_tarball import (
     IDEDATA_MEMBER_NAME,
     PLATFORMIO_INI_MEMBER_NAME,
     STORAGE_MEMBER_NAME,
+    VALIDATED_YAML_MEMBER_NAME,
 )
 from .json import dumps_indent
 from .json import loads as json_loads
 from .peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
-from .storage_path import resolve_data_dir, resolve_idedata_path, resolve_storage_path
+from .storage_path import (
+    resolve_compiled_config_path,
+    resolve_data_dir,
+    resolve_idedata_path,
+    resolve_storage_path,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +62,9 @@ class _ExtractedTarball(NamedTuple):
     idedata_bytes: bytes
     receiver_build_path: Path
     build_path: Path
+    # Optional: present when receiver-side esphome wrote a
+    # validated-config cache (>= 2026.6.0).
+    validated_yaml_bytes: bytes | None
 
 
 def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
@@ -83,6 +95,11 @@ def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
         platformio_ini=extracted.build_path / PLATFORMIO_INI_MEMBER_NAME,
         cached_idedata=cached_idedata_path,
     )
+    if extracted.validated_yaml_bytes is not None:
+        _stage_offloader_validated_yaml(
+            configuration=configuration,
+            payload=extracted.validated_yaml_bytes,
+        )
     return extracted.build_path
 
 
@@ -97,6 +114,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
         with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
             storage_bytes = _read_member_required(tar, STORAGE_MEMBER_NAME)
             idedata_bytes = _read_member_required(tar, IDEDATA_MEMBER_NAME)
+            validated_yaml_bytes = _read_member_optional(tar, VALIDATED_YAML_MEMBER_NAME)
             receiver_storage = _parse_storage_json(storage_bytes)
             device_name = _device_name_from_storage(receiver_storage)
             receiver_build_path = _receiver_build_path_from_storage(receiver_storage)
@@ -111,7 +129,11 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             _safe_extract_excluding(
                 tar,
                 build_path,
-                exclude={STORAGE_MEMBER_NAME, IDEDATA_MEMBER_NAME},
+                exclude={
+                    STORAGE_MEMBER_NAME,
+                    IDEDATA_MEMBER_NAME,
+                    VALIDATED_YAML_MEMBER_NAME,
+                },
             )
     except tarfile.TarError as err:
         raise MaterialiseError(f"tarball is malformed: {err}") from err
@@ -122,6 +144,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
         idedata_bytes=idedata_bytes,
         receiver_build_path=receiver_build_path,
         build_path=build_path,
+        validated_yaml_bytes=validated_yaml_bytes,
     )
 
 
@@ -143,6 +166,21 @@ def _receiver_build_path_from_storage(receiver_storage: dict[str, Any]) -> Path:
     if not isinstance(receiver_build_path_str, str):
         raise MaterialiseError("tarball storage.json missing required build_path field")
     return Path(receiver_build_path_str)
+
+
+def _read_member_optional(tar: tarfile.TarFile, name: str) -> bytes | None:
+    """Return *name*'s bytes or None when absent. Same size cap as required."""
+    try:
+        member = tar.getmember(name)
+    except KeyError:
+        return None
+    if not member.isfile():
+        raise MaterialiseError(f"tarball member {name!r} is not a regular file")
+    _check_member_size(member, total_so_far=0)
+    payload = tar.extractfile(member)
+    if payload is None:
+        raise MaterialiseError(f"tarball member {name!r} unreadable")
+    return payload.read()
 
 
 def _read_member_required(tar: tarfile.TarFile, name: str) -> bytes:
@@ -302,6 +340,26 @@ def _remap_idedata_toolchain_path(data: dict[str, Any]) -> None:
         data.pop("cc_path", None)
     else:
         data["cc_path"] = remapped
+
+
+def _stage_offloader_validated_yaml(
+    *,
+    configuration: str,
+    payload: bytes,
+) -> None:
+    """Stage the receiver's validated-config cache at the offloader's path.
+
+    Written 0600 because the cache resolves !secret references inline.
+    mtime is touched to "now" so esphome's fast path (which gates on
+    cache mtime >= source YAML mtime) takes the cache instead of
+    re-running read_config.
+    """
+    path = resolve_compiled_config_path(configuration)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    os.chmod(path, 0o600)
+    now = time.time()
+    os.utime(path, (now, now))
 
 
 def _force_idedata_cache_hit(*, platformio_ini: Path, cached_idedata: Path) -> None:

--- a/esphome_device_builder/helpers/storage_path.py
+++ b/esphome_device_builder/helpers/storage_path.py
@@ -127,6 +127,20 @@ def resolve_storage_path(configuration: str) -> Path:
     return resolve_data_dir(configuration) / "storage" / f"{Path(configuration).name}.json"
 
 
+def resolve_compiled_config_path(configuration: str) -> Path:
+    """Return the validated-config cache YAML path for *configuration*.
+
+    Mirror of :func:`esphome.compiled_config.compiled_config_path`:
+    ``<data_dir>/storage/<basename>.validated.yaml``. Routed through
+    :func:`resolve_data_dir` for the same reason as
+    :func:`resolve_storage_path` -- receiver-side remote-build configs
+    land under the per-build subtree.
+    """
+    return (
+        resolve_data_dir(configuration) / "storage" / f"{Path(configuration).name}.validated.yaml"
+    )
+
+
 def resolve_idedata_path(configuration: str, *, name: str) -> Path:
     """Return the cached ``idedata/<name>.json`` path for *configuration*.
 

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import tarfile
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -29,6 +31,7 @@ from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     IDEDATA_MEMBER_NAME,
     PLATFORMIO_INI_MEMBER_NAME,
     STORAGE_MEMBER_NAME,
+    VALIDATED_YAML_MEMBER_NAME,
     pack_build_artifacts,
 )
 from esphome_device_builder.helpers.config_hash import read_build_info_hash
@@ -39,6 +42,7 @@ from esphome_device_builder.helpers.remote_artifacts_materialise import (
     materialise_remote_artifacts,
 )
 from esphome_device_builder.helpers.storage_path import (
+    resolve_compiled_config_path,
     resolve_idedata_path,
     resolve_storage_path,
 )
@@ -176,6 +180,69 @@ def test_materialise_lands_build_info_json_for_hash_lookup(
     with patch.object(CORE, "config_path", sentinel):
         yaml_path = offloader_root / "kitchen.yaml"
         assert read_build_info_hash(yaml_path) == "5a94a12d"
+
+
+def test_materialise_stages_validated_yaml_for_esphome_fast_path(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """Stage the receiver-side validated-config cache at the offloader's path.
+
+    The next ``esphome upload`` / ``logs`` then skips ``read_config``.
+    """
+    receiver_root, offloader_root = paired_roots
+    cache_body = b"esphome:\n  name: kitchen\n"
+    tarball = _pack_in_tmp(receiver_root, validated_yaml=cache_body)
+    _materialise_in_tmp(tarball, offloader_root)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        staged = resolve_compiled_config_path("kitchen.yaml")
+    assert staged.read_bytes() == cache_body
+    # 0600 because the cache resolves !secret inline.
+    assert (staged.stat().st_mode & 0o777) == 0o600
+
+
+def test_materialise_handles_missing_validated_yaml(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """Receiver without the cache (old esphome): materialise completes, no cache staged."""
+    receiver_root, offloader_root = paired_roots
+    tarball = _pack_in_tmp(receiver_root)
+    _materialise_in_tmp(tarball, offloader_root)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        staged = resolve_compiled_config_path("kitchen.yaml")
+    assert not staged.exists()
+
+
+def test_pack_skips_stale_validated_yaml_after_esphome_downgrade(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """Drop a stale validated.yaml at pack time after an esphome downgrade.
+
+    The packer rejects any cache whose mtime predates storage.json by
+    more than the threshold, so the offloader doesn't land with a
+    cache that no longer matches the binary on disk.
+    """
+    receiver_root, offloader_root = paired_roots
+    cache_body = b"esphome:\n  name: kitchen\n"
+    sentinel = receiver_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        paths = _write_receiver_state(receiver_root, validated_yaml=cache_body)
+        # Back-date the cache an hour before the sidecar -- the gap a
+        # cross-version downgrade produces.
+        now = time.time()
+        os.utime(paths["storage_path"], (now, now))
+        os.utime(paths["validated_yaml_path"], (now - 3600, now - 3600))
+        tarball = pack_build_artifacts("kitchen.yaml").tarball
+
+    with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
+        assert VALIDATED_YAML_MEMBER_NAME not in tar.getnames()
+
+    _materialise_in_tmp(tarball, offloader_root)
+    with patch.object(CORE, "config_path", offloader_root / "___DASHBOARD_SENTINEL___.yaml"):
+        assert not resolve_compiled_config_path("kitchen.yaml").exists()
 
 
 def test_materialise_handles_missing_build_info_json(

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -578,6 +578,28 @@ def test_materialise_rejects_cumulative_member_size(
         _materialise_in_tmp(tarball, tmp_path)
 
 
+def test_materialise_rejects_cumulative_metadata_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Metadata reads share one running cap so a hostile peer can't stuff each member.
+
+    storage.json + idedata.json each fit under the cap individually
+    but together breach it; the threaded running total catches the
+    breach on the second read.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.remote_artifacts_materialise.FIRMWARE_MAX_TOTAL_BYTES",
+        500,
+    )
+    bloated = b"x" * 300
+    tarball = _synthetic_tarball(
+        storage=bloated,
+        idedata=bloated,
+    )
+    with pytest.raises(MaterialiseError, match=r"cumulative size"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
 def test_materialise_rejects_unreadable_storage_member(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import sys
 import tarfile
 import time
 from pathlib import Path
@@ -198,8 +199,11 @@ def test_materialise_stages_validated_yaml_for_esphome_fast_path(
     with patch.object(CORE, "config_path", sentinel):
         staged = resolve_compiled_config_path("kitchen.yaml")
     assert staged.read_bytes() == cache_body
-    # 0600 because the cache resolves !secret inline.
-    assert (staged.stat().st_mode & 0o777) == 0o600
+    # 0600 because the cache resolves !secret inline. POSIX mode bits
+    # are inapplicable on Windows -- the offloader's chmod call is a
+    # no-op there, so skip the assertion rather than fight ACL shape.
+    if sys.platform != "win32":
+        assert (staged.stat().st_mode & 0o777) == 0o600
 
 
 def test_materialise_handles_missing_validated_yaml(

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -49,6 +49,7 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
 )
 from esphome_device_builder.helpers.build_artifacts import load_build_artifacts
 from esphome_device_builder.helpers.storage_path import (
+    resolve_compiled_config_path,
     resolve_idedata_path,
     resolve_storage_path,
 )
@@ -340,6 +341,7 @@ def _write_receiver_state(
     target_platform: str = "ESP32",
     extras: list[tuple[str, str]] | None = None,
     extra_build_files: dict[str, bytes] | None = None,
+    validated_yaml: bytes | None = None,
 ) -> dict[str, Path]:
     """Lay down a minimal receiver-side build state on disk.
 
@@ -424,13 +426,19 @@ def _write_receiver_state(
         encoding="utf-8",
     )
 
-    return {
+    paths = {
         "build_path": build_path,
         "firmware_bin": firmware_bin,
         "storage_path": storage_path,
         "idedata_path": idedata_path,
         "platformio_ini": build_path / "platformio.ini",
     }
+    if validated_yaml is not None:
+        validated_yaml_path = resolve_compiled_config_path(configuration)
+        validated_yaml_path.parent.mkdir(parents=True, exist_ok=True)
+        validated_yaml_path.write_bytes(validated_yaml)
+        paths["validated_yaml_path"] = validated_yaml_path
+    return paths
 
 
 def _tar_member_names(tarball: bytes) -> list[str]:


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/esphome#16381: ship the validated-config cache through the remote-build tarball so local `upload` / `logs` skip `read_config` in the remote-install flow.

esphome >= 2026.6 writes a `<basename>.validated.yaml` next to the StorageJSON sidecar after every compile; esphome's `upload` / `logs` reload it and skip the full validation pipeline. In our remote-build flow that cache is written on the *receiver*, not the offloader, so today the local upload/logs subprocess still re-validates and the user sees the same "Reading configuration ..." wall the esphome change was meant to eliminate.

Changes:

- **Receiver pack** (`artifacts_tarball.py`): include `<basename>.validated.yaml` as an optional tarball member. Reject any cache whose mtime predates the storage.json sidecar by more than 60 seconds — esphome's writer emits both within milliseconds in one `update_storage_json` call, so a same-compile pair never trips the gate; an esphome downgrade that leaves the cache stale while the sidecar gets rewritten is detected and dropped.
- **Offloader materialise** (`remote_artifacts_materialise.py`): stage the cache at `<basename>.validated.yaml` with mode 0600 (it carries resolved `!secret` values) and refresh its mtime so esphome's fast-path freshness check fires.

Wire-format compatible: older receivers / esphome installs that don't write the cache produce tarballs without the member, and the offloader silently falls back to running `read_config` locally as today.

**Related issue or feature (if applicable):**

- Follows up esphome/esphome#16381

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
