### PR TITLE
Split DevicesController: extract mutations_yaml foundation

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -27,6 +27,9 @@ resolving after the subpackage split. Submodules:
   (``stream_logs``, ``stop_stream``) plus the shared
   ``stream_subprocess`` helper that ``validate_config``
   reuses.
+- ``mutations_yaml`` — shared helpers for the device-mutation
+  WS commands (``yaml_content_for_create`` provenance pick,
+  ``validate_rewritten_yaml_or_raise`` editor-validate gate).
 - ``metadata`` — ``DeviceMetadataBase`` carrying
   ``_resolve_device_metadata`` /
   ``_derive_board_id_from_yaml`` /

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON
@@ -21,8 +21,6 @@ from esphome.zeroconf import AsyncEsphomeZeroconf
 from ...helpers.api import CommandError, api_command
 from ...helpers.device_yaml import (
     configuration_stem,
-    generate_device_yaml,
-    generate_minimal_stub_yaml,
     parse_esphome_meta,
     parse_platform_from_yaml,
 )
@@ -68,6 +66,7 @@ from . import (
     firmware_sync,
     importable,
     logs,
+    mutations_yaml,
     reachability,
     scan_change,
     state_callbacks,
@@ -93,18 +92,6 @@ if TYPE_CHECKING:
     from ...models import BoardCatalogEntry
 
 _LOGGER = logging.getLogger(__name__)
-
-# Provenance tag for ``_yaml_content_for_create``'s return tuple.
-# ``"user"`` → caller-supplied ``file_content`` (validation
-# failure surfaces as ``INVALID_ARGS``).
-# ``"template"`` → :func:`generate_device_yaml` against a known
-# catalog entry (validation failure → ``INTERNAL_ERROR``).
-# ``"stub"`` → :func:`generate_minimal_stub_yaml` (no inputs;
-# validation failure → ``INTERNAL_ERROR``; caller skips the YAML-
-# driven board-id derivation since the stub's hard-coded
-# ``board: esp32dev`` would otherwise pin metadata to whatever
-# catalog entry happens to share that PIO board).
-_CreateYamlSource = Literal["user", "template", "stub"]
 
 # How long the persisted "regen failed" stamp is honoured before a
 # restart-time check is allowed to re-spawn ``--only-generate`` for
@@ -1196,19 +1183,10 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         file_content: str | None,
         ssid: str,
         psk: str,
-    ) -> tuple[str, _CreateYamlSource]:
-        """
-        Pick the YAML body for ``devices/create`` based on the inputs.
-
-        Returns ``(yaml_content, source)``; see :data:`_CreateYamlSource`
-        for the meaning of each tag and which post-processing the
-        caller applies per branch.
-        """
-        if file_content:
-            return file_content, "user"
-        if board:
-            return generate_device_yaml(name, friendly, board, ssid, psk), "template"
-        return generate_minimal_stub_yaml(name, friendly), "stub"
+    ) -> tuple[str, mutations_yaml.CreateYamlSource]:
+        return mutations_yaml.yaml_content_for_create(
+            name, friendly, board, file_content, ssid, psk
+        )
 
     async def _validate_rewritten_yaml_or_raise(
         self,
@@ -1219,96 +1197,14 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         on_failure: ErrorCode = ErrorCode.INVALID_ARGS,
         on_error_cleanup: Callable[[], None] | None = None,
     ) -> None:
-        """
-        Schema-validate *content* via the editor; raise if invalid.
-
-        Used by commands that produce a YAML and depend on a follow-
-        up install to apply the change (``create_device``,
-        ``edit_friendly_name``, future rename / save handlers). A
-        YAML that won't validate means the install fails and the
-        device-on-network keeps its old state — the dashboard ends
-        up showing a half-finished change that will never reach the
-        device. Refusing the write here keeps on-disk state and
-        live state in lockstep.
-
-        Reuses :class:`EditorController`'s warm validator subprocess
-        (one per configuration), so the cost is single-digit hundreds
-        of ms when the session is warm. ``self._db.editor`` is None
-        during dashboard boot before
-        :meth:`EditorController.start` finishes; that window is too
-        narrow for a user to hit in practice, but the guard means
-        the controller still behaves coherently if the editor is
-        unavailable (e.g. the ``esphome`` CLI not on PATH) — better
-        to skip validation than reject every write.
-
-        *action* is interpolated into the error message ("Can't
-        <action> — config doesn't validate: …"); pass the user-
-        facing verb the dialog will show ("rename", "save",
-        "create"). *on_failure* picks the ``ErrorCode`` raised:
-        default ``INVALID_ARGS`` when the user can fix the input
-        themselves, ``INTERNAL_ERROR`` when the broken YAML came
-        from one of *our* generators (``generate_device_yaml``,
-        clone's leaf rewrite, ...) and the user can't do anything
-        but report it. The error list is capped at three entries so
-        a long error pile collapses to "first three + (+N more)"
-        rather than overflowing the toast.
-
-        *on_error_cleanup* is a sync callback that runs in a
-        ``finally`` if validation didn't reach a clean success
-        (rejected, subprocess-wedged, anything). For commands that
-        write the YAML *before* calling this helper (currently
-        ``import_device``, where upstream ``import_config`` writes
-        unconditionally), the callback unlinks the half-imported
-        file so a retry doesn't trip ``FileExistsError``. Unset
-        for commands that haven't written yet (``create_device``,
-        ``clone_device``, ``edit_friendly_name``) — there's
-        nothing to roll back. Runs through ``run_in_executor`` so
-        ``blockbuster`` doesn't flag the sync syscall in tests.
-        """
-        editor = self._db.editor
-        if editor is None:
-            return
-        succeeded = False
-        try:
-            result = await editor.validate_yaml(configuration=configuration, content=content)
-            errors = [
-                *(err.get("message", "") for err in result.get("yaml_errors", [])),
-                *(err.get("message", "") for err in result.get("validation_errors", [])),
-            ]
-            errors = [msg for msg in errors if msg]
-            if not errors:
-                succeeded = True
-                return
-            shown = errors[:3]
-            suffix = f" (+{len(errors) - len(shown)} more)" if len(errors) > len(shown) else ""
-            message_tail = (
-                ". Please report this with a redacted snippet of just the "
-                "esphome: / substitutions: blocks (strip Wi-Fi credentials, "
-                "API keys, and static IPs) so the dashboard generator can "
-                "be fixed."
-                if on_failure is ErrorCode.INTERNAL_ERROR
-                else ". Fix the errors in the editor and try again."
-            )
-            raise CommandError(
-                on_failure,
-                f"Can't {action} — config doesn't validate: "
-                + "; ".join(shown)
-                + suffix
-                + message_tail,
-            )
-        finally:
-            if not succeeded and on_error_cleanup is not None:
-                # Swallow + log cleanup failures so a permission /
-                # FS error during rollback doesn't replace the
-                # original validation diagnostic (or the validator
-                # subprocess error) the caller is about to see. The
-                # leftover YAML is the lesser foot-gun here — the
-                # user can ``devices/delete`` it once they understand
-                # what failed.
-                try:
-                    await asyncio.get_running_loop().run_in_executor(None, on_error_cleanup)
-                except Exception:
-                    _LOGGER.exception("on_error_cleanup raised; original error preserved")
+        await mutations_yaml.validate_rewritten_yaml_or_raise(
+            self,
+            configuration,
+            content,
+            action=action,
+            on_failure=on_failure,
+            on_error_cleanup=on_error_cleanup,
+        )
 
     @api_command("devices/delete")
     async def delete_device(self, *, configuration: str, **kwargs: Any) -> None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1198,7 +1198,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         on_error_cleanup: Callable[[], None] | None = None,
     ) -> None:
         await mutations_yaml.validate_rewritten_yaml_or_raise(
-            self,
+            self._db.editor,
             configuration,
             content,
             action=action,

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from ...models import BoardCatalogEntry
-    from .controller import DevicesController
+    from ..editor import EditorController
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ def yaml_content_for_create(
 
 
 async def validate_rewritten_yaml_or_raise(
-    controller: DevicesController,
+    editor: EditorController | None,
     configuration: str,
     content: str,
     *,
@@ -67,9 +67,11 @@ async def validate_rewritten_yaml_or_raise(
     validating (currently ``import_device``) can roll back the
     half-imported file. *on_failure* picks ``INVALID_ARGS``
     (user can fix the input) vs ``INTERNAL_ERROR`` (broken
-    YAML came from one of our generators).
+    YAML came from one of our generators). *editor* is
+    optional so the controller's bound delegate can pass
+    ``self._db.editor`` straight through during the boot
+    window where it's still None.
     """
-    editor = controller._db.editor
     if editor is None:
         return
     succeeded = False

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -1,0 +1,112 @@
+"""Shared YAML helpers for the device-mutation WS commands."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from ...helpers.api import CommandError
+from ...helpers.device_yaml import generate_device_yaml, generate_minimal_stub_yaml
+from ...models import ErrorCode
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ...models import BoardCatalogEntry
+    from .controller import DevicesController
+
+_LOGGER = logging.getLogger(__name__)
+
+# Provenance tag for ``yaml_content_for_create``'s return tuple.
+# ``"user"`` -> caller-supplied ``file_content`` (validation
+# failure surfaces as ``INVALID_ARGS``).
+# ``"template"`` -> :func:`generate_device_yaml` against a known
+# catalog entry (validation failure -> ``INTERNAL_ERROR``).
+# ``"stub"`` -> :func:`generate_minimal_stub_yaml` (no inputs;
+# validation failure -> ``INTERNAL_ERROR``; caller skips the YAML-
+# driven board-id derivation since the stub's hard-coded
+# ``board: esp32dev`` would otherwise pin metadata to whatever
+# catalog entry happens to share that PIO board).
+CreateYamlSource = Literal["user", "template", "stub"]
+
+
+def yaml_content_for_create(
+    name: str,
+    friendly: str,
+    board: BoardCatalogEntry | None,
+    file_content: str | None,
+    ssid: str,
+    psk: str,
+) -> tuple[str, CreateYamlSource]:
+    """Pick the YAML body for ``devices/create`` based on the inputs."""
+    if file_content:
+        return file_content, "user"
+    if board:
+        return generate_device_yaml(name, friendly, board, ssid, psk), "template"
+    return generate_minimal_stub_yaml(name, friendly), "stub"
+
+
+async def validate_rewritten_yaml_or_raise(
+    controller: DevicesController,
+    configuration: str,
+    content: str,
+    *,
+    action: str,
+    on_failure: ErrorCode = ErrorCode.INVALID_ARGS,
+    on_error_cleanup: Callable[[], None] | None = None,
+) -> None:
+    """
+    Schema-validate *content* via the editor; raise if invalid.
+
+    Refusing the write here keeps on-disk state and live state
+    in lockstep when a YAML wouldn't validate (the install
+    would fail and the device-on-network would keep its old
+    state). *on_error_cleanup* runs in a finally on any
+    non-success path so callers that wrote the YAML before
+    validating (currently ``import_device``) can roll back the
+    half-imported file. *on_failure* picks ``INVALID_ARGS``
+    (user can fix the input) vs ``INTERNAL_ERROR`` (broken
+    YAML came from one of our generators).
+    """
+    editor = controller._db.editor
+    if editor is None:
+        return
+    succeeded = False
+    try:
+        result = await editor.validate_yaml(configuration=configuration, content=content)
+        errors = [
+            *(err.get("message", "") for err in result.get("yaml_errors", [])),
+            *(err.get("message", "") for err in result.get("validation_errors", [])),
+        ]
+        errors = [msg for msg in errors if msg]
+        if not errors:
+            succeeded = True
+            return
+        shown = errors[:3]
+        suffix = f" (+{len(errors) - len(shown)} more)" if len(errors) > len(shown) else ""
+        message_tail = (
+            ". Please report this with a redacted snippet of just the "
+            "esphome: / substitutions: blocks (strip Wi-Fi credentials, "
+            "API keys, and static IPs) so the dashboard generator can "
+            "be fixed."
+            if on_failure is ErrorCode.INTERNAL_ERROR
+            else ". Fix the errors in the editor and try again."
+        )
+        raise CommandError(
+            on_failure,
+            f"Can't {action} — config doesn't validate: "
+            + "; ".join(shown)
+            + suffix
+            + message_tail,
+        )
+    finally:
+        if not succeeded and on_error_cleanup is not None:
+            # Swallow + log cleanup failures so a permission /
+            # FS error during rollback doesn't replace the
+            # original validation diagnostic the caller is
+            # about to see.
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, on_error_cleanup)
+            except Exception:
+                _LOGGER.exception("on_error_cleanup raised; original error preserved")

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -59,18 +59,12 @@ async def validate_rewritten_yaml_or_raise(
     """
     Schema-validate *content* via the editor; raise if invalid.
 
-    Refusing the write here keeps on-disk state and live state
-    in lockstep when a YAML wouldn't validate (the install
-    would fail and the device-on-network would keep its old
-    state). *on_error_cleanup* runs in a finally on any
+    No-op when *editor* is None. *on_failure* selects the
+    ``ErrorCode`` raised: ``INVALID_ARGS`` for user-fixable
+    input, ``INTERNAL_ERROR`` for broken YAML from our own
+    generators. *on_error_cleanup* runs in a finally on any
     non-success path so callers that wrote the YAML before
-    validating (currently ``import_device``) can roll back the
-    half-imported file. *on_failure* picks ``INVALID_ARGS``
-    (user can fix the input) vs ``INTERNAL_ERROR`` (broken
-    YAML came from one of our generators). *editor* is
-    optional so the controller's bound delegate can pass
-    ``self._db.editor`` straight through during the boot
-    window where it's still None.
+    validating can roll back.
     """
     if editor is None:
         return


### PR DESCRIPTION
# What does this implement/fix?

Foundation PR for the **mutations split** (Track B1 in the cleanup plan). The big six `@api_command` methods (`create_device`, `clone_device`, `edit_friendly_name`, `rename_device`, `update_device`, `set_labels`) share two helpers:

- `_yaml_content_for_create` — picks YAML body for `devices/create` (user-supplied / template / stub).
- `_validate_rewritten_yaml_or_raise` — editor-validate gate.

Plus the `_CreateYamlSource` `Literal` that's the return-tuple type tag.

This PR pulls those three pieces into a new `mutations_yaml.py` (112 lines) so the per-command extractions that follow can call `mutations_yaml.*` directly without threading back through the controller. The controller keeps thin bound-method delegates (`_yaml_content_for_create`, `_validate_rewritten_yaml_or_raise`) so the still-on-controller mutation handlers + the `importable.import_device` consumer keep resolving through the same names.

Controller drops 1757 → 1655 lines.

## Why a foundation step

The plan from `cleanup_status_plan_2.md`:

> ### B1. mutations (~840 lines, biggest single drop)
> 
> Three viable shapes:
> - **One PR**: extract everything to `mutations.py` (~840 lines). Big diff, big review.
> - **Three subset PRs**: `mutations_create.py` + `mutations_clone.py` + `mutations_simple.py`. The helpers (`_yaml_content_for_create`, `_validate_rewritten_yaml_or_raise`) need to land somewhere both create and clone/edit can reach.
> - **Helpers first**: extract just `_yaml_content_for_create` + `_validate_rewritten_yaml_or_raise` into `mutations_yaml.py` as a foundation, then the per-command extractions in follow-ups.

This PR is the third option — small, low-risk foundation that lets the per-command extractions land independently.

## Test impact

Zero test changes. No tests reference these helpers directly; the controller's bound delegates keep them addressable as `controller._yaml_content_for_create` / `controller._validate_rewritten_yaml_or_raise`. `Literal` import removed from `controller.py` (the type tag is now in `mutations_yaml`).

3223 tests pass; pure refactor.

**Related issue or feature (if applicable):**

- foundation for the mutations subset PRs queued behind it

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
