### PR TITLE
Extract PeerLinkChannel into channel.py

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
@@ -61,7 +61,6 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-import aiohttp
 from aiohttp import WSMsgType, web
 from esphome.const import __version__ as esphome_version
 
@@ -390,101 +389,6 @@ async def _dispatch_intent(
     return await controller.lookup_peer_for_status(
         dashboard_id=inp.dashboard_id, pin_sha256=inp.pin_sha256
     )
-
-
-# ---------------------------------------------------------------------------
-# Shared peer-link application channel — receiver-side ``PeerLinkSession``
-# and offloader-side ``PeerLinkClient`` both compose around this so the
-# encrypt-and-send / parse-inbound / structured-terminate logic lives in
-# one place. ``ws`` is duck-typed (``send_bytes`` / ``close`` /
-# async-iter); the same channel works against aiohttp's server-side
-# ``web.WebSocketResponse`` and client-side ``ClientWebSocketResponse``.
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class PeerLinkChannel:
-    """
-    Wire-level send / parse / terminate seam shared by both ends.
-
-    Wraps the post-handshake :class:`PeerLinkNoiseSession` plus
-    its WS endpoint and a send lock. Each side's session class
-    composes one of these so the encrypt-then-send pattern (and
-    the validate-decrypt-parse-dict-check parse pattern, and the
-    structured terminate-frame-then-close pattern) only lives in
-    one module. ``log_label`` is what callers want in their log
-    lines: receiver passes its ``dashboard_id``, offloader
-    passes ``"<hostname>:<port>"``.
-    """
-
-    noise: PeerLinkNoiseSession
-    ws: Any  # WebSocketResponse | ClientWebSocketResponse — duck-typed (see class docstring)
-    log_label: str
-    _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-
-    async def send_frame(self, payload: dict[str, Any]) -> bool:
-        """Encrypt *payload* under the send lock and send as a binary WS frame.
-
-        Returns ``True`` on success, ``False`` on JSON-encode /
-        Noise-encrypt / WS-side failure. The lock serialises
-        concurrent callers (heartbeat + future application-message
-        senders) so the Noise nonce advances in one direction only
-        — the Noise cipher state is not safe to share across
-        concurrent encrypts.
-        """
-        try:
-            plaintext = _json.dumps(payload)
-        except (TypeError, ValueError):
-            _LOGGER.warning(
-                "peer-link app frame for %s failed JSON encode", self.log_label, exc_info=True
-            )
-            return False
-        async with self._send_lock:
-            try:
-                ciphertext = self.noise.encrypt(plaintext)
-            except NOISE_ERRORS:
-                _LOGGER.warning(
-                    "peer-link app frame for %s failed Noise encrypt",
-                    self.log_label,
-                    exc_info=True,
-                )
-                return False
-            return await _send_bytes_safely(self.ws, ciphertext, log_label="app frame")
-
-    def parse_frame(self, msg: Any) -> dict[str, Any] | None:
-        """Validate, decrypt, and JSON-parse one inbound frame.
-
-        Thin wrapper around :func:`parse_app_frame` so callers
-        don't have to thread :attr:`noise` and :attr:`log_label`
-        through. See :func:`parse_app_frame` for the per-branch
-        log + ``None``-on-malformed contract.
-        """
-        return parse_app_frame(self.noise, msg, log_label=self.log_label)
-
-    async def send_terminate(self, reason: str) -> None:
-        """Send a structured ``terminate`` frame and close the WS, best-effort.
-
-        The terminate frame routes through :meth:`send_frame` so
-        the encrypt + lock invariants hold; the close that
-        follows is best-effort because a peer that has already
-        gone away won't accept either, and we want the call site
-        idempotent across "WS still up" and "WS dead" states.
-        Narrow suppress to transport-level errors only — including
-        :class:`aiohttp.ClientError` because this channel runs on
-        both sides of the wire (offloader side's ``self.ws`` is a
-        :class:`aiohttp.ClientWebSocketResponse` whose ``.close()``
-        can raise ``ClientConnectionError`` / ``ClientError``
-        when the peer has already gone away). A ``ClientError``
-        escaping here would block the caller's
-        :class:`CancelledError` propagation when used inside a
-        :meth:`PeerLinkClient._run_one_session` cancellation
-        handler. Python 3.8+ already excludes ``CancelledError``
-        from ``Exception``, so the wider suppression below stays
-        compatible with the no-swallow contract.
-        """
-        await self.send_frame({"type": AppMessageType.TERMINATE.value, "reason": reason})
-        with contextlib.suppress(OSError, RuntimeError, aiohttp.ClientError):
-            await self.ws.close()
 
 
 # ---------------------------------------------------------------------------
@@ -979,3 +883,11 @@ def _normalize_label(value: object) -> str:
     """
     raw = _str_or_empty(value).strip()
     return raw[:_PEER_LABEL_MAX_CHARS]
+
+
+# Re-export goes at the bottom of __init__.py so ``_send_bytes_safely``
+# and ``parse_app_frame`` are defined as package attributes by the time
+# ``channel.py``'s lazy imports look them up. Subsequent split PRs move
+# those helpers into sibling submodules and the lazy import becomes a
+# plain module-level one.
+from .channel import PeerLinkChannel as PeerLinkChannel  # noqa: E402

--- a/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
@@ -885,9 +885,7 @@ def _normalize_label(value: object) -> str:
     return raw[:_PEER_LABEL_MAX_CHARS]
 
 
-# Re-export goes at the bottom of __init__.py so ``_send_bytes_safely``
-# and ``parse_app_frame`` are defined as package attributes by the time
-# ``channel.py``'s lazy imports look them up. Subsequent split PRs move
-# those helpers into sibling submodules and the lazy import becomes a
-# plain module-level one.
+# Re-export at the bottom: ``channel.py``'s lazy imports look up
+# ``_send_bytes_safely`` / ``parse_app_frame`` as package attributes,
+# so the channel module must load after they're defined above.
 from .channel import PeerLinkChannel as PeerLinkChannel  # noqa: E402

--- a/esphome_device_builder/controllers/remote_build/peer_link/channel.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/channel.py
@@ -1,0 +1,119 @@
+"""Shared peer-link application channel for both wire ends.
+
+Receiver-side ``PeerLinkSession`` and offloader-side
+``PeerLinkClient`` both compose around this so the
+encrypt-and-send / parse-inbound / structured-terminate logic
+lives in one place. ``ws`` is duck-typed (``send_bytes`` /
+``close`` / async-iter); the same channel works against
+aiohttp's server-side ``web.WebSocketResponse`` and client-side
+``ClientWebSocketResponse``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+
+from ....helpers import json as _json
+from ....helpers.peer_link_noise import NOISE_ERRORS, PeerLinkNoiseSession
+from .wire import AppMessageType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PeerLinkChannel:
+    """
+    Wire-level send / parse / terminate seam shared by both ends.
+
+    Wraps the post-handshake :class:`PeerLinkNoiseSession` plus
+    its WS endpoint and a send lock. Each side's session class
+    composes one of these so the encrypt-then-send pattern (and
+    the validate-decrypt-parse-dict-check parse pattern, and the
+    structured terminate-frame-then-close pattern) only lives in
+    one module. ``log_label`` is what callers want in their log
+    lines: receiver passes its ``dashboard_id``, offloader
+    passes ``"<hostname>:<port>"``.
+    """
+
+    noise: PeerLinkNoiseSession
+    ws: Any  # WebSocketResponse | ClientWebSocketResponse — duck-typed (see class docstring)
+    log_label: str
+    _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def send_frame(self, payload: dict[str, Any]) -> bool:
+        """Encrypt *payload* under the send lock and send as a binary WS frame.
+
+        Returns ``True`` on success, ``False`` on JSON-encode /
+        Noise-encrypt / WS-side failure. The lock serialises
+        concurrent callers (heartbeat + future application-message
+        senders) so the Noise nonce advances in one direction only
+        — the Noise cipher state is not safe to share across
+        concurrent encrypts.
+        """
+        # ``_send_bytes_safely`` and ``parse_app_frame`` are slated
+        # for sibling submodules later in the split arc; lazy import
+        # keeps this PR mechanical and avoids ordering issues with
+        # the package ``__init__.py``.
+        from . import _send_bytes_safely  # noqa: PLC0415
+
+        try:
+            plaintext = _json.dumps(payload)
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "peer-link app frame for %s failed JSON encode", self.log_label, exc_info=True
+            )
+            return False
+        async with self._send_lock:
+            try:
+                ciphertext = self.noise.encrypt(plaintext)
+            except NOISE_ERRORS:
+                _LOGGER.warning(
+                    "peer-link app frame for %s failed Noise encrypt",
+                    self.log_label,
+                    exc_info=True,
+                )
+                return False
+            return await _send_bytes_safely(self.ws, ciphertext, log_label="app frame")
+
+    def parse_frame(self, msg: Any) -> dict[str, Any] | None:
+        """Validate, decrypt, and JSON-parse one inbound frame.
+
+        Thin wrapper around :func:`parse_app_frame` so callers
+        don't have to thread :attr:`noise` and :attr:`log_label`
+        through. See :func:`parse_app_frame` for the per-branch
+        log + ``None``-on-malformed contract.
+        """
+        from . import parse_app_frame  # noqa: PLC0415
+
+        return parse_app_frame(self.noise, msg, log_label=self.log_label)
+
+    async def send_terminate(self, reason: str) -> None:
+        """Send a structured ``terminate`` frame and close the WS, best-effort.
+
+        The terminate frame routes through :meth:`send_frame` so
+        the encrypt + lock invariants hold; the close that
+        follows is best-effort because a peer that has already
+        gone away won't accept either, and we want the call site
+        idempotent across "WS still up" and "WS dead" states.
+        Narrow suppress to transport-level errors only — including
+        :class:`aiohttp.ClientError` because this channel runs on
+        both sides of the wire (offloader side's ``self.ws`` is a
+        :class:`aiohttp.ClientWebSocketResponse` whose ``.close()``
+        can raise ``ClientConnectionError`` / ``ClientError``
+        when the peer has already gone away). A ``ClientError``
+        escaping here would block the caller's
+        :class:`CancelledError` propagation when used inside a
+        :meth:`PeerLinkClient._run_one_session` cancellation
+        handler. Python 3.8+ already excludes ``CancelledError``
+        from ``Exception``, so the wider suppression below stays
+        compatible with the no-swallow contract.
+        """
+        await self.send_frame({"type": AppMessageType.TERMINATE.value, "reason": reason})
+        with contextlib.suppress(OSError, RuntimeError, aiohttp.ClientError):
+            await self.ws.close()

--- a/esphome_device_builder/controllers/remote_build/peer_link/channel.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/channel.py
@@ -47,7 +47,8 @@ class PeerLinkChannel:
     _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     async def send_frame(self, payload: dict[str, Any]) -> bool:
-        """Encrypt *payload* under the send lock and send as a binary WS frame.
+        """
+        Encrypt *payload* under the send lock and send as a binary WS frame.
 
         Returns ``True`` on success, ``False`` on JSON-encode /
         Noise-encrypt / WS-side failure. The lock serialises
@@ -56,10 +57,9 @@ class PeerLinkChannel:
         — the Noise cipher state is not safe to share across
         concurrent encrypts.
         """
-        # ``_send_bytes_safely`` and ``parse_app_frame`` are slated
-        # for sibling submodules later in the split arc; lazy import
-        # keeps this PR mechanical and avoids ordering issues with
-        # the package ``__init__.py``.
+        # Lazy import: ``_send_bytes_safely`` lives in the parent
+        # package's ``__init__.py``, which imports this module — a
+        # top-level import here would deadlock the load.
         from . import _send_bytes_safely  # noqa: PLC0415
 
         try:
@@ -82,7 +82,8 @@ class PeerLinkChannel:
             return await _send_bytes_safely(self.ws, ciphertext, log_label="app frame")
 
     def parse_frame(self, msg: Any) -> dict[str, Any] | None:
-        """Validate, decrypt, and JSON-parse one inbound frame.
+        """
+        Validate, decrypt, and JSON-parse one inbound frame.
 
         Thin wrapper around :func:`parse_app_frame` so callers
         don't have to thread :attr:`noise` and :attr:`log_label`
@@ -94,7 +95,8 @@ class PeerLinkChannel:
         return parse_app_frame(self.noise, msg, log_label=self.log_label)
 
     async def send_terminate(self, reason: str) -> None:
-        """Send a structured ``terminate`` frame and close the WS, best-effort.
+        """
+        Send a structured ``terminate`` frame and close the WS, best-effort.
 
         The terminate frame routes through :meth:`send_frame` so
         the encrypt + lock invariants hold; the close that


### PR DESCRIPTION
# What does this implement/fix?

Third PR in the `peer_link` split arc (follows #769 package conversion + #770 wire enums; plan: `peer_link_split.md`). Moves the `PeerLinkChannel` dataclass byte-for-byte from `peer_link/__init__.py` into a new `peer_link/channel.py` submodule.

External callers (`peer_link_client/_submit.py`, `peer_link_client/client.py`) keep using `from .peer_link import PeerLinkChannel` / equivalent — `__init__.py` re-exports via PEP 484 redundant-alias (`from .channel import PeerLinkChannel as PeerLinkChannel`).

**Where the re-export goes matters here.** `channel.py` has lazy imports for `_send_bytes_safely` and `parse_app_frame` — both still live in `__init__.py` until PRs 4 (plumbing) and 6 (session) extract them. Loading `channel.py` BEFORE those definitions exist on the package object would fail; loading AFTER is the natural order. So the `from .channel import PeerLinkChannel as PeerLinkChannel` line sits at the **bottom** of `__init__.py`, after the helper definitions.

The two cross-module helpers are imported lazily inside the channel methods (`from . import _send_bytes_safely` / `from . import parse_app_frame`) to keep this PR strictly mechanical. Once `_send_bytes_safely` lands in `plumbing.py` and `parse_app_frame` in `session.py`, those lazy imports become regular module-level sibling imports (`from .plumbing import _send_bytes_safely` / `from .session import parse_app_frame`).

**Other mechanical cleanup:** the top-level `import aiohttp` in `__init__.py` is dropped because `aiohttp.ClientError` was only used by `PeerLinkChannel.send_terminate` (which moved with the class). `from aiohttp import WSMsgType, web` stays — those are still used elsewhere in `__init__.py`.

* **`__init__.py`**: 977 → 893 lines (−84).
* **`channel.py`** (new): 119 lines.

Subsequent PRs in the arc:

* `plumbing.py` — low-level WS / Noise helpers (~145 lines)
* `handshake.py` — handshake driver + private types (~180 lines)
* `session.py` — `PeerLinkSession` + receive loop + heartbeat (~330 lines)

All 3389 non-e2e tests pass; ruff + mypy clean.

**Related issue or feature (if applicable):**

- follow-up to #769 + #770; third PR of the peer_link split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
