### PR TITLE
Extract firmware/clean fan-out into clean.py

### DIFF
--- a/esphome_device_builder/controllers/firmware/clean.py
+++ b/esphome_device_builder/controllers/firmware/clean.py
@@ -1,0 +1,185 @@
+"""Firmware-job clean: local clean + fan-out to connected paired receivers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...models import (
+    ErrorCode,
+    FirmwareJob,
+    JobBuildSource,
+    JobSource,
+    JobType,
+)
+from ...models.remote_build import PeerStatus
+from .constants import _ACTIVE_JOB_STATUSES
+
+if TYPE_CHECKING:
+    from .controller import FirmwareController
+
+
+# Job types that produce build artifacts a clean would destroy.
+# A ``firmware/clean`` request that lands while one of these is
+# in-flight for the same configuration is rejected loudly rather
+# than supersede-cancelled — see the ``clean`` handler's docstring
+# for the rationale.
+_BUILD_PRODUCING_JOB_TYPES: frozenset[JobType] = frozenset(
+    {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL, JobType.RENAME}
+)
+
+
+async def clean(controller: FirmwareController, *, configuration: str) -> FirmwareJob:
+    """
+    Queue a build clean job, plus one per connected paired receiver.
+
+    Returns the LOCAL clean job (the one the operator's WS
+    command is awaiting). N additional REMOTE clean jobs are
+    queued silently for fan-out to every currently-connected
+    approved peer; each shows up as its own
+    :class:`FirmwareJob` in the firmware-jobs list and drives
+    the same lifecycle events as remote installs do, so the
+    operator sees per-receiver clean progress in the
+    existing UI.
+
+    **Why fan out:** a stale receiver-side build dir is the
+    same class of problem a stale local build dir is. The
+    operator's "Clean build files" click expects every place
+    this device has been built to drop its artifacts, not
+    just the local one. Without the fan-out, a remote receiver
+    keeps caching the broken state and the next remote
+    compile picks up the same poisoned tree.
+
+    **Best-effort:** a peer that disconnects between this
+    ``clean`` call and the runner picking up its job lands on
+    the existing remote-session-lost FAILED path (the runner's
+    ``_dispatch_and_drive`` returns ``CommandError`` from
+    ``_lookup_open_peer_link_client``). The local job is
+    independent and runs regardless. A peer that isn't
+    connected at all just doesn't get a job queued — the next
+    time the operator clicks clean while that peer is
+    connected, it'll catch up.
+
+    Rejects with ``CommandError(INVALID_ARGS)`` when an active
+    compile / upload / install / rename job exists for the same
+    configuration. Other firmware commands rely on the
+    ``_enqueue`` supersede path to cancel-and-replace the running
+    job — that's the right shape for "user wants to retry the
+    compile" — but a clean wipes the build artifacts the running
+    job is producing, so a quietly-cancelled build that the user
+    didn't intend to abandon is the worse failure mode. Make the
+    user retry once the build settles instead. Two clean jobs
+    for the same configuration still supersede each other (the
+    second one is the user's intent regardless). The supersede
+    check applies only to the LOCAL job; the fan-out's per-peer
+    REMOTE jobs enqueue with ``supersede=False`` so they don't
+    cancel siblings or the just-queued local clean. See
+    :meth:`_enqueue`'s docstring for the carve-out rationale.
+
+    The WS reply returns only the LOCAL clean — that's what the
+    operator's ``firmware/clean`` call awaits. Per-peer REMOTE
+    clean jobs surface through the existing
+    ``subscribe_events`` firmware-jobs stream the dashboard
+    already consumes for in-flight job lists, so the operator
+    sees N+1 rows in the firmware-tasks panel without the
+    handler needing to thread them through the WS reply
+    shape. Don't "fix" this to return a list — the WS contract
+    is "the handler returns the job the operator's click
+    produced"; the fan-out is incidental.
+
+    Multi-offloader fleets: a clean from offloader A and a
+    concurrent compile from offloader B against the same
+    receiver are safe by construction. Each offloader gets its
+    own ``ESPHOME_DATA_DIR`` subtree
+    (``<receiver_data_dir>/.remote_builds/<dashboard_id>/.esphome``),
+    so A's clean only wipes A's per-offloader build dir; B's
+    compile artefacts under B's subtree are untouched. The
+    receiver-side single-flight queue serializes the actual
+    subprocess invocations regardless, but the per-offloader
+    isolation is what makes the cross-offloader race a
+    non-issue at the filesystem level.
+    """
+    await controller._validate_configuration_boundary(configuration)
+    if blocker := _active_build_for(controller, configuration):
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            f"{blocker.job_type.value} job already in progress "
+            f"for {configuration}; wait for it to finish or "
+            f"cancel it before cleaning.",
+        )
+    local_job = controller._create_job(configuration, JobType.CLEAN)
+    enqueued = await controller._enqueue(local_job)
+    await _fan_out_clean_to_connected_peers(controller, configuration)
+    return enqueued
+
+
+async def _fan_out_clean_to_connected_peers(
+    controller: FirmwareController, configuration: str
+) -> None:
+    """Queue one REMOTE clean job per connected approved peer.
+
+    Reads the remote-build controller's RAM-canonical
+    ``(_pairings, _open_peer_links)`` state via
+    :meth:`OffloaderController.build_scheduler_snapshot`.
+    Approved + connected peers get a job each; everything else
+    is silently skipped (a PENDING row can't accept submits,
+    a disconnected approved row would just FAIL on the runner's
+    first ``_lookup_open_peer_link_client``).
+
+    Fan-out is silent on the WS reply — the operator's
+    ``firmware/clean`` call returns the local job; the remote
+    jobs surface through the existing
+    firmware-jobs subscribe-events stream the dashboard already
+    consumes for in-flight job lists. A regression that lost
+    the fan-out shows up as "I clicked Clean but my receiver
+    still has the old build".
+    """
+    offloader = controller._db.remote_build_offloader
+    if offloader is None:
+        return
+    snapshot = offloader.build_scheduler_snapshot()
+    # ``build_scheduler_snapshot`` ``dict(self._pairings)``-copies
+    # on construction, so iteration is already isolated from a
+    # concurrent unpair landing on a different loop tick.
+    for pairing in snapshot.pairings.values():
+        if pairing.status is not PeerStatus.APPROVED:
+            continue
+        if pairing.pin_sha256 not in snapshot.open_peer_links:
+            continue
+        remote_job = controller._create_job(
+            configuration,
+            JobType.CLEAN,
+            build_source=JobBuildSource(
+                source=JobSource.REMOTE,
+                source_pin_sha256=pairing.pin_sha256,
+                source_label=pairing.label,
+                source_esphome_version=pairing.esphome_version,
+            ),
+        )
+        # ``supersede=False``: the fan-out batch is N+1 jobs
+        # all sharing one ``configuration``, so default
+        # supersede semantics ("cancel any prior active job
+        # for this configuration") would cancel the local
+        # clean we just queued plus every prior fan-out
+        # sibling, leaving only the LAST peer's clean alive.
+        # See ``_enqueue``'s docstring for the carve-out
+        # rationale.
+        await controller._enqueue(remote_job, supersede=False)
+
+
+def _active_build_for(controller: FirmwareController, configuration: str) -> FirmwareJob | None:
+    """Return any in-flight build-producing job on *configuration*.
+
+    Filters ``_jobs`` by status (``_ACTIVE_JOB_STATUSES``) and
+    type (``_BUILD_PRODUCING_JOB_TYPES``). Used by ``clean`` to
+    reject rather than supersede when a destructive op would
+    wipe artifacts the running job is producing.
+    """
+    for active in controller._jobs.values():
+        if active.configuration != configuration:
+            continue
+        if active.status not in _ACTIVE_JOB_STATUSES:
+            continue
+        if active.job_type in _BUILD_PRODUCING_JOB_TYPES:
+            return active
+    return None

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -37,11 +37,10 @@ from ...models import (
     FirmwareJob,
     JobBuildSource,
     JobLifecycleData,
-    JobSource,
     JobStatus,
     JobType,
 )
-from ...models.remote_build import PeerStatus
+from . import clean as clean_mod
 from . import cli, factories, follow, lifecycle, persistence, runner
 from .constants import (
     _ACTIVE_JOB_STATUSES,
@@ -80,15 +79,6 @@ _LOGGER = logging.getLogger(__name__)
 _LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPONENT.values()) | {
     "libretiny"
 }
-
-# Job types that produce build artifacts a clean would destroy.
-# A ``firmware/clean`` request that lands while one of these is
-# in-flight for the same configuration is rejected loudly rather
-# than supersede-cancelled — see the ``clean`` handler's docstring
-# for the rationale.
-_BUILD_PRODUCING_JOB_TYPES: frozenset[JobType] = frozenset(
-    {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL, JobType.RENAME}
-)
 
 
 def _resolve_download_component(target_platform: str | None) -> str:
@@ -263,155 +253,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     @api_command("firmware/clean")
     async def clean(self, *, configuration: str, **kwargs: Any) -> FirmwareJob:
-        """
-        Queue a build clean job, plus one per connected paired receiver.
-
-        Returns the LOCAL clean job (the one the operator's WS
-        command is awaiting). N additional REMOTE clean jobs are
-        queued silently for fan-out to every currently-connected
-        approved peer; each shows up as its own
-        :class:`FirmwareJob` in the firmware-jobs list and drives
-        the same lifecycle events as remote installs do, so the
-        operator sees per-receiver clean progress in the
-        existing UI.
-
-        **Why fan out:** a stale receiver-side build dir is the
-        same class of problem a stale local build dir is. The
-        operator's "Clean build files" click expects every place
-        this device has been built to drop its artifacts, not
-        just the local one. Without the fan-out, a remote receiver
-        keeps caching the broken state and the next remote
-        compile picks up the same poisoned tree.
-
-        **Best-effort:** a peer that disconnects between this
-        ``clean`` call and the runner picking up its job lands on
-        the existing remote-session-lost FAILED path (the runner's
-        ``_dispatch_and_drive`` returns ``CommandError`` from
-        ``_lookup_open_peer_link_client``). The local job is
-        independent and runs regardless. A peer that isn't
-        connected at all just doesn't get a job queued — the next
-        time the operator clicks clean while that peer is
-        connected, it'll catch up.
-
-        Rejects with ``CommandError(INVALID_ARGS)`` when an active
-        compile / upload / install / rename job exists for the same
-        configuration. Other firmware commands rely on the
-        ``_enqueue`` supersede path to cancel-and-replace the running
-        job — that's the right shape for "user wants to retry the
-        compile" — but a clean wipes the build artifacts the running
-        job is producing, so a quietly-cancelled build that the user
-        didn't intend to abandon is the worse failure mode. Make the
-        user retry once the build settles instead. Two clean jobs
-        for the same configuration still supersede each other (the
-        second one is the user's intent regardless). The supersede
-        check applies only to the LOCAL job; the fan-out's per-peer
-        REMOTE jobs enqueue with ``supersede=False`` so they don't
-        cancel siblings or the just-queued local clean. See
-        :meth:`_enqueue`'s docstring for the carve-out rationale.
-
-        The WS reply returns only the LOCAL clean — that's what the
-        operator's ``firmware/clean`` call awaits. Per-peer REMOTE
-        clean jobs surface through the existing
-        ``subscribe_events`` firmware-jobs stream the dashboard
-        already consumes for in-flight job lists, so the operator
-        sees N+1 rows in the firmware-tasks panel without the
-        handler needing to thread them through the WS reply
-        shape. Don't "fix" this to return a list — the WS contract
-        is "the handler returns the job the operator's click
-        produced"; the fan-out is incidental.
-
-        Multi-offloader fleets: a clean from offloader A and a
-        concurrent compile from offloader B against the same
-        receiver are safe by construction. Each offloader gets its
-        own ``ESPHOME_DATA_DIR`` subtree
-        (``<receiver_data_dir>/.remote_builds/<dashboard_id>/.esphome``),
-        so A's clean only wipes A's per-offloader build dir; B's
-        compile artefacts under B's subtree are untouched. The
-        receiver-side single-flight queue serializes the actual
-        subprocess invocations regardless, but the per-offloader
-        isolation is what makes the cross-offloader race a
-        non-issue at the filesystem level.
-        """
-        await self._validate_configuration_boundary(configuration)
-        if blocker := self._active_build_for(configuration):
-            raise CommandError(
-                ErrorCode.INVALID_ARGS,
-                f"{blocker.job_type.value} job already in progress "
-                f"for {configuration}; wait for it to finish or "
-                f"cancel it before cleaning.",
-            )
-        local_job = self._create_job(configuration, JobType.CLEAN)
-        enqueued = await self._enqueue(local_job)
-        await self._fan_out_clean_to_connected_peers(configuration)
-        return enqueued
-
-    async def _fan_out_clean_to_connected_peers(self, configuration: str) -> None:
-        """Queue one REMOTE clean job per connected approved peer.
-
-        Reads the remote-build controller's RAM-canonical
-        ``(_pairings, _open_peer_links)`` state via
-        :meth:`OffloaderController.build_scheduler_snapshot`.
-        Approved + connected peers get a job each; everything else
-        is silently skipped (a PENDING row can't accept submits,
-        a disconnected approved row would just FAIL on the runner's
-        first ``_lookup_open_peer_link_client``).
-
-        Fan-out is silent on the WS reply — the operator's
-        ``firmware/clean`` call returns the local job; the remote
-        jobs surface through the existing
-        firmware-jobs subscribe-events stream the dashboard already
-        consumes for in-flight job lists. A regression that lost
-        the fan-out shows up as "I clicked Clean but my receiver
-        still has the old build".
-        """
-        offloader = self._db.remote_build_offloader
-        if offloader is None:
-            return
-        snapshot = offloader.build_scheduler_snapshot()
-        # ``build_scheduler_snapshot`` ``dict(self._pairings)``-copies
-        # on construction, so iteration is already isolated from a
-        # concurrent unpair landing on a different loop tick.
-        for pairing in snapshot.pairings.values():
-            if pairing.status is not PeerStatus.APPROVED:
-                continue
-            if pairing.pin_sha256 not in snapshot.open_peer_links:
-                continue
-            remote_job = self._create_job(
-                configuration,
-                JobType.CLEAN,
-                build_source=JobBuildSource(
-                    source=JobSource.REMOTE,
-                    source_pin_sha256=pairing.pin_sha256,
-                    source_label=pairing.label,
-                    source_esphome_version=pairing.esphome_version,
-                ),
-            )
-            # ``supersede=False``: the fan-out batch is N+1 jobs
-            # all sharing one ``configuration``, so default
-            # supersede semantics ("cancel any prior active job
-            # for this configuration") would cancel the local
-            # clean we just queued plus every prior fan-out
-            # sibling, leaving only the LAST peer's clean alive.
-            # See ``_enqueue``'s docstring for the carve-out
-            # rationale.
-            await self._enqueue(remote_job, supersede=False)
-
-    def _active_build_for(self, configuration: str) -> FirmwareJob | None:
-        """Return any in-flight build-producing job on *configuration*.
-
-        Filters ``_jobs`` by status (``_ACTIVE_JOB_STATUSES``) and
-        type (``_BUILD_PRODUCING_JOB_TYPES``). Used by ``clean`` to
-        reject rather than supersede when a destructive op would
-        wipe artifacts the running job is producing.
-        """
-        for active in self._jobs.values():
-            if active.configuration != configuration:
-                continue
-            if active.status not in _ACTIVE_JOB_STATUSES:
-                continue
-            if active.job_type in _BUILD_PRODUCING_JOB_TYPES:
-                return active
-        return None
+        return await clean_mod.clean(self, configuration=configuration)
 
     @api_command("firmware/reset_build_env")
     async def reset_build_env(self, **kwargs: Any) -> FirmwareJob:


### PR DESCRIPTION
# What does this implement/fix?

Seventh structural-split PR for `controllers/firmware/controller.py` (follows #733 persistence + #735 cli + #739 lifecycle + #740 factories + #745 runner + #746 follow). Pulls the `firmware/clean` fan-out unit — the `clean` public command plus its two private helpers — into a new `clean.py` submodule.

The unit is self-contained: the only caller of `_fan_out_clean_to_connected_peers` and `_active_build_for` is the `clean` WS command itself, and the only caller of `clean` is the WS dispatch table (via the `@api_command` decorator). Tests exercise the public `clean` entry point and don't monkey-patch the private helpers — so the private bound methods can be removed entirely rather than kept as delegates.

Changes:

* **New `clean.py`** (185 lines) — three free functions plus the `_BUILD_PRODUCING_JOB_TYPES` module-level constant (the constant was only consumed by `_active_build_for`, so it moves with its consumer). The free functions call each other directly (peer-function calls) since no test patches them.
* **`controller.py`** — 1037 → 877 lines (−160). The `@api_command` decorator and signature stay on the `clean` method; only the body changes to a thin delegate. The two private helpers (`_fan_out_clean_to_connected_peers`, `_active_build_for`) are removed from the class entirely. Ruff auto-removed the now-unused imports (`JobBuildSource`, `JobSource`, `PeerStatus`, plus the moved `_BUILD_PRODUCING_JOB_TYPES` block).

Combined arc (#733 + #735 + #739 + #740 + #745 + #746 + this): **controller.py 2083 → 877 lines (−58%)**. One module away from the 800-line soft cap.

All 3198 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #733 + #735 + #739 + #740 + #745 + #746; seventh chunk of the firmware/controller.py split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
