### PR TITLE
Extract firmware-job persistence into persistence.py

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import re
 
-from ...models import JobType
+from ...models import JobStatus, JobType
 
 # Metadata key under which the firmware queue persists itself in
 # ``.device-builder.json``.
@@ -116,6 +116,11 @@ _MAX_AUX_TERMINAL_JOBS = 5
 _PRIMARY_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL}
 )
+
+# Statuses considered "active" — queued for execution or
+# currently running. Re-queued on dashboard restart by
+# ``persistence.load_jobs``; exempt from history pruning.
+_ACTIVE_JOB_STATUSES: frozenset[JobStatus] = frozenset({JobStatus.QUEUED, JobStatus.RUNNING})
 
 # Job types eligible for ``--mdns/--dns-address-cache`` forwarding.
 _OTA_ADDRESS_CACHE_JOB_TYPES: frozenset[JobType] = frozenset(

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -54,14 +54,11 @@ from ...models import (
     StreamEvent,
 )
 from ...models.remote_build import PeerStatus
-from ..config import _load_metadata, metadata_transaction
+from . import persistence
 from .constants import (
+    _ACTIVE_JOB_STATUSES,
     _ERROR_PATTERNS,
-    _JOBS_KEY,
-    _MAX_AUX_TERMINAL_JOBS,
-    _MAX_PRIMARY_TERMINAL_JOBS,
     _OTA_ADDRESS_CACHE_JOB_TYPES,
-    _PRIMARY_JOB_TYPES,
     ESPHOME_SUBPROCESS_ENV,
 )
 from .helpers import (
@@ -112,11 +109,6 @@ _LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPON
 _BUILD_PRODUCING_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL, JobType.RENAME}
 )
-
-# Statuses a job has *while in flight*. ``_jobs`` retains terminal
-# entries for the recent-jobs history, so any "is something
-# running for this configuration?" check has to filter for these.
-_ACTIVE_JOB_STATUSES: frozenset[JobStatus] = frozenset({JobStatus.QUEUED, JobStatus.RUNNING})
 
 # Maps each terminal :class:`JobStatus` to the lifecycle event the
 # runner fires when a job reaches that status. Routes through
@@ -1973,111 +1965,14 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
                 await self.cancel(job_id=job_id)
 
     def _prune_history(self) -> None:
-        """
-        Trim ``self._jobs`` to the configured history limits.
-
-        Active (queued/running) jobs are always kept. Terminal
-        compile/upload/install jobs collapse to one entry per
-        configuration (newest wins) and are capped at
-        ``_MAX_PRIMARY_TERMINAL_JOBS``. Terminal clean/reset jobs are
-        kept in a separate pool capped at ``_MAX_AUX_TERMINAL_JOBS``.
-        Caller persists the result.
-        """
-        terminal_states = TERMINAL_JOB_STATUSES
-
-        active: list[FirmwareJob] = []
-        primary: list[FirmwareJob] = []
-        aux: list[FirmwareJob] = []
-        for job in self._jobs.values():
-            if job.status not in terminal_states:
-                active.append(job)
-            elif job.job_type in _PRIMARY_JOB_TYPES:
-                primary.append(job)
-            else:
-                aux.append(job)
-
-        # Sort newest-first so dedup keeps the most recent entry per
-        # device and the cap retains the most recent N overall.
-        primary.sort(key=attrgetter("created_at"), reverse=True)
-        seen_configs: set[str] = set()
-        deduped_primary: list[FirmwareJob] = []
-        for job in primary:
-            if job.configuration:
-                if job.configuration in seen_configs:
-                    continue
-                seen_configs.add(job.configuration)
-            deduped_primary.append(job)
-        deduped_primary = deduped_primary[:_MAX_PRIMARY_TERMINAL_JOBS]
-
-        aux.sort(key=attrgetter("created_at"), reverse=True)
-        aux = aux[:_MAX_AUX_TERMINAL_JOBS]
-
-        self._jobs = {j.job_id: j for j in (*active, *deduped_primary, *aux)}
+        persistence.prune_history(self)
 
     # ------------------------------------------------------------------
     # Internals — persistence
     # ------------------------------------------------------------------
 
     async def _load_jobs(self) -> None:
-        """
-        Load persisted jobs and re-queue any incomplete ones.
-
-        - ``QUEUED`` and ``RUNNING`` both re-queue. The user
-          asked for the build; even though the subprocess died
-          with the dashboard, the request is still pending in
-          their head. Worst case the rebuilt-and-reflashed
-          firmware is identical to what was already on the
-          device — that's idempotent, the user pays a couple
-          minutes of compile time, no harm done.
-        - Terminal (``COMPLETED`` / ``FAILED`` / ``CANCELLED``):
-          load into the in-memory map for the recent-jobs panel
-          but don't touch ``_queue``.
-
-        ``RUNNING`` jobs go through ``FirmwareJob.reset()``
-        before being re-queued so the rebuild looks like a
-        fresh run in the per-run-state fields (``progress`` /
-        ``error`` / ``started_at`` / ``completed_at`` /
-        ``exit_code``) but keeps the pre-crash ``output`` log
-        as diagnostic history with a separator marker showing
-        where the rebuild starts. ``reset`` lives on the model
-        rather than as a free helper here so a future per-run
-        field added to ``FirmwareJob`` lands right next to the
-        method that has to clear it.
-
-        See esphome/device-builder#147 for the policy discussion.
-        """
-        loop = asyncio.get_running_loop()
-        data = await loop.run_in_executor(None, _load_metadata, self._db.settings.config_dir)
-        for job_data in data.get(_JOBS_KEY, []):
-            try:
-                job = FirmwareJob.from_dict(job_data)
-                self._jobs[job.job_id] = job
-                if job.status in _ACTIVE_JOB_STATUSES:
-                    if job.status == JobStatus.RUNNING:
-                        job.reset()
-                    job.status = JobStatus.QUEUED
-                    await self._queue.put(job)
-            except Exception:
-                # ``job_data`` is normally a dict, but a corrupt
-                # persistence file could contain a primitive (string,
-                # int, ``None``) where a dict was expected. ``.get``
-                # would raise ``AttributeError`` on those, defeating
-                # the "skip and continue" intent of this branch.
-                # Probe by isinstance and fall back to the raw repr.
-                identity = (
-                    job_data.get("job_id", "?")
-                    if isinstance(job_data, dict)
-                    else f"<non-dict entry: {job_data!r}>"
-                )
-                _LOGGER.warning("Failed to restore job: %s", identity, exc_info=True)
+        await persistence.load_jobs(self)
 
     async def _persist_jobs(self) -> None:
-        """Save all jobs to disk."""
-        loop = asyncio.get_running_loop()
-        config_dir = self._db.settings.config_dir
-
-        def _save() -> None:
-            with metadata_transaction(config_dir) as data:
-                data[_JOBS_KEY] = [j.to_dict() for j in self._jobs.values()]
-
-        await loop.run_in_executor(None, _save)
+        await persistence.persist_jobs(self)

--- a/esphome_device_builder/controllers/firmware/persistence.py
+++ b/esphome_device_builder/controllers/firmware/persistence.py
@@ -1,0 +1,128 @@
+"""
+Firmware-job persistence: load on startup, prune history, save on transition.
+
+Free functions taking :class:`FirmwareController` as the first
+arg (the canonical devices/firmware_sync.py pattern). The
+controller exposes thin ``_load_jobs`` / ``_persist_jobs`` /
+``_prune_history`` methods so existing test patches on those
+bound names keep working.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from operator import attrgetter
+from typing import TYPE_CHECKING
+
+from ...models import TERMINAL_JOB_STATUSES, FirmwareJob, JobStatus
+from ..config import _load_metadata, metadata_transaction
+from .constants import (
+    _ACTIVE_JOB_STATUSES,
+    _JOBS_KEY,
+    _MAX_AUX_TERMINAL_JOBS,
+    _MAX_PRIMARY_TERMINAL_JOBS,
+    _PRIMARY_JOB_TYPES,
+)
+
+if TYPE_CHECKING:
+    from .controller import FirmwareController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def prune_history(controller: FirmwareController) -> None:
+    """
+    Trim ``controller._jobs`` to the configured history limits.
+
+    Active (queued / running) jobs are always kept. Terminal
+    compile / upload / install jobs collapse to one entry per
+    configuration (newest wins) and cap at
+    :data:`_MAX_PRIMARY_TERMINAL_JOBS`. Terminal clean / reset
+    jobs are kept in a separate pool capped at
+    :data:`_MAX_AUX_TERMINAL_JOBS`. Caller persists the result.
+    """
+    terminal_states = TERMINAL_JOB_STATUSES
+
+    active: list[FirmwareJob] = []
+    primary: list[FirmwareJob] = []
+    aux: list[FirmwareJob] = []
+    for job in controller._jobs.values():
+        if job.status not in terminal_states:
+            active.append(job)
+        elif job.job_type in _PRIMARY_JOB_TYPES:
+            primary.append(job)
+        else:
+            aux.append(job)
+
+    # Sort newest-first so dedup keeps the most recent entry per
+    # device and the cap retains the most recent N overall.
+    primary.sort(key=attrgetter("created_at"), reverse=True)
+    seen_configs: set[str] = set()
+    deduped_primary: list[FirmwareJob] = []
+    for job in primary:
+        if job.configuration:
+            if job.configuration in seen_configs:
+                continue
+            seen_configs.add(job.configuration)
+        deduped_primary.append(job)
+    deduped_primary = deduped_primary[:_MAX_PRIMARY_TERMINAL_JOBS]
+
+    aux.sort(key=attrgetter("created_at"), reverse=True)
+    aux = aux[:_MAX_AUX_TERMINAL_JOBS]
+
+    controller._jobs = {j.job_id: j for j in (*active, *deduped_primary, *aux)}
+
+
+async def load_jobs(controller: FirmwareController) -> None:
+    """
+    Load persisted jobs and re-queue any incomplete ones.
+
+    QUEUED and RUNNING both re-queue — the user asked for the
+    build, and a rebuild-and-reflash is idempotent (worst case
+    they pay a couple minutes of compile time on identical
+    firmware). RUNNING goes through :meth:`FirmwareJob.reset`
+    first so the per-run fields (progress / error / timestamps /
+    exit_code) look fresh, but the pre-crash ``output`` log is
+    kept as diagnostic history with a separator marker showing
+    where the rebuild starts. Terminal jobs load into the
+    in-memory map for the recent-jobs panel but don't touch
+    ``_queue``. See esphome/device-builder#147 for the policy.
+    """
+    loop = asyncio.get_running_loop()
+    data = await loop.run_in_executor(None, _load_metadata, controller._db.settings.config_dir)
+    for job_data in data.get(_JOBS_KEY, []):
+        try:
+            job = FirmwareJob.from_dict(job_data)
+            controller._jobs[job.job_id] = job
+            if job.status in _ACTIVE_JOB_STATUSES:
+                if job.status == JobStatus.RUNNING:
+                    job.reset()
+                job.status = JobStatus.QUEUED
+                await controller._queue.put(job)
+        except Exception:
+            # ``job_data`` is normally a dict, but a corrupt
+            # persistence file could contain a primitive
+            # (string, int, ``None``) where a dict was expected.
+            # ``.get`` would raise ``AttributeError`` on those,
+            # defeating the "skip and continue" intent of this
+            # branch. Probe by isinstance and fall back to the
+            # raw repr.
+            identity = (
+                job_data.get("job_id", "?")
+                if isinstance(job_data, dict)
+                else f"<non-dict entry: {job_data!r}>"
+            )
+            _LOGGER.warning("Failed to restore job: %s", identity, exc_info=True)
+
+
+async def persist_jobs(controller: FirmwareController) -> None:
+    """Save all jobs to disk."""
+    loop = asyncio.get_running_loop()
+    config_dir = controller._db.settings.config_dir
+
+    def _save() -> None:
+        with metadata_transaction(config_dir) as data:
+            data[_JOBS_KEY] = [j.to_dict() for j in controller._jobs.values()]
+
+    await loop.run_in_executor(None, _save)

--- a/esphome_device_builder/controllers/firmware/persistence.py
+++ b/esphome_device_builder/controllers/firmware/persistence.py
@@ -1,12 +1,4 @@
-"""
-Firmware-job persistence: load on startup, prune history, save on transition.
-
-Free functions taking :class:`FirmwareController` as the first
-arg (the canonical devices/firmware_sync.py pattern). The
-controller exposes thin ``_load_jobs`` / ``_persist_jobs`` /
-``_prune_history`` methods so existing test patches on those
-bound names keep working.
-"""
+"""Firmware-job persistence: load on startup, prune history, save on transition."""
 
 from __future__ import annotations
 
@@ -56,7 +48,7 @@ def prune_history(controller: FirmwareController) -> None:
             aux.append(job)
 
     # Sort newest-first so dedup keeps the most recent entry per
-    # device and the cap retains the most recent N overall.
+    # configuration and the cap retains the most recent N overall.
     primary.sort(key=attrgetter("created_at"), reverse=True)
     seen_configs: set[str] = set()
     deduped_primary: list[FirmwareJob] = []
@@ -78,16 +70,10 @@ async def load_jobs(controller: FirmwareController) -> None:
     """
     Load persisted jobs and re-queue any incomplete ones.
 
-    QUEUED and RUNNING both re-queue — the user asked for the
-    build, and a rebuild-and-reflash is idempotent (worst case
-    they pay a couple minutes of compile time on identical
-    firmware). RUNNING goes through :meth:`FirmwareJob.reset`
-    first so the per-run fields (progress / error / timestamps /
-    exit_code) look fresh, but the pre-crash ``output`` log is
-    kept as diagnostic history with a separator marker showing
-    where the rebuild starts. Terminal jobs load into the
-    in-memory map for the recent-jobs panel but don't touch
-    ``_queue``. See esphome/device-builder#147 for the policy.
+    QUEUED and RUNNING re-queue; RUNNING goes through
+    :meth:`FirmwareJob.reset` first to clear per-run state while
+    preserving the pre-crash ``output`` log as history. Terminal
+    jobs load into the in-memory map but don't touch ``_queue``.
     """
     loop = asyncio.get_running_loop()
     data = await loop.run_in_executor(None, _load_metadata, controller._db.settings.config_dir)


### PR DESCRIPTION
# What does this implement/fix?

First structural-split PR targeting `controllers/firmware/controller.py` (2083 lines — has been the largest module in the codebase since the devices/ split landed). Extracts the **firmware-job persistence** concern (load on startup, save on transition, prune history) into a new `persistence.py` submodule.

Free-function pattern matching `controllers/devices/firmware_sync.py` (#663) and the post-#688 / post-#705 splits: each helper takes `controller: FirmwareController` as the first arg. The controller keeps thin one-line delegate methods (`_load_jobs` / `_persist_jobs` / `_prune_history`) so the ~10 test-patch sites under `tests/controllers/firmware/` that monkeypatch those bound names keep working without test changes.

Changes:

* **New `persistence.py`** (128 lines) — `prune_history(controller)`, `load_jobs(controller)`, `persist_jobs(controller)`.
* **`controller.py`** — bodies replaced with one-line delegates; unused imports (`_load_metadata`, `metadata_transaction`, `_JOBS_KEY`, `_MAX_AUX_TERMINAL_JOBS`, `_MAX_PRIMARY_TERMINAL_JOBS`, `_PRIMARY_JOB_TYPES`, `attrgetter`) auto-removed by ruff. Net 2083 → 1978 lines (−105).
* **`constants.py`** — `_ACTIVE_JOB_STATUSES` moves here from controller.py (it was inline at line 119, used in 6 places across controller.py and now also needed by persistence.py — avoids a circular import by living in the leaf constants module).

This is the first of several planned structural-split PRs for `firmware/controller.py`. Remaining concerns to extract in follow-ups: lifecycle/cancel/finalize, subprocess composition (env / command / cache args / chip verification), queue/dispatch.

All 3198 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follows the soft-cap policy added in #619; first chunk of the firmware/controller.py split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
