### PR TITLE
Split OffloaderController: extract peer-link-client lifecycle

### DIFF
--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -63,11 +63,10 @@ from ...models import (
     RemoteBuildPeer,
     StoredPairing,
 )
-from . import discovery, rebind
+from . import discovery, peer_link_lifecycle, rebind
 from ._mdns import endpoints_equal
 from ._models import (
     EDIT_PAIRING_PROBE_ERRORS,
-    PeerLinkClientHandle,
     RebindProbeOutcome,
     RebindProbeResult,
 )
@@ -95,7 +94,6 @@ from .artifacts_tarball import UnpackArtifactsError, unpack_artifacts_response
 from .peer_link_client import (
     DownloadArtifactsError,
     PairStatusResult,
-    PeerLinkClient,
     PeerLinkClientError,
     PeerLinkNoSessionError,
     SubmitJobSessionLostError,
@@ -115,6 +113,8 @@ if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
     from ...helpers.dashboard_identity import DashboardIdentity
     from ...helpers.peer_link_identity import PeerLinkIdentity
+    from ._models import PeerLinkClientHandle
+    from .peer_link_client import PeerLinkClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -855,31 +855,8 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         return configuration, yaml_path
 
     def _lookup_open_peer_link_client(self, pin_sha256: str, *, label: str) -> PeerLinkClient:
-        """Return the live :class:`PeerLinkClient` for *pin_sha256*, raising on miss.
-
-        ``NOT_FOUND`` for a missing pairing; ``PRECONDITION_FAILED``
-        for any of the not-ready states (PENDING, client not
-        spawned, orphaned, mid-reconnect) — all four fold into
-        one raise since the user's recovery is the same (wait +
-        retry); the distinguishing reason rides in the log line.
-        *label* names the calling op in the error message.
-        """
-        pairing = self._pairings.get(pin_sha256)
-        if pairing is None:
-            msg = f"{label}: no pairing for pin_sha256={pin_sha256!r}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-        if pairing.status is not PeerStatus.APPROVED:
-            reason = f"status is {pairing.status.value!r}, not APPROVED"
-        elif (handle := self._peer_link_clients.get(pin_sha256)) is None:
-            reason = "client not yet spawned"
-        elif handle.task.done():
-            reason = "client orphaned (pin mismatch / superseded)"
-        elif not handle.client.is_session_open:
-            reason = "session not connected (mid-reconnect / receiver offline)"
-        else:
-            return handle.client
-        msg = f"{label}: peer-link to {pairing.label!r} not ready ({reason})"
-        raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
+        """Return the live :class:`PeerLinkClient` for *pin_sha256*, raising on miss."""
+        return peer_link_lifecycle.lookup_open_peer_link_client(self, pin_sha256, label=label)
 
     async def _build_submit_job_bundle(self, configuration: str, yaml_path: Path) -> bytes:
         """Build the bundle bytes for *yaml_path*.
@@ -1141,90 +1118,20 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
             task.cancel()
 
     def _spawn_peer_link_client(self, pairing: StoredPairing) -> None:
-        """Spawn the long-lived peer-link client for *pairing*.
-
-        Idempotent on already-running clients — returns early if
-        a client for the row's ``pin_sha256`` is still alive.
-        Skips if the offloader-side identities haven't been
-        loaded yet (start order: identities load before any
-        spawn). Skips if the bus isn't wired (e.g. a unit test
-        path).
-        """
-        if (
-            self._offloader_dashboard_id is None
-            or self._offloader_peer_link_priv is None
-            or self._db.bus is None
-        ):
-            return
-        key = pairing.pin_sha256
-        existing = self._peer_link_clients.get(key)
-        if existing is not None and not existing.task.done():
-            return
-        client = PeerLinkClient(
-            receiver_hostname=pairing.receiver_hostname,
-            receiver_port=pairing.receiver_port,
-            identity_priv=self._offloader_peer_link_priv,
-            dashboard_id=self._offloader_dashboard_id,
-            # Pin the receiver's static pubkey from the
-            # OOB-verified pair flow so the long-lived peer-link
-            # handshake fails fast on identity drift instead of
-            # admitting an attacker with their own keypair to
-            # the application channel.
-            pinned_static_x25519_pub=pairing.static_x25519_pub,
-            pin_sha256=pairing.pin_sha256,
-            receiver_label=pairing.label,
-            bus=self._db.bus,
-            resolver=self._peer_link_resolver,
-        )
-        task = asyncio.create_task(
-            client.run(),
-            name=f"peer-link-client-{pairing.receiver_hostname}:{pairing.receiver_port}",
-        )
-        self._peer_link_clients[key] = PeerLinkClientHandle(client=client, task=task)
+        """Spawn the long-lived peer-link client for *pairing*."""
+        peer_link_lifecycle.spawn_peer_link_client(self, pairing)
 
     def _cancel_peer_link_client(self, pin_sha256: str) -> None:
         """Cancel the peer-link client for *pin_sha256*. No-op if none running."""
-        handle = self._peer_link_clients.pop(pin_sha256, None)
-        if handle is not None and not handle.task.done():
-            handle.task.cancel()
+        peer_link_lifecycle.cancel_peer_link_client(self, pin_sha256)
 
     def _sweep_stale_pairings_at_endpoint(
         self, hostname: str, port: int, *, keep_pin_sha256: str
     ) -> None:
-        """Drop any pairing or alert at ``(hostname, port)`` whose pin isn't *keep_pin_sha256*.
-
-        Cleans up after a re-pair against the same endpoint
-        under a fresh pin (receiver rotated identity, or a
-        different receiver took the hostname). Without the
-        sweep the old row + listener task + alert would leak
-        under pin-keying.
-
-        Walks both ``_pairings`` and ``_offloader_alerts``
-        because an alert can outlive its pairing on the
-        pin-drift branch. Snapshots to lists before iterating
-        to avoid mutate-during-iteration.
-        """
-        for stale_pin, pairing in list(self._pairings.items()):
-            if stale_pin == keep_pin_sha256:
-                continue
-            if pairing.receiver_hostname != hostname or pairing.receiver_port != port:
-                continue
-            self._pairings.pop(stale_pin, None)
-            self._cancel_pair_status_listener(stale_pin)
-            self._cancel_peer_link_client(stale_pin)
-            self._peer_queue_status.pop(stale_pin, None)
-            self._open_peer_links.discard(stale_pin)
-        # Alerts can outlive pairings — sweep them in a second
-        # pass keyed on the alert's stored ``receiver_hostname``
-        # / ``receiver_port`` (also walks the pin-keyed dict so
-        # an alert under the keep_pin_sha256 stays put if the
-        # user is re-confirming the same identity).
-        for stale_pin, alert in list(self._offloader_alerts.items()):
-            if stale_pin == keep_pin_sha256:
-                continue
-            if alert["receiver_hostname"] != hostname or alert["receiver_port"] != port:
-                continue
-            self._dismiss_offloader_alert(stale_pin, hostname, port)
+        """Drop any pairing or alert at ``(hostname, port)`` whose pin isn't *keep_pin_sha256*."""
+        peer_link_lifecycle.sweep_stale_pairings_at_endpoint(
+            self, hostname, port, keep_pin_sha256=keep_pin_sha256
+        )
 
     async def _await_pair_status_flip(self, pairing: StoredPairing) -> None:
         """Hold a Noise WS to the receiver until the row flips status.

--- a/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
@@ -1,0 +1,149 @@
+"""
+Offloader-side peer-link client lifecycle.
+
+Owns spawn / cancel / lookup of the long-lived
+:class:`PeerLinkClient` task per APPROVED
+:class:`StoredPairing`, plus the
+:func:`sweep_stale_pairings_at_endpoint` helper that
+re-pair / endpoint-take-over uses to drop orphaned rows
+sharing a hostname / port. Bodies take
+:class:`OffloaderController` as the first arg; the
+controller keeps thin bound-method delegates so tests can
+instance-patch the spawn / cancel hooks (the dominant
+pattern across the controller-test suite) and so cross-module
+callers (``rebind`` for cancel/respawn,
+``submit_job`` / ``download_artifacts`` / ``cancel_job`` for
+lookup) reach into a stable surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...models import ErrorCode, PeerStatus, StoredPairing
+from ._models import PeerLinkClientHandle
+from .peer_link_client import PeerLinkClient
+
+if TYPE_CHECKING:
+    from .offloader import OffloaderController
+
+
+def spawn_peer_link_client(controller: OffloaderController, pairing: StoredPairing) -> None:
+    """Spawn the long-lived peer-link client for *pairing*.
+
+    Idempotent on already-running clients — returns early if
+    a client for the row's ``pin_sha256`` is still alive.
+    Skips if the offloader-side identities haven't been
+    loaded yet (start order: identities load before any
+    spawn). Skips if the bus isn't wired (e.g. a unit test
+    path).
+    """
+    if (
+        controller._offloader_dashboard_id is None
+        or controller._offloader_peer_link_priv is None
+        or controller._db.bus is None
+    ):
+        return
+    key = pairing.pin_sha256
+    existing = controller._peer_link_clients.get(key)
+    if existing is not None and not existing.task.done():
+        return
+    client = PeerLinkClient(
+        receiver_hostname=pairing.receiver_hostname,
+        receiver_port=pairing.receiver_port,
+        identity_priv=controller._offloader_peer_link_priv,
+        dashboard_id=controller._offloader_dashboard_id,
+        # Pin the receiver's static pubkey from the
+        # OOB-verified pair flow so the long-lived peer-link
+        # handshake fails fast on identity drift instead of
+        # admitting an attacker with their own keypair to
+        # the application channel.
+        pinned_static_x25519_pub=pairing.static_x25519_pub,
+        pin_sha256=pairing.pin_sha256,
+        receiver_label=pairing.label,
+        bus=controller._db.bus,
+        resolver=controller._peer_link_resolver,
+    )
+    task = asyncio.create_task(
+        client.run(),
+        name=f"peer-link-client-{pairing.receiver_hostname}:{pairing.receiver_port}",
+    )
+    controller._peer_link_clients[key] = PeerLinkClientHandle(client=client, task=task)
+
+
+def cancel_peer_link_client(controller: OffloaderController, pin_sha256: str) -> None:
+    """Cancel the peer-link client for *pin_sha256*. No-op if none running."""
+    handle = controller._peer_link_clients.pop(pin_sha256, None)
+    if handle is not None and not handle.task.done():
+        handle.task.cancel()
+
+
+def lookup_open_peer_link_client(
+    controller: OffloaderController, pin_sha256: str, *, label: str
+) -> PeerLinkClient:
+    """Return the live :class:`PeerLinkClient` for *pin_sha256*, raising on miss.
+
+    ``NOT_FOUND`` for a missing pairing; ``PRECONDITION_FAILED``
+    for any of the not-ready states (PENDING, client not
+    spawned, orphaned, mid-reconnect) — all four fold into
+    one raise since the user's recovery is the same (wait +
+    retry); the distinguishing reason rides in the log line.
+    *label* names the calling op in the error message.
+    """
+    pairing = controller._pairings.get(pin_sha256)
+    if pairing is None:
+        msg = f"{label}: no pairing for pin_sha256={pin_sha256!r}"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    if pairing.status is not PeerStatus.APPROVED:
+        reason = f"status is {pairing.status.value!r}, not APPROVED"
+    elif (handle := controller._peer_link_clients.get(pin_sha256)) is None:
+        reason = "client not yet spawned"
+    elif handle.task.done():
+        reason = "client orphaned (pin mismatch / superseded)"
+    elif not handle.client.is_session_open:
+        reason = "session not connected (mid-reconnect / receiver offline)"
+    else:
+        return handle.client
+    msg = f"{label}: peer-link to {pairing.label!r} not ready ({reason})"
+    raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
+
+
+def sweep_stale_pairings_at_endpoint(
+    controller: OffloaderController, hostname: str, port: int, *, keep_pin_sha256: str
+) -> None:
+    """Drop any pairing or alert at ``(hostname, port)`` whose pin isn't *keep_pin_sha256*.
+
+    Cleans up after a re-pair against the same endpoint
+    under a fresh pin (receiver rotated identity, or a
+    different receiver took the hostname). Without the
+    sweep the old row + listener task + alert would leak
+    under pin-keying.
+
+    Walks both ``_pairings`` and ``_offloader_alerts``
+    because an alert can outlive its pairing on the
+    pin-drift branch. Snapshots to lists before iterating
+    to avoid mutate-during-iteration.
+    """
+    for stale_pin, pairing in list(controller._pairings.items()):
+        if stale_pin == keep_pin_sha256:
+            continue
+        if pairing.receiver_hostname != hostname or pairing.receiver_port != port:
+            continue
+        controller._pairings.pop(stale_pin, None)
+        controller._cancel_pair_status_listener(stale_pin)
+        controller._cancel_peer_link_client(stale_pin)
+        controller._peer_queue_status.pop(stale_pin, None)
+        controller._open_peer_links.discard(stale_pin)
+    # Alerts can outlive pairings — sweep them in a second
+    # pass keyed on the alert's stored ``receiver_hostname``
+    # / ``receiver_port`` (also walks the pin-keyed dict so
+    # an alert under the keep_pin_sha256 stays put if the
+    # user is re-confirming the same identity).
+    for stale_pin, alert in list(controller._offloader_alerts.items()):
+        if stale_pin == keep_pin_sha256:
+            continue
+        if alert["receiver_hostname"] != hostname or alert["receiver_port"] != port:
+            continue
+        controller._dismiss_offloader_alert(stale_pin, hostname, port)


### PR DESCRIPTION
# What does this implement/fix?

Extracts the offloader-side peer-link client lifecycle into a new sibling module `controllers/remote_build/peer_link_lifecycle.py`. Third PR in the OffloaderController split arc (after #766 discovery + #772 rebind).

**Moved methods (all kept as bound-method delegates on the controller):**

- `spawn_peer_link_client` — tests instance-patch `_spawn_peer_link_client` throughout the controller test suite; `rebind.commit_endpoint_rebind` calls it via the controller delegate.
- `cancel_peer_link_client` — same: heavy instance-patching + cross-module use from `rebind`.
- `lookup_open_peer_link_client` — `submit_job` / `download_artifacts` / `cancel_job` WS commands call it via `self`.
- `sweep_stale_pairings_at_endpoint` — `request_pair` calls it via `self` to clean up after a pin-drift re-pair.

All four kept as delegates because each has either a test patch site or a cross-module caller that needs to intercept at the controller surface.

## Imports

`PeerLinkClient` and `PeerLinkClientHandle` move to `TYPE_CHECKING` in `offloader.py`: the constructor calls move with the bodies, so only annotations remain (the `_lookup_open_peer_link_client` delegate's return type and the `self._peer_link_clients: dict[str, PeerLinkClientHandle]` attr type). Stays runtime-imported in the new module. `CommandError` / `ErrorCode` / `PeerStatus` stay imported in `offloader.py` because many other paths still use them.

## Test impact

Zero test changes. The bound-delegate shape preserves both the instance-patch hooks (`monkeypatch.setattr(controller.offloader, "_spawn_peer_link_client", ...)`) and the WS-command call paths.

`offloader.py`: **1429 → 1336 lines** (-93). Combined with #766 + #772: 1709 → 1336 (-373, -22%). 214 controller tests + 676 remote-build tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the OffloaderController split arc tracked in `offloader_split.md`. Remaining: pair-status listeners, submit-job commands, pair commands, settings, bus-event handlers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
