### PR TITLE
Add missing pin_sha256/remote_build_port to RemoteBuildHostAddedData

### DIFF
--- a/esphome_device_builder/models/remote_build/offloader_events.py
+++ b/esphome_device_builder/models/remote_build/offloader_events.py
@@ -252,6 +252,11 @@ class RemoteBuildHostAddedData(TypedDict):
     semantics — the frontend keys the discovered-hosts list on
     ``name`` (the mDNS service-instance name) and replaces an
     existing row with the same key when this event fires.
+
+    ``pin_sha256`` and ``remote_build_port`` come from the
+    ``_esphomebuilder._tcp.local.`` TXT record; empty / 0 for
+    receivers that haven't bound the peer-link listener
+    (default-off mode).
     """
 
     name: str
@@ -261,6 +266,8 @@ class RemoteBuildHostAddedData(TypedDict):
     addresses: list[str]
     server_version: str
     esphome_version: str
+    pin_sha256: str
+    remote_build_port: int
 
 
 class RemoteBuildHostRemovedData(TypedDict):


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #688: `RemoteBuildHostAddedData`'s docstring said it carried "the full `RemoteBuildPeer` projection", but the TypedDict declared only 7 of the 9 fields the emitter actually puts on the wire. The emit site at `controllers/remote_build/offloader.py:551` does:

```python
bus.fire(EventType.REMOTE_BUILD_HOST_ADDED, peer.to_dict())
```

where `peer` is a `RemoteBuildPeer`, which carries `pin_sha256` and `remote_build_port` (the peer-link Noise WS pubkey hash + port pulled out of the `_esphomebuilder._tcp.local.` TXT record). Wire shape always included them; the TypedDict didn't.

Adds the two missing fields. Pre-existing carryover from the monolith; flagged by Copilot on #688 and triaged into a separate PR.

**Wire shape on the bus is unchanged** — the runtime payload already carried `pin_sha256` + `remote_build_port` since the fields were added to `RemoteBuildPeer`. This is purely a type-annotation correction so subscribers narrowing through `RemoteBuildHostAddedData` can access them under mypy. The `REMOVED` variant only carries `{"name": str}` and already matches.

**Related issue or feature (if applicable):**

- follow-up to #688

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
