### PR TITLE
Resolve receiver config_dir before relative_to in submit_job (#678)

### DIFF
--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -618,12 +618,21 @@ class SubmitJobReceiver:
         # inside the same config_dir, so ``relative_to`` always
         # succeeds here. ``as_posix`` keeps the wire-side
         # ``configuration`` string stable across receiver
-        # platforms — ``str(rel_yaml)`` would emit
+        # platforms; ``str(rel_yaml)`` would emit
         # ``\\``-separated paths on Windows, drifting the
         # ``FirmwareJob.configuration`` field's shape between a
         # dashboard running on Linux vs Windows even though the
         # filesystem-level join works either way.
-        rel_yaml = extracted_yaml.relative_to(self._config_dir)
+        #
+        # ``self._config_dir`` is whatever the user passed to the
+        # CLI (``esphome-device-builder esphome-configs`` ⇒ relative
+        # ``Path('esphome-configs')``), but ``prepare_bundle_for_compile``
+        # internally resolves ``target_dir`` so ``extracted_yaml`` is
+        # always absolute. ``Path.relative_to`` is purely lexical;
+        # a relative-vs-absolute pairing raises ``ValueError`` even
+        # when both refer to the same on-disk location. Resolve the
+        # config_dir half so the comparison always matches (#678).
+        rel_yaml = extracted_yaml.relative_to(self._config_dir.resolve())
         configuration = rel_yaml.as_posix()
 
         # Snapshot the offloader's display label so the

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -586,13 +586,14 @@ class SubmitJobReceiver:
 
         loop = asyncio.get_running_loop()
         try:
-            extracted_yaml: Path = await loop.run_in_executor(
+            configuration = await loop.run_in_executor(
                 None,
                 _validate_write_extract_bundle,
                 bundle_path,
                 bundle_bytes,
                 target_dir,
                 remote_builds_root,
+                self._config_dir,
             )
         except _PathEscapeError as exc:
             _LOGGER.warning(
@@ -610,26 +611,6 @@ class SubmitJobReceiver:
                 exc,
             )
             raise _SubmitJobRejectionError(_REASON_EXTRACT_FAILED) from exc
-
-        # ``configuration`` on FirmwareJob is the path relative to
-        # the controller's config_dir (``rel_path`` joins back on
-        # the way out). The extracted YAML lives under
-        # ``.esphome/.remote_builds/<dashboard_id>/<device_name>/``
-        # inside the same config_dir, so ``relative_to`` always
-        # succeeds here. ``as_posix`` keeps the wire-side
-        # ``configuration`` string stable across receiver
-        # platforms — ``str(rel_yaml)`` would emit
-        # ``\\``-separated paths on Windows, drifting the
-        # ``FirmwareJob.configuration`` field's shape between a
-        # dashboard running on Linux vs Windows even though the
-        # filesystem-level join works either way.
-        # ``.resolve()`` on the config_dir: ``prepare_bundle_for_compile``
-        # always returns an absolute path; ``self._config_dir`` may
-        # be relative when the dashboard was launched with a relative
-        # ``configuration`` arg, and ``Path.relative_to`` is purely
-        # lexical (#678).
-        rel_yaml = extracted_yaml.relative_to(self._config_dir.resolve())
-        configuration = rel_yaml.as_posix()
 
         # Snapshot the offloader's display label so the
         # firmware-tasks UI can render "from {label}" without
@@ -765,11 +746,12 @@ def _validate_write_extract_bundle(
     bundle_bytes: bytes,
     target_dir: Path,
     remote_builds_root: Path,
-) -> Path:
-    """Sync helper: validate path is under root, write tarball, extract.
+    config_dir: Path,
+) -> str:
+    """Sync helper: validate path, write tarball, extract, return wire-shape ``configuration``.
 
-    All three steps run in the executor so the receiver's WS
-    dispatch coroutine stays non-blocking through both the
+    All four steps run in the executor so the receiver's WS
+    dispatch coroutine stays non-blocking through every
     ``Path.resolve`` walk (which calls ``os.path.realpath``,
     which calls the blocking ``os.path.abspath`` syscall) and
     the multi-MB tarball write. ``Path.resolve`` is a stat-y
@@ -781,7 +763,12 @@ def _validate_write_extract_bundle(
     materialise even an empty tarball outside the remote-builds
     subtree. (2) Write the tarball. (3) Extract via
     ``prepare_bundle_for_compile`` (preserves ``.esphome`` /
-    ``.pioenvs`` for incremental compiles).
+    ``.pioenvs`` for incremental compiles). (4) Compute the
+    POSIX-relative ``configuration`` string for the
+    :class:`FirmwareJob` wire field, resolving *config_dir* so a
+    receiver started with a relative configuration arg
+    (#678) still produces an absolute-vs-absolute
+    ``relative_to`` pair.
 
     Raises :class:`_PathEscapeError` on the path-escape branch
     so the caller can distinguish "bad input shape" from
@@ -804,4 +791,7 @@ def _validate_write_extract_bundle(
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     bundle_path.write_bytes(bundle_bytes)
     extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)
-    return extracted
+    # ``as_posix`` keeps the wire-side ``configuration`` string
+    # stable across receiver platforms — ``str(rel_yaml)`` would
+    # emit ``\\``-separated paths on Windows.
+    return extracted.relative_to(config_dir.resolve()).as_posix()

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -618,20 +618,16 @@ class SubmitJobReceiver:
         # inside the same config_dir, so ``relative_to`` always
         # succeeds here. ``as_posix`` keeps the wire-side
         # ``configuration`` string stable across receiver
-        # platforms; ``str(rel_yaml)`` would emit
+        # platforms — ``str(rel_yaml)`` would emit
         # ``\\``-separated paths on Windows, drifting the
         # ``FirmwareJob.configuration`` field's shape between a
         # dashboard running on Linux vs Windows even though the
         # filesystem-level join works either way.
-        #
-        # ``self._config_dir`` is whatever the user passed to the
-        # CLI (``esphome-device-builder esphome-configs`` ⇒ relative
-        # ``Path('esphome-configs')``), but ``prepare_bundle_for_compile``
-        # internally resolves ``target_dir`` so ``extracted_yaml`` is
-        # always absolute. ``Path.relative_to`` is purely lexical;
-        # a relative-vs-absolute pairing raises ``ValueError`` even
-        # when both refer to the same on-disk location. Resolve the
-        # config_dir half so the comparison always matches (#678).
+        # ``.resolve()`` on the config_dir: ``prepare_bundle_for_compile``
+        # always returns an absolute path; ``self._config_dir`` may
+        # be relative when the dashboard was launched with a relative
+        # ``configuration`` arg, and ``Path.relative_to`` is purely
+        # lexical (#678).
         rel_yaml = extracted_yaml.relative_to(self._config_dir.resolve())
         configuration = rel_yaml.as_posix()
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -174,14 +174,41 @@ async def _paired_instances_ctx(
     receiver_dir: Path,
     offloader_dir: Path,
 ) -> AsyncIterator[PairedInstances]:
-    """Drive the real pair flow against two in-process controllers.
+    """Yield two :class:`RemoteBuildController` instances paired via the real flow.
 
-    The fixture body that used to live inline in ``paired_instances``,
-    factored so a sibling fixture can rerun the same setup with a
-    differently-shaped ``receiver_dir`` (e.g. relative-path
-    reproduction for #678). Both ``receiver_dir`` and ``offloader_dir``
-    must already exist on disk; the helper only owns the controllers,
-    the TestServer, and their teardown.
+    Drives the production pair sequence end-to-end against two
+    in-process controllers — no dict-mocking shortcuts:
+
+    1. Both controllers ``start()`` (loads identities,
+       installs the long-poll listener slot for any future
+       PENDING rows, etc.).
+    2. Receiver opens its pairing window
+       (``set_pairing_window(open=True)``).
+    3. Offloader runs ``preview_pair`` over a real Noise XX WS
+       to capture the receiver's pubkey + pin from the
+       handshake transcript.
+    4. Offloader runs ``request_pair`` (also a real Noise WS)
+       carrying the offloader's ``dashboard_id``; receiver's
+       handler creates a PENDING :class:`StoredPeer` row and
+       fires ``REMOTE_BUILD_PAIR_REQUEST_RECEIVED``.
+    5. Receiver runs ``approve_peer`` to flip PENDING →
+       APPROVED; fires ``REMOTE_BUILD_PAIR_STATUS_CHANGED``.
+    6. Offloader's pair-status listener (spawned in step 4)
+       observes the flip via its long-poll WS, updates the
+       local :class:`StoredPairing` to APPROVED, and spawns
+       the long-lived :class:`PeerLinkClient`.
+
+    Per-side event buses are real, so production-shape event
+    fan-out runs end-to-end. The handshake reads pin + dashboard_id
+    from the live Noise transcript, so any wire-shape regression
+    on either side surfaces here rather than being hidden behind
+    a pre-seeded RAM dict.
+
+    Teardown drains both controllers in dependency order:
+    offloader first (its client task sends a
+    ``terminate{client_stopped}`` to the receiver, the
+    receiver's session loop unwinds), then the receiver (closing
+    any remaining server-side state), then the TestServer.
     """
     receiver_bus = EventBus()
     offloader_bus = EventBus()
@@ -290,13 +317,7 @@ async def _paired_instances_ctx(
 async def paired_instances(
     tmp_path: Path,
 ) -> AsyncGenerator[PairedInstances, None]:
-    """Yield two :class:`RemoteBuildController` instances paired via the real flow.
-
-    Drives the production pair sequence end-to-end against two
-    in-process controllers; the full ordering / handshake notes
-    live on :func:`_paired_instances_ctx`. Receiver and offloader
-    each get an absolute config_dir under ``tmp_path``.
-    """
+    """Yield two :class:`RemoteBuildController` instances paired via the real flow."""
     receiver_dir = tmp_path / "receiver"
     receiver_dir.mkdir()
     offloader_dir = tmp_path / "offloader"
@@ -309,26 +330,10 @@ async def paired_instances(
 async def paired_instances_relative_receiver_config_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> AsyncGenerator[PairedInstances, None]:
-    """Run :func:`paired_instances` with the receiver's config_dir as a relative path.
-
-    Regression cover for #678 (``esphome-device-builder esphome-configs``
-    landed a relative ``Path('esphome-configs')`` on
-    ``settings.config_dir``; the receiver-side
-    ``extracted_yaml.relative_to(self._config_dir)`` in
-    ``submit_job._extract_and_queue`` raised ``ValueError`` because
-    ``prepare_bundle_for_compile`` had resolved the extracted YAML
-    to absolute while ``self._config_dir`` was still relative).
-
-    ``monkeypatch.chdir`` parks the test in ``tmp_path`` so a
-    relative ``Path('receiver')`` resolves under it; the receiver
-    then sees the same shape the CLI delivers in production.
-    """
+    """Like :func:`paired_instances` but the receiver's ``config_dir`` is relative (#678)."""
     monkeypatch.chdir(tmp_path)
     receiver_dir = Path("receiver")
     receiver_dir.mkdir()
-    # The offloader half stays absolute; the bug only ever surfaced
-    # on the receiver because that's where bundle extract + the
-    # buggy ``relative_to`` lived.
     offloader_dir = tmp_path / "offloader"
     offloader_dir.mkdir()
     async with _paired_instances_ctx(receiver_dir, offloader_dir) as instances:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -34,7 +34,8 @@ application messages."
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -168,51 +169,20 @@ class PairedInstances:
         await asyncio.wait_for(self.receiver_closed.received.wait(), timeout=timeout)
 
 
-@pytest.fixture
-async def paired_instances(
-    tmp_path: Path,
-) -> AsyncGenerator[PairedInstances, None]:
-    """Yield two :class:`RemoteBuildController` instances paired via the real flow.
+@asynccontextmanager
+async def _paired_instances_ctx(
+    receiver_dir: Path,
+    offloader_dir: Path,
+) -> AsyncIterator[PairedInstances]:
+    """Drive the real pair flow against two in-process controllers.
 
-    Drives the production pair sequence end-to-end against two
-    in-process controllers — no dict-mocking shortcuts:
-
-    1. Both controllers ``start()`` (loads identities,
-       installs the long-poll listener slot for any future
-       PENDING rows, etc.).
-    2. Receiver opens its pairing window
-       (``set_pairing_window(open=True)``).
-    3. Offloader runs ``preview_pair`` over a real Noise XX WS
-       to capture the receiver's pubkey + pin from the
-       handshake transcript.
-    4. Offloader runs ``request_pair`` (also a real Noise WS)
-       carrying the offloader's ``dashboard_id``; receiver's
-       handler creates a PENDING :class:`StoredPeer` row and
-       fires ``REMOTE_BUILD_PAIR_REQUEST_RECEIVED``.
-    5. Receiver runs ``approve_peer`` to flip PENDING →
-       APPROVED; fires ``REMOTE_BUILD_PAIR_STATUS_CHANGED``.
-    6. Offloader's pair-status listener (spawned in step 4)
-       observes the flip via its long-poll WS, updates the
-       local :class:`StoredPairing` to APPROVED, and spawns
-       the long-lived :class:`PeerLinkClient`.
-
-    Per-side event buses are real, so production-shape event
-    fan-out runs end-to-end. The handshake reads pin + dashboard_id
-    from the live Noise transcript, so any wire-shape regression
-    on either side surfaces here rather than being hidden behind
-    a pre-seeded RAM dict.
-
-    Teardown drains both controllers in dependency order:
-    offloader first (its client task sends a
-    ``terminate{client_stopped}`` to the receiver, the
-    receiver's session loop unwinds), then the receiver (closing
-    any remaining server-side state), then the TestServer.
+    The fixture body that used to live inline in ``paired_instances``,
+    factored so a sibling fixture can rerun the same setup with a
+    differently-shaped ``receiver_dir`` (e.g. relative-path
+    reproduction for #678). Both ``receiver_dir`` and ``offloader_dir``
+    must already exist on disk; the helper only owns the controllers,
+    the TestServer, and their teardown.
     """
-    receiver_dir = tmp_path / "receiver"
-    receiver_dir.mkdir()
-    offloader_dir = tmp_path / "offloader"
-    offloader_dir.mkdir()
-
     receiver_bus = EventBus()
     offloader_bus = EventBus()
     receiver = make_remote_build_controller(config_dir=receiver_dir, bus=receiver_bus)
@@ -314,6 +284,55 @@ async def paired_instances(
         await offloader.stop()
         await receiver.stop()
         await server.close()
+
+
+@pytest.fixture
+async def paired_instances(
+    tmp_path: Path,
+) -> AsyncGenerator[PairedInstances, None]:
+    """Yield two :class:`RemoteBuildController` instances paired via the real flow.
+
+    Drives the production pair sequence end-to-end against two
+    in-process controllers; the full ordering / handshake notes
+    live on :func:`_paired_instances_ctx`. Receiver and offloader
+    each get an absolute config_dir under ``tmp_path``.
+    """
+    receiver_dir = tmp_path / "receiver"
+    receiver_dir.mkdir()
+    offloader_dir = tmp_path / "offloader"
+    offloader_dir.mkdir()
+    async with _paired_instances_ctx(receiver_dir, offloader_dir) as instances:
+        yield instances
+
+
+@pytest.fixture
+async def paired_instances_relative_receiver_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncGenerator[PairedInstances, None]:
+    """Run :func:`paired_instances` with the receiver's config_dir as a relative path.
+
+    Regression cover for #678 (``esphome-device-builder esphome-configs``
+    landed a relative ``Path('esphome-configs')`` on
+    ``settings.config_dir``; the receiver-side
+    ``extracted_yaml.relative_to(self._config_dir)`` in
+    ``submit_job._extract_and_queue`` raised ``ValueError`` because
+    ``prepare_bundle_for_compile`` had resolved the extracted YAML
+    to absolute while ``self._config_dir`` was still relative).
+
+    ``monkeypatch.chdir`` parks the test in ``tmp_path`` so a
+    relative ``Path('receiver')`` resolves under it; the receiver
+    then sees the same shape the CLI delivers in production.
+    """
+    monkeypatch.chdir(tmp_path)
+    receiver_dir = Path("receiver")
+    receiver_dir.mkdir()
+    # The offloader half stays absolute; the bug only ever surfaced
+    # on the receiver because that's where bundle extract + the
+    # buggy ``relative_to`` lived.
+    offloader_dir = tmp_path / "offloader"
+    offloader_dir.mkdir()
+    async with _paired_instances_ctx(receiver_dir, offloader_dir) as instances:
+        yield instances
 
 
 def make_remote_peer_job(

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -58,6 +58,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from esphome_device_builder.helpers.remote_build_layout import RemoteBuildPath
 from esphome_device_builder.models import (
     EventType,
     FirmwareJob,
@@ -220,11 +221,10 @@ async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
 
     receiver_config_dir = paired_instances.receiver._db.settings.config_dir
     extracted_yaml = (
-        receiver_config_dir
-        / ".esphome"
-        / ".remote_builds"
-        / paired_instances.offloader_dashboard_id
-        / "kitchen"
+        RemoteBuildPath(
+            dashboard_id=paired_instances.offloader_dashboard_id,
+            device_name="kitchen",
+        ).subtree(receiver_config_dir)
         / "kitchen.yaml"
     )
     assert extracted_yaml.is_file(), (
@@ -274,18 +274,17 @@ async def test_submit_job_round_trip_with_relative_receiver_config_dir(
     # the wire-side ``job.configuration`` is the POSIX-relative
     # path under config_dir (same shape as the absolute-config-dir
     # case).
-    receiver_config_dir = instances.receiver._db.settings.config_dir
+    receiver_config_dir = instances.receiver._db.settings.config_dir.resolve()
     extracted_yaml = (
-        receiver_config_dir.resolve()
-        / ".esphome"
-        / ".remote_builds"
-        / instances.offloader_dashboard_id
-        / "kitchen"
+        RemoteBuildPath(
+            dashboard_id=instances.offloader_dashboard_id,
+            device_name="kitchen",
+        ).subtree(receiver_config_dir)
         / "kitchen.yaml"
     )
     assert extracted_yaml.is_file()
     assert extracted_yaml.read_bytes() == b"esphome:\n  name: kitchen\n"
-    assert job.configuration == extracted_yaml.relative_to(receiver_config_dir.resolve()).as_posix()
+    assert job.configuration == extracted_yaml.relative_to(receiver_config_dir).as_posix()
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -269,11 +269,6 @@ async def test_submit_job_round_trip_with_relative_receiver_config_dir(
     assert job.job_type is JobType.COMPILE
     instances.receiver._db.firmware._enqueue.assert_awaited_once_with(job)
 
-    # Receiver-side path math reconciles: the YAML lands at the
-    # absolute location even though config_dir is relative, and
-    # the wire-side ``job.configuration`` is the POSIX-relative
-    # path under config_dir (same shape as the absolute-config-dir
-    # case).
     receiver_config_dir = instances.receiver._db.settings.config_dir.resolve()
     extracted_yaml = (
         RemoteBuildPath(

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -244,20 +244,7 @@ async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
 async def test_submit_job_round_trip_with_relative_receiver_config_dir(
     paired_instances_relative_receiver_config_dir: PairedInstances,
 ) -> None:
-    """``submit_job`` round-trip succeeds when the receiver's config_dir is relative (#678).
-
-    Reproduces the user-reported failure mode of starting the
-    receiver-side dashboard with a relative path
-    (``esphome-device-builder esphome-configs``). The real upstream
-    bundle extractor resolves ``target_dir`` to absolute internally,
-    so the post-extract YAML path is absolute; pre-fix, the
-    receiver's ``extracted_yaml.relative_to(self._config_dir)``
-    raised ``ValueError`` because ``Path.relative_to`` is purely
-    lexical and refuses to match a relative path against an
-    absolute one. The ack flowed back as
-    ``accepted=False / extract_failed`` and the offloader logged
-    ``peer-link session ended before ack``.
-    """
+    """``submit_job`` round-trip succeeds when the receiver's config_dir is relative (#678)."""
     instances = paired_instances_relative_receiver_config_dir
     await instances.wait_until_session_opened()
     created_jobs = _wire_receiver_firmware_recorder(instances)
@@ -296,10 +283,7 @@ async def test_submit_job_round_trip_with_relative_receiver_config_dir(
         / "kitchen"
         / "kitchen.yaml"
     )
-    assert extracted_yaml.is_file(), (
-        f"extracted YAML missing at {extracted_yaml} — extract "
-        "failed (regression of #678 or unrelated extractor break)"
-    )
+    assert extracted_yaml.is_file()
     assert extracted_yaml.read_bytes() == b"esphome:\n  name: kitchen\n"
     assert job.configuration == extracted_yaml.relative_to(receiver_config_dir.resolve()).as_posix()
 

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -241,6 +241,70 @@ async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
 
 
 @pytest.mark.asyncio
+async def test_submit_job_round_trip_with_relative_receiver_config_dir(
+    paired_instances_relative_receiver_config_dir: PairedInstances,
+) -> None:
+    """``submit_job`` round-trip succeeds when the receiver's config_dir is relative (#678).
+
+    Reproduces the user-reported failure mode of starting the
+    receiver-side dashboard with a relative path
+    (``esphome-device-builder esphome-configs``). The real upstream
+    bundle extractor resolves ``target_dir`` to absolute internally,
+    so the post-extract YAML path is absolute; pre-fix, the
+    receiver's ``extracted_yaml.relative_to(self._config_dir)``
+    raised ``ValueError`` because ``Path.relative_to`` is purely
+    lexical and refuses to match a relative path against an
+    absolute one. The ack flowed back as
+    ``accepted=False / extract_failed`` and the offloader logged
+    ``peer-link session ended before ack``.
+    """
+    instances = paired_instances_relative_receiver_config_dir
+    await instances.wait_until_session_opened()
+    created_jobs = _wire_receiver_firmware_recorder(instances)
+
+    bundle_bytes = _build_real_bundle()
+    handle = instances.offloader._peer_link_clients[instances.pin_sha256]
+    ack = await handle.client.submit_job(
+        job_id="off-job-678",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=bundle_bytes,
+    )
+
+    assert ack["accepted"] is True, ack
+    assert ack["job_id"] == "off-job-678"
+    assert "reason" not in ack
+
+    assert len(created_jobs) == 1
+    job = created_jobs[0]
+    assert job.remote_peer == instances.offloader_dashboard_id
+    assert job.remote_job_id == "off-job-678"
+    assert job.job_type is JobType.COMPILE
+    instances.receiver._db.firmware._enqueue.assert_awaited_once_with(job)
+
+    # Receiver-side path math reconciles: the YAML lands at the
+    # absolute location even though config_dir is relative, and
+    # the wire-side ``job.configuration`` is the POSIX-relative
+    # path under config_dir (same shape as the absolute-config-dir
+    # case).
+    receiver_config_dir = instances.receiver._db.settings.config_dir
+    extracted_yaml = (
+        receiver_config_dir.resolve()
+        / ".esphome"
+        / ".remote_builds"
+        / instances.offloader_dashboard_id
+        / "kitchen"
+        / "kitchen.yaml"
+    )
+    assert extracted_yaml.is_file(), (
+        f"extracted YAML missing at {extracted_yaml} — extract "
+        "failed (regression of #678 or unrelated extractor break)"
+    )
+    assert extracted_yaml.read_bytes() == b"esphome:\n  name: kitchen\n"
+    assert job.configuration == extracted_yaml.relative_to(receiver_config_dir.resolve()).as_posix()
+
+
+@pytest.mark.asyncio
 async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
     paired_instances: PairedInstances,
 ) -> None:

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -568,17 +568,7 @@ async def test_submit_job_happy_path_extracts_and_queues(
 async def test_submit_job_happy_path_with_relative_config_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Receiver started with a relative ``config_dir`` still queues the job (#678).
-
-    ``esphome-device-builder esphome-configs`` lands a relative
-    ``Path('esphome-configs')`` on ``settings.config_dir``. The
-    bundle extractor resolves ``target_dir`` to absolute internally,
-    so the post-extract ``extracted_yaml`` is absolute. Pre-fix,
-    ``relative_to(self._config_dir)`` raised ``ValueError`` because
-    ``Path.relative_to`` is purely lexical and rejects the
-    relative-vs-absolute pair, even though both refer to the same
-    on-disk subtree.
-    """
+    """Receiver started with a relative ``config_dir`` still queues the job (#678)."""
     monkeypatch.chdir(tmp_path)
     rel_config_dir = Path("esphome-configs")
     rel_config_dir.mkdir()
@@ -591,10 +581,8 @@ async def test_submit_job_happy_path_with_relative_config_dir(
     session = _make_session(dashboard_id="alpha-dashboard")
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
 
-    # Stub ``prepare_bundle_for_compile`` to mirror its real
-    # behaviour: return an ABSOLUTE path under the (resolved)
-    # target_dir. The bug only surfaces when the returned path is
-    # absolute while ``self._config_dir`` is relative.
+    # Stub returns an absolute path so the post-extract path matches
+    # what real ``prepare_bundle_for_compile`` produces.
     abs_config_dir = rel_config_dir.resolve()
     expected_yaml = (
         abs_config_dir

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -565,6 +565,73 @@ async def test_submit_job_happy_path_extracts_and_queues(
 
 
 @pytest.mark.asyncio
+async def test_submit_job_happy_path_with_relative_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receiver started with a relative ``config_dir`` still queues the job (#678).
+
+    ``esphome-device-builder esphome-configs`` lands a relative
+    ``Path('esphome-configs')`` on ``settings.config_dir``. The
+    bundle extractor resolves ``target_dir`` to absolute internally,
+    so the post-extract ``extracted_yaml`` is absolute. Pre-fix,
+    ``relative_to(self._config_dir)`` raised ``ValueError`` because
+    ``Path.relative_to`` is purely lexical and rejects the
+    relative-vs-absolute pair, even though both refer to the same
+    on-disk subtree.
+    """
+    monkeypatch.chdir(tmp_path)
+    rel_config_dir = Path("esphome-configs")
+    rel_config_dir.mkdir()
+
+    firmware = _make_firmware_controller()
+    receiver = SubmitJobReceiver(
+        config_dir=rel_config_dir,
+        firmware_controller=firmware,
+    )
+    session = _make_session(dashboard_id="alpha-dashboard")
+    bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
+
+    # Stub ``prepare_bundle_for_compile`` to mirror its real
+    # behaviour: return an ABSOLUTE path under the (resolved)
+    # target_dir. The bug only surfaces when the returned path is
+    # absolute while ``self._config_dir`` is relative.
+    abs_config_dir = rel_config_dir.resolve()
+    expected_yaml = (
+        abs_config_dir
+        / ".esphome"
+        / ".remote_builds"
+        / "alpha-dashboard"
+        / "kitchen"
+        / "kitchen.yaml"
+    )
+
+    def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        expected_yaml.parent.mkdir(parents=True, exist_ok=True)
+        expected_yaml.write_bytes(b"esphome:\n  name: kitchen\n")
+        return expected_yaml
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        _stub_prepare,
+    )
+
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+    for chunk in _frame_chunks("job-1", bundle):
+        await receiver.handle_submit_job_chunk(session, chunk)
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is True, payload
+    assert payload["job_id"] == "job-1"
+    assert "reason" not in payload
+
+    assert len(firmware.created_jobs) == 1
+    job = firmware.created_jobs[0]
+    assert job.configuration == expected_yaml.relative_to(abs_config_dir).as_posix()
+    firmware._enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_submit_job_clean_target_creates_clean_job(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -33,6 +33,7 @@ from esphome_device_builder.controllers.remote_build.submit_job import (
     _validate_configuration_filename,
 )
 from esphome_device_builder.helpers.peer_link_bundle import BUNDLE_CHUNK_SIZE_BYTES
+from esphome_device_builder.helpers.remote_build_layout import RemoteBuildPath
 from esphome_device_builder.models import (
     JobType,
     SubmitJobChunkFrameData,
@@ -585,11 +586,9 @@ async def test_submit_job_happy_path_with_relative_config_dir(
     # what real ``prepare_bundle_for_compile`` produces.
     abs_config_dir = rel_config_dir.resolve()
     expected_yaml = (
-        abs_config_dir
-        / ".esphome"
-        / ".remote_builds"
-        / "alpha-dashboard"
-        / "kitchen"
+        RemoteBuildPath(dashboard_id="alpha-dashboard", device_name="kitchen").subtree(
+            abs_config_dir
+        )
         / "kitchen.yaml"
     )
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes #678: remote-build fails when the receiver-side dashboard is
started with a relative config_dir (``esphome-device-builder
esphome-configs``).

``SubmitJobReceiver._extract_and_queue`` called
``extracted_yaml.relative_to(self._config_dir)``.
``prepare_bundle_for_compile`` resolves its ``target_dir`` to absolute
before returning, but ``self._config_dir`` was whatever the user
typed on the CLI; ``Path.relative_to`` is purely lexical and refuses
the relative-vs-absolute pair.

Fix: fold the ``relative_to`` math into the existing
``_validate_write_extract_bundle`` executor hop. The helper now
takes ``config_dir`` and returns the POSIX-relative
``configuration`` string directly (the caller never used the
``extracted_yaml`` Path), so the new ``config_dir.resolve()`` call
runs alongside the two existing ``.resolve()`` calls inside the
single thread hop instead of on the event loop. blockbuster-clean
on Linux CI. Caller drops 14 lines of post-extract wire-shape
logic.

Regression tests at both layers: a unit test in
``tests/test_remote_build_submit_job.py`` (relative config_dir via
``monkeypatch.chdir`` + stubbed extractor), and an e2e test in
``tests/e2e/test_submit_job.py`` driving the real Noise + bundle +
extract chain via a new
``paired_instances_relative_receiver_config_dir`` fixture. Both fail
pre-fix with the same ``ValueError`` from the bug report.

The fixture was factored out of ``paired_instances`` into a shared
``_paired_instances_ctx`` async context manager; the original
fixture is a thin wrapper. Existing 24 e2e tests pass unchanged.

**Related issue or feature (if applicable):**

- fixes #678
- follow-up: #683 (DRY-up of hand-built layout paths in unit tests)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
