### PR TITLE
Write secrets.yaml in fleet bench fixture for C-loader fast path

### DIFF
--- a/tests/benchmarks/_fleet.py
+++ b/tests/benchmarks/_fleet.py
@@ -64,6 +64,20 @@ _STORAGE_LOADED: Final[dict[str, object]] = {
 def synthesize_fleet(config_dir: Path, n: int) -> list[Path]:
     """Materialise *n* synthetic devices under *config_dir*; return sorted YAML paths."""
     config_dir.mkdir(parents=True, exist_ok=True)
+    # The synthetic YAML uses ``!secret wifi_ssid`` / ``!secret wifi_password``.
+    # Without a ``secrets.yaml`` next to the configs, ESPHome's C-based
+    # ``ESPHomeLoader`` raises ``EsphomeError`` from ``construct_secret``;
+    # ``parse_yaml`` then silently retries the whole document through the
+    # pure-Python ``ESPHomePurePythonLoader`` (5-10x slower) and that retry
+    # also fails, so ``load_device_yaml`` returns ``None``. The bench
+    # ends up measuring two failed parses per device. Real production
+    # deployments carry a ``secrets.yaml`` (``esphome new`` lays one
+    # down), so writing one here lands the bench on the C-loader fast
+    # path the dashboard actually runs in production.
+    (config_dir / "secrets.yaml").write_text(
+        "wifi_ssid: bench-ssid\nwifi_password: bench-password\n",
+        encoding="utf-8",
+    )
     paths: list[Path] = []
     for index in range(n):
         name = f"device_{index:04d}"

--- a/tests/benchmarks/_fleet.py
+++ b/tests/benchmarks/_fleet.py
@@ -64,16 +64,9 @@ _STORAGE_LOADED: Final[dict[str, object]] = {
 def synthesize_fleet(config_dir: Path, n: int) -> list[Path]:
     """Materialise *n* synthetic devices under *config_dir*; return sorted YAML paths."""
     config_dir.mkdir(parents=True, exist_ok=True)
-    # The synthetic YAML uses ``!secret wifi_ssid`` / ``!secret wifi_password``.
-    # Without a ``secrets.yaml`` next to the configs, ESPHome's C-based
-    # ``ESPHomeLoader`` raises ``EsphomeError`` from ``construct_secret``;
-    # ``parse_yaml`` then silently retries the whole document through the
-    # pure-Python ``ESPHomePurePythonLoader`` (5-10x slower) and that retry
-    # also fails, so ``load_device_yaml`` returns ``None``. The bench
-    # ends up measuring two failed parses per device. Real production
-    # deployments carry a ``secrets.yaml`` (``esphome new`` lays one
-    # down), so writing one here lands the bench on the C-loader fast
-    # path the dashboard actually runs in production.
+    # Write secrets.yaml so ``!secret`` resolves; otherwise ESPHomeLoader
+    # silently falls back to the pure-Python loader (5-10x slower) and the
+    # bench stops reflecting production.
     (config_dir / "secrets.yaml").write_text(
         "wifi_ssid: bench-ssid\nwifi_password: bench-password\n",
         encoding="utf-8",


### PR DESCRIPTION
# What does this implement/fix?

CodSpeed's execution profile for `test_load_devices_fleet[5]`
showed the call tree dominated by pure-Python YAML classes
(`Composer.compose_node`, `Parser.parse_block_mapping`,
`Scanner.check_token`) when it should have been C-only frames
from libyaml's `CParser`. Tracking it down: the synthetic fleet
YAML uses `!secret wifi_ssid` / `!secret wifi_password`, but the
fleet builder wasn't writing a `secrets.yaml` next to the
configs, which silently knocked every bench device off the
C-based fast path:

1. `CParser` scans the document in C just fine.
2. `ESPHomeLoaderMixin.construct_secret` then runs
   `self._rel_path("secrets.yaml")`, hits `FileNotFoundError`,
   raises `EsphomeError`.
3. `parse_yaml` catches it and retries the whole document
   through `ESPHomePurePythonLoader` (pure-Python
   `Parser` / `Composer` / `Scanner`).
4. The retry also fails on `!secret`;
   `load_device_yaml` returns `None` and the device is built
   with degraded data.

So the bench was measuring the failure path: two failed
parses per device, with the second going through pure-Python.

Real production deployments carry a `secrets.yaml` (`esphome
new` lays one down), so writing one here lands the bench on
the same C-loader fast path the dashboard actually pays in
production. Verified locally with the
`tests.benchmarks._fleet.synthesize_fleet` helper:
`ESPHomeLoader` now returns the fully parsed config with
`!secret` references resolved, no fallback.

**Related issue or feature (if applicable):**

- Follow-up to #690.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
