### PR TITLE
Schedule storage regen on add_component + edit_friendly_name (#676)

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1183,12 +1183,11 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
             configuration, new_content, action="update friendly name"
         )
 
-        # Routed through :meth:`_write_yaml_atomic_async`; the
-        # helper's docstring covers the canonical "stage-tempfile
-        # + atomic rename" rationale we lean on here for the
-        # user-editable YAML path.
-        await self._write_yaml_atomic_async(config_path, new_content)
-        await self._scanner.scan()
+        # Routed through :meth:`_persist_yaml_mutation` so the
+        # rewritten YAML lands atomically and ``StorageJSON``
+        # picks up the new ``config_hash`` without waiting for
+        # a compile.
+        await self._persist_yaml_mutation(configuration, new_content)
         return {"configuration": configuration, "rewritten": True}
 
     def _yaml_content_for_create(
@@ -1438,18 +1437,12 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
     async def update_config(self, *, configuration: str, content: str, **kwargs: Any) -> None:
         """Write device config YAML.
 
-        Routed through :meth:`_write_yaml_atomic_async` because the YAML
-        editor's "Save" button lands here; a non-atomic write would
-        lose the user's config on a mid-write crash.
+        Routed through :meth:`_persist_yaml_mutation` so the
+        editor's "Save" lands an atomic write + a StorageJSON
+        regen (mirrors the upstream dashboard's
+        ``EditRequestHandler`` → ``async_schedule_storage_json_update``).
         """
-        await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
-        await self._scanner.scan()
-        # Refresh ``StorageJSON`` so address / loaded_integrations /
-        # config_hash etc. reflect the new YAML without waiting for a
-        # full compile. Mirrors the upstream dashboard's
-        # ``async_schedule_storage_json_update`` (called from its
-        # ``EditRequestHandler`` after writing the YAML).
-        self._schedule_storage_regenerate(configuration)
+        await self._persist_yaml_mutation(configuration, content)
 
     def _schedule_storage_regenerate(self, configuration: str) -> None:
         storage_regen.schedule(self, configuration)
@@ -1542,8 +1535,7 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         new_yaml = merge_component_yaml(existing, component, fields)
         # Atomic write — wizard-driven add-component should not be
         # able to corrupt the source YAML on a mid-write crash.
-        await self._write_yaml_atomic_async(config_path, new_yaml)
-        await self._scanner.scan()
+        await self._persist_yaml_mutation(configuration, new_yaml)
 
         return AddComponentResponse(yaml=new_yaml)
 
@@ -1728,6 +1720,22 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         """
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, atomic_write_file, path, content)
+
+    async def _persist_yaml_mutation(self, configuration: str, content: str) -> None:
+        """Atomic write + scan + StorageJSON regen for in-place YAML mutators.
+
+        Every WS command that rewrites an existing device YAML
+        (``update_config``, ``add_component``, ``edit_friendly_name``)
+        funnels through here so the regen-schedule call can't get
+        forgotten on a new mutator (#676).
+        """
+        await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
+        await self._scanner.scan()
+        # Refresh ``StorageJSON`` so ``loaded_integrations`` /
+        # ``config_hash`` reflect the new YAML without waiting
+        # for a full compile. Mirrors the upstream dashboard's
+        # ``async_schedule_storage_json_update``.
+        self._schedule_storage_regenerate(configuration)
 
     @staticmethod
     async def _read_yaml_async(path: Path) -> str:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1183,10 +1183,6 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
             configuration, new_content, action="update friendly name"
         )
 
-        # Routed through :meth:`_persist_yaml_mutation` so the
-        # rewritten YAML lands atomically and ``StorageJSON``
-        # picks up the new ``config_hash`` without waiting for
-        # a compile.
         await self._persist_yaml_mutation(configuration, new_content)
         return {"configuration": configuration, "rewritten": True}
 
@@ -1435,13 +1431,7 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
 
     @api_command("devices/update_config")
     async def update_config(self, *, configuration: str, content: str, **kwargs: Any) -> None:
-        """Write device config YAML.
-
-        Routed through :meth:`_persist_yaml_mutation` so the
-        editor's "Save" lands an atomic write + a StorageJSON
-        regen (mirrors the upstream dashboard's
-        ``EditRequestHandler`` → ``async_schedule_storage_json_update``).
-        """
+        """Write device config YAML."""
         await self._persist_yaml_mutation(configuration, content)
 
     def _schedule_storage_regenerate(self, configuration: str) -> None:
@@ -1722,19 +1712,12 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         await loop.run_in_executor(None, atomic_write_file, path, content)
 
     async def _persist_yaml_mutation(self, configuration: str, content: str) -> None:
-        """Atomic write + scan + StorageJSON regen for in-place YAML mutators.
-
-        Every WS command that rewrites an existing device YAML
-        (``update_config``, ``add_component``, ``edit_friendly_name``)
-        funnels through here so the regen-schedule call can't get
-        forgotten on a new mutator (#676).
-        """
+        """Atomic write + scan + StorageJSON regen for in-place YAML mutators."""
         await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
         await self._scanner.scan()
-        # Refresh ``StorageJSON`` so ``loaded_integrations`` /
-        # ``config_hash`` reflect the new YAML without waiting
-        # for a full compile. Mirrors the upstream dashboard's
-        # ``async_schedule_storage_json_update``.
+        # Mirrors the upstream dashboard's
+        # ``async_schedule_storage_json_update``; without it
+        # ``loaded_integrations`` stays at its pre-write state.
         self._schedule_storage_regenerate(configuration)
 
     @staticmethod

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -492,10 +492,6 @@ def make_controller() -> MakeControllerFactory:
             controller._regenerate_failed = set()
             controller._regenerate_lock = asyncio.Lock()
 
-        # Mirror ``__init__``'s default so the schedule-regen guard's
-        # falsy check works without each test having to opt into
-        # ``esphome_cmd=...``; ``[]`` short-circuits the spawn the
-        # same way an unstarted controller would in production.
         controller._esphome_cmd = esphome_cmd if esphome_cmd is not None else []
 
         return controller

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -492,8 +492,11 @@ def make_controller() -> MakeControllerFactory:
             controller._regenerate_failed = set()
             controller._regenerate_lock = asyncio.Lock()
 
-        if esphome_cmd is not None:
-            controller._esphome_cmd = esphome_cmd
+        # Mirror ``__init__``'s default so the schedule-regen guard's
+        # falsy check works without each test having to opt into
+        # ``esphome_cmd=...``; ``[]`` short-circuits the spawn the
+        # same way an unstarted controller would in production.
+        controller._esphome_cmd = esphome_cmd if esphome_cmd is not None else []
 
         return controller
 

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -80,7 +80,7 @@ async def test_edit_friendly_name_schedules_storage_regenerate(
     make_controller: MakeControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Rewrite refreshes ``StorageJSON`` so ``config_hash`` reflects the new YAML (#676)."""
+    """Successful rewrite schedules a StorageJSON regen."""
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
     scheduled: list[str] = []

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -75,6 +75,25 @@ async def test_edit_friendly_name_rewrites_literal_leaf_and_scans(
     assert ctrl._scanner.calls == [("scan",)]
 
 
+async def test_edit_friendly_name_schedules_storage_regenerate(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rewrite refreshes ``StorageJSON`` so ``config_hash`` reflects the new YAML (#676)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+    scheduled: list[str] = []
+    monkeypatch.setattr(ctrl, "_schedule_storage_regenerate", scheduled.append, raising=False)
+
+    await ctrl.edit_friendly_name(
+        configuration="kitchen.yaml",
+        new_friendly_name="Reading Lamp",
+    )
+
+    assert scheduled == ["kitchen.yaml"]
+
+
 async def test_edit_friendly_name_redirects_through_substitution(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -647,9 +647,6 @@ def _make_controller(catalog: ComponentCatalog, tmp_path: Any) -> DevicesControl
     ctrl._db.components = catalog
     ctrl._scanner = MagicMock()
     ctrl._scanner.scan = AsyncMock()
-    # Mirror ``__init__``'s default so the schedule-regen guard's
-    # falsy check short-circuits cleanly without spinning up a
-    # subprocess.
     ctrl._esphome_cmd = []
     return ctrl
 
@@ -896,11 +893,7 @@ async def test_add_component_handles_secret_tags_in_existing_yaml(
 async def test_add_component_schedules_storage_regenerate(
     catalog: ComponentCatalog, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``add_component`` refreshes ``StorageJSON`` after the write (#676).
-
-    Without this, ``loaded_integrations`` stays at its pre-add
-    state and the frontend gates Install on a stale list.
-    """
+    """``add_component`` schedules a StorageJSON regen after the write."""
     (tmp_path / "plug.yaml").write_text("esphome:\n  name: plug\n", "utf-8")
     ctrl = _make_controller(catalog, tmp_path)
     scheduled: list[str] = []

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -647,6 +647,10 @@ def _make_controller(catalog: ComponentCatalog, tmp_path: Any) -> DevicesControl
     ctrl._db.components = catalog
     ctrl._scanner = MagicMock()
     ctrl._scanner.scan = AsyncMock()
+    # Mirror ``__init__``'s default so the schedule-regen guard's
+    # falsy check short-circuits cleanly without spinning up a
+    # subprocess.
+    ctrl._esphome_cmd = []
     return ctrl
 
 
@@ -887,6 +891,28 @@ async def test_add_component_handles_secret_tags_in_existing_yaml(
     # mqtt block IS present (just uses !secret) — so MQTT fields stay.
     assert "availability:" in response.yaml
     assert "payload_available: online" in response.yaml
+
+
+async def test_add_component_schedules_storage_regenerate(
+    catalog: ComponentCatalog, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``add_component`` refreshes ``StorageJSON`` after the write (#676).
+
+    Without this, ``loaded_integrations`` stays at its pre-add
+    state and the frontend gates Install on a stale list.
+    """
+    (tmp_path / "plug.yaml").write_text("esphome:\n  name: plug\n", "utf-8")
+    ctrl = _make_controller(catalog, tmp_path)
+    scheduled: list[str] = []
+    monkeypatch.setattr(ctrl, "_schedule_storage_regenerate", scheduled.append, raising=False)
+
+    await ctrl.add_component(
+        configuration="plug.yaml",
+        component_id="featured.athom-smart-plug-v3.relay",
+        fields={},
+    )
+
+    assert scheduled == ["plug.yaml"]
 
 
 def test_drop_unconfigured_dependent_fields_recurses_into_nested_dicts() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fixes #676: after the "Add Component" wizard runs, the editor's
Save button stays inactive and the Install button doesn't appear.
The user has to manually edit and save to unstick both.

## Root cause

``add_component`` and ``edit_friendly_name`` write the YAML to disk
but skip the StorageJSON regen that ``update_config`` already runs.
``StorageJSON.loaded_integrations`` stays at its pre-add state, the
frontend gates Install visibility on that field, and the user
can't reach Install until something refreshes it. Manual save
routes through ``update_config`` which schedules the regen, so the
visible workaround is to edit a character and save.

## Fix

Extracts the shared write + scan + schedule-regen shape into a
``_persist_yaml_mutation`` helper so all three in-place YAML
mutators (``update_config``, ``add_component``,
``edit_friendly_name``) take the same code path. A new mutator
added later can't forget the regen schedule by copying the wrong
template.

Test infrastructure side-fix: the bypass-init ``DevicesController``
factory in ``tests/controllers/devices/conftest.py`` and the
analogous one in ``tests/test_featured_components.py`` now default
``_esphome_cmd = []`` (mirroring ``__init__``). Without this the
regen guard tripped ``AttributeError`` in tests that didn't opt into
``esphome_cmd=...``.

## Tests

Two regression tests; both monkeypatch
``_schedule_storage_regenerate`` to a recorder and assert the
configuration name was captured:

* ``tests/test_featured_components.py::test_add_component_schedules_storage_regenerate``
* ``tests/controllers/devices/test_edit_friendly_name.py::test_edit_friendly_name_schedules_storage_regenerate``

Both fail pre-fix.

**Related issue or feature (if applicable):**

- fixes #676

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
