### PR TITLE
Fix StoredPeer docstring stale storage location

### DIFF
--- a/esphome_device_builder/models/remote_build/receiver.py
+++ b/esphome_device_builder/models/remote_build/receiver.py
@@ -14,12 +14,16 @@ class StoredPeer(DataClassORJSONMixin):
     """
     Receiver-side record of a paired (or pending) offloader.
 
-    Persisted under ``_remote_build.peers``. Created by the
-    pair-request flow over the peer-link WS: an offloader runs
-    a Noise XX handshake with ``intent="pair_request"`` and a
-    payload carrying its ``label`` + ``dashboard_id``. The
-    receiver reads the offloader's static X25519 pubkey from
-    the Noise handshake itself (no cert involved) and stores it.
+    Persisted in its own per-file
+    :class:`~helpers.storage.Store` at
+    ``<config_dir>/.receiver_peers.json`` (the
+    :class:`ReceiverPeers` container wraps the list at that
+    path). Created by the pair-request flow over the peer-link
+    WS: an offloader runs a Noise XX handshake with
+    ``intent="pair_request"`` and a payload carrying its
+    ``label`` + ``dashboard_id``. The receiver reads the
+    offloader's static X25519 pubkey from the Noise handshake
+    itself (no cert involved) and stores it.
 
     ``static_x25519_pub`` is the canonical identifier the
     Noise handshake binds to. ``pin_sha256`` is its lowercase-

--- a/esphome_device_builder/models/remote_build/receiver.py
+++ b/esphome_device_builder/models/remote_build/receiver.py
@@ -14,12 +14,15 @@ class StoredPeer(DataClassORJSONMixin):
     """
     Receiver-side record of a paired (or pending) offloader.
 
-    Persisted in its own per-file
+    APPROVED rows are persisted in their own per-file
     :class:`~helpers.storage.Store` at
     ``<config_dir>/.receiver_peers.json`` (the
     :class:`ReceiverPeers` container wraps the list at that
-    path). Created by the pair-request flow over the peer-link
-    WS: an offloader runs a Noise XX handshake with
+    path). PENDING rows live only in
+    ``ReceiverController._pending_peers`` and never reach
+    disk — their lifetime is bounded by the pairing window.
+    Created by the pair-request flow over the peer-link WS:
+    an offloader runs a Noise XX handshake with
     ``intent="pair_request"`` and a payload carrying its
     ``label`` + ``dashboard_id``. The receiver reads the
     offloader's static X25519 pubkey from the Noise handshake


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the split landed in #688: `StoredPeer`'s docstring still opened with the legacy `_remote_build.peers` storage location, but the row actually lives in its own per-file `~helpers.storage.Store` at `<config_dir>/.receiver_peers.json` (the `ReceiverPeers` container wraps the list there). The class docstring itself goes on to describe the runtime registry correctly later — the opening sentence was the only stale line.

Pre-existing carryover from the monolith; flagged by Copilot on #688 and triaged into a separate PR to keep the split behaviour-free.

**Related issue or feature (if applicable):**

- follow-up to #688

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
