### PR TITLE
Extract firmware-job runner into runner.py

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -16,9 +16,8 @@ import gzip
 import importlib
 import logging
 import sys
-from collections.abc import AsyncIterator, Iterator
-from contextlib import asynccontextmanager
-from datetime import UTC, datetime
+from collections.abc import Iterator
+from contextlib import AbstractAsyncContextManager
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any
 
@@ -31,7 +30,6 @@ from esphome.storage_json import StorageJSON
 from ...helpers.api import CommandError, api_command
 from ...helpers.event_bus import StreamControls, stream_events
 from ...helpers.storage_path import resolve_storage_path
-from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ...models import (
     LOCAL_JOB_BUILD_SOURCE,
     TERMINAL_JOB_EVENTS,
@@ -47,21 +45,16 @@ from ...models import (
     StreamEvent,
 )
 from ...models.remote_build import PeerStatus
-from . import cli, factories, lifecycle, persistence
+from . import cli, factories, lifecycle, persistence, runner
 from .constants import (
     _ACTIVE_JOB_STATUSES,
-    _ERROR_PATTERNS,
 )
 from .helpers import (
     _find_esphome_cmd,
-    _ingest_output_line,
-    _is_no_module_named_esphome,
     _mark_job_terminal,
-    _trim_job_output,
     _validate_port,
     _verify_esphome_importable,
 )
-from .remote_runner import run_remote_job
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -1071,301 +1064,18 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     # ------------------------------------------------------------------
 
     async def _run_queue(self) -> None:
-        """Background loop: process one job at a time."""
-        while True:
-            job = await self._queue.get()
-            if job.status == JobStatus.CANCELLED:
-                continue
-            await self._execute_job(job)
+        await runner.run_queue(self)
 
-    async def _execute_job(self, job: FirmwareJob) -> None:  # noqa: PLR0912, PLR0915
-        """Execute a single firmware job."""
-        job.status = JobStatus.RUNNING
-        job.started_at = datetime.now(UTC).isoformat()
-        self._current_job = job
-        _LOGGER.info(
-            "Starting job %s: %s %s",
-            job.job_id,
-            job.job_type,
-            job.configuration,
-        )
-        started_payload: JobLifecycleData = {"job": job}
-        self._db.bus.fire(EventType.JOB_STARTED, started_payload)
-        await self._persist_jobs()
-
-        try:
-            # Source-routed branch: REMOTE-source jobs dispatch via
-            # peer-link to a paired receiver instead of running a
-            # local subprocess. The receiver's ``OFFLOADER_JOB_*``
-            # fan-out events drive the same lifecycle / output /
-            # progress fires every local subscriber already
-            # consumes — follow_job and the firmware-tasks UI don't
-            # need to know whether the bytes are local or remote.
-            if job.source is JobSource.REMOTE:
-                await self._execute_remote_job(job)
-                return
-
-            # Pre-flight: verify chip type for serial uploads
-            if job.job_type in (JobType.UPLOAD, JobType.INSTALL):
-                await self._verify_chip(job)
-
-            # ``rel_path`` calls ``Path.resolve`` which does a sync
-            # ``os.path.realpath`` — blocking the event loop. Push it
-            # to the executor so the runner stays non-blocking
-            # end-to-end (matters even for the runner because
-            # ``bus.fire`` listeners are interleaved on the loop and
-            # blocking here pauses every follower's event delivery).
-            loop = asyncio.get_running_loop()
-            config_path = str(
-                await loop.run_in_executor(None, self._db.settings.rel_path, job.configuration)
-            )
-            cache_args = self._build_cache_args(job)
-            cmd = self._build_command(job.job_type, config_path, job.port, cache_args, job.new_name)
-            _LOGGER.debug("Running: %s", " ".join(cmd))
-
-            env = self._compose_subprocess_env(job)
-            has_error_in_output = False
-            # Captured at append time because the in-flight trim can
-            # elide the offending line before the post-exit handler
-            # runs. ``_check_error`` already had the line in hand
-            # there; persisting the verdict here lets the post-exit
-            # handler render a specific actionable message even
-            # after a long noisy build trims the head.
-            saw_no_esphome_module = False
-
-            def _check_error(text: str) -> None:
-                nonlocal has_error_in_output, saw_no_esphome_module
-                if not saw_no_esphome_module and _is_no_module_named_esphome(text):
-                    saw_no_esphome_module = True
-                if has_error_in_output:
-                    return
-                for pattern in _ERROR_PATTERNS:
-                    if pattern in text:
-                        has_error_in_output = True
-                        return
-
-            async with self._tracked_subprocess(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                env=env,
-                # Put the whole esphome → platformio → gcc tree in its
-                # own process group so ``_terminate_current_process``
-                # can signal the entire chain, not just the python
-                # parent. Without this, killing the parent leaves the
-                # compiler children orphaned and the build keeps
-                # running until they finish on their own — exactly the
-                # "stop compile doesn't work" symptom.
-                start_new_session=True,
-            ) as proc:
-                # Honour a cancel that landed in the gap between
-                # ``_verify_chip`` finishing and ``create_subprocess_exec``
-                # returning — without this, an early Stop click during
-                # the brief async window where ``_current_process`` was
-                # ``None`` lets the install run to completion before the
-                # post-``proc.wait()`` cancel check sees the flag.
-                if job.job_id in self._cancel_requested:
-                    await self._terminate_current_process()
-
-                assert proc.stdout is not None  # type narrowing
-
-                # ``iter_lines_with_progress`` splits on `\n` _or_ `\r`
-                # so carriage-return-based in-place updates (esptool's
-                # `Writing at 0x... (5%)\r`, PlatformIO's progress
-                # bars) survive the pipe instead of getting buffered
-                # until the next newline. Each chunk keeps its
-                # trailing terminator so the frontend can decide
-                # whether to append a new line or overwrite the last
-                # one.
-                async for line in iter_lines_with_progress(proc.stdout):
-                    # Shared with the source-routed remote runner
-                    # (``remote_runner._on_output``). The helper
-                    # buffers + trims + fires ``JOB_OUTPUT`` and
-                    # advances ``JOB_PROGRESS`` on a parseable
-                    # percentage — same per-line bookkeeping
-                    # whether the build's bytes come from this
-                    # CPU or a paired receiver. ``_check_error``
-                    # stays inline because it mutates the
-                    # nonlocal ``has_error_in_output`` /
-                    # ``saw_no_esphome_module`` flags the
-                    # post-exit handler reads; remote builds
-                    # surface a structured ``failed`` status from
-                    # the receiver instead, so the stderr scrape
-                    # only matters here.
-                    _ingest_output_line(job, self._db.bus, line)
-                    _check_error(line)
-
-                exit_code = await proc.wait()
-                job.exit_code = exit_code
-
-            # If the user cancelled this job mid-run, the subprocess
-            # exits non-zero (terminated by signal). Honour that
-            # intent rather than reporting it as a generic failure.
-            if job.job_id in self._cancel_requested:
-                self._finalize_cancelled(job)
-                _LOGGER.info("Job %s cancelled mid-run (exit %s)", job.job_id, exit_code)
-            else:
-                success = exit_code == 0 and not has_error_in_output
-                if has_error_in_output and exit_code == 0:
-                    if saw_no_esphome_module:
-                        job.error = (
-                            "esphome is not importable from the dashboard's Python "
-                            f"environment ({sys.executable}). Install it with "
-                            "``pip install -e '.[esphome]'`` "
-                            "(or ``pip install esphome``) "
-                            "in the same venv and restart the dashboard."
-                        )
-                    else:
-                        job.error = "Process exited 0 but output contains errors"
-                    _LOGGER.warning("Job %s: %s", job.job_id, job.error)
-
-                # ``_finalize_terminal`` runs the mark + slot-
-                # release + fire sequence in the order the
-                # ``queue_status`` broadcaster needs (see helper
-                # docstring for the regression context).
-                self._finalize_terminal(job, JobStatus.COMPLETED if success else JobStatus.FAILED)
-                _LOGGER.info(
-                    "Job %s %s (exit code %s)",
-                    job.job_id,
-                    job.status,
-                    exit_code,
-                )
-
-        except asyncio.CancelledError:
-            # ``_tracked_subprocess`` already terminated the spawn
-            # on its way out; this branch only needs to finalise
-            # the job model and fire the event.
-            self._finalize_cancelled(job)
-            _LOGGER.info("Job %s cancelled (runner shutdown)", job.job_id)
-            raise
-        except Exception as exc:
-            # If a cancel was requested before this exception escaped,
-            # honour it as CANCELLED instead of FAILED. The
-            # ``_verify_chip`` early-cancel path raises ``ValueError``
-            # to short-circuit the install — without this branch
-            # that error would be reported as a generic failure
-            # rather than the user-driven cancel it actually is.
-            if job.job_id in self._cancel_requested:
-                self._finalize_cancelled(job)
-                _LOGGER.info("Job %s cancelled before subprocess wait: %s", job.job_id, exc)
-            else:
-                job.error = str(exc)
-                self._finalize_terminal(job, JobStatus.FAILED)
-                _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
-        finally:
-            self._current_job = None
-            self._current_process = None
-            if job.status in (
-                JobStatus.COMPLETED,
-                JobStatus.FAILED,
-                JobStatus.CANCELLED,
-            ):
-                _trim_job_output(job)
-                self._prune_history()
-            await self._persist_jobs()
+    async def _execute_job(self, job: FirmwareJob) -> None:
+        await runner.execute_job(self, job)
 
     async def _execute_remote_job(self, job: FirmwareJob) -> None:
-        """
-        Run a ``JobSource.REMOTE`` job by dispatching through peer-link.
+        await runner.execute_remote_job(self, job)
 
-        Reads ``source_pin_sha256`` off *job*, looks up the live
-        :class:`PeerLinkClient` through the remote-build
-        controller, bundles the YAML via the ``esphome bundle``
-        subprocess, dispatches ``submit_job(target="compile")``,
-        then translates receiver-side ``OFFLOADER_JOB_OUTPUT`` /
-        ``OFFLOADER_JOB_STATE_CHANGED`` events into the same
-        local ``JOB_OUTPUT`` / ``JOB_PROGRESS`` /
-        ``JOB_<terminal>`` fires the local subprocess path emits.
-        ``follow_job`` and the firmware-tasks UI consume one
-        event stream regardless of which CPU compiled the bytes.
-
-        Dispatches by ``job.job_type``:
-
-        * :attr:`JobType.COMPILE` — wait for the receiver's
-          terminal frame, finalise based on the wire status.
-        * :attr:`JobType.UPLOAD` / :attr:`JobType.INSTALL` —
-          same compile dispatch (per § Transparent install
-          flow's load-bearing "receiver only ever compiles"
-          policy), but on receiver-completed pull the
-          artifacts back via ``download_artifacts`` and run a
-          local ``esphome upload --file <staged>`` subprocess
-          to flash the device. The local flash step shares the
-          ``_tracked_subprocess`` plumbing the LOCAL path uses
-          so cancel SIGTERM lands on the upload chain the same
-          way.
-
-        Other job types (``CLEAN`` / ``RENAME`` /
-        ``RESET_BUILD_ENV``) are rejected at the runner's top
-        because the receiver-side ``submit_job`` contract is
-        compile-only — these don't have a corresponding wire
-        flow.
-
-        Terminal states are mapped through the same helpers the
-        local path uses (``_mark_job_terminal`` /
-        ``_finalize_cancelled``), so the outer
-        ``_execute_job``'s ``finally`` runs the shared
-        ``_trim_job_output`` / ``_prune_history`` / persist
-        sequence regardless of which branch produced the
-        terminal status.
-        """
-        await run_remote_job(self, job)
-
-    @asynccontextmanager
-    async def _tracked_subprocess(
+    def _tracked_subprocess(
         self, *args: Any, **kwargs: Any
-    ) -> AsyncIterator[asyncio.subprocess.Process]:
-        """
-        Spawn a subprocess that's visible to ``firmware/cancel``.
-
-        Required for every ``create_subprocess_exec`` call in the
-        runner path — both the main install/upload spawn in
-        ``_execute_job`` and pre-flight probes like
-        ``_verify_chip``. Setting ``_current_process`` is what lets
-        a concurrent ``firmware/cancel`` actually land SIGTERM on
-        the running spawn; a direct ``create_subprocess_exec`` call
-        without this registration silently regresses the
-        issue-#136 fix — the cancel handler walks
-        ``_current_process``, no-ops on ``None``, the user clicks
-        Stop, nothing visible happens, and the orphaned subprocess
-        runs to completion in the background.
-
-        Two cleanup contracts on exit:
-
-        - Normal exit / non-cancellation exception: restore the
-          prior ``_current_process`` value so nested usage (a
-          future spawn site that itself wraps another) doesn't
-          accidentally null out an outer registration.
-        - ``asyncio.CancelledError`` (runner-task shutdown):
-          terminate the spawn before propagating, so the build
-          can't outlive the runner that started it. The outer
-          ``except asyncio.CancelledError`` in ``_execute_job``
-          handles the job-finalisation half and relies on this
-          helper for the terminate.
-
-        Pairs with ``_raise_if_cancelled`` — wrap each spawn, then
-        call the helper after to short-circuit if the cancel landed
-        between this subprocess and the next one.
-        """
-        proc = await create_subprocess_exec(*args, **kwargs)
-        prev = self._current_process
-        self._current_process = proc
-        try:
-            yield proc
-        except asyncio.CancelledError:
-            # Runner-shutdown cancellation: the runner task itself
-            # was cancelled (vs. a user-driven ``firmware/cancel``,
-            # which calls ``_terminate_current_process`` from the
-            # cancel handler directly). Reuse the same group-aware
-            # termination helper here so SIGTERM walks the whole
-            # process group (esphome → platformio → gcc / esptool).
-            # ``proc.terminate()`` would only signal the python
-            # parent — on POSIX with ``start_new_session=True``
-            # that orphans the child tree and the build keeps
-            # running until the children finish on their own.
-            await self._terminate_current_process()
-            raise
-        finally:
-            self._current_process = prev
+    ) -> AbstractAsyncContextManager[asyncio.subprocess.Process]:
+        return runner.tracked_subprocess(self, *args, **kwargs)
 
     def _finalize_terminal(self, job: FirmwareJob, status: JobStatus) -> None:
         lifecycle.finalize_terminal(self, job, status)

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -1,0 +1,338 @@
+"""Firmware-job runner: queue loop + local subprocess execution + remote dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
+from ...models import (
+    EventType,
+    FirmwareJob,
+    JobLifecycleData,
+    JobSource,
+    JobStatus,
+    JobType,
+)
+from .constants import _ERROR_PATTERNS
+from .helpers import (
+    _ingest_output_line,
+    _is_no_module_named_esphome,
+    _trim_job_output,
+)
+from .remote_runner import run_remote_job
+
+if TYPE_CHECKING:
+    from .controller import FirmwareController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def run_queue(controller: FirmwareController) -> None:
+    """Background loop: process one job at a time."""
+    while True:
+        job = await controller._queue.get()
+        if job.status == JobStatus.CANCELLED:
+            continue
+        await controller._execute_job(job)
+
+
+async def execute_job(  # noqa: PLR0912, PLR0915
+    controller: FirmwareController, job: FirmwareJob
+) -> None:
+    """Execute a single firmware job."""
+    job.status = JobStatus.RUNNING
+    job.started_at = datetime.now(UTC).isoformat()
+    controller._current_job = job
+    _LOGGER.info(
+        "Starting job %s: %s %s",
+        job.job_id,
+        job.job_type,
+        job.configuration,
+    )
+    started_payload: JobLifecycleData = {"job": job}
+    controller._db.bus.fire(EventType.JOB_STARTED, started_payload)
+    await controller._persist_jobs()
+
+    try:
+        # Source-routed branch: REMOTE-source jobs dispatch via
+        # peer-link to a paired receiver instead of running a
+        # local subprocess. The receiver's ``OFFLOADER_JOB_*``
+        # fan-out events drive the same lifecycle / output /
+        # progress fires every local subscriber already
+        # consumes — follow_job and the firmware-tasks UI don't
+        # need to know whether the bytes are local or remote.
+        if job.source is JobSource.REMOTE:
+            await controller._execute_remote_job(job)
+            return
+
+        # Pre-flight: verify chip type for serial uploads
+        if job.job_type in (JobType.UPLOAD, JobType.INSTALL):
+            await controller._verify_chip(job)
+
+        # ``rel_path`` calls ``Path.resolve`` which does a sync
+        # ``os.path.realpath`` — blocking the event loop. Push it
+        # to the executor so the runner stays non-blocking
+        # end-to-end (matters even for the runner because
+        # ``bus.fire`` listeners are interleaved on the loop and
+        # blocking here pauses every follower's event delivery).
+        loop = asyncio.get_running_loop()
+        config_path = str(
+            await loop.run_in_executor(None, controller._db.settings.rel_path, job.configuration)
+        )
+        cache_args = controller._build_cache_args(job)
+        cmd = controller._build_command(
+            job.job_type, config_path, job.port, cache_args, job.new_name
+        )
+        _LOGGER.debug("Running: %s", " ".join(cmd))
+
+        env = controller._compose_subprocess_env(job)
+        has_error_in_output = False
+        # Captured at append time because the in-flight trim can
+        # elide the offending line before the post-exit handler
+        # runs. ``_check_error`` already had the line in hand
+        # there; persisting the verdict here lets the post-exit
+        # handler render a specific actionable message even
+        # after a long noisy build trims the head.
+        saw_no_esphome_module = False
+
+        def _check_error(text: str) -> None:
+            nonlocal has_error_in_output, saw_no_esphome_module
+            if not saw_no_esphome_module and _is_no_module_named_esphome(text):
+                saw_no_esphome_module = True
+            if has_error_in_output:
+                return
+            for pattern in _ERROR_PATTERNS:
+                if pattern in text:
+                    has_error_in_output = True
+                    return
+
+        async with controller._tracked_subprocess(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=env,
+            # Put the whole esphome → platformio → gcc tree in its
+            # own process group so ``_terminate_current_process``
+            # can signal the entire chain, not just the python
+            # parent. Without this, killing the parent leaves the
+            # compiler children orphaned and the build keeps
+            # running until they finish on their own — exactly the
+            # "stop compile doesn't work" symptom.
+            start_new_session=True,
+        ) as proc:
+            # Honour a cancel that landed in the gap between
+            # ``_verify_chip`` finishing and ``create_subprocess_exec``
+            # returning — without this, an early Stop click during
+            # the brief async window where ``_current_process`` was
+            # ``None`` lets the install run to completion before the
+            # post-``proc.wait()`` cancel check sees the flag.
+            if job.job_id in controller._cancel_requested:
+                await controller._terminate_current_process()
+
+            assert proc.stdout is not None  # type narrowing
+
+            # ``iter_lines_with_progress`` splits on `\n` _or_ `\r`
+            # so carriage-return-based in-place updates (esptool's
+            # `Writing at 0x... (5%)\r`, PlatformIO's progress
+            # bars) survive the pipe instead of getting buffered
+            # until the next newline. Each chunk keeps its
+            # trailing terminator so the frontend can decide
+            # whether to append a new line or overwrite the last
+            # one.
+            async for line in iter_lines_with_progress(proc.stdout):
+                # Shared with the source-routed remote runner
+                # (``remote_runner._on_output``). The helper
+                # buffers + trims + fires ``JOB_OUTPUT`` and
+                # advances ``JOB_PROGRESS`` on a parseable
+                # percentage — same per-line bookkeeping
+                # whether the build's bytes come from this
+                # CPU or a paired receiver. ``_check_error``
+                # stays inline because it mutates the
+                # nonlocal ``has_error_in_output`` /
+                # ``saw_no_esphome_module`` flags the
+                # post-exit handler reads; remote builds
+                # surface a structured ``failed`` status from
+                # the receiver instead, so the stderr scrape
+                # only matters here.
+                _ingest_output_line(job, controller._db.bus, line)
+                _check_error(line)
+
+            exit_code = await proc.wait()
+            job.exit_code = exit_code
+
+        # If the user cancelled this job mid-run, the subprocess
+        # exits non-zero (terminated by signal). Honour that
+        # intent rather than reporting it as a generic failure.
+        if job.job_id in controller._cancel_requested:
+            controller._finalize_cancelled(job)
+            _LOGGER.info("Job %s cancelled mid-run (exit %s)", job.job_id, exit_code)
+        else:
+            success = exit_code == 0 and not has_error_in_output
+            if has_error_in_output and exit_code == 0:
+                if saw_no_esphome_module:
+                    job.error = (
+                        "esphome is not importable from the dashboard's Python "
+                        f"environment ({sys.executable}). Install it with "
+                        "``pip install -e '.[esphome]'`` "
+                        "(or ``pip install esphome``) "
+                        "in the same venv and restart the dashboard."
+                    )
+                else:
+                    job.error = "Process exited 0 but output contains errors"
+                _LOGGER.warning("Job %s: %s", job.job_id, job.error)
+
+            # ``_finalize_terminal`` runs the mark + slot-
+            # release + fire sequence in the order the
+            # ``queue_status`` broadcaster needs (see helper
+            # docstring for the regression context).
+            controller._finalize_terminal(job, JobStatus.COMPLETED if success else JobStatus.FAILED)
+            _LOGGER.info(
+                "Job %s %s (exit code %s)",
+                job.job_id,
+                job.status,
+                exit_code,
+            )
+
+    except asyncio.CancelledError:
+        # ``_tracked_subprocess`` already terminated the spawn
+        # on its way out; this branch only needs to finalise
+        # the job model and fire the event.
+        controller._finalize_cancelled(job)
+        _LOGGER.info("Job %s cancelled (runner shutdown)", job.job_id)
+        raise
+    except Exception as exc:
+        # If a cancel was requested before this exception escaped,
+        # honour it as CANCELLED instead of FAILED. The
+        # ``_verify_chip`` early-cancel path raises ``ValueError``
+        # to short-circuit the install — without this branch
+        # that error would be reported as a generic failure
+        # rather than the user-driven cancel it actually is.
+        if job.job_id in controller._cancel_requested:
+            controller._finalize_cancelled(job)
+            _LOGGER.info("Job %s cancelled before subprocess wait: %s", job.job_id, exc)
+        else:
+            job.error = str(exc)
+            controller._finalize_terminal(job, JobStatus.FAILED)
+            _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
+    finally:
+        controller._current_job = None
+        controller._current_process = None
+        if job.status in (
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+        ):
+            _trim_job_output(job)
+            controller._prune_history()
+        await controller._persist_jobs()
+
+
+async def execute_remote_job(controller: FirmwareController, job: FirmwareJob) -> None:
+    """
+    Run a ``JobSource.REMOTE`` job by dispatching through peer-link.
+
+    Reads ``source_pin_sha256`` off *job*, looks up the live
+    :class:`PeerLinkClient` through the remote-build
+    controller, bundles the YAML via the ``esphome bundle``
+    subprocess, dispatches ``submit_job(target="compile")``,
+    then translates receiver-side ``OFFLOADER_JOB_OUTPUT`` /
+    ``OFFLOADER_JOB_STATE_CHANGED`` events into the same
+    local ``JOB_OUTPUT`` / ``JOB_PROGRESS`` /
+    ``JOB_<terminal>`` fires the local subprocess path emits.
+    ``follow_job`` and the firmware-tasks UI consume one
+    event stream regardless of which CPU compiled the bytes.
+
+    Dispatches by ``job.job_type``:
+
+    * :attr:`JobType.COMPILE` — wait for the receiver's
+      terminal frame, finalise based on the wire status.
+    * :attr:`JobType.UPLOAD` / :attr:`JobType.INSTALL` —
+      same compile dispatch (per § Transparent install
+      flow's load-bearing "receiver only ever compiles"
+      policy), but on receiver-completed pull the
+      artifacts back via ``download_artifacts`` and run a
+      local ``esphome upload --file <staged>`` subprocess
+      to flash the device. The local flash step shares the
+      ``_tracked_subprocess`` plumbing the LOCAL path uses
+      so cancel SIGTERM lands on the upload chain the same
+      way.
+
+    Other job types (``CLEAN`` / ``RENAME`` /
+    ``RESET_BUILD_ENV``) are rejected at the runner's top
+    because the receiver-side ``submit_job`` contract is
+    compile-only — these don't have a corresponding wire
+    flow.
+
+    Terminal states are mapped through the same helpers the
+    local path uses (``_mark_job_terminal`` /
+    ``_finalize_cancelled``), so the outer
+    ``_execute_job``'s ``finally`` runs the shared
+    ``_trim_job_output`` / ``_prune_history`` / persist
+    sequence regardless of which branch produced the
+    terminal status.
+    """
+    await run_remote_job(controller, job)
+
+
+@asynccontextmanager
+async def tracked_subprocess(
+    controller: FirmwareController, *args: Any, **kwargs: Any
+) -> AsyncIterator[asyncio.subprocess.Process]:
+    """
+    Spawn a subprocess that's visible to ``firmware/cancel``.
+
+    Required for every ``create_subprocess_exec`` call in the
+    runner path — both the main install/upload spawn in
+    ``_execute_job`` and pre-flight probes like
+    ``_verify_chip``. Setting ``_current_process`` is what lets
+    a concurrent ``firmware/cancel`` actually land SIGTERM on
+    the running spawn; a direct ``create_subprocess_exec`` call
+    without this registration silently regresses the
+    issue-#136 fix — the cancel handler walks
+    ``_current_process``, no-ops on ``None``, the user clicks
+    Stop, nothing visible happens, and the orphaned subprocess
+    runs to completion in the background.
+
+    Two cleanup contracts on exit:
+
+    - Normal exit / non-cancellation exception: restore the
+      prior ``_current_process`` value so nested usage (a
+      future spawn site that itself wraps another) doesn't
+      accidentally null out an outer registration.
+    - ``asyncio.CancelledError`` (runner-task shutdown):
+      terminate the spawn before propagating, so the build
+      can't outlive the runner that started it. The outer
+      ``except asyncio.CancelledError`` in ``_execute_job``
+      handles the job-finalisation half and relies on this
+      helper for the terminate.
+
+    Pairs with ``_raise_if_cancelled`` — wrap each spawn, then
+    call the helper after to short-circuit if the cancel landed
+    between this subprocess and the next one.
+    """
+    proc = await create_subprocess_exec(*args, **kwargs)
+    prev = controller._current_process
+    controller._current_process = proc
+    try:
+        yield proc
+    except asyncio.CancelledError:
+        # Runner-shutdown cancellation: the runner task itself
+        # was cancelled (vs. a user-driven ``firmware/cancel``,
+        # which calls ``_terminate_current_process`` from the
+        # cancel handler directly). Reuse the same group-aware
+        # termination helper here so SIGTERM walks the whole
+        # process group (esphome → platformio → gcc / esptool).
+        # ``proc.terminate()`` would only signal the python
+        # parent — on POSIX with ``start_new_session=True``
+        # that orphans the child tree and the build keeps
+        # running until the children finish on their own.
+        await controller._terminate_current_process()
+        raise
+    finally:
+        controller._current_process = prev

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -38,10 +38,10 @@ import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware import (
-    controller as controller_module,
+    helpers as helpers_module,
 )
 from esphome_device_builder.controllers.firmware import (
-    helpers as helpers_module,
+    runner as runner_module,
 )
 from esphome_device_builder.controllers.firmware.constants import (
     _INFLIGHT_TRIM_KEEP,
@@ -697,7 +697,7 @@ async def test_compile_inflight_output_trims_when_cap_exceeded(
     because the ``finally``-block ``_trim_job_output(job)`` call
     runs anyway.
     """
-    real_trim = controller_module._trim_job_output
+    real_trim = runner_module._trim_job_output
     inflight_trim_calls: list[tuple[JobStatus, int, int | None]] = []
 
     def _spy_trim(job: Any, *, keep: int | None = None) -> None:
@@ -711,13 +711,13 @@ async def test_compile_inflight_output_trims_when_cap_exceeded(
             real_trim(job, keep=keep)
 
     # Patch both surfaces: the post-exit ``finally``-block call
-    # resolves through ``controller_module`` (the streaming-loop
+    # resolves through ``runner_module`` (the streaming-loop
     # imports it directly), while the mid-run trim now lands via
     # the shared ``_ingest_output_line`` helper in ``helpers.py``
     # — which calls ``_trim_job_output`` from its own module
     # scope. Without patching both, the mid-run branch escapes
     # the spy and the regression check goes silent.
-    monkeypatch.setattr(controller_module, "_trim_job_output", _spy_trim)
+    monkeypatch.setattr(runner_module, "_trim_job_output", _spy_trim)
     monkeypatch.setattr(helpers_module, "_trim_job_output", _spy_trim)
 
     excess = 200

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -65,6 +65,7 @@ import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware import controller as controller_module
+from esphome_device_builder.controllers.firmware import runner as runner_module
 from esphome_device_builder.models import EventType, JobStatus
 from tests._storage_fixtures import write_storage_json
 
@@ -191,7 +192,7 @@ def _patch_subprocess(
     in particular whether the esptool call fired at all.
     """
     record: dict[str, list] = {"esptool_calls": [], "build_calls": []}
-    real = controller_module.create_subprocess_exec
+    real = runner_module.create_subprocess_exec
 
     async def _wrapper(*args: Any, **kwargs: Any) -> Any:
         # esptool spawn:
@@ -221,7 +222,7 @@ def _patch_subprocess(
         record["build_calls"].append(args)
         return await real(sys.executable, "-c", _BUILD_SCRIPT_OK, **kwargs)
 
-    monkeypatch.setattr(controller_module, "create_subprocess_exec", _wrapper)
+    monkeypatch.setattr(runner_module, "create_subprocess_exec", _wrapper)
     return record
 
 
@@ -589,7 +590,7 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     _seed_yaml(tmp_path)
     _seed_storage(tmp_path, target_platform="ESP32C3")
 
-    real = controller_module.create_subprocess_exec
+    real = runner_module.create_subprocess_exec
     verify_spawned = asyncio.Event()
 
     async def _wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -613,7 +614,7 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
         msg = "build subprocess spawned despite mid-verify cancel"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(controller_module, "create_subprocess_exec", _wrapper)
+    monkeypatch.setattr(runner_module, "create_subprocess_exec", _wrapper)
 
     job = await controller.install(configuration="kitchen.yaml", port="/dev/ttyUSB0")
 
@@ -674,7 +675,7 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
     _seed_yaml(tmp_path)
     _seed_storage(tmp_path, target_platform="ESP32C3")
 
-    real = controller_module.create_subprocess_exec
+    real = runner_module.create_subprocess_exec
     cancel_armed = False
 
     async def _wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -703,7 +704,7 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
         msg = "build subprocess spawned despite mid-verify cancel"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(controller_module, "create_subprocess_exec", _wrapper)
+    monkeypatch.setattr(runner_module, "create_subprocess_exec", _wrapper)
 
     job = await controller.install(configuration="kitchen.yaml", port="/dev/ttyUSB0")
     captured = await _run_until_terminal(controller)
@@ -890,7 +891,7 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
     # ordering — the post-spawn cancel check is what's under test.
     _seed_storage(tmp_path, target_platform="ESP32C3")
 
-    real = controller_module.create_subprocess_exec
+    real = runner_module.create_subprocess_exec
     terminate_calls: list[asyncio.subprocess.Process | None] = []
     real_terminate = controller._terminate_current_process
 
@@ -911,7 +912,7 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
             controller._cancel_requested.add(controller._current_job.job_id)
         return await real(sys.executable, "-c", _BUILD_SCRIPT_OK, **kwargs)
 
-    monkeypatch.setattr(controller_module, "create_subprocess_exec", _wrapper)
+    monkeypatch.setattr(runner_module, "create_subprocess_exec", _wrapper)
 
     job = await controller.install(configuration="kitchen.yaml", port="OTA")
     captured = await _run_until_terminal(controller)


### PR DESCRIPTION
# What does this implement/fix?

Fifth structural-split PR for `controllers/firmware/controller.py` (follows #733 persistence + #735 cli + #739 lifecycle + #740 factories). Pulls the queue-run loop and local-subprocess execution path — `_run_queue`, `_execute_job`, `_execute_remote_job`, `_tracked_subprocess` — into a new `runner.py` submodule.

Same free-function-with-bound-method-delegate pattern as the prior four PRs. `_execute_job` is heavily monkey-patched by tests (`test_persistence.py`, `test_branches_coverage.py`); `_run_queue` is spun up via `asyncio.create_task` in the e2e tests; `_tracked_subprocess` is patched as an attribute on the controller in `test_remote_runner.py`; `_execute_remote_job` is called by the runner. All four stay as bound methods on the controller — the delegate signatures are preserved byte-for-byte; only the bodies move.

**Inner cross-calls route through bound-method delegates.** Inside `runner.py`, `execute_job` calls `controller._execute_remote_job(...)`, `controller._tracked_subprocess(...)`, `controller._finalize_terminal(...)`, etc. rather than the free functions directly — preserving the monkey-patch surface per the lesson from #739's Copilot review.

Two test files redirect their `monkeypatch` targets to the new module — mirrors the `test_stop.py` redirect done in #739:

* `tests/controllers/firmware/test_execute_job_e2e.py` — `controller_module._trim_job_output` → `runner_module._trim_job_output`
* `tests/controllers/firmware/test_verify_chip_e2e.py` — `controller_module.create_subprocess_exec` → `runner_module.create_subprocess_exec`

Changes:

* **New `runner.py`** (338 lines) — four free functions extracted as a coherent unit (everything that runs on the queue thread).
* **`controller.py`** — 1518 → 1230 lines (−288). Bodies replaced with thin delegates; ruff auto-removed the unused imports (`asynccontextmanager`, `AsyncIterator`, `sys`, `UTC`/`datetime`, `iter_lines_with_progress`, `create_subprocess_exec`, `run_remote_job`, `_ingest_output_line`, `_is_no_module_named_esphome`, `_trim_job_output`, `_ERROR_PATTERNS`).
* `_tracked_subprocess` delegate's return type switches from `AsyncIterator` (which mypy reads off the underlying generator) to `AbstractAsyncContextManager` (which describes what `@asynccontextmanager` actually produces) — required because the delegate is a thin factory rather than the decorator host.

Combined arc (#733 + #735 + #739 + #740 + this): controller.py **2083 → 1230 lines (−41%)**. The remaining concerns are smaller (boundary validation, the `firmware/clean` fan-out, the WS `firmware/follow_job` streaming machinery); a follow-up will batch the next-biggest set.

All 3198 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #733 + #735 + #739 + #740; fifth chunk of the firmware/controller.py split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
