### PR TITLE
Split OffloaderController: extract pair-status listener

### DIFF
--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -45,12 +45,9 @@ from ...models import (
     OffloaderJobStateChangedData,
     OffloaderPairAlertDismissedData,
     OffloaderPairingEnabledChangedData,
-    OffloaderPairPeerRevokedData,
     OffloaderPairPinMismatchData,
-    OffloaderPairStatusChangedData,
     OffloaderPeerLinkClosedData,
     OffloaderPeerLinkOpenedData,
-    OffloaderPeerRevokedAlert,
     OffloaderPinMismatchAlert,
     OffloaderQueueStatusChangedData,
     OffloaderRemoteBuildSettings,
@@ -63,7 +60,7 @@ from ...models import (
     RemoteBuildPeer,
     StoredPairing,
 )
-from . import discovery, peer_link_lifecycle, rebind
+from . import discovery, pair_status, peer_link_lifecycle, rebind
 from ._mdns import endpoints_equal
 from ._models import (
     EDIT_PAIRING_PROBE_ERRORS,
@@ -100,9 +97,6 @@ from .peer_link_client import (
     SubmitJobTimeoutError,
 )
 from .peer_link_client import (
-    await_pair_status as peer_link_await_pair_status,
-)
-from .peer_link_client import (
     preview_pair as peer_link_preview_pair,
 )
 from .peer_link_client import (
@@ -135,11 +129,6 @@ def _load_offloader_identities(
 _OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES: frozenset[str] = frozenset(
     {"completed", "failed", "cancelled"}
 )
-
-# Reconnect backoff for a pair-status listener whose Noise WS
-# died on transport error — bounds tight-looping against a
-# hard-down receiver.
-_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS = 2.0
 
 # Debounce window for the offloader-side pairings-store write
 # so a burst of approvals collapses to one disk write.
@@ -1102,20 +1091,11 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
 
     def _spawn_pair_status_listener(self, pairing: StoredPairing) -> None:
         """Spawn the pair-status listener task for *pairing* if not already running."""
-        key = pairing.pin_sha256
-        existing = self._pair_status_listeners.get(key)
-        if existing is not None and not existing.done():
-            return
-        self._pair_status_listeners[key] = asyncio.create_task(
-            self._await_pair_status_flip(pairing),
-            name=f"pair-status-{pairing.receiver_hostname}:{pairing.receiver_port}",
-        )
+        pair_status.spawn_pair_status_listener(self, pairing)
 
     def _cancel_pair_status_listener(self, pin_sha256: str) -> None:
         """Cancel the listener for *pin_sha256*. No-op if none running."""
-        task = self._pair_status_listeners.pop(pin_sha256, None)
-        if task is not None and not task.done():
-            task.cancel()
+        pair_status.cancel_pair_status_listener(self, pin_sha256)
 
     def _spawn_peer_link_client(self, pairing: StoredPairing) -> None:
         """Spawn the long-lived peer-link client for *pairing*."""
@@ -1134,147 +1114,14 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         )
 
     async def _await_pair_status_flip(self, pairing: StoredPairing) -> None:
-        """Hold a Noise WS to the receiver until the row flips status.
-
-        Single-shot: opens one Noise WS with ``intent="pair_status"``,
-        awaits the receiver's response (which the receiver-side
-        responder holds open until its own bus fires
-        ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` for the matching
-        ``dashboard_id``), persists the result + fires
-        ``OFFLOADER_PAIR_STATUS_CHANGED``, then exits. On transport
-        error, sleeps :data:`_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS`
-        and reconnects.
-        """
-        peer_link_identity, dashboard_identity = await self._load_offloader_identities_async()
-        try:
-            while True:
-                try:
-                    result = await peer_link_await_pair_status(
-                        hostname=pairing.receiver_hostname,
-                        port=pairing.receiver_port,
-                        identity_priv=peer_link_identity.private_bytes,
-                        dashboard_id=dashboard_identity.dashboard_id,
-                        resolver=self._peer_link_resolver,
-                    )
-                except PeerLinkClientError as exc:
-                    _LOGGER.debug(
-                        "pair-status listener for %s:%s reconnecting: %s",
-                        pairing.receiver_hostname,
-                        pairing.receiver_port,
-                        exc,
-                    )
-                    await asyncio.sleep(_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS)
-                    continue
-                terminal = await self._apply_pair_status_result(pairing, result)
-                if terminal:
-                    return
-                # Non-terminal result reached the apply path —
-                # only happens on a misbehaving receiver returning
-                # an unexpected ``intent_response`` (PENDING / OK /
-                # NO_PAIRING_WINDOW from a `pair_status` query
-                # shouldn't happen). Back off before reconnecting
-                # so a bug in the receiver doesn't burn CPU /
-                # spam logs in a tight reconnect loop.
-                await asyncio.sleep(_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS)
-        finally:
-            # Only clear the slot if it still points at this task.
-            # On a re-pair, ``_cancel_pair_status_listener`` has
-            # already popped this task and ``_spawn_pair_status_listener``
-            # has put the replacement in the slot — blindly
-            # ``pop()``-ing here would evict the replacement and
-            # orphan it (no entry left for ``unpair`` to cancel,
-            # the new listener parks forever).
-            key = pairing.pin_sha256
-            if self._pair_status_listeners.get(key) is asyncio.current_task():
-                del self._pair_status_listeners[key]
+        """Hold a Noise WS to the receiver until the row flips status."""
+        await pair_status.await_pair_status_flip(self, pairing)
 
     async def _apply_pair_status_result(
         self, pairing: StoredPairing, result: PairStatusResult
     ) -> bool:
-        """Apply a pair-status response. Return True when the listener should exit.
-
-        * APPROVED + matching pin → flip the row to APPROVED.
-        * APPROVED + drifted pin → drop the row (peer-revoked;
-          new pubkey under existing trust requires re-pair).
-        * REJECTED → drop the row (admin rejected, window
-          closed, offloader rotated, or row never existed).
-        * Anything else → log + reconnect.
-
-        Race-safe against ``unpair``: every branch keys on
-        ``self._pairings.pop(key, None)``, so if the user
-        unpaired between the await and this branch we skip
-        promotion + event-firing silently.
-        """
-        host = pairing.receiver_hostname
-        port = pairing.receiver_port
-        # Captured before the dict mutates — alerts fire
-        # alongside ``status="removed"`` and need the label.
-        label = pairing.label
-        stored_pin = pairing.pin_sha256
-        key = pairing.pin_sha256
-        if result.status is IntentResponse.APPROVED:
-            if result.pin_sha256 != pairing.pin_sha256:
-                _LOGGER.warning(
-                    "pair-status pin drift for %s:%s; dropping row (stored=%s observed=%s)",
-                    host,
-                    port,
-                    pairing.pin_sha256,
-                    result.pin_sha256,
-                )
-                if self._pairings.pop(key, None) is not None:
-                    self._schedule_pairings_save()
-                    pin_alert: OffloaderPinMismatchAlert = {
-                        "kind": "pin_mismatch",
-                        "receiver_hostname": host,
-                        "receiver_port": port,
-                        "pin_sha256": stored_pin,
-                        "receiver_label": label,
-                        "expected_pin": stored_pin,
-                        "observed_pin": result.pin_sha256,
-                        "fired_at": time.time(),
-                    }
-                    self._offloader_alerts[key] = pin_alert
-                    # Fire diagnostic first so subscribers see
-                    # the full payload before the row drops.
-                    self._fire_offloader_pair_pin_mismatch(
-                        host, port, key, label, stored_pin, result.pin_sha256
-                    )
-                    self._fire_offloader_pair_status_changed(host, port, key, "removed")
-                return True
-            # PENDING → APPROVED in place. If ``unpair`` raced
-            # us between the await and this branch the row's
-            # gone; exit silently rather than resurrect state
-            # the user just deleted.
-            existing = self._pairings.get(key)
-            if existing is None:
-                return True
-            existing.status = PeerStatus.APPROVED
-            self._schedule_pairings_save()
-            self._fire_offloader_pair_status_changed(host, port, key, "approved")
-            self._spawn_peer_link_client(existing)
-            return True
-        if result.status is IntentResponse.REJECTED:
-            if self._pairings.pop(key, None) is not None:
-                self._schedule_pairings_save()
-                revoked_alert: OffloaderPeerRevokedAlert = {
-                    "kind": "peer_revoked",
-                    "receiver_hostname": host,
-                    "receiver_port": port,
-                    "pin_sha256": stored_pin,
-                    "receiver_label": label,
-                    "fired_at": time.time(),
-                }
-                self._offloader_alerts[key] = revoked_alert
-                self._fire_offloader_pair_peer_revoked(host, port, key, label)
-                self._fire_offloader_pair_status_changed(host, port, key, "removed")
-            return True
-        _LOGGER.warning(
-            "pair-status returned unexpected status %r for %s:%s",
-            result.status,
-            host,
-            port,
-        )
-        return False
+        """Apply a pair-status response. Return True when the listener should exit."""
+        return await pair_status.apply_pair_status_result(self, pairing, result)
 
     def _fire_offloader_pair_status_changed(
         self,
@@ -1284,49 +1131,9 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         status: Literal["approved", "removed"],
     ) -> None:
         """Fire ``OFFLOADER_PAIR_STATUS_CHANGED`` for a pairing flip."""
-        payload: OffloaderPairStatusChangedData = {
-            "receiver_hostname": receiver_hostname,
-            "receiver_port": receiver_port,
-            "pin_sha256": pin_sha256,
-            "status": status,
-        }
-        self._db.bus.fire(EventType.OFFLOADER_PAIR_STATUS_CHANGED, payload)
-
-    def _fire_offloader_pair_pin_mismatch(
-        self,
-        receiver_hostname: str,
-        receiver_port: int,
-        pin_sha256: str,
-        receiver_label: str,
-        expected_pin: str,
-        observed_pin: str,
-    ) -> None:
-        """Fire ``OFFLOADER_PAIR_PIN_MISMATCH`` for a drifted-pin pair_status."""
-        payload: OffloaderPairPinMismatchData = {
-            "receiver_hostname": receiver_hostname,
-            "receiver_port": receiver_port,
-            "receiver_label": receiver_label,
-            "pin_sha256": pin_sha256,
-            "expected_pin": expected_pin,
-            "observed_pin": observed_pin,
-        }
-        self._db.bus.fire(EventType.OFFLOADER_PAIR_PIN_MISMATCH, payload)
-
-    def _fire_offloader_pair_peer_revoked(
-        self,
-        receiver_hostname: str,
-        receiver_port: int,
-        pin_sha256: str,
-        receiver_label: str,
-    ) -> None:
-        """Fire ``OFFLOADER_PAIR_PEER_REVOKED`` for a REJECTED pair_status."""
-        payload: OffloaderPairPeerRevokedData = {
-            "receiver_hostname": receiver_hostname,
-            "receiver_port": receiver_port,
-            "receiver_label": receiver_label,
-            "pin_sha256": pin_sha256,
-        }
-        self._db.bus.fire(EventType.OFFLOADER_PAIR_PEER_REVOKED, payload)
+        pair_status.fire_offloader_pair_status_changed(
+            self, receiver_hostname, receiver_port, pin_sha256, status
+        )
 
     # ------------------------------------------------------------------
     # Identity — surface the receiver's own dashboard_id + cert pin to

--- a/esphome_device_builder/controllers/remote_build/pair_status.py
+++ b/esphome_device_builder/controllers/remote_build/pair_status.py
@@ -1,0 +1,272 @@
+"""
+Offloader-side pair-status listener for PENDING pairings.
+
+Each PENDING :class:`StoredPairing` gets a long-lived listener
+task holding an open Noise WS to its receiver with
+``intent="pair_status"``. The receiver-side responder waits on
+its own bus event for the admin's accept / reject click and
+pushes the response back, so the offloader sees the flip with
+sub-second latency without polling. This module owns the spawn
+/ cancel lifecycle, the listener loop body, the apply branch
+that promotes (or drops) the pairing on the response, and the
+three ``OFFLOADER_PAIR_*`` event-fire helpers the apply branch
+uses.
+
+Bodies take :class:`OffloaderController` as the first arg; the
+controller keeps thin bound-method delegates so test
+call-sites (``offloader._await_pair_status_flip``,
+``_apply_pair_status_result``, …) and cross-module callers
+(``request_pair`` / ``unpair`` /
+:func:`peer_link_lifecycle.sweep_stale_pairings_at_endpoint`)
+intercept at the controller surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Literal
+
+from ...models import (
+    EventType,
+    IntentResponse,
+    OffloaderPairPeerRevokedData,
+    OffloaderPairPinMismatchData,
+    OffloaderPairStatusChangedData,
+    OffloaderPeerRevokedAlert,
+    OffloaderPinMismatchAlert,
+    PeerStatus,
+    StoredPairing,
+)
+from .peer_link_client import PairStatusResult, PeerLinkClientError
+from .peer_link_client import await_pair_status as peer_link_await_pair_status
+
+if TYPE_CHECKING:
+    from .offloader import OffloaderController
+
+_LOGGER = logging.getLogger(__name__)
+
+# Reconnect backoff for a pair-status listener whose Noise WS
+# died on transport error — bounds tight-looping against a
+# hard-down receiver.
+_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS = 2.0
+
+
+def spawn_pair_status_listener(controller: OffloaderController, pairing: StoredPairing) -> None:
+    """Spawn the pair-status listener task for *pairing* if not already running."""
+    key = pairing.pin_sha256
+    existing = controller._pair_status_listeners.get(key)
+    if existing is not None and not existing.done():
+        return
+    controller._pair_status_listeners[key] = asyncio.create_task(
+        controller._await_pair_status_flip(pairing),
+        name=f"pair-status-{pairing.receiver_hostname}:{pairing.receiver_port}",
+    )
+
+
+def cancel_pair_status_listener(controller: OffloaderController, pin_sha256: str) -> None:
+    """Cancel the listener for *pin_sha256*. No-op if none running."""
+    task = controller._pair_status_listeners.pop(pin_sha256, None)
+    if task is not None and not task.done():
+        task.cancel()
+
+
+async def await_pair_status_flip(controller: OffloaderController, pairing: StoredPairing) -> None:
+    """Hold a Noise WS to the receiver until the row flips status.
+
+    Single-shot: opens one Noise WS with ``intent="pair_status"``,
+    awaits the receiver's response (which the receiver-side
+    responder holds open until its own bus fires
+    ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` for the matching
+    ``dashboard_id``), persists the result + fires
+    ``OFFLOADER_PAIR_STATUS_CHANGED``, then exits. On transport
+    error, sleeps :data:`_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS`
+    and reconnects.
+    """
+    peer_link_identity, dashboard_identity = await controller._load_offloader_identities_async()
+    try:
+        while True:
+            try:
+                result = await peer_link_await_pair_status(
+                    hostname=pairing.receiver_hostname,
+                    port=pairing.receiver_port,
+                    identity_priv=peer_link_identity.private_bytes,
+                    dashboard_id=dashboard_identity.dashboard_id,
+                    resolver=controller._peer_link_resolver,
+                )
+            except PeerLinkClientError as exc:
+                _LOGGER.debug(
+                    "pair-status listener for %s:%s reconnecting: %s",
+                    pairing.receiver_hostname,
+                    pairing.receiver_port,
+                    exc,
+                )
+                await asyncio.sleep(_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS)
+                continue
+            terminal = await controller._apply_pair_status_result(pairing, result)
+            if terminal:
+                return
+            # Non-terminal result reached the apply path —
+            # only happens on a misbehaving receiver returning
+            # an unexpected ``intent_response`` (PENDING / OK /
+            # NO_PAIRING_WINDOW from a `pair_status` query
+            # shouldn't happen). Back off before reconnecting
+            # so a bug in the receiver doesn't burn CPU /
+            # spam logs in a tight reconnect loop.
+            await asyncio.sleep(_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS)
+    finally:
+        # Only clear the slot if it still points at this task.
+        # On a re-pair, ``_cancel_pair_status_listener`` has
+        # already popped this task and ``_spawn_pair_status_listener``
+        # has put the replacement in the slot — blindly
+        # ``pop()``-ing here would evict the replacement and
+        # orphan it (no entry left for ``unpair`` to cancel,
+        # the new listener parks forever).
+        key = pairing.pin_sha256
+        if controller._pair_status_listeners.get(key) is asyncio.current_task():
+            del controller._pair_status_listeners[key]
+
+
+async def apply_pair_status_result(
+    controller: OffloaderController, pairing: StoredPairing, result: PairStatusResult
+) -> bool:
+    """Apply a pair-status response. Return True when the listener should exit.
+
+    * APPROVED + matching pin → flip the row to APPROVED.
+    * APPROVED + drifted pin → drop the row (peer-revoked;
+      new pubkey under existing trust requires re-pair).
+    * REJECTED → drop the row (admin rejected, window
+      closed, offloader rotated, or row never existed).
+    * Anything else → log + reconnect.
+
+    Race-safe against ``unpair``: every branch keys on
+    ``controller._pairings.pop(key, None)``, so if the user
+    unpaired between the await and this branch we skip
+    promotion + event-firing silently.
+    """
+    host = pairing.receiver_hostname
+    port = pairing.receiver_port
+    # Captured before the dict mutates — alerts fire
+    # alongside ``status="removed"`` and need the label.
+    label = pairing.label
+    stored_pin = pairing.pin_sha256
+    key = pairing.pin_sha256
+    if result.status is IntentResponse.APPROVED:
+        if result.pin_sha256 != pairing.pin_sha256:
+            _LOGGER.warning(
+                "pair-status pin drift for %s:%s; dropping row (stored=%s observed=%s)",
+                host,
+                port,
+                pairing.pin_sha256,
+                result.pin_sha256,
+            )
+            if controller._pairings.pop(key, None) is not None:
+                controller._schedule_pairings_save()
+                pin_alert: OffloaderPinMismatchAlert = {
+                    "kind": "pin_mismatch",
+                    "receiver_hostname": host,
+                    "receiver_port": port,
+                    "pin_sha256": stored_pin,
+                    "receiver_label": label,
+                    "expected_pin": stored_pin,
+                    "observed_pin": result.pin_sha256,
+                    "fired_at": time.time(),
+                }
+                controller._offloader_alerts[key] = pin_alert
+                # Fire diagnostic first so subscribers see
+                # the full payload before the row drops.
+                _fire_offloader_pair_pin_mismatch(
+                    controller, host, port, key, label, stored_pin, result.pin_sha256
+                )
+                controller._fire_offloader_pair_status_changed(host, port, key, "removed")
+            return True
+        # PENDING → APPROVED in place. If ``unpair`` raced
+        # us between the await and this branch the row's
+        # gone; exit silently rather than resurrect state
+        # the user just deleted.
+        existing = controller._pairings.get(key)
+        if existing is None:
+            return True
+        existing.status = PeerStatus.APPROVED
+        controller._schedule_pairings_save()
+        controller._fire_offloader_pair_status_changed(host, port, key, "approved")
+        controller._spawn_peer_link_client(existing)
+        return True
+    if result.status is IntentResponse.REJECTED:
+        if controller._pairings.pop(key, None) is not None:
+            controller._schedule_pairings_save()
+            revoked_alert: OffloaderPeerRevokedAlert = {
+                "kind": "peer_revoked",
+                "receiver_hostname": host,
+                "receiver_port": port,
+                "pin_sha256": stored_pin,
+                "receiver_label": label,
+                "fired_at": time.time(),
+            }
+            controller._offloader_alerts[key] = revoked_alert
+            _fire_offloader_pair_peer_revoked(controller, host, port, key, label)
+            controller._fire_offloader_pair_status_changed(host, port, key, "removed")
+        return True
+    _LOGGER.warning(
+        "pair-status returned unexpected status %r for %s:%s",
+        result.status,
+        host,
+        port,
+    )
+    return False
+
+
+def fire_offloader_pair_status_changed(
+    controller: OffloaderController,
+    receiver_hostname: str,
+    receiver_port: int,
+    pin_sha256: str,
+    status: Literal["approved", "removed"],
+) -> None:
+    """Fire ``OFFLOADER_PAIR_STATUS_CHANGED`` for a pairing flip."""
+    payload: OffloaderPairStatusChangedData = {
+        "receiver_hostname": receiver_hostname,
+        "receiver_port": receiver_port,
+        "pin_sha256": pin_sha256,
+        "status": status,
+    }
+    controller._db.bus.fire(EventType.OFFLOADER_PAIR_STATUS_CHANGED, payload)
+
+
+def _fire_offloader_pair_pin_mismatch(
+    controller: OffloaderController,
+    receiver_hostname: str,
+    receiver_port: int,
+    pin_sha256: str,
+    receiver_label: str,
+    expected_pin: str,
+    observed_pin: str,
+) -> None:
+    """Fire ``OFFLOADER_PAIR_PIN_MISMATCH`` for a drifted-pin pair_status."""
+    payload: OffloaderPairPinMismatchData = {
+        "receiver_hostname": receiver_hostname,
+        "receiver_port": receiver_port,
+        "receiver_label": receiver_label,
+        "pin_sha256": pin_sha256,
+        "expected_pin": expected_pin,
+        "observed_pin": observed_pin,
+    }
+    controller._db.bus.fire(EventType.OFFLOADER_PAIR_PIN_MISMATCH, payload)
+
+
+def _fire_offloader_pair_peer_revoked(
+    controller: OffloaderController,
+    receiver_hostname: str,
+    receiver_port: int,
+    pin_sha256: str,
+    receiver_label: str,
+) -> None:
+    """Fire ``OFFLOADER_PAIR_PEER_REVOKED`` for a REJECTED pair_status."""
+    payload: OffloaderPairPeerRevokedData = {
+        "receiver_hostname": receiver_hostname,
+        "receiver_port": receiver_port,
+        "receiver_label": receiver_label,
+        "pin_sha256": pin_sha256,
+    }
+    controller._db.bus.fire(EventType.OFFLOADER_PAIR_PEER_REVOKED, payload)

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -41,7 +41,7 @@ from esphome_device_builder.controllers.remote_build import (
     ReceiverController,
 )
 from esphome_device_builder.controllers.remote_build import _models as rb_models
-from esphome_device_builder.controllers.remote_build import offloader as rb
+from esphome_device_builder.controllers.remote_build import pair_status as rb_pair_status
 from esphome_device_builder.controllers.remote_build import (
     peer_link_client as remote_build_peer_link_client,
 )
@@ -1775,7 +1775,7 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
         raise AssertionError("park event should never be set in this test")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader.peer_link_await_pair_status",
+        "esphome_device_builder.controllers.remote_build.pair_status.peer_link_await_pair_status",
         _fake_await_pair_status,
     )
 
@@ -1889,7 +1889,7 @@ async def test_request_pair_repair_then_unpair_clean_state(
         raise AssertionError("park event should never be set in this test")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader.peer_link_await_pair_status",
+        "esphome_device_builder.controllers.remote_build.pair_status.peer_link_await_pair_status",
         _fake_await_pair_status,
     )
     fake_identity = MagicMock()
@@ -2307,7 +2307,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
     on the first call and returns APPROVED on the second.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader._PAIR_STATUS_RECONNECT_BACKOFF_SECONDS",
+        "esphome_device_builder.controllers.remote_build.pair_status._PAIR_STATUS_RECONNECT_BACKOFF_SECONDS",
         0.0,
     )
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -2334,7 +2334,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader.peer_link_await_pair_status",
+        "esphome_device_builder.controllers.remote_build.pair_status.peer_link_await_pair_status",
         _fake_poll,
     )
     # Stub identity load so it doesn't try to read real key files.
@@ -2367,7 +2367,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
     tight-loop against it.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader._PAIR_STATUS_RECONNECT_BACKOFF_SECONDS",
+        "esphome_device_builder.controllers.remote_build.pair_status._PAIR_STATUS_RECONNECT_BACKOFF_SECONDS",
         0.0,
     )
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -2397,7 +2397,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader.peer_link_await_pair_status",
+        "esphome_device_builder.controllers.remote_build.pair_status.peer_link_await_pair_status",
         _fake_poll,
     )
     fake_identity = MagicMock()
@@ -3600,7 +3600,7 @@ async def test_await_pair_status_flip_self_removes_listener_on_terminal_exit(
     async def _approved_round_trip(**kwargs: Any) -> PairStatusResult:
         return PairStatusResult(status=IntentResponse.APPROVED, pin_sha256="a" * 64)
 
-    monkeypatch.setattr(rb, "peer_link_await_pair_status", _approved_round_trip)
+    monkeypatch.setattr(rb_pair_status, "peer_link_await_pair_status", _approved_round_trip)
 
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

Extracts the offloader-side pair-status listener cluster into a new sibling module `controllers/remote_build/pair_status.py`. Fourth PR in the OffloaderController split arc (after #766 discovery + #772 rebind + #774 peer-link lifecycle).

**Public entry points** (kept as bound-method delegates on the controller):
- `spawn_pair_status_listener` — tests instance-call; `request_pair` calls it.
- `cancel_pair_status_listener` — tests instance-call; `unpair` and `peer_link_lifecycle.sweep_stale_pairings_at_endpoint` call it.
- `await_pair_status_flip` — tests instance-call directly.
- `apply_pair_status_result` — tests instance-call directly.
- `fire_offloader_pair_status_changed` — `unpair` calls it (offloader-side path).

**Module-private** (only `apply_pair_status_result` uses them):
- `_fire_offloader_pair_pin_mismatch`
- `_fire_offloader_pair_peer_revoked`

## Imports

Moved out of `offloader.py`: `await_pair_status` from `.peer_link_client`; `OffloaderPairPeerRevokedData`, `OffloaderPairStatusChangedData`, `OffloaderPeerRevokedAlert`, the `_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS` constant. `IntentResponse`, `OffloaderPairPinMismatchData`, `OffloaderPinMismatchAlert`, `PairStatusResult`, `PeerStatus`, `time` stay imported in `offloader.py` because other paths still use them (`request_pair`, `_on_offloader_pair_pin_mismatch` event handler, `request_pair`'s `paired_at=time.time()`, the apply delegate's `PairStatusResult` arg).

## Test impact

7 patches repointed in `tests/test_remote_build_peer_link_client.py`:
- 5 sites for `peer_link_await_pair_status` move from `rb` to `rb_pair_status`.
- 2 sites for `_PAIR_STATUS_RECONNECT_BACKOFF_SECONDS` move from `rb` to `rb_pair_status`.

`_load_offloader_identities` patches stay on `rb` (lifecycle helper still in offloader.py).

`offloader.py`: **1336 → 1143 lines** (-193). Combined with #766 + #772 + #774: 1709 → 1143 (-566, **-33%**). 379 controller + peer-link-client tests pass; 676 remote-build tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the OffloaderController split arc tracked in `offloader_split.md`. Remaining: submit-job commands, pair commands, settings, bus-event handlers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
