### PR TITLE
Split DevicesController: extract clone_device

### DIFF
--- a/esphome_device_builder/controllers/devices/__init__.py
+++ b/esphome_device_builder/controllers/devices/__init__.py
@@ -27,6 +27,9 @@ resolving after the subpackage split. Submodules:
   (``stream_logs``, ``stop_stream``) plus the shared
   ``stream_subprocess`` helper that ``validate_config``
   reuses.
+- ``mutations_clone`` — ``devices/clone`` WS command body
+  (duplicate an existing YAML under a fresh hostname,
+  fresh friendly_name, and fresh API encryption key).
 - ``mutations_create`` — ``devices/create`` WS command body
   (the wizard's three-flow YAML creation: file_content /
   template / stub).

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -27,9 +27,6 @@ from ...helpers.event_bus import Event
 from ...helpers.storage_path import resolve_storage_path
 from ...helpers.yaml import (
     YamlUpsertNotSupportedError,
-    generate_api_encryption_key,
-    rewrite_api_encryption_key,
-    rewrite_name_or_substitution,
     upsert_yaml_leaf_under_top_block,
 )
 from ...models import (
@@ -54,7 +51,6 @@ from .._reachability_tracker import ReachabilityTracker
 from ..config import (
     get_device_metadata,
     set_device_labels,
-    set_device_metadata,
 )
 from ..firmware.helpers import _find_esphome_cmd
 from . import (
@@ -64,6 +60,7 @@ from . import (
     firmware_sync,
     importable,
     logs,
+    mutations_clone,
     mutations_create,
     mutations_yaml,
     reachability,
@@ -80,9 +77,7 @@ from ._yaml_search import (
 from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
     _build_address_cache_args,
-    _rewrite_required_yaml_leaf,
     _validate_archive_configuration,
-    friendly_name_slugify,
 )
 from .metadata import DeviceMetadataBase
 
@@ -636,179 +631,13 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         new_friendly_name: str | None = None,
         **kwargs: Any,
     ) -> dict[str, str]:
-        """
-        Duplicate an existing device YAML under a fresh hostname.
-
-        Designed for "I bought 10 of the same bulb" workflows: the
-        clone copies the source YAML's components and wiring intact
-        but takes a fresh ``esphome.name`` (and therefore a fresh
-        mDNS hostname / API endpoint), a fresh ``friendly_name``,
-        and a freshly-generated ``api.encryption.key`` so two
-        siblings forked from the same source don't share encryption
-        material — compromise of one device must not compromise
-        the others.
-
-        ``new_friendly_name`` is optional: when omitted, defaults
-        to ``friendly_name_slugify(new_name)`` to mirror how
-        ``devices/create`` derives the wizard friendly_name. Pass
-        a blank string to leave the source's ``friendly_name:``
-        line untouched (rare — most callers want a per-clone label).
-
-        Indirections (``key: !secret api_key`` /
-        ``key: ${api_key}``) are deliberately preserved on the
-        clone — the indirection target is shared with the source
-        on disk, so rewriting the indirection name to a fresh
-        literal would silently desync the rendered config from
-        whatever ``secrets.yaml`` / substitutions block actually
-        drives the encryption.
-
-        Returns ``{"configuration": "<new_filename>"}``. Errors
-        propagate as ``INVALID_ARGS`` for collisions / empty
-        names; the source file failing to load surfaces as
-        ``INTERNAL_ERROR``.
-        """
-        new_name = new_name.strip()
-        if not new_name:
-            raise CommandError(ErrorCode.INVALID_ARGS, "new_name is required")
-        new_filename = f"{new_name}.yaml"
-        # Compare on the *stem*, not the filename, so cloning
-        # ``kitchen.yml`` to ``new_name=kitchen`` is rejected even
-        # though the filenames differ — both files would still carry
-        # the same ``esphome.name`` and collide on mDNS.
-        source_stem = configuration_stem(configuration)
-        if new_name == source_stem:
-            raise CommandError(
-                ErrorCode.INVALID_ARGS,
-                "new_name must differ from the source device name",
-            )
-
-        loop = asyncio.get_running_loop()
-        source_path = self._db.settings.rel_path(configuration)
-        new_path = self._db.settings.rel_path(new_filename)
-        config_dir = self._db.settings.config_dir
-        # Default the friendly_name to a slug-derived fallback so
-        # the dashboard list doesn't show two entries with the same
-        # label after a clone. Explicit blank string opts out.
-        if new_friendly_name is None:
-            new_friendly_name = friendly_name_slugify(new_name)
-        # Fresh encryption material per clone — generated up here
-        # rather than inside the executor so the off-loop work is
-        # purely I/O.
-        new_key = generate_api_encryption_key()
-
-        # All blocking I/O bundled into one executor hop. Returns the
-        # (raw_source_content, source_metadata, target_existed_at_start)
-        # triple — the caller maps each into either a typed
-        # ``CommandError`` or the rewrite + write step that follows.
-        # ``ext_storage_path`` / metadata helpers / file I/O are all
-        # ``Path``-walking syscalls under the hood; no point in five
-        # round-trips through ``run_in_executor`` when one will do.
-        def _gather() -> tuple[str | None, dict | None, bool]:
-            if new_path.exists():
-                return None, None, True
-            if not source_path.exists():
-                return None, None, False
-            content = source_path.read_text(encoding="utf-8")
-            meta = get_device_metadata(config_dir, configuration)
-            return content, meta, False
-
-        source_content, source_meta, target_existed = await loop.run_in_executor(None, _gather)
-        if target_existed:
-            msg = f"A device named {new_filename} already exists"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
-        if source_content is None:
-            msg = f"Source device {configuration} not found"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
-
-        # Validate the *source* before doing any rewrite work. The
-        # leaf-line rewrites that follow (name / friendly_name / api
-        # key) are structure-preserving, so a valid source always
-        # produces a valid clone — and an invalid source always
-        # produces an invalid clone. Bail early on a broken source
-        # with a message that points at the source's actual schema
-        # errors, so the user fixes the source first and retries.
-        # Surfacing this here also means we don't burn the rewrite
-        # work just to re-discover the source was unflashable.
-        await self._validate_rewritten_yaml_or_raise(configuration, source_content, action="clone")
-
-        # Land the new identity on whichever line the source actually
-        # uses to drive the value. Two patterns appear in real configs:
-        #
-        # 1. **Direct literal** — ``esphome.name: kitchen``. Rewrite
-        #    the leaf line.
-        # 2. **Substitution reference** — ``esphome.name: ${devicename}``
-        #    with ``substitutions.devicename: kitchen``. This is the
-        #    standard ESPHome wizard / dashboard_import shape. Here
-        #    the *leaf* line carries an indirection name; the actual
-        #    value lives in the substitutions block. Rewriting the
-        #    leaf would land a literal name and silently orphan the
-        #    substitution, breaking any other consumer of the same
-        #    variable (a sensor named ``${devicename}_temp``, etc.).
-        #    Rewrite the substitution definition instead so every
-        #    reference re-targets atomically.
-        #
-        # Mixed values (``${prefix}-suffix``) aren't pure references
-        # and fall through to the leaf rewrite — we have no way to
-        # split the prefix without changing the suffix's meaning.
-        # ``_rewrite_required_yaml_leaf`` folds in the "leaf must
-        # exist in this file" precondition + the rewrite. Reject
-        # is the right behaviour for clone — a hostname rewrite
-        # that silently no-ops on a package-driven source would
-        # produce a duplicate device under the source's hostname
-        # and collide on mDNS. (The friendly-name editor takes the
-        # opposite call via ``upsert_yaml_leaf_under_top_block``
-        # — for a display label, ESPHome's package merge means
-        # *inserting* a local leaf is what the user wants.)
-        new_content = _rewrite_required_yaml_leaf(source_content, ("esphome", "name"), new_name)
-        # ``friendly_name`` is optional on the clone path — when
-        # the source doesn't have an inline leaf the clone just
-        # ships without one (vs. ``name`` which we hard-require).
-        # Skip the helper here; the underlying ``rewrite_name_or_substitution``
-        # is already a no-op when the leaf is missing.
-        if new_friendly_name:
-            new_content = rewrite_name_or_substitution(
-                new_content, ("esphome", "friendly_name"), new_friendly_name
-            )
-        # ``rewrite_api_encryption_key`` is a no-op when the source
-        # uses ``!secret`` / ``${...}`` for the key — those
-        # indirections stay shared with the source on purpose.
-        new_content = rewrite_api_encryption_key(new_content, new_key)
-
-        # Carry forward only the source's ``board_id`` — that's the
-        # one piece of dashboard state the scanner can't recover from
-        # the YAML (it's a catalog-key indirection the user picked at
-        # wizard time). Friendly name lives in the YAML we just
-        # wrote, so ``load_device_from_storage`` reads it back on the
-        # next scan; copying to metadata too would just duplicate
-        # truth. ``ip`` is deliberately not carried — the clone
-        # hasn't booted yet, and inheriting the source's address
-        # would mis-route ``devices/logs`` until the first mDNS
-        # announce corrects it. StorageJSON is skipped entirely: it's
-        # a build artefact, the next compile writes a real one, and
-        # ``load_device_from_storage`` handles a missing sidecar by
-        # reading from YAML alone.
-        carry_board_id = source_meta.get("board_id") if source_meta else None
-
-        def _commit() -> None:
-            with open(new_path, "x", encoding="utf-8") as f:
-                f.write(new_content)
-            if carry_board_id:
-                set_device_metadata(config_dir, new_filename, board_id=carry_board_id)
-
-        try:
-            await loop.run_in_executor(None, _commit)
-        except FileExistsError as exc:
-            # Race: another caller created the file between our
-            # gather pass and the ``open(... "x")``. Surface as the
-            # same INVALID_ARGS the preflight produces so the
-            # frontend renders a single message.
-            msg = f"A device named {new_filename} already exists"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
-        # Rescan so the scanner indexes the new YAML and fires the
-        # ADDED event the WS subscribers expect. ``probe_device``
-        # runs from the scan-change handler — no double-probe here.
-        await self._scanner.scan()
-        return {"configuration": new_filename}
+        """Duplicate an existing device YAML under a fresh hostname."""
+        return await mutations_clone.clone_device(
+            self,
+            configuration=configuration,
+            new_name=new_name,
+            new_friendly_name=new_friendly_name,
+        )
 
     @api_command("devices/edit_friendly_name")
     async def edit_friendly_name(

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -1,0 +1,150 @@
+"""``devices/clone`` WS command body."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...helpers.device_yaml import configuration_stem
+from ...helpers.yaml import (
+    generate_api_encryption_key,
+    rewrite_api_encryption_key,
+    rewrite_name_or_substitution,
+)
+from ...models import ErrorCode
+from ..config import get_device_metadata, set_device_metadata
+from .helpers import _rewrite_required_yaml_leaf, friendly_name_slugify
+
+if TYPE_CHECKING:
+    from .controller import DevicesController
+
+
+async def clone_device(
+    controller: DevicesController,
+    *,
+    configuration: str,
+    new_name: str,
+    new_friendly_name: str | None,
+) -> dict[str, str]:
+    """
+    Duplicate an existing device YAML under a fresh hostname.
+
+    Designed for the "I bought 10 of the same bulb" workflow:
+    keeps the source's components and wiring intact but takes
+    a fresh ``esphome.name``, a fresh ``friendly_name``, and a
+    freshly-generated ``api.encryption.key`` so two siblings
+    don't share encryption material. ``!secret`` /
+    ``${substitution}`` indirections for the API key are
+    preserved on purpose since the indirection target is
+    shared with the source on disk and rewriting the
+    indirection name would silently desync the rendered
+    config from the actual ``secrets.yaml`` value.
+    """
+    new_name = new_name.strip()
+    if not new_name:
+        raise CommandError(ErrorCode.INVALID_ARGS, "new_name is required")
+    new_filename = f"{new_name}.yaml"
+    # Compare on the *stem* so cloning ``kitchen.yml`` to
+    # ``new_name=kitchen`` is rejected even though the filenames
+    # differ; both files would still carry the same
+    # ``esphome.name`` and collide on mDNS.
+    source_stem = configuration_stem(configuration)
+    if new_name == source_stem:
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            "new_name must differ from the source device name",
+        )
+
+    loop = asyncio.get_running_loop()
+    source_path = controller._db.settings.rel_path(configuration)
+    new_path = controller._db.settings.rel_path(new_filename)
+    config_dir = controller._db.settings.config_dir
+    if new_friendly_name is None:
+        new_friendly_name = friendly_name_slugify(new_name)
+    # Generate the fresh key off-loop so the executor work below
+    # is purely I/O.
+    new_key = generate_api_encryption_key()
+
+    # All blocking I/O bundled into one executor hop.
+    def _gather() -> tuple[str | None, dict | None, bool]:
+        if new_path.exists():
+            return None, None, True
+        if not source_path.exists():
+            return None, None, False
+        content = source_path.read_text(encoding="utf-8")
+        meta = get_device_metadata(config_dir, configuration)
+        return content, meta, False
+
+    source_content, source_meta, target_existed = await loop.run_in_executor(None, _gather)
+    if target_existed:
+        msg = f"A device named {new_filename} already exists"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if source_content is None:
+        msg = f"Source device {configuration} not found"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+
+    # Validate the source before rewrite work; the leaf rewrites
+    # are structure-preserving so a valid source produces a
+    # valid clone, and bailing here points the user at the
+    # source's actual schema errors instead of burning rewrite
+    # work just to re-discover the source was unflashable.
+    await controller._validate_rewritten_yaml_or_raise(
+        configuration, source_content, action="clone"
+    )
+
+    # Rewrite the identity onto whichever line drives the value:
+    # direct literal (``esphome.name: kitchen``) or substitution
+    # reference (``esphome.name: ${devicename}`` with
+    # ``substitutions.devicename: kitchen``). Rewriting the leaf
+    # for the substitution case would orphan the variable and
+    # break any other consumer of the same name (e.g. a sensor
+    # named ``${devicename}_temp``); rewriting the substitution
+    # definition retargets every reference atomically.
+    # ``_rewrite_required_yaml_leaf`` rejects when the leaf is
+    # missing entirely so a package-driven source can't silently
+    # produce a duplicate hostname.
+    new_content = _rewrite_required_yaml_leaf(source_content, ("esphome", "name"), new_name)
+    # ``friendly_name`` is optional on the clone path; the
+    # underlying helper is already a no-op when the leaf is
+    # missing, so skip the required-leaf wrapper here.
+    if new_friendly_name:
+        new_content = rewrite_name_or_substitution(
+            new_content, ("esphome", "friendly_name"), new_friendly_name
+        )
+    # No-op when the source uses ``!secret`` / ``${...}`` for
+    # the key; those indirections stay shared with the source.
+    new_content = rewrite_api_encryption_key(new_content, new_key)
+
+    # Carry forward only the source's ``board_id`` since that's
+    # the catalog-key indirection the user picked at wizard
+    # time and the scanner can't recover it from the YAML.
+    # Friendly name lives in the YAML we just wrote (no need to
+    # duplicate to metadata). ``ip`` is intentionally not
+    # carried; the clone hasn't booted yet and inheriting the
+    # source's address would mis-route ``devices/logs`` until
+    # the first mDNS announce. StorageJSON is skipped entirely
+    # since it's a build artefact and the next compile writes a
+    # real one.
+    carry_board_id = source_meta.get("board_id") if source_meta else None
+
+    def _commit() -> None:
+        with open(new_path, "x", encoding="utf-8") as f:
+            f.write(new_content)
+        if carry_board_id:
+            set_device_metadata(config_dir, new_filename, board_id=carry_board_id)
+
+    try:
+        await loop.run_in_executor(None, _commit)
+    except FileExistsError as exc:
+        # Race: another caller created the file between our
+        # gather pass and the ``open(... "x")``. Surface as the
+        # same INVALID_ARGS the preflight produces so the
+        # frontend renders a single message.
+        msg = f"A device named {new_filename} already exists"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
+    # Rescan so the scanner indexes the new YAML and fires the
+    # ADDED event WS subscribers expect; ``probe_device`` runs
+    # from the scan-change handler so no double-probe here.
+    await controller._scanner.scan()
+    return {"configuration": new_filename}

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -522,7 +522,7 @@ async def test_clone_device_handles_filesystem_race_on_target_filename(
 
     with (
         patch(
-            "esphome_device_builder.controllers.devices.controller.open",
+            "esphome_device_builder.controllers.devices.mutations_clone.open",
             _raising_open,
             create=True,
         ),


### PR DESCRIPTION
# What does this implement/fix?

Continues the mutations split (Track B1) by extracting `clone_device` — the "I bought 10 of the same bulb" workflow — into a sibling `mutations_clone.py`. Builds on #741 (mutations_yaml foundation) and #744 (mutations_create).

`mutations_clone.py` (~150 lines) hosts `clone_device`. Free function takes `controller` as the first arg; the controller keeps a thin bound-method delegate so WS dispatch and tests calling `controller.clone_device(...)` still resolve unchanged.

Controller drops 1476 → 1311 lines.

## Imports

`_rewrite_required_yaml_leaf`, `friendly_name_slugify`, `generate_api_encryption_key`, and `rewrite_api_encryption_key` were only used by `clone_device` and are removed from `controller.py`'s imports. `configuration_stem`, `rewrite_name_or_substitution`, `get_device_metadata`, and `set_device_metadata` stay since other still-on-controller methods (`rename_device`, `edit_friendly_name`, `_resolve_api_key_via_esphome_config`) also use them.

## Test impact

`test_clone_device_handles_filesystem_race_on_target_filename` patches the `open` builtin via `controller.open` to simulate a `FileExistsError` on the commit closure (the test verifies the race window between the preflight check and `open(... "x")` surfaces as `INVALID_ARGS`, not the underlying `FileExistsError`). Re-pointed at `mutations_clone.open` since the `open()` call moved with the body. Other clone tests use bound-method calls (`ctrl.clone_device(...)`) which keep resolving through the delegate.

3223 tests pass; pure refactor.

**Related issue or feature (if applicable):**

- follow-up to #741 / #744

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
