### PR TITLE
Prioritize stale devices in bulk firmware jobs

### DIFF
--- a/esphome_device_builder/controllers/firmware/bulk.py
+++ b/esphome_device_builder/controllers/firmware/bulk.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, NamedTuple
 
 from ...helpers.api import CommandError
 from ...models import FirmwareJob, JobType
@@ -13,6 +14,78 @@ if TYPE_CHECKING:
     from .controller import FirmwareController
 
 _LOGGER = logging.getLogger(__name__)
+
+_ESPHOME_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-.]?(.+))?$")
+_PRERELEASE_PART_RE = re.compile(r"\d+|\D+")
+_TUPLE_NEW = tuple.__new__
+_PRERELEASE_PARTS = tuple[tuple[int, int | str], ...]
+
+
+class _VersionKey(NamedTuple):
+    major: int
+    minor: int
+    patch: int
+    release_rank: int
+    prerelease: _PRERELEASE_PARTS
+
+
+_UNKNOWN_VERSION_KEY = _TUPLE_NEW(_VersionKey, (-1, -1, -1, 0, ()))
+
+
+def _prerelease_sort_key(prerelease: str) -> _PRERELEASE_PARTS:
+    """Split prerelease strings so numeric parts sort numerically."""
+    return tuple(
+        (0, int(part)) if part.isdecimal() else (1, part)
+        for part in _PRERELEASE_PART_RE.findall(prerelease)
+    )
+
+
+def _esphome_version_sort_key(version: str | None) -> _VersionKey:
+    """Return a sortable key for ESPHome versions."""
+    if not version:
+        return _UNKNOWN_VERSION_KEY
+
+    match = _ESPHOME_VERSION_RE.match(version)
+    if match is None:
+        return _TUPLE_NEW(_VersionKey, (-1, -1, -1, 0, _prerelease_sort_key(version)))
+
+    prerelease = _prerelease_sort_key(match[4] or "")
+    release_rank = 0 if prerelease else 1
+    return _TUPLE_NEW(
+        _VersionKey,
+        (int(match[1]), int(match[2]), int(match[3]), release_rank, prerelease),
+    )
+
+
+def _is_older_esphome_version(deployed: str, current: str) -> bool:
+    """Return true when *deployed* is strictly older than *current*."""
+    if not deployed or not current:
+        return False
+    return _esphome_version_sort_key(deployed) < _esphome_version_sort_key(current)
+
+
+def _configuration_order(controller: FirmwareController, configurations: list[str]) -> list[str]:
+    """Return bulk firmware configs with stale devices first."""
+    devices_controller = controller._db.devices
+    if devices_controller is None:
+        return configurations
+
+    devices = {device.configuration: device for device in devices_controller.get_devices()}
+
+    def sort_key(item: tuple[int, str]) -> tuple[int, _VersionKey, int]:
+        index, config = item
+        device = devices.get(config)
+        if (
+            device is not None
+            and device.update_available
+            and _is_older_esphome_version(device.deployed_version, device.current_version)
+        ):
+            return (0, _esphome_version_sort_key(device.deployed_version), index)
+        if device is not None and device.has_pending_changes:
+            return (1, _UNKNOWN_VERSION_KEY, index)
+        return (2, _UNKNOWN_VERSION_KEY, index)
+
+    return [config for _, config in sorted(enumerate(configurations), key=sort_key)]
 
 
 async def compile_bulk(
@@ -31,7 +104,7 @@ async def compile_bulk(
     """
     await controller._validate_configurations_boundary(configurations)
     jobs: list[FirmwareJob] = []
-    for config in configurations:
+    for config in _configuration_order(controller, configurations):
         try:
             build_source = controller._resolve_install_source(force_local=force_local)
             job = controller._create_job(
@@ -64,7 +137,7 @@ async def install_bulk(
     _validate_port(port)
     await controller._validate_configurations_boundary(configurations)
     jobs: list[FirmwareJob] = []
-    for config in configurations:
+    for config in _configuration_order(controller, configurations):
         try:
             build_source = controller._resolve_install_source()
             job = controller._create_job(

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -158,6 +158,7 @@ def firmware_controller_factory(
         # silent-fallback-LOCAL semantic.
         db_attrs: dict[str, Any] = {
             "bus": bus,
+            "devices": None,
             "remote_build_offloader": None,
             "remote_build_receiver": None,
         }

--- a/tests/controllers/firmware/test_bulk_order.py
+++ b/tests/controllers/firmware/test_bulk_order.py
@@ -1,0 +1,294 @@
+"""Tests for stale-first bulk firmware ordering."""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.controllers.firmware.bulk import _esphome_version_sort_key
+from esphome_device_builder.models import Device, JobType
+from tests.controllers.firmware.conftest import FirmwareControllerFactory
+
+
+class _DevicesController:
+    def __init__(self, devices: list[Device]) -> None:
+        self._devices = devices
+
+    def get_devices(self) -> list[Device]:
+        return self._devices
+
+
+def _device(
+    configuration: str,
+    *,
+    current_version: str = "2026.5.0",
+    deployed_version: str = "2026.5.0",
+    has_pending_changes: bool = False,
+    update_available: bool = False,
+) -> Device:
+    name = configuration.removesuffix(".yaml")
+    return Device(
+        name=name,
+        friendly_name=name,
+        configuration=configuration,
+        current_version=current_version,
+        deployed_version=deployed_version,
+        has_pending_changes=has_pending_changes,
+        update_available=update_available,
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_bulk_queues_stale_devices_before_pending_changes(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = _DevicesController(
+        [
+            _device("current.yaml"),
+            _device("pending.yaml", has_pending_changes=True),
+            _device(
+                "newer-old.yaml",
+                deployed_version="2025.12.0",
+                update_available=True,
+            ),
+            _device(
+                "oldest.yaml",
+                deployed_version="2024.1.0",
+                update_available=True,
+            ),
+        ]
+    )
+
+    jobs = await controller.install_bulk(
+        configurations=[
+            "current.yaml",
+            "pending.yaml",
+            "newer-old.yaml",
+            "oldest.yaml",
+            "unknown.yaml",
+        ]
+    )
+
+    assert [job.configuration for job in jobs] == [
+        "oldest.yaml",
+        "newer-old.yaml",
+        "pending.yaml",
+        "current.yaml",
+        "unknown.yaml",
+    ]
+    assert [job.job_type for job in jobs] == [JobType.INSTALL] * 5
+
+
+@pytest.mark.asyncio
+async def test_bulk_order_preserves_tail_input_order(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = _DevicesController(
+        [
+            _device("current-a.yaml", deployed_version="2026.5.0"),
+            _device("current-b.yaml", deployed_version="2026.5.0"),
+            _device("pending.yaml", has_pending_changes=True),
+            _device("stale.yaml", deployed_version="2024.1.0", update_available=True),
+        ]
+    )
+
+    jobs = await controller.install_bulk(
+        configurations=[
+            "current-a.yaml",
+            "unknown.yaml",
+            "current-b.yaml",
+            "pending.yaml",
+            "stale.yaml",
+        ]
+    )
+
+    assert [job.configuration for job in jobs] == [
+        "stale.yaml",
+        "pending.yaml",
+        "current-a.yaml",
+        "unknown.yaml",
+        "current-b.yaml",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bulk_order_keeps_newer_deployed_versions_in_tail(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = _DevicesController(
+        [
+            _device(
+                "newer.yaml",
+                current_version="2026.5.0",
+                deployed_version="2026.6.0",
+                update_available=True,
+            ),
+            _device("pending.yaml", has_pending_changes=True),
+            _device("stale.yaml", deployed_version="2024.1.0", update_available=True),
+            _device("current.yaml"),
+        ]
+    )
+
+    jobs = await controller.install_bulk(
+        configurations=["newer.yaml", "pending.yaml", "stale.yaml", "current.yaml"]
+    )
+
+    assert [job.configuration for job in jobs] == [
+        "stale.yaml",
+        "pending.yaml",
+        "newer.yaml",
+        "current.yaml",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bulk_order_uses_update_available_as_stale_gate(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = _DevicesController(
+        [
+            _device(
+                "behind-but-not-flagged.yaml",
+                current_version="2026.5.0",
+                deployed_version="2024.1.0",
+                update_available=False,
+            ),
+            _device("pending.yaml", has_pending_changes=True),
+            _device("stale.yaml", deployed_version="2025.1.0", update_available=True),
+        ]
+    )
+
+    jobs = await controller.install_bulk(
+        configurations=["behind-but-not-flagged.yaml", "pending.yaml", "stale.yaml"]
+    )
+
+    assert [job.configuration for job in jobs] == [
+        "stale.yaml",
+        "pending.yaml",
+        "behind-but-not-flagged.yaml",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bulk_order_sorts_prerelease_numbers_numerically(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = _DevicesController(
+        [
+            _device(
+                "beta-10.yaml",
+                current_version="2026.6.0",
+                deployed_version="2026.6.0b10",
+                update_available=True,
+            ),
+            _device(
+                "beta-2.yaml",
+                current_version="2026.6.0",
+                deployed_version="2026.6.0b2",
+                update_available=True,
+            ),
+        ]
+    )
+
+    jobs = await controller.install_bulk(configurations=["beta-10.yaml", "beta-2.yaml"])
+
+    assert [job.configuration for job in jobs] == ["beta-2.yaml", "beta-10.yaml"]
+
+
+@pytest.mark.asyncio
+async def test_bulk_order_keeps_missing_versions_out_of_stale_bucket(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = _DevicesController(
+        [
+            _device("missing-deployed.yaml", deployed_version="", update_available=True),
+            _device(
+                "missing-current.yaml",
+                current_version="",
+                deployed_version="2025.1.0",
+                update_available=True,
+            ),
+            _device("pending.yaml", has_pending_changes=True),
+            _device("stale.yaml", deployed_version="2025.1.0", update_available=True),
+        ]
+    )
+
+    jobs = await controller.install_bulk(
+        configurations=[
+            "missing-deployed.yaml",
+            "missing-current.yaml",
+            "pending.yaml",
+            "stale.yaml",
+        ]
+    )
+
+    assert [job.configuration for job in jobs] == [
+        "stale.yaml",
+        "pending.yaml",
+        "missing-deployed.yaml",
+        "missing-current.yaml",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bulk_order_treats_unknown_deployed_version_as_oldest_stale(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = _DevicesController(
+        [
+            _device(
+                "local-build.yaml",
+                deployed_version="local-build",
+                update_available=True,
+            ),
+            _device("old.yaml", deployed_version="2025.1.0", update_available=True),
+        ]
+    )
+
+    jobs = await controller.install_bulk(configurations=["old.yaml", "local-build.yaml"])
+
+    assert [job.configuration for job in jobs] == ["local-build.yaml", "old.yaml"]
+
+
+def test_esphome_version_sort_key_handles_missing_versions() -> None:
+    assert _esphome_version_sort_key("") == _esphome_version_sort_key(None)
+
+
+@pytest.mark.asyncio
+async def test_compile_bulk_uses_stale_first_order(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = _DevicesController(
+        [
+            _device("fresh.yaml"),
+            _device("old.yaml", deployed_version="2025.1.0", update_available=True),
+        ]
+    )
+
+    jobs = await controller.compile_bulk(configurations=["fresh.yaml", "old.yaml"])
+
+    assert [job.configuration for job in jobs] == ["old.yaml", "fresh.yaml"]
+    assert [job.job_type for job in jobs] == [JobType.COMPILE, JobType.COMPILE]
+
+
+@pytest.mark.asyncio
+async def test_bulk_order_preserves_input_without_devices_controller(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory(with_queue=True)
+    controller._db.devices = None
+
+    jobs = await controller.install_bulk(configurations=["first.yaml", "second.yaml", "third.yaml"])
+
+    assert [job.configuration for job in jobs] == [
+        "first.yaml",
+        "second.yaml",
+        "third.yaml",
+    ]

--- a/tests/controllers/firmware/test_rename_lock.py
+++ b/tests/controllers/firmware/test_rename_lock.py
@@ -179,6 +179,7 @@ async def test_install_bulk_skips_locked_configs_and_queues_the_rest(
             # which reads ``_db.remote_build_offloader`` — match production's
             # pre-start shape (``None`` until the controller is
             # constructed) so the resolver falls through to LOCAL.
+            "devices": None,
             "remote_build_offloader": None,
             "remote_build_receiver": None,
         },


### PR DESCRIPTION
# What does this implement/fix?

Queues bulk firmware jobs in stale-first order in the Device Builder backend:

- devices with an ESPHome version update available first, oldest deployed version first
- devices with pending YAML changes next
- already-current devices and unknown configuration names keep their relative order

This ports the legacy `update-all` ordering intent from esphome/esphome#15991 to the new Device Builder bulk firmware API.

**Related issue or feature (if applicable):**

- supersedes esphome/esphome#15991

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
