### PR TITLE
Split DevicesController: extract add_component WS command

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -9,6 +9,9 @@ resolving after the subpackage split. Submodules:
 - ``helpers`` — pure free functions (``_remove_device_sidecars``,
   ``_apply_featured_presets``, ``_build_address_cache_args``,
   ``friendly_name_slugify`` re-export).
+- ``add_component`` — ``devices/add_component`` WS command
+  body (featured-id resolution + manifest-driven preset
+  merge + atomic YAML rewrite).
 - ``api_key`` — Native API encryption-key resolver
   (in-process YAML loader fast path + ``esphome config``
   subprocess fallback).

--- a/esphome_device_builder/controllers/devices/add_component.py
+++ b/esphome_device_builder/controllers/devices/add_component.py
@@ -1,0 +1,83 @@
+"""``devices/add_component`` WS command body."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ...helpers.yaml import merge_component_yaml
+from ...models import AddComponentResponse
+from .helpers import _apply_featured_presets, _drop_unconfigured_dependent_fields
+
+if TYPE_CHECKING:
+    from .controller import DevicesController
+
+
+async def add_component(
+    controller: DevicesController,
+    *,
+    configuration: str,
+    component_id: str,
+    fields: dict[str, Any] | None,
+) -> AddComponentResponse:
+    """
+    Add a component block to an existing device YAML.
+
+    ``fields`` is a flat mapping of config-entry key → value. For
+    NESTED config entries the value is itself a dict matching the
+    nested entry's structure (recursive).
+
+    Featured-component ids (``featured.<board>.<local>``) are
+    recognised here: the backend resolves them to the underlying
+    catalog component, validates user input against the manifest's
+    ``locked`` / ``suggestions`` constraints, and merges the
+    manifest's preset values into ``fields`` before delegating to
+    the regular merge logic.
+    """
+    assert controller._db.components is not None  # type narrowing
+
+    fields = dict(fields or {})
+    underlying_component_id = component_id
+
+    if component_id.startswith("featured."):
+        record = controller._db.components.get_featured_record(component_id)
+        if record is None:
+            msg = f"Unknown featured component: {component_id}"
+            raise ValueError(msg)
+        underlying_component_id = record.underlying_id
+        fields = _apply_featured_presets(record, fields)
+        # The frontend's catalog-derived id suggestion for featured
+        # components is the dashed ``featured_<board>_<local>`` form
+        # (e.g. ``featured_athom-smart-plug-v3_power_monitor_1`` —
+        # the board id still carries dashes), which ESPHome rejects.
+        # Reset to empty when the supplied id contains a dash so
+        # ``generate_component_yaml`` produces a valid auto-id from
+        # the underlying component + name; a user-typed custom id
+        # without dashes passes through.
+        user_id = fields.get("id")
+        if isinstance(user_id, str) and "-" in user_id:
+            fields["id"] = ""
+
+    component = await controller._db.components.get_component(component_id=underlying_component_id)
+    if component is None:
+        msg = f"Unknown component: {underlying_component_id}"
+        raise ValueError(msg)
+
+    for entry in component.config_entries:
+        if entry.required and entry.key not in fields:
+            msg = f"Missing required field: {entry.key}"
+            raise ValueError(msg)
+
+    config_path = controller._db.settings.rel_path(configuration)
+    existing = await controller._read_yaml_async(config_path)
+    # Honour each field's ``depends_on_component`` gate against
+    # what's actually in the device YAML; drops MQTT-only options
+    # (``availability:``, ``state_topic:``, ...) when the device
+    # has no ``mqtt:`` block, mirroring what the frontend already
+    # does field-by-field on the input form.
+    fields = _drop_unconfigured_dependent_fields(fields, component, existing)
+    new_yaml = merge_component_yaml(existing, component, fields)
+    # Atomic write; wizard-driven add-component should not be able
+    # to corrupt the source YAML on a mid-write crash.
+    await controller._persist_yaml_mutation(configuration, new_yaml)
+
+    return AddComponentResponse(yaml=new_yaml)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -34,7 +34,6 @@ from ...helpers.storage_path import resolve_storage_path
 from ...helpers.yaml import (
     YamlUpsertNotSupportedError,
     generate_api_encryption_key,
-    merge_component_yaml,
     rewrite_api_encryption_key,
     rewrite_name_or_substitution,
     upsert_yaml_leaf_under_top_block,
@@ -66,7 +65,16 @@ from ..config import (
     set_device_metadata,
 )
 from ..firmware.helpers import _find_esphome_cmd
-from . import api_key, archive, firmware_sync, importable, logs, reachability, storage_regen
+from . import (
+    add_component,
+    api_key,
+    archive,
+    firmware_sync,
+    importable,
+    logs,
+    reachability,
+    storage_regen,
+)
 from ._yaml_search import (
     DEFAULT_CONTEXT_LINES,
     MAX_CONTEXT_LINES,
@@ -74,9 +82,7 @@ from ._yaml_search import (
 )
 from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
-    _apply_featured_presets,
     _build_address_cache_args,
-    _drop_unconfigured_dependent_fields,
     _redact_concealed_secrets,
     _rewrite_required_yaml_leaf,
     _validate_archive_configuration,
@@ -1461,68 +1467,13 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         fields: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> AddComponentResponse:
-        """
-        Add a component block to an existing device YAML.
-
-        ``fields`` is a flat mapping of config-entry key → value. For
-        NESTED config entries the value is itself a dict matching the
-        nested entry's structure (recursive).
-
-        Featured-component ids (``featured.<board>.<local>``) are
-        recognised here: the backend resolves them to the underlying
-        catalog component, validates user input against the manifest's
-        ``locked`` / ``suggestions`` constraints, and merges the
-        manifest's preset values into ``fields`` before delegating to
-        the regular merge logic.
-        """
-        assert self._db.components is not None  # type narrowing
-
-        fields = dict(fields or {})
-        underlying_component_id = component_id
-
-        if component_id.startswith("featured."):
-            record = self._db.components.get_featured_record(component_id)
-            if record is None:
-                msg = f"Unknown featured component: {component_id}"
-                raise ValueError(msg)
-            underlying_component_id = record.underlying_id
-            fields = _apply_featured_presets(record, fields)
-            # The frontend's catalog-derived id suggestion for featured
-            # components is the dashed ``featured_<board>_<local>``
-            # form (e.g. ``featured_athom-smart-plug-v3_power_monitor_1``
-            # — the board id still carries dashes), which ESPHome rejects.
-            # Reset to empty when the supplied id contains a dash so
-            # ``generate_component_yaml`` produces a valid auto-id from
-            # the underlying component + name — a user-typed custom id
-            # without dashes passes through.
-            user_id = fields.get("id")
-            if isinstance(user_id, str) and "-" in user_id:
-                fields["id"] = ""
-
-        component = await self._db.components.get_component(component_id=underlying_component_id)
-        if component is None:
-            msg = f"Unknown component: {underlying_component_id}"
-            raise ValueError(msg)
-
-        for entry in component.config_entries:
-            if entry.required and entry.key not in fields:
-                msg = f"Missing required field: {entry.key}"
-                raise ValueError(msg)
-
-        config_path = self._db.settings.rel_path(configuration)
-        existing = await self._read_yaml_async(config_path)
-        # Honour each field's ``depends_on_component`` gate against
-        # what's actually in the device YAML — drops MQTT-only options
-        # (``availability:``, ``state_topic:``, ...) when the device
-        # has no ``mqtt:`` block, mirroring what the frontend already
-        # does field-by-field on the input form.
-        fields = _drop_unconfigured_dependent_fields(fields, component, existing)
-        new_yaml = merge_component_yaml(existing, component, fields)
-        # Atomic write — wizard-driven add-component should not be
-        # able to corrupt the source YAML on a mid-write crash.
-        await self._persist_yaml_mutation(configuration, new_yaml)
-
-        return AddComponentResponse(yaml=new_yaml)
+        """Add a component block to an existing device YAML."""
+        return await add_component.add_component(
+            self,
+            configuration=configuration,
+            component_id=component_id,
+            fields=fields,
+        )
 
     @api_command("devices/import")
     async def import_device(


### PR DESCRIPTION
# What does this implement/fix?

Continues the `controllers/devices/controller.py` size reduction (2196 → 2150 lines) by extracting the `devices/add_component` WS command body into a sibling `add_component.py`. Same shape as the prior splits in #663 / #667 / #670 / #672 / #687: free function takes `controller` as the first arg; the controller keeps a thin bound-method delegate so WS dispatch and tests reaching `add_component` as an instance method continue to resolve.

`add_component.py` hosts:

- `add_component` — the WS handler body. Featured-id resolution, manifest-driven preset merge, depends-on-component field filtering, and the atomic YAML rewrite via `controller._persist_yaml_mutation`.

No test patches needed; tests in `test_featured_components.py` and `test_branches_coverage.py` call `controller.add_component(...)` as a bound method, which still resolves through the controller's delegate. Three module-level imports (`_apply_featured_presets`, `_drop_unconfigured_dependent_fields`, `merge_component_yaml`) are now only referenced inside `add_component.py` and have been removed from controller.py.

3215 tests pass; pure refactor.

**Related issue or feature (if applicable):**

- follow-up to #687

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
