### PR TITLE
Tighten download.py docstrings and reorder helper to bottom

### DIFF
--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -24,63 +24,27 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # Platforms whose ``target_platform`` value isn't the component
-# module name. The dashboard download endpoint needs the
-# ``esphome.components.<X>`` module that exposes
-# ``get_download_types(storage)`` — for ESP32 variants that's the
-# umbrella ``esp32`` component, and for LibreTiny chip families it's
-# the ``libretiny`` component.
-#
-# The LibreTiny set is derived from upstream's
-# ``FAMILY_COMPONENT.values()`` (auto-generated from
-# ``generate_components.py``) so when LibreTiny adds a new chip
-# family / component our mapping picks it up on the next
-# ``esphome`` dependency bump — no edit here. The literal
-# ``"libretiny"`` covers configs that report the umbrella name as
-# ``target_platform`` directly.
-#
-# Mirrors ``esphome/dashboard/web_server.py``'s
-# ``DownloadListRequestHandler`` — same shape, but driven by an
-# upstream-sourced set rather than an inline literal.
+# module name. ESP32 variants collapse to the umbrella ``esp32``
+# component; LibreTiny chip families collapse to ``libretiny``.
+# The LibreTiny set is sourced from upstream's
+# ``FAMILY_COMPONENT.values()`` so it picks up new chip families
+# automatically on the next ``esphome`` dependency bump.
 _LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPONENT.values()) | {
     "libretiny"
 }
 
 
-def _resolve_download_component(target_platform: str | None) -> str:
-    """Return the ``esphome.components`` module name for *target_platform*.
-
-    Accepts ``None`` so callers can pass ``StorageJSON.target_platform``
-    (which is itself nullable) without an explicit ``or ""``
-    coercion at the call site. Returns the empty string for empty
-    / missing input — the caller's ``importlib.import_module`` will
-    fail in its ``try/except`` block and log a warning.
-
-    See ``_LIBRETINY_TARGET_PLATFORMS`` for the keep-in-sync note.
-    """
-    platform = (target_platform or "").lower()
-    if platform.upper() in ESP32_VARIANTS:
-        return "esp32"
-    if platform in _LIBRETINY_TARGET_PLATFORMS:
-        return "libretiny"
-    return platform
-
-
 async def get_binaries(controller: FirmwareController, *, configuration: str) -> list[dict]:
-    """
-    List available firmware binaries for a compiled device.
+    """List firmware binaries for a compiled device as ``[{title, file}]``.
 
-    Returns ``[{title, file}]`` — the file names can be passed to
-    ``firmware/download`` to retrieve the binary content.
+    The ``file`` names can be passed to ``firmware/download`` to
+    retrieve the binary content.
     """
     # ``resolve_storage_path`` collapses to
-    # ``<data_dir>/storage/<Path(configuration).name>.json`` —
-    # the basename collapse defangs separators in the
-    # configuration but a traversal-shaped *configuration*
-    # would still escape the config dir before reaching the
-    # closure (e.g. opening a sidecar at an attacker-controlled
-    # path under ``<data_dir>/storage``). The validator below
-    # is the gate that keeps any traversal payload out of the
-    # inner closure entirely. Do not reorder.
+    # ``<data_dir>/storage/<Path(configuration).name>.json``; a
+    # traversal-shaped *configuration* could still escape to an
+    # attacker-controlled basename inside the storage tree, so the
+    # validator below is the gate. Do not reorder.
     await controller._validate_configuration_boundary(configuration)
     loop = asyncio.get_running_loop()
 
@@ -106,21 +70,13 @@ async def download(
     file: str,
     compressed: bool = False,
 ) -> dict:
-    """
-    Download a compiled firmware binary.
+    """Download a compiled firmware binary as ``{filename, data, size, compressed}``.
 
-    Returns ``{filename, data, size, compressed}`` where ``data`` is
-    base64-encoded bytes. For Web Serial flashing the frontend
-    decodes the base64 itself.
+    ``data`` is base64-encoded bytes; for Web Serial flashing the
+    frontend decodes the base64 itself.
     """
-    # See ``get_binaries`` — ``resolve_storage_path`` collapses
-    # to ``<data_dir>/storage/<Path(configuration).name>.json``,
-    # but a traversal-shaped *configuration* could still resolve
-    # to an attacker-controlled basename inside the storage
-    # tree (e.g. by stripping segments down to a sensitive
-    # leaf), so we re-validate at the WS boundary.
-    # ``_validate_configuration_boundary`` is the only gate;
-    # do not reorder. Coverage:
+    # ``_validate_configuration_boundary`` is the only traversal
+    # gate; do not reorder. Coverage:
     # ``test_download.py::test_download_validator_runs_before_ext_storage_path``.
     await controller._validate_configuration_boundary(configuration)
     loop = asyncio.get_running_loop()
@@ -156,3 +112,18 @@ async def download(
         }
 
     return await loop.run_in_executor(None, _read_binary)
+
+
+def _resolve_download_component(target_platform: str | None) -> str:
+    """Return the ``esphome.components`` module name for *target_platform*.
+
+    ``None`` / empty input collapses to ``""``; the caller's
+    ``importlib.import_module`` then fails in its ``try/except``
+    and logs a warning.
+    """
+    platform = (target_platform or "").lower()
+    if platform.upper() in ESP32_VARIANTS:
+        return "esp32"
+    if platform in _LIBRETINY_TARGET_PLATFORMS:
+        return "libretiny"
+    return platform


### PR DESCRIPTION
# What does this implement/fix?

Docstring/ordering cleanup follow-up to #750 (firmware-binary download extraction). Resolves both Copilot review comments deferred during the structural-split:

1. **Moves `_resolve_download_component` below the public functions** per CLAUDE.md:88-90 (public API at top, private helpers underscore-prefixed at bottom). The original top placement came from byte-for-byte preservation of `controller.py` where the helper had to be defined before the `FirmwareController` class that consumed it — that Python-scope constraint doesn't apply in a fresh module. ([Copilot discussion r3236165612](https://github.com/esphome/device-builder/pull/750#discussion_r3236165612))

2. **Tightens the `_resolve_download_component` docstring**: summary on its own line per CLAUDE.md:34-40, content collapsed to one paragraph. The LibreTiny sync rationale stays as a module-level comment on `_LIBRETINY_TARGET_PLATFORMS` where it belongs (it's about the *constant*, not the function). ([Copilot discussion r3236165679](https://github.com/esphome/device-builder/pull/750#discussion_r3236165679))

Also trims `get_binaries` and `download` docstrings (drop body-restating prose, keep the traversal-gate ordering rules with their security-relevant "do not reorder" anchors).

Pure prose / ordering change; no behaviour change. All download / get_binaries / resolve_download_component tests pass.

**Related issue or feature (if applicable):**

- follow-up to #750; resolves both Copilot review comments

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
