### PR TITLE
Extract peer-link wire enums into wire.py

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
@@ -81,6 +81,9 @@ from ....models import (
     SubmitJobChunkFrameData,
     SubmitJobFrameData,
 )
+from .wire import AppMessageType, TerminateReason
+
+__all__ = ["AppMessageType", "TerminateReason"]
 
 
 class _HandshakeStep(StrEnum):
@@ -180,111 +183,6 @@ HEARTBEAT_DEAD_AFTER_SECONDS = HEARTBEAT_INTERVAL_SECONDS * HEARTBEAT_MISS_THRES
 # requirements (the original comment anticipated this bump).
 # Forward-compatible: smaller frames are always accepted.
 APP_FRAME_MAX_BYTES = 60 * 1024
-
-
-class TerminateReason(StrEnum):
-    """
-    Wire ``reason`` value on a structured ``terminate`` close frame.
-
-    Sent inside an :attr:`AppMessageType.TERMINATE` application
-    frame so the offloader's reconnect logic can branch
-    on the reason rather than guessing from the WS close code.
-
-    * ``SUPERSEDED`` — a fresh peer-link connect from the same
-      ``dashboard_id`` displaces this older session. Standard
-      "restarted offloader" path.
-    * ``HEARTBEAT_TIMEOUT`` — three pings in a row without a
-      matching pong. The session loop closes itself; the wire
-      frame may not actually reach the peer (TCP is presumed
-      dead) but the WS close is still graceful from the
-      receiver's side.
-    * ``SERVER_SHUTTING_DOWN`` — the receiver controller is
-      stopping. Sent to every active session before
-      :meth:`ReceiverController.stop` returns.
-    * ``MALFORMED_FRAME`` — a frame fails Noise decrypt /
-      JSON parse / shape validation. Closes the session
-      immediately; peer can reconnect after the next handshake.
-    """
-
-    SUPERSEDED = "superseded"
-    HEARTBEAT_TIMEOUT = "heartbeat_timeout"
-    SERVER_SHUTTING_DOWN = "server_shutting_down"
-    MALFORMED_FRAME = "malformed_frame"
-
-
-class AppMessageType(StrEnum):
-    """
-    Wire ``type`` discriminator on post-handshake application frames.
-
-    JSON-encoded plaintext is wrapped in a ChaCha20-Poly1305
-    transport frame via the established Noise session (one frame
-    per WS message) before going on the wire.
-
-    Bundle bytes ride inside JSON frames as base64-encoded
-    chunks (``submit_job_chunk``) rather than a parallel
-    binary-only path. The 33 % b64 overhead doesn't matter on
-    typical 5-50 KiB ESPHome bundles, and keeping every frame
-    JSON-shaped lets the dispatch seam stay uniform (one parse
-    branch, easier to trace). Profiling can motivate a binary
-    variant later if multi-MB bundles become common.
-    """
-
-    PING = "ping"
-    PONG = "pong"
-    TERMINATE = "terminate"
-    QUEUE_STATUS = "queue_status"
-    # 5c-1: bundle upload + job lifecycle. ``submit_job`` is the
-    # offloader-initiated header (job_id + configuration +
-    # bundle metadata); the bundle bytes follow as one or more
-    # ``submit_job_chunk`` frames in monotonic order, the last
-    # carrying ``is_last=True``. The receiver replies with a
-    # single ``submit_job_ack`` (``accepted: bool`` plus an
-    # optional ``reason``) once the full bundle has reassembled.
-    # Mid-build, the receiver pushes ``job_state_changed``
-    # (lifecycle transitions) and ``job_output`` (per-line
-    # stdout/stderr) back to the offloader. Wires into the
-    # firmware queue + controller seams.
-    SUBMIT_JOB = "submit_job"
-    SUBMIT_JOB_CHUNK = "submit_job_chunk"
-    SUBMIT_JOB_ACK = "submit_job_ack"
-    JOB_STATE_CHANGED = "job_state_changed"
-    JOB_OUTPUT = "job_output"
-    # Offloader → receiver cooperative cancel. Carries the
-    # offloader-local ``job_id`` from the original ``submit_job``
-    # header; receiver resolves it to the matching
-    # ``FirmwareJob`` via the :class:`JobFanout` correlation
-    # cache and calls ``FirmwareController.cancel``. No ack
-    # frame in the reverse direction — cancellation is fire-
-    # and-forget; the next ``job_state_changed`` with
-    # ``status="cancelled"`` is the confirmation the offloader
-    # already has plumbing for.
-    CANCEL_JOB = "cancel_job"
-    # Offloader → receiver build-artifact fetch. The
-    # offloader sends ``download_artifacts`` carrying the
-    # offloader-supplied ``job_id`` from the original
-    # ``submit_job`` header. The receiver resolves it to the
-    # matching :class:`FirmwareJob` (must be in ``COMPLETED``
-    # status — only completed builds have artifacts on disk),
-    # packs the build directory's ``.pioenvs/<name>/*.bin`` /
-    # ``*.uf2`` outputs plus ``idedata.json`` (esphome already
-    # emits the latter — it carries the per-image flash
-    # offsets the offloader's Web Serial / esptool path
-    # needs) into a gzipped tar in an executor, then streams
-    # the assembled bytes back as ``artifacts_start`` (header
-    # with total_bytes + num_chunks + artifacts_sha256)
-    # followed by ``artifacts_chunk`` frames (base64 inside
-    # the JSON envelope, same shape as ``submit_job_chunk``)
-    # followed by ``artifacts_end`` (success+sha256-confirmed
-    # or failure-with-reason). Single stream rather than one
-    # frame per artifact: the offloader gets bootloader.bin +
-    # partitions.bin + firmware.bin + idedata.json in one
-    # atomic transport with a single SHA-256, and the wire
-    # format doesn't grow when a future platform adds another
-    # required output. See issue #106.
-    DOWNLOAD_ARTIFACTS = "download_artifacts"
-    ARTIFACTS_START = "artifacts_start"
-    ARTIFACTS_CHUNK = "artifacts_chunk"
-    ARTIFACTS_END = "artifacts_end"
 
 
 async def make_peer_link_handler(

--- a/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
@@ -81,9 +81,13 @@ from ....models import (
     SubmitJobChunkFrameData,
     SubmitJobFrameData,
 )
-from .wire import AppMessageType, TerminateReason
 
-__all__ = ["AppMessageType", "TerminateReason"]
+# Redundant aliases mark these as intentional re-exports for both
+# ruff (F401) and mypy (no-redef) — preserves external imports like
+# ``from .peer_link import TerminateReason`` without an ``__all__``
+# that would also accidentally narrow ``import *`` semantics.
+from .wire import AppMessageType as AppMessageType
+from .wire import TerminateReason as TerminateReason
 
 
 class _HandshakeStep(StrEnum):

--- a/esphome_device_builder/controllers/remote_build/peer_link/wire.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/wire.py
@@ -1,0 +1,110 @@
+"""Peer-link wire enums: TerminateReason + AppMessageType."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class TerminateReason(StrEnum):
+    """
+    Wire ``reason`` value on a structured ``terminate`` close frame.
+
+    Sent inside an :attr:`AppMessageType.TERMINATE` application
+    frame so the offloader's reconnect logic can branch
+    on the reason rather than guessing from the WS close code.
+
+    * ``SUPERSEDED`` — a fresh peer-link connect from the same
+      ``dashboard_id`` displaces this older session. Standard
+      "restarted offloader" path.
+    * ``HEARTBEAT_TIMEOUT`` — three pings in a row without a
+      matching pong. The session loop closes itself; the wire
+      frame may not actually reach the peer (TCP is presumed
+      dead) but the WS close is still graceful from the
+      receiver's side.
+    * ``SERVER_SHUTTING_DOWN`` — the receiver controller is
+      stopping. Sent to every active session before
+      :meth:`ReceiverController.stop` returns.
+    * ``MALFORMED_FRAME`` — a frame fails Noise decrypt /
+      JSON parse / shape validation. Closes the session
+      immediately; peer can reconnect after the next handshake.
+    """
+
+    SUPERSEDED = "superseded"
+    HEARTBEAT_TIMEOUT = "heartbeat_timeout"
+    SERVER_SHUTTING_DOWN = "server_shutting_down"
+    MALFORMED_FRAME = "malformed_frame"
+
+
+class AppMessageType(StrEnum):
+    """
+    Wire ``type`` discriminator on post-handshake application frames.
+
+    JSON-encoded plaintext is wrapped in a ChaCha20-Poly1305
+    transport frame via the established Noise session (one frame
+    per WS message) before going on the wire.
+
+    Bundle bytes ride inside JSON frames as base64-encoded
+    chunks (``submit_job_chunk``) rather than a parallel
+    binary-only path. The 33 % b64 overhead doesn't matter on
+    typical 5-50 KiB ESPHome bundles, and keeping every frame
+    JSON-shaped lets the dispatch seam stay uniform (one parse
+    branch, easier to trace). Profiling can motivate a binary
+    variant later if multi-MB bundles become common.
+    """
+
+    PING = "ping"
+    PONG = "pong"
+    TERMINATE = "terminate"
+    QUEUE_STATUS = "queue_status"
+    # 5c-1: bundle upload + job lifecycle. ``submit_job`` is the
+    # offloader-initiated header (job_id + configuration +
+    # bundle metadata); the bundle bytes follow as one or more
+    # ``submit_job_chunk`` frames in monotonic order, the last
+    # carrying ``is_last=True``. The receiver replies with a
+    # single ``submit_job_ack`` (``accepted: bool`` plus an
+    # optional ``reason``) once the full bundle has reassembled.
+    # Mid-build, the receiver pushes ``job_state_changed``
+    # (lifecycle transitions) and ``job_output`` (per-line
+    # stdout/stderr) back to the offloader. Wires into the
+    # firmware queue + controller seams.
+    SUBMIT_JOB = "submit_job"
+    SUBMIT_JOB_CHUNK = "submit_job_chunk"
+    SUBMIT_JOB_ACK = "submit_job_ack"
+    JOB_STATE_CHANGED = "job_state_changed"
+    JOB_OUTPUT = "job_output"
+    # Offloader → receiver cooperative cancel. Carries the
+    # offloader-local ``job_id`` from the original ``submit_job``
+    # header; receiver resolves it to the matching
+    # ``FirmwareJob`` via the :class:`JobFanout` correlation
+    # cache and calls ``FirmwareController.cancel``. No ack
+    # frame in the reverse direction — cancellation is fire-
+    # and-forget; the next ``job_state_changed`` with
+    # ``status="cancelled"`` is the confirmation the offloader
+    # already has plumbing for.
+    CANCEL_JOB = "cancel_job"
+    # Offloader → receiver build-artifact fetch. The
+    # offloader sends ``download_artifacts`` carrying the
+    # offloader-supplied ``job_id`` from the original
+    # ``submit_job`` header. The receiver resolves it to the
+    # matching :class:`FirmwareJob` (must be in ``COMPLETED``
+    # status — only completed builds have artifacts on disk),
+    # packs the build directory's ``.pioenvs/<name>/*.bin`` /
+    # ``*.uf2`` outputs plus ``idedata.json`` (esphome already
+    # emits the latter — it carries the per-image flash
+    # offsets the offloader's Web Serial / esptool path
+    # needs) into a gzipped tar in an executor, then streams
+    # the assembled bytes back as ``artifacts_start`` (header
+    # with total_bytes + num_chunks + artifacts_sha256)
+    # followed by ``artifacts_chunk`` frames (base64 inside
+    # the JSON envelope, same shape as ``submit_job_chunk``)
+    # followed by ``artifacts_end`` (success+sha256-confirmed
+    # or failure-with-reason). Single stream rather than one
+    # frame per artifact: the offloader gets bootloader.bin +
+    # partitions.bin + firmware.bin + idedata.json in one
+    # atomic transport with a single SHA-256, and the wire
+    # format doesn't grow when a future platform adds another
+    # required output. See issue #106.
+    DOWNLOAD_ARTIFACTS = "download_artifacts"
+    ARTIFACTS_START = "artifacts_start"
+    ARTIFACTS_CHUNK = "artifacts_chunk"
+    ARTIFACTS_END = "artifacts_end"


### PR DESCRIPTION
# What does this implement/fix?

Second PR in the `peer_link` split arc (follows #769; plan: `peer_link_split.md`). Moves `TerminateReason` and `AppMessageType` byte-for-byte from `peer_link/__init__.py` into a new `peer_link/wire.py` submodule.

`__init__.py` re-exports both via `from .wire import AppMessageType, TerminateReason` (with an `__all__` pin so a future ruff sweep can't prune the import) so external callers continue using `from .peer_link import TerminateReason` / `AppMessageType` unchanged — `receiver.py`, `submit_job.py`, `artifacts_download.py`, `job_fanout.py`, `peer_link_client/` all stay as-is.

Risk: **LOW.** Pure `StrEnum`s — no state, no test patches against these symbols, no runtime behaviour change.

* **`__init__.py`**: 1079 → 977 lines (−102).
* **`wire.py`** (new): 110 lines.

Subsequent PRs in the arc (one extraction per PR):

* `channel.py` — `PeerLinkChannel` dataclass (~85 lines)
* `plumbing.py` — low-level WS / Noise helpers (~145 lines)
* `handshake.py` — handshake driver + private types (~180 lines)
* `session.py` — `PeerLinkSession` + receive loop + heartbeat (~330 lines)

All 3242 non-e2e tests pass; ruff + mypy clean.

**Related issue or feature (if applicable):**

- follow-up to #769; second PR of the peer_link split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
