### PR TITLE
Carry source_esphome_version on REMOTE firmware jobs

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -422,6 +422,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
                     source=JobSource.REMOTE,
                     source_pin_sha256=pairing.pin_sha256,
                     source_label=pairing.label,
+                    source_esphome_version=pairing.esphome_version,
                 ),
             )
             # ``supersede=False``: the fan-out batch is N+1 jobs
@@ -1840,6 +1841,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             source=build_source.source,
             source_pin_sha256=build_source.source_pin_sha256,
             source_label=build_source.source_label,
+            source_esphome_version=build_source.source_esphome_version,
             device_name=device_name,
             device_friendly_name=device_friendly_name,
         )
@@ -1867,6 +1869,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             source=JobSource.REMOTE,
             source_pin_sha256=pairing.pin_sha256,
             source_label=pairing.label,
+            source_esphome_version=pairing.esphome_version,
         )
 
     async def _enqueue(self, job: FirmwareJob, *, supersede: bool = True) -> FirmwareJob:

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -206,10 +206,7 @@ class FirmwareJob(DataClassORJSONMixin):
     # time, snapshotted from :attr:`StoredPairing.esphome_version`.
     # Empty for ``LOCAL`` jobs and for ``REMOTE`` jobs whose
     # pairing hadn't yet completed a peer-link session (the
-    # pairing field is populated on every session-open). The
-    # install dialog renders this next to the receiver label so
-    # the operator can spot a version skew between the offloader
-    # and the receiver actually compiling the firmware.
+    # pairing field populates on every session-open).
     source_esphome_version: str = ""
 
     def reset(self) -> None:

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -62,6 +62,7 @@ class JobBuildSource:
     source: JobSource = JobSource.LOCAL
     source_pin_sha256: str = ""
     source_label: str = ""
+    source_esphome_version: str = ""
 
 
 LOCAL_JOB_BUILD_SOURCE = JobBuildSource()
@@ -201,6 +202,15 @@ class FirmwareJob(DataClassORJSONMixin):
     # ``source_pin_sha256``; ``source_label`` is purely for
     # rendering.
     source_label: str = ""
+    # Receiver's ``esphome.const.__version__`` at job-creation
+    # time, snapshotted from :attr:`StoredPairing.esphome_version`.
+    # Empty for ``LOCAL`` jobs and for ``REMOTE`` jobs whose
+    # pairing hadn't yet completed a peer-link session (the
+    # pairing field is populated on every session-open). The
+    # install dialog renders this next to the receiver label so
+    # the operator can spot a version skew between the offloader
+    # and the receiver actually compiling the firmware.
+    source_esphome_version: str = ""
 
     def reset(self) -> None:
         """
@@ -231,7 +241,8 @@ class FirmwareJob(DataClassORJSONMixin):
         - **Preserves identity** — ``configuration`` /
           ``job_type`` / ``port`` / ``new_name`` / ``created_at``
           / ``job_id`` / ``source`` / ``source_pin_sha256`` /
-          ``source_label`` / ``remote_peer`` / ``remote_peer_label`` /
+          ``source_label`` / ``source_esphome_version`` /
+          ``remote_peer`` / ``remote_peer_label`` /
           ``remote_job_id`` / ``device_name`` /
           ``device_friendly_name`` describe the job rather than
           the run, so they stay

--- a/tests/controllers/firmware/test_clean.py
+++ b/tests/controllers/firmware/test_clean.py
@@ -64,6 +64,7 @@ def _pairing(
     pin_sha256: str,
     label: str = "receiver",
     status: PeerStatus = PeerStatus.APPROVED,
+    esphome_version: str = "",
 ) -> StoredPairing:
     # ``StoredPairing.pin_sha256`` is validated against a 64-char
     # min length (the wire format is lowercase hex SHA-256). The
@@ -78,6 +79,7 @@ def _pairing(
         label=label,
         paired_at=1.0,
         status=status,
+        esphome_version=esphome_version,
     )
 
 
@@ -320,8 +322,8 @@ async def test_clean_fans_out_to_connected_approved_peers(
     controller = firmware_controller_factory(with_queue=True)
     _wire_remote_build_with_peers(
         controller,
-        (_pairing(pin_sha256="a", label="desktop"), True),
-        (_pairing(pin_sha256="b", label="laptop"), True),
+        (_pairing(pin_sha256="a", label="desktop", esphome_version="2026.5.0"), True),
+        (_pairing(pin_sha256="b", label="laptop", esphome_version="2026.4.1"), True),
     )
 
     returned = await controller.clean(configuration="kitchen.yaml")
@@ -356,6 +358,7 @@ async def test_clean_fans_out_to_connected_approved_peers(
         "b".ljust(64, "0"),
     ]
     assert [j.source_label for j in remote_jobs] == ["desktop", "laptop"]
+    assert [j.source_esphome_version for j in remote_jobs] == ["2026.5.0", "2026.4.1"]
     # Every fan-out job carries the same configuration the
     # operator clicked clean on.
     assert all(j.configuration == "kitchen.yaml" for j in clean_jobs)

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -222,7 +222,7 @@ async def test_install_registers_job_in_jobs_map(
 _PIN = "a" * 64
 
 
-def _make_pairing(label: str = "desktop") -> StoredPairing:
+def _make_pairing(label: str = "desktop", esphome_version: str = "") -> StoredPairing:
     """Build a passing :class:`StoredPairing` for the scheduler tests."""
     return StoredPairing(
         receiver_hostname="build.local",
@@ -232,6 +232,7 @@ def _make_pairing(label: str = "desktop") -> StoredPairing:
         label=label,
         paired_at=1.0,
         status=PeerStatus.APPROVED,
+        esphome_version=esphome_version,
     )
 
 
@@ -323,7 +324,7 @@ async def test_install_routes_to_remote_when_pairing_is_idle_and_connected(
     {receiver_label}".
     """
     controller = firmware_controller_factory(with_queue=True)
-    pairing = _make_pairing(label="desktop")
+    pairing = _make_pairing(label="desktop", esphome_version="2026.5.0")
     _stub_remote_build(
         controller,
         pairings=[pairing],
@@ -337,6 +338,7 @@ async def test_install_routes_to_remote_when_pairing_is_idle_and_connected(
     assert job.source is JobSource.REMOTE
     assert job.source_pin_sha256 == _PIN
     assert job.source_label == "desktop"
+    assert job.source_esphome_version == "2026.5.0"
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_firmware_job.py
+++ b/tests/models/test_firmware_job.py
@@ -145,6 +145,7 @@ def test_reset_preserves_dispatch_origin_fields() -> None:
         source=JobSource.REMOTE,
         source_pin_sha256="a" * 64,
         source_label="desktop",
+        source_esphome_version="2026.5.0",
         remote_peer="alpha-dashboard-id",
         remote_job_id="offloader-job-7",
     )
@@ -154,6 +155,7 @@ def test_reset_preserves_dispatch_origin_fields() -> None:
     assert job.source is JobSource.REMOTE
     assert job.source_pin_sha256 == "a" * 64
     assert job.source_label == "desktop"
+    assert job.source_esphome_version == "2026.5.0"
     assert job.remote_peer == "alpha-dashboard-id"
     assert job.remote_job_id == "offloader-job-7"
 
@@ -191,6 +193,7 @@ def test_remote_source_round_trips_through_serialisation() -> None:
         source=JobSource.REMOTE,
         source_pin_sha256="a" * 64,
         source_label="desktop",
+        source_esphome_version="2026.5.0",
     )
 
     raw = job.to_json()
@@ -199,6 +202,7 @@ def test_remote_source_round_trips_through_serialisation() -> None:
     assert restored.source is JobSource.REMOTE
     assert restored.source_pin_sha256 == "a" * 64
     assert restored.source_label == "desktop"
+    assert restored.source_esphome_version == "2026.5.0"
 
 
 def test_older_sidecar_without_source_field_loads_as_local() -> None:
@@ -226,6 +230,7 @@ def test_older_sidecar_without_source_field_loads_as_local() -> None:
     assert restored.source is JobSource.LOCAL
     assert restored.source_pin_sha256 == ""
     assert restored.source_label == ""
+    assert restored.source_esphome_version == ""
 
 
 def test_malformed_source_value_rejected_on_load() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adds `source_esphome_version` to `JobBuildSource` and
`FirmwareJob`, snapshotted from `StoredPairing.esphome_version` at
job-creation time. The install dialog renders this next to the
receiver label ("Building on macbook-pro (2026.5.0)") so the
operator can spot a version skew between the offloader and the
receiver actually compiling the firmware — useful when paired
receivers run different ESPHome versions and the dispatch-routed
compile lands somewhere the operator didn't expect.

Implementation follows the encapsulation from #712 — the field
lives on `JobBuildSource`, populated in `_resolve_install_source`
from the pairing's `esphome_version`, splatted onto the
`FirmwareJob` inside `_create_job`. Fan-out clean does the same
inline. Zero caller churn outside those three spots.

**Related issue or feature (if applicable):**

- follow-up to #712 (encapsulate FirmwareJob source_* kwargs)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#320

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.