### PR TITLE
Document CodSpeed parametrize-ID length pitfall in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -638,6 +638,26 @@ When changing the sync script or catalog handling, watch for these:
   partial write is recoverable on next compile / scan can stay
   on direct-write paths — the criterion is "would losing this
   file lose user-authored content."
+- **CodSpeed parametrize values need explicit
+  `pytest.param(value, id="<short>")` IDs when the value isn't
+  already a short primitive.** pytest's auto-generated test ID
+  concatenates the parameter values verbatim, so a multi-KB
+  YAML body / bytes payload / anything whose `repr()` runs more
+  than a few dozen characters bakes into the test name. The
+  benchmark run itself passes and the data uploads fine, but
+  the server-side "CodSpeed Performance Analysis" check fails
+  with "Unable to generate the performance report" / "internal
+  error while processing the run's data"; the report ingest
+  hits a length limit on the test identifier and silently
+  drops the whole run. Follow the existing pattern in
+  `tests/benchmarks/test_log_streaming.py` and
+  `tests/benchmarks/test_peer_link_noise_xx.py`:
+  `pytest.param(_LARGE_PAYLOAD, id="newline_1k")`,
+  `pytest.param(1024, id="1KiB")`. Bare ints / short slugs whose
+  autogen ID is already terse
+  (`parametrize("fleet_size", [50, 200])` -> `[50]` / `[200]`)
+  are fine as-is; the trap is parametrize values that carry
+  large content.
 
 ## Useful entry points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,7 +652,7 @@ When changing the sync script or catalog handling, watch for these:
   drops the whole run. Follow the existing pattern in
   `tests/benchmarks/test_log_streaming.py` and
   `tests/benchmarks/test_peer_link_noise_xx.py`:
-  `pytest.param(_LARGE_PAYLOAD, id="newline_1k")`,
+  `pytest.param(_NEWLINE_PAYLOAD, 1000, id="newline_1k")`,
   `pytest.param(1024, id="1KiB")`. Bare ints / short slugs whose
   autogen ID is already terse
   (`parametrize("fleet_size", [50, 200])` -> `[50]` / `[200]`)


### PR DESCRIPTION
# What does this implement/fix?

Documents the CodSpeed parametrize-ID length pitfall we hit on
#690 as a bullet under "Things that have bitten us before". A
benchmark parametrize that wrapped multi-KB YAML bodies without
explicit `pytest.param(..., id="<short>")` IDs produced test
names whose auto-generated suffix baked the full YAML body into
the identifier (`test_merge_component_yaml_sizes[100-esphome:\n  name: bench_device\n  friendly_name: ...]`).
The benchmark run itself passed and the data uploaded, but the
server-side "CodSpeed Performance Analysis" check failed with
"Unable to generate the performance report" / "internal error
while processing the run's data" because the report ingest
silently drops runs whose test identifiers exceed an internal
length limit.

The fix on #690 was to wrap each value with
`pytest.param(value, id="100")`, matching the established
convention in `tests/benchmarks/test_log_streaming.py`
(`pytest.param(_NEWLINE_PAYLOAD, id="newline_1k")`) and
`tests/benchmarks/test_peer_link_noise_xx.py`
(`pytest.param(1024, id="1KiB")`).

Captured the lesson here so future benchmark additions follow the
existing convention without re-discovering the failure mode.

**Related issue or feature (if applicable):**

- Follow-up to #690.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
