### PR TITLE
Stabilise test_pairing_window_auto_closes_when_clients_age_out

### DIFF
--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2685,25 +2685,47 @@ async def test_set_pairing_window_rejects_non_bool(tmp_path: Path) -> None:
 async def test_pairing_window_auto_closes_when_clients_age_out(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The window auto-closes when every client's last-extend ages past the duration."""
-    controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._db.bus = MagicMock()
+    """The window auto-closes when every client's last-extend ages past the duration.
 
-    # Patch the duration to ~0 so the auto-close fires almost immediately.
-    monkeypatch.setattr(rb_rcv, "_PAIRING_WINDOW_DURATION_SECONDS", 0.05)
+    Duration is deliberately well above CI scheduling jitter (matches
+    ``test_explicit_close_cancels_handle_no_duplicate_event``): a
+    too-short value can let the wall-clock gap between
+    ``set_pairing_window`` returning and the next
+    ``is_pairing_window_open`` call exceed the prune cutoff on a
+    loaded runner, so ``is_pairing_window_open`` returns False before
+    we've asserted the open transition. The close half is awaited on
+    a bus-fire side-effect — proper edge sync instead of a fixed
+    sleep — so the test takes ~duration plus one event-loop tick.
+    """
+    controller = _make_controller(config_dir=tmp_path)
+
+    close_fired = asyncio.Event()
+
+    def _fire_side_effect(event_type: object, payload: object) -> None:
+        if (
+            event_type is EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED
+            and isinstance(payload, dict)
+            and payload.get("open") is False
+        ):
+            close_fired.set()
+
+    bus = MagicMock()
+    bus.fire.side_effect = _fire_side_effect
+    controller.offloader._db.bus = bus
+
+    monkeypatch.setattr(rb_rcv, "_PAIRING_WINDOW_DURATION_SECONDS", 0.5)
 
     await controller.receiver.set_pairing_window(open=True, client="tab-1")
     assert controller.receiver.is_pairing_window_open() is True
-    controller.offloader._db.bus.fire.reset_mock()
+    bus.fire.reset_mock()
 
-    # Wait for the deadline to lapse + a hair for the task to settle.
-    await asyncio.sleep(0.2)
+    # Auto-close fires from a loop.call_later TimerHandle scheduled
+    # inside set_pairing_window; await its bus emit deterministically.
+    await asyncio.wait_for(close_fired.wait(), timeout=5.0)
 
     assert controller.receiver.is_pairing_window_open() is False
-    # An auto-close event fired (open=False).
-    fire = controller.offloader._db.bus.fire
-    assert fire.call_count >= 1
-    last_event_type, last_payload = fire.call_args.args
+    assert bus.fire.call_count >= 1
+    last_event_type, last_payload = bus.fire.call_args.args
     assert last_event_type is EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED
     assert last_payload["open"] is False
 


### PR DESCRIPTION
# What does this implement/fix?

`test_pairing_window_auto_closes_when_clients_age_out` patched
`_PAIRING_WINDOW_DURATION_SECONDS` to `0.05` and asserted
`is_pairing_window_open() is True` immediately after the awaited
`set_pairing_window` returned. On a loaded CI runner (observed on
linux gw0, same shape we hit on windows xdist) the wall-clock gap
between the setter returning and the next `is_pairing_window_open`
call can exceed 50 ms, which trips the prune cutoff inside
`is_pairing_window_open` so the assertion sees False.

The sibling test
`test_explicit_close_cancels_handle_no_duplicate_event` already
documents the same class of bug and pads the duration to 1.0 s.
This PR applies the same shape:

- Bump the duration to `0.5` s (~10x slack against scheduling
  jitter, but still fast).
- Replace the `await asyncio.sleep(0.2)` with a bus-fire
  `side_effect` that flips an `asyncio.Event` when the
  `REMOTE_BUILD_PAIRING_WINDOW_CHANGED` close event lands. The
  test now syncs on the deterministic edge of the auto-close
  firing instead of a fixed wall-clock wait.

No production change. Test runtime is unchanged in steady state
(~0.6 s locally over 10 trials).

**Related issue or feature (if applicable):**

- N/A (test-only flake)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (Test-only; no surface change.)
