### PR TITLE
Log expected and observed pubkeys on peer-link pin drift

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -353,15 +353,24 @@ class PeerLinkClient:
                 # it advertised; a mismatched pubkey means a
                 # legitimate rotation or a MITM / mDNS spoof.
                 # Abort either way before any application frames.
-                if session.remote_static_pub != self._pinned_static_x25519_pub:
-                    observed = session.remote_static_pub
+                observed = session.remote_static_pub
+                if observed != self._pinned_static_x25519_pub:
+                    # ``stored_pin`` is the sha256 written to disk at
+                    # pair time; ``expected_pin`` is what the raw
+                    # pinned bytes hash to right now. They must agree
+                    # (set from the same ``result.remote_static_pub``
+                    # in :meth:`OffloaderController.request_pair`);
+                    # logging both surfaces a divergence as a
+                    # stored-row corruption symptom instead of a
+                    # wire-level one.
                     _LOGGER.warning(
                         "peer-link client to %s:%d observed pin drift "
-                        "(expected_pin=%s expected_bytes=%s observed_pin=%s "
-                        "observed_bytes=%s); orphaning until the operator "
-                        "re-pairs or unpairs",
+                        "(stored_pin=%s expected_pin=%s expected_bytes=%s "
+                        "observed_pin=%s observed_bytes=%s); orphaning "
+                        "until the operator re-pairs or unpairs",
                         self._hostname,
                         self._port,
+                        self._pin_sha256,
                         pin_sha256_for_pubkey(self._pinned_static_x25519_pub),
                         self._pinned_static_x25519_pub.hex(),
                         pin_sha256_for_pubkey(observed),

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -30,6 +30,7 @@ from ....helpers import json as _json
 from ....helpers.peer_link_noise import (
     NOISE_ERRORS,
     PeerLinkNoiseSession,
+    pin_sha256_for_pubkey,
 )
 from ....helpers.peer_link_resolver import make_peer_link_http_session
 from ....models import (
@@ -291,12 +292,9 @@ class PeerLinkClient:
                     self._orphaned = True
                     return
                 if close_reason == _LOCAL_CLOSE_PIN_MISMATCH:
-                    _LOGGER.warning(
-                        "peer-link client to %s:%d observed pin drift; orphaning "
-                        "until the operator re-pairs or unpairs",
-                        self._hostname,
-                        self._port,
-                    )
+                    # Detection site in :meth:`_run_one_session` logs
+                    # the warning with both pubkeys; this branch only
+                    # owns the orphan transition.
                     self._orphaned = True
                     return
                 # Reset on session that reached ``intent_response: ok``
@@ -356,7 +354,20 @@ class PeerLinkClient:
                 # legitimate rotation or a MITM / mDNS spoof.
                 # Abort either way before any application frames.
                 if session.remote_static_pub != self._pinned_static_x25519_pub:
-                    self._fire_pin_mismatch(observed=session.remote_static_pub)
+                    observed = session.remote_static_pub
+                    _LOGGER.warning(
+                        "peer-link client to %s:%d observed pin drift "
+                        "(expected_pin=%s expected_bytes=%s observed_pin=%s "
+                        "observed_bytes=%s); orphaning until the operator "
+                        "re-pairs or unpairs",
+                        self._hostname,
+                        self._port,
+                        pin_sha256_for_pubkey(self._pinned_static_x25519_pub),
+                        self._pinned_static_x25519_pub.hex(),
+                        pin_sha256_for_pubkey(observed),
+                        observed.hex(),
+                    )
+                    self._fire_pin_mismatch(observed=observed)
                     self._last_connect_error = "pin mismatch"
                     return _LOCAL_CLOSE_PIN_MISMATCH
                 response = _json.loads(session.decrypt(response_ct))

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -3178,6 +3178,7 @@ async def test_peer_link_client_auth_rejected_when_dashboard_id_unknown(
 @pytest.mark.asyncio
 async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A pinned pubkey that doesn't match the receiver's actual key aborts the connect.
 
@@ -3198,6 +3199,10 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
        hammering whatever's at the wrong endpoint.
     4. NOT fire ``OFFLOADER_PEER_LINK_OPENED`` — application
        frames must not flow against the wrong identity.
+    5. Emit one ``WARNING`` log line carrying both pin_sha256
+       fingerprints and the raw 32-byte hex of each pubkey
+       (the diagnostic that distinguishes "wire bytes differ"
+       from "bytes match but ``!=`` tripped anyway").
     """
     server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)
@@ -3228,32 +3233,50 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
         receiver_label="my-laptop",
         bus=bus,
     )
-    task = asyncio.create_task(client.run())
-    try:
-        # Pin-mismatch fires before close; close fires before
-        # orphaning. Wait on close (the terminal signal).
-        await asyncio.wait_for(closed.received.wait(), timeout=2.0)
-        # Yield once so any pending ``run`` post-close work
-        # (orphan flag set, return) finishes before we assert.
-        for _ in range(10):
-            if task.done():
-                break
-            await asyncio.sleep(0)
+    with caplog.at_level(
+        "WARNING",
+        logger="esphome_device_builder.controllers.remote_build.peer_link_client.client",
+    ):
+        task = asyncio.create_task(client.run())
+        try:
+            # Pin-mismatch fires before close; close fires before
+            # orphaning. Wait on close (the terminal signal).
+            await asyncio.wait_for(closed.received.wait(), timeout=2.0)
+            # Yield once so any pending ``run`` post-close work
+            # (orphan flag set, return) finishes before we assert.
+            for _ in range(10):
+                if task.done():
+                    break
+                await asyncio.sleep(0)
 
-        assert closed[0]["reason"] == "pin_mismatch"
-        assert len(pin_mismatch) == 1
-        assert pin_mismatch[0]["receiver_hostname"] == "127.0.0.1"
-        assert pin_mismatch[0]["receiver_label"] == "my-laptop"
-        assert pin_mismatch[0]["expected_pin"] != pin_mismatch[0]["observed_pin"]
-        # Application channel never opened — bundles can't flow
-        # against the wrong identity.
-        assert len(opened) == 0
-        # Client orphaned: reconnect loop exits without further
-        # backoff. ``run`` has returned, so the task is done.
-        assert task.done()
-        assert client.is_orphaned is True
-    finally:
-        await cancel_and_drain(task)
+            assert closed[0]["reason"] == "pin_mismatch"
+            assert len(pin_mismatch) == 1
+            assert pin_mismatch[0]["receiver_hostname"] == "127.0.0.1"
+            assert pin_mismatch[0]["receiver_label"] == "my-laptop"
+            assert pin_mismatch[0]["expected_pin"] != pin_mismatch[0]["observed_pin"]
+            # Application channel never opened — bundles can't flow
+            # against the wrong identity.
+            assert len(opened) == 0
+            # Client orphaned: reconnect loop exits without further
+            # backoff. ``run`` has returned, so the task is done.
+            assert task.done()
+            assert client.is_orphaned is True
+
+            # Exactly one drift warning, carrying both fingerprints
+            # AND the raw 32-byte hex of each pubkey so an operator
+            # can tell a bytes-comparison bug from a wire-level
+            # identity mismatch from a single log line.
+            drift_records = [
+                rec for rec in caplog.records if "observed pin drift" in rec.getMessage()
+            ]
+            assert len(drift_records) == 1
+            msg = drift_records[0].getMessage()
+            assert pin_sha256_for_pubkey(wrong_pub) in msg
+            assert pin_sha256_for_pubkey(receiver_pub) in msg
+            assert wrong_pub.hex() in msg
+            assert receiver_pub.hex() in msg
+        finally:
+            await cancel_and_drain(task)
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -3199,10 +3199,11 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
        hammering whatever's at the wrong endpoint.
     4. NOT fire ``OFFLOADER_PEER_LINK_OPENED`` — application
        frames must not flow against the wrong identity.
-    5. Emit one ``WARNING`` log line carrying both pin_sha256
-       fingerprints and the raw 32-byte hex of each pubkey
-       (the diagnostic that distinguishes "wire bytes differ"
-       from "bytes match but ``!=`` tripped anyway").
+    5. Emit one ``WARNING`` log line carrying the on-disk
+       ``stored_pin``, both pin_sha256 fingerprints, and the
+       raw 32-byte hex of each pubkey (the diagnostic that
+       distinguishes "stored row corruption" / "wire bytes
+       differ" / "bytes match but ``!=`` tripped anyway").
     """
     server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)
@@ -3222,6 +3223,13 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
     # XOR-with-0x01 form has none.
     wrong_pub = bytes([receiver_pub[0] ^ 0x01]) + receiver_pub[1:]
     assert wrong_pub != receiver_pub
+    # Real pair-row invariant: ``pin_sha256 == sha256(static_x25519_pub)``
+    # (both are set from the same ``result.remote_static_pub`` in
+    # :meth:`OffloaderController.request_pair`). The pin-drift
+    # warning logs both so an operator can spot a stored-row
+    # corruption (``stored_pin != expected_pin``); we mirror the
+    # production invariant here.
+    wrong_pin = pin_sha256_for_pubkey(wrong_pub)
 
     client = PeerLinkClient(
         receiver_hostname="127.0.0.1",
@@ -3229,7 +3237,7 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
         identity_priv=initiator_priv,
         dashboard_id="alpha",
         pinned_static_x25519_pub=wrong_pub,
-        pin_sha256="a" * 64,
+        pin_sha256=wrong_pin,
         receiver_label="my-laptop",
         bus=bus,
     )
@@ -3262,19 +3270,21 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
             assert task.done()
             assert client.is_orphaned is True
 
-            # Exactly one drift warning, carrying both fingerprints
-            # AND the raw 32-byte hex of each pubkey so an operator
-            # can tell a bytes-comparison bug from a wire-level
-            # identity mismatch from a single log line.
+            # Exactly one drift warning, carrying ``stored_pin``,
+            # both fingerprints AND the raw 32-byte hex of each
+            # pubkey so an operator can tell a stored-row corruption
+            # from a bytes-comparison bug from a wire-level identity
+            # mismatch from a single log line.
             drift_records = [
                 rec for rec in caplog.records if "observed pin drift" in rec.getMessage()
             ]
             assert len(drift_records) == 1
             msg = drift_records[0].getMessage()
-            assert pin_sha256_for_pubkey(wrong_pub) in msg
-            assert pin_sha256_for_pubkey(receiver_pub) in msg
-            assert wrong_pub.hex() in msg
-            assert receiver_pub.hex() in msg
+            assert f"stored_pin={wrong_pin}" in msg
+            assert f"expected_pin={pin_sha256_for_pubkey(wrong_pub)}" in msg
+            assert f"expected_bytes={wrong_pub.hex()}" in msg
+            assert f"observed_pin={pin_sha256_for_pubkey(receiver_pub)}" in msg
+            assert f"observed_bytes={receiver_pub.hex()}" in msg
         finally:
             await cancel_and_drain(task)
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -3199,11 +3199,6 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
        hammering whatever's at the wrong endpoint.
     4. NOT fire ``OFFLOADER_PEER_LINK_OPENED`` — application
        frames must not flow against the wrong identity.
-    5. Emit one ``WARNING`` log line carrying the on-disk
-       ``stored_pin``, both pin_sha256 fingerprints, and the
-       raw 32-byte hex of each pubkey (the diagnostic that
-       distinguishes "stored row corruption" / "wire bytes
-       differ" / "bytes match but ``!=`` tripped anyway").
     """
     server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)


### PR DESCRIPTION
## What does this implement/fix?

Extends the offloader-side pin-drift warning to include both
`pin_sha256` fingerprints **and** the raw 32-byte hex of each
pubkey. Today the warning only carries `hostname:port`, which
isn't enough to distinguish:

- **bytes genuinely differ on the wire** — the receiver presented
  a different X25519 identity (legitimate rotation, mDNS spoof,
  cross-wired connection landing on a different process); or
- **bytes match but the `!=` check still tripped** — a
  bytes-comparison / encoding round-trip bug somewhere between
  mashumaro deserialize of `StoredPairing.static_x25519_pub` and
  the comparison in `_run_one_session`.

The fingerprints + raw bytes in one log line let an operator
answer that question from a single warning instead of having to
subscribe to `OFFLOADER_PAIR_PIN_MISMATCH` bus events to extract
the same fields from the typed payload.

Also moves the warning from the `run()` orphan-decision branch
down to the detection site in `_run_one_session` where the
observed pubkey is in scope; the `run()` branch keeps the orphan
transition only.

Background: a beta user reported pin drift on every offloader
reconnect after restarting a WSL2-hosted receiver. The receiver's
`.device-builder-peer-link-key.bin` mtime is stable across
restarts and `ss -4nlp` confirms a single listener per side, so
neither the 'fresh key on every restart' nor the 'cross-wired
endpoint' theory survives. The next diagnostic is to see what
bytes the offloader actually observed; this PR makes that
visible without patching anything else.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (ruff, codespell, yaml/json/python checks).
- [x] Tests have been added or updated under tests/ where applicable. (test_remote_build_peer_link_client.py + test_remote_build_peer_link.py + test_peer_link_noise.py still pass green — 252 tests.)
- [x] components.json has **not** been hand-edited (regenerate via script/sync_components.py if a sync is needed).
- [x] Architecture-level changes are reflected in docs/ARCHITECTURE.md and/or docs/API.md. (Diagnostic-only; no surface change.)