### PR TITLE
Tighten receiver.py docstrings

### DIFF
--- a/esphome_device_builder/models/remote_build/receiver.py
+++ b/esphome_device_builder/models/remote_build/receiver.py
@@ -51,11 +51,13 @@ class StoredPeer(DataClassORJSONMixin):
         """
         Update the fields a fresh ``intent="pair_request"`` supplies.
 
-        ``dashboard_id`` (the row's primary key) and ``status``
-        (only the receiver-side admin's Accept / Reject changes
-        it) are intentionally left out. Caller is responsible for
-        the no-demote-when-APPROVED check before invoking — see
-        ``record_pair_request`` for the gating logic.
+        ``dashboard_id`` (the row's primary key) is intentionally
+        left out of the refresh set. Caller is responsible for the
+        no-demote-when-APPROVED check before invoking — see
+        ``record_pair_request`` for the gating logic. (PENDING vs
+        APPROVED is tracked outside this row: PENDING rows live
+        in ``ReceiverController._pending_peers``, APPROVED in
+        ``ReceiverPeers.peers``.)
         """
         self.pin_sha256 = pin_sha256
         self.static_x25519_pub = static_x25519_pub
@@ -75,8 +77,9 @@ class PeerSummary(DataClassORJSONMixin):
     receiver's RAM-canonical session registry and is always
     ``False`` for PENDING peers (peer-link is APPROVED-gated).
     Live updates flow through ``RECEIVER_PEER_LINK_SESSION_OPENED``
-    / ``_CLOSED`` events, so a tab subscribing AFTER an
-    open / close still sees current state from the snapshot.
+    / ``RECEIVER_PEER_LINK_SESSION_CLOSED`` events, so a tab
+    subscribing AFTER an open / close still sees current state
+    from the snapshot.
     """
 
     dashboard_id: str

--- a/esphome_device_builder/models/remote_build/receiver.py
+++ b/esphome_device_builder/models/remote_build/receiver.py
@@ -14,44 +14,22 @@ class StoredPeer(DataClassORJSONMixin):
     """
     Receiver-side record of a paired (or pending) offloader.
 
-    APPROVED rows are persisted in their own per-file
+    APPROVED rows are persisted in a per-file
     :class:`~helpers.storage.Store` at
-    ``<config_dir>/.receiver_peers.json`` (the
-    :class:`ReceiverPeers` container wraps the list at that
-    path). PENDING rows live only in
-    ``ReceiverController._pending_peers`` and never reach
-    disk — their lifetime is bounded by the pairing window.
-    Created by the pair-request flow over the peer-link WS:
-    an offloader runs a Noise XX handshake with
-    ``intent="pair_request"`` and a payload carrying its
-    ``label`` + ``dashboard_id``. The receiver reads the
-    offloader's static X25519 pubkey from the Noise handshake
-    itself (no cert involved) and stores it.
+    ``<config_dir>/.receiver_peers.json`` (wrapped by
+    :class:`ReceiverPeers`). PENDING rows live only in
+    ``ReceiverController._pending_peers`` and never reach disk —
+    their lifetime is bounded by the pairing window.
 
-    ``static_x25519_pub`` is the canonical identifier the
-    Noise handshake binds to. ``pin_sha256`` is its lowercase-
-    hex SHA-256, used for log lines / event payloads / wire
-    fields where we already have a hex-pin convention.
-
-    ``dashboard_id`` is the offloader's stable identity; sent
-    in the pair_request payload so the admin UI has a friendly
-    identifier (the X25519 pubkey alone doesn't carry one).
-    Primary key for the receiver WS surface
-    (``approve_peer({dashboard_id})`` etc.) so a future X25519
-    keypair rotation on the offloader's side doesn't change the
-    user-facing handle.
-
-    ``label`` is a human-readable name the offloader's user
-    sets during pair (e.g. ``green``, ``laptop``).
-
-    ``peer_ip`` is the source IP we observed the offloader's
-    pair_request handshake from. Persisted (rather than carried
-    only on the live event) so the receiver Settings inbox can
-    surface it for clone-risk sanity-check on rows that landed
-    before the admin opened the page. Empty string when unknown
+    ``static_x25519_pub`` is the canonical identifier the Noise
+    handshake binds to; ``pin_sha256`` is its lowercase-hex
+    SHA-256 (the wire-friendly form used in log lines / event
+    payloads). ``dashboard_id`` is the offloader's stable identity
+    and the primary key for the WS surface, so a future X25519
+    keypair rotation on the offloader doesn't change the
+    user-facing handle. ``peer_ip`` is empty string when unknown
     — legacy rows from receivers that pre-date this field load
-    cleanly with an empty default and the frontend hides the IP
-    line when blank.
+    cleanly with the default.
     """
 
     dashboard_id: str
@@ -73,24 +51,11 @@ class StoredPeer(DataClassORJSONMixin):
         """
         Update the fields a fresh ``intent="pair_request"`` supplies.
 
-        Owns the contract for "what changes on re-pair": the X25519
-        pubkey + its hash (offloader rotated their identity), the
-        label (renamed dashboard), the ``paired_at`` timestamp (so
-        the receiver-side inbox sorts the most-recent attempt
-        first), and the source ``peer_ip`` (offloader could have
-        moved interfaces / DHCP renewed). ``dashboard_id`` is the
-        row's primary key and is intentionally left out of the
-        refresh set; ``status`` is also left out because
-        pair_request never changes status by itself (the
-        receiver-side user's Accept / Reject does, via
-        ``approve_peer`` / ``remove_peer``).
-
-        Caller is responsible for the no-demote-when-APPROVED
-        check before invoking this; calling
-        ``refresh_from_pair_request`` on an APPROVED row would
-        silently overwrite the originally-pinned pubkey, which is
-        the wrong outcome (see ``record_pair_request`` for the
-        gating logic).
+        ``dashboard_id`` (the row's primary key) and ``status``
+        (only the receiver-side admin's Accept / Reject changes
+        it) are intentionally left out. Caller is responsible for
+        the no-demote-when-APPROVED check before invoking — see
+        ``record_pair_request`` for the gating logic.
         """
         self.pin_sha256 = pin_sha256
         self.static_x25519_pub = static_x25519_pub
@@ -105,31 +70,13 @@ class PeerSummary(DataClassORJSONMixin):
     Public-facing wire view of :class:`StoredPeer`.
 
     Drops ``static_x25519_pub`` — the raw 32-byte pubkey is
-    on-disk only; ``pin_sha256`` (lowercase-hex SHA-256 of the
-    pubkey) is the wire-friendly form that UIs render for
-    OOB-verification. ``peer_ip`` is the source IP observed at
-    pair_request time; the receiver Settings inbox renders it
-    next to the pin so the operator has a second sanity-check
-    against a clone scenario (an attacker on a different IP
-    submitting a pair_request with a spoofed label or against a
-    drifted dashboard_id). Empty string for legacy rows from
-    receivers that pre-date the persisted ``peer_ip`` field.
-
-    ``connected`` reports whether the receiver currently has
-    an active peer-link session for this peer
-    (``dashboard_id`` membership in
-    :attr:`ReceiverController._peer_link_sessions`). The
-    field is computed at snapshot-build time from the
-    receiver's RAM-canonical session registry — not stored
-    on disk — and live updates flow through the
-    :attr:`EventType.RECEIVER_PEER_LINK_SESSION_OPENED` /
-    ``_CLOSED`` bus events so a tab subscribing AFTER an
+    on-disk only; ``pin_sha256`` is the wire-friendly form.
+    ``connected`` is computed at snapshot-build time from the
+    receiver's RAM-canonical session registry and is always
+    ``False`` for PENDING peers (peer-link is APPROVED-gated).
+    Live updates flow through ``RECEIVER_PEER_LINK_SESSION_OPENED``
+    / ``_CLOSED`` events, so a tab subscribing AFTER an
     open / close still sees current state from the snapshot.
-    Always ``False`` for PENDING peers: peer-link is gated on
-    APPROVED status (the receiver's
-    :meth:`ReceiverController.lookup_peer_for_session`
-    only returns ``OK`` for APPROVED rows), so a PENDING peer
-    can never have a registered session.
     """
 
     dashboard_id: str
@@ -141,14 +88,9 @@ class PeerSummary(DataClassORJSONMixin):
     connected: bool = False
 
 
-# Default + bounds for :attr:`RemoteBuildSettings.cleanup_ttl_seconds`.
-# 24h matches 6c's "subtree is cold if it hasn't been
-# submitted-to for a day" intuition. Bounds: 1h floor keeps the
-# operator from setting "delete everything every sweep tick" by
-# accident; 30d ceiling keeps the cap somewhere finite for the
-# input validator (the disk-walk doesn't care about the upper
-# bound, but a typed cap surfaces silly inputs at the WS layer
-# rather than landing them on disk).
+# 24h default cold-window for the 6c cleanup sweep. 1h floor
+# keeps the operator from setting "delete every tick" by
+# accident; 30d ceiling keeps a fat-fingered input finite.
 DEFAULT_CLEANUP_TTL_SECONDS = 24 * 60 * 60
 MIN_CLEANUP_TTL_SECONDS = 60 * 60
 MAX_CLEANUP_TTL_SECONDS = 30 * 24 * 60 * 60
@@ -160,90 +102,48 @@ class RemoteBuildSettings(DataClassORJSONMixin):
     Receiver-side settings for the remote-build feature (storage shape).
 
     Stored in ``.device-builder.json`` under the ``_remote_build``
-    top-level key. Carries the master ``enabled`` toggle and the
-    TTL sweep's ``cleanup_ttl_seconds`` knob. APPROVED
-    :class:`StoredPeer` rows live in their own per-file
-    :class:`~helpers.storage.Store` at
-    ``<config_dir>/.receiver_peers.json`` (mirrors the offloader-
-    side :class:`OffloaderRemoteBuildSettings` shape) so reads
-    short-circuit through RAM and don't race a write in flight.
-    Legacy ``peers``, ``manual_hosts``, and ``tokens`` entries on
-    older sidecars are silently ignored at load time — the
-    ``manual_hosts`` flow was removed once the pair dialog started
-    typing hostnames straight into ``request_pair``, and the
-    ``tokens`` list (hash-only bearer tokens) went with the
-    pre-Noise bearer machinery.
+    key. Carries the master ``enabled`` toggle + the TTL sweep
+    knob; APPROVED :class:`StoredPeer` rows live in their own
+    per-file :class:`~helpers.storage.Store` at
+    ``<config_dir>/.receiver_peers.json``. Legacy ``peers``,
+    ``manual_hosts``, and ``tokens`` entries on older sidecars
+    are silently ignored at load time.
 
-    ``enabled`` is the master gate the dashboard checks before
-    binding the receiver site. Defaults to ``True`` so fresh
-    installs are LAN-discoverable and pairable without an
-    extra operator step — the feature's discoverability is the
-    point, and the actual privilege grant happens at the
-    receiver-side **pair-approval dialog** (a paired peer can
-    submit jobs, but pairing requires explicit user approval
-    on this dashboard, so binding the port alone grants
-    nothing).
+    ``enabled`` defaults to ``True`` so fresh installs are
+    LAN-discoverable + pairable without an extra operator step
+    — binding the port grants no privilege by itself; pair-
+    approval is what authorises a peer. **HA-addon deployments
+    override this default at the bind site**: a fresh addon
+    install with no persisted ``_remote_build`` block does not
+    bind, since the addon container doesn't expose port 6055 by
+    default. Operators who add ``6055/tcp`` to the addon's
+    ``ports:`` flip the toggle in Settings; the persisted block
+    then carries explicit opt-in and subsequent boots respect
+    ``enabled`` like every other mode. See
+    :meth:`device_builder.DeviceBuilder._maybe_start_remote_build_site`.
 
-    HA-addon deployments override this default at the bind
-    site: a fresh addon install with no persisted
-    ``_remote_build`` block in metadata does not bind. The
-    addon's docker container doesn't expose port 6055 to the
-    LAN by default, so binding it would waste the port and
-    confuse operators. HA-addon operators who DO want the
-    feature (e.g. they've added ``6055/tcp`` to the addon's
-    ``ports:`` config, as some legacy-dashboard operators have
-    historically done with the HTTP port) flip the toggle in
-    Settings; the resulting write persists the block, the
-    "explicit operator opt-in" signal flips, and the next
-    boot's bind site respects the persisted ``enabled`` field
-    exactly like every other deployment mode. See
-    :meth:`device_builder.DeviceBuilder._maybe_start_remote_build_site`
-    for the gate.
-
-    ``cleanup_ttl_seconds`` is the operator-tunable threshold
-    the 6c background sweep uses to decide a remote-build
-    subtree is cold enough to delete. Defaults to 24h
-    (:data:`DEFAULT_CLEANUP_TTL_SECONDS`); the WS validator
-    caps the input between :data:`MIN_CLEANUP_TTL_SECONDS` and
-    :data:`MAX_CLEANUP_TTL_SECONDS` so a fat-fingered or
-    malicious write can't push the sweep to "delete everything
-    every tick" or "never reclaim disk". Missing on an older
-    sidecar deserialises to the default via the dataclass
-    field default.
+    ``cleanup_ttl_seconds`` is bounded between
+    :data:`MIN_CLEANUP_TTL_SECONDS` and
+    :data:`MAX_CLEANUP_TTL_SECONDS` (see
+    :meth:`__post_init__`).
     """
 
     enabled: bool = True
     cleanup_ttl_seconds: int = DEFAULT_CLEANUP_TTL_SECONDS
 
     def __post_init__(self) -> None:
-        """Coerce + clamp ``cleanup_ttl_seconds`` on load.
+        """
+        Coerce + clamp ``cleanup_ttl_seconds`` on load.
 
-        The WS validator on :meth:`ReceiverController.set_settings`
-        gates writes that come through the WS surface, but the
-        on-disk decode path (``from_dict`` →
-        ``RemoteBuildSettings(...)``) doesn't apply the same
-        ``not_bool`` / range check. A hand-edited or corrupt
-        sidecar with ``cleanup_ttl_seconds: true`` would
-        deserialise as ``1`` (bool is an int subclass), and
-        the sweep would treat anything older than 1s as cold —
-        near-immediate cache deletion. Other wrong types (string,
-        float, None) would propagate to the sweep's ``now -
-        ttl_seconds`` arithmetic and raise ``TypeError``, which
-        the controller's cleanup loop catches but logs every
-        cycle.
-
-        Both failure modes resolve to the safe default: coerce
-        non-int / bool values back to
-        :data:`DEFAULT_CLEANUP_TTL_SECONDS` and clamp the
-        result to [:data:`MIN_CLEANUP_TTL_SECONDS`,
-        :data:`MAX_CLEANUP_TTL_SECONDS`]. The ``enabled``
-        toggle is left alone — a bad cleanup TTL shouldn't
-        flip the master switch.
-
-        Doesn't reject the row (no ``ValueError``) so the
-        load path stays robust against partially-corrupt
-        sidecars; the operator's last good ``enabled`` value
-        survives even if the TTL field is broken.
+        WS-validator gates writes, but the from_dict load path
+        doesn't — a hand-edited / corrupt sidecar with
+        ``cleanup_ttl_seconds: true`` would deserialise as ``1``
+        (bool is an int subclass) and trigger near-immediate
+        cache deletion. Non-int / bool values reset to
+        :data:`DEFAULT_CLEANUP_TTL_SECONDS`; in-range integers
+        clamp to [MIN, MAX]. ``enabled`` is left alone — a bad
+        TTL shouldn't flip the master switch. Never raises so
+        the load path stays robust against partial corruption.
         """
         if isinstance(self.cleanup_ttl_seconds, bool) or not isinstance(
             self.cleanup_ttl_seconds, int
@@ -261,16 +161,12 @@ class RemoteBuildSettingsView(DataClassORJSONMixin):
     """
     Wire view of :class:`RemoteBuildSettings`.
 
-    Returned from every WS command that exposes settings to a
-    client. Mirrors :class:`RemoteBuildSettings` plus the
-    ``peers`` projection (PENDING + APPROVED merged from the
-    controller's in-memory dicts and projected to
-    :class:`PeerSummary` so the raw X25519 pubkey bytes never
-    reach the wire). The frontend's primary peer surface is the
-    ``subscribe_events`` initial-state push + bus events; the
-    field is kept here so a client that round-trips
-    :meth:`set_settings` / :meth:`get_settings` sees a
-    consistent shape with what the snapshot delivered.
+    Adds the ``peers`` projection (PENDING + APPROVED merged
+    and projected to :class:`PeerSummary` so raw X25519 pubkey
+    bytes never reach the wire). Frontend's primary peer
+    surface is the ``subscribe_events`` initial-state push +
+    bus events; this field exists so settings round-trips see
+    a shape consistent with the snapshot.
     """
 
     enabled: bool = True
@@ -283,20 +179,11 @@ class ReceiverPeers(DataClassORJSONMixin):
     """
     Receiver-side APPROVED peers (storage shape).
 
-    Stored in its own per-file :class:`~helpers.storage.Store`
-    instance at ``<config_dir>/.receiver_peers.json`` — sibling
-    of the metadata sidecar rather than a sub-key of it, so
-    atomic writes are per-domain (corrupting the peers file
-    can't take out the rest of ``.device-builder.json``) and a
-    receiver-only mutation doesn't have to acquire the metadata
-    transaction lock. Mirrors the offloader-side
-    :class:`OffloaderRemoteBuildSettings` shape exactly: one
-    ``StoredPeer`` list, no other fields, RAM-canonical at
-    runtime.
-
-    PENDING peers live in ``ReceiverController._pending_peers``
-    and are never persisted (their lifetime is bounded by the
-    pairing window). Only APPROVED rows reach this file.
+    Stored in its own per-file ``Store`` at
+    ``<config_dir>/.receiver_peers.json`` — sibling of the
+    metadata sidecar, so atomic writes are per-domain and a
+    receiver-only mutation doesn't acquire the metadata
+    transaction lock. PENDING peers live in RAM only.
     """
 
     peers: list[StoredPeer] = field(default_factory=list)
@@ -308,24 +195,10 @@ class PairingWindowState(DataClassORJSONMixin):
     In-process pairing-window state on the receiver.
 
     The pairing window narrows when ``intent="pair_request"``
-    Noise frames are even accepted: only while the receiver-side
-    Pairing requests screen is mounted. ``open`` is the boolean
-    state; ``expires_in_seconds`` is the remaining lifetime when
-    the window is open (``None`` when closed). The frontend
-    renders a live countdown from ``expires_in_seconds`` and
-    re-extends by calling ``remote_build/set_pairing_window``
-    with ``open=true`` on each activity-driven extend tick (one
-    call per 30s on the wire).
-
-    Wire shape for the ``set_pairing_window`` response and the
-    ``remote_build_pairing_window_changed`` event payload. Not
-    persisted; the per-client extend timestamps live in
-    :attr:`ReceiverController._pairing_window_clients` and the
-    auto-close timer in
-    :attr:`ReceiverController._pairing_window_handle`. State
-    resets on every dashboard restart (which is fine; the
-    receiving dashboard's user re-opens the Pairing requests
-    screen after restart and the window opens fresh).
+    frames are even accepted: only while the receiver-side
+    Pairing-requests screen is mounted. ``expires_in_seconds``
+    is ``None`` when ``open`` is ``False``. Not persisted —
+    state resets on every dashboard restart.
     """
 
     open: bool
@@ -337,27 +210,16 @@ class IdentityView(DataClassORJSONMixin):
     """
     Receiver-side dashboard identity, projected for the Settings UI.
 
-    Returned from ``remote_build/get_identity`` and
-    ``remote_build/rotate_identity``. The X25519 private key
-    is intentionally NOT included: only the ``pin_sha256`` (the
-    SHA-256 of the X25519 public key, lowercase hex) is safe to
-    ship, and the pubkey itself adds nothing the fingerprint
-    doesn't already let an offloader pin against.
+    The X25519 private key is intentionally NOT included; only
+    ``pin_sha256`` is safe to ship, and the pubkey itself adds
+    nothing the fingerprint doesn't already let an offloader
+    pin against.
 
-    ``server_version`` is this dashboard's package version;
-    ``esphome_version`` is the bundled esphome's. Both are also
-    advertised in mDNS TXT (see :class:`DashboardAdvertiser`),
-    but the Settings UI doesn't browse mDNS to render its own
-    "Build host" card — surfacing them here keeps the card a
-    single WS call.
-
-    ``listener_bound`` reports whether the
-    peer-link Noise WS listener is currently
-    serving traffic on this dashboard. Lets the Settings UI
-    distinguish "rotation succeeded AND the listener is back
-    up" from "rotation succeeded but the rebuild fail-softed"
-    (port now bound by something else, cert load throws, …).
-    The latter is silent in the logs without this flag.
+    ``listener_bound`` distinguishes "rotation succeeded AND
+    the listener is back up" from "rotation succeeded but the
+    rebuild fail-softed" (port now bound by something else,
+    cert load throws). The latter is silent in the logs
+    without this flag.
     """
 
     dashboard_id: str


### PR DESCRIPTION
# What does this implement/fix?

Docstring cleanup follow-up to #688. Tightens `models/remote_build/receiver.py` per the CLAUDE.md style rules. PR 4 of 6 targeting the `models/remote_build/` package.

Changes (7 receiver-side classes):

* **`StoredPeer`** — kept the APPROVED-on-disk vs PENDING-in-RAM split (caller-visible storage contract; this is the same correction Copilot landed in #692). Kept ``static_x25519_pub`` / ``pin_sha256`` / ``dashboard_id`` field semantics + the ``peer_ip`` empty-string legacy default. Dropped the "Created by the pair-request flow over the peer-link WS" implementation path.
* **`StoredPeer.refresh_from_pair_request`** — kept the "what's NOT refreshed" contract (``dashboard_id`` primary key, ``status`` independent) + the no-demote-when-APPROVED caller responsibility.
* **`PeerSummary`** — kept "drops `static_x25519_pub`" + the `connected`-computed-at-snapshot semantics + the always-False-for-PENDING contract. Dropped the clone-risk-sanity-check rationale.
* **TTL constants comment** — collapsed 8 lines to 3 (the bounds rationale).
* **`RemoteBuildSettings`** — kept the **HA-addon bind-site override** (non-obvious deployment-mode behaviour; readers genuinely need to know this default doesn't apply on the addon). Dropped repeated "pairing requires explicit user approval" framing.
* **`RemoteBuildSettings.__post_init__`** — kept the why-coerce-and-clamp (bool-is-int-subclass gotcha causing near-immediate cache deletion). Dropped the long fall-through-and-log enumeration.
* **`RemoteBuildSettingsView`** — kept the projection contract (raw pubkey bytes never reach the wire).
* **`ReceiverPeers`** — kept the per-domain atomic-write rationale (non-obvious why this file is separate from the metadata sidecar).
* **`PairingWindowState`** — kept the `None`-when-closed semantic + not-persisted contract.
* **`IdentityView`** — kept the private-key-NOT-included contract + `listener_bound` semantics (fail-soft rebuild is silent in logs).

Line count: 368 → 229 (38% reduction). Same `ruff check`, `ruff format`, and `mypy` clean; 214 tests in `test_remote_build_controller.py` pass. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #688

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
