### PR TITLE
Tighten clean.py docstrings

### DIFF
--- a/esphome_device_builder/controllers/firmware/clean.py
+++ b/esphome_device_builder/controllers/firmware/clean.py
@@ -20,84 +20,25 @@ if TYPE_CHECKING:
 
 
 # Job types that produce build artifacts a clean would destroy.
-# A ``firmware/clean`` request that lands while one of these is
-# in-flight for the same configuration is rejected loudly rather
-# than supersede-cancelled — see the ``clean`` handler's docstring
-# for the rationale.
+# A clean against an in-flight one of these is rejected loudly
+# rather than supersede-cancelled.
 _BUILD_PRODUCING_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL, JobType.RENAME}
 )
 
 
 async def clean(controller: FirmwareController, *, configuration: str) -> FirmwareJob:
-    """
-    Queue a build clean job, plus one per connected paired receiver.
+    """Queue a clean job + one per connected paired receiver; return the LOCAL job.
 
-    Returns the LOCAL clean job (the one the operator's WS
-    command is awaiting). N additional REMOTE clean jobs are
-    queued silently for fan-out to every currently-connected
-    approved peer; each shows up as its own
-    :class:`FirmwareJob` in the firmware-jobs list and drives
-    the same lifecycle events as remote installs do, so the
-    operator sees per-receiver clean progress in the
-    existing UI.
-
-    **Why fan out:** a stale receiver-side build dir is the
-    same class of problem a stale local build dir is. The
-    operator's "Clean build files" click expects every place
-    this device has been built to drop its artifacts, not
-    just the local one. Without the fan-out, a remote receiver
-    keeps caching the broken state and the next remote
-    compile picks up the same poisoned tree.
-
-    **Best-effort:** a peer that disconnects between this
-    ``clean`` call and the runner picking up its job lands on
-    the existing remote-session-lost FAILED path (the runner's
-    ``_dispatch_and_drive`` returns ``CommandError`` from
-    ``_lookup_open_peer_link_client``). The local job is
-    independent and runs regardless. A peer that isn't
-    connected at all just doesn't get a job queued — the next
-    time the operator clicks clean while that peer is
-    connected, it'll catch up.
+    Per-peer REMOTE clean jobs surface through the firmware-jobs
+    ``subscribe_events`` stream rather than the WS reply — the
+    operator sees N+1 rows in the firmware-tasks panel.
 
     Rejects with ``CommandError(INVALID_ARGS)`` when an active
     compile / upload / install / rename job exists for the same
-    configuration. Other firmware commands rely on the
-    ``_enqueue`` supersede path to cancel-and-replace the running
-    job — that's the right shape for "user wants to retry the
-    compile" — but a clean wipes the build artifacts the running
-    job is producing, so a quietly-cancelled build that the user
-    didn't intend to abandon is the worse failure mode. Make the
-    user retry once the build settles instead. Two clean jobs
-    for the same configuration still supersede each other (the
-    second one is the user's intent regardless). The supersede
-    check applies only to the LOCAL job; the fan-out's per-peer
-    REMOTE jobs enqueue with ``supersede=False`` so they don't
-    cancel siblings or the just-queued local clean. See
-    :meth:`_enqueue`'s docstring for the carve-out rationale.
-
-    The WS reply returns only the LOCAL clean — that's what the
-    operator's ``firmware/clean`` call awaits. Per-peer REMOTE
-    clean jobs surface through the existing
-    ``subscribe_events`` firmware-jobs stream the dashboard
-    already consumes for in-flight job lists, so the operator
-    sees N+1 rows in the firmware-tasks panel without the
-    handler needing to thread them through the WS reply
-    shape. Don't "fix" this to return a list — the WS contract
-    is "the handler returns the job the operator's click
-    produced"; the fan-out is incidental.
-
-    Multi-offloader fleets: a clean from offloader A and a
-    concurrent compile from offloader B against the same
-    receiver are safe by construction. Each offloader gets its
-    own ``ESPHOME_DATA_DIR`` subtree
-    (``<receiver_data_dir>/.remote_builds/<dashboard_id>/.esphome``),
-    so A's clean only wipes A's per-offloader build dir; B's
-    compile artefacts under B's subtree are untouched. The
-    receiver-side single-flight queue serializes the actual
-    subprocess invocations regardless, but the per-offloader
-    isolation is what makes the cross-offloader race a
-    non-issue at the filesystem level.
+    configuration; the supersede path would silently cancel a
+    build the user didn't intend to abandon. Two clean jobs for
+    the same configuration still supersede each other.
     """
     await controller._validate_configuration_boundary(configuration)
     if blocker := _active_build_for(controller, configuration):
@@ -116,23 +57,11 @@ async def clean(controller: FirmwareController, *, configuration: str) -> Firmwa
 async def _fan_out_clean_to_connected_peers(
     controller: FirmwareController, configuration: str
 ) -> None:
-    """Queue one REMOTE clean job per connected approved peer.
+    """Queue one REMOTE clean job per APPROVED+connected paired peer.
 
-    Reads the remote-build controller's RAM-canonical
-    ``(_pairings, _open_peer_links)`` state via
-    :meth:`OffloaderController.build_scheduler_snapshot`.
-    Approved + connected peers get a job each; everything else
-    is silently skipped (a PENDING row can't accept submits,
-    a disconnected approved row would just FAIL on the runner's
-    first ``_lookup_open_peer_link_client``).
-
-    Fan-out is silent on the WS reply — the operator's
-    ``firmware/clean`` call returns the local job; the remote
-    jobs surface through the existing
-    firmware-jobs subscribe-events stream the dashboard already
-    consumes for in-flight job lists. A regression that lost
-    the fan-out shows up as "I clicked Clean but my receiver
-    still has the old build".
+    Silently skips PENDING pairings and disconnected approved peers;
+    a regression that lost the fan-out shows up as "I clicked Clean
+    but my receiver still has the old build".
     """
     offloader = controller._db.remote_build_offloader
     if offloader is None:
@@ -156,25 +85,14 @@ async def _fan_out_clean_to_connected_peers(
                 source_esphome_version=pairing.esphome_version,
             ),
         )
-        # ``supersede=False``: the fan-out batch is N+1 jobs
-        # all sharing one ``configuration``, so default
-        # supersede semantics ("cancel any prior active job
-        # for this configuration") would cancel the local
-        # clean we just queued plus every prior fan-out
-        # sibling, leaving only the LAST peer's clean alive.
-        # See ``_enqueue``'s docstring for the carve-out
-        # rationale.
+        # ``supersede=False``: the fan-out batch is N+1 jobs sharing
+        # one ``configuration``; default supersede would leave only
+        # the LAST peer's clean alive.
         await controller._enqueue(remote_job, supersede=False)
 
 
 def _active_build_for(controller: FirmwareController, configuration: str) -> FirmwareJob | None:
-    """Return any in-flight build-producing job on *configuration*.
-
-    Filters ``_jobs`` by status (``_ACTIVE_JOB_STATUSES``) and
-    type (``_BUILD_PRODUCING_JOB_TYPES``). Used by ``clean`` to
-    reject rather than supersede when a destructive op would
-    wipe artifacts the running job is producing.
-    """
+    """Return any in-flight build-producing job on *configuration*, else None."""
     for active in controller._jobs.values():
         if active.configuration != configuration:
             continue

--- a/esphome_device_builder/controllers/firmware/clean.py
+++ b/esphome_device_builder/controllers/firmware/clean.py
@@ -20,25 +20,23 @@ if TYPE_CHECKING:
 
 
 # Job types that produce build artifacts a clean would destroy.
-# A clean against an in-flight one of these is rejected loudly
-# rather than supersede-cancelled.
+# A clean is rejected loudly (not supersede-cancelled) while any
+# of these is in-flight for the same configuration.
 _BUILD_PRODUCING_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL, JobType.RENAME}
 )
 
 
 async def clean(controller: FirmwareController, *, configuration: str) -> FirmwareJob:
-    """Queue a clean job + one per connected paired receiver; return the LOCAL job.
+    """
+    Queue a clean job + one per connected paired receiver; return the LOCAL job.
 
     Per-peer REMOTE clean jobs surface through the firmware-jobs
-    ``subscribe_events`` stream rather than the WS reply — the
-    operator sees N+1 rows in the firmware-tasks panel.
-
-    Rejects with ``CommandError(INVALID_ARGS)`` when an active
-    compile / upload / install / rename job exists for the same
-    configuration; the supersede path would silently cancel a
-    build the user didn't intend to abandon. Two clean jobs for
-    the same configuration still supersede each other.
+    ``subscribe_events`` stream, not the WS reply. Rejects with
+    ``CommandError(INVALID_ARGS)`` while a compile / upload /
+    install / rename is in flight for the same configuration —
+    supersede would silently abandon a build the user didn't
+    mean to cancel. Two clean jobs still supersede each other.
     """
     await controller._validate_configuration_boundary(configuration)
     if blocker := _active_build_for(controller, configuration):
@@ -57,11 +55,10 @@ async def clean(controller: FirmwareController, *, configuration: str) -> Firmwa
 async def _fan_out_clean_to_connected_peers(
     controller: FirmwareController, configuration: str
 ) -> None:
-    """Queue one REMOTE clean job per APPROVED+connected paired peer.
+    """
+    Queue one REMOTE clean job per APPROVED+connected paired peer.
 
-    Silently skips PENDING pairings and disconnected approved peers;
-    a regression that lost the fan-out shows up as "I clicked Clean
-    but my receiver still has the old build".
+    Silently skips PENDING pairings and disconnected approved peers.
     """
     offloader = controller._db.remote_build_offloader
     if offloader is None:


### PR DESCRIPTION
# What does this implement/fix?

Docstring/comment cleanup follow-up to #748 (`firmware/clean` fan-out extraction). #748 preserved bodies byte-for-byte per the split-then-clean cadence; this is the deferred prose pass.

The `clean()` docstring was ~70 lines for a ~10-line body — narrative + multi-paragraph rationale that belongs in the PR description, not the function contract. Trimmed to the load-bearing facts:

* Returns the LOCAL job; per-peer REMOTE jobs surface through `subscribe_events` (not the WS reply).
* Rejects with `CommandError(INVALID_ARGS)` when an active compile/upload/install/rename is in flight for the same configuration; supersede-cancellation is the wrong shape for clean because it'd silently abandon a build the user didn't mean to cancel.

Dropped:
* "Why fan out" paragraph (PR-description material, not contract).
* "Best-effort" paragraph about peer-disconnect timing (caller doesn't need it — error surfaces via the existing FAILED path).
* "Multi-offloader fleets" paragraph (defensive future-reader rationale).
* "Don't 'fix' this to return a list" defensive note.

Same shape for `_fan_out_clean_to_connected_peers` and `_active_build_for`. The `_BUILD_PRODUCING_JOB_TYPES` constant comment drops a "see the clean handler's docstring for the rationale" cross-reference. The `supersede=False` inline comment trims its multi-paragraph justification down to the one-line gotcha.

Pure prose change; no behaviour change. All clean tests pass.

**Related issue or feature (if applicable):**

- follow-up to #748; split-then-clean prose pass

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
