### PR TITLE
Trim stale MANUAL refs from RemoteBuildPeer docstring

### DIFF
--- a/esphome_device_builder/models/remote_build/offloader.py
+++ b/esphome_device_builder/models/remote_build/offloader.py
@@ -399,23 +399,17 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     """
     A peer dashboard known to this dashboard.
 
-    Wire shape returned from ``remote_build/list_hosts``. Two
-    sources land in the same row shape:
-
-    * ``source=MDNS``: discovered via the
-      ``_esphomebuilder._tcp.local.`` browse. ``name`` is the
-      mDNS service-instance name (leftmost label, e.g.
-      ``desktop``); ``hostname`` is the SRV target (e.g.
-      ``desktop.local.``); ``addresses`` is the parsed A / AAAA
-      list with IPv6 scope preserved; versions come from TXT.
-    * ``source=MANUAL``: user-supplied via
-      ``remote_build/add_manual_host``. ``name`` is the full
-      hostname verbatim (NOT the leftmost label) so an IP-only
-      entry like ``192.168.1.10`` reads sensibly in the UI rather
-      than truncating to ``"192"``. ``hostname`` is the same
-      user-entered string, ``port`` is the user-entered port,
-      ``addresses`` is empty, and version fields are blank until
-      a pairing attempt runs the connection.
+    Wire shape returned from ``remote_build/list_hosts``. The
+    only source today is ``source=MDNS``: discovered via the
+    ``_esphomebuilder._tcp.local.`` browse. ``name`` is the
+    mDNS service-instance name (leftmost label, e.g.
+    ``desktop``); ``hostname`` is the SRV target (e.g.
+    ``desktop.local.``); ``addresses`` is the parsed A / AAAA
+    list with IPv6 scope preserved; versions come from TXT.
+    Cross-subnet pair flows bypass discovery entirely and go
+    straight through ``request_pair`` — see
+    :class:`RemoteBuildPeerSource` for why no manual-host enum
+    member exists.
     """
 
     name: str
@@ -435,12 +429,8 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     # ``helpers/peer_link_identity.py``). The offloader uses
     # both to match a discovered broadcast against a stored
     # pairing's ``pin_sha256`` and dial the right peer-link
-    # port for the auto-rebind probe. Empty string / 0 for:
-    # receivers that haven't bound the
-    # peer-link listener (default-off mode), and ``MANUAL``
-    # rows (which never go through the mDNS resolve path; the
-    # user typed the hostname/port and the pair flow captures
-    # the pin into ``StoredPairing`` rather than back onto this
-    # row).
+    # port for the auto-rebind probe. Empty string / 0 for
+    # receivers that haven't bound the peer-link listener
+    # (default-off mode).
     pin_sha256: str = ""
     remote_build_port: int = 0

--- a/esphome_device_builder/models/remote_build/offloader.py
+++ b/esphome_device_builder/models/remote_build/offloader.py
@@ -399,8 +399,12 @@ class RemoteBuildPeer(DataClassORJSONMixin):
     """
     A peer dashboard known to this dashboard.
 
-    Wire shape returned from ``remote_build/list_hosts``. The
-    only source today is ``source=MDNS``: discovered via the
+    Wire shape reaching the frontend through
+    :meth:`OffloaderController.hosts_snapshot` (the sync read
+    used by ``subscribe_events.initial_state.hosts``) plus the
+    matching ``REMOTE_BUILD_HOST_ADDED`` /
+    ``REMOTE_BUILD_HOST_REMOVED`` events. The only source
+    today is ``source="mdns"``: discovered via the
     ``_esphomebuilder._tcp.local.`` browse. ``name`` is the
     mDNS service-instance name (leftmost label, e.g.
     ``desktop``); ``hostname`` is the SRV target (e.g.


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #688: `RemoteBuildPeer`'s docstring described two sources (`MDNS` and `MANUAL`) and referenced a `remote_build/add_manual_host` WS command, but the manual-hosts flow was removed when the pair dialog started typing hostnames straight into `request_pair` — `RemoteBuildPeerSource` has only `MDNS` today, and the `manual_hosts` removal is already called out in the `RemoteBuildSettings` docstring (*"the manual_hosts flow was removed once the pair dialog started typing hostnames straight into request_pair"*).

Drops the stale `source=MANUAL` bullet from the class docstring and the `MANUAL` clause from the `pin_sha256` field comment, and adds a one-line pointer to `RemoteBuildPeerSource` for why no manual-host enum member exists.

Pre-existing carryover from the monolith; flagged by Copilot on #688 and triaged into a separate PR to keep the split behaviour-free.

**Related issue or feature (if applicable):**

- follow-up to #688

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
