### PR TITLE
Extract frame dispatch + event firing into _dispatch.py

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
@@ -1,0 +1,426 @@
+"""Inbound peer-link frame dispatch + outbound event-firing helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from ....helpers.peer_link_bundle import (
+    FIRMWARE_MAX_TOTAL_BYTES,
+    BundleAssembler,
+    BundleAssemblerError,
+    decode_chunk,
+)
+from ....helpers.peer_link_frames import frame_schema, is_valid_frame
+from ....helpers.peer_link_noise import pin_sha256_for_pubkey
+from ....models import (
+    ArtifactsChunkFrameData,
+    ArtifactsEndFrameData,
+    ArtifactsStartFrameData,
+    EventType,
+    JobOutputFrameData,
+    JobStateChangedFrameData,
+    OffloaderJobOutputData,
+    OffloaderJobStateChangedData,
+    OffloaderPairPinMismatchData,
+    OffloaderPeerLinkClosedData,
+    OffloaderPeerLinkOpenedData,
+    OffloaderQueueStatusChangedData,
+    SubmitJobAckFrameData,
+)
+from .._client_models import DownloadArtifactsError, DownloadArtifactsResult
+
+if TYPE_CHECKING:
+    from .client import PeerLinkClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Voluptuous schemas for the peer-supplied inbound wire frames
+# the offloader receive loop dispatches into bus events / ack
+# futures / download assemblers. Built via
+# :func:`helpers.peer_link_frames.frame_schema` so the
+# ``bool``-vs-``int`` special case (Python's
+# ``isinstance(True, int) is True``) is handled the same way
+# every shared frame schema in the project does. Optional
+# fields (``SubmitJobAckFrameData.reason`` /
+# ``ArtifactsEndFrameData.reason``) live outside the schema —
+# the dispatch reads ``frame.get("reason")`` post-validate.
+_SUBMIT_JOB_ACK_SCHEMA = frame_schema({"job_id": str, "accepted": bool})
+
+_JOB_STATE_CHANGED_SCHEMA = frame_schema({"job_id": str, "status": str, "error_message": str})
+
+_JOB_OUTPUT_SCHEMA = frame_schema({"job_id": str, "stream": str, "line": str})
+
+_QUEUE_STATUS_SCHEMA = frame_schema({"idle": bool, "running": bool, "queue_depth": int})
+
+# Schemas for the 6a artifact-download stream frames.
+_ARTIFACTS_START_SCHEMA = frame_schema(
+    {
+        "job_id": str,
+        "total_bytes": int,
+        "num_chunks": int,
+        "artifacts_sha256": str,
+        "firmware_offset": str,
+    }
+)
+
+_ARTIFACTS_CHUNK_SCHEMA = frame_schema(
+    {
+        "job_id": str,
+        "chunk_index": int,
+        "data_b64": str,
+        "is_last": bool,
+    }
+)
+
+_ARTIFACTS_END_SCHEMA = frame_schema({"job_id": str, "accepted": bool})
+
+# Allowed ``status`` values on inbound ``job_state_changed``
+# frames, mirroring :class:`JobStateChangedFrameData`'s
+# ``Literal``. Membership check after the str-shape gate so a
+# misbehaving receiver sending ``status="unknown"`` is dropped
+# at the wire layer instead of fanning out a malformed bus
+# event for downstream consumers.
+_JOB_STATE_CHANGED_VALID_STATUS: frozenset[str] = frozenset(
+    {"queued", "running", "completed", "failed", "cancelled"}
+)
+
+# Allowed ``stream`` values on inbound ``job_output`` frames,
+# mirroring :class:`JobOutputFrameData`'s ``Literal``.
+_JOB_OUTPUT_VALID_STREAM: frozenset[str] = frozenset({"stdout", "stderr"})
+
+
+def log_malformed(client: PeerLinkClient, frame_type: str, parsed: dict[str, Any]) -> None:
+    """Debug-log a frame that failed shape validation.
+
+    Single call site for the per-dispatcher
+    "malformed X frame from Y:Z" line so the format string
+    doesn't drift across the four dispatchers.
+    """
+    _LOGGER.debug(
+        "peer-link client malformed %s frame from %s:%d: %r",
+        frame_type,
+        client._hostname,
+        client._port,
+        parsed,
+    )
+
+
+def dispatch_queue_status(client: PeerLinkClient, parsed: dict[str, Any]) -> None:
+    """Validate a ``queue_status`` frame and fire the offloader-side bus event.
+
+    Drop silently on shape mismatch — the receiver will
+    broadcast another snapshot on the next queue
+    transition. The frame's ``queue_depth`` is ``int``;
+    :func:`frame_schema` wraps every ``int`` field with
+    :func:`not_bool` so a ``bool`` (which subclasses
+    ``int``) doesn't slip through as a valid integer.
+    """
+    if not is_valid_frame(_QUEUE_STATUS_SCHEMA, parsed):
+        log_malformed(client, "queue_status", parsed)
+        return
+    fire_queue_status(client, parsed["idle"], parsed["running"], parsed["queue_depth"])
+
+
+def dispatch_submit_job_ack(client: PeerLinkClient, parsed: dict[str, Any]) -> None:
+    """Resolve the matching ack future for an inbound ``submit_job_ack`` frame.
+
+    Drops silently on:
+
+    * Shape mismatch (missing / wrong-typed required fields)
+      — the awaiter times out cleanly rather than seeing a
+      malformed frame as a successful accept.
+    * No matching future under *job_id* — the awaiter
+      already raised :class:`SubmitJobTimeoutError` and
+      popped its entry, or the receiver acked a job we
+      didn't submit.
+    * Future already done — duplicate ack under one
+      *job_id*; the first wins and the second's
+      ``set_result`` would raise ``InvalidStateError``.
+
+    Optional ``reason`` (only present on rejection) is read
+    post-validate and copied through.
+    """
+    if not is_valid_frame(_SUBMIT_JOB_ACK_SCHEMA, parsed):
+        log_malformed(client, "submit_job_ack", parsed)
+        return
+    job_id = cast(str, parsed["job_id"])
+    ack_fut = client._submit_job_acks.get(job_id)
+    if ack_fut is None or ack_fut.done():
+        _LOGGER.debug(
+            "peer-link client dropping submit_job_ack from %s:%d "
+            "(job_id=%r, has_future=%s, done=%s)",
+            client._hostname,
+            client._port,
+            job_id,
+            ack_fut is not None,
+            ack_fut.done() if ack_fut is not None else False,
+        )
+        return
+    accepted = cast(bool, parsed["accepted"])
+    ack: SubmitJobAckFrameData = {
+        "type": "submit_job_ack",
+        "job_id": job_id,
+        "accepted": accepted,
+    }
+    # ``SubmitJobAckFrameData.reason`` is ``NotRequired`` and
+    # carries the rejection code on ``accepted=False``. A
+    # receiver that includes ``reason`` on accept is off-
+    # contract — preserve the typed shape by dropping the
+    # spurious field (logged at debug for the operator).
+    reason = parsed.get("reason")
+    if isinstance(reason, str):
+        if accepted:
+            _LOGGER.debug(
+                "peer-link client dropping spurious reason=%r on accepted ack "
+                "from %s:%d (job_id=%r)",
+                reason,
+                client._hostname,
+                client._port,
+                job_id,
+            )
+        else:
+            ack["reason"] = reason
+    ack_fut.set_result(ack)
+
+
+def dispatch_job_state_changed(client: PeerLinkClient, parsed: dict[str, Any]) -> None:
+    """Validate + fan an inbound ``job_state_changed`` frame onto the bus.
+
+    Same pattern as :func:`dispatch_queue_status`: validate
+    first, drop silently on shape mismatch (a future
+    retransmit will land cleanly), enrich with this
+    client's receiver coordinates so subscribers can
+    disambiguate transitions across multiple paired
+    receivers.
+    """
+    if not is_valid_frame(_JOB_STATE_CHANGED_SCHEMA, parsed):
+        log_malformed(client, "job_state_changed", parsed)
+        return
+    if cast(str, parsed["status"]) not in _JOB_STATE_CHANGED_VALID_STATUS:
+        log_malformed(client, "job_state_changed", parsed)
+        return
+    wire = cast(JobStateChangedFrameData, parsed)
+    payload: OffloaderJobStateChangedData = {
+        "receiver_hostname": client._hostname,
+        "receiver_port": client._port,
+        "pin_sha256": client._pin_sha256,
+        "job_id": wire["job_id"],
+        "status": wire["status"],
+        "error_message": wire["error_message"],
+    }
+    client._bus.fire(EventType.OFFLOADER_JOB_STATE_CHANGED, payload)
+
+
+def dispatch_job_output(client: PeerLinkClient, parsed: dict[str, Any]) -> None:
+    """Validate + fan an inbound ``job_output`` frame onto the bus.
+
+    High-rate path during an active build (one frame per
+    line of compiler / linker output). Validate cheaply and
+    drop on shape mismatch; subscribers see ``stream`` /
+    ``line`` typed by :class:`OffloaderJobOutputData`.
+    """
+    if not is_valid_frame(_JOB_OUTPUT_SCHEMA, parsed):
+        log_malformed(client, "job_output", parsed)
+        return
+    if cast(str, parsed["stream"]) not in _JOB_OUTPUT_VALID_STREAM:
+        log_malformed(client, "job_output", parsed)
+        return
+    wire = cast(JobOutputFrameData, parsed)
+    payload: OffloaderJobOutputData = {
+        "receiver_hostname": client._hostname,
+        "receiver_port": client._port,
+        "pin_sha256": client._pin_sha256,
+        "job_id": wire["job_id"],
+        "stream": wire["stream"],
+        "line": wire["line"],
+    }
+    client._bus.fire(EventType.OFFLOADER_JOB_OUTPUT, payload)
+
+
+def dispatch_artifacts_start(client: PeerLinkClient, parsed: dict[str, Any]) -> None:
+    """Validate ``artifacts_start`` + install the assembler for the in-flight download.
+
+    Drops silently on shape mismatch / unknown job_id —
+    the receive loop is hot and a malformed frame from a
+    buggy peer shouldn't crash anyone. A stray
+    ``artifacts_start`` for a job we never asked for
+    means the awaiter already raised + popped its state
+    (or it was a different session entirely); the safe
+    thing is to ignore.
+    """
+    if not is_valid_frame(_ARTIFACTS_START_SCHEMA, parsed):
+        log_malformed(client, "artifacts_start", parsed)
+        return
+    wire = cast(ArtifactsStartFrameData, parsed)
+    state = client._artifacts_downloads.get(wire["job_id"])
+    if state is None:
+        log_malformed(client, "artifacts_start", parsed)
+        return
+    try:
+        state.assembler = BundleAssembler(
+            total_bytes=wire["total_bytes"],
+            num_chunks=wire["num_chunks"],
+            sha256_hex=wire["artifacts_sha256"],
+            max_total_bytes=FIRMWARE_MAX_TOTAL_BYTES,
+        )
+    except BundleAssemblerError as exc:
+        if not state.future.done():
+            state.future.set_exception(
+                DownloadArtifactsError(
+                    f"download_artifacts: invalid start header: {exc}",
+                    reason="invalid_start_header",
+                )
+            )
+        return
+    state.firmware_offset = wire["firmware_offset"]
+
+
+def dispatch_artifacts_chunk(client: PeerLinkClient, parsed: dict[str, Any]) -> None:
+    """Validate ``artifacts_chunk`` + feed the assembler.
+
+    Out-of-order / oversized / decode-failure chunks
+    from a buggy receiver resolve the future with
+    :class:`DownloadArtifactsError`; the awaiter unwinds
+    and the WS layer surfaces the structured reason.
+    """
+    if not is_valid_frame(_ARTIFACTS_CHUNK_SCHEMA, parsed):
+        log_malformed(client, "artifacts_chunk", parsed)
+        return
+    wire = cast(ArtifactsChunkFrameData, parsed)
+    state = client._artifacts_downloads.get(wire["job_id"])
+    if state is None or state.assembler is None:
+        log_malformed(client, "artifacts_chunk", parsed)
+        return
+    try:
+        raw = decode_chunk(wire["data_b64"])
+        state.assembler.feed(wire["chunk_index"], raw, is_last=wire["is_last"])
+    except BundleAssemblerError as exc:
+        if not state.future.done():
+            state.future.set_exception(
+                DownloadArtifactsError(
+                    f"download_artifacts: chunk failed: {exc}",
+                    reason=exc.code.value,
+                )
+            )
+
+
+def dispatch_artifacts_end(client: PeerLinkClient, parsed: dict[str, Any]) -> None:
+    """Validate ``artifacts_end`` + resolve the download future.
+
+    Success path (``accepted=true``): finalise the
+    assembler (validates count + SHA-256), set the
+    future to the bytes. Failure path
+    (``accepted=false``): pop ``reason`` and set the
+    future to a :class:`DownloadArtifactsError` carrying
+    it.
+    """
+    if not is_valid_frame(_ARTIFACTS_END_SCHEMA, parsed):
+        log_malformed(client, "artifacts_end", parsed)
+        return
+    wire = cast(ArtifactsEndFrameData, parsed)
+    state = client._artifacts_downloads.get(wire["job_id"])
+    if state is None or state.future.done():
+        return
+    if not wire["accepted"]:
+        reason = parsed.get("reason", "unknown")
+        state.future.set_exception(
+            DownloadArtifactsError(
+                f"download_artifacts: receiver rejected ({reason})",
+                reason=str(reason),
+            )
+        )
+        return
+    if state.assembler is None:
+        state.future.set_exception(
+            DownloadArtifactsError(
+                "download_artifacts: receiver acked success without sending artifacts_start",
+                reason="missing_start",
+            )
+        )
+        return
+    try:
+        tarball = state.assembler.finalise()
+    except BundleAssemblerError as exc:
+        state.future.set_exception(
+            DownloadArtifactsError(
+                f"download_artifacts: finalise failed: {exc}",
+                reason=exc.code.value,
+            )
+        )
+        return
+    state.future.set_result(
+        DownloadArtifactsResult(tarball=tarball, firmware_offset=state.firmware_offset)
+    )
+
+
+def fire_opened(client: PeerLinkClient, *, esphome_version: str = "") -> None:
+    """Fire ``OFFLOADER_PEER_LINK_OPENED`` for a session that reached intent_response=ok."""
+    payload: OffloaderPeerLinkOpenedData = {
+        "receiver_hostname": client._hostname,
+        "receiver_port": client._port,
+        "pin_sha256": client._pin_sha256,
+        "esphome_version": esphome_version,
+    }
+    client._bus.fire(EventType.OFFLOADER_PEER_LINK_OPENED, payload)
+
+
+def fire_closed(client: PeerLinkClient, reason: str, *, error_detail: str = "") -> None:
+    """Fire ``OFFLOADER_PEER_LINK_CLOSED`` for a session unwinding."""
+    payload: OffloaderPeerLinkClosedData = {
+        "receiver_hostname": client._hostname,
+        "receiver_port": client._port,
+        "pin_sha256": client._pin_sha256,
+        "reason": reason,
+        "error_detail": error_detail,
+    }
+    client._bus.fire(EventType.OFFLOADER_PEER_LINK_CLOSED, payload)
+
+
+def fire_pin_mismatch(client: PeerLinkClient, *, observed: bytes) -> None:
+    """Fire ``OFFLOADER_PAIR_PIN_MISMATCH`` after a peer-link pin drift.
+
+    Same event shape the pair-status listener already fires
+    from :meth:`OffloaderController._apply_pair_status_result`
+    on its own pin-drift branch. The controller listens for
+    the event and stores the alert in
+    ``_offloader_alerts`` so the snapshot path
+    (``subscribe_events.initial_state.offloader_alerts``)
+    carries it for late-subscribing tabs.
+
+    ``expected_pin`` / ``observed_pin`` are the
+    SHA-256 hashes of the pinned + observed pubkeys, in the
+    same lowercase-hex form
+    :class:`StoredPairing.pin_sha256` uses on disk.
+    """
+    payload: OffloaderPairPinMismatchData = {
+        "receiver_hostname": client._hostname,
+        "receiver_port": client._port,
+        "receiver_label": client._receiver_label,
+        "pin_sha256": client._pin_sha256,
+        "expected_pin": pin_sha256_for_pubkey(client._pinned_static_x25519_pub),
+        "observed_pin": pin_sha256_for_pubkey(observed),
+    }
+    client._bus.fire(EventType.OFFLOADER_PAIR_PIN_MISMATCH, payload)
+
+
+def fire_queue_status(client: PeerLinkClient, idle: bool, running: bool, queue_depth: int) -> None:
+    """Fire ``OFFLOADER_QUEUE_STATUS_CHANGED`` for an inbound snapshot.
+
+    The peer-link receive loop validates the wire shape
+    (boolean / int) before getting here, so the event
+    payload's primitive contract holds without re-checking.
+    Listeners on the bus include the
+    :class:`OffloaderController`'s cache update and the
+    ``subscribe_events`` re-broadcast.
+    """
+    payload: OffloaderQueueStatusChangedData = {
+        "receiver_hostname": client._hostname,
+        "receiver_port": client._port,
+        "pin_sha256": client._pin_sha256,
+        "idle": idle,
+        "running": running,
+        "queue_depth": queue_depth,
+    }
+    client._bus.fire(EventType.OFFLOADER_QUEUE_STATUS_CHANGED, payload)

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -31,44 +31,25 @@ from yarl import URL
 from ....helpers import json as _json
 from ....helpers.peer_link_bundle import (
     BUNDLE_CHUNK_SIZE_BYTES,
-    FIRMWARE_MAX_TOTAL_BYTES,
-    BundleAssembler,
-    BundleAssemblerError,
     chunk_bundle,
     compute_bundle_sha256,
-    decode_chunk,
     encode_chunk,
 )
-from ....helpers.peer_link_frames import frame_schema, is_valid_frame
 from ....helpers.peer_link_noise import (
     NOISE_ERRORS,
     PeerLinkNoiseSession,
-    pin_sha256_for_pubkey,
 )
 from ....helpers.peer_link_resolver import make_peer_link_http_session
 from ....models import (
-    ArtifactsChunkFrameData,
-    ArtifactsEndFrameData,
-    ArtifactsStartFrameData,
     CancelJobFrameData,
     DownloadArtifactsFrameData,
-    EventType,
     IntentResponse,
-    JobOutputFrameData,
-    JobStateChangedFrameData,
-    OffloaderJobOutputData,
-    OffloaderJobStateChangedData,
-    OffloaderPairPinMismatchData,
-    OffloaderPeerLinkClosedData,
-    OffloaderPeerLinkOpenedData,
-    OffloaderQueueStatusChangedData,
     PeerLinkIntent,
     SubmitJobAckFrameData,
     SubmitJobChunkFrameData,
     SubmitJobFrameData,
 )
 from .._client_models import (
-    DownloadArtifactsError,
     DownloadArtifactsResult,
     PeerLinkNoSessionError,
     SubmitJobSessionLostError,
@@ -84,6 +65,7 @@ from ..peer_link import (
     TerminateReason,
     run_peer_link_heartbeat,
 )
+from . import _dispatch
 from .one_shot import (
     _DEFAULT_TIMEOUT_SECONDS,
     _drive_initiator_handshake_and_read_response,
@@ -150,61 +132,6 @@ _LOCAL_CLOSE_PIN_MISMATCH = "pin_mismatch"
 # raises :class:`SubmitJobTimeoutError` and the WS command
 # surfaces a structured error to the caller.
 _SUBMIT_JOB_ACK_TIMEOUT_SECONDS = 60.0
-
-
-# Voluptuous schemas for the peer-supplied inbound wire frames
-# the offloader receive loop dispatches into bus events / ack
-# futures / download assemblers. Built via
-# :func:`helpers.peer_link_frames.frame_schema` so the
-# ``bool``-vs-``int`` special case (Python's
-# ``isinstance(True, int) is True``) is handled the same way
-# every shared frame schema in the project does. Optional
-# fields (``SubmitJobAckFrameData.reason`` /
-# ``ArtifactsEndFrameData.reason``) live outside the schema —
-# the dispatch reads ``frame.get("reason")`` post-validate.
-_SUBMIT_JOB_ACK_SCHEMA = frame_schema({"job_id": str, "accepted": bool})
-
-_JOB_STATE_CHANGED_SCHEMA = frame_schema({"job_id": str, "status": str, "error_message": str})
-
-_JOB_OUTPUT_SCHEMA = frame_schema({"job_id": str, "stream": str, "line": str})
-
-_QUEUE_STATUS_SCHEMA = frame_schema({"idle": bool, "running": bool, "queue_depth": int})
-
-# Schemas for the 6a artifact-download stream frames.
-_ARTIFACTS_START_SCHEMA = frame_schema(
-    {
-        "job_id": str,
-        "total_bytes": int,
-        "num_chunks": int,
-        "artifacts_sha256": str,
-        "firmware_offset": str,
-    }
-)
-
-_ARTIFACTS_CHUNK_SCHEMA = frame_schema(
-    {
-        "job_id": str,
-        "chunk_index": int,
-        "data_b64": str,
-        "is_last": bool,
-    }
-)
-
-_ARTIFACTS_END_SCHEMA = frame_schema({"job_id": str, "accepted": bool})
-
-# Allowed ``status`` values on inbound ``job_state_changed``
-# frames, mirroring :class:`JobStateChangedFrameData`'s
-# ``Literal``. Membership check after the str-shape gate so a
-# misbehaving receiver sending ``status="unknown"`` is dropped
-# at the wire layer instead of fanning out a malformed bus
-# event for downstream consumers.
-_JOB_STATE_CHANGED_VALID_STATUS: frozenset[str] = frozenset(
-    {"queued", "running", "completed", "failed", "cancelled"}
-)
-
-# Allowed ``stream`` values on inbound ``job_output`` frames,
-# mirroring :class:`JobOutputFrameData`'s ``Literal``.
-_JOB_OUTPUT_VALID_STREAM: frozenset[str] = frozenset({"stdout", "stderr"})
 
 
 class PeerLinkClient:
@@ -1092,322 +1019,37 @@ class PeerLinkClient:
         }
 
     def _dispatch_queue_status(self, parsed: dict[str, Any]) -> None:
-        """Validate a ``queue_status`` frame and fire the offloader-side bus event.
-
-        Drop silently on shape mismatch — the receiver will
-        broadcast another snapshot on the next queue
-        transition. The frame's ``queue_depth`` is ``int``;
-        :func:`frame_schema` wraps every ``int`` field with
-        :func:`not_bool` so a ``bool`` (which subclasses
-        ``int``) doesn't slip through as a valid integer.
-        """
-        if not is_valid_frame(_QUEUE_STATUS_SCHEMA, parsed):
-            self._log_malformed("queue_status", parsed)
-            return
-        self._fire_queue_status(parsed["idle"], parsed["running"], parsed["queue_depth"])
+        _dispatch.dispatch_queue_status(self, parsed)
 
     def _dispatch_submit_job_ack(self, parsed: dict[str, Any]) -> None:
-        """Resolve the matching ack future for an inbound ``submit_job_ack`` frame.
-
-        Drops silently on:
-
-        * Shape mismatch (missing / wrong-typed required fields)
-          — the awaiter times out cleanly rather than seeing a
-          malformed frame as a successful accept.
-        * No matching future under *job_id* — the awaiter
-          already raised :class:`SubmitJobTimeoutError` and
-          popped its entry, or the receiver acked a job we
-          didn't submit.
-        * Future already done — duplicate ack under one
-          *job_id*; the first wins and the second's
-          ``set_result`` would raise ``InvalidStateError``.
-
-        Optional ``reason`` (only present on rejection) is read
-        post-validate and copied through.
-        """
-        if not is_valid_frame(_SUBMIT_JOB_ACK_SCHEMA, parsed):
-            self._log_malformed("submit_job_ack", parsed)
-            return
-        job_id = cast(str, parsed["job_id"])
-        ack_fut = self._submit_job_acks.get(job_id)
-        if ack_fut is None or ack_fut.done():
-            _LOGGER.debug(
-                "peer-link client dropping submit_job_ack from %s:%d "
-                "(job_id=%r, has_future=%s, done=%s)",
-                self._hostname,
-                self._port,
-                job_id,
-                ack_fut is not None,
-                ack_fut.done() if ack_fut is not None else False,
-            )
-            return
-        accepted = cast(bool, parsed["accepted"])
-        ack: SubmitJobAckFrameData = {
-            "type": "submit_job_ack",
-            "job_id": job_id,
-            "accepted": accepted,
-        }
-        # ``SubmitJobAckFrameData.reason`` is ``NotRequired`` and
-        # carries the rejection code on ``accepted=False``. A
-        # receiver that includes ``reason`` on accept is off-
-        # contract — preserve the typed shape by dropping the
-        # spurious field (logged at debug for the operator).
-        reason = parsed.get("reason")
-        if isinstance(reason, str):
-            if accepted:
-                _LOGGER.debug(
-                    "peer-link client dropping spurious reason=%r on accepted ack "
-                    "from %s:%d (job_id=%r)",
-                    reason,
-                    self._hostname,
-                    self._port,
-                    job_id,
-                )
-            else:
-                ack["reason"] = reason
-        ack_fut.set_result(ack)
+        _dispatch.dispatch_submit_job_ack(self, parsed)
 
     def _log_malformed(self, frame_type: str, parsed: dict[str, Any]) -> None:
-        """Debug-log a frame that failed shape validation.
-
-        Single call site for the per-dispatcher
-        "malformed X frame from Y:Z" line so the format string
-        doesn't drift across the four dispatchers.
-        """
-        _LOGGER.debug(
-            "peer-link client malformed %s frame from %s:%d: %r",
-            frame_type,
-            self._hostname,
-            self._port,
-            parsed,
-        )
+        _dispatch.log_malformed(self, frame_type, parsed)
 
     def _dispatch_job_state_changed(self, parsed: dict[str, Any]) -> None:
-        """Validate + fan an inbound ``job_state_changed`` frame onto the bus.
-
-        Same pattern as :meth:`_dispatch_queue_status`: validate
-        first, drop silently on shape mismatch (a future
-        retransmit will land cleanly), enrich with this
-        client's receiver coordinates so subscribers can
-        disambiguate transitions across multiple paired
-        receivers.
-        """
-        if not is_valid_frame(_JOB_STATE_CHANGED_SCHEMA, parsed):
-            self._log_malformed("job_state_changed", parsed)
-            return
-        if cast(str, parsed["status"]) not in _JOB_STATE_CHANGED_VALID_STATUS:
-            self._log_malformed("job_state_changed", parsed)
-            return
-        wire = cast(JobStateChangedFrameData, parsed)
-        payload: OffloaderJobStateChangedData = {
-            "receiver_hostname": self._hostname,
-            "receiver_port": self._port,
-            "pin_sha256": self._pin_sha256,
-            "job_id": wire["job_id"],
-            "status": wire["status"],
-            "error_message": wire["error_message"],
-        }
-        self._bus.fire(EventType.OFFLOADER_JOB_STATE_CHANGED, payload)
+        _dispatch.dispatch_job_state_changed(self, parsed)
 
     def _dispatch_job_output(self, parsed: dict[str, Any]) -> None:
-        """Validate + fan an inbound ``job_output`` frame onto the bus.
-
-        High-rate path during an active build (one frame per
-        line of compiler / linker output). Validate cheaply and
-        drop on shape mismatch; subscribers see ``stream`` /
-        ``line`` typed by :class:`OffloaderJobOutputData`.
-        """
-        if not is_valid_frame(_JOB_OUTPUT_SCHEMA, parsed):
-            self._log_malformed("job_output", parsed)
-            return
-        if cast(str, parsed["stream"]) not in _JOB_OUTPUT_VALID_STREAM:
-            self._log_malformed("job_output", parsed)
-            return
-        wire = cast(JobOutputFrameData, parsed)
-        payload: OffloaderJobOutputData = {
-            "receiver_hostname": self._hostname,
-            "receiver_port": self._port,
-            "pin_sha256": self._pin_sha256,
-            "job_id": wire["job_id"],
-            "stream": wire["stream"],
-            "line": wire["line"],
-        }
-        self._bus.fire(EventType.OFFLOADER_JOB_OUTPUT, payload)
+        _dispatch.dispatch_job_output(self, parsed)
 
     def _dispatch_artifacts_start(self, parsed: dict[str, Any]) -> None:
-        """Validate ``artifacts_start`` + install the assembler for the in-flight download.
-
-        Drops silently on shape mismatch / unknown job_id —
-        the receive loop is hot and a malformed frame from a
-        buggy peer shouldn't crash anyone. A stray
-        ``artifacts_start`` for a job we never asked for
-        means the awaiter already raised + popped its state
-        (or it was a different session entirely); the safe
-        thing is to ignore.
-        """
-        if not is_valid_frame(_ARTIFACTS_START_SCHEMA, parsed):
-            self._log_malformed("artifacts_start", parsed)
-            return
-        wire = cast(ArtifactsStartFrameData, parsed)
-        state = self._artifacts_downloads.get(wire["job_id"])
-        if state is None:
-            self._log_malformed("artifacts_start", parsed)
-            return
-        try:
-            state.assembler = BundleAssembler(
-                total_bytes=wire["total_bytes"],
-                num_chunks=wire["num_chunks"],
-                sha256_hex=wire["artifacts_sha256"],
-                max_total_bytes=FIRMWARE_MAX_TOTAL_BYTES,
-            )
-        except BundleAssemblerError as exc:
-            if not state.future.done():
-                state.future.set_exception(
-                    DownloadArtifactsError(
-                        f"download_artifacts: invalid start header: {exc}",
-                        reason="invalid_start_header",
-                    )
-                )
-            return
-        state.firmware_offset = wire["firmware_offset"]
+        _dispatch.dispatch_artifacts_start(self, parsed)
 
     def _dispatch_artifacts_chunk(self, parsed: dict[str, Any]) -> None:
-        """Validate ``artifacts_chunk`` + feed the assembler.
-
-        Out-of-order / oversized / decode-failure chunks
-        from a buggy receiver resolve the future with
-        :class:`DownloadArtifactsError`; the awaiter unwinds
-        and the WS layer surfaces the structured reason.
-        """
-        if not is_valid_frame(_ARTIFACTS_CHUNK_SCHEMA, parsed):
-            self._log_malformed("artifacts_chunk", parsed)
-            return
-        wire = cast(ArtifactsChunkFrameData, parsed)
-        state = self._artifacts_downloads.get(wire["job_id"])
-        if state is None or state.assembler is None:
-            self._log_malformed("artifacts_chunk", parsed)
-            return
-        try:
-            raw = decode_chunk(wire["data_b64"])
-            state.assembler.feed(wire["chunk_index"], raw, is_last=wire["is_last"])
-        except BundleAssemblerError as exc:
-            if not state.future.done():
-                state.future.set_exception(
-                    DownloadArtifactsError(
-                        f"download_artifacts: chunk failed: {exc}",
-                        reason=exc.code.value,
-                    )
-                )
+        _dispatch.dispatch_artifacts_chunk(self, parsed)
 
     def _dispatch_artifacts_end(self, parsed: dict[str, Any]) -> None:
-        """Validate ``artifacts_end`` + resolve the download future.
-
-        Success path (``accepted=true``): finalise the
-        assembler (validates count + SHA-256), set the
-        future to the bytes. Failure path
-        (``accepted=false``): pop ``reason`` and set the
-        future to a :class:`DownloadArtifactsError` carrying
-        it.
-        """
-        if not is_valid_frame(_ARTIFACTS_END_SCHEMA, parsed):
-            self._log_malformed("artifacts_end", parsed)
-            return
-        wire = cast(ArtifactsEndFrameData, parsed)
-        state = self._artifacts_downloads.get(wire["job_id"])
-        if state is None or state.future.done():
-            return
-        if not wire["accepted"]:
-            reason = parsed.get("reason", "unknown")
-            state.future.set_exception(
-                DownloadArtifactsError(
-                    f"download_artifacts: receiver rejected ({reason})",
-                    reason=str(reason),
-                )
-            )
-            return
-        if state.assembler is None:
-            state.future.set_exception(
-                DownloadArtifactsError(
-                    "download_artifacts: receiver acked success without sending artifacts_start",
-                    reason="missing_start",
-                )
-            )
-            return
-        try:
-            tarball = state.assembler.finalise()
-        except BundleAssemblerError as exc:
-            state.future.set_exception(
-                DownloadArtifactsError(
-                    f"download_artifacts: finalise failed: {exc}",
-                    reason=exc.code.value,
-                )
-            )
-            return
-        state.future.set_result(
-            DownloadArtifactsResult(tarball=tarball, firmware_offset=state.firmware_offset)
-        )
+        _dispatch.dispatch_artifacts_end(self, parsed)
 
     def _fire_opened(self, *, esphome_version: str = "") -> None:
-        payload: OffloaderPeerLinkOpenedData = {
-            "receiver_hostname": self._hostname,
-            "receiver_port": self._port,
-            "pin_sha256": self._pin_sha256,
-            "esphome_version": esphome_version,
-        }
-        self._bus.fire(EventType.OFFLOADER_PEER_LINK_OPENED, payload)
+        _dispatch.fire_opened(self, esphome_version=esphome_version)
 
     def _fire_closed(self, reason: str, *, error_detail: str = "") -> None:
-        payload: OffloaderPeerLinkClosedData = {
-            "receiver_hostname": self._hostname,
-            "receiver_port": self._port,
-            "pin_sha256": self._pin_sha256,
-            "reason": reason,
-            "error_detail": error_detail,
-        }
-        self._bus.fire(EventType.OFFLOADER_PEER_LINK_CLOSED, payload)
+        _dispatch.fire_closed(self, reason, error_detail=error_detail)
 
     def _fire_pin_mismatch(self, *, observed: bytes) -> None:
-        """Fire ``OFFLOADER_PAIR_PIN_MISMATCH`` after a peer-link pin drift.
-
-        Same event shape the pair-status listener already fires
-        from :meth:`OffloaderController._apply_pair_status_result`
-        on its own pin-drift branch. The controller listens for
-        the event and stores the alert in
-        ``_offloader_alerts`` so the snapshot path
-        (``subscribe_events.initial_state.offloader_alerts``)
-        carries it for late-subscribing tabs.
-
-        ``expected_pin`` / ``observed_pin`` are the
-        SHA-256 hashes of the pinned + observed pubkeys, in the
-        same lowercase-hex form
-        :class:`StoredPairing.pin_sha256` uses on disk.
-        """
-        payload: OffloaderPairPinMismatchData = {
-            "receiver_hostname": self._hostname,
-            "receiver_port": self._port,
-            "receiver_label": self._receiver_label,
-            "pin_sha256": self._pin_sha256,
-            "expected_pin": pin_sha256_for_pubkey(self._pinned_static_x25519_pub),
-            "observed_pin": pin_sha256_for_pubkey(observed),
-        }
-        self._bus.fire(EventType.OFFLOADER_PAIR_PIN_MISMATCH, payload)
+        _dispatch.fire_pin_mismatch(self, observed=observed)
 
     def _fire_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
-        """Fire ``OFFLOADER_QUEUE_STATUS_CHANGED`` for an inbound snapshot.
-
-        The peer-link receive loop validates the wire shape
-        (boolean / int) before getting here, so the event
-        payload's primitive contract holds without re-checking.
-        Listeners on the bus include the
-        :class:`OffloaderController`'s cache update and the
-        ``subscribe_events`` re-broadcast.
-        """
-        payload: OffloaderQueueStatusChangedData = {
-            "receiver_hostname": self._hostname,
-            "receiver_port": self._port,
-            "pin_sha256": self._pin_sha256,
-            "idle": idle,
-            "running": running,
-            "queue_depth": queue_depth,
-        }
-        self._bus.fire(EventType.OFFLOADER_QUEUE_STATUS_CHANGED, payload)
+        _dispatch.fire_queue_status(self, idle, running, queue_depth)


### PR DESCRIPTION
# What does this implement/fix?

PR 2 of 3 splitting `controllers/remote_build/peer_link_client/`. Builds on #701; pulls inbound-frame dispatch and outbound event-firing out of `client.py` into a new `_dispatch.py` submodule.

| File | Before | After | Δ |
|---|---:|---:|---:|
| `client.py` | 1413 | 1055 | −358 |
| `_dispatch.py` (new) | — | 426 | +426 |

Eight `_dispatch_*` methods, `_log_malformed`, and four `_fire_*` methods become free functions taking the client as first arg — the canonical pattern from `controllers/devices/firmware_sync.py` (#663) and #670 / #672. The bound methods on `PeerLinkClient` stay as thin one-line delegates so:

* The dispatch table built by `_build_sync_frame_dispatch` (which captures `self._dispatch_*` as bound-method references) keeps working unchanged.
* Tests calling `client._dispatch_submit_job_ack(frame)` etc. as instance methods (~20 call sites in `tests/test_remote_build_peer_link_client.py`) still work.

Module-level constants used only by the dispatch helpers move with them: the voluptuous frame schemas (`_SUBMIT_JOB_ACK_SCHEMA`, `_JOB_STATE_CHANGED_SCHEMA`, `_JOB_OUTPUT_SCHEMA`, `_QUEUE_STATUS_SCHEMA`, `_ARTIFACTS_START_SCHEMA`, `_ARTIFACTS_CHUNK_SCHEMA`, `_ARTIFACTS_END_SCHEMA`) and the validity frozensets (`_JOB_STATE_CHANGED_VALID_STATUS`, `_JOB_OUTPUT_VALID_STREAM`).

`client.py` is still over the 800-line cap (grandfathered from the monolith; #701 reduced it from 1881 by extracting the one-shot helpers, this PR takes it down to 1055). PR 3 will extract `submit_job` / `cancel_job` / `download_artifacts` and their helpers, bringing the final `client.py` under cap.

All 3198 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #701
- follows the soft-cap policy added in #619

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
