### PR TITLE
Extract peer-link wire I/O helpers into wire_io.py

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
@@ -62,10 +62,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import WSMsgType, web
-from esphome.const import __version__ as esphome_version
 
 from ....api.ws import WEBSOCKETS_KEY
-from ....helpers import json as _json
 from ....helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
 from ....helpers.peer_link_identity import get_or_create_peer_link_identity
 from ....helpers.peer_link_noise import (
@@ -87,6 +85,15 @@ from ....models import (
 # that would also accidentally narrow ``import *`` semantics.
 from .wire import AppMessageType as AppMessageType
 from .wire import TerminateReason as TerminateReason
+from .wire_io import (
+    _normalize_label,
+    _parse_intent,
+    _parse_json,
+    _read_handshake_message,
+    _send_handshake_message,
+    _send_response,
+    _str_or_empty,
+)
 
 
 class _HandshakeStep(StrEnum):
@@ -137,21 +144,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 PEER_LINK_PATH = "/remote-build/peer-link"
-
-# Generous handshake timeout. Noise XX is three messages with one
-# DH each; latency is bounded by the LAN round-trip. 10s tolerates
-# a slow / loaded receiver; a peer that hasn't sent msg1 in 10s
-# isn't a real offloader.
-_HANDSHAKE_READ_TIMEOUT_SECONDS = 10.0
-
-# Cap msg3's offloader-supplied ``label`` before it lands in
-# settings + the event payload. Peer-supplied input over the wire
-# could be arbitrarily large within the WS frame limit; truncation
-# (rather than rejection) matches the "two-side flow, usually one
-# user" framing — a too-long label is cosmetic noise, not a reason
-# to fail pairing. 128 chars matches the cap the legacy token-label
-# path uses (``_TOKEN_LABEL_MAX`` in :mod:`controllers.remote_build`).
-_PEER_LABEL_MAX_CHARS = 128
 
 # Heartbeat cadence for the long-lived peer-link session. The
 # receiver sends an encrypted ``ping`` frame every 30s and expects
@@ -731,161 +723,7 @@ def _monotonic() -> float:
     return asyncio.get_running_loop().time()
 
 
-# ---------------------------------------------------------------------------
-# WS / Noise plumbing helpers
-# ---------------------------------------------------------------------------
-
-
-async def _read_handshake_message(
-    session: PeerLinkNoiseSession,
-    ws: web.WebSocketResponse,
-    step: _HandshakeStep,
-) -> bytes | None:
-    """Read one binary WS frame as a Noise handshake message; return payload or None on error."""
-    try:
-        msg = await asyncio.wait_for(ws.receive(), timeout=_HANDSHAKE_READ_TIMEOUT_SECONDS)
-    except TimeoutError:
-        _LOGGER.debug("peer-link timed out waiting for %s", step)
-        return None
-    if msg.type != WSMsgType.BINARY:
-        _LOGGER.debug(
-            "peer-link expected binary frame for %s; got %s",
-            step,
-            msg.type,
-        )
-        return None
-    try:
-        return session.read_handshake_message(msg.data)
-    except NOISE_ERRORS:
-        _LOGGER.warning("peer-link Noise %s read failed", step, exc_info=True)
-        return None
-
-
-async def _send_bytes_safely(
-    ws: web.WebSocketResponse,
-    encoded: bytes,
-    *,
-    log_label: str,
-) -> bool:
-    """
-    Write *encoded* to *ws* and return True on success.
-
-    Any send-side failure — peer hung up
-    (``ConnectionResetError``), aiohttp/WS-state error, OS-level
-    socket error — is debug-logged and surfaces as a False
-    return so the caller can short-circuit the rest of the
-    handshake / response sequence. Disconnects are normal-
-    operation events on flaky LANs; ``api/ws.py`` similarly
-    treats ``ConnectionResetError`` on send as not worth a
-    traceback.
-    """
-    try:
-        await ws.send_bytes(encoded)
-    except Exception:
-        _LOGGER.debug("peer-link send %s failed", log_label, exc_info=True)
-        return False
-    return True
-
-
-async def _send_handshake_message(
-    session: PeerLinkNoiseSession,
-    ws: web.WebSocketResponse,
-    payload: bytes,
-    step: _HandshakeStep,
-) -> bool:
-    """Send one Noise handshake message as a binary WS frame; return True on success."""
-    try:
-        encoded = session.write_handshake_message(payload)
-    except NOISE_ERRORS:
-        _LOGGER.warning("peer-link Noise %s write failed", step, exc_info=True)
-        return False
-    return await _send_bytes_safely(ws, encoded, log_label=str(step))
-
-
-async def _send_response(
-    session: PeerLinkNoiseSession,
-    ws: web.WebSocketResponse,
-    response: IntentResponse,
-) -> None:
-    """Send the post-handshake intent_response as a single ChaCha20-Poly1305 frame.
-
-    The payload carries the response discriminator
-    (``intent_response``) plus the receiver's
-    :data:`esphome.const.__version__` (``esphome_version``).
-    Both halves run the same shared field on every intent so a
-    caller that opens any flow — preview / pair_request /
-    pair_status / peer_link — gets the receiver's version
-    alongside the discriminator. Offloader-side consumption
-    centres on the long-lived ``peer_link`` session, where the
-    captured value lands on :attr:`StoredPairing.esphome_version`
-    and refreshes on every reconnect so a receiver upgrade
-    surfaces in pick_build_path's version-compat gate on the
-    next session-open without operator action.
-    """
-    body = _json.dumps({"intent_response": response.value, "esphome_version": esphome_version})
-    try:
-        encrypted = session.encrypt(body)
-    except NOISE_ERRORS:
-        _LOGGER.warning("peer-link transport encrypt failed", exc_info=True)
-        return
-    await _send_bytes_safely(ws, encrypted, log_label="response")
-
-
-def _parse_intent(payload: bytes) -> PeerLinkIntent | None:
-    """
-    Pull the ``intent`` field out of the cleartext msg1 payload.
-
-    Returns the parsed :class:`PeerLinkIntent` member or ``None``
-    when the payload doesn't carry a recognised intent (missing
-    field, non-string, unknown wire value, malformed JSON). The
-    caller maps ``None`` to ``IntentResponse.REJECTED`` and
-    closes the WS after completing the handshake (so the
-    rejection arrives in an authenticated transport frame).
-    """
-    parsed = _parse_json(payload)
-    if not isinstance(parsed, dict):
-        return None
-    raw = parsed.get("intent")
-    if not isinstance(raw, str):
-        return None
-    try:
-        return PeerLinkIntent(raw)
-    except ValueError:
-        return None
-
-
-def _parse_json(payload: bytes) -> Any | None:
-    """Decode a JSON payload, returning ``None`` on any decode failure."""
-    if not payload:
-        return None
-    try:
-        return _json.loads(payload)
-    except _json.JSONDecodeError:
-        return None
-
-
-def _str_or_empty(value: object) -> str:
-    """Return the string value or empty when not a string."""
-    return value if isinstance(value, str) else ""
-
-
-def _normalize_label(value: object) -> str:
-    """
-    Normalise an msg3-supplied ``label`` to a stripped, length-bounded form.
-
-    Peer-supplied input lands on disk + on the event bus; an
-    unbounded label would let a misbehaving offloader push
-    multi-megabyte strings into ``.device-builder.json`` and
-    every receiver-UI subscriber. Strip whitespace and truncate
-    at :data:`_PEER_LABEL_MAX_CHARS`; non-string / missing
-    values fall through to ``""`` so the receiver UI just shows
-    no label rather than failing the pairing.
-    """
-    raw = _str_or_empty(value).strip()
-    return raw[:_PEER_LABEL_MAX_CHARS]
-
-
-# Re-export at the bottom: ``channel.py``'s lazy imports look up
-# ``_send_bytes_safely`` / ``parse_app_frame`` as package attributes,
-# so the channel module must load after they're defined above.
+# Re-export at the bottom: ``channel.py``'s lazy import looks up
+# ``parse_app_frame`` as a package attribute, so the channel module
+# must load after it's defined above.
 from .channel import PeerLinkChannel as PeerLinkChannel  # noqa: E402

--- a/esphome_device_builder/controllers/remote_build/peer_link/channel.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/channel.py
@@ -22,6 +22,7 @@ import aiohttp
 from ....helpers import json as _json
 from ....helpers.peer_link_noise import NOISE_ERRORS, PeerLinkNoiseSession
 from .wire import AppMessageType
+from .wire_io import _send_bytes_safely
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,11 +58,6 @@ class PeerLinkChannel:
         — the Noise cipher state is not safe to share across
         concurrent encrypts.
         """
-        # Lazy import: ``_send_bytes_safely`` lives in the parent
-        # package's ``__init__.py``, which imports this module — a
-        # top-level import here would deadlock the load.
-        from . import _send_bytes_safely  # noqa: PLC0415
-
         try:
             plaintext = _json.dumps(payload)
         except (TypeError, ValueError):

--- a/esphome_device_builder/controllers/remote_build/peer_link/wire_io.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/wire_io.py
@@ -1,0 +1,189 @@
+"""Peer-link low-level WS / Noise plumbing helpers.
+
+Handshake-message read / write, intent-response send, JSON /
+intent parsing, and label normalisation. Pure leaf helpers
+consumed by the handshake driver, the channel, and the session
+loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aiohttp import WSMsgType, web
+from esphome.const import __version__ as esphome_version
+
+from ....helpers import json as _json
+from ....helpers.peer_link_noise import NOISE_ERRORS, PeerLinkNoiseSession
+from ....models import IntentResponse, PeerLinkIntent
+
+if TYPE_CHECKING:
+    from . import _HandshakeStep
+
+_LOGGER = logging.getLogger(__name__)
+
+# Generous handshake timeout. Noise XX is three messages with one
+# DH each; latency is bounded by the LAN round-trip. 10s tolerates
+# a slow / loaded receiver; a peer that hasn't sent msg1 in 10s
+# isn't a real offloader.
+_HANDSHAKE_READ_TIMEOUT_SECONDS = 10.0
+
+# Cap msg3's offloader-supplied ``label`` before it lands in
+# settings + the event payload. Peer-supplied input over the wire
+# could be arbitrarily large within the WS frame limit; truncation
+# (rather than rejection) matches the "two-side flow, usually one
+# user" framing — a too-long label is cosmetic noise, not a reason
+# to fail pairing. 128 chars matches the cap the legacy token-label
+# path uses (``_TOKEN_LABEL_MAX`` in :mod:`controllers.remote_build`).
+_PEER_LABEL_MAX_CHARS = 128
+
+
+async def _read_handshake_message(
+    session: PeerLinkNoiseSession,
+    ws: web.WebSocketResponse,
+    step: _HandshakeStep,
+) -> bytes | None:
+    """Read one binary WS frame as a Noise handshake message; return payload or None on error."""
+    try:
+        msg = await asyncio.wait_for(ws.receive(), timeout=_HANDSHAKE_READ_TIMEOUT_SECONDS)
+    except TimeoutError:
+        _LOGGER.debug("peer-link timed out waiting for %s", step)
+        return None
+    if msg.type != WSMsgType.BINARY:
+        _LOGGER.debug(
+            "peer-link expected binary frame for %s; got %s",
+            step,
+            msg.type,
+        )
+        return None
+    try:
+        return session.read_handshake_message(msg.data)
+    except NOISE_ERRORS:
+        _LOGGER.warning("peer-link Noise %s read failed", step, exc_info=True)
+        return None
+
+
+async def _send_bytes_safely(
+    ws: web.WebSocketResponse,
+    encoded: bytes,
+    *,
+    log_label: str,
+) -> bool:
+    """
+    Write *encoded* to *ws* and return True on success.
+
+    Any send-side failure — peer hung up
+    (``ConnectionResetError``), aiohttp/WS-state error, OS-level
+    socket error — is debug-logged and surfaces as a False
+    return so the caller can short-circuit the rest of the
+    handshake / response sequence. Disconnects are normal-
+    operation events on flaky LANs; ``api/ws.py`` similarly
+    treats ``ConnectionResetError`` on send as not worth a
+    traceback.
+    """
+    try:
+        await ws.send_bytes(encoded)
+    except Exception:
+        _LOGGER.debug("peer-link send %s failed", log_label, exc_info=True)
+        return False
+    return True
+
+
+async def _send_handshake_message(
+    session: PeerLinkNoiseSession,
+    ws: web.WebSocketResponse,
+    payload: bytes,
+    step: _HandshakeStep,
+) -> bool:
+    """Send one Noise handshake message as a binary WS frame; return True on success."""
+    try:
+        encoded = session.write_handshake_message(payload)
+    except NOISE_ERRORS:
+        _LOGGER.warning("peer-link Noise %s write failed", step, exc_info=True)
+        return False
+    return await _send_bytes_safely(ws, encoded, log_label=str(step))
+
+
+async def _send_response(
+    session: PeerLinkNoiseSession,
+    ws: web.WebSocketResponse,
+    response: IntentResponse,
+) -> None:
+    """Send the post-handshake intent_response as a single ChaCha20-Poly1305 frame.
+
+    The payload carries the response discriminator
+    (``intent_response``) plus the receiver's
+    :data:`esphome.const.__version__` (``esphome_version``).
+    Both halves run the same shared field on every intent so a
+    caller that opens any flow — preview / pair_request /
+    pair_status / peer_link — gets the receiver's version
+    alongside the discriminator. Offloader-side consumption
+    centres on the long-lived ``peer_link`` session, where the
+    captured value lands on :attr:`StoredPairing.esphome_version`
+    and refreshes on every reconnect so a receiver upgrade
+    surfaces in pick_build_path's version-compat gate on the
+    next session-open without operator action.
+    """
+    body = _json.dumps({"intent_response": response.value, "esphome_version": esphome_version})
+    try:
+        encrypted = session.encrypt(body)
+    except NOISE_ERRORS:
+        _LOGGER.warning("peer-link transport encrypt failed", exc_info=True)
+        return
+    await _send_bytes_safely(ws, encrypted, log_label="response")
+
+
+def _parse_intent(payload: bytes) -> PeerLinkIntent | None:
+    """
+    Pull the ``intent`` field out of the cleartext msg1 payload.
+
+    Returns the parsed :class:`PeerLinkIntent` member or ``None``
+    when the payload doesn't carry a recognised intent (missing
+    field, non-string, unknown wire value, malformed JSON). The
+    caller maps ``None`` to ``IntentResponse.REJECTED`` and
+    closes the WS after completing the handshake (so the
+    rejection arrives in an authenticated transport frame).
+    """
+    parsed = _parse_json(payload)
+    if not isinstance(parsed, dict):
+        return None
+    raw = parsed.get("intent")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return PeerLinkIntent(raw)
+    except ValueError:
+        return None
+
+
+def _parse_json(payload: bytes) -> Any | None:
+    """Decode a JSON payload, returning ``None`` on any decode failure."""
+    if not payload:
+        return None
+    try:
+        return _json.loads(payload)
+    except _json.JSONDecodeError:
+        return None
+
+
+def _str_or_empty(value: object) -> str:
+    """Return the string value or empty when not a string."""
+    return value if isinstance(value, str) else ""
+
+
+def _normalize_label(value: object) -> str:
+    """
+    Normalise an msg3-supplied ``label`` to a stripped, length-bounded form.
+
+    Peer-supplied input lands on disk + on the event bus; an
+    unbounded label would let a misbehaving offloader push
+    multi-megabyte strings into ``.device-builder.json`` and
+    every receiver-UI subscriber. Strip whitespace and truncate
+    at :data:`_PEER_LABEL_MAX_CHARS`; non-string / missing
+    values fall through to ``""`` so the receiver UI just shows
+    no label rather than failing the pairing.
+    """
+    raw = _str_or_empty(value).strip()
+    return raw[:_PEER_LABEL_MAX_CHARS]

--- a/esphome_device_builder/controllers/remote_build/peer_link/wire_io.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/wire_io.py
@@ -1,4 +1,5 @@
-"""Peer-link low-level WS / Noise plumbing helpers.
+"""
+Peer-link low-level WS / Noise plumbing helpers.
 
 Handshake-message read / write, intent-response send, JSON /
 intent parsing, and label normalisation. Pure leaf helpers

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/one_shot.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/one_shot.py
@@ -59,8 +59,8 @@ _RESPONSE_DECODE_ERRORS: tuple[type[Exception], ...] = (
 
 
 # 10s matches the receiver-side per-step timeout in
-# ``peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS`` so we don't give
-# up before the receiver does, but doesn't pin a coroutine forever.
+# ``peer_link.wire_io._HANDSHAKE_READ_TIMEOUT_SECONDS`` so we don't
+# give up before the receiver does, but doesn't pin a coroutine forever.
 _DEFAULT_TIMEOUT_SECONDS = 10.0
 
 

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -45,7 +45,6 @@ from esphome_device_builder.controllers.remote_build import (
 )
 from esphome_device_builder.controllers.remote_build.job_fanout import JobFanout
 from esphome_device_builder.controllers.remote_build.peer_link import (
-    _PEER_LABEL_MAX_CHARS,
     APP_FRAME_MAX_BYTES,
     PEER_LINK_PATH,
     PeerLinkChannel,
@@ -55,15 +54,18 @@ from esphome_device_builder.controllers.remote_build.peer_link import (
     _DispatchInput,
     _drive_peer_link_session,
     _HandshakeStep,
+    _receive_loop,
+    make_peer_link_handler,
+)
+from esphome_device_builder.controllers.remote_build.peer_link.wire_io import (
+    _PEER_LABEL_MAX_CHARS,
     _normalize_label,
     _parse_intent,
     _parse_json,
     _read_handshake_message,
-    _receive_loop,
     _send_bytes_safely,
     _send_handshake_message,
     _send_response,
-    make_peer_link_handler,
 )
 from esphome_device_builder.controllers.remote_build.submit_job import (
     SubmitJobReceiver,
@@ -380,7 +382,7 @@ async def test_read_handshake_message_timeout_returns_none(
 ) -> None:
     """A peer that opens TCP but never sends msg1 falls through the timeout branch."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
+        "esphome_device_builder.controllers.remote_build.peer_link.wire_io._HANDSHAKE_READ_TIMEOUT_SECONDS",
         0.01,
     )
     session = PeerLinkNoiseSession.responder(secrets.token_bytes(32))
@@ -502,7 +504,7 @@ async def test_drive_session_msg1_timeout_returns_quietly(
 ) -> None:
     """A peer that never sends msg1 closes the WS without dispatching anything."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
+        "esphome_device_builder.controllers.remote_build.peer_link.wire_io._HANDSHAKE_READ_TIMEOUT_SECONDS",
         0.01,
     )
     controller = MagicMock(spec=ReceiverController)
@@ -628,7 +630,7 @@ async def test_drive_session_unknown_intent_msg3_read_failure(
 ) -> None:
     """Unknown intent + peer disconnects before msg3 closes without a response frame."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
+        "esphome_device_builder.controllers.remote_build.peer_link.wire_io._HANDSHAKE_READ_TIMEOUT_SECONDS",
         0.01,
     )
     controller = MagicMock(spec=ReceiverController)
@@ -677,7 +679,7 @@ async def test_drive_session_happy_path_msg3_read_failure(
 ) -> None:
     """Known intent + msg2 sends + msg3 read times out → driver bails before dispatch."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS",
+        "esphome_device_builder.controllers.remote_build.peer_link.wire_io._HANDSHAKE_READ_TIMEOUT_SECONDS",
         0.01,
     )
     controller = MagicMock(spec=ReceiverController)


### PR DESCRIPTION
# What does this implement/fix?

Fourth PR in the `peer_link` split arc (follows #769 package conversion + #770 wire enums + #773 channel; plan: `peer_link_split.md`). Moves the WS / Noise plumbing helpers + their two constants byte-for-byte from `peer_link/__init__.py` into a new `peer_link/wire_io.py` submodule.

**Moved:**

* Constants: `_HANDSHAKE_READ_TIMEOUT_SECONDS`, `_PEER_LABEL_MAX_CHARS`
* WS / Noise frame I/O: `_read_handshake_message`, `_send_bytes_safely`, `_send_handshake_message`, `_send_response`
* Payload-content helpers: `_parse_intent`, `_parse_json`, `_str_or_empty`, `_normalize_label`

**`channel.py`'s lazy `from . import _send_bytes_safely` becomes a clean module-level `from .wire_io import _send_bytes_safely`** now that the target sibling exists — the placeholder is gone. `__init__.py` drops the unused `esphome_version` + `_json` top-level imports (both were only used by `_send_response`, now in `wire_io`).

**Test redirects** (the MEDIUM-risk part of this PR):

* Four `monkeypatch.setattr` sites against `peer_link._HANDSHAKE_READ_TIMEOUT_SECONDS` redirect to `peer_link.wire_io._HANDSHAKE_READ_TIMEOUT_SECONDS` — patching the package-level re-export wouldn't reach `wire_io`'s internal lookup.
* Test imports of `_PEER_LABEL_MAX_CHARS` / `_normalize_label` / `_parse_intent` / `_parse_json` / `_read_handshake_message` / `_send_bytes_safely` / `_send_handshake_message` / `_send_response` redirect to the new submodule.
* Docstring-pointer comment in `peer_link_client/one_shot.py` follows too.

* **`__init__.py`**: 893 → 729 lines (−164).
* **`wire_io.py`** (new): 189 lines.

Subsequent PRs in the arc:

* `handshake.py` — handshake driver + private types (~180 lines)
* `session.py` — `PeerLinkSession` + receive loop + heartbeat (~330 lines)

All 3389 non-e2e tests pass; ruff + mypy clean.

**Related issue or feature (if applicable):**

- follow-up to #769 + #770 + #773; fourth PR of the peer_link split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
