### PR TITLE
Tighten reachability.py docstrings and comments

### DIFF
--- a/esphome_device_builder/controllers/devices/reachability.py
+++ b/esphome_device_builder/controllers/devices/reachability.py
@@ -1,23 +1,4 @@
-"""
-Per-device reachability streaming + on-demand mDNS refresh.
-
-Drawer-only: while the device drawer is open the frontend opens
-a ``devices/subscribe_reachability`` stream so it can show
-"mDNS heard 12s ago, ping 47s ago, MQTT 2 min ago, RTT 4 ms"
-without bloating the broadcast ``subscribe_events`` channel for
-every other connected client. While subscribed AND the device's
-active source is mDNS, an A-record refresh loop runs alongside
-the stream so the displayed "last seen" age doesn't grow
-unboundedly past the cached TTL.
-
-The controller keeps thin bound-method delegates
-(``subscribe_reachability``, ``_reachability_refresh_loop``,
-``_build_reachability_snapshot``, ``_on_reachability_observation``,
-``get_reachability_snapshot``, ``refresh_device_mdns``) so the
-WS dispatch, the :class:`ReachabilityTracker` observation
-callback, and tests that call them as instance methods all
-resolve to the same names.
-"""
+"""Per-device reachability streaming + on-demand mDNS refresh."""
 
 from __future__ import annotations
 
@@ -52,23 +33,13 @@ async def subscribe(
     """
     Stream per-signal reachability for a single device.
 
-    Wire shape:
-      → ``{"command": "devices/subscribe_reachability",
-            "message_id": "<id>",
-            "args": {"device_name": "kitchen"}}``
-      ← ``{"event": "reachability_state", "message_id": "<id>",
-            "data": <ReachabilitySnapshot>}``  (initial + on every change)
-      ← ``{"result": {"subscribed": true}, "message_id": "<id>"}``
-      → ``{"command": "devices/stop_stream",
-            "args": {"stream_id": "<id>"}}``  (to end the stream)
-
-    While subscribed AND the device's active source is mDNS,
-    the backend force-refreshes the A record every 60s so a
-    stale broadcast doesn't keep the displayed "last seen" age
-    growing forever. Ping-source devices are already covered by
-    the regular ping sweep; MQTT-source by the discover-publish
-    loop. Both feed the tracker through the same path the
-    initial subscription read.
+    Drawer-only: the per-device freshness display ("mDNS heard
+    12s ago, ping 47s ago, MQTT 2 min ago, RTT 4 ms") would
+    bloat the broadcast ``subscribe_events`` channel for every
+    other connected client; this stream stays scoped to the
+    drawer's lifetime. Spawns the mDNS A-record refresh loop
+    alongside so the displayed age doesn't grow past the
+    cached TTL while the user watches.
     """
     if client is None:
         return
@@ -94,19 +65,14 @@ async def subscribe(
     def _handle_event(event: Event[DeviceReachabilityData], controls: StreamControls) -> None:
         data = event.data
         if data["device"] != device_name:
-            # The bus event is broadcast (one listener for every
-            # subscriber); filter inside the closure so each
-            # subscriber only forwards the events for its device.
+            # Bus event is broadcast to all subscribers; filter
+            # so each only forwards its own device's events.
             return
         controls.push("reachability_state", data)
 
     try:
-        # Spawn the 60s mDNS refresh loop alongside the stream
-        # so it gets cancelled together with the subscription
-        # when the WS disconnects or ``devices/stop_stream``
-        # cancels this task. Routed through the controller's
-        # bound delegate so tests patching the loop on the
-        # instance still intercept.
+        # Routed through the controller's bound delegate so tests
+        # patching the loop on the instance still intercept.
         refresh_task = asyncio.create_task(controller._reachability_refresh_loop(device_name))
         await stream_events(
             client=client,
@@ -128,57 +94,29 @@ async def refresh_loop(controller: DevicesController, device_name: str) -> None:
     """
     Schedule mDNS refreshes off the cached A record's expiry.
 
-    Quiet when active source is ping (the regular sweep already
-    runs every 60s) or MQTT (the discover-publish loop already
-    ticks every 2s).
-
-    Why scheduled-on-expiry rather than fixed-interval: the
-    canonical ``async_resolve_host`` short-circuits on cache
-    hit (``_load_from_cache`` returns the cached value if
-    the record is present and not expired), so a
-    fixed-interval probe within the cache's lifetime
-    wouldn't actually go on the wire — we'd just keep
-    re-reading the same cached entry until it eventually
-    ages out and the next iteration finally reaches
-    ``async_request``.
-
-    On every iteration, re-read the cached A record's
-    remaining TTL. If a fresh entry is alive, sleep until it
-    ages out (``ttl_remaining + padding``) then loop —
-    rechecking after the sleep handles the case where an
-    unrelated mDNS announce reached us during the sleep
-    window and re-armed the cache; we just sleep again for
-    the new lifetime instead of issuing a redundant query.
-    Only when the recheck shows expired / absent does the
-    wire query fire — by then ``_load_from_cache`` will fail
-    and ``async_resolve_host`` will actually go on the wire.
-    ESPHome devices are mDNS-silent except in response to
-    probes; ``ServiceBrowser`` only keeps the PTR record
-    (4500s TTL) alive, not A/AAAA (120s). Without this loop
-    the A record decays unrecoverably 120s after the most
-    recent probe.
+    Quiet on ping (regular sweep covers it) and MQTT
+    (discover-publish loop ticks every 2s). Scheduled-on-expiry
+    rather than fixed-interval because ``async_resolve_host``
+    short-circuits on cache hits, so a fixed-interval probe
+    inside the cache lifetime never reaches the wire.
+    ``ServiceBrowser`` only refreshes the PTR record (4500s
+    TTL); A/AAAA decay at 120s without this loop.
     """
     while True:
-        # Use the A/AAAA-specific TTL — not the union-of-types
-        # ``get_mdns_cache_info``: PTR has a 4500s TTL and
-        # stays cached for ages, so a sleep keyed on it
-        # would never wake up to refresh A. We're driving
-        # the loop off the A record's much shorter 120s
-        # decay because that's the one we actually need to
-        # keep alive for the drawer's freshness display.
+        # Use the A/AAAA-specific TTL; the union-of-types
+        # ``get_mdns_cache_info`` includes PTR's 4500s TTL and
+        # would never wake up to refresh A.
         a_ttl_remaining = controller._state_monitor.get_mdns_a_record_ttl_remaining(device_name)
         if a_ttl_remaining is not None and a_ttl_remaining > 0:
-            # A still alive — sleep until just past expiry,
-            # then re-check rather than probing immediately.
-            # A fresh announce arriving during the sleep
-            # would re-arm the cache and the recheck spares
-            # us a redundant wire query.
+            # A still alive; sleep until just past expiry, then
+            # re-check (an unrelated announce during the sleep
+            # would re-arm the cache and the recheck spares us
+            # a redundant wire query).
             await asyncio.sleep(a_ttl_remaining + _MDNS_REFRESH_PADDING_SECONDS)
             continue
-        # A expired or absent — probe the wire to refresh
-        # it. The padding before the first probe also gives
-        # the subscription's initial snapshot a chance to
-        # land before we issue our first query.
+        # A expired or absent; padding before the first probe
+        # gives the subscription's initial snapshot a chance
+        # to land before we issue the first query.
         await asyncio.sleep(_MDNS_REFRESH_PADDING_SECONDS)
         if controller._state_monitor.priority_for(device_name) is ReachabilitySource.MDNS:
             await controller.refresh_device_mdns(device_name)
@@ -188,13 +126,9 @@ def build_snapshot(controller: DevicesController, name: str) -> DeviceReachabili
     """
     Stitch state + tracker fields into the reachability wire shape.
 
-    The state monitor owns ``state`` / ``active_source`` / ``ip``;
-    the tracker owns the per-signal freshness fields. Both
-    ``get_reachability_snapshot`` (initial WS subscribe) and
-    ``on_observation`` (per-event push) need the merged dict,
-    so the device-lookup + delegate-to-tracker combo lives once
-    here. Returns ``None`` when no configured device matches
-    *name*.
+    The state monitor owns ``state`` / ``active_source`` /
+    ``ip``; the tracker owns the per-signal freshness fields.
+    Returns ``None`` when no configured device matches *name*.
     """
     bucket = controller._scanner.get_by_name(name)
     if not bucket:
@@ -212,13 +146,12 @@ def on_observation(controller: DevicesController, name: str) -> None:
     """
     Forward a reachability freshness observation onto the event bus.
 
-    Fires :data:`EventType.DEVICE_REACHABILITY` carrying the full
-    wire-shape snapshot for *name*. The device drawer's per-device
-    subscription filters by ``data["device"]`` and pushes the
-    snapshot to the client. The event is *not* forwarded by the
-    broadcast ``subscribe_events`` channel — adding a periodic
-    per-device freshness ping to every connected client would
-    bloat the bus for no UI gain.
+    Fires :data:`EventType.DEVICE_REACHABILITY`; the drawer's
+    per-device subscription filters by ``data["device"]`` and
+    pushes the snapshot. Not forwarded by the broadcast
+    ``subscribe_events`` channel since a per-device freshness
+    ping to every connected client would bloat the bus for no
+    UI gain.
     """
     snapshot = controller._build_reachability_snapshot(name)
     if snapshot is None:


### PR DESCRIPTION
# What does this implement/fix?

Style cleanup pass on `controllers/devices/reachability.py` to bring the docstrings and inline comments into line with the conventions the sibling submodules follow. No behaviour change.

- **Top docstring** collapsed to a one-liner.
- **`subscribe()` docstring** shrunk; dropped the wire-shape examples (the WS API is documented in `docs/API.md`) and kept the drawer-only-scope rationale.
- **`refresh_loop` docstring** shrunk from ~20 lines to ~7; kept the load-bearing whys (scheduled-on-expiry vs fixed-interval, PTR-vs-A TTL split). Inline comments compressed.
- **`build_snapshot` / `on_observation` docstrings** trimmed.
- **`refresh_device_mdns`** stays as a one-liner.
- **Em-dashes** replaced with semicolons / commas.

`reachability.py` drops 231 → 164 lines. 13 reachability subscription tests pass.

**Related issue or feature (if applicable):**

- follow-up to #663 / #666

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
