### PR TITLE
Tighten _submit.py docstrings and comments

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
@@ -31,20 +31,10 @@ if TYPE_CHECKING:
     from .client import PeerLinkClient
 
 
-# How long :func:`submit_job` waits for the receiver's
-# ``submit_job_ack`` after the last chunk goes out. Sized
-# for the receiver's worst-case
-# bundle-finalise + extract + queue-acquire path: SHA-256 over
-# 4 MiB (capped at :data:`BUNDLE_MAX_TOTAL_BYTES`) is sub-100ms
-# even on a Raspberry Pi class SoC, ``prepare_bundle_for_compile``
-# walks the tar entries (a few hundred files, low-MiB), and the
-# firmware queue's lock contention is bounded by the size of an
-# individual ``_enqueue`` call. 60s gives generous headroom for
-# a busy receiver under disk-IO contention without letting a
-# silently-dead session pin the offloader's submit handler
-# forever. Mismatch with no ack arriving inside the window
-# raises :class:`SubmitJobTimeoutError` and the WS command
-# surfaces a structured error to the caller.
+# 60s headroom for the receiver's worst-case bundle-finalise +
+# extract + queue-acquire path on a constrained SoC, without
+# pinning the offloader's submit handler forever if the wire
+# goes silent.
 _SUBMIT_JOB_ACK_TIMEOUT_SECONDS = 60.0
 
 
@@ -58,52 +48,13 @@ async def submit_job(
     device_name: str = "",
     device_friendly_name: str = "",
 ) -> SubmitJobAckFrameData:
-    """Send a ``submit_job`` header + chunked bundle and await the receiver's ack.
+    """
+    Send a ``submit_job`` header + chunked bundle and await the receiver's ack.
 
-    Drives the offloader-side counterpart of the receiver's
-    :class:`SubmitJobReceiver` accept path
-    (:mod:`controllers.remote_build.submit_job`):
-
-    1. Validate a session is live; raise
-       :class:`PeerLinkNoSessionError` if not.
-    2. Compute the bundle's SHA-256 + chunk count.
-    3. Register a per-``job_id`` ack future on
-       :attr:`_submit_job_acks` BEFORE the header goes out
-       so a same-tick ack can't lose to the future
-       registration (the receive loop runs on the same
-       event loop; pre-registering avoids the race
-       regardless).
-    4. Send the header and stream every chunk through
-       :meth:`PeerLinkChannel.send_frame`. A send failure
-       (transport gone away mid-flow, JSON encode failure,
-       Noise encrypt failure) raises
-       :class:`SubmitJobSessionLostError` immediately
-       rather than waiting for the timeout.
-    5. Await the ack future with
-       :data:`_SUBMIT_JOB_ACK_TIMEOUT_SECONDS`. Timeout
-       raises :class:`SubmitJobTimeoutError`. Session loss
-       during the wait raises
-       :class:`SubmitJobSessionLostError` (the receive
-       loop's ``finally`` propagates it via
-       ``set_exception``).
-
-    Concurrency: the WS dispatch is single-flight per
-    connection, so the controller's WS handler invokes this
-    sequentially per session. Multiple WS connections can
-    invoke concurrently — distinct *job_id* values keep the
-    ack futures separate, and :class:`PeerLinkChannel` holds
-    the send lock that serialises wire encrypts. Same-
-    ``job_id`` re-entry inside one session is rejected as
-    :class:`PeerLinkNoSessionError` (a leftover ack future
-    signals the previous flow hasn't completed); the WS
-    layer should generate a fresh ``job_id`` per submit.
-
-    No mid-session retry on timeout / session-loss: the
-    receiver may have already accepted and queued the job,
-    and a duplicate send under a fresh ``job_id`` would land
-    a second :class:`FirmwareJob` on the receiver's queue.
-    Operator-initiated retry on a fresh peer-link session
-    is the correct recovery.
+    Same-``job_id`` reentry mid-flow raises :class:`PeerLinkNoSessionError`;
+    the WS layer should generate a fresh id per submit. Callers must not
+    retry on timeout / session-loss: the receiver may have queued the job
+    already.
     """
     channel = _require_open_channel(client, label="submit_job")
     ack_fut = _register_submit_job_ack_future(client, job_id)
@@ -124,26 +75,11 @@ async def submit_job(
 
 
 async def cancel_job(client: PeerLinkClient, *, job_id: str) -> bool:
-    """Send a ``cancel_job`` frame for *job_id* over the live session.
+    """
+    Send a ``cancel_job`` frame for *job_id* over the live session.
 
-    Fire-and-forget — the receiver's :class:`JobFanout`
-    will fan out the resulting ``JOB_CANCELLED`` event as a
-    ``job_state_changed{status: cancelled}`` frame, which
-    the offloader's existing
-    :attr:`OFFLOADER_JOB_STATE_CHANGED` listener handles.
-    No per-call ack future, no timeout state on
-    :class:`PeerLinkClient` — the next ``job_state_changed``
-    on the inbound stream is the confirmation. A cancel-
-    of-already-terminal or unknown job is silently dropped
-    at the receiver (debug-logged); the offloader UI shows
-    the most recent ``status`` regardless.
-
-    Returns ``True`` if the frame made it onto the wire,
-    ``False`` on a same-tick channel failure (Noise encrypt
-    / WS send returned ``False``). Raises
-    :class:`PeerLinkNoSessionError` when no live session
-    exists; the WS layer maps that to
-    ``CommandError(PRECONDITION_FAILED)``.
+    Fire-and-forget; returns ``True`` if the frame went on the wire,
+    ``False`` on same-tick channel failure.
     """
     channel = _require_open_channel(client, label="cancel_job")
     frame: CancelJobFrameData = {"type": "cancel_job", "job_id": job_id}
@@ -151,40 +87,17 @@ async def cancel_job(client: PeerLinkClient, *, job_id: str) -> bool:
 
 
 async def download_artifacts(client: PeerLinkClient, *, job_id: str) -> DownloadArtifactsResult:
-    """Fetch the build-artifact tarball for *job_id* from the paired receiver.
+    """
+    Fetch the build-artifact tarball for *job_id* from the paired receiver.
 
-    Sends ``download_artifacts{job_id}``, parks on a per-
-    job future the receive-loop dispatch fills as
-    ``artifacts_start`` / ``artifacts_chunk`` /
-    ``artifacts_end`` frames land. Returns a
-    :class:`DownloadArtifactsResult` carrying the
-    SHA-256-verified gzipped-tar bytes plus the
-    receiver-resolved ``firmware.bin`` flash offset (taken
-    from the ``artifacts_start`` header — the tarball
-    itself doesn't carry the firmware partition's offset,
-    only the ``extra`` flash-image entries do).
+    Returns the tarball + receiver-resolved ``firmware.bin`` flash offset
+    (taken from the ``artifacts_start`` header — the tarball itself only
+    carries the bootloader / partition / ota_data offsets via
+    ``idedata.json``).
 
-    Raises :class:`PeerLinkNoSessionError` if no live
-    session exists; the WS layer maps that to
-    ``CommandError(PRECONDITION_FAILED)``. Raises
-    :class:`DownloadArtifactsError` (with structured
-    ``reason``) on receiver-reported failure or
-    offloader-side assembly mismatch. Raises
-    :class:`SubmitJobSessionLostError` if the session
-    ends mid-download (same drain shape as
-    :func:`submit_job`).
-
-    No timeout — artifact tarballs are 1-2 MiB typical
-    (max :data:`FIRMWARE_MAX_TOTAL_BYTES` = 16 MiB);
-    chunk stream completes within seconds on a LAN. If a
-    bound becomes necessary it slots in as
-    ``asyncio.wait_for`` around the future.
-
-    Same-``job_id`` re-entry inside one session raises
-    :class:`PeerLinkNoSessionError` (a leftover future
-    signals the previous download hasn't completed); the
-    WS layer should serialise downloads or generate a
-    fresh request per page-load.
+    Same-``job_id`` reentry raises :class:`PeerLinkNoSessionError`.
+    Receiver-reported failures surface as :class:`DownloadArtifactsError`;
+    session loss mid-download as :class:`SubmitJobSessionLostError`.
     """
     channel = _require_open_channel(client, label="download_artifacts")
     if job_id in client._artifacts_downloads:
@@ -211,16 +124,7 @@ async def download_artifacts(client: PeerLinkClient, *, job_id: str) -> Download
 
 
 def _require_open_channel(client: PeerLinkClient, *, label: str) -> PeerLinkChannel:
-    """Return the live :class:`PeerLinkChannel` or raise :class:`PeerLinkNoSessionError`.
-
-    ``label`` is folded into the exception message so each
-    caller (``submit_job``, ``cancel_job``) names itself in
-    the no-session log line. Every
-    application-message sender that needs a live session
-    flows through this single check; a future sender
-    inherits the same exception class + WS-layer mapping
-    without duplicating the channel-presence test.
-    """
+    """Return the live :class:`PeerLinkChannel` or raise :class:`PeerLinkNoSessionError`."""
     channel = client._active_channel
     if channel is None:
         msg = f"{label}: no live peer-link session to {client._hostname}:{client._port}"
@@ -231,24 +135,15 @@ def _require_open_channel(client: PeerLinkClient, *, label: str) -> PeerLinkChan
 def _register_submit_job_ack_future(
     client: PeerLinkClient, job_id: str
 ) -> asyncio.Future[SubmitJobAckFrameData]:
-    """Allocate + register the per-``job_id`` ack future, refusing duplicates.
-
-    The future is registered on :attr:`_submit_job_acks`
-    BEFORE the header goes out so a same-tick ack can't
-    lose to the future registration (the receive loop runs
-    on the same event loop; pre-registering avoids the
-    race regardless). A second call for the same *job_id*
-    while the first is still pending raises
-    :class:`PeerLinkNoSessionError` — same exception class
-    the WS layer maps to "refuse the submit, ask the caller
-    to retry under a fresh id."
-    """
+    """Allocate + register the per-``job_id`` ack future, refusing duplicates."""
     if job_id in client._submit_job_acks:
         msg = (
             f"submit_job: ack future already registered for job_id={job_id!r} "
             f"(duplicate submit on the same session)"
         )
         raise PeerLinkNoSessionError(msg)
+    # Register BEFORE the header goes out so a same-tick ack from the
+    # receive loop can't beat the registration into the map.
     ack_fut: asyncio.Future[SubmitJobAckFrameData] = asyncio.get_running_loop().create_future()
     client._submit_job_acks[job_id] = ack_fut
     return ack_fut
@@ -265,22 +160,10 @@ async def _send_submit_job_frames(
     device_name: str = "",
     device_friendly_name: str = "",
 ) -> None:
-    """Send the ``submit_job`` header and every chunk frame, in order.
+    """
+    Send the ``submit_job`` header and every chunk frame, in order.
 
-    Streams chunks via :func:`chunk_bundle`'s generator
-    rather than materialising the list — slicing
-    ``bundle_bytes`` produces a fresh ``bytes`` object per
-    chunk, and holding them all alive at once would roughly
-    double peak memory (up to :data:`BUNDLE_MAX_TOTAL_BYTES`,
-    4 MiB). ``num_chunks`` is computed via integer ceil on
-    ``total_bundle_bytes`` so the header still announces the
-    exact count without a materialise step.
-
-    Raises :class:`SubmitJobSessionLostError` immediately if
-    any send returns ``False`` (transport gone away
-    mid-flow, JSON encode failure, Noise encrypt failure)
-    rather than ploughing on through the chunk loop and
-    relying on the ack-await timeout to surface the failure.
+    Raises :class:`SubmitJobSessionLostError` immediately on mid-flow send failure.
     """
     total_bytes = len(bundle_bytes)
     num_chunks = (total_bytes + BUNDLE_CHUNK_SIZE_BYTES - 1) // BUNDLE_CHUNK_SIZE_BYTES
@@ -299,6 +182,10 @@ async def _send_submit_job_frames(
         raise SubmitJobSessionLostError(
             f"submit_job: header send failed mid-flow to {client._hostname}:{client._port}"
         )
+    # Streamed via ``chunk_bundle``'s generator rather than
+    # materialising the list — slicing produces a fresh ``bytes``
+    # per chunk and holding all of them alive would roughly double
+    # peak memory (up to BUNDLE_MAX_TOTAL_BYTES = 4 MiB).
     for chunk_index, raw, is_last in chunk_bundle(bundle_bytes):
         chunk_frame: SubmitJobChunkFrameData = {
             "type": "submit_job_chunk",
@@ -320,14 +207,7 @@ async def _await_submit_job_ack(
     *,
     job_id: str,
 ) -> SubmitJobAckFrameData:
-    """Park on *ack_fut* with a bounded timeout; raise structured errors.
-
-    Timeout maps to :class:`SubmitJobTimeoutError`; session
-    loss while parked surfaces as
-    :class:`SubmitJobSessionLostError` (the receive loop's
-    ``finally`` propagates it via ``set_exception``, which
-    :meth:`asyncio.wait_for` re-raises).
-    """
+    """Park on *ack_fut* with a bounded timeout; raise structured errors."""
     try:
         return await asyncio.wait_for(ack_fut, timeout=_SUBMIT_JOB_ACK_TIMEOUT_SECONDS)
     except TimeoutError as exc:


### PR DESCRIPTION
# What does this implement/fix?

Docstring + comment cleanup follow-up to the structural split in #705. Tightens `_submit.py` per the CLAUDE.md style rules (single-line default, multi-line only when there's non-obvious caller-visible behaviour the signature doesn't already convey, content on the line after `"""`).

Same split-then-clean cadence as #663 → #666 and #670 → #671.

Changes:

* **`submit_job`** — collapsed the 5-step procedure list + cross-references to the receiver-side accept path. Kept the non-obvious caller-visible contracts: same-`job_id` reentry rejection and the no-retry-on-timeout constraint (callers must not retry because the receiver may have already queued the job).
* **`cancel_job`** — collapsed the JobFanout cross-reference + no-ack-future implementation note. Kept fire-and-forget semantic + True/False return semantics (the bool return isn't self-describing).
* **`download_artifacts`** — collapsed retry / timeout-design rationale. Kept the non-obvious `firmware_offset` semantics (it's pulled from the `artifacts_start` header, not the tarball; the tarball only carries the bootloader / partition / ota_data offsets through `idedata.json`) and the full error contract.
* **`_require_open_channel`**, **`_register_submit_job_ack_future`**, **`_send_submit_job_frames`**, **`_await_submit_job_ack`** — private helpers, collapsed to single-line where the signature carries the contract; preserved the two non-obvious code-level invariants as inline comments (the pre-register-before-send race in `_register_submit_job_ack_future` and the stream-via-generator memory tradeoff in `_send_submit_job_frames`).
* **`_SUBMIT_JOB_ACK_TIMEOUT_SECONDS` comment** — kept the why (60s headroom for receiver-side bundle-finalise + queue-acquire under disk-IO contention on constrained SoCs) but dropped the implementation breakdown.

Line count: 338 → 218 (35% reduction). Same `ruff check`, `ruff format`, and `mypy` clean; all 248 targeted tests in `test_remote_build_peer_link_client.py` + `test_remote_build_artifacts_download.py` + `test_remote_runner.py` pass. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #705

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
