### PR TITLE
Extract firmware-binary download endpoints into download.py

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -11,9 +11,6 @@ live in ``constants.py`` and ``helpers.py``.
 from __future__ import annotations
 
 import asyncio
-import base64
-import gzip
-import importlib
 import logging
 import sys
 from collections.abc import Iterator
@@ -21,14 +18,7 @@ from contextlib import AbstractAsyncContextManager
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any
 
-from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
-from esphome.components.libretiny.const import (
-    FAMILY_COMPONENT as _LIBRETINY_FAMILY_COMPONENT,
-)
-from esphome.storage_json import StorageJSON
-
 from ...helpers.api import CommandError, api_command
-from ...helpers.storage_path import resolve_storage_path
 from ...models import (
     LOCAL_JOB_BUILD_SOURCE,
     TERMINAL_JOB_STATUSES,
@@ -42,6 +32,7 @@ from ...models import (
 )
 from . import clean as clean_mod
 from . import cli, factories, follow, lifecycle, persistence, runner
+from . import download as download_mod
 from .constants import (
     _ACTIVE_JOB_STATUSES,
 )
@@ -57,47 +48,6 @@ if TYPE_CHECKING:
     from ...helpers.event_bus import EventBus
 
 _LOGGER = logging.getLogger(__name__)
-
-# Platforms whose ``target_platform`` value isn't the component
-# module name. The dashboard download endpoint needs the
-# ``esphome.components.<X>`` module that exposes
-# ``get_download_types(storage)`` — for ESP32 variants that's the
-# umbrella ``esp32`` component, and for LibreTiny chip families it's
-# the ``libretiny`` component.
-#
-# The LibreTiny set is derived from upstream's
-# ``FAMILY_COMPONENT.values()`` (auto-generated from
-# ``generate_components.py``) so when LibreTiny adds a new chip
-# family / component our mapping picks it up on the next
-# ``esphome`` dependency bump — no edit here. The literal
-# ``"libretiny"`` covers configs that report the umbrella name as
-# ``target_platform`` directly.
-#
-# Mirrors ``esphome/dashboard/web_server.py``'s
-# ``DownloadListRequestHandler`` — same shape, but driven by an
-# upstream-sourced set rather than an inline literal.
-_LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPONENT.values()) | {
-    "libretiny"
-}
-
-
-def _resolve_download_component(target_platform: str | None) -> str:
-    """Return the ``esphome.components`` module name for *target_platform*.
-
-    Accepts ``None`` so callers can pass ``StorageJSON.target_platform``
-    (which is itself nullable) without an explicit ``or ""``
-    coercion at the call site. Returns the empty string for empty
-    / missing input — the caller's ``importlib.import_module`` will
-    fail in its ``try/except`` block and log a warning.
-
-    See ``_LIBRETINY_TARGET_PLATFORMS`` for the keep-in-sync note.
-    """
-    platform = (target_platform or "").lower()
-    if platform.upper() in ESP32_VARIANTS:
-        return "esp32"
-    if platform in _LIBRETINY_TARGET_PLATFORMS:
-        return "libretiny"
-    return platform
 
 
 class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
@@ -616,37 +566,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     @api_command("firmware/get_binaries")
     async def get_binaries(self, *, configuration: str, **kwargs: Any) -> list[dict]:
-        """
-        List available firmware binaries for a compiled device.
-
-        Returns ``[{title, file}]`` — the file names can be passed to
-        ``firmware/download`` to retrieve the binary content.
-        """
-        # ``resolve_storage_path`` collapses to
-        # ``<data_dir>/storage/<Path(configuration).name>.json`` —
-        # the basename collapse defangs separators in the
-        # configuration but a traversal-shaped *configuration*
-        # would still escape the config dir before reaching the
-        # closure (e.g. opening a sidecar at an attacker-controlled
-        # path under ``<data_dir>/storage``). The validator below
-        # is the gate that keeps any traversal payload out of the
-        # inner closure entirely. Do not reorder.
-        await self._validate_configuration_boundary(configuration)
-        loop = asyncio.get_running_loop()
-
-        def _get_types() -> list[dict]:
-            storage = StorageJSON.load(resolve_storage_path(configuration))
-            if storage is None:
-                return []
-            try:
-                component = _resolve_download_component(storage.target_platform)
-                module = importlib.import_module(f"esphome.components.{component}")
-                return list(module.get_download_types(storage))
-            except Exception:
-                _LOGGER.warning("Could not determine download types for %s", configuration)
-                return []
-
-        return await loop.run_in_executor(None, _get_types)
+        return await download_mod.get_binaries(self, configuration=configuration)
 
     @api_command("firmware/download")
     async def download(
@@ -657,56 +577,9 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         compressed: bool = False,
         **kwargs: Any,
     ) -> dict:
-        """
-        Download a compiled firmware binary.
-
-        Returns ``{filename, data, size, compressed}`` where ``data`` is
-        base64-encoded bytes. For Web Serial flashing the frontend
-        decodes the base64 itself.
-        """
-        # See ``get_binaries`` — ``resolve_storage_path`` collapses
-        # to ``<data_dir>/storage/<Path(configuration).name>.json``,
-        # but a traversal-shaped *configuration* could still resolve
-        # to an attacker-controlled basename inside the storage
-        # tree (e.g. by stripping segments down to a sensitive
-        # leaf), so we re-validate at the WS boundary.
-        # ``_validate_configuration_boundary`` is the only gate;
-        # do not reorder. Coverage:
-        # ``test_download.py::test_download_validator_runs_before_ext_storage_path``.
-        await self._validate_configuration_boundary(configuration)
-        loop = asyncio.get_running_loop()
-
-        def _read_binary() -> dict:
-            storage = StorageJSON.load(resolve_storage_path(configuration))
-            if storage is None or storage.firmware_bin_path is None:
-                msg = "No firmware binary — compile the device first"
-                raise FileNotFoundError(msg)
-
-            base_dir = storage.firmware_bin_path.parent.resolve()
-            path = (base_dir / file).resolve()
-            # Path traversal protection
-            path.relative_to(base_dir)
-
-            if not path.is_file():
-                msg = f"Binary not found: {file}"
-                raise FileNotFoundError(msg)
-
-            data = path.read_bytes()
-            if compressed:
-                data = gzip.compress(data, 9)
-
-            filename = f"{storage.name}-{file}"
-            if compressed:
-                filename += ".gz"
-
-            return {
-                "filename": filename,
-                "data": base64.b64encode(data).decode("ascii"),
-                "size": len(data),
-                "compressed": compressed,
-            }
-
-        return await loop.run_in_executor(None, _read_binary)
+        return await download_mod.download(
+            self, configuration=configuration, file=file, compressed=compressed
+        )
 
     # ------------------------------------------------------------------
     # Internals — queue processing

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -1,0 +1,158 @@
+"""Firmware-binary discovery + download endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import gzip
+import importlib
+import logging
+from typing import TYPE_CHECKING
+
+from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
+from esphome.components.libretiny.const import (
+    FAMILY_COMPONENT as _LIBRETINY_FAMILY_COMPONENT,
+)
+from esphome.storage_json import StorageJSON
+
+from ...helpers.storage_path import resolve_storage_path
+
+if TYPE_CHECKING:
+    from .controller import FirmwareController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Platforms whose ``target_platform`` value isn't the component
+# module name. The dashboard download endpoint needs the
+# ``esphome.components.<X>`` module that exposes
+# ``get_download_types(storage)`` — for ESP32 variants that's the
+# umbrella ``esp32`` component, and for LibreTiny chip families it's
+# the ``libretiny`` component.
+#
+# The LibreTiny set is derived from upstream's
+# ``FAMILY_COMPONENT.values()`` (auto-generated from
+# ``generate_components.py``) so when LibreTiny adds a new chip
+# family / component our mapping picks it up on the next
+# ``esphome`` dependency bump — no edit here. The literal
+# ``"libretiny"`` covers configs that report the umbrella name as
+# ``target_platform`` directly.
+#
+# Mirrors ``esphome/dashboard/web_server.py``'s
+# ``DownloadListRequestHandler`` — same shape, but driven by an
+# upstream-sourced set rather than an inline literal.
+_LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPONENT.values()) | {
+    "libretiny"
+}
+
+
+def _resolve_download_component(target_platform: str | None) -> str:
+    """Return the ``esphome.components`` module name for *target_platform*.
+
+    Accepts ``None`` so callers can pass ``StorageJSON.target_platform``
+    (which is itself nullable) without an explicit ``or ""``
+    coercion at the call site. Returns the empty string for empty
+    / missing input — the caller's ``importlib.import_module`` will
+    fail in its ``try/except`` block and log a warning.
+
+    See ``_LIBRETINY_TARGET_PLATFORMS`` for the keep-in-sync note.
+    """
+    platform = (target_platform or "").lower()
+    if platform.upper() in ESP32_VARIANTS:
+        return "esp32"
+    if platform in _LIBRETINY_TARGET_PLATFORMS:
+        return "libretiny"
+    return platform
+
+
+async def get_binaries(controller: FirmwareController, *, configuration: str) -> list[dict]:
+    """
+    List available firmware binaries for a compiled device.
+
+    Returns ``[{title, file}]`` — the file names can be passed to
+    ``firmware/download`` to retrieve the binary content.
+    """
+    # ``resolve_storage_path`` collapses to
+    # ``<data_dir>/storage/<Path(configuration).name>.json`` —
+    # the basename collapse defangs separators in the
+    # configuration but a traversal-shaped *configuration*
+    # would still escape the config dir before reaching the
+    # closure (e.g. opening a sidecar at an attacker-controlled
+    # path under ``<data_dir>/storage``). The validator below
+    # is the gate that keeps any traversal payload out of the
+    # inner closure entirely. Do not reorder.
+    await controller._validate_configuration_boundary(configuration)
+    loop = asyncio.get_running_loop()
+
+    def _get_types() -> list[dict]:
+        storage = StorageJSON.load(resolve_storage_path(configuration))
+        if storage is None:
+            return []
+        try:
+            component = _resolve_download_component(storage.target_platform)
+            module = importlib.import_module(f"esphome.components.{component}")
+            return list(module.get_download_types(storage))
+        except Exception:
+            _LOGGER.warning("Could not determine download types for %s", configuration)
+            return []
+
+    return await loop.run_in_executor(None, _get_types)
+
+
+async def download(
+    controller: FirmwareController,
+    *,
+    configuration: str,
+    file: str,
+    compressed: bool = False,
+) -> dict:
+    """
+    Download a compiled firmware binary.
+
+    Returns ``{filename, data, size, compressed}`` where ``data`` is
+    base64-encoded bytes. For Web Serial flashing the frontend
+    decodes the base64 itself.
+    """
+    # See ``get_binaries`` — ``resolve_storage_path`` collapses
+    # to ``<data_dir>/storage/<Path(configuration).name>.json``,
+    # but a traversal-shaped *configuration* could still resolve
+    # to an attacker-controlled basename inside the storage
+    # tree (e.g. by stripping segments down to a sensitive
+    # leaf), so we re-validate at the WS boundary.
+    # ``_validate_configuration_boundary`` is the only gate;
+    # do not reorder. Coverage:
+    # ``test_download.py::test_download_validator_runs_before_ext_storage_path``.
+    await controller._validate_configuration_boundary(configuration)
+    loop = asyncio.get_running_loop()
+
+    def _read_binary() -> dict:
+        storage = StorageJSON.load(resolve_storage_path(configuration))
+        if storage is None or storage.firmware_bin_path is None:
+            msg = "No firmware binary — compile the device first"
+            raise FileNotFoundError(msg)
+
+        base_dir = storage.firmware_bin_path.parent.resolve()
+        path = (base_dir / file).resolve()
+        # Path traversal protection
+        path.relative_to(base_dir)
+
+        if not path.is_file():
+            msg = f"Binary not found: {file}"
+            raise FileNotFoundError(msg)
+
+        data = path.read_bytes()
+        if compressed:
+            data = gzip.compress(data, 9)
+
+        filename = f"{storage.name}-{file}"
+        if compressed:
+            filename += ".gz"
+
+        return {
+            "filename": filename,
+            "data": base64.b64encode(data).decode("ascii"),
+            "size": len(data),
+            "compressed": compressed,
+        }
+
+    return await loop.run_in_executor(None, _read_binary)

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -280,7 +280,7 @@ def _validated_yaml_is_fresh(validated_yaml: Path, storage_json: Path) -> bool:
 
 def _download_type_files(storage: StorageJSON) -> list[str]:
     """Return paths (relative to firmware_bin_path.parent) listed by ``get_download_types``."""
-    from ..firmware.controller import _resolve_download_component  # noqa: PLC0415
+    from ..firmware.download import _resolve_download_component  # noqa: PLC0415
 
     component = _resolve_download_component(storage.target_platform)
     if not component:

--- a/tests/controllers/firmware/test_download.py
+++ b/tests/controllers/firmware/test_download.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import pytest
 
-import esphome_device_builder.controllers.firmware.controller as controller_module
+import esphome_device_builder.controllers.firmware.download as download_module
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 from tests._storage_fixtures import write_storage_json
@@ -48,7 +48,7 @@ def _redirect_ext_storage_path(monkeypatch: Any, tmp_path: Path) -> None:
     reads through).
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.controller.resolve_storage_path",
+        "esphome_device_builder.controllers.firmware.download.resolve_storage_path",
         lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json",
     )
 
@@ -206,7 +206,7 @@ async def test_download_validator_runs_before_ext_storage_path(
         return tmp_path / ".esphome" / "storage" / f"{configuration}.json"
 
     # Replace the autouse redirect with our spy for this test.
-    controller_module.resolve_storage_path = _spy
+    download_module.resolve_storage_path = _spy
 
     controller = firmware_controller_factory()
     with pytest.raises(CommandError) as excinfo:

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -32,7 +32,7 @@ import esphome.components as parent
 import pytest
 from esphome.components.esp32 import VARIANTS as _ESP32_VARIANTS
 
-from esphome_device_builder.controllers.firmware.controller import (
+from esphome_device_builder.controllers.firmware.download import (
     _LIBRETINY_TARGET_PLATFORMS,
     _resolve_download_component,
 )
@@ -49,7 +49,7 @@ def _redirect_ext_storage_path(monkeypatch: Any, tmp_path: Path) -> None:
     binding gets the tmpfs layout instead.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.controller.resolve_storage_path",
+        "esphome_device_builder.controllers.firmware.download.resolve_storage_path",
         lambda configuration: tmp_path / ".esphome" / "storage" / f"{configuration}.json",
     )
 

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -67,7 +67,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware import controller as controller_module
+from esphome_device_builder.controllers.firmware import download as download_module
 from esphome_device_builder.controllers.firmware import runner as runner_module
 from esphome_device_builder.models import EventType, JobStatus
 from tests._storage_fixtures import write_storage_json
@@ -172,7 +172,7 @@ def _redirect_ext_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     def _ext(configuration: str) -> Path:
         return storage_dir / f"{configuration}.json"
 
-    monkeypatch.setattr(controller_module, "resolve_storage_path", _ext)
+    monkeypatch.setattr(download_module, "resolve_storage_path", _ext)
 
 
 def _is_esptool_spawn(args: tuple[Any, ...]) -> bool:

--- a/tests/test_resolve_download_component.py
+++ b/tests/test_resolve_download_component.py
@@ -26,7 +26,7 @@ import importlib
 import pytest
 from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
 
-from esphome_device_builder.controllers.firmware.controller import (
+from esphome_device_builder.controllers.firmware.download import (
     _LIBRETINY_TARGET_PLATFORMS,
     _resolve_download_component,
 )


### PR DESCRIPTION
# What does this implement/fix?

Eighth structural-split PR for `controllers/firmware/controller.py` (follows #733 persistence + #735 cli + #739 lifecycle + #740 factories + #745 runner + #746 follow + #748 clean). Pulls the firmware-binary discovery / download surface — `get_binaries`, `download`, plus the `_resolve_download_component` helper and the `_LIBRETINY_TARGET_PLATFORMS` module-level constant — into a new `download.py` submodule.

The unit is self-contained: `get_binaries` and `download` are `@api_command` public methods; `_resolve_download_component` is a private helper used only by them (and one lazy-imported reuse in `artifacts_tarball.py` — updated to the new path); the LibreTiny-platform constant is read only by the helper. Imports that follow the unit out (`base64`, `gzip`, `importlib`, `ESP32_VARIANTS`, `_LIBRETINY_FAMILY_COMPONENT`, `StorageJSON`, `resolve_storage_path`) were only consumed by the moved bodies, so ruff auto-pruned 7 unused imports from `controller.py`.

Tests redirect their imports / monkey-patch targets to the new module — mirrors the same scope-of-the-move pattern used in #745:

* `tests/test_resolve_download_component.py` — import path `controller` → `download`.
* `tests/controllers/firmware/test_get_binaries.py` — both the import path and the `resolve_storage_path` setattr target redirect to the new module.
* `tests/controllers/firmware/test_download.py` — `controller_module` alias renamed to `download_module`; both setattr sites for `resolve_storage_path` follow.
* `tests/controllers/firmware/test_verify_chip_e2e.py` — the autouse fixture's `resolve_storage_path` setattr follows the symbol to `download.py`.

Production code: `artifacts_tarball.py`'s lazy `_resolve_download_component` import path updates too.

Changes:

* **New `download.py`** (158 lines) — two free functions + the helper + the constant + their imports.
* **`controller.py`** — 877 → 750 lines (−127). The `@api_command` decorators stay on the public methods; only the bodies change to thin delegates. The module-level constant + helper are removed from controller.py entirely.

Combined arc (#733 + #735 + #739 + #740 + #745 + #746 + #748 + this): **controller.py 2083 → 750 lines (−64%)**. **Under the 800-line soft cap.**

All 3227 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #733 + #735 + #739 + #740 + #745 + #746 + #748; eighth chunk of the firmware/controller.py split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
