### PR TITLE
Split OffloaderController: extract submit-job commands

### DIFF
--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -24,7 +24,6 @@ import logging
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
-from uuid import uuid4
 
 from zeroconf import ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
@@ -60,7 +59,7 @@ from ...models import (
     RemoteBuildPeer,
     StoredPairing,
 )
-from . import discovery, pair_status, peer_link_lifecycle, rebind
+from . import discovery, pair_status, peer_link_lifecycle, rebind, submit_job_commands
 from ._mdns import endpoints_equal
 from ._models import (
     EDIT_PAIRING_PROBE_ERRORS,
@@ -77,7 +76,6 @@ from ._summaries import pairing_summary
 from ._validators import (
     HostFieldContext,
     PairLabelField,
-    download_artifacts_error_to_command_error,
     enforce_pin_match,
     intent_response_to_command_error,
     validate_bool,
@@ -85,16 +83,10 @@ from ._validators import (
     validate_pair_label,
     validate_pin_sha256,
     validate_port,
-    validate_submit_job_target,
 )
-from .artifacts_tarball import UnpackArtifactsError, unpack_artifacts_response
 from .peer_link_client import (
-    DownloadArtifactsError,
     PairStatusResult,
     PeerLinkClientError,
-    PeerLinkNoSessionError,
-    SubmitJobSessionLostError,
-    SubmitJobTimeoutError,
 )
 from .peer_link_client import (
     preview_pair as peer_link_preview_pair,
@@ -829,50 +821,16 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         return self._pairing_summary_for(pairing)
 
     async def _validate_submit_job_config(self, configuration: object) -> tuple[str, Path]:
-        """Validate the WS *configuration* arg, return ``(name, yaml_path)``.
-
-        Path-traversal boundary via :meth:`DashboardSettings.rel_path`;
-        executor hop because ``Path.resolve`` is a syscall. Returns
-        the resolved path so the downstream bundle build doesn't
-        redo the hop.
-        """
-        if not isinstance(configuration, str) or not configuration:
-            msg = "configuration must be a non-empty string"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
-        loop = asyncio.get_running_loop()
-        yaml_path = await loop.run_in_executor(None, self._db.settings.rel_path, configuration)
-        return configuration, yaml_path
+        """Validate the WS *configuration* arg, return ``(name, yaml_path)``."""
+        return await submit_job_commands.validate_submit_job_config(self, configuration)
 
     def _lookup_open_peer_link_client(self, pin_sha256: str, *, label: str) -> PeerLinkClient:
         """Return the live :class:`PeerLinkClient` for *pin_sha256*, raising on miss."""
         return peer_link_lifecycle.lookup_open_peer_link_client(self, pin_sha256, label=label)
 
     async def _build_submit_job_bundle(self, configuration: str, yaml_path: Path) -> bytes:
-        """Build the bundle bytes for *yaml_path*.
-
-        Wraps :func:`helpers.config_bundle.build_yaml_bundle`
-        (spawns the ``esphome bundle`` CLI). Maps
-        :class:`FileNotFoundError` → ``NOT_FOUND`` and
-        :class:`BundleBuildError` → ``INVALID_ARGS``; anything
-        else propagates to ``INTERNAL_ERROR``. *configuration*
-        is the original wire-arg used in diagnostics.
-        """
-        from ...helpers.config_bundle import (  # noqa: PLC0415
-            BundleBuildError,
-            build_yaml_bundle,
-        )
-
-        try:
-            return await build_yaml_bundle(yaml_path)
-        except FileNotFoundError as exc:
-            raise CommandError(
-                ErrorCode.NOT_FOUND, f"submit_job: YAML not found: {configuration}"
-            ) from exc
-        except BundleBuildError as exc:
-            raise CommandError(
-                ErrorCode.INVALID_ARGS,
-                f"submit_job: bundle build failed for {configuration}: {exc.output or exc}",
-            ) from exc
+        """Build the bundle bytes for *yaml_path*."""
+        return await submit_job_commands.build_submit_job_bundle(self, configuration, yaml_path)
 
     @api_command("remote_build/submit_job")
     async def submit_job(
@@ -883,51 +841,10 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         target: str,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Bundle *configuration* and dispatch a build to the receiver behind *pin_sha256*.
-
-        Offloader-side counterpart of :class:`SubmitJobReceiver`.
-        Packs the config + referenced files (includes, secrets,
-        fonts, images, …) into a gzipped tarball via the
-        ``esphome bundle`` CLI subprocess and streams it over
-        the existing peer-link session. Live job lifecycle +
-        output ride ``OFFLOADER_JOB_STATE_CHANGED`` /
-        ``OFFLOADER_JOB_OUTPUT`` events on the
-        ``subscribe_events`` stream; this call returns only the
-        receiver's ``submit_job_ack``.
-
-        Subprocess instead of in-process because the CLI is the
-        stable upstream contract — in-process ``read_config``
-        would couple us to the ESPHome validation pipeline,
-        which shifts across releases. Bundle is rebuilt every
-        call so a YAML edit can't ship a stale cache.
-
-        Returns ``{"job_id": <our id>, "accepted": <bool>,
-        "reason": <str>}`` (``reason`` only on rejection).
-        """
-        clean_pin = validate_pin_sha256(pin_sha256)
-        clean_target = validate_submit_job_target(target)
-        clean_config, yaml_path = await self._validate_submit_job_config(configuration)
-        client = self._lookup_open_peer_link_client(clean_pin, label="submit_job")
-        bundle_bytes = await self._build_submit_job_bundle(clean_config, yaml_path)
-        job_id = uuid4().hex[:12]
-        try:
-            ack = await client.submit_job(
-                job_id=job_id,
-                configuration_filename=clean_config,
-                target=clean_target,
-                bundle_bytes=bundle_bytes,
-            )
-        except PeerLinkNoSessionError as exc:
-            raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
-        except (SubmitJobTimeoutError, SubmitJobSessionLostError) as exc:
-            raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
-        result: dict[str, Any] = {
-            "job_id": ack["job_id"],
-            "accepted": ack["accepted"],
-        }
-        if "reason" in ack:
-            result["reason"] = ack["reason"]
-        return result
+        """Bundle *configuration* and dispatch a build to the receiver behind *pin_sha256*."""
+        return await submit_job_commands.submit_job(
+            self, pin_sha256=pin_sha256, configuration=configuration, target=target
+        )
 
     @api_command("remote_build/download_artifacts")
     async def download_artifacts(
@@ -937,40 +854,10 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         job_id: str,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Fetch the build's flash-artifact set for *job_id* from the paired receiver.
-
-        Sends ``download_artifacts{job_id}`` over the live
-        peer-link to *pin_sha256*, parks on the assembled-bytes
-        future the receive loop fills via
-        ``artifacts_start`` / ``_chunk`` / ``_end`` frames,
-        unpacks the SHA-256-verified gzipped tarball, and
-        rewrites ``idedata.extra.flash_images[].path`` from
-        receiver-absolute paths to the bare basenames the
-        frontend's install path looks up.
-
-        Returns ``{job_id, idedata, images, total_bytes}`` —
-        ``images`` is ``firmware.bin`` first, then
-        ``idedata.extra.flash_images`` in declared order.
-        """
-        clean_pin = validate_pin_sha256(pin_sha256)
-        if not isinstance(job_id, str) or not job_id:
-            msg = "job_id must be a non-empty string"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
-        client = self._lookup_open_peer_link_client(clean_pin, label="download_artifacts")
-        try:
-            packed = await client.download_artifacts(job_id=job_id)
-        except PeerLinkNoSessionError as exc:
-            raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
-        except SubmitJobSessionLostError as exc:
-            raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
-        except DownloadArtifactsError as exc:
-            raise download_artifacts_error_to_command_error(exc) from exc
-        try:
-            return await asyncio.get_running_loop().run_in_executor(
-                None, unpack_artifacts_response, packed, job_id
-            )
-        except UnpackArtifactsError as exc:
-            raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
+        """Fetch the build's flash-artifact set for *job_id* from the paired receiver."""
+        return await submit_job_commands.download_artifacts(
+            self, pin_sha256=pin_sha256, job_id=job_id
+        )
 
     @api_command("remote_build/cancel_job")
     async def cancel_job(
@@ -980,28 +867,8 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         job_id: str,
         **kwargs: Any,
     ) -> dict[str, bool]:
-        """Send a ``cancel_job`` frame to the receiver behind *pin_sha256*.
-
-        Fire-and-forget cancel for a previously-submitted
-        remote-driven job; the receiver's resulting
-        ``job_state_changed{cancelled}`` is the confirmation,
-        surfaced via ``OFFLOADER_JOB_STATE_CHANGED``.
-
-        Returns ``{"sent": <bool>}`` reflecting whether the
-        frame made it onto the wire; ``sent=false`` is a
-        same-tick channel failure the caller should treat as
-        an error.
-        """
-        clean_pin = validate_pin_sha256(pin_sha256)
-        if not isinstance(job_id, str) or not job_id:
-            msg = "job_id must be a non-empty string"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
-        client = self._lookup_open_peer_link_client(clean_pin, label="cancel_job")
-        try:
-            sent = await client.cancel_job(job_id=job_id)
-        except PeerLinkNoSessionError as exc:
-            raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
-        return {"sent": sent}
+        """Send a ``cancel_job`` frame to the receiver behind *pin_sha256*."""
+        return await submit_job_commands.cancel_job(self, pin_sha256=pin_sha256, job_id=job_id)
 
     def get_pairing(self, pin_sha256: str) -> StoredPairing | None:
         """Return the :class:`StoredPairing` for *pin_sha256*, or ``None``."""

--- a/esphome_device_builder/controllers/remote_build/submit_job_commands.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job_commands.py
@@ -1,0 +1,211 @@
+"""
+Offloader-side ``submit_job`` / ``download_artifacts`` / ``cancel_job`` WS commands.
+
+Top-half of the remote-build dispatch loop: the offloader
+packs the YAML config (and its referenced files) into a
+gzipped tarball via the ``esphome bundle`` CLI, streams it to
+the receiver behind a paired peer-link, and tracks the build's
+lifecycle / artifacts. Symmetric to the receiver-side
+:mod:`.submit_job` (which owns the bottom half — bundle
+unpack, compile, ack); the wire shapes meet in
+:mod:`.peer_link_client`.
+
+Bodies take :class:`OffloaderController` as the first arg; the
+controller keeps the three ``@api_command``-decorated WS
+methods plus the two ``_validate`` / ``_build`` helpers as
+thin bound-method delegates so test call-sites and the WS
+dispatch resolve unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from ...helpers.api import CommandError
+from ...models import ErrorCode
+from ._validators import (
+    download_artifacts_error_to_command_error,
+    validate_pin_sha256,
+    validate_submit_job_target,
+)
+from .artifacts_tarball import UnpackArtifactsError, unpack_artifacts_response
+from .peer_link_client import (
+    DownloadArtifactsError,
+    PeerLinkNoSessionError,
+    SubmitJobSessionLostError,
+    SubmitJobTimeoutError,
+)
+
+if TYPE_CHECKING:
+    from .offloader import OffloaderController
+
+
+async def validate_submit_job_config(
+    controller: OffloaderController, configuration: object
+) -> tuple[str, Path]:
+    """Validate the WS *configuration* arg, return ``(name, yaml_path)``.
+
+    Path-traversal boundary via :meth:`DashboardSettings.rel_path`;
+    executor hop because ``Path.resolve`` is a syscall. Returns
+    the resolved path so the downstream bundle build doesn't
+    redo the hop.
+    """
+    if not isinstance(configuration, str) or not configuration:
+        msg = "configuration must be a non-empty string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    loop = asyncio.get_running_loop()
+    yaml_path = await loop.run_in_executor(None, controller._db.settings.rel_path, configuration)
+    return configuration, yaml_path
+
+
+async def build_submit_job_bundle(
+    controller: OffloaderController, configuration: str, yaml_path: Path
+) -> bytes:
+    """Build the bundle bytes for *yaml_path*.
+
+    Wraps :func:`helpers.config_bundle.build_yaml_bundle`
+    (spawns the ``esphome bundle`` CLI). Maps
+    :class:`FileNotFoundError` → ``NOT_FOUND`` and
+    :class:`BundleBuildError` → ``INVALID_ARGS``; anything
+    else propagates to ``INTERNAL_ERROR``. *configuration*
+    is the original wire-arg used in diagnostics.
+    """
+    from ...helpers.config_bundle import (  # noqa: PLC0415
+        BundleBuildError,
+        build_yaml_bundle,
+    )
+
+    try:
+        return await build_yaml_bundle(yaml_path)
+    except FileNotFoundError as exc:
+        raise CommandError(
+            ErrorCode.NOT_FOUND, f"submit_job: YAML not found: {configuration}"
+        ) from exc
+    except BundleBuildError as exc:
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            f"submit_job: bundle build failed for {configuration}: {exc.output or exc}",
+        ) from exc
+
+
+async def submit_job(
+    controller: OffloaderController,
+    *,
+    pin_sha256: str,
+    configuration: str,
+    target: str,
+) -> dict[str, Any]:
+    """Bundle *configuration* and dispatch a build to the receiver behind *pin_sha256*.
+
+    Offloader-side counterpart of :class:`SubmitJobReceiver`.
+    Packs the config + referenced files (includes, secrets,
+    fonts, images, …) into a gzipped tarball via the
+    ``esphome bundle`` CLI subprocess and streams it over
+    the existing peer-link session. Live job lifecycle +
+    output ride ``OFFLOADER_JOB_STATE_CHANGED`` /
+    ``OFFLOADER_JOB_OUTPUT`` events on the
+    ``subscribe_events`` stream; this call returns only the
+    receiver's ``submit_job_ack``.
+
+    Subprocess instead of in-process because the CLI is the
+    stable upstream contract — in-process ``read_config``
+    would couple us to the ESPHome validation pipeline,
+    which shifts across releases. Bundle is rebuilt every
+    call so a YAML edit can't ship a stale cache.
+
+    Returns ``{"job_id": <our id>, "accepted": <bool>,
+    "reason": <str>}`` (``reason`` only on rejection).
+    """
+    clean_pin = validate_pin_sha256(pin_sha256)
+    clean_target = validate_submit_job_target(target)
+    clean_config, yaml_path = await controller._validate_submit_job_config(configuration)
+    client = controller._lookup_open_peer_link_client(clean_pin, label="submit_job")
+    bundle_bytes = await controller._build_submit_job_bundle(clean_config, yaml_path)
+    job_id = uuid4().hex[:12]
+    try:
+        ack = await client.submit_job(
+            job_id=job_id,
+            configuration_filename=clean_config,
+            target=clean_target,
+            bundle_bytes=bundle_bytes,
+        )
+    except PeerLinkNoSessionError as exc:
+        raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
+    except (SubmitJobTimeoutError, SubmitJobSessionLostError) as exc:
+        raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
+    result: dict[str, Any] = {
+        "job_id": ack["job_id"],
+        "accepted": ack["accepted"],
+    }
+    if "reason" in ack:
+        result["reason"] = ack["reason"]
+    return result
+
+
+async def download_artifacts(
+    controller: OffloaderController, *, pin_sha256: str, job_id: str
+) -> dict[str, Any]:
+    """Fetch the build's flash-artifact set for *job_id* from the paired receiver.
+
+    Sends ``download_artifacts{job_id}`` over the live
+    peer-link to *pin_sha256*, parks on the assembled-bytes
+    future the receive loop fills via
+    ``artifacts_start`` / ``_chunk`` / ``_end`` frames,
+    unpacks the SHA-256-verified gzipped tarball, and
+    rewrites ``idedata.extra.flash_images[].path`` from
+    receiver-absolute paths to the bare basenames the
+    frontend's install path looks up.
+
+    Returns ``{job_id, idedata, images, total_bytes}`` —
+    ``images`` is ``firmware.bin`` first, then
+    ``idedata.extra.flash_images`` in declared order.
+    """
+    clean_pin = validate_pin_sha256(pin_sha256)
+    if not isinstance(job_id, str) or not job_id:
+        msg = "job_id must be a non-empty string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    client = controller._lookup_open_peer_link_client(clean_pin, label="download_artifacts")
+    try:
+        packed = await client.download_artifacts(job_id=job_id)
+    except PeerLinkNoSessionError as exc:
+        raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
+    except SubmitJobSessionLostError as exc:
+        raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
+    except DownloadArtifactsError as exc:
+        raise download_artifacts_error_to_command_error(exc) from exc
+    try:
+        return await asyncio.get_running_loop().run_in_executor(
+            None, unpack_artifacts_response, packed, job_id
+        )
+    except UnpackArtifactsError as exc:
+        raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
+
+
+async def cancel_job(
+    controller: OffloaderController, *, pin_sha256: str, job_id: str
+) -> dict[str, bool]:
+    """Send a ``cancel_job`` frame to the receiver behind *pin_sha256*.
+
+    Fire-and-forget cancel for a previously-submitted
+    remote-driven job; the receiver's resulting
+    ``job_state_changed{cancelled}`` is the confirmation,
+    surfaced via ``OFFLOADER_JOB_STATE_CHANGED``.
+
+    Returns ``{"sent": <bool>}`` reflecting whether the
+    frame made it onto the wire; ``sent=false`` is a
+    same-tick channel failure the caller should treat as
+    an error.
+    """
+    clean_pin = validate_pin_sha256(pin_sha256)
+    if not isinstance(job_id, str) or not job_id:
+        msg = "job_id must be a non-empty string"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    client = controller._lookup_open_peer_link_client(clean_pin, label="cancel_job")
+    try:
+        sent = await client.cancel_job(job_id=job_id)
+    except PeerLinkNoSessionError as exc:
+        raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
+    return {"sent": sent}

--- a/esphome_device_builder/controllers/remote_build/submit_job_commands.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job_commands.py
@@ -1,17 +1,13 @@
 """
 Offloader-side ``submit_job`` / ``download_artifacts`` / ``cancel_job`` WS commands.
 
-Top-half of the remote-build dispatch loop: the offloader
-packs the YAML config (and its referenced files) into a
-gzipped tarball via the ``esphome bundle`` CLI, streams it to
-the receiver behind a paired peer-link, and tracks the build's
-lifecycle / artifacts. Symmetric to the receiver-side
-:mod:`.submit_job` (which owns the bottom half — bundle
-unpack, compile, ack); the wire shapes meet in
-:mod:`.peer_link_client`.
+The offloader packs the YAML config (and its referenced
+files) into a gzipped tarball via the ``esphome bundle`` CLI,
+streams it to the receiver behind a paired peer-link, and
+tracks the build's lifecycle / artifacts.
 
-Bodies take :class:`OffloaderController` as the first arg; the
-controller keeps the three ``@api_command``-decorated WS
+Bodies take :class:`OffloaderController` as the first arg;
+the controller keeps the three ``@api_command``-decorated WS
 methods plus the two ``_validate`` / ``_build`` helpers as
 thin bound-method delegates so test call-sites and the WS
 dispatch resolve unchanged.
@@ -100,21 +96,12 @@ async def submit_job(
 ) -> dict[str, Any]:
     """Bundle *configuration* and dispatch a build to the receiver behind *pin_sha256*.
 
-    Offloader-side counterpart of :class:`SubmitJobReceiver`.
-    Packs the config + referenced files (includes, secrets,
-    fonts, images, …) into a gzipped tarball via the
-    ``esphome bundle`` CLI subprocess and streams it over
-    the existing peer-link session. Live job lifecycle +
-    output ride ``OFFLOADER_JOB_STATE_CHANGED`` /
+    Streams the gzipped tarball over the existing peer-link
+    session. Live job lifecycle + output ride
+    ``OFFLOADER_JOB_STATE_CHANGED`` /
     ``OFFLOADER_JOB_OUTPUT`` events on the
     ``subscribe_events`` stream; this call returns only the
     receiver's ``submit_job_ack``.
-
-    Subprocess instead of in-process because the CLI is the
-    stable upstream contract — in-process ``read_config``
-    would couple us to the ESPHome validation pipeline,
-    which shifts across releases. Bundle is rebuilt every
-    call so a YAML edit can't ship a stale cache.
 
     Returns ``{"job_id": <our id>, "accepted": <bool>,
     "reason": <str>}`` (``reason`` only on rejection).


### PR DESCRIPTION
# What does this implement/fix?

Extracts the offloader-side `submit_job` / `download_artifacts` / `cancel_job` WS command bodies plus the `_validate_submit_job_config` / `_build_submit_job_bundle` helpers into a new sibling module `controllers/remote_build/submit_job_commands.py`. Fifth PR in the OffloaderController split arc (after #766 + #772 + #774 + #775).

The three `@api_command`-decorated methods stay on the controller as bound delegates (WS dispatch requires the decorated method on the class); the two `_` helpers stay as bound delegates too because `submit_job` reaches into them via `self.` and tests instance-call them. Bodies take `OffloaderController` as the first arg.

The module name diverges from the receiver-side `submit_job.py` to avoid the collision flagged in `offloader_split.md`; receiver-side is the bottom half (bundle unpack + compile + ack), offloader-side is the top half (bundle + dispatch + artifact fetch + cancel).

## Imports

Moved out of `offloader.py`: `uuid4`, `validate_submit_job_target`, `download_artifacts_error_to_command_error`, `UnpackArtifactsError`, `unpack_artifacts_response`, `DownloadArtifactsError`, `PeerLinkNoSessionError`, `SubmitJobSessionLostError`, `SubmitJobTimeoutError`. Stays imported: `validate_pin_sha256`, `PeerLinkClientError`, `asyncio`, `Path` (delegate signatures + other paths).

## Test impact

Zero test changes. All bound delegates preserve the call sites in `tests/test_remote_build_peer_link_client.py` (`offloader.submit_job(...)`, `download_artifacts(...)`, `cancel_job(...)`).

`offloader.py`: **1143 → 1012 lines** (-131). Combined with #766 + #772 + #774 + #775: 1709 → 1012 (-697, **-41%**). 678 remote-build tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the OffloaderController split arc tracked in `offloader_split.md`. Remaining: pair commands, settings, bus-event handlers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
