### PR TITLE
Drop unused configuration parameter from _resolve_install_source

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -241,7 +241,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         despite an available paired receiver.
         """
         await self._validate_configuration_boundary(configuration)
-        build_source = self._resolve_install_source(configuration, force_local=force_local)
+        build_source = self._resolve_install_source(force_local=force_local)
         job = self._create_job(
             configuration,
             JobType.COMPILE,
@@ -497,7 +497,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         """
         _validate_port(port)
         await self._validate_configuration_boundary(configuration)
-        build_source = self._resolve_install_source(configuration, force_local=force_local)
+        build_source = self._resolve_install_source(force_local=force_local)
         job = self._create_job(
             configuration,
             JobType.INSTALL,
@@ -583,7 +583,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:
-                build_source = self._resolve_install_source(config, force_local=force_local)
+                build_source = self._resolve_install_source(force_local=force_local)
                 job = self._create_job(
                     config,
                     JobType.COMPILE,
@@ -616,7 +616,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         jobs: list[FirmwareJob] = []
         for config in configurations:
             try:
-                build_source = self._resolve_install_source(config)
+                build_source = self._resolve_install_source()
                 job = self._create_job(
                     config,
                     JobType.INSTALL,
@@ -1492,10 +1492,8 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             device_friendly_name=device_friendly_name,
         )
 
-    def _resolve_install_source(
-        self, configuration: str, *, force_local: bool = False
-    ) -> JobBuildSource:
-        return factories.resolve_install_source(self, configuration, force_local=force_local)
+    def _resolve_install_source(self, *, force_local: bool = False) -> JobBuildSource:
+        return factories.resolve_install_source(self, force_local=force_local)
 
     async def _enqueue(self, job: FirmwareJob, *, supersede: bool = True) -> FirmwareJob:
         return await factories.enqueue(self, job, supersede=supersede)

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -77,17 +77,9 @@ def create_job(
 
 
 def resolve_install_source(
-    controller: FirmwareController, configuration: str, *, force_local: bool = False
+    controller: FirmwareController, *, force_local: bool = False
 ) -> JobBuildSource:
-    """
-    Pick LOCAL or REMOTE based on the scheduler snapshot; return the build source.
-
-    ``configuration`` isn't read today — the decision is purely a
-    function of ``force_local`` and the offloader's
-    :meth:`build_scheduler_snapshot`. The parameter is preserved
-    for future-extensible per-config policy and to match the call
-    sites (every caller passes its own configuration).
-    """
+    """Pick LOCAL or REMOTE from the scheduler snapshot; return the build source."""
     if force_local:
         return LOCAL_JOB_BUILD_SOURCE
     offloader = controller._db.remote_build_offloader


### PR DESCRIPTION
# What does this implement/fix?

Cleanup follow-up to #740. Copilot's review on that PR flagged `resolve_install_source`'s unused `configuration` parameter ([discussion #r3235673045](https://github.com/esphome/device-builder/pull/740#discussion_r3235673045)) — the decision is purely a function of `force_local` plus the offloader's `build_scheduler_snapshot()`, and the configuration string is never read inside the body. #740 left the parameter in place and only made the docstring honest about it (since dropping it crosses the structural-split's behaviour-free mandate); this PR is the small targeted trim.

Changes:

* **`factories.py`** — `resolve_install_source(controller, configuration, *, force_local=False)` → `resolve_install_source(controller, *, force_local=False)`. Docstring collapsed to a one-line contract now that the per-config caveat is gone.
* **`controller.py`** — same trim on the bound-method delegate `_resolve_install_source`; four call sites in `compile` / `install` / `compile_bulk` / `install_bulk` drop their first positional argument.

No external callers (every existing caller is inside `controller.py`); no test directly invokes the method; the only test mentions are docstring cross-references that still read correctly.

All 3198 non-e2e tests pass; ruff + mypy clean. Strict behaviour-free trim.

**Related issue or feature (if applicable):**

- follow-up to #740 (resolves Copilot's `resolve_install_source` discussion)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
