### PR TITLE
Split OffloaderController: extract rebind

### DIFF
--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Iterator
-from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
@@ -35,7 +33,6 @@ from ...helpers.api import CommandError, api_command
 from ...helpers.build_scheduler import BuildSchedulerInputs
 from ...helpers.dashboard_identity import get_or_create_identity
 from ...helpers.event_bus import Event
-from ...helpers.hostname import normalize_hostname
 from ...helpers.peer_link_identity import get_or_create_peer_link_identity
 from ...helpers.peer_link_resolver import PeerLinkDNSResolver, make_peer_link_resolver
 from ...helpers.storage import Store
@@ -47,7 +44,6 @@ from ...models import (
     OffloaderAlertSnapshotEntry,
     OffloaderJobStateChangedData,
     OffloaderPairAlertDismissedData,
-    OffloaderPairEndpointReboundData,
     OffloaderPairingEnabledChangedData,
     OffloaderPairPeerRevokedData,
     OffloaderPairPinMismatchData,
@@ -67,7 +63,7 @@ from ...models import (
     RemoteBuildPeer,
     StoredPairing,
 )
-from . import discovery
+from . import discovery, rebind
 from ._mdns import endpoints_equal
 from ._models import (
     EDIT_PAIRING_PROBE_ERRORS,
@@ -148,11 +144,6 @@ _PAIR_STATUS_RECONNECT_BACKOFF_SECONDS = 2.0
 # Debounce window for the offloader-side pairings-store write
 # so a burst of approvals collapses to one disk write.
 _PAIRINGS_SAVE_DELAY_SECONDS = 1.0
-
-# Per-pin sliding window between mDNS rebind probes. Doubles
-# as in-flight guard + retry throttle so a permanently-down
-# host doesn't trigger a probe per mDNS Updated burst.
-_REBIND_PROBE_COOLDOWN_SECONDS = 30.0
 
 
 class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
@@ -481,189 +472,30 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         new_hostname: str,
         new_port: int,
     ) -> RebindProbeResult:
-        """Probe + identity-verify a candidate endpoint without mutating state.
-
-        Shared by the mDNS auto-rebind path and the user-driven
-        endpoint edit; each caller maps the typed outcome onto
-        its own surface. One ``intent="preview"`` round-trip
-        covers three checks: reachability (TCP + handshake),
-        identity (pubkey vs stored pin), and race-safety
-        (captured pairing object still in the dict, still
-        APPROVED).
-        """
-        assert self._offloader_peer_link_priv is not None
-        try:
-            observed_pin = await peer_link_preview_pair(
-                hostname=new_hostname,
-                port=new_port,
-                identity_priv=self._offloader_peer_link_priv,
-                resolver=self._peer_link_resolver,
-            )
-        except PeerLinkClientError as exc:
-            return RebindProbeResult(RebindProbeOutcome.UNREACHABLE, transport_error=exc)
-        if observed_pin != pairing.pin_sha256:
-            return RebindProbeResult(RebindProbeOutcome.PIN_MISMATCH, observed_pin=observed_pin)
-        current = self._pairings.get(pairing.pin_sha256)
-        if current is not pairing:
-            return RebindProbeResult(RebindProbeOutcome.PAIRING_REPLACED)
-        if current.status is not PeerStatus.APPROVED:
-            return RebindProbeResult(RebindProbeOutcome.STATUS_CHANGED)
-        return RebindProbeResult(RebindProbeOutcome.OK)
+        """Probe + identity-verify a candidate endpoint without mutating state."""
+        return await rebind.probe_pairing_endpoint(
+            self, pairing=pairing, new_hostname=new_hostname, new_port=new_port
+        )
 
     def _commit_endpoint_rebind(self, pairing: StoredPairing, *, hostname: str, port: int) -> None:
-        """Mutate *pairing* to (*hostname*, *port*) and run the rebind epilogue.
-
-        Clears the per-pin probe cooldown — a successful rebind
-        means the next mDNS Updated should probe immediately.
-        Caller owns the probe + identity verify; no checks here.
-        """
-        pairing.receiver_hostname = hostname
-        pairing.receiver_port = port
-        self._schedule_pairings_save()
-        self._respawn_peer_link_at_new_endpoint(pairing)
-        self._rebind_probe_until.pop(pairing.pin_sha256, None)
-
-    def _respawn_peer_link_at_new_endpoint(self, pairing: StoredPairing) -> None:
-        """Cancel + respawn the peer-link client and fire the rebind event.
-
-        The caller has already mutated *pairing*'s
-        hostname/port; this is the shared epilogue.
-        """
-        self._cancel_peer_link_client(pairing.pin_sha256)
-        self._spawn_peer_link_client(pairing)
-        self._fire_offloader_pair_endpoint_rebound(
-            pin_sha256=pairing.pin_sha256,
-            receiver_hostname=pairing.receiver_hostname,
-            receiver_port=pairing.receiver_port,
-        )
+        """Mutate *pairing* to (*hostname*, *port*) and run the rebind epilogue."""
+        rebind.commit_endpoint_rebind(self, pairing, hostname=hostname, port=port)
 
     # ------------------------------------------------------------------
     # mDNS auto-rebind
     # ------------------------------------------------------------------
 
     def _maybe_schedule_rebind_probe(self, peer: RemoteBuildPeer) -> None:
-        """Spawn a probe-and-rebind task if *peer* is a known pin at a new endpoint.
-
-        Called from :meth:`_upsert_host` on every resolved
-        broadcast. Cheap early-returns dominate (most discoveries
-        are unpaired peers or steady-state re-announces); only a
-        rare hostname / port change for an APPROVED pairing
-        spawns a probe task. The probe slot is rate-limited via
-        :attr:`_rebind_probe_until` so a burst of zeroconf
-        Updated callbacks or a permanently-unreachable host both
-        collapse to one probe per
-        :data:`_REBIND_PROBE_COOLDOWN_SECONDS`.
-        """
-        pin = peer.pin_sha256
-        new_port = peer.remote_build_port
-        if not pin or new_port == 0:
-            return
-        pairing = self._pairings.get(pin)
-        if pairing is None or pairing.status is not PeerStatus.APPROVED:
-            return
-        new_hostname = normalize_hostname(peer.hostname)
-        if endpoints_equal(
-            pairing.receiver_hostname, pairing.receiver_port, new_hostname, new_port
-        ):
-            return
-        if self._offloader_peer_link_priv is None:
-            return
-        now = time.monotonic()
-        if self._rebind_probe_until.get(pin, 0.0) > now:
-            return
-        self._rebind_probe_until[pin] = now + _REBIND_PROBE_COOLDOWN_SECONDS
-        self._track_task(
-            self._probe_and_rebind_endpoint(
-                pairing=pairing, new_hostname=new_hostname, new_port=new_port
-            ),
-            name=f"rebind-probe-{pin[:8]}",
-        )
+        """Spawn a probe-and-rebind task if *peer* is a known pin at a new endpoint."""
+        rebind.maybe_schedule_rebind_probe(self, peer)
 
     async def _probe_and_rebind_endpoint(
         self, *, pairing: StoredPairing, new_hostname: str, new_port: int
     ) -> None:
-        """Probe the candidate endpoint; rebind the pairing iff the pin still matches.
-
-        One ``preview`` round-trip checks reachability + identity
-        in one call. ``preview`` bypasses the pairing window so a
-        quiet receiver doesn't deadlock the rebind path. On a
-        successful match, mutate :class:`StoredPairing` in place,
-        schedule the debounced save, cancel + respawn the
-        peer-link client at the new coordinates, fire
-        :attr:`EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND`, and
-        clear the cooldown so a future move is probed
-        immediately. Failure paths leave the cooldown in place.
-        """
-        pin = pairing.pin_sha256
-        with self._clear_cooldown_on_unexpected_exit(pin):
-            result = await self._probe_pairing_endpoint(
-                pairing=pairing, new_hostname=new_hostname, new_port=new_port
-            )
-            if result.outcome is RebindProbeOutcome.UNREACHABLE:
-                # Pass the captured ``PeerLinkClientError`` as
-                # ``exc_info=`` so the debug log carries the
-                # full traceback for diagnosing handshake /
-                # connect failures in the field — same shape
-                # the inline ``except`` block had before this
-                # path was factored into ``_probe_pairing_endpoint``.
-                _LOGGER.debug(
-                    "rebind probe %s -> %s:%d failed (unreachable / handshake error)",
-                    pin,
-                    new_hostname,
-                    new_port,
-                    exc_info=result.transport_error,
-                )
-                return
-            if result.outcome is RebindProbeOutcome.PIN_MISMATCH:
-                _LOGGER.warning(
-                    "rebind probe %s -> %s:%d observed pin %s; ignoring (spoof or rotation)",
-                    pin,
-                    new_hostname,
-                    new_port,
-                    result.observed_pin,
-                )
-                return
-            if result.outcome is not RebindProbeOutcome.OK:
-                # PAIRING_REPLACED / STATUS_CHANGED — silent skip;
-                # cooldown stays in place so a burst of mDNS
-                # Updated callbacks doesn't re-fire the probe
-                # against state that's already moved on.
-                return
-            self._commit_endpoint_rebind(pairing, hostname=new_hostname, port=new_port)
-            _LOGGER.info("rebound pairing %s to %s:%d", pin, new_hostname, new_port)
-
-    @contextmanager
-    def _clear_cooldown_on_unexpected_exit(self, pin: str) -> Iterator[None]:
-        """Pop *pin* from ``_rebind_probe_until`` iff the wrapped block raises.
-
-        Graceful failure paths inside the probe (unreachable
-        host, pin mismatch, mid-probe re-pair) preserve the
-        cooldown entry to throttle retries. Cancellation /
-        unexpected exceptions shouldn't lock the pin out of
-        future legitimate rebind attempts, so on any escaped
-        exception we drop the entry before the exception
-        propagates.
-        """
-        try:
-            yield
-        except BaseException:
-            self._rebind_probe_until.pop(pin, None)
-            raise
-
-    def _fire_offloader_pair_endpoint_rebound(
-        self,
-        *,
-        pin_sha256: str,
-        receiver_hostname: str,
-        receiver_port: int,
-    ) -> None:
-        """Fire ``OFFLOADER_PAIR_ENDPOINT_REBOUND`` after a successful rebind."""
-        payload: OffloaderPairEndpointReboundData = {
-            "pin_sha256": pin_sha256,
-            "receiver_hostname": receiver_hostname,
-            "receiver_port": receiver_port,
-        }
-        self._db.bus.fire(EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND, payload)
+        """Probe the candidate endpoint; rebind the pairing iff the pin still matches."""
+        await rebind.probe_and_rebind_endpoint(
+            self, pairing=pairing, new_hostname=new_hostname, new_port=new_port
+        )
 
     def hosts_snapshot(self) -> list[RemoteBuildPeer]:
         """Return the current mDNS-discovered hosts for ``subscribe_events`` seeding."""

--- a/esphome_device_builder/controllers/remote_build/rebind.py
+++ b/esphome_device_builder/controllers/remote_build/rebind.py
@@ -1,0 +1,251 @@
+"""
+Offloader-side endpoint rebind for stored pairings.
+
+Owns the probe-and-rebind path that keeps an APPROVED
+:class:`StoredPairing` row tracking its receiver across
+hostname / port moves. Two callers feed in: mDNS
+auto-rebind via :func:`maybe_schedule_rebind_probe` (fired
+from :mod:`.discovery` on every resolved broadcast) and the
+user-driven :meth:`OffloaderController.edit_pairing_endpoint`
+WS command. Both share the
+:func:`probe_pairing_endpoint` identity-verify step.
+
+Bodies take :class:`OffloaderController` as the first arg;
+the controller keeps thin bound-method delegates for
+``_probe_pairing_endpoint`` / ``_probe_and_rebind_endpoint``
+/ ``_commit_endpoint_rebind`` / ``_maybe_schedule_rebind_probe``
+so cross-module callers and tests intercept at stable hook
+points.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from ...helpers.hostname import normalize_hostname
+from ...models import (
+    EventType,
+    OffloaderPairEndpointReboundData,
+    PeerStatus,
+    RemoteBuildPeer,
+    StoredPairing,
+)
+from ._mdns import endpoints_equal
+from ._models import RebindProbeOutcome, RebindProbeResult
+from .peer_link_client import PeerLinkClientError
+from .peer_link_client import preview_pair as peer_link_preview_pair
+
+if TYPE_CHECKING:
+    from .offloader import OffloaderController
+
+_LOGGER = logging.getLogger(__name__)
+
+# Per-pin sliding window between mDNS rebind probes. Doubles
+# as in-flight guard + retry throttle so a permanently-down
+# host doesn't trigger a probe per mDNS Updated burst.
+_REBIND_PROBE_COOLDOWN_SECONDS = 30.0
+
+
+async def probe_pairing_endpoint(
+    controller: OffloaderController,
+    *,
+    pairing: StoredPairing,
+    new_hostname: str,
+    new_port: int,
+) -> RebindProbeResult:
+    """Probe + identity-verify a candidate endpoint without mutating state.
+
+    Shared by the mDNS auto-rebind path and the user-driven
+    endpoint edit; each caller maps the typed outcome onto
+    its own surface. One ``intent="preview"`` round-trip
+    covers three checks: reachability (TCP + handshake),
+    identity (pubkey vs stored pin), and race-safety
+    (captured pairing object still in the dict, still
+    APPROVED).
+    """
+    assert controller._offloader_peer_link_priv is not None
+    try:
+        observed_pin = await peer_link_preview_pair(
+            hostname=new_hostname,
+            port=new_port,
+            identity_priv=controller._offloader_peer_link_priv,
+            resolver=controller._peer_link_resolver,
+        )
+    except PeerLinkClientError as exc:
+        return RebindProbeResult(RebindProbeOutcome.UNREACHABLE, transport_error=exc)
+    if observed_pin != pairing.pin_sha256:
+        return RebindProbeResult(RebindProbeOutcome.PIN_MISMATCH, observed_pin=observed_pin)
+    current = controller._pairings.get(pairing.pin_sha256)
+    if current is not pairing:
+        return RebindProbeResult(RebindProbeOutcome.PAIRING_REPLACED)
+    if current.status is not PeerStatus.APPROVED:
+        return RebindProbeResult(RebindProbeOutcome.STATUS_CHANGED)
+    return RebindProbeResult(RebindProbeOutcome.OK)
+
+
+def commit_endpoint_rebind(
+    controller: OffloaderController, pairing: StoredPairing, *, hostname: str, port: int
+) -> None:
+    """Mutate *pairing* to (*hostname*, *port*) and run the rebind epilogue.
+
+    Clears the per-pin probe cooldown — a successful rebind
+    means the next mDNS Updated should probe immediately.
+    Caller owns the probe + identity verify; no checks here.
+    """
+    pairing.receiver_hostname = hostname
+    pairing.receiver_port = port
+    controller._schedule_pairings_save()
+    _respawn_peer_link_at_new_endpoint(controller, pairing)
+    controller._rebind_probe_until.pop(pairing.pin_sha256, None)
+
+
+def _respawn_peer_link_at_new_endpoint(
+    controller: OffloaderController, pairing: StoredPairing
+) -> None:
+    """Cancel + respawn the peer-link client and fire the rebind event.
+
+    The caller has already mutated *pairing*'s
+    hostname/port; this is the shared epilogue.
+    """
+    controller._cancel_peer_link_client(pairing.pin_sha256)
+    controller._spawn_peer_link_client(pairing)
+    _fire_offloader_pair_endpoint_rebound(
+        controller,
+        pin_sha256=pairing.pin_sha256,
+        receiver_hostname=pairing.receiver_hostname,
+        receiver_port=pairing.receiver_port,
+    )
+
+
+def maybe_schedule_rebind_probe(controller: OffloaderController, peer: RemoteBuildPeer) -> None:
+    """Spawn a probe-and-rebind task if *peer* is a known pin at a new endpoint.
+
+    Called from :func:`.discovery.upsert_host` on every
+    resolved broadcast. Cheap early-returns dominate (most
+    discoveries are unpaired peers or steady-state
+    re-announces); only a rare hostname / port change for an
+    APPROVED pairing spawns a probe task. The probe slot is
+    rate-limited via :attr:`OffloaderController._rebind_probe_until`
+    so a burst of zeroconf Updated callbacks or a
+    permanently-unreachable host both collapse to one probe
+    per :data:`_REBIND_PROBE_COOLDOWN_SECONDS`.
+    """
+    pin = peer.pin_sha256
+    new_port = peer.remote_build_port
+    if not pin or new_port == 0:
+        return
+    pairing = controller._pairings.get(pin)
+    if pairing is None or pairing.status is not PeerStatus.APPROVED:
+        return
+    new_hostname = normalize_hostname(peer.hostname)
+    if endpoints_equal(pairing.receiver_hostname, pairing.receiver_port, new_hostname, new_port):
+        return
+    if controller._offloader_peer_link_priv is None:
+        return
+    now = time.monotonic()
+    if controller._rebind_probe_until.get(pin, 0.0) > now:
+        return
+    controller._rebind_probe_until[pin] = now + _REBIND_PROBE_COOLDOWN_SECONDS
+    controller._track_task(
+        controller._probe_and_rebind_endpoint(
+            pairing=pairing, new_hostname=new_hostname, new_port=new_port
+        ),
+        name=f"rebind-probe-{pin[:8]}",
+    )
+
+
+async def probe_and_rebind_endpoint(
+    controller: OffloaderController,
+    *,
+    pairing: StoredPairing,
+    new_hostname: str,
+    new_port: int,
+) -> None:
+    """Probe the candidate endpoint; rebind the pairing iff the pin still matches.
+
+    One ``preview`` round-trip checks reachability + identity
+    in one call. ``preview`` bypasses the pairing window so a
+    quiet receiver doesn't deadlock the rebind path. On a
+    successful match, mutate :class:`StoredPairing` in place,
+    schedule the debounced save, cancel + respawn the
+    peer-link client at the new coordinates, fire
+    :attr:`EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND`, and
+    clear the cooldown so a future move is probed
+    immediately. Failure paths leave the cooldown in place.
+    """
+    pin = pairing.pin_sha256
+    with _clear_cooldown_on_unexpected_exit(controller, pin):
+        result = await controller._probe_pairing_endpoint(
+            pairing=pairing, new_hostname=new_hostname, new_port=new_port
+        )
+        if result.outcome is RebindProbeOutcome.UNREACHABLE:
+            # Pass the captured ``PeerLinkClientError`` as
+            # ``exc_info=`` so the debug log carries the
+            # full traceback for diagnosing handshake /
+            # connect failures in the field — same shape
+            # the inline ``except`` block had before this
+            # path was factored into ``_probe_pairing_endpoint``.
+            _LOGGER.debug(
+                "rebind probe %s -> %s:%d failed (unreachable / handshake error)",
+                pin,
+                new_hostname,
+                new_port,
+                exc_info=result.transport_error,
+            )
+            return
+        if result.outcome is RebindProbeOutcome.PIN_MISMATCH:
+            _LOGGER.warning(
+                "rebind probe %s -> %s:%d observed pin %s; ignoring (spoof or rotation)",
+                pin,
+                new_hostname,
+                new_port,
+                result.observed_pin,
+            )
+            return
+        if result.outcome is not RebindProbeOutcome.OK:
+            # PAIRING_REPLACED / STATUS_CHANGED — silent skip;
+            # cooldown stays in place so a burst of mDNS
+            # Updated callbacks doesn't re-fire the probe
+            # against state that's already moved on.
+            return
+        controller._commit_endpoint_rebind(pairing, hostname=new_hostname, port=new_port)
+        _LOGGER.info("rebound pairing %s to %s:%d", pin, new_hostname, new_port)
+
+
+@contextmanager
+def _clear_cooldown_on_unexpected_exit(controller: OffloaderController, pin: str) -> Iterator[None]:
+    """Pop *pin* from ``_rebind_probe_until`` iff the wrapped block raises.
+
+    Graceful failure paths inside the probe (unreachable
+    host, pin mismatch, mid-probe re-pair) preserve the
+    cooldown entry to throttle retries. Cancellation /
+    unexpected exceptions shouldn't lock the pin out of
+    future legitimate rebind attempts, so on any escaped
+    exception we drop the entry before the exception
+    propagates.
+    """
+    try:
+        yield
+    except BaseException:
+        controller._rebind_probe_until.pop(pin, None)
+        raise
+
+
+def _fire_offloader_pair_endpoint_rebound(
+    controller: OffloaderController,
+    *,
+    pin_sha256: str,
+    receiver_hostname: str,
+    receiver_port: int,
+) -> None:
+    """Fire ``OFFLOADER_PAIR_ENDPOINT_REBOUND`` after a successful rebind."""
+    payload: OffloaderPairEndpointReboundData = {
+        "pin_sha256": pin_sha256,
+        "receiver_hostname": receiver_hostname,
+        "receiver_port": receiver_port,
+    }
+    controller._db.bus.fire(EventType.OFFLOADER_PAIR_ENDPOINT_REBOUND, payload)

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -30,6 +30,7 @@ from esphome_device_builder.controllers.remote_build import (
     ReceiverController,
 )
 from esphome_device_builder.controllers.remote_build import offloader as rb
+from esphome_device_builder.controllers.remote_build import rebind as rb_rebind
 from esphome_device_builder.controllers.remote_build import receiver as rb_rcv
 from esphome_device_builder.controllers.remote_build._mdns import (
     decode_txt_value,
@@ -362,10 +363,12 @@ def _patch_probe_internals(
     monkeypatch.setattr(controller.offloader, "_spawn_peer_link_client", spawn)
     if preview_side_effect is not None:
         monkeypatch.setattr(
-            rb, "peer_link_preview_pair", AsyncMock(side_effect=preview_side_effect)
+            rb_rebind, "peer_link_preview_pair", AsyncMock(side_effect=preview_side_effect)
         )
     elif preview_return is not None:
-        monkeypatch.setattr(rb, "peer_link_preview_pair", AsyncMock(return_value=preview_return))
+        monkeypatch.setattr(
+            rb_rebind, "peer_link_preview_pair", AsyncMock(return_value=preview_return)
+        )
     if seed_cooldown_for is not None:
         controller.offloader._rebind_probe_until[seed_cooldown_for] = cooldown_until
     return cancel, spawn
@@ -684,7 +687,7 @@ async def test_maybe_schedule_rebind_probe_dedupes_within_cooldown(
         await blocked.wait()
         return pin
 
-    monkeypatch.setattr(rb, "peer_link_preview_pair", _hanging_preview)
+    monkeypatch.setattr(rb_rebind, "peer_link_preview_pair", _hanging_preview)
     monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client", MagicMock())
     monkeypatch.setattr(controller.offloader, "_spawn_peer_link_client", MagicMock())
 
@@ -923,7 +926,7 @@ async def test_edit_pairing_endpoint_raises_not_found_when_pairing_replaced_mid_
         controller.offloader._pairings[pin] = fresh
         return pin
 
-    monkeypatch.setattr(rb, "peer_link_preview_pair", _replace_during_preview)
+    monkeypatch.setattr(rb_rebind, "peer_link_preview_pair", _replace_during_preview)
     cancel = MagicMock()
     spawn = MagicMock()
     monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client", cancel)
@@ -994,7 +997,7 @@ async def test_edit_pairing_endpoint_status_changed_mid_probe_raises_preconditio
         pairing.status = PeerStatus.PENDING
         return pin
 
-    monkeypatch.setattr(rb, "peer_link_preview_pair", _flip_status_during_preview)
+    monkeypatch.setattr(rb_rebind, "peer_link_preview_pair", _flip_status_during_preview)
     cancel = MagicMock()
     spawn = MagicMock()
     monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client", cancel)


### PR DESCRIPTION
# What does this implement/fix?

Extracts the offloader-side endpoint-rebind cluster into a new sibling module `controllers/remote_build/rebind.py`. Second PR in the OffloaderController split arc (after #766).

**Moved with public entry points** (called from tests or other modules, kept as bound-method delegates on the controller):
- `probe_pairing_endpoint` — shared by mDNS auto-rebind and `edit_pairing_endpoint`
- `commit_endpoint_rebind` — shared by both rebind callers
- `maybe_schedule_rebind_probe` — called from `discovery.upsert_host` via `controller._maybe_schedule_rebind_probe`
- `probe_and_rebind_endpoint` — the auto-rebind task body

**Moved as module-private** (no test or cross-module callers; called inside `rebind.py` only):
- `_respawn_peer_link_at_new_endpoint`
- `_clear_cooldown_on_unexpected_exit`
- `_fire_offloader_pair_endpoint_rebound`

Imports moved out of `offloader.py`: `Iterator` / `contextmanager` (only the cooldown context manager used them), `normalize_hostname`, `OffloaderPairEndpointReboundData`, the `_REBIND_PROBE_COOLDOWN_SECONDS` constant. `RebindProbeOutcome` / `RebindProbeResult` / `peer_link_preview_pair` / `PeerLinkClientError` stay imported in `offloader.py` because `edit_pairing_endpoint` and `preview_pair` still use them directly.

`offloader.py`: **1597 → 1429 lines** (-168). Combined with #766: 1709 → 1429 (-280, -16%).

## Test impact

4 `monkeypatch.setattr(rb, "peer_link_preview_pair", ...)` sites in `tests/test_remote_build_controller.py` repointed to `rb_rebind` (a new module alias for `controllers.remote_build.rebind`). All 4 patches exercise paths that route through `_probe_pairing_endpoint`, whose body now lives in `rebind.py`. The standalone `preview_pair` WS command path stays on `offloader.py` and keeps its own `peer_link_preview_pair` import (no tests patch that path today).

214 controller tests + 676 remote-build tests pass. Pure behaviour-free refactor.

**Related issue or feature (if applicable):**

- Part of the OffloaderController split arc tracked in `offloader_split.md`. Remaining: peer-link-client lifecycle, pair-status listeners, submit-job commands, pair commands, settings, bus-event handlers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
