### PR TITLE
CLAUDE.md: soften docstring length cap from hard-3 to default-3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,10 +59,16 @@ the official ESPHome container and Home Assistant add-on.
     doesn't need to learn what *another* function does to read
     this one.
 
-  Hard cap for new code: three lines between the `"""` markers
-  (blank lines count). The example above is at the cap. If the
-  contract genuinely needs more, the function probably needs
-  splitting first.
+  Default target for new code: three lines between the `"""`
+  markers (blank lines count). The example above is at that
+  target. Longer is acceptable when the contract genuinely
+  needs it — non-obvious priority orders, security-relevant
+  fallbacks, an empirical anchor (e.g. issue number proving a
+  value matters), or a multi-stage flow whose ordering is
+  load-bearing. What's never acceptable is paragraphs that
+  restate what the body of the function already says; if a
+  reader who's reading the code would only be confused by the
+  docstring, drop those parts, don't just clip arbitrarily.
 
 - **Comments**: same bar. Default to writing no comments. Add
   one only when the *why* is non-obvious: a hidden constraint, a


### PR DESCRIPTION
# What does this implement/fix?

Soften the CLAUDE.md docstring guidance from a **hard cap of three lines** to a **default target of three lines, with longer acceptable when the contract genuinely needs it**.

The hard-cap phrasing has been making Copilot flag docstrings that legitimately need more — recent examples on the cleanup PRs:

- `metadata._resolve_device_metadata` carries the `board_id` 3-tier fallback priority + the `build_info.json`-wins-over-stale-sidecar rationale; both are non-obvious to a reader looking at the body.
- `firmware_sync.persist_expected_config_hash` carries the empirical hash-mismatch anchor (`acfloatmonitor32.yaml`: pre-codegen `f3e21d5a` vs firmware-baked `5a94a12d`) that proves why we read instead of recompute.
- `state_callbacks.on_api_encryption_change` carries the issue-#437 anchor + the deliberate "wire-says-no doesn't clear `api_encrypted`" semantic.

Each is over three lines for a real reason; the hard-cap framing was making Copilot push back regardless.

The new wording keeps the actual intent (don't paraphrase the body, don't write paragraph essays) and makes the line count a target rather than a gate. The "never acceptable: paragraphs restating what the body already says" sentence does the actual filtering work that the cap was reaching for.

**Related issue or feature (if applicable):**

- follow-up observation from #663 / #672 / #687 / #702 / #714 / #722-725 cleanup PRs

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
