### PR TITLE
Tighten client.py docstrings and comments

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -1,20 +1,18 @@
 """
-Long-lived offloader-side peer-link Noise WS session (issue #106).
+Long-lived offloader-side peer-link Noise WS session.
 
 :class:`PeerLinkClient` is the one-per-pairing initiator that
-opens the long-lived ``intent="peer_link"`` WS, runs the Noise
-XX handshake (via :func:`.one_shot._drive_initiator_handshake_and_read_response`),
-parks on a receive loop with an encrypted heartbeat, and
-reconnects with bounded backoff on every close other than a
-receiver-side ``superseded``. Submit-job / cancel-job /
-artifact-download flows ride the same channel; inbound frames
-fan out to bus events the offloader controller and the
-firmware fan-out listen to.
+opens the long-lived ``intent="peer_link"`` WS, runs the Noise XX
+handshake via :func:`.one_shot._drive_initiator_handshake_and_read_response`,
+parks on a receive loop with an encrypted heartbeat, and reconnects
+with bounded backoff on every close other than a receiver-side
+``superseded``. Submit-job / cancel-job / artifact-download flows
+ride the same channel; inbound frames fan out to bus events the
+offloader controller and the firmware fan-out listen to.
 
-The one-shot initiator helpers (``preview_pair`` /
-``request_pair`` / ``await_pair_status``) live in
-:mod:`.one_shot` — same Noise XX handshake, different lifetime
-shape.
+The one-shot initiator helpers (``preview_pair`` / ``request_pair``
+/ ``await_pair_status``) live in :mod:`.one_shot` — same handshake,
+different lifetime shape.
 """
 
 from __future__ import annotations
@@ -68,40 +66,29 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-# Auto-reconnect cadence after a session ends. Initial 1-second
-# wait keeps a transient drop (LAN flap, brief receiver restart)
-# from looking like a hang to the user; the 30s cap keeps an
-# extended outage from spamming the receiver's accept queue.
-# Reset to the initial value on every successful connect so a
-# flaky path doesn't permanently degrade to the cap.
+# 1s initial keeps a transient drop (LAN flap, brief receiver
+# restart) from looking like a hang; 30s cap keeps an extended
+# outage from spamming the receiver's accept queue. Reset on
+# every successful connect.
 _RECONNECT_INITIAL_BACKOFF_SECONDS = 1.0
 _RECONNECT_MAX_BACKOFF_SECONDS = 30.0
 
 
-# Offloader-side close reasons that aren't on the wire (the
-# wire-level reasons live in :class:`TerminateReason` — those
-# come *from* the receiver). These describe close paths that
-# originate on our side: transport error, our own heartbeat
-# timeout, controller-initiated stop. Surfaced verbatim in the
-# ``OFFLOADER_PEER_LINK_CLOSED`` event payload's ``reason``
-# field so subscribers can distinguish "we lost the connection"
-# from "the receiver kicked us."
+# Offloader-side close reasons (wire-level ones live in
+# :class:`TerminateReason`). Surfaced verbatim in the
+# ``OFFLOADER_PEER_LINK_CLOSED`` event so subscribers can
+# distinguish "we lost the connection" from "the receiver
+# kicked us."
 _LOCAL_CLOSE_TRANSPORT_ERROR = "transport_error"
 _LOCAL_CLOSE_HEARTBEAT_TIMEOUT = "heartbeat_timeout"
 _LOCAL_CLOSE_CLIENT_STOPPED = "client_stopped"
 _LOCAL_CLOSE_PEER_HUNG_UP = "peer_hung_up"
 _LOCAL_CLOSE_AUTH_REJECTED = "auth_rejected"
-# Receiver's static X25519 pubkey hash (from the live Noise XX
-# handshake) didn't match the value the offloader OOB-confirmed
-# at pair time. Either the receiver's identity legitimately
-# rotated, or an attacker has interposed (e.g. mDNS spoof
-# pointing the offloader at an attacker-controlled host that
-# completed the handshake with its own keypair). The
-# :class:`PeerLinkClient` aborts the connection before any
-# application frames flow and orphans itself so the reconnect
-# loop doesn't hammer the wrong endpoint; the operator's
-# resolution is to re-pair (clearing the alert) or unpair
-# (removing the row).
+# Receiver's post-handshake pubkey didn't match the OOB-confirmed
+# value — either legitimate rotation or a MITM / mDNS spoof.
+# Aborts before any application frames flow and orphans so the
+# reconnect loop doesn't hammer the wrong endpoint; operator
+# recovery is re-pair or unpair.
 _LOCAL_CLOSE_PIN_MISMATCH = "pin_mismatch"
 
 
@@ -110,25 +97,18 @@ class PeerLinkClient:
     Long-lived offloader-side peer-link Noise WS session.
 
     One instance per APPROVED :class:`StoredPairing`, owned by
-    :class:`OffloaderController`. Drive via
-    :meth:`run` (cancellable asyncio task) — connects to the
-    receiver's peer-link port, runs the Noise XX handshake with
-    ``intent="peer_link"``, parks on a receive loop, drives an
+    :class:`OffloaderController`. Drive via :meth:`run`
+    (cancellable asyncio task): connects to the receiver's
+    peer-link port, runs the Noise XX handshake with
+    ``intent="peer_link"``, parks on a receive loop with an
     encrypted heartbeat, and reconnects on any close other than
     a receiver-side ``superseded`` (which would loop forever
     against whatever instance now holds our slot).
 
-    Bus events fire on every transition: ``OFFLOADER_PEER_LINK_OPENED``
-    once the post-handshake ``intent_response: ok`` lands and
-    the dispatch loop is parked, and ``OFFLOADER_PEER_LINK_CLOSED``
-    on every clean exit (carries a ``reason`` so the offloader-
-    side frontend Settings UI can branch on close cause).
-
-    Cancelling the :meth:`run` task is the controller-side
-    teardown path — the run loop's ``finally`` chain sends a
-    ``terminate{reason: client_stopped}`` to the receiver before
-    the WS closes so the receiver-side session loop unwinds
-    cleanly without waiting for its heartbeat to time out.
+    Cancelling :meth:`run` is the controller-side teardown path —
+    the finally chain sends ``terminate{reason: client_stopped}``
+    so the receiver's session loop unwinds cleanly without
+    waiting for its heartbeat to time out.
     """
 
     def __init__(
@@ -148,93 +128,52 @@ class PeerLinkClient:
         self._port = receiver_port
         self._identity_priv = identity_priv
         self._dashboard_id = dashboard_id
-        # Shared :class:`aiohttp` resolver wired to the
-        # dashboard's :class:`AsyncZeroconf` so ``.local``
-        # receiver hostnames resolve through mDNS instead of the
-        # OS resolver (which often doesn't have mDNS plumbed).
-        # ``None`` falls back to ``aiohttp``'s default resolver,
-        # which is the only viable shape for unit tests that
-        # don't construct a real Zeroconf.
+        # ``None`` falls back to aiohttp's default resolver —
+        # the only viable shape for unit tests that don't
+        # construct a real Zeroconf.
         self._resolver = resolver
-        # Pinned receiver pubkey from the OOB-verified pair flow,
-        # captured during ``preview_pair`` and stored on
-        # :class:`StoredPairing.static_x25519_pub`. Compared
-        # against ``session.remote_static_pub`` post-handshake on
-        # every connect so an attacker with their own X25519
-        # keypair can't complete Noise XX against this client and
-        # reach the application channel. ``pin_sha256`` is the
-        # SHA-256 of the same pubkey, carried on every event the
-        # client fires so the controller's listener can key into
-        # ``_open_peer_links`` / ``_offloader_alerts`` /
-        # ``_peer_queue_status`` (pin-keyed offloader state).
-        # ``receiver_label`` is carried so
-        # the pin-mismatch alert can name the row at firing time.
+        # Compared against ``session.remote_static_pub``
+        # post-handshake on every connect so an attacker with
+        # their own keypair can't complete Noise XX against this
+        # client. ``pin_sha256`` is the same value hashed, used
+        # to key into pin-keyed offloader state.
+        # ``receiver_label`` lets the pin-mismatch alert name
+        # the row at firing time.
         self._pinned_static_x25519_pub = pinned_static_x25519_pub
         self._pin_sha256 = pin_sha256
         self._receiver_label = receiver_label
         self._bus = bus
-        # Set to True when we observe a receiver-side
-        # ``terminate{reason: superseded}`` close — means a
-        # newer offloader instance with the same dashboard_id
-        # has taken our slot. Reconnecting would just collide
-        # with that instance and trigger an endless flap, so
-        # we orphan the run loop instead. The controller can
-        # explicitly :meth:`run` again (e.g. after a config
-        # reload) to reset.
+        # True after a receiver-side ``terminate{superseded}`` or
+        # post-handshake pin-mismatch — reconnecting would just
+        # hammer the wrong endpoint. Controller can reset by
+        # spawning a fresh :meth:`run` task.
         self._orphaned = False
-        # Set ``True`` once a session reached
-        # ``intent_response: ok`` and the dispatch loop parked.
-        # The reconnect-backoff logic in :meth:`run` resets the
-        # backoff window only when the previous session opened —
-        # if we never got past the handshake (transport error,
-        # auth rejected) the backoff advances exponentially so a
-        # broken receiver doesn't get hammered.
+        # True once a session reached ``intent_response: ok`` —
+        # :meth:`run`'s backoff resets only on previously-opened
+        # sessions; never-opened cycles advance exponentially so
+        # a broken receiver doesn't get hammered.
         self._session_was_opened = False
-        # Live :class:`PeerLinkChannel` for the currently-open
-        # session, or ``None`` when between sessions. Set inside
-        # :meth:`_run_session_loops` before the receive loop
-        # parks, cleared in the same method's ``finally`` after
-        # the loop exits. :meth:`submit_job` reads this to know
-        # whether a session is live (raising
-        # :class:`PeerLinkNoSessionError` if not) and to drive
-        # the chunk send through the same channel the receive
-        # loop is parked on. Only one writer (the run task) and
-        # one reader (the controller's WS submit handler), both
-        # on the same event loop, so no lock is needed.
+        # Set inside :meth:`_run_session_loops` before parking;
+        # cleared in its ``finally``. :meth:`submit_job` reads
+        # this to raise :class:`PeerLinkNoSessionError` when the
+        # session's gone. Single writer (run task), single reader
+        # (controller's WS submit handler), same event loop — no
+        # lock needed.
         self._active_channel: PeerLinkChannel | None = None
-        # Per-job ack futures, keyed on the ``job_id`` we put on
-        # the ``submit_job`` header. Populated by
-        # :meth:`submit_job` before the header goes out, drained
-        # by the receive loop on the matching ``submit_job_ack``
-        # frame, and force-completed in
-        # :meth:`_run_session_loops`'s ``finally`` if the session
-        # closes mid-flow (so ``submit_job`` doesn't hang on the
-        # ack timeout when the wire is already gone). Future's
-        # ``set_result`` value is the validated ack frame; on
-        # session-loss the future gets
-        # :class:`SubmitJobSessionLostError`.
-        self._submit_job_acks: dict[str, asyncio.Future[SubmitJobAckFrameData]] = {}
-        # Last-connection-failure description for the operator-
-        # facing "Last connection error" line on the paired-rows
-        # list. Populated in :meth:`_run_one_session`'s exception
-        # paths with ``f"{type(exc).__name__}: {exc}"`` for
-        # transport / Noise failures, ``"auth rejected"`` for the
-        # post-handshake intent_response branch, and
-        # ``"pin mismatch"`` for the orphan-on-rotation path.
-        # Cleared when a session reaches the post-handshake open
-        # state so a stale failure message doesn't survive a
-        # successful reconnect. Empty on a never-connected pairing
-        # where the client task hasn't completed its first attempt.
-        self._last_connect_error: str = ""
-        # Per-job download state for ``download_artifacts``.
-        # Populated by :meth:`download_artifacts` before the
-        # request goes out, drained by the receive loop's
-        # ``artifacts_start`` / ``artifacts_chunk`` /
-        # ``artifacts_end`` dispatch, and force-completed in
+        # Per-job ack futures populated by :meth:`submit_job`
+        # before the header goes out, drained by the receive
+        # loop's submit_job_ack dispatch, force-completed with
+        # :class:`SubmitJobSessionLostError` in
         # :meth:`_run_session_loops`'s ``finally`` on session
-        # loss (same shape as ``_submit_job_acks``).
-        # ``DownloadArtifactsState`` holds the in-flight
-        # :class:`BundleAssembler` plus the result future.
+        # loss so callers don't hang on the ack timeout.
+        self._submit_job_acks: dict[str, asyncio.Future[SubmitJobAckFrameData]] = {}
+        # Operator-facing "Last connection error" line. Populated
+        # by :meth:`_run_one_session`'s exception paths, cleared
+        # on every successful session-open so a stale message
+        # doesn't survive a reconnect.
+        self._last_connect_error: str = ""
+        # Per-job in-flight download state — same drain shape as
+        # ``_submit_job_acks`` (force-completed on session loss).
         self._artifacts_downloads: dict[str, _DownloadArtifactsState] = {}
 
     @property
@@ -247,15 +186,7 @@ class PeerLinkClient:
 
     @property
     def pin_sha256(self) -> str:
-        """OOB-verified pin (sha256 of the receiver's pubkey).
-
-        Stable identifier for this client — matches the key in
-        :attr:`OffloaderController._peer_link_clients` and the
-        ``pin_sha256`` field on every event this client fires.
-        Surfaced as a property so the controller's WS handler
-        can confirm it matches the request before driving a
-        :meth:`submit_job`.
-        """
+        """OOB-verified pin (sha256 of the receiver's pubkey)."""
         return self._pin_sha256
 
     @property
@@ -265,68 +196,39 @@ class PeerLinkClient:
 
     @property
     def is_orphaned(self) -> bool:
-        """True if the run loop has been poisoned and won't reconnect.
+        """
+        True if the run loop has been poisoned and won't reconnect.
 
-        Set in two cases, both of which mean reconnecting would
-        just hammer the wrong endpoint:
-
-        * Receiver-side ``terminate{reason: superseded}`` close
-          — a newer offloader instance with the same
-          ``dashboard_id`` has taken our slot. Reconnecting
-          would collide with that instance.
-        * Pin-mismatch on the post-handshake pin-check —
-          ``session.remote_static_pub`` didn't match the
-          OOB-confirmed pubkey, so we're talking to a
-          rotated-but-legitimate receiver or to an attacker.
-          Either way the operator's resolution (re-pair to
-          confirm the new identity, or unpair) is the only
-          path forward.
-
-        The controller's restart path (a fresh :meth:`run`)
-        clears the flag.
+        Set on receiver-side ``superseded`` close (another
+        offloader instance with the same ``dashboard_id`` took
+        our slot) or post-handshake pin-mismatch. Operator
+        recovery is re-pair or unpair; the controller's restart
+        path (a fresh :meth:`run`) clears the flag.
         """
         return self._orphaned
 
     @property
     def is_connecting(self) -> bool:
-        """True if the run loop is alive but no session is currently open.
+        """
+        True if the run loop is alive but no session is currently open.
 
-        The ``True`` window covers both the very first connect
-        attempt (``_run_one_session`` before the post-handshake
-        ``intent_response: ok``) and every subsequent reconnect
-        cycle inside :meth:`run`'s backoff loop. Goes ``False``
-        in two distinct directions:
-
-        * Forward to ``connected``: a session reached the
-          post-handshake open state and parked on the receive
-          loop. :meth:`is_session_open` returns ``True``.
-        * Sideways to ``orphaned``: a pin-mismatch / superseded
-          close poisoned the run loop. :meth:`is_orphaned`
-          returns ``True``.
-
-        UI uses the tri-state to render "Connected" /
-        "Connecting…" / "Disconnected (last error: …)"; an
-        orphaned client is the disconnected case where the
-        operator has to re-pair or unpair to recover.
+        Tri-state with :attr:`is_session_open` (connected) and
+        :attr:`is_orphaned` (terminal-until-re-pair). UI renders
+        "Connecting…" / "Connected" / "Disconnected (last error: …)"
+        from the three properties.
         """
         return not self._orphaned and not self.is_session_open
 
     @property
     def last_connect_error(self) -> str:
-        """Most-recent connection failure as a one-line description.
+        """
+        Most-recent connection failure as a one-line description.
 
-        Set by :meth:`_run_one_session`'s exception paths to
-        ``f"{type(exc).__name__}: {exc}"`` for transport / Noise
-        failures, to ``"auth rejected"`` for handshake-rejected
-        sessions, and to ``"pin mismatch"`` for the orphan-on-
-        rotation path. Cleared when a session reaches the
-        post-handshake open state — a stale message must not
-        survive a successful reconnect.
-
-        Empty on a never-connected pairing (the run loop hasn't
-        completed its first attempt yet) and on cleanly-stopped
-        clients (``client_stopped`` close on controller
-        shutdown).
+        ``"{ExcType}: {msg}"`` for transport / Noise failures,
+        ``"auth rejected"`` for handshake rejections,
+        ``"pin mismatch"`` on orphan-on-rotation. Cleared on
+        every successful session-open. Empty on a
+        never-connected pairing.
         """
         return self._last_connect_error
 
@@ -357,40 +259,25 @@ class PeerLinkClient:
         return await _submit.download_artifacts(self, job_id=job_id)
 
     async def run(self) -> None:
-        """Run the connect-loop forever. Cancellable.
+        """
+        Run the connect-loop forever. Cancellable.
 
-        Each iteration:
-
-        1. Open WS, drive Noise XX with ``intent="peer_link"``.
-        2. On ``intent_response: ok``, fire
-           ``OFFLOADER_PEER_LINK_OPENED``, park on the receive
-           loop with a heartbeat task running alongside.
-        3. On any session end (receiver-side ``terminate``,
-           heartbeat miss, transport error, peer-hung-up),
-           fire ``OFFLOADER_PEER_LINK_CLOSED`` with the
-           appropriate reason.
-        4. If the close reason is ``superseded``, mark the
-           client orphaned and exit. Otherwise sleep
-           exponential-backoff (interrupted on cancellation)
-           and loop.
-
-        Cancellation at any point sends a structured
-        ``terminate{reason: client_stopped}`` if a session is
-        active, then propagates the ``CancelledError`` to the
-        controller so the task drops cleanly.
+        Each iteration opens a WS, drives Noise XX with
+        ``intent="peer_link"``, parks on the receive loop with a
+        heartbeat, fires OPENED / CLOSED bus events on every
+        transition, and reconnects with exponential backoff
+        (interrupted on cancellation). ``superseded`` /
+        ``pin_mismatch`` closes orphan the client and exit.
+        Cancellation sends ``terminate{reason: client_stopped}``
+        via the inner session's handler before propagating.
         """
         backoff = _RECONNECT_INITIAL_BACKOFF_SECONDS
         try:
             while not self._orphaned:
                 close_reason = await self._run_one_session()
-                # ``_last_connect_error`` was populated by the
-                # exception paths inside ``_run_one_session`` (or
-                # left empty for clean closes — receiver-driven
-                # ``terminate`` frames, heartbeat timeouts that
-                # reach here without an exception, etc.). Pass it
-                # through so the close event carries the specific
+                # ``_last_connect_error`` carries the specific
                 # failure detail alongside the category-level
-                # ``reason``.
+                # ``reason`` for clean operator-facing UX.
                 self._fire_closed(close_reason, error_detail=self._last_connect_error)
                 if close_reason == TerminateReason.SUPERSEDED.value:
                     _LOGGER.info(
@@ -402,17 +289,6 @@ class PeerLinkClient:
                     self._orphaned = True
                     return
                 if close_reason == _LOCAL_CLOSE_PIN_MISMATCH:
-                    # Pin drift means we're either talking to a
-                    # rotated-but-legitimate receiver or to an
-                    # attacker; in both cases reconnecting just
-                    # hammers the wrong endpoint. The bus event
-                    # ``OFFLOADER_PAIR_PIN_MISMATCH`` already
-                    # fired from ``_run_one_session`` carries the
-                    # diagnostic payload, and the controller's
-                    # listener has populated the alerts dict so
-                    # the operator sees the warning. Resolution is
-                    # user-driven: re-pair (clears the alert) or
-                    # unpair (drops the row).
                     _LOGGER.warning(
                         "peer-link client to %s:%d observed pin drift; orphaning "
                         "until the operator re-pairs or unpairs",
@@ -421,13 +297,10 @@ class PeerLinkClient:
                     )
                     self._orphaned = True
                     return
-                # Reset backoff after a session that actually
-                # reached ``intent_response: ok`` so a flaky path
-                # doesn't permanently degrade to the cap. If we
-                # never got past the handshake (transport error,
-                # auth rejected, Noise failure), advance the
-                # backoff exponentially — a broken receiver
-                # mustn't be hammered every second.
+                # Reset on session that reached ``intent_response: ok``
+                # so a flaky path doesn't permanently degrade to
+                # the cap; advance exponentially otherwise so a
+                # broken receiver isn't hammered every second.
                 if self._session_was_opened:
                     backoff = _RECONNECT_INITIAL_BACKOFF_SECONDS
                 else:
@@ -435,41 +308,30 @@ class PeerLinkClient:
                 await asyncio.sleep(backoff)
         except asyncio.CancelledError:
             # ``_run_one_session`` already sent the structured
-            # ``terminate`` frame in its own CancelledError
-            # handler (where the WS and Noise session are still
-            # live as locals). All we need to do here is fire
-            # the bus event so subscribers see the transition.
-            # Even a cancellation before the first session
-            # opened benefits from firing this — the controller
-            # subscribed to ``OFFLOADER_PEER_LINK_CLOSED`` would
-            # otherwise have to track "did this client ever
-            # open" itself; the no-OPENED-then-CLOSED sequence
-            # is a no-op for any subscriber that keys off
+            # ``terminate`` frame in its own CancelledError handler
+            # (where the WS and Noise session are still live as
+            # locals). Fire the bus event so subscribers see the
+            # transition; no-op for subscribers that key off
             # OPENED first.
             self._fire_closed(_LOCAL_CLOSE_CLIENT_STOPPED)
             raise
 
     async def _run_one_session(self) -> str:
-        """Run one connect → handshake → receive loop iteration.
+        """
+        Run one connect → handshake → receive loop iteration.
 
-        Returns the close reason to propagate into
-        ``OFFLOADER_PEER_LINK_CLOSED``. Always returns —
-        exceptions are caught and mapped onto a local close
-        reason. ``CancelledError`` is the one exception that
-        propagates (the run loop's outer handler sends the
-        terminate frame).
+        Returns the close reason. Exceptions are caught and
+        mapped onto a local close reason; ``CancelledError`` is
+        the one exception that propagates (the run loop's outer
+        handler fires the bus event).
         """
         self._session_was_opened = False
         url = URL.build(scheme="ws", host=self._hostname, port=self._port, path=PEER_LINK_PATH)
-        # ``total`` deliberately omitted: the peer-link session
-        # is long-lived (idle-by-design once parked on the
-        # receive loop), so a session-wide timeout would forcibly
-        # drop a healthy session after ``_DEFAULT_TIMEOUT_SECONDS``.
-        # Bound the *handshake* reads with ``asyncio.wait_for``
-        # below — that's what the receiver does in
-        # ``remote_build_peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS``
-        # — so a stalled handshake still fails fast without
-        # putting a ceiling on the dispatch loop's lifetime.
+        # ``total`` deliberately omitted — peer-link is idle-by-
+        # design once parked on the receive loop, so a session-wide
+        # timeout would forcibly drop a healthy session.
+        # Handshake reads are bounded with ``asyncio.wait_for``
+        # downstream so a stalled handshake still fails fast.
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=_DEFAULT_TIMEOUT_SECONDS)
         try:
             async with (
@@ -485,16 +347,12 @@ class PeerLinkClient:
                     msg3_payload=msg3_payload,
                     read_timeout_seconds=_DEFAULT_TIMEOUT_SECONDS,
                 )
-                # Pin-check the receiver's static pubkey BEFORE
-                # decrypting / acting on the response. Noise XX
-                # authenticates that the responder holds the
-                # private key matching the pubkey it advertised,
-                # so a mismatched pubkey here means we connected
-                # to a different identity than the one we
-                # OOB-confirmed at pair time. Could be a
-                # legitimate receiver-side rotation or a MITM /
-                # mDNS spoof; either way we abort before any
-                # application frames flow.
+                # Pin-check BEFORE decrypting / acting on the
+                # response. Noise XX authenticates that the
+                # responder holds the private key for the pubkey
+                # it advertised; a mismatched pubkey means a
+                # legitimate rotation or a MITM / mDNS spoof.
+                # Abort either way before any application frames.
                 if session.remote_static_pub != self._pinned_static_x25519_pub:
                     self._fire_pin_mismatch(observed=session.remote_static_pub)
                     self._last_connect_error = "pin mismatch"
@@ -512,22 +370,7 @@ class PeerLinkClient:
                     )
                     self._last_connect_error = "auth rejected"
                     return _LOCAL_CLOSE_AUTH_REJECTED
-                # Lift the receiver's ``esphome_version`` off the
-                # response so OPENED carries it onto the bus.
                 receiver_version = _extract_receiver_esphome_version(response)
-                # Session is live — build the shared channel
-                # over (noise, ws), fire OPENED, park on the
-                # receive loop with a heartbeat task running
-                # alongside. Setting ``_session_was_opened``
-                # tells :meth:`run`'s backoff logic to reset on
-                # the next iteration. Clearing
-                # ``_last_connect_error`` here means a successful
-                # reconnect drops the previous failure message
-                # off the operator-facing snapshot — a stale "the
-                # last connect tried 4 attempts ago failed with
-                # ConnectionRefusedError" would mislead the
-                # operator into thinking the live session is
-                # broken.
                 channel = PeerLinkChannel(
                     noise=session, ws=ws, log_label=f"{self._hostname}:{self._port}"
                 )
@@ -537,11 +380,10 @@ class PeerLinkClient:
                 try:
                     return await self._run_session_loops(channel)
                 except asyncio.CancelledError:
-                    # Best-effort structured close before the
-                    # WS goes away under us. The channel's
-                    # ``send_terminate`` doesn't go through any
-                    # ``_closing`` gate (this terminate IS the
-                    # close), so the frame goes out reliably.
+                    # Best-effort structured close before the WS
+                    # goes away under us. ``send_terminate`` skips
+                    # the ``_closing`` gate — this terminate IS
+                    # the close — so the frame goes out reliably.
                     await channel.send_terminate(_LOCAL_CLOSE_CLIENT_STOPPED)
                     raise
         except (TimeoutError, aiohttp.ClientError, OSError, ValueError, TypeError) as exc:
@@ -566,18 +408,15 @@ class PeerLinkClient:
             return _LOCAL_CLOSE_TRANSPORT_ERROR
 
     async def _run_session_loops(self, channel: PeerLinkChannel) -> str:
-        """Run the receive loop with a heartbeat task in parallel.
+        """
+        Run the receive loop with a heartbeat task in parallel.
 
-        Returns the close reason. Both loops mutate a shared
-        :class:`_SessionLoopState`: the receive loop bumps
-        ``last_pong_at`` on each pong and writes
-        ``close_reason`` on transport-error / terminate-frame
-        / unknown-msg-type exits; the heartbeat task's
-        ``_on_dead`` callback writes
-        ``HEARTBEAT_TIMEOUT`` so the close reason reflects the
-        real cause instead of falling through to the default
-        ``peer_hung_up``. Both loops share the
-        :class:`PeerLinkChannel` for encrypt / parse / send.
+        Returns the close reason. The receive loop and heartbeat
+        share a :class:`_SessionLoopState`: receive bumps
+        ``last_pong_at`` on pong and writes ``close_reason`` on
+        transport-error / terminate / unknown-msg-type exits;
+        heartbeat's ``_on_dead`` writes ``HEARTBEAT_TIMEOUT`` so
+        the reason reflects the real cause.
         """
         state = _SessionLoopState(
             last_pong_at=asyncio.get_running_loop().time(),
@@ -594,17 +433,11 @@ class PeerLinkClient:
                 self._hostname,
                 self._port,
             )
-            # Best-effort close — include ``aiohttp.ClientError``
-            # alongside the basic transport types because
-            # :meth:`aiohttp.ClientWebSocketResponse.close` can
-            # raise ``ClientConnectionError`` / ``ClientError``
-            # when the peer has already gone away. Letting that
-            # escape here would crash the heartbeat task and let
-            # the receive loop fall through to its
-            # ``peer_hung_up`` default, masking the real
-            # heartbeat-timeout cause. ``CancelledError`` stays
-            # unsuppressed (Python 3.8+ excludes it from
-            # ``Exception``).
+            # ``ws.close()`` can raise ``ClientConnectionError`` /
+            # ``ClientError`` when the peer has already gone
+            # away; letting that escape would crash the heartbeat
+            # task and fall through to the ``peer_hung_up``
+            # default, masking the real cause.
             with contextlib.suppress(OSError, RuntimeError, aiohttp.ClientError):
                 await channel.ws.close()
 
@@ -617,28 +450,21 @@ class PeerLinkClient:
             name=f"peer-link-client-heartbeat[{self._hostname}:{self._port}]",
         )
         # Expose the channel to :meth:`submit_job` for the
-        # duration of the receive loop. Cleared in ``finally``
-        # so a post-session :meth:`submit_job` raises
-        # :class:`PeerLinkNoSessionError` instead of writing
-        # into a stale channel.
+        # session's duration. Cleared in ``finally`` so a
+        # post-session submit raises :class:`PeerLinkNoSessionError`
+        # instead of writing into a stale channel.
         self._active_channel = channel
-        # Bound the synchronous-dispatch lookup table once per
-        # session — sync handlers fan an inbound frame into the
-        # bus / ack futures with no need for the channel itself.
-        # PING / PONG / TERMINATE / malformed each touch the
-        # session loop's mutable state (close_reason,
-        # last_pong_at) or the channel (PONG response), so they
-        # stay branched in the loop body rather than fitting
-        # the table's ``(self, parsed) -> None`` shape.
+        # Built once per session for the receive-loop hot path —
+        # one dict lookup per frame. PING / PONG / TERMINATE /
+        # malformed touch session-local state or close the loop
+        # and stay branched in the loop body.
         sync_dispatch = self._build_sync_frame_dispatch()
         try:
             async for msg in channel.ws:
                 parsed = channel.parse_frame(msg)
                 if parsed is None:
-                    # Any of the four malformed-frame branches —
-                    # ``parse_frame`` already logged the per-branch
-                    # context. Map to the offloader-side
-                    # transport-error reason on the wire-status event.
+                    # ``parse_frame`` already logged per-branch
+                    # context for the malformed-frame case.
                     state.close_reason = _LOCAL_CLOSE_TRANSPORT_ERROR
                     break
                 msg_type = parsed.get("type")
@@ -668,14 +494,11 @@ class PeerLinkClient:
             return state.close_reason
         finally:
             self._active_channel = None
-            # Drain any in-flight :meth:`submit_job` callers so
-            # they raise :class:`SubmitJobSessionLostError`
-            # immediately instead of waiting on the per-flow
-            # timeout. The session ended before the ack came
-            # back; no point keeping the awaiter parked. Snapshot
-            # the dict before iterating because
-            # :meth:`submit_job`'s ``finally`` pops the entry as
-            # soon as the future fires.
+            # Drain in-flight submitters so they raise
+            # :class:`SubmitJobSessionLostError` immediately
+            # instead of waiting on the per-flow timeout. Snapshot
+            # the dict before iterating — :meth:`submit_job`'s
+            # ``finally`` pops the entry as soon as the future fires.
             for pending_job_id, pending_fut in list(self._submit_job_acks.items()):
                 if not pending_fut.done():
                     pending_fut.set_exception(
@@ -685,10 +508,7 @@ class PeerLinkClient:
                             f"for job_id={pending_job_id!r}"
                         )
                     )
-            # Same drain shape for 6a in-flight artifact downloads —
-            # the receiver won't be sending any more chunks now
-            # that the session's gone; resolve every pending
-            # future so :meth:`download_artifacts` unwinds.
+            # Same drain shape for in-flight artifact downloads.
             for pending_job_id, dl_state in list(self._artifacts_downloads.items()):
                 if not dl_state.future.done():
                     dl_state.future.set_exception(
@@ -699,31 +519,23 @@ class PeerLinkClient:
                         )
                     )
             heartbeat_task.cancel()
-            # Drain via ``gather(return_exceptions=True)`` rather
-            # than ``suppress(CancelledError) + await`` — suppressing
+            # ``gather(return_exceptions=True)`` rather than
+            # ``suppress(CancelledError) + await`` — suppressing
             # CancelledError swallows any outer cancellation that
-            # arrives during the drain and breaks the propagation
-            # contract (see ``feedback_no_suppress_cancelled_error``).
+            # arrives during the drain (see
+            # ``feedback_no_suppress_cancelled_error``).
             await asyncio.gather(heartbeat_task, return_exceptions=True)
 
     def _build_sync_frame_dispatch(
         self,
     ) -> dict[str, Callable[[dict[str, Any]], None]]:
-        """Return the inbound-frame → sync handler map for one session.
+        """
+        Return the inbound-frame → sync handler map for one session.
 
-        Built once per session (in :meth:`_run_session_loops`)
-        rather than per inbound frame to keep the receive-loop
-        hot path's per-frame work down to one dict lookup. The
-        bound-method values capture ``self`` so adding a new
-        sync frame type is a one-line table entry plus the
-        handler implementation, no loop-body branch.
-
-        Excluded from the table on purpose:
-        ``PING`` / ``PONG`` / ``TERMINATE`` mutate the
-        session-local :class:`_SessionLoopState` or close the
-        loop, neither of which fits the ``(parsed)`` shape.
-        Malformed frames (``parse_frame`` returned ``None``) are
-        a separate branch upstream of this lookup.
+        PING / PONG / TERMINATE are excluded — they mutate
+        :class:`_SessionLoopState` or close the loop and don't
+        fit the ``(parsed) -> None`` shape. Malformed frames
+        branch upstream of this lookup.
         """
         return {
             AppMessageType.QUEUE_STATUS.value: self._dispatch_queue_status,

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -145,8 +145,9 @@ class PeerLinkClient:
         self._bus = bus
         # True after a receiver-side ``terminate{superseded}`` or
         # post-handshake pin-mismatch — reconnecting would just
-        # hammer the wrong endpoint. Controller can reset by
-        # spawning a fresh :meth:`run` task.
+        # hammer the wrong endpoint. One-shot: never cleared on
+        # the instance. Controller recovers by dropping this
+        # client and constructing a fresh :class:`PeerLinkClient`.
         self._orphaned = False
         # True once a session reached ``intent_response: ok`` —
         # :meth:`run`'s backoff resets only on previously-opened
@@ -201,9 +202,10 @@ class PeerLinkClient:
 
         Set on receiver-side ``superseded`` close (another
         offloader instance with the same ``dashboard_id`` took
-        our slot) or post-handshake pin-mismatch. Operator
-        recovery is re-pair or unpair; the controller's restart
-        path (a fresh :meth:`run`) clears the flag.
+        our slot) or post-handshake pin-mismatch. One-shot:
+        never cleared on this instance. Operator recovery is
+        re-pair or unpair; the controller drops this client and
+        constructs a fresh one.
         """
         return self._orphaned
 


### PR DESCRIPTION
# What does this implement/fix?

Docstring + comment cleanup follow-up completing the `peer_link_client/` package cleanup (after #707, #708, #709). Tightens `client.py` per the CLAUDE.md style rules.

Changes:

* **Module docstring** — collapsed from 17 to 12 lines, kept the package-level picture (long-lived initiator, handshake → receive loop → reconnect, fanout to bus events, contrast with `.one_shot` helpers).
* **`PeerLinkClient` class docstring** — kept the lifecycle + cancellation contract (5-line opening + 4-line cancellation paragraph). Dropped the OPENED / CLOSED bus event restatement (already covered by `_fire_opened` / `_fire_closed` in `_dispatch.py`).
* **`__init__` field comments** — trimmed every per-attribute block (was 8-13 lines each, now 4-6). Kept the non-obvious whys: pin-check rationale, single-writer/single-reader contract on `_active_channel`, drain semantics on `_submit_job_acks` / `_artifacts_downloads`, never-connected behaviour of `_last_connect_error`. Dropped restatements of "what `_resolver` is" / "what `pin_sha256` is for" that the names already imply.
* **Property docstrings** — `pin_sha256` collapsed to single-line; `is_orphaned`, `is_connecting`, `last_connect_error` kept caller-visible contracts in 4-5 line form (orphan reasons, tri-state UI semantics, error-format examples).
* **`run`** — collapsed 24-line procedure list to a 6-line summary that names the orphaning cases + cancellation handling.
* **`_run_one_session`** — kept the return-value contract (close reason on success, `CancelledError` propagates) in 4 lines.
* **`_run_session_loops`** — kept the state-sharing seam between receive loop and heartbeat task in 5 lines.
* **`_build_sync_frame_dispatch`** — kept the why-PING/PONG/TERMINATE-aren't-in-the-table in 4 lines.
* **Body inline comments** — trimmed the long rationale blocks around the pin-check, the timeout=None choice, the heartbeat's ws.close() suppression set, the dispatch-table-build, and the post-session drain. Kept the non-obvious whys (Noise XX auth model, idle-by-design dispatch loop, ClientError on close, gather-vs-suppress for cancellation drain).

Line count: 772 → 584 (24% reduction). With #707 / #708 / #709 also landed, the full `peer_link_client/` package goes from 2050 lines to 1457 (29% reduction).

Same `ruff check`, `ruff format`, and `mypy` clean; all 248 targeted tests pass. No production-side behaviour change.

**Related issue or feature (if applicable):**

- completes the cleanup arc started by #707, #708, #709 — wraps up the `peer_link_client/` package split-then-clean cycle (structural splits #701, #703, #705).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
