### PR TITLE
Drop unused controller arg from logs.stream_subprocess

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -2193,4 +2193,4 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         *,
         line_transform: Callable[[str], str] | None = None,
     ) -> None:
-        await logs.stream_subprocess(self, cmd, client, message_id, line_transform=line_transform)
+        await logs.stream_subprocess(cmd, client, message_id, line_transform=line_transform)

--- a/esphome_device_builder/controllers/devices/logs.py
+++ b/esphome_device_builder/controllers/devices/logs.py
@@ -71,7 +71,6 @@ def stop_stream(client: Any, stream_id: str) -> dict:
 
 
 async def stream_subprocess(
-    controller: DevicesController,
     cmd: list[str],
     client: Any,
     message_id: str,


### PR DESCRIPTION
# What does this implement/fix?

Tiny follow-up to #687: drops the unused `controller` parameter from `logs.stream_subprocess`. The function only references its `cmd` / `client` / `message_id` / `line_transform` parameters; the `controller` arg was added in #687 for symmetry with `logs.stream_logs` but never actually read inside the body.

The controller's `_stream_subprocess` delegate updates its single call site to drop the `self,` first arg.

`logs.stream_logs` keeps its `controller` parameter — it really does need it (reads `_db.settings.rel_path`, `_esphome_cmd`, `get_ota_address_cache_args`, and routes back through `_stream_subprocess` for test-interception).

3215 tests pass.

**Related issue or feature (if applicable):**

- follow-up to #687

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
