### PR TITLE
Tighten enums.py docstrings

### DIFF
--- a/esphome_device_builder/models/remote_build/enums.py
+++ b/esphome_device_builder/models/remote_build/enums.py
@@ -9,18 +9,10 @@ class RemoteBuildPeerSource(StrEnum):
     """
     How a peer dashboard ended up in the discovered-hosts surface.
 
-    The discovered-hosts surface is
-    :meth:`OffloaderController.hosts_snapshot` (sync read used
-    by ``subscribe_events.initial_state.hosts``) plus the
-    matching ``REMOTE_BUILD_HOST_ADDED`` /
-    ``REMOTE_BUILD_HOST_REMOVED`` events.
-
     Today the only source is ``mdns`` — discovered via the
-    ``_esphomebuilder._tcp.local.`` browse. The enum stays as a
-    discriminator on :class:`RemoteBuildPeer` for cross-subnet
-    pair flows that bypass mDNS by typing the hostname / port
-    directly into ``request_pair`` (no intermediate "save this
-    host" step needed; the pair either succeeds or doesn't).
+    ``_esphomebuilder._tcp.local.`` browse. Cross-subnet pair
+    flows bypass discovery entirely and go straight through
+    ``request_pair``, so no manual-host enum member exists.
     """
 
     MDNS = "mdns"
@@ -30,23 +22,10 @@ class PeerStatus(StrEnum):
     """
     Lifecycle state of a :class:`StoredPeer` row.
 
-    ``PENDING``: an offloader's pair-request landed and the
-    receiver's admin hasn't accepted yet. The peer-link auth
-    gate lets a connection from this peer's pubkey complete the
-    Noise handshake but only honours an ``intent="pair_status"``
-    query; every other intent is rejected at the post-handshake
-    dispatch.
-
-    ``APPROVED``: admin clicked Accept. Full access — the auth
-    gate looks up the offloader's static X25519 pubkey hash
-    (extracted from the Noise XX handshake transcript) against
-    this row on every connection.
-
-    No explicit ``REJECTED`` terminal state — a rejected request
-    deletes the row. If the same offloader retries, it lands as
-    a fresh pending row and the admin chooses again. Avoids the
-    bookkeeping a rejected-list would need; a future re-auth
-    wizard can revisit if blocklisting becomes useful.
+    PENDING rows accept only ``intent="pair_status"`` polls at
+    the peer-link auth gate; APPROVED rows accept every intent.
+    No explicit REJECTED state — a rejected request deletes the
+    row.
     """
 
     PENDING = "pending"
@@ -57,22 +36,18 @@ class PeerLinkIntent(StrEnum):
     """
     Wire ``intent`` discriminator on the peer-link Noise WS msg1 payload.
 
-    Sent in cleartext on msg1 (Noise XX hasn't established a key
-    yet for that frame's payload) so the receiver can route the
-    session before the handshake completes. The sensitive
-    metadata (``dashboard_id``, ``label``) waits until msg3,
-    which is encrypted under the now-finalized cipher.
+    Sent cleartext (Noise XX msg1 isn't encrypted yet); sensitive
+    fields (``dashboard_id``, ``label``) wait until the
+    encrypted-under-finalised-cipher msg3.
 
-    * ``PREVIEW`` — capture the receiver's static pubkey for
-      OOB pin verification. Doesn't change any receiver state.
-    * ``PAIR_REQUEST`` — gated by the pairing window from #106
-      design choice (c). Creates / refreshes a PENDING
-      ``StoredPeer`` row and fires
-      ``REMOTE_BUILD_PAIR_REQUEST_RECEIVED``.
-    * ``PEER_LINK`` — establishes a long-lived peer-link session
-      for an already-APPROVED peer. The WS stays open for
-      application messages (bundle upload, build, firmware
-      download).
+    * ``PREVIEW`` — capture the receiver's pubkey for OOB pin
+      verification; doesn't mutate receiver state.
+    * ``PAIR_REQUEST`` — creates / refreshes a PENDING
+      :class:`StoredPeer` row and fires
+      ``REMOTE_BUILD_PAIR_REQUEST_RECEIVED``. Gated by the
+      pairing window.
+    * ``PEER_LINK`` — establishes the long-lived peer-link
+      session for an APPROVED peer.
     * ``PAIR_STATUS`` — informational poll for a previously-
       submitted pair_request's current state.
     """
@@ -87,35 +62,19 @@ class IntentResponse(StrEnum):
     """
     Wire ``intent_response`` value the receiver returns over the peer-link.
 
-    Sent in the post-handshake transport frame after the Noise XX
-    handshake completes. ``StrEnum`` so members serialise to their
-    wire string verbatim through ``json.dumps`` and so equality
-    comparisons against the raw string still work for callers that
-    haven't migrated yet.
+    Sent in the post-handshake transport frame. ``StrEnum`` so
+    members serialise to their wire string verbatim.
 
-    Per-intent semantics (cross-referenced with #106 design choice
-    (h)):
-
-    * ``OK`` — success on ``intent="preview"`` (handshake captured
-      pubkey, nothing else needed) or on ``intent="peer_link"``
-      from an APPROVED peer (caller can keep the WS open for
-      application messages).
-    * ``APPROVED`` — ``intent="pair_status"`` poll observing an
-      APPROVED row, or ``intent="pair_request"`` from a peer
-      that's already APPROVED (we don't demote them; the offloader
-      is expected to switch to ``intent="peer_link"``).
-    * ``PENDING`` — ``intent="pair_request"`` created or refreshed
-      a PENDING row, or ``intent="pair_status"`` /
-      ``intent="peer_link"`` polled a row that's still PENDING.
-    * ``REJECTED`` — unknown ``dashboard_id``, pin mismatch
-      (handshake's pubkey doesn't match the stored row), or
-      unknown ``intent``. The offloader's UI surfaces a
-      "send a fresh pair_request" CTA.
-    * ``NO_PAIRING_WINDOW`` — ``intent="pair_request"`` arrived
-      while the receiver-side pairing window is closed; no row
-      created. The offloader's UI prompts the user to ask the
-      receiving dashboard's user to open the Pairing requests
-      screen.
+    * ``OK`` — preview captured pubkey; or peer_link accepted
+      (caller keeps the WS open).
+    * ``APPROVED`` — pair_status / pair_request on an
+      already-APPROVED peer.
+    * ``PENDING`` — pair_request created or refreshed a PENDING
+      row, or pair_status / peer_link saw a still-PENDING row.
+    * ``REJECTED`` — unknown ``dashboard_id``, pin mismatch, or
+      unknown ``intent``.
+    * ``NO_PAIRING_WINDOW`` — pair_request arrived while the
+      receiver-side pairing window is closed.
     """
 
     OK = "ok"


### PR DESCRIPTION
# What does this implement/fix?

Docstring cleanup follow-up to the structural split in #688. Tightens `models/remote_build/enums.py` per the CLAUDE.md style rules. First of six cleanup PRs targeting the `models/remote_build/` package (one per file).

Changes:

* **`RemoteBuildPeerSource`** — kept the "today only `mdns` exists; cross-subnet pair flows bypass discovery" rationale (non-obvious why a 1-member enum exists). Dropped the `hosts_snapshot` cross-reference.
* **`PeerStatus`** — kept the auth-gate behavioural contract (PENDING accepts only pair_status polls; APPROVED accepts every intent; no REJECTED state). Dropped the bookkeeping-cost rationale.
* **`PeerLinkIntent`** — kept the per-value semantics (caller-visible wire contracts) plus the "msg1 cleartext / msg3 encrypted" framing. Dropped issue cross-references and bullet-internal restatements.
* **`IntentResponse`** — same compaction. Kept the per-value semantics. Dropped the cross-reference to design choice (h).

Line count: 125 → 84 (33% reduction). Same `ruff check`, `ruff format`, and `mypy` clean; all 214 tests in `test_remote_build_controller.py` pass. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #688

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
