### PR TITLE
Split DevicesController: extract state-callbacks mixin

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -34,6 +34,10 @@ resolving after the subpackage split. Submodules:
   ``_persist_device_metadata_async``. Mixed in directly
   on ``DevicesController`` since the methods only touch
   ``self._db`` and same-mixin siblings.
+- ``state_callbacks`` — ``DeviceStateCallbacksMixin``
+  carrying the six ``_on_*_change`` callbacks
+  (state / ip / version / mac / api_encryption /
+  config_hash). Same mixin shape as ``metadata``.
 - ``reachability`` — per-device reachability streaming + the
   on-subscription mDNS A-record refresh loop.
 - ``storage_regen`` — background ``--only-generate`` scheduler

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -27,7 +27,6 @@ from ...helpers.device_yaml import (
     parse_platform_from_yaml,
 )
 from ...helpers.event_bus import Event
-from ...helpers.mac_addresses import derive_interface_macs
 from ...helpers.storage_path import resolve_storage_path
 from ...helpers.yaml import (
     YamlUpsertNotSupportedError,
@@ -43,8 +42,6 @@ from ...models import (
     DeviceEventData,
     DeviceReachabilityData,
     DevicesResponse,
-    DeviceState,
-    DeviceStateChangedData,
     ErrorCode,
     EventType,
     JobLifecycleData,
@@ -87,6 +84,7 @@ from .helpers import (
     friendly_name_slugify,
 )
 from .metadata import DeviceMetadataMixin
+from .state_callbacks import DeviceStateCallbacksMixin
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -128,6 +126,7 @@ _YAML_SEARCH_PER_FILE_MATCH_CAP = 5
 
 class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
     DeviceMetadataMixin,
+    DeviceStateCallbacksMixin,
 ):
     """Manage device configurations, file watching, and CLI operations."""
 
@@ -1744,192 +1743,6 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def refresh_device_mdns(self, name: str) -> None:
         """Force-refresh a device's mDNS A record. No-op if zeroconf is down."""
         await reachability.refresh_device_mdns(self, name)
-
-    def _on_state_change(self, name: str, state: DeviceState, source: str) -> None:
-        """Forward state monitor updates onto the event bus."""
-        for device in self._devices_by_name(name):
-            old_state = device.state
-            device.state = state
-            _LOGGER.info(
-                "Device %s (%s): %s → %s (via %s)",
-                name,
-                device.configuration,
-                old_state,
-                state,
-                source,
-            )
-            # Frontend's ``DeviceStateChangedEventData`` is the flat
-            # ``{configuration, state}`` shape — sending the full ``device``
-            # object made the destructure resolve both fields to
-            # ``undefined`` and the table never updated. Match the type
-            # exactly so the row's state cell flips on the next event.
-            self._db.bus.fire(
-                EventType.DEVICE_STATE_CHANGED,
-                DeviceStateChangedData(
-                    configuration=device.configuration,
-                    state=state.value,
-                ),
-            )
-
-    def _on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:
-        """
-        Forward IP updates onto the event bus and persist the primary value.
-
-        ``ip=""`` (with an empty *addresses* list) means the device
-        dropped off mDNS — we keep the last-known primary on disk so
-        the OTA address cache stays warm across the device's offline
-        window. The DNS pre-resolve and next mDNS resolve will
-        overwrite it on reconnect.
-
-        Only ``ip`` is persisted; ``addresses`` is the live mDNS view
-        and gets repopulated by the next monitor pass after a restart.
-        """
-        new_addresses = list(addresses)
-        for device in self._devices_by_name(name):
-            if device.ip == ip and device.ip_addresses == new_addresses:
-                continue
-            ip_changed = device.ip != ip
-            device.ip = ip
-            device.ip_addresses = list(new_addresses)
-            _LOGGER.debug(
-                "Device %s (%s) IPs: %s",
-                name,
-                device.configuration,
-                ", ".join(new_addresses) or "(cleared)",
-            )
-            if ip and ip_changed:
-                self._db.create_background_task(
-                    self._persist_device_ip_async(device.configuration, ip)
-                )
-            self._fire_device_updated(device)
-
-    def _on_version_change(self, name: str, version: str) -> None:
-        """Apply a fresh ESPHome version observed via mDNS."""
-        for device in self._devices_by_name(name):
-            if device.deployed_version == version:
-                continue
-
-            # StorageJSON.load/save are blocking — push to a background task
-            # so any error gets surfaced via the loop's exception handler.
-            self._db.create_background_task(
-                self._persist_storage_version_async(device.configuration, version)
-            )
-
-            old_version = device.deployed_version
-            device.deployed_version = version
-            device.update_available = bool(
-                device.current_version and version != device.current_version
-            )
-            _LOGGER.info(
-                "Device %s (%s) version: %s → %s (via mdns)",
-                name,
-                device.configuration,
-                old_version or "?",
-                version,
-            )
-            self._fire_device_updated(device)
-
-    def _on_mac_address_change(self, name: str, mac: str) -> None:
-        """
-        Apply a MAC address observed via mDNS and derive interface MACs.
-
-        The mDNS broadcast is always the device's primary MAC (Wi-Fi
-        STA / eFuse base on ESP32, the single MAC on RP2040). When
-        the YAML loads ``ethernet`` or any ``esp32_ble*`` /
-        ``bluetooth_*`` integration we compute the corresponding
-        interface MAC via :func:`derive_interface_macs` so the drawer
-        can show every MAC the device owns without forcing the
-        firmware to broadcast all of them.
-
-        Persists ``mac_address`` to the per-device metadata sidecar
-        so the dashboard shows the value immediately on restart —
-        ESPHome devices stay mDNS-silent until probed. The derived
-        MACs aren't persisted: they're deterministic from primary +
-        ``loaded_integrations``, so a YAML edit that toggles
-        bluetooth picks up the new derived MAC on the next reload
-        without going through a stale-cache window. The early-return
-        on equality skips both the in-memory write and the sidecar
-        I/O on a steady-state announcement, keeping the typical
-        "same value re-broadcast every 60s" cycle off-disk.
-        """
-        for device in self._devices_by_name(name):
-            if device.mac_address == mac:
-                continue
-            device.mac_address = mac
-            device.ethernet_mac, device.bluetooth_mac = derive_interface_macs(
-                mac, device.target_platform, device.loaded_integrations
-            )
-            self._db.create_background_task(
-                self._persist_device_metadata_async(device.configuration, mac_address=mac)
-            )
-            self._fire_device_updated(device)
-
-    def _on_api_encryption_change(self, name: str, encryption: str) -> None:
-        r"""
-        Apply the API-encryption state observed via mDNS.
-
-        Stores the broadcast value (or empty string for "TXT absent —
-        device is plaintext") on the in-memory device. The dashboard's
-        four-state lock indicator reads this together with
-        ``api_encrypted`` to distinguish active / pending-flash /
-        mismatch / plaintext.
-
-        Also folds the wire signal into ``api_encrypted`` itself when
-        a truthy cipher string arrives. ESPHome's compile pipeline
-        runs the Jinja preprocessor over packages before YAML parsing
-        (``api: |\n  # set ns = ...  ${ns.cfg}``); the dashboard's
-        ``yaml_util.load_yaml`` doesn't, so the scan-time YAML pass
-        can come back ``api_encrypted=False`` for a fully-encrypted
-        device (issue #437). The live broadcast is the truthful
-        signal — promoting ``api_encrypted`` here closes the gap for
-        non-frontend consumers (HA integration, table-row menu
-        gating, the ``Show API key`` affordance) that otherwise hide
-        encryption-aware affordances on a YAML-detection miss. The
-        symmetric "wire confirms plaintext" case (empty-string
-        broadcast) deliberately doesn't *clear* ``api_encrypted`` —
-        a wire-says-no while YAML-says-yes is the legitimate
-        "mismatch" / "pending" shape the existing state machine
-        already handles.
-        """
-        for device in self._devices_by_name(name):
-            wire_promotes_encrypted = bool(encryption) and not device.api_encrypted
-            if device.api_encryption_active == encryption and not wire_promotes_encrypted:
-                continue
-            device.api_encryption_active = encryption
-            if wire_promotes_encrypted:
-                device.api_encrypted = True
-            self._fire_device_updated(device)
-
-    def _on_config_hash_change(self, name: str, config_hash: str) -> None:
-        """
-        Apply a running-firmware config hash observed via mDNS.
-
-        Stores the hash on the in-memory device and, when both
-        expected and deployed hashes are known, flips
-        ``has_pending_changes`` to reflect the comparison so the
-        dashboard can tell "device runs the latest compile" apart
-        from "device has older firmware". Devices on firmware that
-        predates the ``config_hash`` TXT broadcast never trigger this
-        callback and stay on the legacy mtime check.
-        """
-        for device in self._devices_by_name(name):
-            if device.deployed_config_hash == config_hash:
-                continue
-            old_hash = device.deployed_config_hash
-            device.deployed_config_hash = config_hash
-            # Mtime side stays with the periodic scanner poll so this
-            # callback can stay off-disk and non-blocking. A YAML edit
-            # between polls (~5s window) self-corrects on the next scan.
-            if device.expected_config_hash:
-                device.has_pending_changes = device.expected_config_hash != config_hash
-            _LOGGER.info(
-                "Device %s (%s) config_hash: %s → %s (via mdns)",
-                name,
-                device.configuration,
-                old_hash or "?",
-                config_hash,
-            )
-            self._fire_device_updated(device)
 
     def _on_importable_added(self, device: AdoptableDevice) -> None:
         importable.on_importable_added(self, device)

--- a/esphome_device_builder/controllers/devices/state_callbacks.py
+++ b/esphome_device_builder/controllers/devices/state_callbacks.py
@@ -1,0 +1,192 @@
+"""Per-attribute state-monitor callback mixin for ``DevicesController``."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ...helpers.mac_addresses import derive_interface_macs
+from ...models import DeviceState, DeviceStateChangedData, EventType
+
+if TYPE_CHECKING:
+    from ...device_builder import DeviceBuilder
+    from ...models import Device
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DeviceStateCallbacksMixin:
+    """Per-attribute mDNS state callbacks for ``DevicesController``."""
+
+    if TYPE_CHECKING:
+        # Supplied by the host controller class.
+        _db: DeviceBuilder
+
+        def _devices_by_name(self, name: str) -> list[Device]: ...
+        def _fire_device_updated(self, device: Device) -> None: ...
+        async def _persist_device_ip_async(self, configuration: str, ip: str) -> None: ...
+        async def _persist_device_metadata_async(
+            self, configuration: str, **fields: object
+        ) -> None: ...
+        async def _persist_storage_version_async(
+            self, configuration: str, version: str
+        ) -> None: ...
+
+    def _on_state_change(self, name: str, state: DeviceState, source: str) -> None:
+        """Forward state monitor updates onto the event bus."""
+        for device in self._devices_by_name(name):
+            old_state = device.state
+            device.state = state
+            _LOGGER.info(
+                "Device %s (%s): %s → %s (via %s)",
+                name,
+                device.configuration,
+                old_state,
+                state,
+                source,
+            )
+            # Frontend's ``DeviceStateChangedEventData`` is the flat
+            # ``{configuration, state}`` shape; sending the full
+            # ``device`` object made the destructure resolve both
+            # fields to ``undefined`` and the table never updated.
+            self._db.bus.fire(
+                EventType.DEVICE_STATE_CHANGED,
+                DeviceStateChangedData(
+                    configuration=device.configuration,
+                    state=state.value,
+                ),
+            )
+
+    def _on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:
+        """
+        Forward IP updates onto the event bus and persist the primary value.
+
+        ``ip=""`` (with an empty *addresses* list) means the device
+        dropped off mDNS; the last-known primary stays on disk so
+        the OTA address cache survives the offline window. Only
+        ``ip`` is persisted; ``addresses`` is the live mDNS view
+        and gets repopulated by the next monitor pass.
+        """
+        new_addresses = list(addresses)
+        for device in self._devices_by_name(name):
+            if device.ip == ip and device.ip_addresses == new_addresses:
+                continue
+            ip_changed = device.ip != ip
+            device.ip = ip
+            device.ip_addresses = list(new_addresses)
+            _LOGGER.debug(
+                "Device %s (%s) IPs: %s",
+                name,
+                device.configuration,
+                ", ".join(new_addresses) or "(cleared)",
+            )
+            if ip and ip_changed:
+                self._db.create_background_task(
+                    self._persist_device_ip_async(device.configuration, ip)
+                )
+            self._fire_device_updated(device)
+
+    def _on_version_change(self, name: str, version: str) -> None:
+        """Apply a fresh ESPHome version observed via mDNS."""
+        for device in self._devices_by_name(name):
+            if device.deployed_version == version:
+                continue
+
+            # StorageJSON.load/save are blocking; push to a background
+            # task so any error gets surfaced via the loop's exception
+            # handler.
+            self._db.create_background_task(
+                self._persist_storage_version_async(device.configuration, version)
+            )
+
+            old_version = device.deployed_version
+            device.deployed_version = version
+            device.update_available = bool(
+                device.current_version and version != device.current_version
+            )
+            _LOGGER.info(
+                "Device %s (%s) version: %s → %s (via mdns)",
+                name,
+                device.configuration,
+                old_version or "?",
+                version,
+            )
+            self._fire_device_updated(device)
+
+    def _on_mac_address_change(self, name: str, mac: str) -> None:
+        """
+        Apply a MAC address observed via mDNS and derive interface MACs.
+
+        The mDNS broadcast is always the device's primary MAC.
+        When the YAML loads ``ethernet`` or any
+        ``esp32_ble*`` / ``bluetooth_*`` integration the
+        corresponding interface MAC is derived via
+        :func:`derive_interface_macs`. Only the primary is
+        persisted; derived MACs recompute on the next reload from
+        primary + ``loaded_integrations``.
+        """
+        for device in self._devices_by_name(name):
+            if device.mac_address == mac:
+                continue
+            device.mac_address = mac
+            device.ethernet_mac, device.bluetooth_mac = derive_interface_macs(
+                mac, device.target_platform, device.loaded_integrations
+            )
+            self._db.create_background_task(
+                self._persist_device_metadata_async(device.configuration, mac_address=mac)
+            )
+            self._fire_device_updated(device)
+
+    def _on_api_encryption_change(self, name: str, encryption: str) -> None:
+        r"""
+        Apply the API-encryption state observed via mDNS.
+
+        Stores the broadcast value (or empty string for "TXT
+        absent, device is plaintext") on the in-memory device.
+        Also promotes ``api_encrypted`` to True when a truthy
+        cipher arrives, since ESPHome's Jinja-templated
+        ``packages`` (issue #437) can leave the scan-time YAML
+        pass with ``api_encrypted=False`` for a fully-encrypted
+        device. The empty-string broadcast deliberately doesn't
+        clear ``api_encrypted``: wire-says-no with YAML-says-yes
+        is the legitimate "mismatch" / "pending" shape the
+        existing state machine handles.
+        """
+        for device in self._devices_by_name(name):
+            wire_promotes_encrypted = bool(encryption) and not device.api_encrypted
+            if device.api_encryption_active == encryption and not wire_promotes_encrypted:
+                continue
+            device.api_encryption_active = encryption
+            if wire_promotes_encrypted:
+                device.api_encrypted = True
+            self._fire_device_updated(device)
+
+    def _on_config_hash_change(self, name: str, config_hash: str) -> None:
+        """
+        Apply a running-firmware config hash observed via mDNS.
+
+        Stores the hash on the in-memory device and, when both
+        expected and deployed hashes are known, flips
+        ``has_pending_changes`` to reflect the comparison.
+        Devices on firmware that predates the ``config_hash`` TXT
+        broadcast never trigger this callback and stay on the
+        legacy mtime check.
+        """
+        for device in self._devices_by_name(name):
+            if device.deployed_config_hash == config_hash:
+                continue
+            old_hash = device.deployed_config_hash
+            device.deployed_config_hash = config_hash
+            # Mtime side stays with the periodic scanner poll so this
+            # callback can stay off-disk and non-blocking. A YAML
+            # edit between polls (~5s) self-corrects on the next scan.
+            if device.expected_config_hash:
+                device.has_pending_changes = device.expected_config_hash != config_hash
+            _LOGGER.info(
+                "Device %s (%s) config_hash: %s → %s (via mdns)",
+                name,
+                device.configuration,
+                old_hash or "?",
+                config_hash,
+            )
+            self._fire_device_updated(device)


### PR DESCRIPTION
# What does this implement/fix?

Continues the `controllers/devices/controller.py` size reduction (2011 → 1827 lines, **finally under 2000**) by extracting the six per-attribute state-monitor callbacks into a sibling `state_callbacks.py` as `DeviceStateCallbacksMixin`. Same mixin shape as #702's `DeviceMetadataMixin`.

`state_callbacks.py` hosts:

- `_on_state_change` — fires `DEVICE_STATE_CHANGED` with the flat `{configuration, state}` payload the frontend destructures.
- `_on_ip_change` — fan-out IP + addresses, persists primary IP via the metadata mixin.
- `_on_version_change` — schedules the StorageJSON `esphome_version` write via the firmware_sync delegate, sets `update_available`.
- `_on_mac_address_change` — applies primary MAC + derives `ethernet_mac` / `bluetooth_mac` from `loaded_integrations`, persists via metadata mixin.
- `_on_api_encryption_change` — applies the wire signal, promotes `api_encrypted` for the issue-#437 Jinja-templated-packages case.
- `_on_config_hash_change` — applies the deployed hash, flips `has_pending_changes` against the expected hash.

## Why mixin works here

Same audit as metadata: every callback only touches controller-internal helpers (`_devices_by_name`, `_fire_device_updated`, `_persist_device_metadata_async` / `_persist_device_ip_async` / `_persist_storage_version_async`) and `self._db`. No reach into `_scanner` / `_state_monitor` / `_reachability` / external state. Inheritance keeps:

- Test instance-patches (`controller._on_state_change(...)` etc.) working unchanged.
- The bound-method captures in `DeviceStateMonitor.__init__` (the controller passes `self._on_state_change` etc. as `on_state_change=` callbacks at startup) resolving correctly.

## Test impact

Zero test changes. Tests in `tests/test_mdns_*.py` (state, version, mac_address, api_encryption, config_hash) and `tests/test_state_fanout_duplicate_names.py` call the methods as bound methods on the controller instance, which still resolve via inheritance.

3223 tests pass; pure refactor.

**Related issue or feature (if applicable):**

- follow-up to #702

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
