### PR TITLE
Add peer-link pin-drift triage logging on both sides

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link.py
@@ -351,6 +351,7 @@ async def _drive_peer_link_session(  # noqa: PLR0911 — the early-returns are t
     against a fake ``WebSocketResponse`` without standing up an
     aiohttp server.
     """
+    _LOGGER.info("peer-link WS accepted from %s", peer_ip)
     session = PeerLinkNoiseSession.responder(identity_priv)
 
     # --- handshake msg1 (offloader → receiver, plaintext payload) ---
@@ -392,6 +393,13 @@ async def _drive_peer_link_session(  # noqa: PLR0911 — the early-returns are t
     pin = pin_sha256_for_pubkey(remote_static_pub)
     dashboard_id = _str_or_empty(msg3.get("dashboard_id"))
     label = _normalize_label(msg3.get("label"))
+    _LOGGER.info(
+        "peer-link handshake from %s ok (intent=%s dashboard_id=%s observed_offloader_pin=%s)",
+        peer_ip,
+        intent.value,
+        dashboard_id,
+        pin,
+    )
 
     response = await _dispatch_intent(
         controller,

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -333,6 +333,7 @@ class PeerLinkClient:
         # Handshake reads are bounded with ``asyncio.wait_for``
         # downstream so a stalled handshake still fails fast.
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=_DEFAULT_TIMEOUT_SECONDS)
+        await self._log_resolved_target()
         try:
             async with (
                 make_peer_link_http_session(timeout=timeout, resolver=self._resolver) as http,
@@ -604,3 +605,33 @@ class PeerLinkClient:
 
     def _fire_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
         _dispatch.fire_queue_status(self, idle, running, queue_depth)
+
+    async def _log_resolved_target(self) -> None:
+        """Resolve ``hostname:port`` through the configured resolver and log it.
+
+        Pairs with the pin-drift warning's ``observed_bytes`` so an
+        operator can tell whether reconnects after a receiver restart
+        are landing on the expected endpoint (mDNS / NAT / mirrored-
+        networking races route the same hostname to a different host).
+        """
+        if self._resolver is None:
+            _LOGGER.info("peer-link client connecting to %s:%d", self._hostname, self._port)
+            return
+        try:
+            resolved = await self._resolver.resolve(self._hostname, self._port)
+        except Exception as exc:
+            _LOGGER.info(
+                "peer-link client connecting to %s:%d (resolve failed: %s: %s)",
+                self._hostname,
+                self._port,
+                type(exc).__name__,
+                exc,
+            )
+            return
+        hosts = ", ".join(str(r.get("host", "?")) for r in resolved) or "<empty>"
+        _LOGGER.info(
+            "peer-link client connecting to %s:%d (resolved: %s)",
+            self._hostname,
+            self._port,
+            hosts,
+        )

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -333,12 +333,17 @@ class PeerLinkClient:
         # Handshake reads are bounded with ``asyncio.wait_for``
         # downstream so a stalled handshake still fails fast.
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=_DEFAULT_TIMEOUT_SECONDS)
-        await self._log_resolved_target()
         try:
             async with (
                 make_peer_link_http_session(timeout=timeout, resolver=self._resolver) as http,
                 http.ws_connect(url, max_msg_size=APP_FRAME_MAX_BYTES) as ws,
             ):
+                _LOGGER.info(
+                    "peer-link client connected to %s:%d (peer=%s)",
+                    self._hostname,
+                    self._port,
+                    ws.get_extra_info("peername"),
+                )
                 session = PeerLinkNoiseSession.initiator(self._identity_priv)
                 msg3_payload = _json.dumps({"dashboard_id": self._dashboard_id})
                 response_ct = await _drive_initiator_handshake_and_read_response(
@@ -605,33 +610,3 @@ class PeerLinkClient:
 
     def _fire_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
         _dispatch.fire_queue_status(self, idle, running, queue_depth)
-
-    async def _log_resolved_target(self) -> None:
-        """Resolve ``hostname:port`` through the configured resolver and log it.
-
-        Pairs with the pin-drift warning's ``observed_bytes`` so an
-        operator can tell whether reconnects after a receiver restart
-        are landing on the expected endpoint (mDNS / NAT / mirrored-
-        networking races route the same hostname to a different host).
-        """
-        if self._resolver is None:
-            _LOGGER.info("peer-link client connecting to %s:%d", self._hostname, self._port)
-            return
-        try:
-            resolved = await self._resolver.resolve(self._hostname, self._port)
-        except Exception as exc:
-            _LOGGER.info(
-                "peer-link client connecting to %s:%d (resolve failed: %s: %s)",
-                self._hostname,
-                self._port,
-                type(exc).__name__,
-                exc,
-            )
-            return
-        hosts = ", ".join(str(r.get("host", "?")) for r in resolved) or "<empty>"
-        _LOGGER.info(
-            "peer-link client connecting to %s:%d (resolved: %s)",
-            self._hostname,
-            self._port,
-            hosts,
-        )

--- a/esphome_device_builder/helpers/peer_link_identity.py
+++ b/esphome_device_builder/helpers/peer_link_identity.py
@@ -151,7 +151,8 @@ def rotate_peer_link_identity(config_dir: Path) -> PeerLinkIdentity:
 
 
 def _log_loaded_identity(key_path: Path, public_bytes: bytes, pin_sha256: str) -> None:
-    """Log the loaded identity with file stat + raw pubkey hex for drift diagnosis.
+    """
+    Log the loaded identity with file stat + raw pubkey hex for drift diagnosis.
 
     Pairs with the offloader-side pin-drift warning's
     ``observed_bytes`` so an operator can compare what this
@@ -160,16 +161,21 @@ def _log_loaded_identity(key_path: Path, public_bytes: bytes, pin_sha256: str) -
     """
     try:
         stat = key_path.stat()
-        size = stat.st_size
-        mtime = stat.st_mtime
-    except OSError:
-        size = -1
-        mtime = 0.0
+    except OSError as exc:
+        _LOGGER.info(
+            "Loaded peer-link identity from %s (stat_failed: %s: %s pub=%s pin=%s)",
+            key_path,
+            type(exc).__name__,
+            exc,
+            public_bytes.hex(),
+            pin_sha256,
+        )
+        return
     _LOGGER.info(
         "Loaded peer-link identity from %s (size=%d mtime=%.0f pub=%s pin=%s)",
         key_path,
-        size,
-        mtime,
+        stat.st_size,
+        stat.st_mtime,
         public_bytes.hex(),
         pin_sha256,
     )

--- a/esphome_device_builder/helpers/peer_link_identity.py
+++ b/esphome_device_builder/helpers/peer_link_identity.py
@@ -104,10 +104,12 @@ def get_or_create_peer_link_identity(config_dir: Path) -> PeerLinkIdentity:
     public_bytes = (
         X25519PrivateKey.from_private_bytes(private_bytes).public_key().public_bytes_raw()
     )
+    pin_sha256 = hashlib.sha256(public_bytes).hexdigest()
+    _log_loaded_identity(key_path, public_bytes, pin_sha256)
     return PeerLinkIdentity(
         private_bytes=private_bytes,
         public_bytes=public_bytes,
-        pin_sha256=hashlib.sha256(public_bytes).hexdigest(),
+        pin_sha256=pin_sha256,
     )
 
 
@@ -134,16 +136,43 @@ def rotate_peer_link_identity(config_dir: Path) -> PeerLinkIdentity:
     public_bytes = (
         X25519PrivateKey.from_private_bytes(private_bytes).public_key().public_bytes_raw()
     )
+    pin_sha256 = hashlib.sha256(public_bytes).hexdigest()
+    _log_loaded_identity(key_path, public_bytes, pin_sha256)
     return PeerLinkIdentity(
         private_bytes=private_bytes,
         public_bytes=public_bytes,
-        pin_sha256=hashlib.sha256(public_bytes).hexdigest(),
+        pin_sha256=pin_sha256,
     )
 
 
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
+
+
+def _log_loaded_identity(key_path: Path, public_bytes: bytes, pin_sha256: str) -> None:
+    """Log the loaded identity with file stat + raw pubkey hex for drift diagnosis.
+
+    Pairs with the offloader-side pin-drift warning's
+    ``observed_bytes`` so an operator can compare what this
+    process loaded against what a paired offloader actually
+    observed on the wire.
+    """
+    try:
+        stat = key_path.stat()
+        size = stat.st_size
+        mtime = stat.st_mtime
+    except OSError:
+        size = -1
+        mtime = 0.0
+    _LOGGER.info(
+        "Loaded peer-link identity from %s (size=%d mtime=%.0f pub=%s pin=%s)",
+        key_path,
+        size,
+        mtime,
+        public_bytes.hex(),
+        pin_sha256,
+    )
 
 
 def _load_key(key_path: Path) -> bytes | None:

--- a/esphome_device_builder/helpers/peer_link_identity.py
+++ b/esphome_device_builder/helpers/peer_link_identity.py
@@ -151,14 +151,7 @@ def rotate_peer_link_identity(config_dir: Path) -> PeerLinkIdentity:
 
 
 def _log_loaded_identity(key_path: Path, public_bytes: bytes, pin_sha256: str) -> None:
-    """
-    Log the loaded identity with file stat + raw pubkey hex for drift diagnosis.
-
-    Pairs with the offloader-side pin-drift warning's
-    ``observed_bytes`` so an operator can compare what this
-    process loaded against what a paired offloader actually
-    observed on the wire.
-    """
+    """Emit one INFO line with key-file stat, raw pubkey hex, and pin."""
     try:
         stat = key_path.stat()
     except OSError as exc:

--- a/tests/test_peer_link_identity.py
+++ b/tests/test_peer_link_identity.py
@@ -203,3 +203,46 @@ def test_returns_peer_link_identity_dataclass(tmp_path: Path) -> None:
     # The dataclass is frozen, attempting to mutate raises.
     with pytest.raises((AttributeError, TypeError)):  # frozen dataclass
         identity.private_bytes = b"replacement"  # type: ignore[misc]
+
+
+def test_loaded_identity_log_carries_pubkey_and_file_stat(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Every load logs the key-file path, size, mtime, raw pubkey hex, and pin.
+
+    Pairs with the offloader-side pin-drift warning's
+    ``observed_bytes``: an operator can cross-check what the
+    receiver process actually loaded against what a paired
+    offloader observed on the wire.
+    """
+    with caplog.at_level("INFO", logger=identitymod.__name__):
+        identity = get_or_create_peer_link_identity(tmp_path)
+
+    key_path = tmp_path / _KEY_FILENAME
+    records = [
+        rec for rec in caplog.records if "Loaded peer-link identity from" in rec.getMessage()
+    ]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert str(key_path) in msg
+    assert f"size={_KEY_LENGTH}" in msg
+    assert f"pub={identity.public_bytes.hex()}" in msg
+    assert f"pin={identity.pin_sha256}" in msg
+
+
+def test_loaded_identity_log_fires_on_rotate(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``rotate_peer_link_identity`` logs the new pubkey + pin after the write."""
+    get_or_create_peer_link_identity(tmp_path)
+    caplog.clear()
+    with caplog.at_level("INFO", logger=identitymod.__name__):
+        rotated = rotate_peer_link_identity(tmp_path)
+
+    records = [
+        rec for rec in caplog.records if "Loaded peer-link identity from" in rec.getMessage()
+    ]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert f"pub={rotated.public_bytes.hex()}" in msg
+    assert f"pin={rotated.pin_sha256}" in msg

--- a/tests/test_peer_link_identity.py
+++ b/tests/test_peer_link_identity.py
@@ -24,6 +24,7 @@ from esphome_device_builder.helpers.peer_link_identity import (
     _KEY_LENGTH,
     _KEY_MODE,
     PeerLinkIdentity,
+    _log_loaded_identity,
     get_or_create_peer_link_identity,
     rotate_peer_link_identity,
 )
@@ -208,13 +209,7 @@ def test_returns_peer_link_identity_dataclass(tmp_path: Path) -> None:
 def test_loaded_identity_log_carries_pubkey_and_file_stat(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Every load logs the key-file path, size, mtime, raw pubkey hex, and pin.
-
-    Pairs with the offloader-side pin-drift warning's
-    ``observed_bytes``: an operator can cross-check what the
-    receiver process actually loaded against what a paired
-    offloader observed on the wire.
-    """
+    """Every load logs the key-file path, size, mtime, raw pubkey hex, and pin."""
     with caplog.at_level("INFO", logger=identitymod.__name__):
         identity = get_or_create_peer_link_identity(tmp_path)
 
@@ -228,6 +223,32 @@ def test_loaded_identity_log_carries_pubkey_and_file_stat(
     assert f"size={_KEY_LENGTH}" in msg
     assert f"pub={identity.public_bytes.hex()}" in msg
     assert f"pin={identity.pin_sha256}" in msg
+
+
+def test_loaded_identity_log_marks_stat_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When ``stat()`` fails the log carries an explicit ``stat_failed`` marker."""
+    key_path = tmp_path / "missing-on-purpose.bin"
+    pub = b"\x11" * 32
+    pin = hashlib.sha256(pub).hexdigest()
+
+    with caplog.at_level("INFO", logger=identitymod.__name__):
+        _log_loaded_identity(key_path, pub, pin)
+
+    records = [
+        rec for rec in caplog.records if "Loaded peer-link identity from" in rec.getMessage()
+    ]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    # File doesn't exist → ``stat()`` raises FileNotFoundError;
+    # operator sees ``stat_failed: ...`` instead of misleading
+    # ``size=-1 mtime=0`` placeholders.
+    assert "stat_failed: FileNotFoundError" in msg
+    assert "size=" not in msg
+    assert "mtime=" not in msg
+    assert f"pub={pub.hex()}" in msg
+    assert f"pin={pin}" in msg
 
 
 def test_loaded_identity_log_fires_on_rotate(

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import io
+import logging
 import secrets
 import tarfile
 from collections.abc import AsyncGenerator, AsyncIterator, Iterator
@@ -5682,3 +5683,219 @@ async def test_controller_download_artifacts_malformed_tarball_maps_to_invalid_a
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.INVALID_ARGS
+
+
+# ---------------------------------------------------------------------------
+# Connection-target + receiver-side accept diagnostics (pin-drift triage)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receiver_logs_accept_and_handshake_ok_on_preview_session(
+    receiver_server: tuple[TestServer, ReceiverController, str, bytes],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Receiver emits ``WS accepted`` + ``handshake ... ok`` for every completed session.
+
+    Paired with the offloader-side pin-drift warning, these two
+    lines tell an operator whether the offloader's reconnect even
+    reached this receiver (accept fires) and whether Noise XX
+    completed against this process (handshake ok fires). Together
+    they rule out the "different process answered" branch when the
+    pin-drift warning fires elsewhere.
+    """
+    server, _, _, _ = receiver_server
+    initiator_priv = secrets.token_bytes(32)
+
+    with caplog.at_level(
+        "INFO", logger="esphome_device_builder.controllers.remote_build.peer_link"
+    ):
+        await preview_pair(
+            hostname="127.0.0.1",
+            port=server.port,
+            identity_priv=initiator_priv,
+        )
+
+    accept = [rec for rec in caplog.records if "peer-link WS accepted from" in rec.getMessage()]
+    handshake = [rec for rec in caplog.records if "peer-link handshake from" in rec.getMessage()]
+    assert len(accept) >= 1
+    assert len(handshake) >= 1
+    initiator_pub = (
+        X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
+    )
+    expected_offloader_pin = pin_sha256_for_pubkey(initiator_pub)
+    assert f"observed_offloader_pin={expected_offloader_pin}" in handshake[-1].getMessage()
+    assert "intent=preview" in handshake[-1].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_run_one_session_logs_connect_target_no_resolver(
+    receiver_server: tuple[TestServer, ReceiverController, str, bytes],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A successful connect with ``resolver=None`` logs hostname:port only.
+
+    The pin-drift triage line should fire on the same code path
+    every real reconnect uses; running the client to OPENED and
+    asserting the line is present pins the wiring, not just the
+    helper.
+    """
+    server, receiver, _, receiver_pub = receiver_server
+    initiator_priv = secrets.token_bytes(32)
+    await _seed_approved_peer_for_initiator(
+        receiver, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+
+    bus = EventBus()
+    opened = capture_events(bus, EventType.OFFLOADER_PEER_LINK_OPENED)
+
+    client = PeerLinkClient(
+        receiver_hostname="127.0.0.1",
+        receiver_port=server.port,
+        identity_priv=initiator_priv,
+        dashboard_id="alpha",
+        pinned_static_x25519_pub=receiver_pub,
+        pin_sha256="a" * 64,
+        receiver_label="test-receiver",
+        bus=bus,
+    )
+    with caplog.at_level(
+        "INFO",
+        logger="esphome_device_builder.controllers.remote_build.peer_link_client.client",
+    ):
+        task = asyncio.create_task(client.run())
+        try:
+            await asyncio.wait_for(opened.received.wait(), timeout=2.0)
+        finally:
+            await cancel_and_drain(task)
+
+    records = [
+        rec
+        for rec in caplog.records
+        if f"peer-link client connecting to 127.0.0.1:{server.port}" in rec.getMessage()
+    ]
+    assert len(records) >= 1
+    # No ``resolved:`` annotation when resolver isn't configured.
+    assert "resolved" not in records[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_run_one_session_logs_connect_target_with_resolver(
+    receiver_server: tuple[TestServer, ReceiverController, str, bytes],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A configured resolver surfaces its hits via ``(resolved: <hosts>)`` in the log."""
+    server, receiver, _, receiver_pub = receiver_server
+    initiator_priv = secrets.token_bytes(32)
+    await _seed_approved_peer_for_initiator(
+        receiver, dashboard_id="alpha", initiator_priv=initiator_priv
+    )
+
+    bus = EventBus()
+    opened = capture_events(bus, EventType.OFFLOADER_PEER_LINK_OPENED)
+
+    # aiohttp's stock ThreadedResolver hands the real getaddrinfo
+    # result back. For 127.0.0.1 that's a single-entry list whose
+    # ``host`` is ``127.0.0.1`` — the same IP aiohttp ends up
+    # connecting to, so the ws_connect path stays viable.
+    resolver = aiohttp.ThreadedResolver()
+    client = PeerLinkClient(
+        receiver_hostname="127.0.0.1",
+        receiver_port=server.port,
+        identity_priv=initiator_priv,
+        dashboard_id="alpha",
+        pinned_static_x25519_pub=receiver_pub,
+        pin_sha256="a" * 64,
+        receiver_label="test-receiver",
+        bus=bus,
+        resolver=resolver,
+    )
+    with caplog.at_level(
+        "INFO",
+        logger="esphome_device_builder.controllers.remote_build.peer_link_client.client",
+    ):
+        task = asyncio.create_task(client.run())
+        try:
+            await asyncio.wait_for(opened.received.wait(), timeout=2.0)
+        finally:
+            await cancel_and_drain(task)
+
+    records = [
+        rec
+        for rec in caplog.records
+        if "peer-link client connecting to 127.0.0.1" in rec.getMessage()
+        and "resolved:" in rec.getMessage()
+    ]
+    assert len(records) >= 1
+    assert "127.0.0.1" in records[0].getMessage().split("resolved:", 1)[1]
+
+
+@pytest.mark.asyncio
+async def test_run_one_session_logs_resolve_failure(
+    caplog: pytest.LogCaptureFixture,
+    bound_unused_tcp_port: int,
+) -> None:
+    """A resolver that raises is surfaced as ``(resolve failed: <ExcType>: <msg>)``.
+
+    Connection itself will fail downstream; the diagnostic line
+    must still appear on the per-attempt code path so an operator
+    chasing pin drift can see whether the resolver path is at
+    fault. We point at a never-accepting port so the test doesn't
+    depend on what the real receiver does after the failure.
+    """
+
+    class _RaisingResolver:
+        async def resolve(self, host: str, port: int, family: int = 0) -> list[dict[str, Any]]:
+            raise OSError("mdns timeout")
+
+        async def close(self) -> None:
+            return None
+
+    # Sync off the *log emit* rather than the resolver call —
+    # the line we assert on lands in the ``except`` branch after
+    # ``resolve`` raises. A handler on the client logger flips
+    # the event the moment the matching record is emitted, so
+    # the test awaits a deterministic edge instead of polling.
+    loop = asyncio.get_running_loop()
+    log_seen = asyncio.Event()
+
+    class _LogSignalHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            if "resolve failed: OSError: mdns timeout" in record.getMessage():
+                loop.call_soon_threadsafe(log_seen.set)
+
+    bus = EventBus()
+    client = PeerLinkClient(
+        receiver_hostname="laptop.local",
+        receiver_port=bound_unused_tcp_port,
+        identity_priv=secrets.token_bytes(32),
+        dashboard_id="alpha",
+        pinned_static_x25519_pub=b"\x00" * 32,
+        pin_sha256="0" * 64,
+        receiver_label="laptop",
+        bus=bus,
+        resolver=cast(Any, _RaisingResolver()),
+    )
+
+    logger = logging.getLogger(
+        "esphome_device_builder.controllers.remote_build.peer_link_client.client"
+    )
+    handler = _LogSignalHandler(level=logging.INFO)
+    logger.addHandler(handler)
+    try:
+        with caplog.at_level(
+            "INFO",
+            logger="esphome_device_builder.controllers.remote_build.peer_link_client.client",
+        ):
+            task = asyncio.create_task(client.run())
+            try:
+                await asyncio.wait_for(log_seen.wait(), timeout=2.0)
+            finally:
+                await cancel_and_drain(task)
+    finally:
+        logger.removeHandler(handler)
+
+    records = [
+        rec for rec in caplog.records if "resolve failed: OSError: mdns timeout" in rec.getMessage()
+    ]
+    assert len(records) >= 1

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import io
-import logging
 import secrets
 import tarfile
 from collections.abc import AsyncGenerator, AsyncIterator, Iterator
@@ -5695,15 +5694,7 @@ async def test_receiver_logs_accept_and_handshake_ok_on_preview_session(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Receiver emits ``WS accepted`` + ``handshake ... ok`` for every completed session.
-
-    Paired with the offloader-side pin-drift warning, these two
-    lines tell an operator whether the offloader's reconnect even
-    reached this receiver (accept fires) and whether Noise XX
-    completed against this process (handshake ok fires). Together
-    they rule out the "different process answered" branch when the
-    pin-drift warning fires elsewhere.
-    """
+    """Receiver emits ``WS accepted`` + ``handshake ... ok`` for every completed session."""
     server, _, _, _ = receiver_server
     initiator_priv = secrets.token_bytes(32)
 
@@ -5729,16 +5720,18 @@ async def test_receiver_logs_accept_and_handshake_ok_on_preview_session(
 
 
 @pytest.mark.asyncio
-async def test_run_one_session_logs_connect_target_no_resolver(
+async def test_run_one_session_logs_connected_peer_after_tcp_connect(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A successful connect with ``resolver=None`` logs hostname:port only.
+    """A successful TCP connect logs the actual connected peer address.
 
-    The pin-drift triage line should fire on the same code path
-    every real reconnect uses; running the client to OPENED and
-    asserting the line is present pins the wiring, not just the
-    helper.
+    Logging via aiohttp's ``on_connection_create_end`` trace hook
+    means the line fires once per real connect (after the
+    TCPConnector already resolved + established the socket); failed
+    connect attempts during an outage stay at DEBUG via the
+    existing transport-error path. Pairs with the pin-drift
+    warning's ``observed_bytes`` for the WSL2 mDNS-flap branch.
     """
     server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)
@@ -5755,7 +5748,7 @@ async def test_run_one_session_logs_connect_target_no_resolver(
         identity_priv=initiator_priv,
         dashboard_id="alpha",
         pinned_static_x25519_pub=receiver_pub,
-        pin_sha256="a" * 64,
+        pin_sha256=pin_sha256_for_pubkey(receiver_pub),
         receiver_label="test-receiver",
         bus=bus,
     )
@@ -5772,130 +5765,12 @@ async def test_run_one_session_logs_connect_target_no_resolver(
     records = [
         rec
         for rec in caplog.records
-        if f"peer-link client connecting to 127.0.0.1:{server.port}" in rec.getMessage()
+        if f"peer-link client connected to 127.0.0.1:{server.port}" in rec.getMessage()
     ]
     assert len(records) >= 1
-    # No ``resolved:`` annotation when resolver isn't configured.
-    assert "resolved" not in records[0].getMessage()
-
-
-@pytest.mark.asyncio
-async def test_run_one_session_logs_connect_target_with_resolver(
-    receiver_server: tuple[TestServer, ReceiverController, str, bytes],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A configured resolver surfaces its hits via ``(resolved: <hosts>)`` in the log."""
-    server, receiver, _, receiver_pub = receiver_server
-    initiator_priv = secrets.token_bytes(32)
-    await _seed_approved_peer_for_initiator(
-        receiver, dashboard_id="alpha", initiator_priv=initiator_priv
-    )
-
-    bus = EventBus()
-    opened = capture_events(bus, EventType.OFFLOADER_PEER_LINK_OPENED)
-
-    # aiohttp's stock ThreadedResolver hands the real getaddrinfo
-    # result back. For 127.0.0.1 that's a single-entry list whose
-    # ``host`` is ``127.0.0.1`` — the same IP aiohttp ends up
-    # connecting to, so the ws_connect path stays viable.
-    resolver = aiohttp.ThreadedResolver()
-    client = PeerLinkClient(
-        receiver_hostname="127.0.0.1",
-        receiver_port=server.port,
-        identity_priv=initiator_priv,
-        dashboard_id="alpha",
-        pinned_static_x25519_pub=receiver_pub,
-        pin_sha256="a" * 64,
-        receiver_label="test-receiver",
-        bus=bus,
-        resolver=resolver,
-    )
-    with caplog.at_level(
-        "INFO",
-        logger="esphome_device_builder.controllers.remote_build.peer_link_client.client",
-    ):
-        task = asyncio.create_task(client.run())
-        try:
-            await asyncio.wait_for(opened.received.wait(), timeout=2.0)
-        finally:
-            await cancel_and_drain(task)
-
-    records = [
-        rec
-        for rec in caplog.records
-        if "peer-link client connecting to 127.0.0.1" in rec.getMessage()
-        and "resolved:" in rec.getMessage()
-    ]
-    assert len(records) >= 1
-    assert "127.0.0.1" in records[0].getMessage().split("resolved:", 1)[1]
-
-
-@pytest.mark.asyncio
-async def test_run_one_session_logs_resolve_failure(
-    caplog: pytest.LogCaptureFixture,
-    bound_unused_tcp_port: int,
-) -> None:
-    """A resolver that raises is surfaced as ``(resolve failed: <ExcType>: <msg>)``.
-
-    Connection itself will fail downstream; the diagnostic line
-    must still appear on the per-attempt code path so an operator
-    chasing pin drift can see whether the resolver path is at
-    fault. We point at a never-accepting port so the test doesn't
-    depend on what the real receiver does after the failure.
-    """
-
-    class _RaisingResolver:
-        async def resolve(self, host: str, port: int, family: int = 0) -> list[dict[str, Any]]:
-            raise OSError("mdns timeout")
-
-        async def close(self) -> None:
-            return None
-
-    # Sync off the *log emit* rather than the resolver call —
-    # the line we assert on lands in the ``except`` branch after
-    # ``resolve`` raises. A handler on the client logger flips
-    # the event the moment the matching record is emitted, so
-    # the test awaits a deterministic edge instead of polling.
-    loop = asyncio.get_running_loop()
-    log_seen = asyncio.Event()
-
-    class _LogSignalHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            if "resolve failed: OSError: mdns timeout" in record.getMessage():
-                loop.call_soon_threadsafe(log_seen.set)
-
-    bus = EventBus()
-    client = PeerLinkClient(
-        receiver_hostname="laptop.local",
-        receiver_port=bound_unused_tcp_port,
-        identity_priv=secrets.token_bytes(32),
-        dashboard_id="alpha",
-        pinned_static_x25519_pub=b"\x00" * 32,
-        pin_sha256="0" * 64,
-        receiver_label="laptop",
-        bus=bus,
-        resolver=cast(Any, _RaisingResolver()),
-    )
-
-    logger = logging.getLogger(
-        "esphome_device_builder.controllers.remote_build.peer_link_client.client"
-    )
-    handler = _LogSignalHandler(level=logging.INFO)
-    logger.addHandler(handler)
-    try:
-        with caplog.at_level(
-            "INFO",
-            logger="esphome_device_builder.controllers.remote_build.peer_link_client.client",
-        ):
-            task = asyncio.create_task(client.run())
-            try:
-                await asyncio.wait_for(log_seen.wait(), timeout=2.0)
-            finally:
-                await cancel_and_drain(task)
-    finally:
-        logger.removeHandler(handler)
-
-    records = [
-        rec for rec in caplog.records if "resolve failed: OSError: mdns timeout" in rec.getMessage()
-    ]
-    assert len(records) >= 1
+    msg = records[0].getMessage()
+    # ``peer=`` carries the actual remote address from the transport's
+    # ``peername``, which is what tells the operator whether the
+    # reconnect landed on a different host than expected.
+    assert "peer=" in msg
+    assert "127.0.0.1" in msg.split("peer=", 1)[1]

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -5724,15 +5724,7 @@ async def test_run_one_session_logs_connected_peer_after_tcp_connect(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A successful TCP connect logs the actual connected peer address.
-
-    Logging via aiohttp's ``on_connection_create_end`` trace hook
-    means the line fires once per real connect (after the
-    TCPConnector already resolved + established the socket); failed
-    connect attempts during an outage stay at DEBUG via the
-    existing transport-error path. Pairs with the pin-drift
-    warning's ``observed_bytes`` for the WSL2 mDNS-flap branch.
-    """
+    """A successful WS connect logs the actual peer address from ``ws.get_extra_info``."""
     server, receiver, _, receiver_pub = receiver_server
     initiator_priv = secrets.token_bytes(32)
     await _seed_approved_peer_for_initiator(


### PR DESCRIPTION
# What does this implement/fix?

Adds INFO-level diagnostic logging on both ends of the peer-link
flow so an operator chasing a pin-drift warning (the one #731
added) can localise the root cause from a single log set rather
than having to subscribe to bus events:

- **Receiver identity load** (`helpers.peer_link_identity`): on
  every `get_or_create_peer_link_identity` /
  `rotate_peer_link_identity`, log the key-file path, size,
  mtime, the raw 32-byte public-key hex, and the pin. The
  previous shape only logged on **generate**; a clean reload
  was silent. When `stat()` itself fails the log carries an
  explicit `stat_failed: <ExcType>: <msg>` marker so operators
  can't mistake the failure for real data.
- **Receiver session driver**
  (`controllers/remote_build/peer_link.py::_drive_peer_link_session`):
  log `peer-link WS accepted from <ip>` before the Noise
  responder starts, and `peer-link handshake from <ip> ok
  (intent=... dashboard_id=... observed_offloader_pin=...)`
  after msg3 is decrypted. Together these answer "did the
  offloader's failed reconnect even reach this receiver
  process?" If the pin-drift warning fires on the offloader
  but no accept line appears at the real receiver during the
  same window, the offloader's connection landed somewhere
  else (the WSL2 mirrored-networking / mDNS-flap branch).
- **Offloader client**
  (`controllers/remote_build/peer_link_client/client.py::_run_one_session`):
  log the actual connected peer (via
  `ws.get_extra_info("peername")`) right after `ws_connect`
  returns. Surfaces mDNS / NAT cases where the same hostname
  routes to a different IP across reconnects. The line fires
  only on successful connect, so failed attempts during an
  outage don't spam INFO (the existing transport-error handler
  already covers those at DEBUG); and we don't pay any extra
  resolution lookup or trace-machinery overhead.

No behavior change. Per long-lived peer-link session: one extra
INFO line at reconnect, zero per WS message.

Tests under `tests/test_peer_link_identity.py` and
`tests/test_remote_build_peer_link_client.py` cover the new
logs end-to-end via the `receiver_server` fixture +
`client.run()` / `preview_pair`; the receiver-side stat-failure
branch is covered by a direct call on `_log_loaded_identity`
since the end-to-end path also stat()s the key file from
`is_file()` and can't isolate the failure branch.

**Related issue or feature (if applicable):**

- follow-up to #731

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (Diagnostic-only; no surface change.)
