### PR TITLE
Replace DeviceMetadataMixin with DeviceMetadataBase linear base class

### DIFF
--- a/esphome_device_builder/controllers/_device_builder_base.py
+++ b/esphome_device_builder/controllers/_device_builder_base.py
@@ -1,0 +1,15 @@
+"""Base class for controllers that hold the shared ``DeviceBuilder`` ref."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..device_builder import DeviceBuilder
+
+
+class DeviceBuilderBase:
+    """Owns ``self._db`` so subclasses don't reach for it in their own ``__init__``."""
+
+    def __init__(self, device_builder: DeviceBuilder) -> None:
+        self._db = device_builder

--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -31,9 +31,11 @@ resolving after the subpackage split. Submodules:
   ``_resolve_device_metadata`` /
   ``_derive_board_id_from_yaml`` /
   ``_persist_device_ip_async`` /
-  ``_persist_device_metadata_async``. Owns ``self._db``
-  via its ``__init__``; ``DevicesController`` inherits
-  linearly and calls ``super().__init__(device_builder)``.
+  ``_persist_device_metadata_async``. Inherits from
+  ``controllers._device_builder_base.DeviceBuilderBase`` so
+  ``self._db`` comes via ``super().__init__(device_builder)``;
+  ``DevicesController`` inherits ``DeviceMetadataBase``
+  linearly, no mixin protocol.
 - ``reachability`` — per-device reachability streaming + the
   on-subscription mDNS A-record refresh loop.
 - ``storage_regen`` — background ``--only-generate`` scheduler

--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -27,13 +27,13 @@ resolving after the subpackage split. Submodules:
   (``stream_logs``, ``stop_stream``) plus the shared
   ``stream_subprocess`` helper that ``validate_config``
   reuses.
-- ``metadata`` — ``DeviceMetadataMixin`` carrying
+- ``metadata`` — ``DeviceMetadataBase`` carrying
   ``_resolve_device_metadata`` /
   ``_derive_board_id_from_yaml`` /
   ``_persist_device_ip_async`` /
-  ``_persist_device_metadata_async``. Mixed in directly
-  on ``DevicesController`` since the methods only touch
-  ``self._db`` and same-mixin siblings.
+  ``_persist_device_metadata_async``. Owns ``self._db``
+  via its ``__init__``; ``DevicesController`` inherits
+  linearly and calls ``super().__init__(device_builder)``.
 - ``reachability`` — per-device reachability streaming + the
   on-subscription mDNS A-record refresh loop.
 - ``storage_regen`` — background ``--only-generate`` scheduler

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -86,7 +86,7 @@ from .helpers import (
     _validate_archive_configuration,
     friendly_name_slugify,
 )
-from .metadata import DeviceMetadataMixin
+from .metadata import DeviceMetadataBase
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -127,12 +127,12 @@ _YAML_SEARCH_PER_FILE_MATCH_CAP = 5
 
 
 class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
-    DeviceMetadataMixin,
+    DeviceMetadataBase,
 ):
     """Manage device configurations, file watching, and CLI operations."""
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
-        self._db = device_builder
+        super().__init__(device_builder)
         self._esphome_cmd: list[str] = []
         # Unsubscribe handle for the firmware-job-completion listener
         # wired up in start(); held so stop() can detach cleanly.

--- a/esphome_device_builder/controllers/devices/metadata.py
+++ b/esphome_device_builder/controllers/devices/metadata.py
@@ -1,9 +1,10 @@
-"""Device-metadata resolution + sidecar-write mixin for ``DevicesController``."""
+"""Device-metadata resolution + sidecar-write base class for ``DevicesController``."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.build_size import coerce_sidecar_int
@@ -13,19 +14,16 @@ from .._device_scanner import DeviceFileMetadata
 from ..config import get_device_metadata, set_device_metadata
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from ...device_builder import DeviceBuilder
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class DeviceMetadataMixin:
-    """Metadata resolution + persistence for ``DevicesController``."""
+class DeviceMetadataBase:
+    """Owns ``_db`` and the metadata resolution + persistence helpers."""
 
-    if TYPE_CHECKING:
-        # Supplied by the host controller class.
-        _db: DeviceBuilder
+    def __init__(self, device_builder: DeviceBuilder) -> None:
+        self._db = device_builder
 
     def _resolve_device_metadata(self, config_dir: Path, filename: str) -> DeviceFileMetadata:
         """

--- a/esphome_device_builder/controllers/devices/metadata.py
+++ b/esphome_device_builder/controllers/devices/metadata.py
@@ -5,25 +5,20 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ...helpers.build_size import coerce_sidecar_int
 from ...helpers.config_hash import read_build_info_hash
 from ...helpers.device_yaml import parse_platform_from_yaml
+from .._device_builder_base import DeviceBuilderBase
 from .._device_scanner import DeviceFileMetadata
 from ..config import get_device_metadata, set_device_metadata
-
-if TYPE_CHECKING:
-    from ...device_builder import DeviceBuilder
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class DeviceMetadataBase:
-    """Owns ``_db`` and the metadata resolution + persistence helpers."""
-
-    def __init__(self, device_builder: DeviceBuilder) -> None:
-        self._db = device_builder
+class DeviceMetadataBase(DeviceBuilderBase):
+    """Metadata resolution + persistence; inherits ``_db`` from ``DeviceBuilderBase``."""
 
     def _resolve_device_metadata(self, config_dir: Path, filename: str) -> DeviceFileMetadata:
         """


### PR DESCRIPTION
# What does this implement/fix?

`DeviceMetadataMixin` was carrying a `TYPE_CHECKING`-only
`_db: DeviceBuilder` annotation and relying on whichever host
class mixed it in to set `self._db` first in its own `__init__`.
That's a soft contract — "I'll only be mixed into a class that
happens to set `_db` for me" — and we only have one host class
(`DevicesController`), so the mixin framing is fiction.

Promote `DeviceMetadataMixin` to `DeviceMetadataBase`: a real
base class that owns `_db` via its own `__init__(device_builder)`
and provides the same four methods (`_resolve_device_metadata`,
`_derive_board_id_from_yaml`, `_persist_device_ip_async`,
`_persist_device_metadata_async`). `DevicesController` inherits
linearly and calls `super().__init__(device_builder)` instead
of inlining `self._db = device_builder`. The `TYPE_CHECKING`
guard for `_db` goes away because `_db` is now a real attribute
set by the base.

No behaviour change: same methods, same call sites, same `_db`
access semantics; just a real init contract instead of a
mixin-shaped assumption. Full test suite (3151 unit tests) +
ruff + mypy all clean.

**Related issue or feature (if applicable):**

- N/A; cleanup of recently-landed code.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
