### PR TITLE
Extract firmware bulk submission into bulk.py

### DIFF
--- a/esphome_device_builder/controllers/firmware/bulk.py
+++ b/esphome_device_builder/controllers/firmware/bulk.py
@@ -1,0 +1,81 @@
+"""Firmware-job bulk submission: compile_bulk + install_bulk."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...models import FirmwareJob, JobType
+from .helpers import _validate_port
+
+if TYPE_CHECKING:
+    from .controller import FirmwareController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def compile_bulk(
+    controller: FirmwareController,
+    *,
+    configurations: list[str],
+    force_local: bool = False,
+) -> list[FirmwareJob]:
+    """Queue compile for multiple devices.
+
+    Per-device errors (most commonly the rename lock) skip that
+    device and keep going. Each job routes through
+    :meth:`_resolve_install_source` so paired-build auto-routing
+    applies (mirrors :meth:`compile` / :meth:`install_bulk`);
+    ``force_local=True`` keeps every job LOCAL.
+    """
+    await controller._validate_configurations_boundary(configurations)
+    jobs: list[FirmwareJob] = []
+    for config in configurations:
+        try:
+            build_source = controller._resolve_install_source(force_local=force_local)
+            job = controller._create_job(
+                config,
+                JobType.COMPILE,
+                build_source=build_source,
+            )
+            await controller._enqueue(job)
+        except CommandError as exc:
+            _LOGGER.info("Skipping %s in compile_bulk: %s", config, exc.message)
+            continue
+        jobs.append(job)
+    return jobs
+
+
+async def install_bulk(
+    controller: FirmwareController, *, configurations: list[str], port: str = "OTA"
+) -> list[FirmwareJob]:
+    """Queue update (compile + upload) for multiple devices. Defaults to OTA.
+
+    ``port`` is shared across every queued job; pass an explicit
+    IP only when you really want every device installed against
+    the same target (rare — almost always callers want the
+    per-device default of ``"OTA"``).
+
+    Per-device errors (most commonly the rename lock) skip that
+    device and keep going — a rename-in-flight on one of the
+    selected devices shouldn't abort the install for the rest.
+    """
+    _validate_port(port)
+    await controller._validate_configurations_boundary(configurations)
+    jobs: list[FirmwareJob] = []
+    for config in configurations:
+        try:
+            build_source = controller._resolve_install_source()
+            job = controller._create_job(
+                config,
+                JobType.INSTALL,
+                port=port,
+                build_source=build_source,
+            )
+            await controller._enqueue(job)
+        except CommandError as exc:
+            _LOGGER.info("Skipping %s in install_bulk: %s", config, exc.message)
+            continue
+        jobs.append(job)
+    return jobs

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -26,8 +26,8 @@ from ...models import (
     JobStatus,
     JobType,
 )
+from . import bulk, cli, factories, follow, jobs, lifecycle, persistence, runner
 from . import clean as clean_mod
-from . import cli, factories, follow, jobs, lifecycle, persistence, runner
 from . import download as download_mod
 from .helpers import (
     _find_esphome_cmd,
@@ -345,64 +345,13 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         force_local: bool = False,
         **kwargs: Any,
     ) -> list[FirmwareJob]:
-        """Queue compile for multiple devices.
-
-        Per-device errors (most commonly the rename lock) skip that
-        device and keep going. Each job routes through
-        :meth:`_resolve_install_source` so paired-build auto-routing
-        applies (mirrors :meth:`compile` / :meth:`install_bulk`);
-        ``force_local=True`` keeps every job LOCAL.
-        """
-        await self._validate_configurations_boundary(configurations)
-        jobs: list[FirmwareJob] = []
-        for config in configurations:
-            try:
-                build_source = self._resolve_install_source(force_local=force_local)
-                job = self._create_job(
-                    config,
-                    JobType.COMPILE,
-                    build_source=build_source,
-                )
-                await self._enqueue(job)
-            except CommandError as exc:
-                _LOGGER.info("Skipping %s in compile_bulk: %s", config, exc.message)
-                continue
-            jobs.append(job)
-        return jobs
+        return await bulk.compile_bulk(self, configurations=configurations, force_local=force_local)
 
     @api_command("firmware/install_bulk")
     async def install_bulk(
         self, *, configurations: list[str], port: str = "OTA", **kwargs: Any
     ) -> list[FirmwareJob]:
-        """Queue update (compile + upload) for multiple devices. Defaults to OTA.
-
-        ``port`` is shared across every queued job; pass an explicit
-        IP only when you really want every device installed against
-        the same target (rare — almost always callers want the
-        per-device default of ``"OTA"``).
-
-        Per-device errors (most commonly the rename lock) skip that
-        device and keep going — a rename-in-flight on one of the
-        selected devices shouldn't abort the install for the rest.
-        """
-        _validate_port(port)
-        await self._validate_configurations_boundary(configurations)
-        jobs: list[FirmwareJob] = []
-        for config in configurations:
-            try:
-                build_source = self._resolve_install_source()
-                job = self._create_job(
-                    config,
-                    JobType.INSTALL,
-                    port=port,
-                    build_source=build_source,
-                )
-                await self._enqueue(job)
-            except CommandError as exc:
-                _LOGGER.info("Skipping %s in install_bulk: %s", config, exc.message)
-                continue
-            jobs.append(job)
-        return jobs
+        return await bulk.install_bulk(self, configurations=configurations, port=port)
 
     # ------------------------------------------------------------------
     # API commands — job inspection


### PR DESCRIPTION
# What does this implement/fix?

Tenth structural-split PR for `controllers/firmware/controller.py` (follows #733 persistence + #735 cli + #739 lifecycle + #740 factories + #745 runner + #746 follow + #748 clean + #750 download + #754 jobs). Pulls the bulk-submission pair — `compile_bulk` and `install_bulk` — into a new `bulk.py` submodule.

The two methods share the same skip-and-continue shape over a list of configurations: validate the whole batch up-front, then loop through them building per-config jobs and letting transient state conflicts (rename-lock) skip the offending entry. Coherent unit, no internal cross-dependencies between the two.

The `@api_command` decorators stay on the controller methods so the WS dispatch table keeps working unchanged; only the bodies move into free functions. Tests exercise the public methods directly; no internal monkey-patches.

Changes:

* **New `bulk.py`** (81 lines) — two free functions extracted as a coherent unit.
* **`controller.py`** — 640 → 589 lines (−51). Bodies replaced with thin delegates. No imports become unused — `_validate_port`, `CommandError`, `JobType`, `FirmwareJob` still have callers elsewhere in controller.py.

Combined arc (#733 + #735 + #739 + #740 + #745 + #746 + #748 + #750 + #754 + this): **controller.py 2083 → 589 lines (−72%)**.

All 3227 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #733 + #735 + #739 + #740 + #745 + #746 + #748 + #750 + #754; tenth chunk of the firmware/controller.py split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
