### PR TITLE
Refine status framing: base late beta, remote early beta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,10 @@ board catalog. Frontend is a separate repo
 (`esphome/device-builder-dashboard-frontend`) and ships prebuilt
 inside our wheel.
 
-Mid to late beta. Targeted to land as an opt-in preview
-toggle in the official ESPHome container and Home Assistant add-on.
+Base functions are in late beta; remote / offload functions are in
+early beta. Expect undocumented breaking changes until the project
+is marked stable. Targeted to land as an opt-in preview toggle in
+the official ESPHome container and Home Assistant add-on.
 
 ## Code style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ board catalog. Frontend is a separate repo
 (`esphome/device-builder-dashboard-frontend`) and ships prebuilt
 inside our wheel.
 
-Roughly alpha closing on beta. Targeted to land as an opt-in preview
+Mid to late beta. Targeted to land as an opt-in preview
 toggle in the official ESPHome container and Home Assistant add-on.
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/esphome-device-builder.svg)](https://pypi.org/project/esphome-device-builder/) [![codecov](https://codecov.io/gh/esphome/device-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/esphome/device-builder) [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/esphome/device-builder)
 
-> **Status:** in active development, mid to late beta. Issues
+> **Status:** in active development. Base functions are in late beta;
+> remote / offload functions are in early beta. Expect undocumented
+> breaking changes until the project is marked stable. Issues
 > and feedback welcome — please check existing issues / the
 > [project board](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder-dashboard%22)
 > first, and join the [Discord channel](https://discord.gg/Rf2jWGVjaK)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/esphome-device-builder.svg)](https://pypi.org/project/esphome-device-builder/) [![codecov](https://codecov.io/gh/esphome/device-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/esphome/device-builder) [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/esphome/device-builder)
 
-> **Status:** in active development. Roughly alpha, closing on beta. Issues
+> **Status:** in active development, mid to late beta. Issues
 > and feedback welcome — please check existing issues / the
 > [project board](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder-dashboard%22)
 > first, and join the [Discord channel](https://discord.gg/Rf2jWGVjaK)


### PR DESCRIPTION
# What does this implement/fix?

Refines the project status framing in both ``README.md`` and
``CLAUDE.md``: base functions are in late beta; remote / offload
functions are in early beta. Notes that undocumented breaking
changes are still possible until the project is marked stable.
No code or behaviour change.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
