### PR TITLE
Convert peer_link.py to peer_link/ package

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
@@ -65,17 +65,17 @@ import aiohttp
 from aiohttp import WSMsgType, web
 from esphome.const import __version__ as esphome_version
 
-from ...api.ws import WEBSOCKETS_KEY
-from ...helpers import json as _json
-from ...helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
-from ...helpers.peer_link_identity import get_or_create_peer_link_identity
-from ...helpers.peer_link_noise import (
+from ....api.ws import WEBSOCKETS_KEY
+from ....helpers import json as _json
+from ....helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
+from ....helpers.peer_link_identity import get_or_create_peer_link_identity
+from ....helpers.peer_link_noise import (
     NOISE_ERRORS,
     HandshakeNotCompleteError,
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
-from ...models import (
+from ....models import (
     IntentResponse,
     PeerLinkIntent,
     SubmitJobChunkFrameData,
@@ -126,7 +126,7 @@ class _DispatchInput:
 
 
 if TYPE_CHECKING:
-    from .receiver import ReceiverController
+    from ..receiver import ReceiverController
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -941,7 +941,9 @@ async def _read_handshake_message(
         )
         return None
     try:
-        return session.read_handshake_message(msg.data)
+        # ``msg.data`` is ``Any`` (aiohttp's WSMessage shape); the cast
+        # tells mypy the return type holds even when the input widens.
+        return cast(bytes, session.read_handshake_message(msg.data))
     except NOISE_ERRORS:
         _LOGGER.warning("peer-link Noise %s read failed", step, exc_info=True)
         return None


### PR DESCRIPTION
# What does this implement/fix?

First PR in the `peer_link.py` split arc (1071 lines). Pure file rename: `controllers/remote_build/peer_link.py` becomes `controllers/remote_build/peer_link/__init__.py` with the same content. Establishes the package shape so subsequent PRs can extract the wire enums, channel, plumbing, handshake, and session into named submodules inside the package — same cadence as the firmware/controller.py split arc (#733-#756).

**External imports unchanged.** `from .peer_link import X` still resolves to the same module. Test monkey-patch paths unchanged — `peer_link.<attr>` still hits the `__init__.py` module attributes.

Two minimal edits make the rename land:

* **Relative-import depth bumped by one level.** `...api` → `....api`, `...helpers` → `....helpers`, `...models` → `....models`, `.receiver` → `..receiver`. Required because `__init__.py` is one directory deeper than `peer_link.py` was.
* **`cast(bytes, ...)` added on line 944.** The original `peer_link.py` passed mypy because `msg.data` (`Any` from aiohttp's `WSMessage`) was widening the return; the same source under a package fires `no-any-return` at the same line. `cast` is already imported via the existing `from typing import …, cast` block — behaviour unchanged at runtime, just a type assertion mypy needs.

Subsequent PRs in the arc (extractions, one concern each):

1. `wire.py` — `TerminateReason`, `AppMessageType` enums (~104 lines)
2. `channel.py` — `PeerLinkChannel` dataclass (~85 lines)
3. `plumbing.py` — low-level WS / Noise helpers (~145 lines)
4. `handshake.py` — handshake driver + private types (~180 lines)
5. `session.py` — `PeerLinkSession` + receive loop + heartbeat (~330 lines)

After all five, `peer_link/__init__.py` shrinks to ~120-150 lines (just the module docstring, `PEER_LINK_PATH`, `make_peer_link_handler`, and the submodule re-exports).

All 3227 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- first PR of the peer_link split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
