### PR TITLE
Split DevicesController: extract validate_config WS command

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -40,6 +40,8 @@ resolving after the subpackage split. Submodules:
   on-subscription mDNS A-record refresh loop.
 - ``state_callbacks`` — the six per-attribute mDNS callbacks
   (state / ip / version / mac / api_encryption / config_hash).
+- ``validate`` — ``devices/validate`` WS command body
+  (``esphome config`` subprocess + ANSI-conceal-SGR redaction).
 - ``storage_regen`` — background ``--only-generate`` scheduler
   + the disk-stamp guard that keeps it from looping on a
   broken YAML.

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -71,6 +71,7 @@ from . import (
     reachability,
     state_callbacks,
     storage_regen,
+    validate,
 )
 from ._yaml_search import (
     DEFAULT_CONTEXT_LINES,
@@ -80,7 +81,6 @@ from ._yaml_search import (
 from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
     _build_address_cache_args,
-    _redact_concealed_secrets,
     _rewrite_required_yaml_leaf,
     _validate_archive_configuration,
     friendly_name_slugify,
@@ -1515,32 +1515,14 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         message_id: str = "",
         **kwargs: Any,
     ) -> None:
-        """
-        Validate a device YAML config. Streams output per-connection.
-
-        ``show_secrets`` passes ``--show-secrets`` to ``esphome config``
-        so resolved ``!secret`` values appear in the output instead of
-        the default ``<removed>`` redaction. Default is ``False`` —
-        secrets only appear when the user actively asks for them.
-        Mirrors the legacy dashboard's ``streamer_mode`` semantics
-        but as a per-call opt-in rather than a global setting, so one
-        user wanting to see secrets in a multi-user deployment doesn't
-        change the default for everyone else.
-        """
-        config_path = str(self._db.settings.rel_path(configuration))
-        cmd = [*self._esphome_cmd, "--dashboard", "config", config_path]
-        line_transform: Callable[[str], str] | None = None
-        if show_secrets:
-            cmd.append("--show-secrets")
-        else:
-            # ``esphome config`` without ``--show-secrets`` doesn't
-            # redact — it wraps each ``password|key|psk|ssid`` value
-            # in the ANSI conceal SGR (8/28). Browsers don't honour
-            # that escape, so the resolved secret bytes were leaking
-            # plain into the validate dialog. Strip the wrapped runs
-            # before the line leaves the WS handler.
-            line_transform = _redact_concealed_secrets
-        await self._stream_subprocess(cmd, client, message_id, line_transform=line_transform)
+        """Validate a device YAML config; streams output per-connection."""
+        await validate.validate_config(
+            self,
+            configuration=configuration,
+            show_secrets=show_secrets,
+            client=client,
+            message_id=message_id,
+        )
 
     @api_command("devices/logs")
     async def stream_logs(

--- a/esphome_device_builder/controllers/devices/validate.py
+++ b/esphome_device_builder/controllers/devices/validate.py
@@ -23,12 +23,11 @@ async def validate_config(
     """
     Validate a device YAML config; streams output per-connection.
 
-    ``show_secrets`` opts into ``--show-secrets`` so resolved
-    ``!secret`` values appear in the output. Default is False;
-    a per-call opt-in rather than the legacy dashboard's global
-    ``streamer_mode`` so one user wanting secrets in a
-    multi-user deployment doesn't change the default for
-    everyone else.
+    ``show_secrets`` passes ``--show-secrets`` to ``esphome
+    config`` when True so resolved ``!secret`` values appear
+    in the output; when False, ANSI-conceal-wrapped secret
+    runs are stripped from each line before it leaves the
+    WS handler.
     """
     config_path = str(controller._db.settings.rel_path(configuration))
     cmd = [*controller._esphome_cmd, "--dashboard", "config", config_path]

--- a/esphome_device_builder/controllers/devices/validate.py
+++ b/esphome_device_builder/controllers/devices/validate.py
@@ -1,0 +1,46 @@
+"""``devices/validate`` WS command body."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .helpers import _redact_concealed_secrets
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .controller import DevicesController
+
+
+async def validate_config(
+    controller: DevicesController,
+    *,
+    configuration: str,
+    show_secrets: bool,
+    client: Any,
+    message_id: str,
+) -> None:
+    """
+    Validate a device YAML config; streams output per-connection.
+
+    ``show_secrets`` opts into ``--show-secrets`` so resolved
+    ``!secret`` values appear in the output. Default is False;
+    a per-call opt-in rather than the legacy dashboard's global
+    ``streamer_mode`` so one user wanting secrets in a
+    multi-user deployment doesn't change the default for
+    everyone else.
+    """
+    config_path = str(controller._db.settings.rel_path(configuration))
+    cmd = [*controller._esphome_cmd, "--dashboard", "config", config_path]
+    line_transform: Callable[[str], str] | None = None
+    if show_secrets:
+        cmd.append("--show-secrets")
+    else:
+        # ``esphome config`` without ``--show-secrets`` doesn't
+        # redact; it wraps each ``password|key|psk|ssid`` value
+        # in the ANSI conceal SGR (8/28). Browsers don't honour
+        # the escape, so the resolved secret bytes were leaking
+        # plain into the validate dialog. Strip the wrapped runs
+        # before the line leaves the WS handler.
+        line_transform = _redact_concealed_secrets
+    await controller._stream_subprocess(cmd, client, message_id, line_transform=line_transform)


### PR DESCRIPTION
# What does this implement/fix?

Continues the `controllers/devices/controller.py` size reduction (1842 → 1825 lines) by extracting the `devices/validate` WS command body into a sibling `validate.py`. Same shape as the prior `@api_command` extracts (`api_key.py`, `add_component.py`): free function takes `controller` as the first arg; the controller keeps a thin bound-method delegate.

`validate.py` (46 lines) hosts the body of `validate_config` — the `esphome config` subprocess invocation plus the ANSI-conceal-SGR redaction the dashboard needs when `show_secrets=False`.

## Why a separate module from `logs.py`

`validate_config` and `stream_logs` both stream subprocess output via `_stream_subprocess`, but they're different WS commands answering different questions. Folding `validate` into `logs.py` would mix concerns; the shared helper (`logs.stream_subprocess`) stays where it is and `validate` routes through `controller._stream_subprocess` like the other callers.

## Test impact

Zero test changes. No tests reference `controller.validate_config` directly or patch module-level symbols inside its body. The `_redact_concealed_secrets` import in `controller.py` was only used by the validate path and is removed.

3223 tests pass; pure refactor.

**Related issue or feature (if applicable):**

- follow-up to #687 (the logs split that left `validate_config` as the last subprocess-streaming WS command on the controller)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
