### PR TITLE
Quote YAML reserved indicators in generated component values

### DIFF
--- a/esphome_device_builder/helpers/yaml.py
+++ b/esphome_device_builder/helpers/yaml.py
@@ -815,7 +815,10 @@ def _format_yaml_value(value: Any) -> str:
     if isinstance(value, str):
         if value in ("true", "false", "null", "yes", "no", "on", "off"):
             return f'"{value}"'
-        if value.startswith("!") or ":" in value or "#" in value:
+        # YAML 1.2 reserved indicators that cannot start a plain scalar.
+        # Without this, schema defaults like `%` for humidity
+        # `unit_of_measurement` emit bare and fail YAML parsing (#675).
+        if not value or value[0] in "!&*%@`?|>,[]{}" or ":" in value or "#" in value:
             return f'"{value}"'
         return value
     return str(value)

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -993,18 +993,47 @@ def test_generate_component_yaml_quotes_yaml_keyword_strings(keyword: str) -> No
 
 @pytest.mark.parametrize(
     "value",
-    ["foo:bar", "foo#bar", "!secret api_key"],
-    ids=["colon", "hash", "tag-prefix"],
+    [
+        "foo:bar",
+        "foo#bar",
+        "!secret api_key",
+        "%",
+        "@host",
+        "*anchor",
+        "| pipe",
+        "> folded",
+        "& anchor",
+        "? key",
+        ", comma",
+        "[flow]",
+        "{flow}",
+    ],
+    ids=[
+        "colon",
+        "hash",
+        "tag-prefix",
+        "percent",
+        "at-sign",
+        "alias",
+        "literal-block",
+        "folded-block",
+        "anchor",
+        "complex-key",
+        "comma",
+        "flow-seq",
+        "flow-map",
+    ],
 )
 def test_generate_component_yaml_quotes_strings_with_special_chars(value: str) -> None:
-    """Strings containing ``:`` / ``#`` or starting with ``!`` get quoted.
+    """Strings with YAML reserved indicators get quoted.
 
-    Each of these is YAML structural punctuation: ``:`` opens a
-    mapping value, ``#`` opens a comment, and ``!`` introduces a tag.
-    Emitting any of them unquoted either breaks the parse or
+    ``:`` opens a mapping value and ``#`` opens a comment anywhere in
+    a scalar; the other characters are YAML 1.2 reserved indicators
+    that cannot start a plain scalar. Emitting any of them unquoted
+    either breaks the parse (``unit_of_measurement: %`` from #675) or
     silently changes the meaning (``key: foo#bar`` becomes ``key:
-    foo`` with a trailing comment). Pin all three so a refactor that
-    drops one of the disjuncts surfaces here.
+    foo`` with a trailing comment). Pin all of them so a refactor
+    that drops one of the disjuncts surfaces here.
     """
     component = _component(component_id="myc", category=ComponentCategory.MISC)
     out = generate_component_yaml(component, {"v": value})


### PR DESCRIPTION
# What does this implement/fix?

`_format_yaml_value` in `esphome_device_builder/helpers/yaml.py` quotes
strings containing `:` or `#` and strings starting with `!`, but lets
every other YAML reserved indicator through bare. For `sensor.aht10`
the cached schema's default `unit_of_measurement` for humidity is the
literal `%`, so the GUI emits

```yaml
unit_of_measurement: %
```

which fails YAML parsing with `found character '%' that cannot start
any token`. The same shape would fire for any component whose default
unit starts with `@`, `*`, `&`, `?`, `|`, `>`, a flow indicator, or a
backtick.

Extend the quoting branch to cover the YAML 1.2 reserved indicators
when they appear at position 0, and add the empty-string guard so the
new index access is safe. Extend the existing parametrized quoting
test (`test_generate_component_yaml_quotes_strings_with_special_chars`)
with one case per new indicator.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/675

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.