### PR TITLE
Encapsulate FirmwareJob source_* kwargs in JobBuildSource

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -40,11 +40,13 @@ from ...helpers.remote_build_layout import parse_from_configuration as parse_rem
 from ...helpers.storage_path import resolve_storage_path
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ...models import (
+    LOCAL_JOB_BUILD_SOURCE,
     TERMINAL_JOB_EVENTS,
     TERMINAL_JOB_STATUSES,
     ErrorCode,
     EventType,
     FirmwareJob,
+    JobBuildSource,
     JobLifecycleData,
     JobSource,
     JobStatus,
@@ -268,16 +270,11 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         despite an available paired receiver.
         """
         await self._validate_configuration_boundary(configuration)
-        if force_local:
-            source, pin_sha256, label = JobSource.LOCAL, "", ""
-        else:
-            source, pin_sha256, label = self._resolve_install_source(configuration)
+        build_source = self._resolve_install_source(configuration, force_local=force_local)
         job = self._create_job(
             configuration,
             JobType.COMPILE,
-            source=source,
-            source_pin_sha256=pin_sha256,
-            source_label=label,
+            build_source=build_source,
         )
         return await self._enqueue(job)
 
@@ -421,9 +418,11 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             remote_job = self._create_job(
                 configuration,
                 JobType.CLEAN,
-                source=JobSource.REMOTE,
-                source_pin_sha256=pairing.pin_sha256,
-                source_label=pairing.label,
+                build_source=JobBuildSource(
+                    source=JobSource.REMOTE,
+                    source_pin_sha256=pairing.pin_sha256,
+                    source_label=pairing.label,
+                ),
             )
             # ``supersede=False``: the fan-out batch is N+1 jobs
             # all sharing one ``configuration``, so default
@@ -526,17 +525,12 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         """
         _validate_port(port)
         await self._validate_configuration_boundary(configuration)
-        if force_local:
-            source, pin_sha256, label = JobSource.LOCAL, "", ""
-        else:
-            source, pin_sha256, label = self._resolve_install_source(configuration)
+        build_source = self._resolve_install_source(configuration, force_local=force_local)
         job = self._create_job(
             configuration,
             JobType.INSTALL,
             port=port,
-            source=source,
-            source_pin_sha256=pin_sha256,
-            source_label=label,
+            build_source=build_source,
         )
         return await self._enqueue(job)
 
@@ -617,16 +611,11 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:
-                if force_local:
-                    source, pin_sha256, label = JobSource.LOCAL, "", ""
-                else:
-                    source, pin_sha256, label = self._resolve_install_source(config)
+                build_source = self._resolve_install_source(config, force_local=force_local)
                 job = self._create_job(
                     config,
                     JobType.COMPILE,
-                    source=source,
-                    source_pin_sha256=pin_sha256,
-                    source_label=label,
+                    build_source=build_source,
                 )
                 await self._enqueue(job)
             except CommandError as exc:
@@ -655,14 +644,12 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:
-                source, pin_sha256, label = self._resolve_install_source(config)
+                build_source = self._resolve_install_source(config)
                 job = self._create_job(
                     config,
                     JobType.INSTALL,
                     port=port,
-                    source=source,
-                    source_pin_sha256=pin_sha256,
-                    source_label=label,
+                    build_source=build_source,
                 )
                 await self._enqueue(job)
             except CommandError as exc:
@@ -1801,9 +1788,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         remote_peer: str = "",
         remote_peer_label: str = "",
         remote_job_id: str = "",
-        source: JobSource = JobSource.LOCAL,
-        source_pin_sha256: str = "",
-        source_label: str = "",
+        build_source: JobBuildSource = LOCAL_JOB_BUILD_SOURCE,
         device_name: str = "",
         device_friendly_name: str = "",
     ) -> FirmwareJob:
@@ -1839,14 +1824,12 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         (the dashboard's own Device list already carries the
         friendly name).
 
-        ``source`` / ``source_pin_sha256`` / ``source_label`` are
-        the offloader-side dispatch-origin fields: ``LOCAL`` for
-        jobs the offloader compiles itself, ``REMOTE`` for jobs
-        the offloader dispatches to a paired receiver via the
-        source-routed runner. ``source_pin_sha256``
-        identifies the receiver; ``source_label`` is the display
-        name. Defaults make every existing call site continue to
-        produce LOCAL jobs.
+        ``build_source`` is the offloader-side dispatch-origin
+        bundle: :class:`JobSource` (``LOCAL`` / ``REMOTE``) plus
+        the receiver's ``pin_sha256`` and display label.
+        Defaults to :data:`LOCAL_JOB_BUILD_SOURCE` so every
+        existing call site that doesn't pass an explicit source
+        continues to produce LOCAL jobs.
         """
         job = FirmwareJob(
             job_id=uuid4().hex[:12],
@@ -1858,34 +1841,44 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             remote_peer=remote_peer,
             remote_peer_label=remote_peer_label,
             remote_job_id=remote_job_id,
-            source=source,
-            source_pin_sha256=source_pin_sha256,
-            source_label=source_label,
+            source=build_source.source,
+            source_pin_sha256=build_source.source_pin_sha256,
+            source_label=build_source.source_label,
             device_name=device_name,
             device_friendly_name=device_friendly_name,
         )
         self._jobs[job.job_id] = job
         return job
 
-    def _resolve_install_source(self, configuration: str) -> tuple[JobSource, str, str]:
-        """Pick LOCAL or REMOTE for *configuration*; return ``(source, pin, label)``.
+    def _resolve_install_source(
+        self, configuration: str, *, force_local: bool = False
+    ) -> JobBuildSource:
+        """Pick LOCAL or REMOTE for *configuration*; return its build source.
 
-        Pure sync helper. Returns LOCAL when remote-build isn't
-        wired up yet (firmware-queue restart-recovery can fire
-        before remote-build's ``start()``).
+        Pure sync helper. Returns ``LOCAL_JOB_BUILD_SOURCE`` when
+        ``force_local`` is set (the install dialog's "Build locally
+        instead" override) and when remote-build isn't wired up yet
+        (firmware-queue restart-recovery can fire before remote-
+        build's ``start()``).
         """
+        if force_local:
+            return LOCAL_JOB_BUILD_SOURCE
         offloader = self._db.remote_build_offloader
         if offloader is None:
-            return JobSource.LOCAL, "", ""
+            return LOCAL_JOB_BUILD_SOURCE
         decision = pick_build_path(offloader.build_scheduler_snapshot())
         if decision.path is not BuildPath.REMOTE or decision.pin_sha256 is None:
-            return JobSource.LOCAL, "", ""
+            return LOCAL_JOB_BUILD_SOURCE
         pairing = offloader.get_pairing(decision.pin_sha256)
         if pairing is None:
             # Scheduler picked a pin that's no longer paired (race
             # vs an ``unpair`` on the same loop tick).
-            return JobSource.LOCAL, "", ""
-        return JobSource.REMOTE, pairing.pin_sha256, pairing.label
+            return LOCAL_JOB_BUILD_SOURCE
+        return JobBuildSource(
+            source=JobSource.REMOTE,
+            source_pin_sha256=pairing.pin_sha256,
+            source_label=pairing.label,
+        )
 
     async def _enqueue(self, job: FirmwareJob, *, supersede: bool = True) -> FirmwareJob:
         """

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -1824,12 +1824,8 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         (the dashboard's own Device list already carries the
         friendly name).
 
-        ``build_source`` is the offloader-side dispatch-origin
-        bundle: :class:`JobSource` (``LOCAL`` / ``REMOTE``) plus
-        the receiver's ``pin_sha256`` and display label.
-        Defaults to :data:`LOCAL_JOB_BUILD_SOURCE` so every
-        existing call site that doesn't pass an explicit source
-        continues to produce LOCAL jobs.
+        ``build_source`` bundles the dispatch-origin ``source_*``
+        fields; defaults to :data:`LOCAL_JOB_BUILD_SOURCE`.
         """
         job = FirmwareJob(
             job_id=uuid4().hex[:12],
@@ -1853,14 +1849,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     def _resolve_install_source(
         self, configuration: str, *, force_local: bool = False
     ) -> JobBuildSource:
-        """Pick LOCAL or REMOTE for *configuration*; return its build source.
-
-        Pure sync helper. Returns ``LOCAL_JOB_BUILD_SOURCE`` when
-        ``force_local`` is set (the install dialog's "Build locally
-        instead" override) and when remote-build isn't wired up yet
-        (firmware-queue restart-recovery can fire before remote-
-        build's ``start()``).
-        """
+        """Pick LOCAL or REMOTE for *configuration*; return its build source."""
         if force_local:
             return LOCAL_JOB_BUILD_SOURCE
         offloader = self._db.remote_build_offloader

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -55,6 +55,31 @@ class JobSource(StrEnum):
     REMOTE = "remote"
 
 
+@dataclass(frozen=True, slots=True)
+class JobBuildSource:
+    """
+    Bundle of :class:`FirmwareJob` ``source_*`` dispatch-origin fields.
+
+    Resolved up-front by
+    :meth:`FirmwareController._resolve_install_source` (or constructed
+    directly by callers that already know the peer, e.g. the
+    ``firmware/clean`` fan-out) and threaded as a single arg through
+    :meth:`FirmwareController._create_job`. Adding a new dispatch-
+    origin field requires editing this dataclass + the matching
+    :class:`FirmwareJob` field, not the kwarg list of every call site.
+    """
+
+    source: JobSource = JobSource.LOCAL
+    source_pin_sha256: str = ""
+    source_label: str = ""
+
+
+# Module-level singleton for the common LOCAL case — every caller
+# that defaults to local routing shares this instance instead of
+# building a fresh dataclass each call.
+LOCAL_JOB_BUILD_SOURCE = JobBuildSource()
+
+
 # Terminal job states — a job in any of these isn't running and
 # isn't waiting to run.
 TERMINAL_JOB_STATUSES: frozenset[JobStatus] = frozenset(

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -57,26 +57,13 @@ class JobSource(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class JobBuildSource:
-    """
-    Bundle of :class:`FirmwareJob` ``source_*`` dispatch-origin fields.
-
-    Resolved up-front by
-    :meth:`FirmwareController._resolve_install_source` (or constructed
-    directly by callers that already know the peer, e.g. the
-    ``firmware/clean`` fan-out) and threaded as a single arg through
-    :meth:`FirmwareController._create_job`. Adding a new dispatch-
-    origin field requires editing this dataclass + the matching
-    :class:`FirmwareJob` field, not the kwarg list of every call site.
-    """
+    """Bundle of :class:`FirmwareJob` ``source_*`` dispatch-origin fields."""
 
     source: JobSource = JobSource.LOCAL
     source_pin_sha256: str = ""
     source_label: str = ""
 
 
-# Module-level singleton for the common LOCAL case — every caller
-# that defaults to local routing shares this instance instead of
-# building a fresh dataclass each call.
 LOCAL_JOB_BUILD_SOURCE = JobBuildSource()
 
 


### PR DESCRIPTION
# What does this implement/fix?

Encapsulates the `FirmwareJob.source_*` dispatch-origin fields
(`source` / `source_pin_sha256` / `source_label`) behind a single
frozen-slots `JobBuildSource` dataclass, plus a
`LOCAL_JOB_BUILD_SOURCE` module-level singleton for the default
case.

- `_resolve_install_source` returns a `JobBuildSource` and absorbs
  the `force_local` branch every caller used to duplicate.
- `_create_job` takes one `build_source: JobBuildSource =
  LOCAL_JOB_BUILD_SOURCE` kwarg in place of three separate
  `source` / `source_pin_sha256` / `source_label` kwargs.
- Callers (`compile`, `install`, `compile_bulk`, `install_bulk`)
  collapse from a 5-line unpack-and-thread block to a 2-line
  call.
- `_fan_out_clean_to_connected_peers` constructs a
  `JobBuildSource` inline since it already has the peer in hand.

Pure refactor. Persistence and wire shape are unchanged —
`FirmwareJob` still carries the flat `source_*` fields, just
constructed from the bundle now. The motivation is to make
adding a new dispatch-origin field (a follow-up will add
`source_esphome_version` so the install dialog can show the
receiver's ESPHome version in the "Building on …" sub-line) a 4-
edit change with zero caller churn, instead of the previous
"thread the kwarg through every call site."

**Related issue or feature (if applicable):**

- prep for: surface the remote receiver's ESPHome version in the
  install-dialog "Building on …" sub-line

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
