### PR TITLE
Split DevicesController: extract metadata mixin

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -27,6 +27,13 @@ resolving after the subpackage split. Submodules:
   (``stream_logs``, ``stop_stream``) plus the shared
   ``stream_subprocess`` helper that ``validate_config``
   reuses.
+- ``metadata`` — ``DeviceMetadataMixin`` carrying
+  ``_resolve_device_metadata`` /
+  ``_derive_board_id_from_yaml`` /
+  ``_persist_device_ip_async`` /
+  ``_persist_device_metadata_async``. Mixed in directly
+  on ``DevicesController`` since the methods only touch
+  ``self._db`` and same-mixin siblings.
 - ``reachability`` — per-device reachability streaming + the
   on-subscription mDNS A-record refresh loop.
 - ``storage_regen`` — background ``--only-generate`` scheduler

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -19,8 +19,6 @@ from esphome.storage_json import StorageJSON
 from esphome.zeroconf import AsyncEsphomeZeroconf
 
 from ...helpers.api import CommandError, api_command
-from ...helpers.build_size import coerce_sidecar_int
-from ...helpers.config_hash import read_build_info_hash
 from ...helpers.device_yaml import (
     configuration_stem,
     generate_device_yaml,
@@ -55,7 +53,7 @@ from ...models import (
 )
 from .._build_size_refresher import BuildSizeRefresher
 from .._device_mqtt_coordinator import DeviceMqttCoordinator
-from .._device_scanner import DeviceFileMetadata, DeviceScanner, ScanChange
+from .._device_scanner import DeviceScanner, ScanChange
 from .._device_state_monitor import DeviceStateMonitor
 from .._reachability_tracker import ReachabilityTracker
 from ..config import (
@@ -88,6 +86,7 @@ from .helpers import (
     _validate_archive_configuration,
     friendly_name_slugify,
 )
+from .metadata import DeviceMetadataMixin
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -127,7 +126,9 @@ _REGEN_FAILURE_TTL_SECONDS: float = 3600.0
 _YAML_SEARCH_PER_FILE_MATCH_CAP = 5
 
 
-class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
+class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
+    DeviceMetadataMixin,
+):
     """Manage device configurations, file watching, and CLI operations."""
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
@@ -1639,115 +1640,6 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, path.read_text, "utf-8")
 
-    def _resolve_device_metadata(self, config_dir: Path, filename: str) -> DeviceFileMetadata:
-        """
-        Resolve a device's persisted ``board_id`` / ``ip`` / config hash / MAC.
-
-        ``board_id`` priority:
-          1. The metadata sidecar — set explicitly when the user
-             picks a board through the UI, or backfilled by a
-             previous scan.
-          2. Parse the YAML's ``esphome.platform`` / ``board`` /
-             ``variant`` and match by PlatformIO board id
-             (``find_by_pio_board``).
-          3. Same YAML — match by platform + variant
-             (``find_by_platform_variant``). Picks up generic
-             ``esp32: { variant: esp32c3 }``-style configs that don't
-             name a specific PlatformIO ``board:``. Generic catalog
-             entries are preferred so the dashboard tags these with
-             the matching ``generic-esp32-c3`` rather than a random
-             vendor board that shares the variant.
-
-        On any successful YAML-derived match we persist the result to
-        metadata so subsequent scans skip the YAML parse.
-
-        ``ip`` is the last-known resolved address from the metadata
-        sidecar (``""`` if never seen).
-
-        ``expected_config_hash`` is read from
-        ``<build_path>/build_info.json`` — ESPHome's authoritative
-        post-codegen value. The metadata sidecar is consulted *only*
-        as a fallback for devices whose build directory was wiped
-        (clean) but where we'd previously cached a value. Reading
-        from ``build_info.json`` first keeps the dashboard from
-        getting stuck on a stale sidecar value if a previous run
-        wrote a wrong hash (e.g. the pre-codegen subprocess hash
-        the dashboard used to compute) — the next scan after this
-        change picks up the canonical value automatically.
-
-        ``mac_address`` is the canonical ``XX:XX:XX:XX:XX:XX`` form
-        last observed on the device's mDNS ``mac`` TXT, persisted
-        to the sidecar so the dashboard renders the value
-        immediately on restart (ESPHome devices are mDNS-silent
-        until probed). Empty when the device hasn't been seen yet
-        — the next mDNS announcement repopulates via
-        :meth:`_on_mac_address_change`. The derived
-        ``ethernet_mac`` / ``bluetooth_mac`` are recomputed by
-        :func:`derive_interface_macs` at ``Device`` construction
-        time, not stored in the sidecar.
-        """
-        md = get_device_metadata(config_dir, filename)
-        ip = str(md.get("ip", ""))
-        # build_info.json wins; sidecar is the post-clean fallback.
-        expected_config_hash = read_build_info_hash(config_dir / filename) or str(
-            md.get("expected_config_hash", "")
-        )
-        board_id = str(md.get("board_id", ""))
-        if not board_id:
-            board_id = self._derive_board_id_from_yaml(config_dir, filename)
-        mac_address = str(md.get("mac_address", ""))
-        # ``coerce_sidecar_int`` handles the bad-data fall-throughs
-        # (``None`` / object / decimal-string / etc.) — same
-        # defensive shape used by the build-size cache reads in
-        # ``helpers/build_size.py``. The metadata resolver is on
-        # the scanner's per-device hot path; a single corrupt
-        # entry shouldn't fail the whole scan.
-        build_size_bytes = coerce_sidecar_int(md.get("build_size_bytes"))
-        # Defensive filter: a hand-edited sidecar could land non-string
-        # entries in the labels list. The scanner is on the hot path,
-        # so silently drop bad entries rather than failing the whole
-        # device load.
-        raw_labels = md.get("labels")
-        labels: tuple[str, ...]
-        if isinstance(raw_labels, list):
-            labels = tuple(item for item in raw_labels if isinstance(item, str))
-        else:
-            labels = ()
-        return DeviceFileMetadata(
-            board_id=board_id,
-            ip=ip,
-            expected_config_hash=expected_config_hash,
-            mac_address=mac_address,
-            build_size_bytes=build_size_bytes,
-            labels=labels,
-        )
-
-    def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:
-        """Parse the device YAML and look up a matching catalog board, or ``""``."""
-        if self._db.boards is None:
-            return ""
-        yaml_path = config_dir / filename
-        try:
-            yaml_content = yaml_path.read_text(encoding="utf-8")
-        except OSError:
-            return ""
-        platform, pio_board, variant = parse_platform_from_yaml(yaml_content)
-
-        matched = None
-        if pio_board:
-            matched = self._db.boards.find_by_pio_board(pio_board, variant)
-        if matched is None and platform:
-            matched = self._db.boards.find_by_platform_variant(platform, variant)
-        if matched is None:
-            return ""
-
-        # Backfill metadata so future scans skip the YAML parse.
-        try:
-            set_device_metadata(config_dir, filename, board_id=matched.id)
-        except Exception:
-            _LOGGER.warning("Could not persist derived board_id for %s", filename)
-        return matched.id
-
     def _on_scan_change(self, kind: ScanChange, device: Device) -> None:
         """Forward scanner changes onto the event bus."""
         event = {
@@ -1910,34 +1802,6 @@ class DevicesController:  # noqa: PLR0904 (grandfathered; new public methods nee
                     self._persist_device_ip_async(device.configuration, ip)
                 )
             self._fire_device_updated(device)
-
-    async def _persist_device_ip_async(self, configuration: str, ip: str) -> None:
-        """Save *ip* to the device-builder metadata sidecar."""
-        await self._persist_device_metadata_async(configuration, ip=ip)
-
-    async def _persist_device_metadata_async(self, configuration: str, **fields: Any) -> None:
-        """
-        Run a blocking ``set_device_metadata`` write on the default executor.
-
-        Centralises the ``loop.run_in_executor(None, lambda: set_device_metadata(
-        config_dir, configuration, **fields))`` boilerplate that every
-        async-context sidecar write was repeating. Callers pass the
-        same kwargs they'd hand directly to
-        ``controllers.config.set_device_metadata``; the helper takes
-        care of the loop lookup and the ``config_dir`` resolution
-        from the device builder's settings.
-
-        Stays a method (not a free function) because every call site
-        already needs ``self._db`` to reach the loop and config_dir
-        — pulling it out to the module level would make every caller
-        thread the same two values explicitly with no readability
-        win.
-        """
-        loop = asyncio.get_running_loop()
-        config_dir = self._db.settings.config_dir
-        await loop.run_in_executor(
-            None, lambda: set_device_metadata(config_dir, configuration, **fields)
-        )
 
     def _on_version_change(self, name: str, version: str) -> None:
         """Apply a fresh ESPHome version observed via mDNS."""

--- a/esphome_device_builder/controllers/devices/metadata.py
+++ b/esphome_device_builder/controllers/devices/metadata.py
@@ -1,0 +1,166 @@
+"""Device-metadata resolution + sidecar-write mixin for ``DevicesController``."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ...helpers.build_size import coerce_sidecar_int
+from ...helpers.config_hash import read_build_info_hash
+from ...helpers.device_yaml import parse_platform_from_yaml
+from .._device_scanner import DeviceFileMetadata
+from ..config import get_device_metadata, set_device_metadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ...device_builder import DeviceBuilder
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DeviceMetadataMixin:
+    """
+    Metadata resolution + persistence methods for ``DevicesController``.
+
+    Mixed in directly (``class DevicesController(DeviceMetadataMixin):
+    ...``) since every method only reads ``self._db`` plus same-mixin
+    methods; no reach into other controller state. Test instance-patches
+    on ``_persist_device_metadata_async`` / ``_derive_board_id_from_yaml``
+    work as before because the methods are real attributes on the
+    instance via inheritance.
+    """
+
+    # Type stub for mypy: the host controller injects ``_db``. Declared
+    # under TYPE_CHECKING so the mixin doesn't shadow the host attribute
+    # at import time.
+    if TYPE_CHECKING:
+        _db: DeviceBuilder
+
+    def _resolve_device_metadata(self, config_dir: Path, filename: str) -> DeviceFileMetadata:
+        """
+        Resolve a device's persisted ``board_id`` / ``ip`` / config hash / MAC.
+
+        ``board_id`` priority:
+          1. The metadata sidecar — set explicitly when the user
+             picks a board through the UI, or backfilled by a
+             previous scan.
+          2. Parse the YAML's ``esphome.platform`` / ``board`` /
+             ``variant`` and match by PlatformIO board id
+             (``find_by_pio_board``).
+          3. Same YAML — match by platform + variant
+             (``find_by_platform_variant``). Picks up generic
+             ``esp32: { variant: esp32c3 }``-style configs that don't
+             name a specific PlatformIO ``board:``. Generic catalog
+             entries are preferred so the dashboard tags these with
+             the matching ``generic-esp32-c3`` rather than a random
+             vendor board that shares the variant.
+
+        On any successful YAML-derived match we persist the result to
+        metadata so subsequent scans skip the YAML parse.
+
+        ``ip`` is the last-known resolved address from the metadata
+        sidecar (``""`` if never seen).
+
+        ``expected_config_hash`` is read from
+        ``<build_path>/build_info.json`` — ESPHome's authoritative
+        post-codegen value. The metadata sidecar is consulted *only*
+        as a fallback for devices whose build directory was wiped
+        (clean) but where we'd previously cached a value. Reading
+        from ``build_info.json`` first keeps the dashboard from
+        getting stuck on a stale sidecar value if a previous run
+        wrote a wrong hash (e.g. the pre-codegen subprocess hash
+        the dashboard used to compute) — the next scan after this
+        change picks up the canonical value automatically.
+
+        ``mac_address`` is the canonical ``XX:XX:XX:XX:XX:XX`` form
+        last observed on the device's mDNS ``mac`` TXT, persisted
+        to the sidecar so the dashboard renders the value
+        immediately on restart (ESPHome devices are mDNS-silent
+        until probed). Empty when the device hasn't been seen yet
+        — the next mDNS announcement repopulates via
+        :meth:`_on_mac_address_change`. The derived
+        ``ethernet_mac`` / ``bluetooth_mac`` are recomputed by
+        :func:`derive_interface_macs` at ``Device`` construction
+        time, not stored in the sidecar.
+        """
+        md = get_device_metadata(config_dir, filename)
+        ip = str(md.get("ip", ""))
+        # build_info.json wins; sidecar is the post-clean fallback.
+        expected_config_hash = read_build_info_hash(config_dir / filename) or str(
+            md.get("expected_config_hash", "")
+        )
+        board_id = str(md.get("board_id", ""))
+        if not board_id:
+            board_id = self._derive_board_id_from_yaml(config_dir, filename)
+        mac_address = str(md.get("mac_address", ""))
+        # ``coerce_sidecar_int`` handles the bad-data fall-throughs
+        # (``None`` / object / decimal-string / etc.) — same
+        # defensive shape used by the build-size cache reads in
+        # ``helpers/build_size.py``. The metadata resolver is on
+        # the scanner's per-device hot path; a single corrupt
+        # entry shouldn't fail the whole scan.
+        build_size_bytes = coerce_sidecar_int(md.get("build_size_bytes"))
+        # Defensive filter: a hand-edited sidecar could land non-string
+        # entries in the labels list. The scanner is on the hot path,
+        # so silently drop bad entries rather than failing the whole
+        # device load.
+        raw_labels = md.get("labels")
+        labels: tuple[str, ...]
+        if isinstance(raw_labels, list):
+            labels = tuple(item for item in raw_labels if isinstance(item, str))
+        else:
+            labels = ()
+        return DeviceFileMetadata(
+            board_id=board_id,
+            ip=ip,
+            expected_config_hash=expected_config_hash,
+            mac_address=mac_address,
+            build_size_bytes=build_size_bytes,
+            labels=labels,
+        )
+
+    def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:
+        """Parse the device YAML and look up a matching catalog board, or ``""``."""
+        if self._db.boards is None:
+            return ""
+        yaml_path = config_dir / filename
+        try:
+            yaml_content = yaml_path.read_text(encoding="utf-8")
+        except OSError:
+            return ""
+        platform, pio_board, variant = parse_platform_from_yaml(yaml_content)
+
+        matched = None
+        if pio_board:
+            matched = self._db.boards.find_by_pio_board(pio_board, variant)
+        if matched is None and platform:
+            matched = self._db.boards.find_by_platform_variant(platform, variant)
+        if matched is None:
+            return ""
+
+        # Backfill metadata so future scans skip the YAML parse.
+        try:
+            set_device_metadata(config_dir, filename, board_id=matched.id)
+        except Exception:
+            _LOGGER.warning("Could not persist derived board_id for %s", filename)
+        return matched.id
+
+    async def _persist_device_ip_async(self, configuration: str, ip: str) -> None:
+        """Save *ip* to the device-builder metadata sidecar."""
+        await self._persist_device_metadata_async(configuration, ip=ip)
+
+    async def _persist_device_metadata_async(self, configuration: str, **fields: Any) -> None:
+        """
+        Run a blocking ``set_device_metadata`` write on the default executor.
+
+        Centralises the ``loop.run_in_executor(None, lambda: set_device_metadata(
+        config_dir, configuration, **fields))`` boilerplate that every
+        async-context sidecar write was repeating.
+        """
+        loop = asyncio.get_running_loop()
+        config_dir = self._db.settings.config_dir
+        await loop.run_in_executor(
+            None, lambda: set_device_metadata(config_dir, configuration, **fields)
+        )

--- a/esphome_device_builder/controllers/devices/metadata.py
+++ b/esphome_device_builder/controllers/devices/metadata.py
@@ -24,10 +24,10 @@ class DeviceMetadataMixin:
     """
     Metadata resolution + persistence methods for ``DevicesController``.
 
-    Mixed in directly (``class DevicesController(DeviceMetadataMixin):
-    ...``) since every method only reads ``self._db`` plus same-mixin
-    methods; no reach into other controller state. Test instance-patches
-    on ``_persist_device_metadata_async`` / ``_derive_board_id_from_yaml``
+    Mixed in directly on ``DevicesController`` since every method
+    only reads ``self._db`` plus same-mixin methods; no reach into
+    other controller state. Test instance-patches on
+    ``_persist_device_metadata_async`` / ``_derive_board_id_from_yaml``
     work as before because the methods are real attributes on the
     instance via inheritance.
     """
@@ -155,9 +155,9 @@ class DeviceMetadataMixin:
         """
         Run a blocking ``set_device_metadata`` write on the default executor.
 
-        Centralises the ``loop.run_in_executor(None, lambda: set_device_metadata(
-        config_dir, configuration, **fields))`` boilerplate that every
-        async-context sidecar write was repeating.
+        Centralises the ``run_in_executor`` + ``config_dir`` lookup
+        boilerplate that every async-context sidecar write was
+        repeating.
         """
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -565,7 +565,7 @@ def stub_create_device_metadata_helpers(monkeypatch: pytest.MonkeyPatch, tmp_pat
         lambda _filename: storage_path,
     )
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.set_device_metadata",
+        "esphome_device_builder.controllers.devices.metadata.set_device_metadata",
         lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(

--- a/tests/controllers/devices/test_derive_board_id.py
+++ b/tests/controllers/devices/test_derive_board_id.py
@@ -213,7 +213,7 @@ def test_derive_swallows_persist_failure_and_still_returns_id(
         raise OSError(msg)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.set_device_metadata",
+        "esphome_device_builder.controllers.devices.metadata.set_device_metadata",
         _boom,
     )
 

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -47,7 +47,7 @@ def _make_controller(monkeypatch: Any, board_id: str = "esp32-c3-devkitm-1") -> 
 def _stub_get_metadata(monkeypatch: Any, payload: dict[str, Any]) -> None:
     """Make ``get_device_metadata`` return *payload* — no JSON IO."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.get_device_metadata",
+        "esphome_device_builder.controllers.devices.metadata.get_device_metadata",
         lambda _config_dir, _filename: payload,
     )
 

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -283,7 +283,7 @@ async def test_refresh_after_compile_persists_hash_and_reloads(
         return "1a2b3c4d"
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.set_device_metadata",
+        "esphome_device_builder.controllers.devices.metadata.set_device_metadata",
         _fake_set_metadata,
     )
     monkeypatch.setattr(
@@ -320,7 +320,7 @@ async def test_refresh_after_compile_skips_persist_on_hash_failure(
         return None  # YAML didn't validate, subprocess failed, etc.
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller.set_device_metadata",
+        "esphome_device_builder.controllers.devices.metadata.set_device_metadata",
         _fake_set_metadata,
     )
     monkeypatch.setattr(


### PR DESCRIPTION
# What does this implement/fix?

Continues the `controllers/devices/controller.py` size reduction (2147 → 2013 lines) by extracting the device-metadata helpers into a sibling `metadata.py`. **Departs from the free-function-with-controller-arg pattern** used in the prior extracts (#663 / #667 / #670 / #672 / #687 / #697); this one uses a **mixin** since the four methods only touch `self._db` and same-mixin siblings — no reach into `_scanner` / `_state_monitor` / `_reachability` / `_devices_by_name`.

`metadata.py` hosts `DeviceMetadataMixin` carrying:

- `_resolve_device_metadata` — captured by `DeviceScanner(get_metadata=...)` at controller `__init__`.
- `_derive_board_id_from_yaml` — YAML platform/board parse + catalog match + sidecar backfill.
- `_persist_device_ip_async` / `_persist_device_metadata_async` — executor-dispatched sidecar writes.

The controller mixes it in directly (`class DevicesController(DeviceMetadataMixin):`) so the methods are real attributes on the instance via inheritance. No bound-delegate boilerplate; no `controller=` first-arg threading.

## Pattern note

The other split modules thread `controller` as the first arg of every free function because they reach into controller-owned state (`_scanner`, `_state_monitor`, `_reachability`, `_devices_by_name`, etc.) and the explicit threading documents the dependency. This module doesn't have that dependency — it's all `self._db` (the DeviceBuilder injection point) plus same-module sibling calls — so the mixin is genuinely cleaner here:

- No bound-method delegate stubs in controller.py
- No routing layer for test interception (tests that instance-patch `controller._persist_device_metadata_async` keep working since the method really is on the instance)
- Methods read `self._db.boards` / `self._foo` naturally

If a future change adds a `_scanner` or `_state_monitor` access to one of these methods, that's a signal the mixin pattern stops fitting and we should fall back to the explicit-controller-arg shape.

## Test patches

Five patches that targeted controller-module symbols moved with the body (`set_device_metadata` × 4, `get_device_metadata` × 1) are re-pointed at `metadata`:

- `tests/controllers/firmware/test_refresh.py` (2 patches)
- `tests/controllers/devices/conftest.py` (1 patch)
- `tests/controllers/devices/test_derive_board_id.py` (1 patch)
- `tests/controllers/devices/test_metadata_resolver.py` (1 patch)

Tests that call the methods as bound methods (`controller._resolve_device_metadata(...)`) work unchanged.

3223 tests pass; pure refactor.

**Related issue or feature (if applicable):**

- follow-up to #697

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
