### PR TITLE
Extract firmware job-state surface into jobs.py

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -15,30 +15,22 @@ import logging
 import sys
 from collections.abc import Iterator
 from contextlib import AbstractAsyncContextManager
-from operator import attrgetter
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError, api_command
 from ...models import (
     LOCAL_JOB_BUILD_SOURCE,
-    TERMINAL_JOB_STATUSES,
     ErrorCode,
-    EventType,
     FirmwareJob,
     JobBuildSource,
-    JobLifecycleData,
     JobStatus,
     JobType,
 )
 from . import clean as clean_mod
-from . import cli, factories, follow, lifecycle, persistence, runner
+from . import cli, factories, follow, jobs, lifecycle, persistence, runner
 from . import download as download_mod
-from .constants import (
-    _ACTIVE_JOB_STATUSES,
-)
 from .helpers import (
     _find_esphome_cmd,
-    _mark_job_terminal,
     _validate_port,
     _verify_esphome_importable,
 )
@@ -424,43 +416,14 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         configuration: str | None = None,
         **kwargs: Any,
     ) -> list[FirmwareJob]:
-        """List jobs, optionally filtered by status or configuration."""
-        jobs = list(self._jobs.values())
-        if status:
-            jobs = [j for j in jobs if j.status == status]
-        if configuration:
-            jobs = [j for j in jobs if j.configuration == configuration]
-        return sorted(jobs, key=attrgetter("created_at"), reverse=True)
+        return await jobs.get_jobs(self, status=status, configuration=configuration)
 
     @api_command("firmware/get_job")
     async def get_job(self, *, job_id: str, **kwargs: Any) -> FirmwareJob | None:
-        """Get a specific job with full output."""
-        return self._jobs.get(job_id)
+        return await jobs.get_job(self, job_id=job_id)
 
     def active_remote_peer_jobs(self) -> Iterator[FirmwareJob]:
-        """Yield every QUEUED / RUNNING job that arrived via the peer-link.
-
-        Synchronous, no-copy generator over :attr:`_jobs` for the
-        peer-link tier's lookups (the 6c cleanup sweep keys off
-        this to skip in-flight subtrees; future schedulers /
-        diagnostics surfaces should call this rather than
-        reaching into ``_jobs`` directly). The single-underscore
-        prefix on ``_jobs`` marks it as private to the firmware
-        controller; this public accessor is the load-bearing
-        seam so a future refactor (lock-wrapped jobs map,
-        QUEUED + RUNNING split into two dicts, indexed view)
-        doesn't silently break callers.
-
-        ``remote_peer`` filters to peer-link-originated jobs
-        only — :class:`FirmwareJob.remote_peer` is empty for
-        locally-submitted jobs (see :mod:`models.firmware`).
-        """
-        for job in self._jobs.values():
-            if job.status not in _ACTIVE_JOB_STATUSES:
-                continue
-            if not job.remote_peer:
-                continue
-            yield job
+        return jobs.active_remote_peer_jobs(self)
 
     @api_command("firmware/follow_job")
     async def follow_job(
@@ -481,84 +444,11 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     @api_command("firmware/cancel")
     async def cancel(self, *, job_id: str, **kwargs: Any) -> None:
-        """Cancel a queued or running job.
-
-        Queued jobs are flipped to ``CANCELLED`` immediately. Running
-        jobs receive a SIGTERM and are escalated to SIGKILL after a
-        short grace period — the runner loop sees the dead process and
-        finalises the job with status ``CANCELLED`` (instead of the
-        usual ``FAILED`` for non-zero exits) thanks to the
-        ``_cancel_requested`` flag set here.
-
-        Either path fires ``JOB_CANCELLED`` on the bus so frontends
-        following all-jobs streams stay consistent.
-
-        User-facing rejections (unknown ``job_id``, already-terminal
-        job) raise ``CommandError`` so the WS dispatcher surfaces
-        the message verbatim. A bare ``ValueError`` would be wrapped
-        as ``"Command failed: firmware/cancel"`` and the operator
-        would lose the offending id / status. The state-out-of-sync
-        case stays as ``RuntimeError`` — it's a server bug, not user
-        input, and ``INTERNAL_ERROR`` is the right code.
-        """
-        job = self._jobs.get(job_id)
-        if not job:
-            msg = f"Job not found: {job_id}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-
-        if job.status == JobStatus.QUEUED:
-            # Mark + persist before fire so a restart-after-cancel
-            # reload sees the job as CANCELLED (the test pins
-            # this in ``test_cancelled_job_survives_restart_without_
-            # being_requeued``). Doesn't go through
-            # :meth:`_finalize_terminal` because the helper
-            # collapses mark + fire and we need to land
-            # ``_persist_jobs`` in between; the slot-release the
-            # helper does is a no-op anyway for a QUEUED job
-            # (``_current_job`` belongs to whatever's actually
-            # running, not this queue entry).
-            _mark_job_terminal(job, JobStatus.CANCELLED)
-            self._prune_history()
-            await self._persist_jobs()
-            cancelled_payload: JobLifecycleData = {"job": job}
-            self._db.bus.fire(EventType.JOB_CANCELLED, cancelled_payload)
-            return
-
-        if job.status == JobStatus.RUNNING:
-            if self._current_job is None or self._current_job.job_id != job_id:
-                msg = "Running job is not the active subprocess (state out of sync)"
-                raise RuntimeError(msg)
-            self._cancel_requested.add(job_id)
-            # Wake any runner parked on its cancel event (the
-            # source-routed remote runner registers one; the
-            # local subprocess path doesn't need one because
-            # SIGTERM is the wake signal).
-            cancel_event = self._cancel_events.get(job_id)
-            if cancel_event is not None:
-                cancel_event.set()
-            await self._terminate_current_process()
-            return
-
-        msg = f"Cannot cancel a {job.status.value} job"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+        await jobs.cancel(self, job_id=job_id)
 
     @api_command("firmware/clear")
     async def clear(self, *, status: JobStatus | str | None = None, **kwargs: Any) -> None:
-        """
-        Remove finished jobs from the list.
-
-        If ``status`` is given, only remove jobs with that status.
-        Otherwise removes completed, failed, and cancelled jobs.
-        """
-        terminal = TERMINAL_JOB_STATUSES
-        to_remove = [
-            jid
-            for jid, job in self._jobs.items()
-            if (status and job.status == status) or (not status and job.status in terminal)
-        ]
-        for jid in to_remove:
-            del self._jobs[jid]
-        await self._persist_jobs()
+        await jobs.clear(self, status=status)
 
     # ------------------------------------------------------------------
     # API commands — binary download

--- a/esphome_device_builder/controllers/firmware/jobs.py
+++ b/esphome_device_builder/controllers/firmware/jobs.py
@@ -1,0 +1,149 @@
+"""Job-state queries + lifecycle commands: get_jobs, get_job, cancel, clear."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from operator import attrgetter
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...models import (
+    TERMINAL_JOB_STATUSES,
+    ErrorCode,
+    EventType,
+    FirmwareJob,
+    JobLifecycleData,
+    JobStatus,
+)
+from .constants import _ACTIVE_JOB_STATUSES
+from .helpers import _mark_job_terminal
+
+if TYPE_CHECKING:
+    from .controller import FirmwareController
+
+
+async def get_jobs(
+    controller: FirmwareController,
+    *,
+    status: JobStatus | str | None = None,
+    configuration: str | None = None,
+) -> list[FirmwareJob]:
+    """List jobs, optionally filtered by status or configuration."""
+    jobs = list(controller._jobs.values())
+    if status:
+        jobs = [j for j in jobs if j.status == status]
+    if configuration:
+        jobs = [j for j in jobs if j.configuration == configuration]
+    return sorted(jobs, key=attrgetter("created_at"), reverse=True)
+
+
+async def get_job(controller: FirmwareController, *, job_id: str) -> FirmwareJob | None:
+    """Get a specific job with full output."""
+    return controller._jobs.get(job_id)
+
+
+def active_remote_peer_jobs(controller: FirmwareController) -> Iterator[FirmwareJob]:
+    """Yield every QUEUED / RUNNING job that arrived via the peer-link.
+
+    Synchronous, no-copy generator over :attr:`_jobs` for the
+    peer-link tier's lookups (the 6c cleanup sweep keys off
+    this to skip in-flight subtrees; future schedulers /
+    diagnostics surfaces should call this rather than
+    reaching into ``_jobs`` directly). The single-underscore
+    prefix on ``_jobs`` marks it as private to the firmware
+    controller; this public accessor is the load-bearing
+    seam so a future refactor (lock-wrapped jobs map,
+    QUEUED + RUNNING split into two dicts, indexed view)
+    doesn't silently break callers.
+
+    ``remote_peer`` filters to peer-link-originated jobs
+    only — :class:`FirmwareJob.remote_peer` is empty for
+    locally-submitted jobs (see :mod:`models.firmware`).
+    """
+    for job in controller._jobs.values():
+        if job.status not in _ACTIVE_JOB_STATUSES:
+            continue
+        if not job.remote_peer:
+            continue
+        yield job
+
+
+async def cancel(controller: FirmwareController, *, job_id: str) -> None:
+    """Cancel a queued or running job.
+
+    Queued jobs are flipped to ``CANCELLED`` immediately. Running
+    jobs receive a SIGTERM and are escalated to SIGKILL after a
+    short grace period — the runner loop sees the dead process and
+    finalises the job with status ``CANCELLED`` (instead of the
+    usual ``FAILED`` for non-zero exits) thanks to the
+    ``_cancel_requested`` flag set here.
+
+    Either path fires ``JOB_CANCELLED`` on the bus so frontends
+    following all-jobs streams stay consistent.
+
+    User-facing rejections (unknown ``job_id``, already-terminal
+    job) raise ``CommandError`` so the WS dispatcher surfaces
+    the message verbatim. A bare ``ValueError`` would be wrapped
+    as ``"Command failed: firmware/cancel"`` and the operator
+    would lose the offending id / status. The state-out-of-sync
+    case stays as ``RuntimeError`` — it's a server bug, not user
+    input, and ``INTERNAL_ERROR`` is the right code.
+    """
+    job = controller._jobs.get(job_id)
+    if not job:
+        msg = f"Job not found: {job_id}"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+
+    if job.status == JobStatus.QUEUED:
+        # Mark + persist before fire so a restart-after-cancel
+        # reload sees the job as CANCELLED (the test pins
+        # this in ``test_cancelled_job_survives_restart_without_
+        # being_requeued``). Doesn't go through
+        # :meth:`_finalize_terminal` because the helper
+        # collapses mark + fire and we need to land
+        # ``_persist_jobs`` in between; the slot-release the
+        # helper does is a no-op anyway for a QUEUED job
+        # (``_current_job`` belongs to whatever's actually
+        # running, not this queue entry).
+        _mark_job_terminal(job, JobStatus.CANCELLED)
+        controller._prune_history()
+        await controller._persist_jobs()
+        cancelled_payload: JobLifecycleData = {"job": job}
+        controller._db.bus.fire(EventType.JOB_CANCELLED, cancelled_payload)
+        return
+
+    if job.status == JobStatus.RUNNING:
+        if controller._current_job is None or controller._current_job.job_id != job_id:
+            msg = "Running job is not the active subprocess (state out of sync)"
+            raise RuntimeError(msg)
+        controller._cancel_requested.add(job_id)
+        # Wake any runner parked on its cancel event (the
+        # source-routed remote runner registers one; the
+        # local subprocess path doesn't need one because
+        # SIGTERM is the wake signal).
+        cancel_event = controller._cancel_events.get(job_id)
+        if cancel_event is not None:
+            cancel_event.set()
+        await controller._terminate_current_process()
+        return
+
+    msg = f"Cannot cancel a {job.status.value} job"
+    raise CommandError(ErrorCode.INVALID_ARGS, msg)
+
+
+async def clear(controller: FirmwareController, *, status: JobStatus | str | None = None) -> None:
+    """
+    Remove finished jobs from the list.
+
+    If ``status`` is given, only remove jobs with that status.
+    Otherwise removes completed, failed, and cancelled jobs.
+    """
+    terminal = TERMINAL_JOB_STATUSES
+    to_remove = [
+        jid
+        for jid, job in controller._jobs.items()
+        if (status and job.status == status) or (not status and job.status in terminal)
+    ]
+    for jid in to_remove:
+        del controller._jobs[jid]
+    await controller._persist_jobs()


### PR DESCRIPTION
# What does this implement/fix?

Ninth structural-split PR for `controllers/firmware/controller.py` (follows #733 persistence + #735 cli + #739 lifecycle + #740 factories + #745 runner + #746 follow + #748 clean + #750 download). Pulls the job-state query and lifecycle-command surface — `get_jobs`, `get_job`, `cancel`, `clear`, plus the `active_remote_peer_jobs` public iterator — into a new `jobs.py` submodule.

The unit is a coherent slice of the public WS API: every method reads/manipulates the `_jobs` dict directly. Tests only exercise the public methods (`test_get_jobs.py`, `test_cancel.py`, `test_supersede.py`); the remote-build tier replaces `active_remote_peer_jobs` via instance-attribute assignment (`firmware.active_remote_peer_jobs = MagicMock(...)` in `test_remote_build_controller.py:3961+4015`) which works identically with bound-method delegates.

The `@api_command` decorators stay on the controller methods so the WS dispatch table keeps working unchanged; only the bodies move into free functions. `active_remote_peer_jobs` has no decorator (it's an internal public accessor) but follows the same delegate shape.

Changes:

* **New `jobs.py`** (149 lines) — five free functions extracted as a coherent unit.
* **`controller.py`** — 750 → 640 lines (−110). Bodies replaced with thin delegates; ruff auto-removed 6 now-unused imports (`EventType`, `JobLifecycleData`, `attrgetter`, `_ACTIVE_JOB_STATUSES`, `_mark_job_terminal`, `TERMINAL_JOB_STATUSES`).

Combined arc (#733 + #735 + #739 + #740 + #745 + #746 + #748 + #750 + this): **controller.py 2083 → 640 lines (−69%)**.

All 3227 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #733 + #735 + #739 + #740 + #745 + #746 + #748 + #750; ninth chunk of the firmware/controller.py split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
