### PR TITLE
Tighten receiver_events.py docstrings

### DIFF
--- a/esphome_device_builder/models/remote_build/receiver_events.py
+++ b/esphome_device_builder/models/remote_build/receiver_events.py
@@ -4,33 +4,17 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict
 
-# ---------------------------------------------------------------------------
-# Event payload shapes (TypedDict so the bus.fire data dict is type-checked at
-# the call site without changing the wire shape; mirrors HA's
-# ``EventStateChangedData`` / ``EventStateReportedData`` pattern).
-# ---------------------------------------------------------------------------
-
 
 class RemoteBuildIdentityRotatedData(TypedDict):
     """
     Payload for ``EventType.REMOTE_BUILD_IDENTITY_ROTATED``.
 
     Fires after ``rotate_identity`` persists the new X25519
-    keypair to disk and attempts the listener rebuild. The
-    event ONLY signals that the rotation landed on disk and
-    the rebuild was attempted — not that the listener is
-    currently serving traffic against the new key. The
-    rebuild can fail-soft (port collision, permission denied,
-    listener unbound at rotation time), in which case the
-    rotater's ``IdentityView`` response carries
-    ``listener_bound=False`` and the new pin will hit the
-    wire on the next successful bind. Subscribers (the
-    offloader-side peer-link, the receiver Settings UI) use
-    the event to refresh their cached pin without polling
-    ``get_identity``; they should check
-    ``IdentityView.listener_bound`` (via a follow-up
-    ``get_identity`` call or by inspecting their own session
-    state) before assuming end-to-end propagation.
+    keypair to disk and *attempts* the listener rebuild — the
+    rebuild can fail-soft (port collision, permission denied),
+    in which case ``IdentityView.listener_bound`` returns
+    ``False``. Subscribers should check ``listener_bound``
+    before assuming end-to-end propagation.
     """
 
     dashboard_id: str
@@ -43,16 +27,10 @@ class RemoteBuildPairRequestReceivedData(TypedDict):
 
     Fired by the peer-link Noise WS handler when a fresh
     ``intent="pair_request"`` arrives during an open pairing
-    window. The receiver Settings UI surfaces the row in the
-    Pairing requests inbox; ``peer_ip`` lets the operator
-    sanity-check the source against expectations before
-    OOB-confirming the pin.
-
-    ``paired_at`` carries the receiver-clock unix timestamp at
-    row creation, matching the ``StoredPeer.paired_at`` field
-    on the in-memory PENDING entry. Lets a subscriber rendering
-    the inbox from the event stream sort the most-recent attempt
-    first without a follow-up snapshot read.
+    window. ``peer_ip`` lets the operator sanity-check the source
+    before OOB-confirming the pin; ``paired_at`` lets a subscriber
+    rendering the inbox sort most-recent-first without a follow-up
+    snapshot read.
     """
 
     dashboard_id: str
@@ -66,18 +44,12 @@ class RemoteBuildPairStatusChangedData(TypedDict):
     """
     Payload for ``EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED``.
 
-    Fires from three paths:
-
-    * ``approve_peer`` promoting a PENDING dict entry to
-      APPROVED (``status="approved"``).
-    * ``remove_peer`` dropping either a PENDING dict entry or
-      an APPROVED list row (``status="removed"``).
-    * Pairing-window-close clearing the in-memory PENDING dict
-      (``status="removed"`` per cleared entry).
-
-    The ``status="removed"`` event is what wakes any in-flight
-    ``intent="pair_status"`` long-poll on a paired offloader so
-    its listener task drops the offloader's local state.
+    ``status="approved"`` fires from ``approve_peer``;
+    ``status="removed"`` from ``remove_peer`` and from
+    pairing-window-close clearing the PENDING dict. The
+    ``"removed"`` events wake any in-flight
+    ``intent="pair_status"`` long-poll on the matching offloader
+    so its listener task drops its local state.
     """
 
     dashboard_id: str
@@ -91,8 +63,7 @@ class RemoteBuildPairingWindowChangedData(TypedDict):
     Fires whenever the in-process pairing window opens, extends,
     or closes. ``expires_in_seconds`` is ``None`` when ``open`` is
     ``False``; otherwise it's the remaining lifetime against the
-    latest extend, which the receiver-side frontend renders as a
-    live countdown.
+    latest extend, which the frontend renders as a live countdown.
     """
 
     open: bool
@@ -103,15 +74,11 @@ class ReceiverPeerLinkSessionOpenedData(TypedDict):
     """
     Payload for ``EventType.RECEIVER_PEER_LINK_SESSION_OPENED``.
 
-    Fired by :meth:`ReceiverController.register_peer_link_session`
-    after the receiver has installed an offloader's peer-link
-    Noise WS session in its ``_peer_link_sessions`` registry —
-    i.e. the post-handshake ``_run_peer_link_session`` is about
-    to enter its dispatch loop. Receiver-side counterpart to
-    :class:`OffloaderPeerLinkOpenedData`.
-
-    ``dashboard_id`` is the offloader's stable identity captured
-    from the Noise XX handshake transcript.
+    Fires from
+    :meth:`ReceiverController.register_peer_link_session` once
+    the post-handshake dispatch loop is parked. ``dashboard_id``
+    is the offloader's stable identity captured from the Noise
+    XX handshake transcript.
     """
 
     dashboard_id: str
@@ -121,15 +88,10 @@ class ReceiverPeerLinkSessionClosedData(TypedDict):
     """
     Payload for ``EventType.RECEIVER_PEER_LINK_SESSION_CLOSED``.
 
-    Fired by :meth:`ReceiverController.unregister_peer_link_session`
-    when the receiver's session loop unwinds (offloader
-    disconnect, heartbeat timeout, controller shutdown,
-    ``superseded`` eviction). Receiver-side counterpart to
-    :class:`OffloaderPeerLinkClosedData` — but no ``reason``
-    field, because the receiver only sees "the loop returned"
-    and the rich reason classification (transport vs heartbeat
-    vs structured terminate) lives on the offloader side where
-    those branches diverge.
+    Fires when the receiver's session loop unwinds. No ``reason``
+    field — the receiver only sees "the loop returned"; the rich
+    transport / heartbeat / terminate classification lives on
+    the offloader side where those branches diverge.
     """
 
     dashboard_id: str


### PR DESCRIPTION
# What does this implement/fix?

Docstring cleanup follow-up to #688. Tightens `models/remote_build/receiver_events.py` per the CLAUDE.md style rules. PR 2 of 6 targeting the `models/remote_build/` package.

Changes:

* **Module-level section comment** — dropped (the "TypedDict so bus.fire data dict is type-checked at the call site, mirrors HA's EventStateChangedData" framing is rationale + cross-ref).
* **`RemoteBuildIdentityRotatedData`** — kept the non-obvious caller contract (the event signals rotation landed + listener rebuild attempted, not that the listener is currently bound; subscribers should check `IdentityView.listener_bound`). Dropped the fail-soft enumeration.
* **`RemoteBuildPairRequestReceivedData`** — kept `peer_ip` and `paired_at` field semantics (caller-visible). Dropped firing-context restatement.
* **`RemoteBuildPairStatusChangedData`** — kept the three firing paths (compressed) and the long-poll-wake side effect (non-obvious behaviour).
* **`RemoteBuildPairingWindowChangedData`** — kept the `expires_in_seconds: None` contract.
* **`ReceiverPeerLinkSessionOpenedData`** / **`ReceiverPeerLinkSessionClosedData`** — kept the no-reason-field asymmetry note (non-obvious — explains why this is shaped differently from the offloader-side counterpart).

Line count: 135 → 97 (28% reduction). Same `ruff check`, `ruff format`, and `mypy` clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #688

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
