### PR TITLE
Use RemoteBuildPath.subtree for layout paths in submit_job unit tests

### DIFF
--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -524,7 +524,8 @@ async def test_submit_job_happy_path_extracts_and_queues(
     # plumbing; the real extraction is covered by esphome's own
     # tests + the e2e harness later.
     expected_yaml = (
-        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+        RemoteBuildPath(dashboard_id="alpha-dashboard", device_name="kitchen").subtree(tmp_path)
+        / "kitchen.yaml"
     )
 
     def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
@@ -642,7 +643,8 @@ async def test_submit_job_clean_target_creates_clean_job(
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
 
     expected_yaml = (
-        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+        RemoteBuildPath(dashboard_id="alpha-dashboard", device_name="kitchen").subtree(tmp_path)
+        / "kitchen.yaml"
     )
 
     def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
@@ -705,7 +707,8 @@ async def test_submit_job_carries_display_fields_through_to_firmware_job(
     session = _make_session(dashboard_id="alpha-dashboard")
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
     expected_yaml = (
-        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+        RemoteBuildPath(dashboard_id="alpha-dashboard", device_name="kitchen").subtree(tmp_path)
+        / "kitchen.yaml"
     )
 
     def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
@@ -761,7 +764,8 @@ async def test_submit_job_malformed_display_fields_coerce_to_empty(
     session = _make_session(dashboard_id="alpha-dashboard")
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
     expected_yaml = (
-        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+        RemoteBuildPath(dashboard_id="alpha-dashboard", device_name="kitchen").subtree(tmp_path)
+        / "kitchen.yaml"
     )
 
     def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
@@ -816,7 +820,8 @@ async def test_submit_job_missing_display_fields_falls_through_to_empty_strings(
     session = _make_session(dashboard_id="alpha-dashboard")
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
     expected_yaml = (
-        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+        RemoteBuildPath(dashboard_id="alpha-dashboard", device_name="kitchen").subtree(tmp_path)
+        / "kitchen.yaml"
     )
 
     def _stub_prepare(bundle_path: Path, target_dir: Path) -> Path:
@@ -893,7 +898,8 @@ async def test_submit_job_bundle_path_survives_prepare_bundle_wipe(
     session = _make_session(dashboard_id="alpha-dashboard")
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")
     expected_yaml = (
-        tmp_path / ".esphome" / ".remote_builds" / "alpha-dashboard" / "kitchen" / "kitchen.yaml"
+        RemoteBuildPath(dashboard_id="alpha-dashboard", device_name="kitchen").subtree(tmp_path)
+        / "kitchen.yaml"
     )
 
     # Mirror upstream prepare_bundle_for_compile's preserve set


### PR DESCRIPTION
# What does this implement/fix?

Closes #683. Replaces six hand-built
``<config_dir>/.esphome/.remote_builds/<dashboard_id>/<device_name>/<yaml>``
path expressions in ``tests/test_remote_build_submit_job.py`` with
``RemoteBuildPath(dashboard_id=..., device_name=...).subtree(config_dir)
/ "<yaml>"``. The helper in
``esphome_device_builder.helpers.remote_build_layout`` is the
single source of truth for the on-disk layout; the duplications
silently drift when the layout moves (e.g. PR #552 already moved
the bundle tarball out of ``target_dir``).

Pure test-only refactor; no production code touched.

**Related issue or feature (if applicable):**

- closes #683

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
