### PR TITLE
Drop dead resolve_storage_path fixture in test_verify_chip_e2e

### DIFF
--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -25,10 +25,12 @@ The expected chip variant comes from a real StorageJSON sidecar
 seeded via ``write_storage_json`` — ``_verify_chip`` reads
 ``StorageJSON.target_platform`` directly (the upstream-canonical
 chip variant) rather than ``Device.target_platform`` (which now
-carries the platform *key*, not the variant). Tests redirect
-``ext_storage_path`` in the firmware controller's namespace so
-``StorageJSON.load`` finds the sidecar at
-``tmp_path/.esphome/storage/<configuration>.json``.
+carries the platform *key*, not the variant). The global
+``_core_config_path_in_tmp`` autouse fixture in ``tests/conftest.py``
+pins ``CORE.config_path`` onto ``tmp_path`` so production
+``resolve_storage_path`` resolves to
+``tmp_path/.esphome/storage/<configuration>.json`` — the same path
+``write_storage_json`` writes to. No per-module redirect required.
 
 Branches the runner depends on:
 
@@ -67,7 +69,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware import download as download_module
 from esphome_device_builder.controllers.firmware import runner as runner_module
 from esphome_device_builder.models import EventType, JobStatus
 from tests._storage_fixtures import write_storage_json
@@ -152,27 +153,6 @@ class _StubDevices:
 def _wire_devices(controller: FirmwareController) -> None:
     """Attach a no-op ``DevicesController`` stub for ``_build_cache_args``."""
     controller._db.devices = _StubDevices()  # type: ignore[attr-defined]
-
-
-@pytest.fixture(autouse=True)
-def _redirect_ext_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Redirect ``ext_storage_path`` to ``tmp_path/.esphome/storage/``.
-
-    The production helper resolves through ``CORE.config_path``
-    which isn't set in isolated tests; the redirect makes
-    ``StorageJSON.load(ext_storage_path(filename))`` (called from
-    ``_verify_chip``) read the sidecar ``_seed_storage`` lays
-    down. Same pattern as ``test_download.py``'s redirect — the
-    fixture is autouse so every test in this module is covered
-    without a per-test ``@pytest.mark.usefixtures`` decoration.
-    """
-    storage_dir = tmp_path / ".esphome" / "storage"
-    storage_dir.mkdir(parents=True, exist_ok=True)
-
-    def _ext(configuration: str) -> Path:
-        return storage_dir / f"{configuration}.json"
-
-    monkeypatch.setattr(download_module, "resolve_storage_path", _ext)
 
 
 def _is_esptool_spawn(args: tuple[Any, ...]) -> bool:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to Copilot's review comment on #750 ([discussion #r3236165654](https://github.com/esphome/device-builder/pull/750#discussion_r3236165654)).

The autouse `_redirect_ext_storage` fixture in `test_verify_chip_e2e.py` patched `download_module.resolve_storage_path` (was `controller_module` pre-#750). But `_verify_chip`'s body lives in `cli.py` since #735 and reads `resolve_storage_path` from its own module binding — so the patch never reached the production code path. **Both before and after #750's rename, the fixture was dead code.**

The 16 verify_chip e2e tests pass because the global `tests/conftest.py` `_core_config_path_in_tmp` autouse fixture pins `CORE.config_path` onto `tmp_path`, which makes production `resolve_storage_path("kitchen.yaml")` resolve to `<tmp_path>/.esphome/storage/kitchen.yaml.json` — the same path `write_storage_json` writes the sidecar to. So the e2e tests have been relying on the CORE-based resolution end-to-end; the local redirect never did anything.

Two ways to fix the dead patch:

* **Repoint** it at `cli_module.resolve_storage_path` (where `_verify_chip` actually reads the symbol). Makes the patch effective — but redundant with the CORE-based resolution that's already making the tests pass.
* **Delete** it entirely. The CORE-based resolution is the load-bearing mechanism; removing the redundant patch makes the test honest about what it depends on.

Going with delete. Less code, no behavioural change (tests pass either way), and a future reader doesn't have to figure out which of two overlapping mechanisms is the one carrying the test.

Changes:

* Delete the autouse `_redirect_ext_storage` fixture and the `download_module` import that supports it.
* Update the module docstring to describe the actual storage-resolution mechanism (the global `CORE.config_path` fixture) instead of the deleted redirect.

All 3227 non-e2e tests still pass, including all 16 `test_verify_chip_e2e.py` tests — confirming the fixture was dead code.

**Related issue or feature (if applicable):**

- resolves Copilot review comment on #750

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
