### PR TITLE
Bump atomic-parent-mkdir test timeout to 2s

### DIFF
--- a/tests/test_helpers_storage.py
+++ b/tests/test_helpers_storage.py
@@ -302,8 +302,8 @@ async def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
     )
     store.async_delay_save(lambda: b"nested", delay=0.0)
     # 2s rather than the 1s used by the simple-write tests below;
-    # the parent-directory mkdir on top of the atomic write tips
-    # this past 1s on loaded Windows runners (#689 flake).
+    # the parent-directory mkdir on top of the atomic write can tip
+    # this past 1s on loaded Windows runners.
     await _drain_loop_until(store_path.exists, timeout=2.0)
     assert store_path.read_bytes() == b"nested"
 

--- a/tests/test_helpers_storage.py
+++ b/tests/test_helpers_storage.py
@@ -301,7 +301,10 @@ async def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
         shutdown_register=lambda _cb: None,
     )
     store.async_delay_save(lambda: b"nested", delay=0.0)
-    await _drain_loop_until(store_path.exists, timeout=1.0)
+    # 2s rather than the 1s used by the simple-write tests below;
+    # the parent-directory mkdir on top of the atomic write tips
+    # this past 1s on loaded Windows runners (#689 flake).
+    await _drain_loop_until(store_path.exists, timeout=2.0)
     assert store_path.read_bytes() == b"nested"
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a flake in `tests/test_helpers_storage.py::test_atomic_write_creates_parent_directory` that surfaced on the Windows / Python 3.14 job for #689 (and is reproducible on any sufficiently loaded Windows runner).

The test does `mkdir(parents=True, exist_ok=True)` on a `subdir/nested/` path *plus* the atomic-write tempfile + rename — the only test in this file that pays the mkdir cost on top of the write. The slowest-tests output from the failing run shows it ran in 1.01s, right past the 1.0s `_drain_loop_until` deadline. Sibling tests at lines 113 and 134 already use `timeout=2.0` for their longer paths; this just brings the parent-mkdir test in line with that ceiling. The simple-write tests at lines 289 / 325 / 347 / 449 stay at 1.0s since they don't pay the mkdir overhead.

**Related issue or feature (if applicable):**

- fixes the flake hit on #689's Windows job

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
