### PR TITLE
Split DevicesController: extract scan-handler backbone

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -38,6 +38,10 @@ resolving after the subpackage split. Submodules:
   linearly, no mixin protocol.
 - ``reachability`` — per-device reachability streaming + the
   on-subscription mDNS A-record refresh loop.
+- ``scan_change`` — scan-handler backbone: forwards ADDED /
+  UPDATED / REMOVED scanner changes onto the event bus and
+  fans out side effects (mDNS probe, regen scheduling,
+  reachability cleanup).
 - ``state_callbacks`` — the six per-attribute mDNS callbacks
   (state / ip / version / mac / api_encryption / config_hash).
 - ``validate`` — ``devices/validate`` WS command body

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -69,6 +69,7 @@ from . import (
     importable,
     logs,
     reachability,
+    scan_change,
     state_callbacks,
     storage_regen,
     validate,
@@ -1622,75 +1623,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         return await loop.run_in_executor(None, path.read_text, "utf-8")
 
     def _on_scan_change(self, kind: ScanChange, device: Device) -> None:
-        """Forward scanner changes onto the event bus."""
-        event = {
-            ScanChange.ADDED: EventType.DEVICE_ADDED,
-            ScanChange.UPDATED: EventType.DEVICE_UPDATED,
-            ScanChange.REMOVED: EventType.DEVICE_REMOVED,
-        }[kind]
-        self._db.bus.fire(event, DeviceEventData(device=device))
-        # Eagerly probe mDNS for newly-added devices. Catches the
-        # YAML-dropped-on-disk case the API entrypoints
-        # (``devices/import``, ``devices/create``) can't see — e.g.
-        # the user copies a config into ``config_dir`` from another
-        # dashboard or git clones their setup. Without this the new
-        # card sits at "Unknown" until the next periodic ping sweep
-        # or mDNS announcement, even when the device is already on
-        # the network. ``probe_device`` short-circuits to the
-        # zeroconf cache when present; otherwise it spawns a
-        # fire-and-forget resolve task.
-        if kind is ScanChange.ADDED:
-            self._state_monitor.probe_device(device.name)
-        # The YAML cache key changed (mtime / size / inode) — clear
-        # any prior failure marker so an edit gets a fresh chance at
-        # ``--only-generate``. Same for REMOVED so re-creating the
-        # file later doesn't inherit the old failure.
-        if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
-            self._regenerate_failed.discard(device.configuration)
-        # First-sight devices that have no compile output yet end up
-        # carrying the ``<filename>.local`` address fallback and an
-        # empty ``loaded_integrations`` list. Schedule a background
-        # ``--only-generate`` so the next scan picks up the real
-        # ``StorageJSON``-derived values without making the user wait
-        # for a real compile. Same upstream pattern used in
-        # ``async_schedule_storage_json_update``.
-        #
-        # Also fire when ``expected_config_hash`` is empty even
-        # though ``loaded_integrations`` is populated. That happens
-        # for devices configured before build_info.json existed (or
-        # imported from an older dashboard) — they have a working
-        # ``StorageJSON`` so the integrations / address / version
-        # all come through, but the build directory either pre-dates
-        # the build_info.json era or was wiped. Without this nudge
-        # the drawer's "Local config hash" shows a permanent em-dash
-        # for those devices because nothing else triggers a
-        # ``--only-generate`` until the user edits the YAML.
-        needs_storage_regen = kind is ScanChange.ADDED and (
-            not device.loaded_integrations or not device.expected_config_hash
-        )
-        if needs_storage_regen:
-            self._schedule_storage_regenerate(device.configuration)
-        # When a configured device is deleted, re-emit cached
-        # discoveries. Upstream's ``DashboardImportDiscovery`` only
-        # fires ``on_update`` on first sight (``is_new`` check), so
-        # without this nudge a device stays silent until it
-        # re-announces — which can be many minutes for a quiet device.
-        # Use the "revisit all" variant rather than matching on
-        # ``device.name``: the user may have adopted with a YAML name
-        # that differs from the discovered hostname (e.g. they edited
-        # the MAC suffix off), in which case a name-keyed lookup
-        # would miss. ``_on_import_update`` already filters configured
-        # + ignored entries so re-emitting the full set is cheap and
-        # only surfaces what should actually appear.
-        if kind is ScanChange.REMOVED:
-            self._state_monitor.revisit_all_importables()
-            # Drop reachability history for the gone device. Without
-            # this, the four per-signal maps would accumulate one
-            # entry per device that's ever lived in the catalog,
-            # since nothing else clears them — the mDNS Removed
-            # branch only fires when the device's broadcast goes
-            # away, not when its YAML is deleted.
-            self._reachability.clear(device.name)
+        scan_change.on_scan_change(self, kind, device)
 
     def _devices_by_name(self, name: str) -> list[Device]:
         """Every configured device whose ``name`` field matches ``name``.

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -12,19 +12,7 @@ if TYPE_CHECKING:
 
 
 def on_scan_change(controller: DevicesController, kind: ScanChange, device: Device) -> None:
-    """
-    Forward scanner changes onto the event bus and fan out side effects.
-
-    On ADDED, eagerly probes mDNS so a freshly-dropped YAML
-    doesn't sit at "Unknown" until the next periodic ping
-    sweep. On UPDATED / REMOVED, clears any prior storage-regen
-    failure marker so a YAML edit gets a fresh chance.
-    Schedules ``--only-generate`` for first-sight devices that
-    have no compile output yet (or pre-build_info.json devices
-    with empty ``expected_config_hash``); on REMOVED, re-emits
-    cached importables and clears the per-signal reachability
-    history.
-    """
+    """Forward scanner changes onto the event bus and fan out per-kind side effects."""
     event = {
         ScanChange.ADDED: EventType.DEVICE_ADDED,
         ScanChange.UPDATED: EventType.DEVICE_UPDATED,

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -1,0 +1,82 @@
+"""Scan-change orchestrator for ``DevicesController``."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...models import Device, DeviceEventData, EventType
+from .._device_scanner import ScanChange
+
+if TYPE_CHECKING:
+    from .controller import DevicesController
+
+
+def on_scan_change(controller: DevicesController, kind: ScanChange, device: Device) -> None:
+    """
+    Forward scanner changes onto the event bus and fan out side effects.
+
+    On ADDED, eagerly probes mDNS so a freshly-dropped YAML
+    doesn't sit at "Unknown" until the next periodic ping
+    sweep. On UPDATED / REMOVED, clears any prior storage-regen
+    failure marker so a YAML edit gets a fresh chance.
+    Schedules ``--only-generate`` for first-sight devices that
+    have no compile output yet (or pre-build_info.json devices
+    with empty ``expected_config_hash``); on REMOVED, re-emits
+    cached importables and clears the per-signal reachability
+    history.
+    """
+    event = {
+        ScanChange.ADDED: EventType.DEVICE_ADDED,
+        ScanChange.UPDATED: EventType.DEVICE_UPDATED,
+        ScanChange.REMOVED: EventType.DEVICE_REMOVED,
+    }[kind]
+    controller._db.bus.fire(event, DeviceEventData(device=device))
+    if kind is ScanChange.ADDED:
+        # ``probe_device`` short-circuits to the zeroconf cache
+        # when present; otherwise it spawns a fire-and-forget
+        # resolve task. Without this, YAMLs dropped on disk
+        # outside the API entrypoints (git clone, copy from
+        # another dashboard) sit at "Unknown" until the next
+        # periodic ping sweep.
+        controller._state_monitor.probe_device(device.name)
+    if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
+        # YAML cache key changed; clear any prior failure
+        # marker so the next edit gets a fresh chance at
+        # ``--only-generate`` (and re-creating a deleted file
+        # later doesn't inherit the old failure).
+        controller._regenerate_failed.discard(device.configuration)
+    # First-sight devices with no compile output carry the
+    # ``<filename>.local`` address fallback and an empty
+    # ``loaded_integrations`` list. Schedule a background
+    # ``--only-generate`` so the next scan picks up the real
+    # StorageJSON-derived values without making the user wait
+    # for a real compile. Also fire when ``expected_config_hash``
+    # is empty even though ``loaded_integrations`` is populated:
+    # devices configured before build_info.json existed have a
+    # working StorageJSON but no hash, and would otherwise show
+    # a permanent em-dash for "Local config hash" until the user
+    # edits the YAML.
+    needs_storage_regen = kind is ScanChange.ADDED and (
+        not device.loaded_integrations or not device.expected_config_hash
+    )
+    if needs_storage_regen:
+        # Routed through the controller's bound delegate so tests
+        # patching ``_schedule_storage_regenerate`` on the
+        # instance still intercept.
+        controller._schedule_storage_regenerate(device.configuration)
+    if kind is ScanChange.REMOVED:
+        # Upstream's DashboardImportDiscovery only fires
+        # on_update on first sight; without a nudge a deleted
+        # device's discovery row stays silent until the device
+        # re-announces (potentially many minutes for a quiet
+        # one). The "revisit all" variant covers the case where
+        # the user adopted with a YAML name that differs from
+        # the discovered hostname; ``_on_import_update`` already
+        # filters configured + ignored entries so re-emitting
+        # the full set is cheap.
+        controller._state_monitor.revisit_all_importables()
+        # Drop reachability history; the per-signal maps would
+        # otherwise accumulate one entry per device that's ever
+        # lived in the catalog (the mDNS Removed branch only
+        # fires on broadcast disappearance, not YAML deletion).
+        controller._reachability.clear(device.name)


### PR DESCRIPTION
# What does this implement/fix?

Continues the `controllers/devices/controller.py` size reduction (1824 → 1757 lines) by extracting `_on_scan_change` (the scan-handler backbone) into a sibling `scan_change.py`. Same shape as the prior free-function extracts (archive / firmware_sync / importable / logs / api_key / add_component / state_callbacks / validate).

`scan_change.py` (82 lines) hosts `on_scan_change` — forwards ADDED / UPDATED / REMOVED scanner changes onto the event bus and fans out the per-kind side effects:

- ADDED: probe mDNS so the new device card doesn't sit at "Unknown" until the next ping sweep; schedule `--only-generate` for first-sight or pre-`build_info.json`-era devices.
- UPDATED / REMOVED: clear any prior storage-regen failure marker so a YAML edit gets a fresh chance.
- REMOVED: re-emit cached importables (so a deleted device's discovery row reappears without waiting for a re-announce) and clear per-signal reachability history.

## Why a free function (not a mixin)

`on_scan_change` reaches into five different controller-state attributes (`_db.bus`, `_state_monitor.probe_device` + `revisit_all_importables`, `_regenerate_failed`, `_schedule_storage_regenerate`, `_reachability.clear`) — too many cross-component dependencies to honestly fit the mixin audit rule from #702 / #714. Free functions with explicit `controller=` threading document the dependency.

## Test impact

Zero test changes. Tests call `controller._on_scan_change(...)` as a bound method (`tests/controllers/devices/test_metadata_resolver.py`, `test_branches_coverage.py`, `test_subscribe_reachability.py`) and the DeviceScanner captures `self._on_scan_change` as its `on_change=` callback at controller `__init__` — both still resolve through the bound-method delegate.

3223 tests pass; pure refactor.

**Related issue or feature (if applicable):**

- follow-up to #734

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
