### PR TITLE
Tighten firmware_sync.py docstrings and comments

### DIFF
--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -20,11 +20,13 @@ def on_job_completed(controller: DevicesController, event: Event[JobLifecycleDat
     """
     Refresh a device's cached state after a successful firmware job.
 
-    Without this hook a freshly-flashed device keeps its stale
+    Without this hook, a freshly-flashed device keeps its stale
     ``has_pending_changes=True`` (the still-orange "update
     pending" dot) since the disk scanner only re-evaluates on
-    YAML stat change. COMPILE / INSTALL also recompute
-    ``expected_config_hash``; UPLOAD reuses the prior compile's.
+    YAML stat change.
+
+    COMPILE / INSTALL also recompute ``expected_config_hash``;
+    UPLOAD reuses the prior compile's.
     """
     job = event.data["job"]
     if job.status != JobStatus.COMPLETED:
@@ -100,9 +102,9 @@ async def persist_expected_config_hash(controller: DevicesController, configurat
     apply, so reproducing the build's hash in-process is
     fragile (verified against ``acfloatmonitor32.yaml``:
     pre-codegen ``f3e21d5a`` vs firmware-baked ``5a94a12d``).
-    Logs a warning rather than failing on a missing /
-    malformed file so an upstream ESPHome shape change
-    surfaces visibly.
+    Logs a warning rather than failing on a missing or
+    malformed ``build_info.json`` so an upstream ESPHome
+    shape change surfaces visibly.
     """
     yaml_path = controller._db.settings.rel_path(configuration)
     new_hash = await compute_yaml_config_hash(yaml_path)
@@ -127,8 +129,8 @@ def sync_deployed_hash_after_flash(controller: DevicesController, configuration:
     existing ``_on_config_hash_change`` callback handle the
     device-field write + ``DEVICE_UPDATED`` event, and seeds
     the monitor's per-name cache so the rebooted device's
-    matching announce de-dups instead of firing a redundant
-    event.
+    matching announce deduplicates instead of firing a
+    redundant event.
     """
     device = next(
         (d for d in controller._scanner.devices if d.configuration == configuration),

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -1,27 +1,4 @@
-"""
-Firmware-job → device-state sync helpers.
-
-Subscribed to the firmware queue's ``JOB_COMPLETED`` event by the
-controller. After a successful COMPILE / UPLOAD / INSTALL,
-recomputes the YAML's ``expected_config_hash`` from
-``build_info.json`` and optimistically pins
-``deployed_config_hash`` to the freshly-flashed value so the
-"update pending" dot clears immediately rather than waiting on
-the rebooted device's next mDNS announce. RENAME triggers a full
-scan; CLEAN just nudges the build-size cache.
-
-The controller keeps thin bound-method delegates
-(``_on_firmware_job_completed``, ``_refresh_after_firmware_job``,
-``_persist_expected_config_hash``, ``_sync_deployed_hash_after_flash``,
-``_persist_storage_version_async``) so:
-
-* WS callbacks see the methods at their original names.
-* Tests can monkeypatch ``_refresh_after_firmware_job`` /
-  ``_persist_storage_version_async`` on the instance and the
-  patched callable is what runs (the dispatcher here calls
-  ``controller._refresh_after_firmware_job(...)``, not the
-  module function directly).
-"""
+"""Firmware-job → device-state sync helpers."""
 
 from __future__ import annotations
 
@@ -43,49 +20,39 @@ def on_job_completed(controller: DevicesController, event: Event[JobLifecycleDat
     """
     Refresh a device's cached state after a successful firmware job.
 
-    Without this hook, a freshly-flashed device keeps its stale
-    ``has_pending_changes=True`` — the symptom users see as a
-    still-orange "update pending" dot — because the disk scanner
-    only re-evaluates when the YAML file's stat changes.
-
-    COMPILE and INSTALL also recompute the YAML's
-    ``expected_config_hash`` here so the next mDNS resolve can
-    compare against the firmware's broadcast hash; UPLOAD doesn't
-    recompile, so it reuses whatever the previous compile cached.
+    Without this hook a freshly-flashed device keeps its stale
+    ``has_pending_changes=True`` (the still-orange "update
+    pending" dot) since the disk scanner only re-evaluates on
+    YAML stat change. COMPILE / INSTALL also recompute
+    ``expected_config_hash``; UPLOAD reuses the prior compile's.
     """
     job = event.data["job"]
     if job.status != JobStatus.COMPLETED:
         return
     job_type = job.job_type
     if job_type == JobType.RENAME:
-        # ``esphome rename`` deletes the old YAML and writes a new
-        # one with a different filename — neither path is the
-        # ``configuration`` field on the job. A full scan is the
-        # simplest way to pick up both the disappearance of the
-        # old entry and the appearance of the new one.
+        # ``esphome rename`` deletes the old YAML and writes a
+        # new one with a different filename; full scan is the
+        # simplest way to pick up both transitions.
         controller._db.create_background_task(controller._scanner.scan())
         return
     configuration = job.configuration
     if not configuration:
         return
     if job_type == JobType.CLEAN:
-        # ``esphome clean`` removes the per-device build tree;
-        # the build-size cache for this device is now stale
-        # (cached non-zero, current dir mtime → 0). The pair-
-        # equality short-circuit in
-        # ``refresh_build_size_if_stale`` detects that and
-        # walks once to clear the cached triple, so the drawer
-        # / table flip back to the em-dash placeholder. No
-        # hash recompute / flash bookkeeping needed for CLEAN.
+        # ``esphome clean`` wipes the build tree; the
+        # build-size cache is now stale and the worker's
+        # pair-equality short-circuit clears the cached triple
+        # so the drawer / table flip back to the placeholder.
         controller._build_size.request(configuration)
         return
     if job_type not in (JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL):
         return
     recompute_hash = job_type in (JobType.COMPILE, JobType.INSTALL)
     flashed = job_type in (JobType.UPLOAD, JobType.INSTALL)
-    # Routed through the controller's bound delegate so tests that
-    # monkeypatch ``_refresh_after_firmware_job`` on the instance
-    # still intercept the call.
+    # Routed through the controller's bound delegate so tests
+    # that monkeypatch ``_refresh_after_firmware_job`` on the
+    # instance still intercept.
     controller._db.create_background_task(
         controller._refresh_after_firmware_job(
             configuration, recompute_hash=recompute_hash, flashed=flashed
@@ -103,43 +70,23 @@ async def refresh_after_job(
     """
     Persist the YAML's freshly-compiled hash and reload the device.
 
-    When *recompute_hash* is True, recomputes the YAML's
-    ``CORE.config_hash`` and writes it to the metadata sidecar so
-    the next mDNS resolve can compare against the firmware's
-    broadcast. The device is always reloaded afterwards — even
-    when hash computation is skipped or fails — so the mtime side
-    of ``has_pending_changes`` still flips after a successful
-    compile.
-
-    When *flashed* is True (UPLOAD or INSTALL completed), the
-    firmware on the device was just replaced with the binary that
-    compiled to ``expected_config_hash``. The reloaded device
-    otherwise keeps the *previous* mDNS-cached
-    ``deployed_config_hash`` — usually a now-stale value — so the
-    hash comparison reads ``expected != deployed`` and the dot
-    stays orange until the rebooted device's mDNS announce
-    propagates. That can be many seconds, sometimes longer if the
-    device's network announce gets dropped, and the user sees a
-    successful flash with a still-orange dot. Optimistically pin
-    deployed = expected on the reloaded device and recompute the
-    flag so the dot clears immediately. mDNS still gets to
-    correct the hash later — if the new firmware advertises a
-    different hash (e.g. because the OTA actually failed and the
-    device kept the old image), ``_on_config_hash_change`` will
-    push the real value back in.
+    Always reloads after the optional hash recompute so the
+    mtime side of ``has_pending_changes`` flips. When *flashed*,
+    optimistically pins ``deployed_config_hash = expected`` so
+    the dot clears immediately rather than waiting on the
+    rebooted device's mDNS announce; if the OTA actually failed
+    silently, ``_on_config_hash_change`` pushes the real value
+    back on the next announce.
     """
     if recompute_hash:
         await controller._persist_expected_config_hash(configuration)
     await controller._scanner.reload(configuration)
     if flashed:
         controller._sync_deployed_hash_after_flash(configuration)
-    # A real compile moves the freshness pair the build-size
-    # cache keys off (build-dir mtime + ``build_info.json``
-    # mtime); hand off to the build-size worker so the drawer
-    # / table show an up-to-date "Build size" value the next
-    # time the frontend reads the device list. The worker
-    # short-circuits when the pair didn't actually move (e.g.
-    # an UPLOAD-only job that didn't recompile).
+    # A real compile moves the build-size cache's freshness
+    # pair (build-dir mtime + ``build_info.json`` mtime); the
+    # worker short-circuits when the pair didn't actually move
+    # (e.g. UPLOAD-only).
     controller._build_size.request(configuration)
 
 
@@ -147,36 +94,24 @@ async def persist_expected_config_hash(controller: DevicesController, configurat
     """
     Read the canonical config_hash from build_info.json and persist it.
 
-    ESPHome's build (and ``--only-generate``) writes the
-    ``config_hash`` to ``build_info.json`` after running the full
-    validate + codegen pipeline. We read that value back rather
-    than recompute it, because reproducing the build's hash
-    in-process is fragile — ``CORE.config_hash`` is sensitive to
-    post-codegen state (id-pinning, default backfill,
-    normalisation) that ``read_config`` alone doesn't apply.
-    Verified against ``acfloatmonitor32.yaml``: pre-codegen yields
-    ``f3e21d5a`` while the firmware bakes in ``5a94a12d``.
-
-    No-op when the hash can't be read. The caller is on the
-    post-build / post-only-generate path, so a missing or
-    malformed ``build_info.json`` here is unexpected — log a
-    warning so an upstream ESPHome shape change doesn't
-    silently leave the sidecar out of date.
-    ``compute_has_pending_changes`` will lean on the bin mtime
-    in that gap, which catches the "user just edited the YAML"
-    case but won't notice firmware that's drifted from the
-    compile (e.g. flashed elsewhere) — the dot can read
-    in-sync when it shouldn't until the next real flash
-    rewrites the sidecar.
+    Read rather than recompute: ``CORE.config_hash`` is
+    sensitive to post-codegen state (id-pinning, default
+    backfill, normalisation) that ``read_config`` alone doesn't
+    apply, so reproducing the build's hash in-process is
+    fragile (verified against ``acfloatmonitor32.yaml``:
+    pre-codegen ``f3e21d5a`` vs firmware-baked ``5a94a12d``).
+    Logs a warning rather than failing on a missing /
+    malformed file so an upstream ESPHome shape change
+    surfaces visibly.
     """
     yaml_path = controller._db.settings.rel_path(configuration)
     new_hash = await compute_yaml_config_hash(yaml_path)
     if not new_hash:
         _LOGGER.warning(
-            "Could not read config_hash from build_info.json for %s — "
-            "the drawer's Local hash may stay stale until the next flash. "
-            "If this persists across compiles, check that ESPHome's "
-            "build_info.json schema hasn't changed.",
+            "Could not read config_hash from build_info.json for %s; "
+            "the drawer's Local hash may stay stale until the next "
+            "flash. If this persists across compiles, check that "
+            "ESPHome's build_info.json schema hasn't changed.",
             configuration,
         )
         return
@@ -188,14 +123,11 @@ def sync_deployed_hash_after_flash(controller: DevicesController, configuration:
     """
     Optimistically align ``deployed_config_hash`` with the just-flashed image.
 
-    See :func:`refresh_after_job` for the rationale. Driving the
-    update through ``apply_config_hash`` lets the existing
-    ``_on_config_hash_change`` callback handle the device-field
-    write + ``DEVICE_UPDATED`` event, so the post-flash sync
-    follows the same code path as a real mDNS announce.
-    ``apply_config_hash`` also seeds the monitor's per-name cache,
-    so when the rebooted device's announce lands with the *same*
-    hash the de-dup short-circuits and we don't fire a redundant
+    Driving the update through ``apply_config_hash`` lets the
+    existing ``_on_config_hash_change`` callback handle the
+    device-field write + ``DEVICE_UPDATED`` event, and seeds
+    the monitor's per-name cache so the rebooted device's
+    matching announce de-dups instead of firing a redundant
     event.
     """
     device = next(


### PR DESCRIPTION
# What does this implement/fix?

Style cleanup pass on `controllers/devices/firmware_sync.py` to bring the docstrings and inline comments into line with the conventions the sibling submodules follow. No behaviour change.

- **Top docstring** collapsed to a one-liner; the bound-method-delegate boilerplate lives in the package `__init__.py`.
- **`on_job_completed` docstring** trimmed; kept the load-bearing why (scanner-only-evaluates-on-stat-change rationale).
- **`on_job_completed` inline comments** compressed; RENAME and CLEAN paragraphs each fit in three lines.
- **`refresh_after_job` docstring** shrunk from ~30 lines to ~7; kept the optimistic-pin rationale and the OTA-failed-silently recovery path.
- **`persist_expected_config_hash` docstring** shrunk; kept the read-vs-recompute justification + the empirical hash-mismatch example (`acfloatmonitor32.yaml` verification).
- **`sync_deployed_hash_after_flash` docstring** trimmed.
- **Em-dashes** replaced with semicolons / commas.

`firmware_sync.py` drops 215 → 147 lines. 332 device + firmware refresh tests pass.

**Related issue or feature (if applicable):**

- follow-up to #663

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
