### PR TITLE
Extract firmware-job lifecycle endpoints into lifecycle.py

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -32,7 +32,6 @@ from esphome.storage_json import StorageJSON
 from ...helpers.api import CommandError, api_command
 from ...helpers.build_scheduler import BuildPath, pick_build_path
 from ...helpers.event_bus import StreamControls, stream_events
-from ...helpers.process import terminate_subtree_with_grace
 from ...helpers.storage_path import resolve_storage_path
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ...models import (
@@ -50,7 +49,7 @@ from ...models import (
     StreamEvent,
 )
 from ...models.remote_build import PeerStatus
-from . import cli, persistence
+from . import cli, lifecycle, persistence
 from .constants import (
     _ACTIVE_JOB_STATUSES,
     _ERROR_PATTERNS,
@@ -103,17 +102,6 @@ _LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPON
 _BUILD_PRODUCING_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL, JobType.RENAME}
 )
-
-# Maps each terminal :class:`JobStatus` to the lifecycle event the
-# runner fires when a job reaches that status. Routes through
-# :meth:`FirmwareController._finalize_terminal` so every
-# finalisation site stays paired with the right event — keeps the
-# six-call-site signature consistent.
-_STATUS_TO_TERMINAL_EVENT: dict[JobStatus, EventType] = {
-    JobStatus.COMPLETED: EventType.JOB_COMPLETED,
-    JobStatus.FAILED: EventType.JOB_FAILED,
-    JobStatus.CANCELLED: EventType.JOB_CANCELLED,
-}
 
 
 def _resolve_download_component(target_platform: str | None) -> str:
@@ -1383,113 +1371,16 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             self._current_process = prev
 
     def _finalize_terminal(self, job: FirmwareJob, status: JobStatus) -> None:
-        """Stamp *job* terminal, release the runner slot, fire the matching event.
-
-        The three-step "this job is over" sequence every
-        finalisation site has to run, bundled so a future call
-        site can't accidentally skip one. Steps in order:
-
-        1. :func:`_mark_job_terminal` stamps ``status`` +
-           ``completed_at`` on the model (raises on a
-           non-terminal *status* — preserves the existing
-           loud-fail guard).
-        2. Release the runner slot (``_current_job`` /
-           ``_current_process``) if *job* holds it. Guarded on
-           ``is job`` so the QUEUED-cancel path in :meth:`cancel`
-           (where ``_current_job`` belongs to whatever's actually
-           running) doesn't evict the wrong job.
-        3. Fire the matching lifecycle event
-           (``JOB_COMPLETED`` / ``JOB_FAILED`` / ``JOB_CANCELLED``)
-           on the bus.
-
-        Step 2 has to land *before* step 3: the ``queue_status``
-        broadcaster
-        (:meth:`ReceiverController._on_firmware_queue_transition`)
-        reads :meth:`queue_status_snapshot` *synchronously*
-        inside the fire and needs to see the post-terminal idle
-        state. Without the prior release the snapshot reports
-        ``running=True``, the offloader's ``_peer_queue_status``
-        cache freezes there, and
-        :func:`helpers.build_scheduler.pick_build_path` rejects
-        the pairing on every subsequent install — the silent
-        LOCAL-fallback regression after the first remote build.
-        The ``finally`` block in :meth:`_execute_job` still
-        re-clears both fields as a backstop for exception paths
-        that bypass this helper.
-
-        Callers that want to ride a payload field (e.g.
-        ``job.error = "..."``) into the event must set it on the
-        job *before* invoking this helper — the broadcast reads
-        whatever's on the model at fire time.
-        """
-        _mark_job_terminal(job, status)
-        if self._current_job is job:
-            self._current_job = None
-            self._current_process = None
-        payload: JobLifecycleData = {"job": job}
-        self._db.bus.fire(_STATUS_TO_TERMINAL_EVENT[status], payload)
+        lifecycle.finalize_terminal(self, job, status)
 
     def _finalize_cancelled(self, job: FirmwareJob) -> None:
-        """
-        Run the runtime-cancel finalisation: discard, mark, fire.
-
-        Drops the id from ``_cancel_requested`` (so a subsequent
-        re-queue starts clean) then routes through
-        :meth:`_finalize_terminal` for the mark + slot-release +
-        fire sequence. Each call site adds its own log line so
-        the message can name the phase that was cancelled.
-
-        Doesn't cover the QUEUED-cancel path in ``cancel`` itself —
-        that one also runs ``_prune_history`` + ``_persist_jobs``
-        because the runner never sees the job, and inlining those
-        here would couple the runtime-cancel sites to disk I/O
-        they don't otherwise need.
-        """
-        self._cancel_requested.discard(job.job_id)
-        self._finalize_terminal(job, JobStatus.CANCELLED)
+        lifecycle.finalize_cancelled(self, job)
 
     def _raise_if_cancelled(self, job: FirmwareJob, phase: str) -> None:
-        """
-        Short-circuit a runner phase if a cancel landed mid-phase.
-
-        Called between subprocess spawns so a cancel that came in
-        while one pre-flight was running stops the next one from
-        starting. Raises ``ValueError`` so ``_execute_job``'s
-        cancel-aware ``except Exception`` branch finalises the job
-        as ``CANCELLED`` (vs. the bare ``FAILED`` path used for
-        unrelated exceptions). ``phase`` shows up in the error
-        message to make the cause clear in the log.
-        """
-        if job.job_id in self._cancel_requested:
-            msg = f"Cancelled during {phase}"
-            raise ValueError(msg)
+        lifecycle.raise_if_cancelled(self, job, phase)
 
     async def _terminate_current_process(self) -> None:
-        """Signal the running subprocess (and its children); escalate if it lingers.
-
-        The runner loop is the one that actually finalises the
-        ``FirmwareJob`` on exit (so we don't double-write status from
-        two coroutines). We only nudge the process here.
-
-        ESPHome forks PlatformIO which forks gcc / esptool / etc. The
-        spawn site uses ``start_new_session=True`` (POSIX) so the whole
-        tree shares a process group; we signal the group instead of
-        just the python parent — without that, the compiler children
-        get orphaned and the build keeps going until they finish.
-
-        Windows has no process groups in the POSIX sense; we use
-        ``taskkill /F /T`` to walk the parent-child tree from the
-        kernel's accounting and force-kill the whole subtree in one
-        shot. There's no graceful SIGTERM stage on Windows because the
-        compile chain doesn't honour any of the polite signals.
-        """
-        proc = self._current_process
-        if proc is None:
-            return
-        await terminate_subtree_with_grace(
-            proc,
-            job_label=f"job {self._current_job.job_id}" if self._current_job else "job ?",
-        )
+        await lifecycle.terminate_current_process(self)
 
     async def _verify_chip(self, job: FirmwareJob) -> None:
         await cli.verify_chip(self, job)

--- a/esphome_device_builder/controllers/firmware/lifecycle.py
+++ b/esphome_device_builder/controllers/firmware/lifecycle.py
@@ -57,7 +57,10 @@ def finalize_cancelled(controller: FirmwareController, job: FirmwareJob) -> None
     couple the runtime-cancel sites to disk I/O.
     """
     controller._cancel_requested.discard(job.job_id)
-    finalize_terminal(controller, job, JobStatus.CANCELLED)
+    # Route through the bound-method delegate so test patches
+    # on ``controller._finalize_terminal`` intercept the cancel
+    # path the same way they do every other finalisation site.
+    controller._finalize_terminal(job, JobStatus.CANCELLED)
 
 
 def raise_if_cancelled(controller: FirmwareController, job: FirmwareJob, phase: str) -> None:

--- a/esphome_device_builder/controllers/firmware/lifecycle.py
+++ b/esphome_device_builder/controllers/firmware/lifecycle.py
@@ -1,0 +1,93 @@
+"""Firmware-job lifecycle endpoints: finalize, cancel, terminate."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...helpers.process import terminate_subtree_with_grace
+from ...models import EventType, FirmwareJob, JobLifecycleData, JobStatus
+from .helpers import _mark_job_terminal
+
+if TYPE_CHECKING:
+    from .controller import FirmwareController
+
+
+# Maps each terminal :class:`JobStatus` to the lifecycle event
+# the runner fires when a job reaches it. Routes through
+# :func:`finalize_terminal` so every finalisation site stays
+# paired with the right event.
+_STATUS_TO_TERMINAL_EVENT: dict[JobStatus, EventType] = {
+    JobStatus.COMPLETED: EventType.JOB_COMPLETED,
+    JobStatus.FAILED: EventType.JOB_FAILED,
+    JobStatus.CANCELLED: EventType.JOB_CANCELLED,
+}
+
+
+def finalize_terminal(controller: FirmwareController, job: FirmwareJob, status: JobStatus) -> None:
+    """
+    Stamp *job* terminal, release the runner slot, fire the matching event.
+
+    Step ordering matters: the runner-slot release lands *before*
+    the bus.fire so the ``queue_status`` broadcaster's
+    synchronous :meth:`queue_status_snapshot` read sees the
+    post-terminal idle state. Without that ordering the
+    offloader's ``_peer_queue_status`` cache freezes at
+    ``running=True`` after the first remote build, and the
+    scheduler silently falls back to LOCAL on every subsequent
+    install. Callers that want to ride a payload field (e.g.
+    ``job.error = "..."``) into the event must set it on the
+    job before invoking this helper.
+    """
+    _mark_job_terminal(job, status)
+    if controller._current_job is job:
+        controller._current_job = None
+        controller._current_process = None
+    payload: JobLifecycleData = {"job": job}
+    controller._db.bus.fire(_STATUS_TO_TERMINAL_EVENT[status], payload)
+
+
+def finalize_cancelled(controller: FirmwareController, job: FirmwareJob) -> None:
+    """
+    Run the runtime-cancel finalisation: discard, mark, fire.
+
+    Doesn't cover the QUEUED-cancel path in
+    :meth:`FirmwareController.cancel` itself — that one also
+    runs ``_prune_history`` + ``_persist_jobs`` because the
+    runner never sees the job, and inlining those here would
+    couple the runtime-cancel sites to disk I/O.
+    """
+    controller._cancel_requested.discard(job.job_id)
+    finalize_terminal(controller, job, JobStatus.CANCELLED)
+
+
+def raise_if_cancelled(controller: FirmwareController, job: FirmwareJob, phase: str) -> None:
+    """
+    Short-circuit a runner phase if a cancel landed mid-phase.
+
+    Raises ``ValueError`` so :meth:`_execute_job`'s cancel-aware
+    ``except Exception`` branch finalises the job as CANCELLED
+    (vs. the bare FAILED path used for unrelated exceptions).
+    """
+    if job.job_id in controller._cancel_requested:
+        msg = f"Cancelled during {phase}"
+        raise ValueError(msg)
+
+
+async def terminate_current_process(controller: FirmwareController) -> None:
+    """
+    Signal the running subprocess (and its children); escalate if it lingers.
+
+    The runner loop is the one that actually finalises the
+    :class:`FirmwareJob` on exit — this helper only nudges the
+    process. Uses :func:`terminate_subtree_with_grace` so SIGTERM
+    walks the whole process group (esphome → platformio → gcc /
+    esptool) on POSIX, and ``taskkill /F /T`` on Windows where
+    the compile chain doesn't honour polite signals.
+    """
+    proc = controller._current_process
+    if proc is None:
+        return
+    await terminate_subtree_with_grace(
+        proc,
+        job_label=f"job {controller._current_job.job_id}" if controller._current_job else "job ?",
+    )

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware import controller as _firmware_controller_mod
+from esphome_device_builder.controllers.firmware import lifecycle as _firmware_lifecycle_mod
 from esphome_device_builder.helpers import process as _process_mod
 from esphome_device_builder.helpers.process import _signal_process_group
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
@@ -165,7 +165,7 @@ async def test_terminate_kills_grandchild_via_process_group(
     # time. Wrap the controller's binding so the SIGKILL escalation
     # fires after 0.1s instead of the full window.
     monkeypatch.setattr(
-        _firmware_controller_mod,
+        _firmware_lifecycle_mod,
         "terminate_subtree_with_grace",
         partial(_process_mod.terminate_subtree_with_grace, grace_seconds=0.1),
     )


### PR DESCRIPTION
# What does this implement/fix?

Third structural-split PR for `controllers/firmware/controller.py` (follows #733 persistence + #735 cli). Pulls firmware-job lifecycle endpoints (`_finalize_terminal` / `_finalize_cancelled` / `_raise_if_cancelled` / `_terminate_current_process`) into a new `lifecycle.py` submodule.

Free-function pattern matching the prior two PRs: takes `controller: FirmwareController` as first arg. The controller keeps thin one-line delegate methods so the ~10 test sites that exercise these as bound method names (`tests/controllers/firmware/test_cancel.py`, `test_stop.py`, `test_supersede.py`, `test_queue_status.py`, `test_branches_coverage.py`, `test_remote_runner.py`, `conftest.py`) keep working unchanged.

Changes:

* **New `lifecycle.py`** (93 lines) — four functions extracted as a coherent unit (everything related to ending a job: finalisation, runtime cancel, mid-phase cancel-short-circuit, subprocess termination). `_STATUS_TO_TERMINAL_EVENT` module constant moves with them (only `finalize_terminal` uses it).
* **`controller.py`** — 1783 → 1674 lines (−109). Bodies replaced with one-line delegates.
* **`tests/controllers/firmware/test_stop.py`** — one monkeypatch on `terminate_subtree_with_grace` redirects from the controller module to the lifecycle module (that's where the symbol is now imported). Same test scenario unchanged.

Combined with #733 + #735, controller.py is down 2083 → 1674 lines (−20%). One major concern remaining for the firmware split arc: the queue-run loop (`_run_queue` / `_execute_job` — the big hot path).

All 3198 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #733 + #735; third chunk of the firmware/controller.py split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
