### PR TITLE
Tighten bulk.py docstrings

### DIFF
--- a/esphome_device_builder/controllers/firmware/bulk.py
+++ b/esphome_device_builder/controllers/firmware/bulk.py
@@ -21,13 +21,10 @@ async def compile_bulk(
     configurations: list[str],
     force_local: bool = False,
 ) -> list[FirmwareJob]:
-    """Queue compile for multiple devices.
+    """Queue compile for *configurations*; skip per-device errors and keep going.
 
-    Per-device errors (most commonly the rename lock) skip that
-    device and keep going. Each job routes through
-    :meth:`_resolve_install_source` so paired-build auto-routing
-    applies (mirrors :meth:`compile` / :meth:`install_bulk`);
-    ``force_local=True`` keeps every job LOCAL.
+    ``force_local=True`` keeps every job LOCAL (otherwise paired-build
+    auto-routing may send some REMOTE).
     """
     await controller._validate_configurations_boundary(configurations)
     jobs: list[FirmwareJob] = []
@@ -50,16 +47,11 @@ async def compile_bulk(
 async def install_bulk(
     controller: FirmwareController, *, configurations: list[str], port: str = "OTA"
 ) -> list[FirmwareJob]:
-    """Queue update (compile + upload) for multiple devices. Defaults to OTA.
+    """Queue install (compile + upload) for *configurations*; defaults to OTA.
 
-    ``port`` is shared across every queued job; pass an explicit
-    IP only when you really want every device installed against
-    the same target (rare — almost always callers want the
-    per-device default of ``"OTA"``).
-
-    Per-device errors (most commonly the rename lock) skip that
-    device and keep going — a rename-in-flight on one of the
-    selected devices shouldn't abort the install for the rest.
+    ``port`` is shared across every queued job — pass an explicit IP
+    only when every device should install against the same target.
+    Per-device errors skip that device and keep going.
     """
     _validate_port(port)
     await controller._validate_configurations_boundary(configurations)


### PR DESCRIPTION
# What does this implement/fix?

Docstring cleanup follow-up to #756. Resolves Copilot's `"mirrors :meth:\`compile\` / :meth:\`install_bulk\`"` flag ([discussion #r3236324741](https://github.com/esphome/device-builder/pull/756#discussion_r3236324741)) — the cross-reference framing CLAUDE.md:58-60 calls out — and trims the body-restating prose on both `compile_bulk` and `install_bulk` docstrings.

Both docstrings were preserved byte-for-byte through #756's structural move (mechanical-only PR per `feedback_split_then_clean_strict`); this is the deferred clean pass.

Changes:

* `compile_bulk` — drops the body-restating "each job routes through `_resolve_install_source` so paired-build auto-routing applies (mirrors ...)" sentence. Keeps the load-bearing contract: summary line + `force_local` semantics.
* `install_bulk` — collapses the `port` and per-device-skip paragraphs into a single tighter paragraph. Same contract preserved.

Pure prose change; no behaviour change. All 3227 non-e2e tests still pass.

**Related issue or feature (if applicable):**

- follow-up to #756; resolves Copilot review comment

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
