### PR TITLE
Tighten follow.py docstrings and comments

### DIFF
--- a/esphome_device_builder/controllers/firmware/follow.py
+++ b/esphome_device_builder/controllers/firmware/follow.py
@@ -25,44 +25,26 @@ async def follow_job(
     client: Any = None,
     message_id: str = "",
 ) -> None:
-    """
-    Follow a job's output: send historical lines then stream new ones.
+    """Follow a job: replay history, stream new output (``tail -f``-style).
 
-    Behaves like ``tail -f`` with history. If the job is already
-    finished, sends all output and a final result event.
+    Already-terminal jobs get one history send + a final result
+    event, then end. Live jobs keep streaming until completion.
 
-    Race-free against the streaming loop: ``stream_events``
-    subscribes to ``JOB_OUTPUT`` *before* the snapshot is sent,
-    so the streaming loop cannot append between the snapshot
-    capture and the subscription. Without that ordering, the
-    previous shape iterated ``job.output`` directly and only
-    subscribed afterwards, which had two failure modes:
-
-    1. Lines appended to ``job.output`` during the history send
-       (each ``send_event`` await yields the loop) fired a
-       ``JOB_OUTPUT`` event with no subscriber attached and were
-       dropped for this follower.
-    2. The in-flight cap's ``_trim_job_output`` reassigns
-       ``job.output`` to a new list, so an iteration over the
-       old list reference stops seeing post-trim appends — making
-       the gap above strictly bigger after every cap-crossing.
-
-    Both failure modes are closed by snapshotting *before*
-    ``stream_events`` runs and replaying inside ``send_initial``
-    — every line fired after that point queues through the
-    listener and lands strictly after history.
+    Snapshot-then-subscribe ordering matters: the listener is
+    attached *before* the history replay so lines fired during
+    replay queue through the listener and land strictly after
+    history. The earlier iterate-then-subscribe shape dropped
+    every line appended during replay, and the gap widened
+    forever after the first in-flight ``_trim_job_output`` reassign.
     """
     job = controller._jobs.get(job_id)
     if not job:
         msg = f"Job not found: {job_id}"
         raise ValueError(msg)
 
-    # Capture snapshot before stream_events attaches listeners.
-    # The listener (attached inside stream_events) catches every
-    # line fired after this point; nothing fires between the
-    # snapshot and the subscribe because both happen in
-    # synchronous-adjacent statements (stream_events' setup is
-    # sync up to the first ``await`` inside ``send_initial``).
+    # Capture snapshot before ``stream_events`` attaches listeners.
+    # Both happen in synchronous-adjacent statements so nothing
+    # fires between freeze and subscribe.
     snapshot = list(job.output)
     is_terminal = job.status in TERMINAL_JOB_STATUSES
     terminal_status = job.status.value if is_terminal else ""
@@ -79,25 +61,18 @@ async def follow_job(
                 {
                     "status": terminal_status,
                     "exit_code": terminal_exit_code,
-                    # ``error`` carries the human-readable
-                    # failure reason :func:`_fail_locally` /
-                    # ``_finalize_terminal`` stamped on the job
-                    # (e.g. ``"remote build: peer-link session
-                    # lost (transport_error: ...)"``). The
-                    # frontend install dialog surfaces this in
-                    # its red error banner; without the field
-                    # the banner falls back to a generic
-                    # "Install failed." that misattributes a
-                    # receiver-restart to a broken build env.
-                    # ``None`` for successful jobs and for
-                    # jobs from before the field was set;
-                    # frontend treats both equivalently.
+                    # ``error`` carries the human-readable failure
+                    # reason the frontend install dialog renders in
+                    # its red banner. Without it the banner falls
+                    # back to a generic "Install failed." that
+                    # misattributes a receiver-restart to a broken
+                    # build env. ``None`` for successful jobs.
                     "error": terminal_error,
                 },
             )
-            # No live drain — already-terminal job has nothing
-            # more to deliver; end the stream so the helper
-            # returns instead of parking on ``queue.get``.
+            # End the stream so the helper returns instead of
+            # parking on ``queue.get`` — already-terminal job has
+            # nothing more to deliver.
             controls.end()
 
     def _handle_event(event: Event, controls: StreamControls) -> None:
@@ -136,47 +111,30 @@ async def follow_jobs(
     message_id: str = "",
     snapshot: bool = True,
 ) -> None:
-    """
-    Stream every job's lifecycle events to one client connection.
+    """Stream every job's lifecycle events + live output to one client.
 
-    Designed for a "manage compile tasks" panel: subscribe once
-    and the frontend sees every queued / started / progress /
-    completed / failed / cancelled event for every job, plus
-    live ``output`` lines tagged with their ``job_id``.
+    With ``snapshot=True`` (default), the full retained job set
+    (active + trimmed terminal history) is replayed first so a
+    refresh paints immediately with no follow-up
+    ``firmware/get_jobs``. Each event payload is bus-shape
+    (``job_id``-keyed) so the frontend updates its in-memory map
+    without extra queries.
 
-    When ``snapshot`` is True (default), the controller's full
-    retained set of jobs — both active and the trimmed terminal
-    history — is replayed first so the panel paints the complete
-    picture immediately after a page refresh, with no extra round
-    trip to ``firmware/get_jobs``. Each event keeps the same
-    ``job`` payload shape as the bus, so the frontend can update
-    its in-memory map by ``job_id`` without extra queries.
-
-    Runs until the client disconnects (which surfaces here as a
-    ``CancelledError`` from ``send_event``).
-
-    Race-free against concurrent jobs the same way ``follow_job``
-    is: ``stream_events`` attaches listeners *before* the
-    snapshot replay is awaited, so a ``JOB_*`` event firing
-    during the snapshot loop queues through the listener
-    instead of being lost. The earlier shape sent the snapshot
-    first and only attached listeners afterwards, so a job
-    completing mid-replay silently disappeared from the stream.
+    Runs until the client disconnects (surfaces as
+    ``CancelledError`` from ``send_event``). Same
+    snapshot-then-subscribe ordering as :func:`follow_job` — a
+    ``JOB_*`` event firing during snapshot replay queues through
+    the listener rather than being lost.
     """
     if client is None:
         return
 
-    # Serialize the snapshot to dicts synchronously *before*
-    # ``stream_events`` attaches listeners. Capturing the
-    # ``FirmwareJob`` objects and calling ``to_dict()`` later
-    # (inside ``send_initial``) is racy: between listener
-    # attach and each ``to_dict()`` the runner can append to a
-    # running job's ``output`` or transition its status — that
-    # mutation is folded into the snapshot dict AND delivered
-    # again via the listener, so the client sees the same line
-    # twice. Dict-freeze here makes the snapshot atomic against
-    # the producer (no awaits between freeze and listener
-    # attach) and de-duplicates the handoff.
+    # Freeze the snapshot to dicts synchronously *before*
+    # ``stream_events`` attaches listeners. Deferring ``to_dict()``
+    # into ``send_initial`` would let the runner mutate a running
+    # job between freeze and serialise — that mutation lands in
+    # both the snapshot AND the listener, so the client sees the
+    # same line twice.
     snapshot_payloads = (
         [job.to_dict() for job in sorted(controller._jobs.values(), key=attrgetter("created_at"))]
         if snapshot
@@ -189,23 +147,15 @@ async def follow_jobs(
 
     def _handle_event(event: Event, controls: StreamControls) -> None:
         if event.event_type == EventType.JOB_OUTPUT:
-            # Forward the bus event name through verbatim — the
-            # all-jobs follower's wire protocol matches the
-            # ``EventType`` value byte-for-byte for these high-
-            # rate events. Pass the StrEnum member directly;
-            # ``StreamControls.push`` accepts any str.
             controls.push(EventType.JOB_OUTPUT, event.data)
         elif event.event_type == EventType.JOB_PROGRESS:
             controls.push(EventType.JOB_PROGRESS, event.data)
         else:
-            # Lifecycle event (queued/started/completed/failed/
-            # cancelled). Use ``push_priority`` so a backlog of
-            # ``job_output`` lines can't drop a status
-            # transition — a missed ``job_completed`` would
-            # leave the all-jobs panel stuck on the old status
-            # forever (no resync after the initial snapshot).
-            # Output/progress are tolerable to lose; status
-            # transitions are not.
+            # Lifecycle event — use ``push_priority`` so a backlog
+            # of high-rate output/progress can't drop a status
+            # transition. A missed JOB_COMPLETED leaves the panel
+            # stuck on the old status forever (no resync after
+            # the initial snapshot).
             job = event.data.get("job")
             if job is None:
                 return


### PR DESCRIPTION
# What does this implement/fix?

Docstring/comment cleanup follow-up to #746 (firmware-job follow extraction). #746 preserved bodies byte-for-byte per the split-then-clean cadence; this is the deferred prose pass.

Changes:

* `follow_job` docstring collapses ~30 lines of race-against-`stream_events` narrative into the load-bearing facts: snapshot-then-subscribe ordering matters; the earlier shape dropped lines fired during replay; `_trim_job_output`'s list-reassign widens the gap forever. The same race-rationale paragraphs in `follow_jobs` trim down the same way.
* The `"error"` field comment inside `_send_initial` keeps its *why* (frontend banner falls back to "Install failed." without the field) and drops the multi-paragraph internals.
* Inline comments in `follow_jobs`: the snapshot-freeze comment collapses to one paragraph keeping the race rationale; the `JOB_OUTPUT` / `JOB_PROGRESS` "forward verbatim" explanation drops as body-restatement; the `push_priority` *why* stays (a missed `JOB_COMPLETED` is the load-bearing failure mode).

Pure prose change; no behaviour change. All follow tests pass.

**Related issue or feature (if applicable):**

- follow-up to #746; split-then-clean prose pass

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
