### PR TITLE
Add config/detect_chip for server-side chip detection

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -6,6 +6,8 @@ import asyncio
 import hmac
 import logging
 import os
+import re
+import sys
 import tempfile
 import threading
 from collections.abc import Iterator
@@ -32,6 +34,7 @@ from ..helpers.secrets_state import (
     read_secrets_yaml,
 )
 from ..helpers.storage_path import resolve_storage_path
+from ..helpers.subprocess import run_subprocess_capture
 from ..models import (
     ErrorCode,
     Label,
@@ -912,6 +915,377 @@ def delete_label_cascade(config_dir: Path, label_id: str) -> tuple[bool, set[str
 
 
 # ---------------------------------------------------------------------------
+# Chip / variant detection helpers (config/detect_chip)
+# ---------------------------------------------------------------------------
+
+# Maps esptool's "Detecting chip type… <X>" family string (lower-cased)
+# to (chip_family, variant, platform) where:
+#
+# - ``chip_family`` matches a ``WIZARD_BOARD_PLATFORMS.label`` value
+#   in the frontend so callers can hand it straight to the board-
+#   picker filter (e.g. ``"ESP32-C3"``). Families that aren't in
+#   the frontend table are still returned verbatim — the frontend
+#   gracefully falls through to "no filter" rather than crashing.
+# - ``variant`` / ``platform`` mirror ESPHome's own variant + platform
+#   keys (the lowercase values that show up in StorageJSON and the
+#   board catalogue).
+#
+# esptool can only identify ESP chips. Non-ESP platforms (RP2040 /
+# RP2350, BK72xx, RTL87xx, LN882x, nRF52) need their own probe path;
+# they're not in this table.
+_CHIP_FAMILY_MAP: dict[str, tuple[str, str, str]] = {
+    "esp32": ("ESP32", "esp32", "esp32"),
+    "esp32-s2": ("ESP32-S2", "esp32s2", "esp32"),
+    "esp32-s3": ("ESP32-S3", "esp32s3", "esp32"),
+    "esp32-c2": ("ESP32-C2", "esp32c2", "esp32"),
+    "esp32-c3": ("ESP32-C3", "esp32c3", "esp32"),
+    "esp32-c5": ("ESP32-C5", "esp32c5", "esp32"),
+    "esp32-c6": ("ESP32-C6", "esp32c6", "esp32"),
+    "esp32-c61": ("ESP32-C61", "esp32c61", "esp32"),
+    "esp32-h2": ("ESP32-H2", "esp32h2", "esp32"),
+    "esp32-p4": ("ESP32-P4", "esp32p4", "esp32"),
+    "esp8266": ("ESP8266", "", "esp8266"),
+}
+
+# ESP-IDF ``esp_app_desc_t`` lives at the start of every IDF app
+# image. With ESPHome's default partition layout the app partition
+# starts at 0x10000 and the descriptor sits at offset 0x20 within,
+# i.e. 0x10020 in flash. The layout is:
+#
+#   magic         u32       offset 0      0xabcd5432, little-endian
+#   secure_ver    u32       offset 4
+#   reserved      u8[8]     offset 8
+#   version       char[32]  offset 16
+#   project_name  char[32]  offset 48
+#   …             (more fields we don't need)
+#
+# ESPHome populates ``project_name`` from ``esphome.name``, which
+# vendors flashing factory firmware set to a catalogue board id —
+# that's how the wizard auto-routes a starter-kit straight to its
+# specific setup screen.
+_APP_DESC_OFFSET = 0x10020
+_APP_DESC_SIZE = 256
+_APP_DESC_MAGIC = 0xABCD5432
+_PROJECT_NAME_OFFSET = 48
+_PROJECT_NAME_SIZE = 32
+
+# Windows port names (COM1 … COM256). Linux / macOS ports start with
+# ``/dev/`` and are validated separately. Catches accidental command
+# injection via the port arg — only well-formed paths reach esptool.
+_WINDOWS_PORT_RE = re.compile(r"^COM\d{1,3}$", re.IGNORECASE)
+
+
+def _is_valid_port_name(port: str) -> bool:
+    """Reject port strings that don't look like a real device path.
+
+    Defence-in-depth — esptool ultimately validates the port itself,
+    but accepting arbitrary strings here would let a malicious caller
+    pass an argv that triggers esptool to read from a path it
+    shouldn't (e.g. a config file). Restrict to ``/dev/<basename>``
+    (POSIX serial nodes) or ``COM<n>`` (Windows).
+    """
+    if port.startswith("/dev/"):
+        # Reject path traversal and shell metacharacters.
+        rest = port[len("/dev/") :]
+        return (
+            bool(rest)
+            and "/" not in rest
+            and ".." not in rest
+            and all(c.isalnum() or c in "-_." for c in rest)
+        )
+    return bool(_WINDOWS_PORT_RE.match(port))
+
+
+def _chip_family_to_descriptor(esptool_family: str) -> dict[str, str] | None:
+    """Map ``"ESP32-C3"`` → ``{chip_family, variant, platform}``."""
+    key = esptool_family.strip().lower()
+    entry = _CHIP_FAMILY_MAP.get(key)
+    if entry is None:
+        return None
+    family, variant, platform = entry
+    return {"chip_family": family, "variant": variant, "platform": platform}
+
+
+def _parse_project_name(blob: bytes) -> str | None:
+    """Pull ``project_name`` out of a 256-byte ``esp_app_desc_t`` blob.
+
+    Returns ``None`` whenever the magic word doesn't match (not an
+    IDF app, or partition-layout drift) or the field is empty.
+    Callers treat this as "no factory firmware present" and fall
+    through to chip-family filtering.
+    """
+    if len(blob) < _PROJECT_NAME_OFFSET + _PROJECT_NAME_SIZE:
+        return None
+    magic = int.from_bytes(blob[0:4], "little")
+    if magic != _APP_DESC_MAGIC:
+        return None
+    raw = blob[_PROJECT_NAME_OFFSET : _PROJECT_NAME_OFFSET + _PROJECT_NAME_SIZE]
+    nul = raw.find(b"\x00")
+    if nul != -1:
+        raw = raw[:nul]
+    try:
+        name = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    return name or None
+
+
+def _find_esptool_cmd() -> list[str]:
+    """Locate the ``esptool`` CLI, preferring the same interpreter as ours.
+
+    Mirrors :func:`controllers.firmware.helpers._find_esphome_cmd`.
+    The backend's own interpreter (``sys.executable``) is the
+    authoritative source: a sibling ``esptool`` script in the same
+    bin directory is preferred when present (its shebang is pinned
+    to our interpreter, so it can't accidentally jump to a different
+    Python), with ``[sys.executable, "-m", "esptool"]`` as the
+    fallback for envs that ship esptool as a module without a
+    standalone script.
+
+    Using the sibling script also dodges the ``"No module named
+    esptool"`` failure mode we hit under VS Code's debugpy launch
+    chain — ``python -m esptool`` from inside a debug-wrapped
+    process can fail module resolution in ways the parent process
+    doesn't, while the standalone script with its absolute-path
+    shebang is launched as a plain executable and always works.
+    """
+    python = sys.executable
+    bin_dir = Path(python).parent
+
+    sibling = bin_dir / ("esptool.exe" if os.name == "nt" else "esptool")
+    if sibling.exists():
+        return [str(sibling)]
+
+    return [python, "-m", "esptool"]
+
+
+# Timeouts for the two esptool subcommands ``detect_chip_cmd``
+# invokes. ``chip-id`` against a healthy ESP usually completes in
+# 2-3 s (reset pulse + ROM handshake + read MAC); the 30 s ceiling
+# leaves headroom for slow USB hubs, macOS re-enumeration delays,
+# and the occasional retry esptool does internally before giving up.
+# ``read-flash`` of 256 B is similar but adds stub upload (a few
+# hundred ms) — same ceiling is fine.
+_CHIP_DETECT_TIMEOUT = 30.0
+_READ_FLASH_TIMEOUT = 30.0
+
+
+def _classify_esptool_failure(output: str) -> str:
+    """Map an esptool error blob to one of the ``_DETECT_*`` reasons.
+
+    Pattern-matches on substrings the esptool CLI prints today —
+    fragile in principle, but the patterns have been stable across
+    v4 → v5 (busy / no-response are OS-level errors that ride
+    through unchanged from pyserial).
+    """
+    lower = output.lower()
+    if "no module named" in lower or "modulenotfounderror" in lower:
+        return _DETECT_NO_ESPTOOL
+    if (
+        "resource busy" in lower
+        or "could not open port" in lower
+        or "port is busy" in lower
+        or "errno 16" in lower
+        or "access is denied" in lower  # Windows equivalent of EBUSY
+        or "permissionerror" in lower
+    ):
+        return _DETECT_BUSY
+    if (
+        "failed to connect" in lower
+        or "no serial data received" in lower
+        or "wrong boot mode detected" in lower
+    ):
+        return _DETECT_NO_RESPONSE
+    return _DETECT_UNKNOWN
+
+
+def _parse_chip_family_line(output: str) -> dict[str, str] | None:
+    r"""Pull the chip family out of an esptool stdout blob.
+
+    esptool prints the family in three places we can target, listed
+    here from most to least reliable:
+
+    1. ``"Chip type:          ESP32-C3 (QFN32) (revision v0.3)"`` —
+       prints unconditionally after a successful detect+connect,
+       happens *after* the collapsing stage finishes (so escape
+       codes never overwrite it).
+    2. ``"Connected to ESP32-C3 on /dev/..."`` — same post-stage
+       guarantee, but the family is embedded mid-line so the
+       extraction is slightly more fragile.
+    3. ``"Detecting chip type... ESP32-C3"`` — what ``_verify_chip``
+       in the firmware controller parses. Lives *inside* the
+       collapsible stage; when esptool's "smart features" are
+       active (TERM set + colours enabled) the line is still in
+       the byte stream but the post-stage ``\x1b[1A\x1b[2K``
+       sequence visually erases it. The bytes themselves survive,
+       so the parser still finds the line — kept as a final
+       fallback for completeness.
+    """
+    # 1) "Chip type:" line — most reliable, immune to stage collapsing.
+    for line in output.splitlines():
+        idx = line.find("Chip type:")
+        if idx != -1:
+            after = line[idx + len("Chip type:") :].strip()
+            # Strip the parenthesised package / revision suffix
+            # (``ESP32-C3 (QFN32) (revision v0.3)`` → ``ESP32-C3``).
+            family = after.split("(")[0].strip()
+            descriptor = _chip_family_to_descriptor(family)
+            if descriptor is not None:
+                return descriptor
+
+    # 2) "Connected to X on" line.
+    for line in output.splitlines():
+        idx = line.find("Connected to ")
+        if idx != -1:
+            after = line[idx + len("Connected to ") :]
+            family = after.split(" on ")[0].strip()
+            descriptor = _chip_family_to_descriptor(family)
+            if descriptor is not None:
+                return descriptor
+
+    # 3) "Detecting chip type..." legacy fallback.
+    for line in output.splitlines():
+        if "Detecting chip type" in line:
+            family = line.split("...")[-1].strip()
+            descriptor = _chip_family_to_descriptor(family)
+            if descriptor is not None:
+                return descriptor
+
+    return None
+
+
+async def _run_esptool(args: list[str], timeout: float) -> tuple[int, bytes]:
+    """Spawn esptool with *args* and capture stdout+stderr.
+
+    Uses :func:`_find_esptool_cmd` to pick the right invocation
+    (sibling script preferred over ``python -m esptool``) and runs
+    through :func:`helpers.subprocess.run_subprocess_capture` — the
+    same one-shot helper :func:`_verify_esphome_importable` uses
+    for the esphome CLI sanity check.
+
+    Returns ``(returncode, stdout)``. On timeout, returncode is the
+    one assigned by the OS to the killed process (typically negative
+    on POSIX). Caller checks the return code; non-zero gets
+    classified by :func:`_classify_esptool_failure`.
+    """
+    cmd = _find_esptool_cmd()
+    result = await run_subprocess_capture(*cmd, *args, timeout=timeout)
+    return result.returncode if result.returncode is not None else -1, result.stdout
+
+
+async def _detect_chip_via_esptool(
+    port: str,
+) -> tuple[dict[str, str] | None, str | None]:
+    """Run ``esptool chip-id`` and parse the chip family.
+
+    Returns ``(descriptor, None)`` on success or
+    ``(None, failure_reason)`` on failure. ``failure_reason`` is one
+    of the ``_DETECT_*`` constants — the handler maps it to a
+    user-facing message.
+    """
+    returncode, stdout = await _run_esptool(["--port", port, "chip-id"], _CHIP_DETECT_TIMEOUT)
+    output = stdout.decode("utf-8", errors="replace")
+    if returncode != 0:
+        _LOGGER.debug("esptool chip-id on %s exited %d: %s", port, returncode, output)
+        return None, _classify_esptool_failure(output)
+    descriptor = _parse_chip_family_line(output)
+    if descriptor is None:
+        _LOGGER.debug(
+            "esptool chip-id on %s succeeded but family wasn't in our map: %s",
+            port,
+            output,
+        )
+        return None, _DETECT_UNKNOWN_CHIP
+    return descriptor, None
+
+
+async def _read_app_descriptor_board_id(port: str) -> str | None:
+    """Best-effort: read 256 B at 0x10020 and decode project_name.
+
+    Failure here is non-fatal — the caller still has chip-family
+    info to narrow the picker with. Uses a tempfile because
+    esptool's ``read-flash`` writes the binary payload to a named
+    file, not stdout.
+    """
+    fd, path = tempfile.mkstemp(prefix="esp_app_desc_", suffix=".bin")
+    os.close(fd)
+    try:
+        returncode, _stdout = await _run_esptool(
+            [
+                "--port",
+                port,
+                "read-flash",
+                hex(_APP_DESC_OFFSET),
+                str(_APP_DESC_SIZE),
+                path,
+            ],
+            _READ_FLASH_TIMEOUT,
+        )
+        if returncode != 0:
+            return None
+        try:
+            blob = Path(path).read_bytes()
+        except OSError:
+            return None
+        return _parse_project_name(blob)
+    finally:
+        with suppress(OSError):
+            os.unlink(path)
+
+
+# Failure classifications for ``_detect_chip_via_esptool``. The
+# handler in ``detect_chip_cmd`` maps each to a user-facing message
+# — they all surface as ``UNAVAILABLE`` to the WS client, the
+# distinction is in the human text. ``BUSY`` is the load-bearing one
+# (a serial monitor or stale WebSerial session is the single most
+# common reason detection fails); without it the user gets a
+# misleading "is a device connected?" message even though the cable
+# is plugged in.
+_DETECT_BUSY = "busy"
+_DETECT_NO_RESPONSE = "no_response"
+_DETECT_TIMEOUT = "timeout"
+_DETECT_NO_ESPTOOL = "no_esptool"
+_DETECT_UNKNOWN_CHIP = "unknown_chip"
+_DETECT_UNKNOWN = "unknown"
+
+
+def _detect_failure_message(reason: str | None, port: str) -> str:
+    """Translate a ``_DETECT_*`` reason into a user-facing message.
+
+    These reach the user directly via the WS error's ``details``
+    field, which the frontend renders inline in the wizard's
+    detection-failed state. Keep them short, specific, and
+    action-oriented — the user just clicked a port and got a red
+    box; they need to know what to do next, not what went wrong
+    internally.
+    """
+    if reason == _DETECT_BUSY:
+        return (
+            f"{port} is already in use by another application. Close any "
+            "browser tab using Web Serial or any serial monitor connected "
+            "to this port, then try again."
+        )
+    if reason == _DETECT_NO_RESPONSE:
+        return (
+            f"No response from a chip on {port}. Check the USB cable, "
+            "and on boards without auto-reset try holding the BOOT button "
+            "while you plug it in."
+        )
+    if reason == _DETECT_UNKNOWN_CHIP:
+        return (
+            f"Detected a device on {port}, but it isn't a recognised ESP "
+            "chip family. This command only supports ESP32 / ESP8266 "
+            "variants — pick a board manually from the list."
+        )
+    if reason == _DETECT_NO_ESPTOOL:
+        return (
+            "Could not run esptool on the server. Make sure esptool is "
+            "installed in the dashboard's Python environment."
+        )
+    return f"Could not detect a chip on {port}. Is a supported ESP device connected?"
+
+
+# ---------------------------------------------------------------------------
 # ConfigController
 # ---------------------------------------------------------------------------
 
@@ -936,6 +1310,45 @@ class ConfigController:
             {"port": p.path, "desc": p.description if p.description != "n/a" else p.path}
             for p in ports
         ]
+
+    @api_command("config/detect_chip")
+    async def detect_chip_cmd(self, **kwargs: Any) -> dict:
+        """Identify what's plugged into a server-side serial port.
+
+        Runs ``esptool chip-id`` to detect the chip family, then
+        best-effort reads the IDF ``esp_app_desc_t`` at flash
+        offset ``0x10020`` for the ``project_name`` field (the
+        board_id baked in by ESPHome at compile time when factory
+        firmware is present). Closes the parity gap with WebSerial,
+        which already does the same locally via esptool-js.
+
+        Returns ``{chip_family, variant, platform, board_id?}``.
+        ``board_id`` is omitted whenever the manifest read fails or
+        the device isn't running an IDF image — callers treat that
+        as "narrow the picker by chip family" and let the user pick
+        the specific board.
+
+        Failures all surface as ``UNAVAILABLE`` but with distinct
+        messages so the user can act: "port busy" (close the
+        offending app), "no response" (check the cable / BOOT
+        button), "unknown chip" (the device responded but isn't
+        an ESP variant we recognise), etc.
+        """
+        port = kwargs.get("port")
+        if not isinstance(port, str) or not port:
+            raise CommandError(ErrorCode.INVALID_ARGS, "port is required")
+        if not _is_valid_port_name(port):
+            raise CommandError(ErrorCode.INVALID_ARGS, f"invalid port: {port!r}")
+
+        chip_info, failure = await _detect_chip_via_esptool(port)
+        if chip_info is None:
+            raise CommandError(ErrorCode.UNAVAILABLE, _detect_failure_message(failure, port))
+
+        result: dict = dict(chip_info)
+        board_id = await _read_app_descriptor_board_id(port)
+        if board_id:
+            result["board_id"] = board_id
+        return result
 
     @api_command("config/get_preferences")
     async def get_prefs(self, **kwargs: Any) -> UserPreferences:

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -918,17 +918,13 @@ def delete_label_cascade(config_dir: Path, label_id: str) -> tuple[bool, set[str
 # Chip / variant detection helpers (config/detect_chip)
 # ---------------------------------------------------------------------------
 
-# Maps esptool's "Detecting chip type… <X>" family string (lower-cased)
-# to (chip_family, variant, platform) where:
-#
-# - ``chip_family`` matches a ``WIZARD_BOARD_PLATFORMS.label`` value
-#   in the frontend so callers can hand it straight to the board-
-#   picker filter (e.g. ``"ESP32-C3"``). Families that aren't in
-#   the frontend table are still returned verbatim — the frontend
-#   gracefully falls through to "no filter" rather than crashing.
-# - ``variant`` / ``platform`` mirror ESPHome's own variant + platform
-#   keys (the lowercase values that show up in StorageJSON and the
-#   board catalogue).
+# Maps esptool's chip family string (lower-cased) to
+# ``(chip_family, variant, platform)``. ``chip_family`` matches a
+# ``WIZARD_BOARD_PLATFORMS.label`` value in the frontend so callers
+# can hand it straight to the board-picker filter; ``variant`` and
+# ``platform`` mirror ESPHome's own keys. Families not in this
+# table cause ``_chip_family_to_descriptor`` to return ``None``,
+# which the WS handler surfaces as ``_DETECT_UNKNOWN_CHIP``.
 #
 # esptool can only identify ESP chips. Non-ESP platforms (RP2040 /
 # RP2350, BK72xx, RTL87xx, LN882x, nRF52) need their own probe path;
@@ -969,9 +965,9 @@ _APP_DESC_MAGIC = 0xABCD5432
 _PROJECT_NAME_OFFSET = 48
 _PROJECT_NAME_SIZE = 32
 
-# Windows port names (COM1 … COM256). Linux / macOS ports start with
+# Windows ``COM<n>`` port names. Linux / macOS ports start with
 # ``/dev/`` and are validated separately. Catches accidental command
-# injection via the port arg — only well-formed paths reach esptool.
+# injection via the port arg — only well-formed names reach esptool.
 _WINDOWS_PORT_RE = re.compile(r"^COM\d{1,3}$", re.IGNORECASE)
 
 
@@ -1075,19 +1071,23 @@ def _classify_esptool_failure(output: str) -> str:
 
     Pattern-matches on substrings the esptool CLI prints today —
     fragile in principle, but the patterns have been stable across
-    v4 → v5 (busy / no-response are OS-level errors that ride
-    through unchanged from pyserial).
+    v4 → v5 (the underlying errors come from pyserial / the OS,
+    not esptool itself).
     """
     lower = output.lower()
     if "no module named" in lower or "modulenotfounderror" in lower:
         return _DETECT_NO_ESPTOOL
+    # POSIX EACCES (errno 13) and pyserial's PermissionError typically
+    # mean the user isn't in the dialout group on Linux — different
+    # fix from EBUSY (close another app), so they get their own bucket.
+    if "errno 13" in lower or "permissionerror" in lower or "permission denied" in lower:
+        return _DETECT_PERMISSION
     if (
         "resource busy" in lower
         or "could not open port" in lower
         or "port is busy" in lower
         or "errno 16" in lower
         or "access is denied" in lower  # Windows equivalent of EBUSY
-        or "permissionerror" in lower
     ):
         return _DETECT_BUSY
     if (
@@ -1154,7 +1154,7 @@ def _parse_chip_family_line(output: str) -> dict[str, str] | None:
     return None
 
 
-async def _run_esptool(args: list[str], timeout: float) -> tuple[int, bytes]:
+async def _run_esptool(args: list[str], timeout: float) -> tuple[int, bytes, bool]:
     """Spawn esptool with *args* and capture stdout+stderr.
 
     Uses :func:`_find_esptool_cmd` to pick the right invocation
@@ -1163,14 +1163,15 @@ async def _run_esptool(args: list[str], timeout: float) -> tuple[int, bytes]:
     same one-shot helper :func:`_verify_esphome_importable` uses
     for the esphome CLI sanity check.
 
-    Returns ``(returncode, stdout)``. On timeout, returncode is the
-    one assigned by the OS to the killed process (typically negative
-    on POSIX). Caller checks the return code; non-zero gets
-    classified by :func:`_classify_esptool_failure`.
+    Returns ``(returncode, stdout, timed_out)``. The caller treats
+    ``timed_out`` separately from a normal non-zero exit so the WS
+    error message can recommend an unplug/replug rather than
+    pointing at the cable.
     """
     cmd = _find_esptool_cmd()
     result = await run_subprocess_capture(*cmd, *args, timeout=timeout)
-    return result.returncode if result.returncode is not None else -1, result.stdout
+    rc = result.returncode if result.returncode is not None else -1
+    return rc, result.stdout, result.timed_out
 
 
 async def _detect_chip_via_esptool(
@@ -1183,7 +1184,12 @@ async def _detect_chip_via_esptool(
     of the ``_DETECT_*`` constants — the handler maps it to a
     user-facing message.
     """
-    returncode, stdout = await _run_esptool(["--port", port, "chip-id"], _CHIP_DETECT_TIMEOUT)
+    returncode, stdout, timed_out = await _run_esptool(
+        ["--port", port, "chip-id"], _CHIP_DETECT_TIMEOUT
+    )
+    if timed_out:
+        _LOGGER.debug("esptool chip-id on %s timed out after %ss", port, _CHIP_DETECT_TIMEOUT)
+        return None, _DETECT_TIMEOUT
     output = stdout.decode("utf-8", errors="replace")
     if returncode != 0:
         _LOGGER.debug("esptool chip-id on %s exited %d: %s", port, returncode, output)
@@ -1210,7 +1216,7 @@ async def _read_app_descriptor_board_id(port: str) -> str | None:
     fd, path = tempfile.mkstemp(prefix="esp_app_desc_", suffix=".bin")
     os.close(fd)
     try:
-        returncode, _stdout = await _run_esptool(
+        returncode, _stdout, timed_out = await _run_esptool(
             [
                 "--port",
                 port,
@@ -1221,7 +1227,7 @@ async def _read_app_descriptor_board_id(port: str) -> str | None:
             ],
             _READ_FLASH_TIMEOUT,
         )
-        if returncode != 0:
+        if timed_out or returncode != 0:
             return None
         try:
             blob = Path(path).read_bytes()
@@ -1242,6 +1248,7 @@ async def _read_app_descriptor_board_id(port: str) -> str | None:
 # misleading "is a device connected?" message even though the cable
 # is plugged in.
 _DETECT_BUSY = "busy"
+_DETECT_PERMISSION = "permission"
 _DETECT_NO_RESPONSE = "no_response"
 _DETECT_TIMEOUT = "timeout"
 _DETECT_NO_ESPTOOL = "no_esptool"
@@ -1249,40 +1256,49 @@ _DETECT_UNKNOWN_CHIP = "unknown_chip"
 _DETECT_UNKNOWN = "unknown"
 
 
-def _detect_failure_message(reason: str | None, port: str) -> str:
-    """Translate a ``_DETECT_*`` reason into a user-facing message.
+# Per-reason message templates. ``{port}`` is interpolated by
+# ``_detect_failure_message`` so each template stays a plain string
+# literal — easier to scan than nested f-strings inside a branchy
+# function (and keeps ruff happy about the if/elif chain length).
+_DETECT_FAILURE_MESSAGES: dict[str, str] = {
+    _DETECT_BUSY: (
+        "{port} is already in use by another application. Close any "
+        "browser tab using Web Serial or any serial monitor connected "
+        "to this port, then try again."
+    ),
+    _DETECT_PERMISSION: (
+        "Permission denied opening {port}. On Linux your user may "
+        "need to be in the ``dialout`` group "
+        "(``sudo usermod -a -G dialout $USER`` and log back in)."
+    ),
+    _DETECT_NO_RESPONSE: (
+        "No response from a chip on {port}. Check the USB cable, "
+        "and on boards without auto-reset try holding the BOOT button "
+        "while you plug it in."
+    ),
+    _DETECT_TIMEOUT: (
+        "esptool didn't finish in time on {port}. The chip may be "
+        "unresponsive — unplug and replug, then try again."
+    ),
+    _DETECT_UNKNOWN_CHIP: (
+        "Detected a device on {port}, but it isn't a recognised ESP "
+        "chip family. This command only supports ESP32 / ESP8266 "
+        "variants — pick a board manually from the list."
+    ),
+    _DETECT_NO_ESPTOOL: (
+        "Could not run esptool on the server. Make sure esptool is "
+        "installed in the dashboard's Python environment."
+    ),
+}
 
-    These reach the user directly via the WS error's ``details``
-    field, which the frontend renders inline in the wizard's
-    detection-failed state. Keep them short, specific, and
-    action-oriented — the user just clicked a port and got a red
-    box; they need to know what to do next, not what went wrong
-    internally.
-    """
-    if reason == _DETECT_BUSY:
-        return (
-            f"{port} is already in use by another application. Close any "
-            "browser tab using Web Serial or any serial monitor connected "
-            "to this port, then try again."
-        )
-    if reason == _DETECT_NO_RESPONSE:
-        return (
-            f"No response from a chip on {port}. Check the USB cable, "
-            "and on boards without auto-reset try holding the BOOT button "
-            "while you plug it in."
-        )
-    if reason == _DETECT_UNKNOWN_CHIP:
-        return (
-            f"Detected a device on {port}, but it isn't a recognised ESP "
-            "chip family. This command only supports ESP32 / ESP8266 "
-            "variants — pick a board manually from the list."
-        )
-    if reason == _DETECT_NO_ESPTOOL:
-        return (
-            "Could not run esptool on the server. Make sure esptool is "
-            "installed in the dashboard's Python environment."
-        )
-    return f"Could not detect a chip on {port}. Is a supported ESP device connected?"
+
+def _detect_failure_message(reason: str | None, port: str) -> str:
+    """Translate a ``_DETECT_*`` reason into a user-facing message."""
+    template = _DETECT_FAILURE_MESSAGES.get(
+        reason or "",
+        "Could not detect a chip on {port}. Is a supported ESP device connected?",
+    )
+    return template.format(port=port)
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -7,7 +7,6 @@ import hmac
 import logging
 import os
 import re
-import sys
 import tempfile
 import threading
 from collections.abc import Iterator
@@ -1026,35 +1025,6 @@ def _parse_project_name(blob: bytes) -> str | None:
     return name or None
 
 
-def _find_esptool_cmd() -> list[str]:
-    """Locate the ``esptool`` CLI, preferring the same interpreter as ours.
-
-    Mirrors :func:`controllers.firmware.helpers._find_esphome_cmd`.
-    The backend's own interpreter (``sys.executable``) is the
-    authoritative source: a sibling ``esptool`` script in the same
-    bin directory is preferred when present (its shebang is pinned
-    to our interpreter, so it can't accidentally jump to a different
-    Python), with ``[sys.executable, "-m", "esptool"]`` as the
-    fallback for envs that ship esptool as a module without a
-    standalone script.
-
-    Using the sibling script also dodges the ``"No module named
-    esptool"`` failure mode we hit under VS Code's debugpy launch
-    chain — ``python -m esptool`` from inside a debug-wrapped
-    process can fail module resolution in ways the parent process
-    doesn't, while the standalone script with its absolute-path
-    shebang is launched as a plain executable and always works.
-    """
-    python = sys.executable
-    bin_dir = Path(python).parent
-
-    sibling = bin_dir / ("esptool.exe" if os.name == "nt" else "esptool")
-    if sibling.exists():
-        return [str(sibling)]
-
-    return [python, "-m", "esptool"]
-
-
 # Timeouts for the two esptool subcommands ``detect_chip_cmd``
 # invokes. ``chip-id`` against a healthy ESP usually completes in
 # 2-3 s (reset pulse + ROM handshake + read MAC); the 30 s ceiling
@@ -1157,17 +1127,23 @@ def _parse_chip_family_line(output: str) -> dict[str, str] | None:
 async def _run_esptool(args: list[str], timeout: float) -> tuple[int, bytes, bool]:
     """Spawn esptool with *args* and capture stdout+stderr.
 
-    Uses :func:`_find_esptool_cmd` to pick the right invocation
-    (sibling script preferred over ``python -m esptool``) and runs
-    through :func:`helpers.subprocess.run_subprocess_capture` — the
-    same one-shot helper :func:`_verify_esphome_importable` uses
-    for the esphome CLI sanity check.
+    Uses :func:`controllers.firmware.helpers._find_esptool_cmd` to
+    pick the right invocation (sibling script preferred over
+    ``python -m esptool``) and runs through
+    :func:`helpers.subprocess.run_subprocess_capture` — the same
+    one-shot helper :func:`_verify_esphome_importable` uses.
 
     Returns ``(returncode, stdout, timed_out)``. The caller treats
     ``timed_out`` separately from a normal non-zero exit so the WS
     error message can recommend an unplug/replug rather than
     pointing at the cable.
+
+    Lazy-imported to avoid a ``config`` ↔ ``firmware.persistence``
+    circular import (persistence reaches back into config for
+    ``_load_metadata`` / ``metadata_transaction``).
     """
+    from .firmware.helpers import _find_esptool_cmd  # noqa: PLC0415
+
     cmd = _find_esptool_cmd()
     result = await run_subprocess_capture(*cmd, *args, timeout=timeout)
     rc = result.returncode if result.returncode is not None else -1

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -1181,16 +1181,39 @@ async def _detect_chip_via_esptool(
     return descriptor, None
 
 
+def _make_descriptor_tempfile() -> str:
+    """Allocate (and close) a tempfile for esptool's ``read-flash`` output."""
+    fd, path = tempfile.mkstemp(prefix="esp_app_desc_", suffix=".bin")
+    os.close(fd)
+    return path
+
+
+def _read_descriptor_file(path: str) -> str | None:
+    """Read *path* and decode ``project_name`` from the app descriptor."""
+    try:
+        blob = Path(path).read_bytes()
+    except OSError:
+        return None
+    return _parse_project_name(blob)
+
+
+def _unlink_quietly(path: str) -> None:
+    """``os.unlink(path)`` swallowing ``OSError``."""
+    with suppress(OSError):
+        os.unlink(path)
+
+
 async def _read_app_descriptor_board_id(port: str) -> str | None:
     """Best-effort: read 256 B at 0x10020 and decode project_name.
 
     Failure here is non-fatal — the caller still has chip-family
     info to narrow the picker with. Uses a tempfile because
     esptool's ``read-flash`` writes the binary payload to a named
-    file, not stdout.
+    file, not stdout. The tempfile-create / read / unlink are sync
+    FS calls so they run via ``asyncio.to_thread`` to keep
+    blockbuster happy.
     """
-    fd, path = tempfile.mkstemp(prefix="esp_app_desc_", suffix=".bin")
-    os.close(fd)
+    path = await asyncio.to_thread(_make_descriptor_tempfile)
     try:
         returncode, _stdout, timed_out = await _run_esptool(
             [
@@ -1205,14 +1228,9 @@ async def _read_app_descriptor_board_id(port: str) -> str | None:
         )
         if timed_out or returncode != 0:
             return None
-        try:
-            blob = Path(path).read_bytes()
-        except OSError:
-            return None
-        return _parse_project_name(blob)
+        return await asyncio.to_thread(_read_descriptor_file, path)
     finally:
-        with suppress(OSError):
-            os.unlink(path)
+        await asyncio.to_thread(_unlink_quietly, path)
 
 
 # Failure classifications for ``_detect_chip_via_esptool``. The

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -16,6 +15,7 @@ from ...helpers.remote_build_layout import parse_from_configuration as parse_rem
 from ...helpers.storage_path import resolve_storage_path
 from ...models import FirmwareJob, JobType
 from .constants import _OTA_ADDRESS_CACHE_JOB_TYPES, ESPHOME_SUBPROCESS_ENV
+from .helpers import _find_esptool_cmd
 
 if TYPE_CHECKING:
     from .controller import FirmwareController
@@ -125,9 +125,7 @@ async def verify_chip(controller: FirmwareController, job: FirmwareJob) -> None:
     expected_platform = storage.target_platform.lower()
 
     async with controller._tracked_subprocess(
-        sys.executable,
-        "-m",
-        "esptool",
+        *_find_esptool_cmd(),
         "--port",
         job.port,
         "chip-id",

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -15,6 +15,7 @@ import os
 import re
 import sys
 from datetime import UTC, datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -167,7 +168,7 @@ def _find_esphome_cmd() -> list[str]:
     ``python -m esphome`` and surfaces a friendlier traceback when
     something goes wrong inside esphome).
     """
-    return _find_sibling_cli("esphome")
+    return list(_find_sibling_cli("esphome"))
 
 
 def _find_esptool_cmd() -> list[str]:
@@ -181,16 +182,26 @@ def _find_esptool_cmd() -> list[str]:
     a debug-wrapped process can fail module resolution in ways the
     parent process doesn't.
     """
-    return _find_sibling_cli("esptool")
+    return list(_find_sibling_cli("esptool"))
 
 
-def _find_sibling_cli(name: str) -> list[str]:
-    """Sibling script next to ``sys.executable``, else ``python -m <name>``."""
+@lru_cache(maxsize=8)
+def _find_sibling_cli(name: str) -> tuple[str, ...]:
+    """Sibling script next to ``sys.executable``, else ``python -m <name>``.
+
+    Result is cached so the ``sibling.exists()`` filesystem probe
+    runs once per ``name`` — async callers (``_run_esptool``,
+    ``verify_chip``) would otherwise trip ``blockbuster`` on every
+    invocation, since ``Path.exists`` calls ``os.stat`` synchronously.
+
+    Returns a tuple so the cached value can't be mutated by callers
+    that copy it into their own argv list.
+    """
     python = sys.executable
     sibling = Path(python).parent / (f"{name}.exe" if os.name == "nt" else name)
     if sibling.exists():
-        return [str(sibling)]
-    return [python, "-m", name]
+        return (str(sibling),)
+    return (python, "-m", name)
 
 
 def _parse_progress(line: str) -> int | None:

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -167,14 +167,30 @@ def _find_esphome_cmd() -> list[str]:
     ``python -m esphome`` and surfaces a friendlier traceback when
     something goes wrong inside esphome).
     """
+    return _find_sibling_cli("esphome")
+
+
+def _find_esptool_cmd() -> list[str]:
+    """Locate the ``esptool`` CLI, preferring the same interpreter as ours.
+
+    Same sibling-script-first lookup as :func:`_find_esphome_cmd`.
+    The sibling script's shebang is pinned to our interpreter so it
+    can't accidentally jump to a different Python — and it dodges
+    the ``"No module named esptool"`` failure mode under VS Code's
+    debugpy launch chain, where ``python -m esptool`` from inside
+    a debug-wrapped process can fail module resolution in ways the
+    parent process doesn't.
+    """
+    return _find_sibling_cli("esptool")
+
+
+def _find_sibling_cli(name: str) -> list[str]:
+    """Sibling script next to ``sys.executable``, else ``python -m <name>``."""
     python = sys.executable
-    bin_dir = Path(python).parent
-
-    sibling_esphome = bin_dir / ("esphome.exe" if os.name == "nt" else "esphome")
-    if sibling_esphome.exists():
-        return [str(sibling_esphome)]
-
-    return [python, "-m", "esphome"]
+    sibling = Path(python).parent / (f"{name}.exe" if os.name == "nt" else name)
+    if sibling.exists():
+        return [str(sibling)]
+    return [python, "-m", name]
 
 
 def _parse_progress(line: str) -> int | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,14 @@ _STARTUP_BLOCKING_OK: tuple[tuple[str, str], ...] = (
     # once at HA-add-on startup as an aiohttp ``on_startup`` hook —
     # the cost is paid once, not on the request path.
     ("device_builder.py", "_start_ingress_site"),
+    # ``_find_sibling_cli`` probes for ``<bin>/esphome`` and
+    # ``<bin>/esptool`` to pick between a sibling script and
+    # ``python -m <cli>``. The result is ``lru_cache``-d so the
+    # ``os.stat`` only fires once per ``name`` per process — first
+    # call is on a request path (``_run_esptool`` for chip detect,
+    # ``verify_chip`` for firmware install) but every subsequent
+    # one hits the cache.
+    ("controllers/firmware/helpers.py", "_find_sibling_cli"),
 )
 
 

--- a/tests/controllers/firmware/test_helpers.py
+++ b/tests/controllers/firmware/test_helpers.py
@@ -40,6 +40,7 @@ from esphome_device_builder.controllers.firmware.constants import (
 )
 from esphome_device_builder.controllers.firmware.helpers import (
     _find_esphome_cmd,
+    _find_esptool_cmd,
     _names_touched_by_job,
     _trim_job_output,
     _verify_esphome_importable,
@@ -374,6 +375,36 @@ def test_find_esphome_cmd_picks_esphome_exe_on_windows(
     cmd = _find_esphome_cmd()
 
     assert cmd == [str(bin_dir / "esphome.exe")]
+
+
+def test_find_esptool_cmd_prefers_sibling_script(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sibling ``esptool`` next to ``sys.executable`` wins over ``-m esptool``."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    sibling = bin_dir / ("esptool.exe" if os.name == "nt" else "esptool")
+    sibling.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+
+    assert _find_esptool_cmd() == [str(sibling)]
+
+
+def test_find_esptool_cmd_falls_back_to_python_dash_m(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No sibling esptool → ``[sys.executable, '-m', 'esptool']``."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+
+    assert _find_esptool_cmd() == [str(fake_python), "-m", "esptool"]
 
 
 def test_find_esphome_cmd_does_not_substitute_sibling_python(

--- a/tests/controllers/firmware/test_helpers.py
+++ b/tests/controllers/firmware/test_helpers.py
@@ -41,6 +41,7 @@ from esphome_device_builder.controllers.firmware.constants import (
 from esphome_device_builder.controllers.firmware.helpers import (
     _find_esphome_cmd,
     _find_esptool_cmd,
+    _find_sibling_cli,
     _names_touched_by_job,
     _trim_job_output,
     _verify_esphome_importable,
@@ -259,8 +260,22 @@ async def test_verify_esphome_importable_returns_false_on_timeout(
 
 
 # ---------------------------------------------------------------------------
-# _find_esphome_cmd
+# _find_esphome_cmd / _find_esptool_cmd
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_sibling_cli_cache() -> Any:
+    """Reset the ``_find_sibling_cli`` lru_cache before each test.
+
+    The cache exists so async callers don't trip blockbuster on
+    repeated ``os.stat`` calls, but it would carry state between
+    tests that ``monkeypatch.setattr(sys, "executable", ...)`` —
+    making the second test see the first test's resolved path.
+    """
+    _find_sibling_cli.cache_clear()
+    yield
+    _find_sibling_cli.cache_clear()
 
 
 def test_find_esphome_cmd_prefers_sibling_binary_when_present(

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -11,11 +11,14 @@ and the recorded subprocess invocations) drive the assertions.
 touches; it's the runner entry point and exists to be driven
 in tests this way.
 
-The chip-id check spawns ``[sys.executable, '-m', 'esptool',
-'--port', <port>, 'chip-id']`` via ``create_subprocess_exec``.
-Tests substitute that helper module-level so each one's "esptool"
-output can be controlled while the real subsequent build still
-runs through the same wrapper (substitute returns a no-op
+The chip-id check spawns ``[*_find_esptool_cmd(), '--port', <port>,
+'chip-id']`` via ``create_subprocess_exec``. The resolved command is
+either a sibling ``esptool`` script next to ``sys.executable`` or
+``[sys.executable, '-m', 'esptool']`` as a fallback (see
+``_find_esptool_cmd`` in ``controllers.firmware.helpers``). Tests
+substitute ``create_subprocess_exec`` module-level so each one's
+"esptool" output can be controlled while the real subsequent build
+still runs through the same wrapper (substitute returns a no-op
 success-exit script for non-esptool calls).
 
 The expected chip variant comes from a real StorageJSON sidecar
@@ -171,6 +174,19 @@ def _redirect_ext_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     monkeypatch.setattr(controller_module, "resolve_storage_path", _ext)
 
 
+def _is_esptool_spawn(args: tuple[Any, ...]) -> bool:
+    """Match either esptool-spawn argv shape ``_find_esptool_cmd`` produces.
+
+    Sibling script (``<bin>/esptool``) on dev venvs;
+    ``[sys.executable, '-m', 'esptool']`` fallback on slim images.
+    """
+    if not args:
+        return False
+    if Path(str(args[0])).name in ("esptool", "esptool.exe"):
+        return True
+    return len(args) >= 3 and args[0] == sys.executable and args[1] == "-m" and args[2] == "esptool"
+
+
 def _patch_subprocess(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -194,14 +210,7 @@ def _patch_subprocess(
     real = controller_module.create_subprocess_exec
 
     async def _wrapper(*args: Any, **kwargs: Any) -> Any:
-        # esptool spawn:
-        # ``sys.executable -m esptool --port <port> chip-id``.
-        if (
-            len(args) >= 3
-            and args[0] == sys.executable
-            and args[1] == "-m"
-            and args[2] == "esptool"
-        ):
+        if _is_esptool_spawn(args):
             record["esptool_calls"].append(args)
             return await real(
                 sys.executable,
@@ -593,12 +602,7 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     verify_spawned = asyncio.Event()
 
     async def _wrapper(*args: Any, **kwargs: Any) -> Any:
-        if (
-            len(args) >= 3
-            and args[0] == sys.executable
-            and args[1] == "-m"
-            and args[2] == "esptool"
-        ):
+        if _is_esptool_spawn(args):
             verify_spawned.set()
             # Sleep long enough that any non-cancelled run would
             # blow the test timeout — the assertion that the test
@@ -679,12 +683,7 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
 
     async def _wrapper(*args: Any, **kwargs: Any) -> Any:
         nonlocal cancel_armed
-        if (
-            len(args) >= 3
-            and args[0] == sys.executable
-            and args[1] == "-m"
-            and args[2] == "esptool"
-        ):
+        if _is_esptool_spawn(args):
             # Simulate the in-flight cancel: queue the flag set
             # before the verify subprocess returns. The fake exits
             # quickly (no real hang) so the runner reaches the post-

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -40,14 +40,18 @@ from esphome.util import SerialPort
 from esphome_device_builder.controllers.config import (
     _APP_DESC_MAGIC,
     _APP_DESC_SIZE,
+    _DETECT_UNKNOWN,
     _PROJECT_NAME_OFFSET,
     _PROJECT_NAME_SIZE,
     ConfigController,
     _chip_family_to_descriptor,
+    _classify_esptool_failure,
     _is_valid_port_name,
     _load_metadata,
     _parse_chip_family_line,
     _parse_project_name,
+    _read_descriptor_file,
+    _run_esptool,
     _save_metadata,
     delete_label_cascade,
     get_device_ip,
@@ -1120,6 +1124,126 @@ def test_parse_project_name_returns_none_when_empty() -> None:
         b"\x00" * _PROJECT_NAME_SIZE
     )
     assert _parse_project_name(bytes(blob)) is None
+
+
+def test_parse_project_name_returns_none_when_blob_truncated() -> None:
+    """Short blob (less than offset+size) returns None instead of slicing past it."""
+    assert _parse_project_name(b"\x00" * 16) is None
+
+
+def test_parse_project_name_returns_none_on_unicode_decode_error() -> None:
+    """Invalid UTF-8 in project_name returns None rather than raising."""
+    blob = bytearray(_app_descriptor_blob("placeholder"))
+    # Stuff invalid UTF-8 continuation bytes in front of the NUL.
+    blob[_PROJECT_NAME_OFFSET : _PROJECT_NAME_OFFSET + 4] = b"\xff\xfe\xfd\x00"
+    assert _parse_project_name(bytes(blob)) is None
+
+
+def test_classify_esptool_failure_returns_unknown_for_unrecognised_output() -> None:
+    """Output that matches no busy / permission / no-response pattern → ``_DETECT_UNKNOWN``."""
+    assert _classify_esptool_failure("some unfamiliar esptool error") == _DETECT_UNKNOWN
+
+
+def test_read_descriptor_file_returns_none_on_oserror(tmp_path: Path) -> None:
+    """Missing file → ``None`` (read failure surfaced as "no manifest")."""
+    assert _read_descriptor_file(str(tmp_path / "does-not-exist.bin")) is None
+
+
+@pytest.mark.asyncio
+async def test_run_esptool_calls_run_subprocess_capture_with_resolved_cmd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_run_esptool`` resolves the CLI via ``_find_esptool_cmd`` and forwards args.
+
+    Mocks ``run_subprocess_capture`` (the underlying one-shot helper) and
+    asserts the full argv shape — sibling-script first slot, then the
+    caller's args — plus that the captured ``(rc, stdout, timed_out)``
+    tuple is propagated verbatim.
+    """
+    captured_args: list[tuple[Any, ...]] = []
+    captured_kwargs: dict[str, Any] = {}
+
+    class _FakeCaptured:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = b"Chip type:          ESP32-C3\n"
+            self.timed_out = False
+
+    async def fake_capture(*args: Any, **kwargs: Any) -> _FakeCaptured:
+        captured_args.append(args)
+        captured_kwargs.update(kwargs)
+        return _FakeCaptured()
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.config.run_subprocess_capture", fake_capture
+    )
+
+    rc, stdout, timed_out = await _run_esptool(["--port", "/dev/ttyUSB0", "chip-id"], 30.0)
+
+    assert rc == 0
+    assert stdout == b"Chip type:          ESP32-C3\n"
+    assert timed_out is False
+    # Forwarded args land after the resolved CLI prefix, timeout is keyword.
+    assert captured_args[0][-3:] == ("--port", "/dev/ttyUSB0", "chip-id")
+    assert captured_kwargs == {"timeout": 30.0}
+
+
+@pytest.mark.asyncio
+async def test_run_esptool_substitutes_minus_one_when_returncode_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_run_esptool`` maps a None returncode (timeout-kill) to ``-1``.
+
+    Otherwise a falsy ``None`` could pass for a clean exit and the
+    caller would treat the empty stdout as a parse failure.
+    """
+
+    class _FakeCaptured:
+        def __init__(self) -> None:
+            self.returncode = None
+            self.stdout = b""
+            self.timed_out = True
+
+    async def fake_capture(*args: Any, **kwargs: Any) -> _FakeCaptured:
+        return _FakeCaptured()
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.config.run_subprocess_capture", fake_capture
+    )
+
+    rc, _stdout, timed_out = await _run_esptool(["--port", "/dev/ttyUSB0", "chip-id"], 1.0)
+    assert rc == -1
+    assert timed_out is True
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_omits_board_id_when_read_flash_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manifest read returning non-zero → ``board_id`` omitted, chip info kept.
+
+    Exercises the ``timed_out or returncode != 0`` early-return inside
+    ``_read_app_descriptor_board_id`` — the other manifest tests
+    write a blob unconditionally, so they don't reach this branch.
+    """
+
+    def fake(args: list[str]) -> tuple[int, bytes]:
+        if "chip-id" in args:
+            return 0, b"Chip type:          ESP32-C3\n"
+        # read-flash fails — non-zero exit, no blob written.
+        return 1, b"timeout reading flash"
+
+    _mock_run_esptool(monkeypatch, fake)
+    controller = _make_controller(tmp_path)
+
+    result = await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+
+    assert result == {
+        "chip_family": "ESP32-C3",
+        "variant": "esp32c3",
+        "platform": "esp32",
+    }
+    assert "board_id" not in result
 
 
 def test_is_valid_port_name_accepts_real_paths() -> None:

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -38,8 +38,17 @@ import pytest
 from esphome.util import SerialPort
 
 from esphome_device_builder.controllers.config import (
+    _APP_DESC_MAGIC,
+    _APP_DESC_SIZE,
+    _PROJECT_NAME_OFFSET,
+    _PROJECT_NAME_SIZE,
     ConfigController,
+    _chip_family_to_descriptor,
+    _find_esptool_cmd,
+    _is_valid_port_name,
     _load_metadata,
+    _parse_chip_family_line,
+    _parse_project_name,
     _save_metadata,
     delete_label_cascade,
     get_device_ip,
@@ -1012,6 +1021,354 @@ async def test_get_serial_ports_substitutes_path_for_na_description(
     result = await controller.get_serial_ports_cmd()
 
     assert result == [{"port": "/dev/ttyUSB0", "desc": "/dev/ttyUSB0"}]
+
+
+# ---------------------------------------------------------------------------
+# Chip detection — config/detect_chip
+# ---------------------------------------------------------------------------
+
+
+def _app_descriptor_blob(project_name: str = "starter-kit") -> bytes:
+    """Build a synthetic ``esp_app_desc_t`` payload for parser tests.
+
+    Mirrors the layout the parser reads: magic word at offset 0,
+    project_name (NUL-terminated, ASCII) at offset 48. Everything
+    else is zero — the parser only touches those two fields.
+    """
+    blob = bytearray(_APP_DESC_SIZE)
+    blob[0:4] = _APP_DESC_MAGIC.to_bytes(4, "little")
+    encoded = project_name.encode("utf-8")
+    assert len(encoded) < _PROJECT_NAME_SIZE
+    blob[_PROJECT_NAME_OFFSET : _PROJECT_NAME_OFFSET + len(encoded)] = encoded
+    return bytes(blob)
+
+
+def test_parse_chip_family_line_from_chip_type_line() -> None:
+    """Primary path — the post-stage ``Chip type:`` line.
+
+    Pins the parser against the exact output esptool v5.2 produces
+    against an M5Stamp-C3 (captured from a live device).
+    """
+    output = (
+        "esptool v5.2.0\n"
+        "Serial port /dev/cu.usbserial-54FC0197371:\n"
+        "Connecting....\n"
+        "Detecting chip type... ESP32-C3\n"
+        "Connected to ESP32-C3 on /dev/cu.usbserial-54FC0197371:\n"
+        "Chip type:          ESP32-C3 (QFN32) (revision v0.3)\n"
+        "MAC:                a0:76:4e:19:de:78\n"
+    )
+    assert _parse_chip_family_line(output) == {
+        "chip_family": "ESP32-C3",
+        "variant": "esp32c3",
+        "platform": "esp32",
+    }
+
+
+def test_parse_chip_family_line_falls_back_to_connected_to() -> None:
+    """Fallback when ``Chip type:`` is absent.
+
+    Secure Download Mode prints a different shape but still emits
+    ``Connected to X on …`` before bailing.
+    """
+    output = (
+        "Connecting....\n"
+        "Connected to ESP32-S3 on /dev/cu.usbmodem1234:\n"
+        "Chip is in Secure Download Mode\n"
+    )
+    assert _parse_chip_family_line(output) == {
+        "chip_family": "ESP32-S3",
+        "variant": "esp32s3",
+        "platform": "esp32",
+    }
+
+
+def test_parse_chip_family_line_legacy_detecting_line() -> None:
+    """Legacy fallback — the pre-stage ``Detecting chip type`` line.
+
+    Same shape ``_verify_chip`` in the firmware controller parses.
+    """
+    output = "Detecting chip type... ESP32-C3"
+    assert _parse_chip_family_line(output) == {
+        "chip_family": "ESP32-C3",
+        "variant": "esp32c3",
+        "platform": "esp32",
+    }
+
+
+def test_parse_chip_family_line_returns_none_when_unparseable() -> None:
+    assert _parse_chip_family_line("nothing useful here") is None
+
+
+def test_parse_chip_family_line_returns_none_for_unknown_family() -> None:
+    assert _parse_chip_family_line("Chip type: ESP32-Z99 (revision v9.9)") is None
+
+
+def test_find_esptool_cmd_prefers_sibling_script(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When an ``esptool`` script lives next to ``sys.executable``, use it.
+
+    Mirrors ``_find_esphome_cmd``'s sibling-script preference — and
+    dodges the ``python -m esptool`` failure mode we hit under VS
+    Code debugpy launches where the wrapper layer breaks ``-m``
+    module resolution even though ``import esptool`` works fine in
+    the parent process.
+    """
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text("#!/bin/sh\n")
+    fake_python.chmod(0o755)
+    sibling = fake_bin / "esptool"
+    sibling.write_text("#!/bin/sh\n")
+    sibling.chmod(0o755)
+
+    monkeypatch.setattr("sys.executable", str(fake_python))
+    assert _find_esptool_cmd() == [str(sibling)]
+
+
+def test_find_esptool_cmd_falls_back_to_module_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without a sibling script — return ``[python, -m, esptool]``."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text("#!/bin/sh\n")
+    fake_python.chmod(0o755)
+
+    monkeypatch.setattr("sys.executable", str(fake_python))
+    assert _find_esptool_cmd() == [str(fake_python), "-m", "esptool"]
+
+
+def test_chip_family_to_descriptor_maps_esp8266() -> None:
+    assert _chip_family_to_descriptor("ESP8266") == {
+        "chip_family": "ESP8266",
+        "variant": "",
+        "platform": "esp8266",
+    }
+
+
+def test_parse_project_name_returns_project_name_when_magic_matches() -> None:
+    blob = _app_descriptor_blob("starter-kit")
+    assert _parse_project_name(blob) == "starter-kit"
+
+
+def test_parse_project_name_returns_none_on_bad_magic() -> None:
+    blob = bytearray(_app_descriptor_blob("starter-kit"))
+    blob[0:4] = (0xDEADBEEF).to_bytes(4, "little")
+    assert _parse_project_name(bytes(blob)) is None
+
+
+def test_parse_project_name_returns_none_when_empty() -> None:
+    # Magic matches but project_name is all zeros — a factory image
+    # that didn't set the project name. Treat as "no manifest" so
+    # the wizard falls through to chip-family filtering.
+    blob = bytearray(_app_descriptor_blob("placeholder"))
+    blob[_PROJECT_NAME_OFFSET : _PROJECT_NAME_OFFSET + _PROJECT_NAME_SIZE] = (
+        b"\x00" * _PROJECT_NAME_SIZE
+    )
+    assert _parse_project_name(bytes(blob)) is None
+
+
+def test_is_valid_port_name_accepts_real_paths() -> None:
+    assert _is_valid_port_name("/dev/ttyUSB0")
+    assert _is_valid_port_name("/dev/cu.usbserial-10")
+    assert _is_valid_port_name("COM3")
+    assert _is_valid_port_name("COM127")
+
+
+def test_is_valid_port_name_rejects_traversal_and_metacharacters() -> None:
+    # Defence-in-depth — esptool would itself reject these, but
+    # keeping the gate at the WS boundary means a malicious port
+    # arg can't ever reach the subprocess argv.
+    assert not _is_valid_port_name("/dev/../etc/passwd")
+    assert not _is_valid_port_name("/dev/tty;rm")
+    assert not _is_valid_port_name("/dev/tty USB0")
+    assert not _is_valid_port_name("/etc/passwd")
+    assert not _is_valid_port_name("")
+    assert not _is_valid_port_name("not-a-port")
+
+
+def _mock_run_esptool(monkeypatch: pytest.MonkeyPatch, side_effect):
+    """Wire a fake ``_run_esptool`` that dispatches by argv shape.
+
+    ``side_effect`` is a callable ``(args: list[str]) → (rc, stdout_bytes)``.
+    The dashboard's two esptool calls are ``--port X chip-id`` and
+    ``--port X read-flash 0x10020 256 <tempfile>``; *side_effect*
+    inspects ``args`` to decide which response to return.
+    """
+
+    async def fake(args: list[str], timeout: float) -> tuple[int, bytes]:
+        return side_effect(args)
+
+    monkeypatch.setattr("esphome_device_builder.controllers.config._run_esptool", fake)
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_returns_chip_and_board_id_on_full_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both esptool calls succeed → result carries chip info AND board_id."""
+    blob = _app_descriptor_blob("starter-kit")
+
+    def fake(args: list[str]) -> tuple[int, bytes]:
+        if "chip-id" in args:
+            return 0, b"Chip type:          ESP32-C3 (QFN32) (revision v0.3)\n"
+        # read-flash writes the blob to the tempfile path (last positional)
+        Path(args[-1]).write_bytes(blob)
+        return 0, b""
+
+    _mock_run_esptool(monkeypatch, fake)
+    controller = _make_controller(tmp_path)
+
+    result = await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+
+    assert result == {
+        "chip_family": "ESP32-C3",
+        "variant": "esp32c3",
+        "platform": "esp32",
+        "board_id": "starter-kit",
+    }
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_omits_board_id_when_manifest_read_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manifest read failure is non-fatal — chip info still returned."""
+
+    def fake(args: list[str]) -> tuple[int, bytes]:
+        if "chip-id" in args:
+            return 0, b"Chip type:          ESP32-C3\n"
+        # Simulate a non-IDF app (magic mismatch) so the read succeeds
+        # but the parser bails — exercises the parse-failure branch.
+        Path(args[-1]).write_bytes(b"\xff" * _APP_DESC_SIZE)
+        return 0, b""
+
+    _mock_run_esptool(monkeypatch, fake)
+    controller = _make_controller(tmp_path)
+
+    result = await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+
+    assert result == {
+        "chip_family": "ESP32-C3",
+        "variant": "esp32c3",
+        "platform": "esp32",
+    }
+    assert "board_id" not in result
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_rejects_missing_or_invalid_port(tmp_path: Path) -> None:
+    controller = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc:
+        await controller.detect_chip_cmd()
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+    with pytest.raises(CommandError) as exc:
+        await controller.detect_chip_cmd(port="/etc/passwd")
+    assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_surfaces_port_busy_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Port-busy is the #1 detection failure in practice.
+
+    A stale WebSerial session or serial monitor holding the port
+    needs the user to close that other app rather than poking at
+    the cable. The classifier pattern-matches on the esptool error
+    blob (EBUSY on POSIX → "Resource busy", on Windows → "Access is
+    denied").
+    """
+    posix_blob = (
+        b"esptool v5.2.0\n"
+        b"A fatal error occurred: Could not open /dev/ttyUSB0, the port is busy or doesn't exist.\n"
+        b"([Errno 16] could not open port /dev/ttyUSB0: [Errno 16] Resource busy)\n"
+    )
+    _mock_run_esptool(monkeypatch, lambda args: (1, posix_blob))
+    controller = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc:
+        await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+    assert exc.value.code == ErrorCode.UNAVAILABLE
+    assert "another application" in exc.value.message.lower() or (
+        "web serial" in exc.value.message.lower()
+    )
+    assert "/dev/ttyUSB0" in exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_surfaces_no_response_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Chip didn't answer — surface cable / BOOT-button advice.
+
+    Esptool ran and the port was free, but the chip is silent. The
+    user needs hardware-side advice, not a "port busy" hint.
+    """
+    _mock_run_esptool(
+        monkeypatch,
+        lambda args: (
+            1,
+            b"A fatal error occurred: Failed to connect to ESP32: No serial data received.",
+        ),
+    )
+    controller = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc:
+        await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+    assert exc.value.code == ErrorCode.UNAVAILABLE
+    assert "cable" in exc.value.message.lower() or "boot" in exc.value.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_surfaces_unknown_chip_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Detected chip family isn't in our table.
+
+    A future Espressif part or a non-ESP impostor that somehow
+    answered — point the user at the manual board picker instead
+    of silently filtering against nothing.
+    """
+    _mock_run_esptool(
+        monkeypatch,
+        lambda args: (0, b"Chip type:          ESP32-Z99 (revision v9.9)\n"),
+    )
+    controller = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc:
+        await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+    assert exc.value.code == ErrorCode.UNAVAILABLE
+    assert "manually" in exc.value.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_surfaces_no_esptool_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Esptool isn't reachable from the spawned interpreter.
+
+    Very rare — esphome drags esptool in transitively — but possible
+    under a debug-launched dashboard whose sibling-script lookup
+    falls back to ``python -m esptool`` for an interpreter that
+    doesn't have esptool on ``sys.path``.
+    """
+    _mock_run_esptool(
+        monkeypatch,
+        lambda args: (1, b"/usr/bin/python3: No module named esptool\n"),
+    )
+    controller = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc:
+        await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+    assert exc.value.code == ErrorCode.UNAVAILABLE
+    assert "esptool" in exc.value.message.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -1044,11 +1044,7 @@ def _app_descriptor_blob(project_name: str = "starter-kit") -> bytes:
 
 
 def test_parse_chip_family_line_from_chip_type_line() -> None:
-    """Primary path — the post-stage ``Chip type:`` line.
-
-    Pins the parser against the exact output esptool v5.2 produces
-    against an M5Stamp-C3 (captured from a live device).
-    """
+    """Parser picks the family out of esptool v5.2's ``Chip type:`` line."""
     output = (
         "esptool v5.2.0\n"
         "Serial port /dev/cu.usbserial-54FC0197371:\n"
@@ -1066,11 +1062,7 @@ def test_parse_chip_family_line_from_chip_type_line() -> None:
 
 
 def test_parse_chip_family_line_falls_back_to_connected_to() -> None:
-    """Fallback when ``Chip type:`` is absent.
-
-    Secure Download Mode prints a different shape but still emits
-    ``Connected to X on …`` before bailing.
-    """
+    """Parser falls back to ``Connected to X on …`` when ``Chip type:`` is absent."""
     output = (
         "Connecting....\n"
         "Connected to ESP32-S3 on /dev/cu.usbmodem1234:\n"
@@ -1084,10 +1076,7 @@ def test_parse_chip_family_line_falls_back_to_connected_to() -> None:
 
 
 def test_parse_chip_family_line_legacy_detecting_line() -> None:
-    """Legacy fallback — the pre-stage ``Detecting chip type`` line.
-
-    Same shape ``_verify_chip`` in the firmware controller parses.
-    """
+    """Parser still handles esptool's legacy ``Detecting chip type…`` line."""
     output = "Detecting chip type... ESP32-C3"
     assert _parse_chip_family_line(output) == {
         "chip_family": "ESP32-C3",
@@ -1107,14 +1096,7 @@ def test_parse_chip_family_line_returns_none_for_unknown_family() -> None:
 def test_find_esptool_cmd_prefers_sibling_script(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When an ``esptool`` script lives next to ``sys.executable``, use it.
-
-    Mirrors ``_find_esphome_cmd``'s sibling-script preference — and
-    dodges the ``python -m esptool`` failure mode we hit under VS
-    Code debugpy launches where the wrapper layer breaks ``-m``
-    module resolution even though ``import esptool`` works fine in
-    the parent process.
-    """
+    """A sibling ``esptool`` next to ``sys.executable`` wins over ``-m esptool``."""
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_python = fake_bin / "python3"
@@ -1194,14 +1176,17 @@ def test_is_valid_port_name_rejects_traversal_and_metacharacters() -> None:
 def _mock_run_esptool(monkeypatch: pytest.MonkeyPatch, side_effect):
     """Wire a fake ``_run_esptool`` that dispatches by argv shape.
 
-    ``side_effect`` is a callable ``(args: list[str]) → (rc, stdout_bytes)``.
-    The dashboard's two esptool calls are ``--port X chip-id`` and
-    ``--port X read-flash 0x10020 256 <tempfile>``; *side_effect*
-    inspects ``args`` to decide which response to return.
+    ``side_effect`` is a callable ``(args: list[str]) → (rc, stdout_bytes)``
+    or ``(rc, stdout_bytes, timed_out)``; the wrapper pads a missing
+    ``timed_out`` to ``False`` so happy-path tests stay concise.
     """
 
-    async def fake(args: list[str], timeout: float) -> tuple[int, bytes]:
-        return side_effect(args)
+    async def fake(args: list[str], timeout: float) -> tuple[int, bytes, bool]:
+        result = side_effect(args)
+        if len(result) == 2:
+            rc, stdout = result
+            return rc, stdout, False
+        return result
 
     monkeypatch.setattr("esphome_device_builder.controllers.config._run_esptool", fake)
 
@@ -1277,14 +1262,7 @@ async def test_detect_chip_rejects_missing_or_invalid_port(tmp_path: Path) -> No
 async def test_detect_chip_surfaces_port_busy_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Port-busy is the #1 detection failure in practice.
-
-    A stale WebSerial session or serial monitor holding the port
-    needs the user to close that other app rather than poking at
-    the cable. The classifier pattern-matches on the esptool error
-    blob (EBUSY on POSIX → "Resource busy", on Windows → "Access is
-    denied").
-    """
+    """Port-busy errors surface a message that points at closing the other app."""
     posix_blob = (
         b"esptool v5.2.0\n"
         b"A fatal error occurred: Could not open /dev/ttyUSB0, the port is busy or doesn't exist.\n"
@@ -1306,11 +1284,7 @@ async def test_detect_chip_surfaces_port_busy_message(
 async def test_detect_chip_surfaces_no_response_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Chip didn't answer — surface cable / BOOT-button advice.
-
-    Esptool ran and the port was free, but the chip is silent. The
-    user needs hardware-side advice, not a "port busy" hint.
-    """
+    """A silent chip surfaces a message that points at the cable / BOOT button."""
     _mock_run_esptool(
         monkeypatch,
         lambda args: (
@@ -1327,15 +1301,45 @@ async def test_detect_chip_surfaces_no_response_message(
 
 
 @pytest.mark.asyncio
+async def test_detect_chip_surfaces_permission_denied_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Linux EACCES surfaces a ``dialout`` group hint, not the busy-port copy."""
+    _mock_run_esptool(
+        monkeypatch,
+        lambda args: (
+            1,
+            b"[Errno 13] could not open port /dev/ttyUSB0: "
+            b"PermissionError(13, 'Permission denied')",
+        ),
+    )
+    controller = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc:
+        await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+    assert exc.value.code == ErrorCode.UNAVAILABLE
+    assert "dialout" in exc.value.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_detect_chip_surfaces_timeout_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A subprocess timeout surfaces unplug/replug advice, not the unknown-error copy."""
+    _mock_run_esptool(monkeypatch, lambda args: (-1, b"", True))
+    controller = _make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc:
+        await controller.detect_chip_cmd(port="/dev/ttyUSB0")
+    assert exc.value.code == ErrorCode.UNAVAILABLE
+    assert "didn't finish in time" in exc.value.message.lower()
+
+
+@pytest.mark.asyncio
 async def test_detect_chip_surfaces_unknown_chip_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Detected chip family isn't in our table.
-
-    A future Espressif part or a non-ESP impostor that somehow
-    answered — point the user at the manual board picker instead
-    of silently filtering against nothing.
-    """
+    """An unrecognised chip family points the user at the manual board picker."""
     _mock_run_esptool(
         monkeypatch,
         lambda args: (0, b"Chip type:          ESP32-Z99 (revision v9.9)\n"),
@@ -1352,13 +1356,7 @@ async def test_detect_chip_surfaces_unknown_chip_message(
 async def test_detect_chip_surfaces_no_esptool_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Esptool isn't reachable from the spawned interpreter.
-
-    Very rare — esphome drags esptool in transitively — but possible
-    under a debug-launched dashboard whose sibling-script lookup
-    falls back to ``python -m esptool`` for an interpreter that
-    doesn't have esptool on ``sys.path``.
-    """
+    """A ``No module named esptool`` output surfaces an esptool-install hint."""
     _mock_run_esptool(
         monkeypatch,
         lambda args: (1, b"/usr/bin/python3: No module named esptool\n"),

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -44,7 +44,6 @@ from esphome_device_builder.controllers.config import (
     _PROJECT_NAME_SIZE,
     ConfigController,
     _chip_family_to_descriptor,
-    _find_esptool_cmd,
     _is_valid_port_name,
     _load_metadata,
     _parse_chip_family_line,
@@ -1091,37 +1090,6 @@ def test_parse_chip_family_line_returns_none_when_unparseable() -> None:
 
 def test_parse_chip_family_line_returns_none_for_unknown_family() -> None:
     assert _parse_chip_family_line("Chip type: ESP32-Z99 (revision v9.9)") is None
-
-
-def test_find_esptool_cmd_prefers_sibling_script(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A sibling ``esptool`` next to ``sys.executable`` wins over ``-m esptool``."""
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    fake_python = fake_bin / "python3"
-    fake_python.write_text("#!/bin/sh\n")
-    fake_python.chmod(0o755)
-    sibling = fake_bin / "esptool"
-    sibling.write_text("#!/bin/sh\n")
-    sibling.chmod(0o755)
-
-    monkeypatch.setattr("sys.executable", str(fake_python))
-    assert _find_esptool_cmd() == [str(sibling)]
-
-
-def test_find_esptool_cmd_falls_back_to_module_invocation(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Without a sibling script — return ``[python, -m, esptool]``."""
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    fake_python = fake_bin / "python3"
-    fake_python.write_text("#!/bin/sh\n")
-    fake_python.chmod(0o755)
-
-    monkeypatch.setattr("sys.executable", str(fake_python))
-    assert _find_esptool_cmd() == [str(fake_python), "-m", "esptool"]
 
 
 def test_chip_family_to_descriptor_maps_esp8266() -> None:

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -1146,11 +1146,15 @@ def _mock_run_esptool(monkeypatch: pytest.MonkeyPatch, side_effect):
 
     ``side_effect`` is a callable ``(args: list[str]) → (rc, stdout_bytes)``
     or ``(rc, stdout_bytes, timed_out)``; the wrapper pads a missing
-    ``timed_out`` to ``False`` so happy-path tests stay concise.
+    ``timed_out`` to ``False`` so happy-path tests stay concise. The
+    side-effect runs via ``asyncio.to_thread`` because the manifest-
+    read tests use ``Path.write_bytes`` to plant a synthetic blob in
+    the tempfile esptool would otherwise produce — blockbuster
+    flags that as a sync write on the event-loop thread otherwise.
     """
 
     async def fake(args: list[str], timeout: float) -> tuple[int, bytes, bool]:
-        result = side_effect(args)
+        result = await asyncio.to_thread(side_effect, args)
         if len(result) == 2:
             rc, stdout = result
             return rc, stdout, False


### PR DESCRIPTION
# What does this implement/fix?

Browsers without WebSerial (Safari, Firefox, iOS) and HA-add-on iframes can't run the wizard's WebSerial chip-detect path. The new `config/detect_chip` WS command runs `esptool` on a server-side serial port and returns the chip family + optional `board_id` from the IDF app descriptor, giving server-serial parity with WebSerial in the new-device wizard.

- New `@api_command("config/detect_chip")` in `controllers/config.py`.
- `_find_esptool_cmd` mirrors `_find_esphome_cmd`'s sibling-script-first lookup; bypasses the `python -m esptool` failure mode that hits under VS Code debugpy launches.
- Failure classifier maps esptool errors to actionable messages (port busy, no response, unknown chip, no esptool).
- Stdout parser tolerates esptool v5's stage line-collapsing by trying the post-stage `Chip type:` line first, then `Connected to …`, then the legacy `Detecting chip type…` line.
- Manifest read at flash offset `0x10020` decodes `esp_app_desc_t.project_name` so the wizard auto-routes factory firmware to its catalogue board.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#325

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.