### PR TITLE
Bump test_async_delay_save_writes_after_delay timeout for Windows CI

### DIFF
--- a/tests/test_helpers_storage.py
+++ b/tests/test_helpers_storage.py
@@ -84,7 +84,10 @@ async def test_async_load_decodes_existing_file(store_path: Path, store: Store[b
 async def test_async_delay_save_writes_after_delay(store_path: Path, store: Store[bytes]) -> None:
     """A scheduled save lands on disk after the delay elapses."""
     store.async_delay_save(lambda: b"delayed", delay=0.05)
-    await _drain_loop_until(store_path.exists)
+    # 2s rather than the 1s default; busy Windows xdist workers can take
+    # longer than 1s for the executor hop + atomic rename after the 50ms
+    # timer fires.
+    await _drain_loop_until(store_path.exists, timeout=2.0)
     assert store_path.read_bytes() == b"delayed"
 
 


### PR DESCRIPTION
# What does this implement/fix?

`test_async_delay_save_writes_after_delay` schedules a save with `delay=0.05` and then waits up to the default 1.0s for the file to appear. On busy Windows xdist workers (observed: `gw3` on `windows-latest`, Python 3.14.4), the executor hop plus the staging-tempfile + `os.replace` atomic write after the 50ms timer fires can take longer than 1s, and the predicate times out at exactly 1.000s elapsed.

Bump the timeout to 2.0s to match the slack the rest of this file already gives the same code path. The neighbouring `test_async_delay_save_collapses_within_window`, `test_async_delay_save_extends_deadline_on_later_call`, and `test_atomic_write_creates_parent_directory` all wait 2.0s for the same write to land for the same reason; this test was the holdout still using the 1.0s default.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
