### PR TITLE
Split OffloaderController: extract pair commands

### DIFF
--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from zeroconf import ServiceStateChange
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
-from ...helpers.api import CommandError, api_command
+from ...helpers.api import api_command
 from ...helpers.build_scheduler import BuildSchedulerInputs
 from ...helpers.dashboard_identity import get_or_create_identity
 from ...helpers.event_bus import Event
@@ -37,13 +37,10 @@ from ...helpers.peer_link_resolver import PeerLinkDNSResolver, make_peer_link_re
 from ...helpers.storage import Store
 from ...models import (
     PAIRING_VERSION_MAX_LEN,
-    ErrorCode,
     EventType,
-    IntentResponse,
     OffloaderAlertSnapshotEntry,
     OffloaderJobStateChangedData,
     OffloaderPairAlertDismissedData,
-    OffloaderPairingEnabledChangedData,
     OffloaderPairPinMismatchData,
     OffloaderPeerLinkClosedData,
     OffloaderPeerLinkOpenedData,
@@ -59,13 +56,15 @@ from ...models import (
     RemoteBuildPeer,
     StoredPairing,
 )
-from . import discovery, pair_status, peer_link_lifecycle, rebind, submit_job_commands
-from ._mdns import endpoints_equal
-from ._models import (
-    EDIT_PAIRING_PROBE_ERRORS,
-    RebindProbeOutcome,
-    RebindProbeResult,
+from . import (
+    discovery,
+    pair_commands,
+    pair_status,
+    peer_link_lifecycle,
+    rebind,
+    submit_job_commands,
 )
+from ._models import RebindProbeResult
 from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
     OFFLOADER_PAIRINGS_FILE,
@@ -73,27 +72,8 @@ from ._storage_codecs import (
     encode_pairings,
 )
 from ._summaries import pairing_summary
-from ._validators import (
-    HostFieldContext,
-    PairLabelField,
-    enforce_pin_match,
-    intent_response_to_command_error,
-    validate_bool,
-    validate_hostname,
-    validate_pair_label,
-    validate_pin_sha256,
-    validate_port,
-)
-from .peer_link_client import (
-    PairStatusResult,
-    PeerLinkClientError,
-)
-from .peer_link_client import (
-    preview_pair as peer_link_preview_pair,
-)
-from .peer_link_client import (
-    request_pair as peer_link_request_pair,
-)
+from ._validators import validate_bool
+from .peer_link_client import PairStatusResult
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -542,73 +522,13 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         enabled: bool,
         **kwargs: Any,
     ) -> PairingSummary:
-        """
-        Flip the per-pairing enable switch for transparent install.
-
-        Distinct from ``unpair`` — the row stays in
-        ``_pairings``, peer-link client keeps its session open,
-        the manual-dispatch surface still works. Disables only
-        the auto-routing in ``pick_build_path``.
-
-        Unknown pin raises ``NOT_FOUND``. Fires
-        ``OFFLOADER_PAIRING_ENABLED_CHANGED`` for cross-tab
-        sync and debounce-saves the pairings store.
-        """
-        clean_pin = validate_pin_sha256(pin_sha256)
-        clean_enabled = validate_bool(
-            enabled, command="remote_build/set_pairing_enabled", field="enabled"
-        )
-        pairing = self._pairings.get(clean_pin)
-        if pairing is None:
-            msg = f"remote_build/set_pairing_enabled: no pairing for pin_sha256={clean_pin!r}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-        pairing.enabled = clean_enabled
-        payload: OffloaderPairingEnabledChangedData = {
-            "pin_sha256": clean_pin,
-            "enabled": clean_enabled,
-        }
-        self._db.bus.fire(EventType.OFFLOADER_PAIRING_ENABLED_CHANGED, payload)
-        self._schedule_pairings_save()
-        return self._pairing_summary_for(pairing)
-
-    # ------------------------------------------------------------------
-    # Offloader-side pair flow — initiator commands that open Noise XX
-    # WebSockets to a receiver's peer-link endpoint. The
-    # wire-shape driver lives in
-    # :mod:`controllers.remote_build_peer_link_client`; the WS command
-    # here owns input validation, identity loading, and error mapping.
-    # ------------------------------------------------------------------
+        """Flip the per-pairing enable switch for transparent install."""
+        return await pair_commands.set_pairing_enabled(self, pin_sha256=pin_sha256, enabled=enabled)
 
     @api_command("remote_build/preview_pair")
     async def preview_pair(self, *, hostname: str, port: int, **kwargs: Any) -> dict[str, str]:
-        """Open a brief Noise XX WS to *hostname*:*port* and return the receiver's pin.
-
-        ``intent="preview"`` captures the receiver's static
-        X25519 pubkey from the handshake transcript. The
-        frontend renders the returned ``pin_sha256`` for the
-        user to OOB-verify against the receiver's "Build
-        server" Settings card before calling ``request_pair``.
-
-        Returns ``{"pin_sha256": "<lowercase-hex-64>"}``.
-        """
-        clean_host = validate_hostname(hostname, context=HostFieldContext.RECEIVER)
-        clean_port = validate_port(port, context=HostFieldContext.RECEIVER)
-        loop = asyncio.get_running_loop()
-        identity = await loop.run_in_executor(
-            None,
-            get_or_create_peer_link_identity,
-            self._db.settings.config_dir,
-        )
-        try:
-            pin = await peer_link_preview_pair(
-                hostname=clean_host,
-                port=clean_port,
-                identity_priv=identity.private_bytes,
-                resolver=self._peer_link_resolver,
-            )
-        except PeerLinkClientError as exc:
-            raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
-        return {"pin_sha256": pin}
+        """Open a brief Noise XX WS to *hostname*:*port* and return the receiver's pin."""
+        return await pair_commands.preview_pair(self, hostname=hostname, port=port)
 
     @api_command("remote_build/request_pair")
     async def request_pair(
@@ -621,91 +541,15 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         offloader_label: str,
         **kwargs: Any,
     ) -> PairingSummary:
-        """Open a Noise XX WS, send ``intent="pair_request"``, persist a local row.
-
-        The second handshake with a receiver, after the user
-        OOB-confirmed the receiver's pin via :meth:`preview_pair`.
-        Sends ``{"label": offloader_label, "dashboard_id":
-        <ours>}`` in the encrypted msg3; the receiver's response
-        decides what state the local :class:`StoredPairing` row
-        lands in.
-
-        Two labels: *receiver_label* is the offloader-side
-        display name (stored locally, never sent); *offloader_label*
-        is the offloader's self-identification sent to the
-        receiver so its Pairing requests inbox shows a friendly
-        name.
-
-        TOCTOU defense: the *pin_sha256* arg is compared against
-        the receiver's actual pubkey from the live handshake; a
-        mismatch (rotation or MITM) returns
-        ``PRECONDITION_FAILED`` and persists nothing.
-
-        Only APPROVED rows reach disk. PENDING lives in-memory
-        for the offloader process's lifetime; a restart drops
-        them and the user re-runs ``request_pair``.
-        """
-        clean_host = validate_hostname(hostname, context=HostFieldContext.RECEIVER)
-        clean_port = validate_port(port, context=HostFieldContext.RECEIVER)
-        clean_pin = validate_pin_sha256(pin_sha256)
-        clean_receiver_label = validate_pair_label(
-            receiver_label, field=PairLabelField.RECEIVER_LABEL
+        """Open a Noise XX WS, send ``intent="pair_request"``, persist a local row."""
+        return await pair_commands.request_pair(
+            self,
+            hostname=hostname,
+            port=port,
+            pin_sha256=pin_sha256,
+            receiver_label=receiver_label,
+            offloader_label=offloader_label,
         )
-        clean_offloader_label = validate_pair_label(
-            offloader_label, field=PairLabelField.OFFLOADER_LABEL
-        )
-        peer_link_identity, dashboard_identity = await self._load_offloader_identities_async()
-
-        try:
-            result = await peer_link_request_pair(
-                hostname=clean_host,
-                port=clean_port,
-                identity_priv=peer_link_identity.private_bytes,
-                label=clean_offloader_label,
-                dashboard_id=dashboard_identity.dashboard_id,
-                resolver=self._peer_link_resolver,
-            )
-        except PeerLinkClientError as exc:
-            raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
-
-        enforce_pin_match(expected=clean_pin, observed=result.pin_sha256)
-        if (err := intent_response_to_command_error(result.status)) is not None:
-            raise err
-        if result.status not in (IntentResponse.PENDING, IntentResponse.APPROVED):
-            msg = f"unexpected receiver intent_response={result.status.value!r}"
-            raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
-
-        # APPROVED here means the receiver short-circuited the
-        # inbox dance (re-pair against a still-APPROVED row).
-        target_status = (
-            PeerStatus.APPROVED if result.status is IntentResponse.APPROVED else PeerStatus.PENDING
-        )
-        pairing = StoredPairing(
-            receiver_hostname=clean_host,
-            receiver_port=clean_port,
-            pin_sha256=result.pin_sha256,
-            static_x25519_pub=result.remote_static_pub,
-            label=clean_receiver_label,
-            paired_at=time.time(),
-            status=target_status,
-        )
-        key = result.pin_sha256
-        # Sweep any stale entry at the same endpoint under a
-        # different pin (rotation, or a different receiver took
-        # the hostname) so the old row's listener + alert don't
-        # orphan under pin-keying.
-        self._sweep_stale_pairings_at_endpoint(clean_host, clean_port, keep_pin_sha256=key)
-        # Cancel any prior listener for the same pin — its
-        # closure captured the old pairing reference.
-        self._pairings[key] = pairing
-        self._cancel_pair_status_listener(key)
-        self._dismiss_offloader_alert(key, clean_host, clean_port)
-        if target_status is PeerStatus.APPROVED:
-            self._schedule_pairings_save()
-            self._spawn_peer_link_client(pairing)
-            return self._pairing_summary_for(pairing)
-        self._spawn_pair_status_listener(pairing)
-        return self._pairing_summary_for(pairing)
 
     @api_command("remote_build/unpair")
     async def unpair(
@@ -714,43 +558,8 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         pin_sha256: str,
         **kwargs: Any,
     ) -> dict[str, bool]:
-        """Drop the local :class:`StoredPairing` row keyed on *pin_sha256*.
-
-        Idempotent — returns ``{"removed": False}`` rather than
-        raising on a missing row so the frontend's Unpair button
-        always succeeds visually.
-
-        Receiver-side state is **not** notified; the receiver's
-        :class:`StoredPeer` row sticks until the receiver's admin
-        clicks Remove. The next ``peer_link`` from this offloader
-        returns ``REJECTED`` because our local row is gone.
-
-        In-flight pair-status / peer-link tasks for this pin are
-        cancelled before mutating the dict so their open Noise WS
-        closes promptly.
-        """
-        key = validate_pin_sha256(pin_sha256)
-
-        # Cancel before mutating the dict so open Noise WSs close
-        # promptly. Idempotent on absent keys.
-        self._cancel_pair_status_listener(key)
-        self._cancel_peer_link_client(key)
-        previous = self._pairings.pop(key, None)
-        if previous is None:
-            return {"removed": False}
-        self._schedule_pairings_save()
-        self._fire_offloader_pair_status_changed(
-            previous.receiver_hostname, previous.receiver_port, key, "removed"
-        )
-        self._dismiss_offloader_alert(key, previous.receiver_hostname, previous.receiver_port)
-        # Drop derived per-peer caches so the snapshot doesn't
-        # surface stale data for a row the user just removed.
-        self._peer_queue_status.pop(key, None)
-        for job_id, entry in list(self._offloader_remote_jobs.items()):
-            if entry["pin_sha256"] == key:
-                self._offloader_remote_jobs.pop(job_id, None)
-        self._open_peer_links.discard(key)
-        return {"removed": True}
+        """Drop the local :class:`StoredPairing` row keyed on *pin_sha256*."""
+        return await pair_commands.unpair(self, pin_sha256=pin_sha256)
 
     @api_command("remote_build/edit_pairing_endpoint")
     async def edit_pairing_endpoint(
@@ -761,64 +570,10 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         port: int,
         **kwargs: Any,
     ) -> PairingSummary:
-        """Manually rebind *pin_sha256*'s pairing onto new (*hostname*, *port*) coords.
-
-        User-driven analog of the mDNS auto-rebind, for cases
-        the auto path can't catch: cross-subnet receivers, mDNS
-        disabled, receiver moved to a non-broadcast hostname.
-
-        Same trust model: a one-shot ``preview_pair`` probe
-        verifies the new endpoint answers with the same pin
-        :class:`StoredPairing` was paired against. Pin mismatch
-        deliberately doesn't fall through — accepting a new
-        identity under the user's existing trust is what the
-        re-auth wizard exists for.
-
-        Returns the updated :class:`PairingSummary`;
-        ``connected`` typically reads ``False`` because the
-        respawned :class:`PeerLinkClient` is still handshaking
-        when this method returns.
-        """
-        pin = validate_pin_sha256(pin_sha256)
-        clean_host = validate_hostname(hostname, context=HostFieldContext.RECEIVER)
-        clean_port = validate_port(port, context=HostFieldContext.RECEIVER)
-
-        pairing = self._pairings.get(pin)
-        if pairing is None:
-            msg = f"edit_pairing_endpoint: no pairing for pin_sha256={pin!r}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-        if pairing.status is not PeerStatus.APPROVED:
-            msg = f"edit_pairing_endpoint: pairing status is {pairing.status.value!r}, not APPROVED"
-            raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
-        # System-readiness before user-input semantics: surface
-        # "identity not loaded yet" distinctly rather than a
-        # confusing "matches current" on a startup race.
-        if self._offloader_peer_link_priv is None:
-            msg = "edit_pairing_endpoint: offloader peer-link identity not loaded yet"
-            raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
-        if endpoints_equal(
-            pairing.receiver_hostname, pairing.receiver_port, clean_host, clean_port
-        ):
-            msg = f"edit_pairing_endpoint: new endpoint matches current ({clean_host}:{clean_port})"
-            raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
-
-        result = await self._probe_pairing_endpoint(
-            pairing=pairing, new_hostname=clean_host, new_port=clean_port
+        """Manually rebind *pin_sha256*'s pairing onto new (*hostname*, *port*) coords."""
+        return await pair_commands.edit_pairing_endpoint(
+            self, pin_sha256=pin_sha256, hostname=hostname, port=port
         )
-        if result.outcome is not RebindProbeOutcome.OK:
-            code, template = EDIT_PAIRING_PROBE_ERRORS[result.outcome]
-            raise CommandError(
-                code,
-                template.format(
-                    host=clean_host,
-                    port=clean_port,
-                    pin=pin,
-                    observed=result.observed_pin,
-                    error=result.transport_error,
-                ),
-            )
-        self._commit_endpoint_rebind(pairing, hostname=clean_host, port=clean_port)
-        return self._pairing_summary_for(pairing)
 
     async def _validate_submit_job_config(self, configuration: object) -> tuple[str, Path]:
         """Validate the WS *configuration* arg, return ``(name, yaml_path)``."""

--- a/esphome_device_builder/controllers/remote_build/pair_commands.py
+++ b/esphome_device_builder/controllers/remote_build/pair_commands.py
@@ -94,7 +94,8 @@ async def set_pairing_enabled(
 async def preview_pair(
     controller: OffloaderController, *, hostname: str, port: int
 ) -> dict[str, str]:
-    """Open a brief Noise XX WS to *hostname*:*port* and return the receiver's pin.
+    """
+    Open a brief Noise XX WS to *hostname*:*port* and return the receiver's pin.
 
     ``intent="preview"`` captures the receiver's static
     X25519 pubkey from the handshake transcript. The
@@ -133,7 +134,8 @@ async def request_pair(
     receiver_label: str,
     offloader_label: str,
 ) -> PairingSummary:
-    """Open a Noise XX WS, send ``intent="pair_request"``, persist a local row.
+    """
+    Open a Noise XX WS, send ``intent="pair_request"``, persist a local row.
 
     Sends ``{"label": offloader_label, "dashboard_id":
     <ours>}`` in the encrypted msg3; the receiver's response
@@ -217,7 +219,8 @@ async def request_pair(
 
 
 async def unpair(controller: OffloaderController, *, pin_sha256: str) -> dict[str, bool]:
-    """Drop the local :class:`StoredPairing` row keyed on *pin_sha256*.
+    """
+    Drop the local :class:`StoredPairing` row keyed on *pin_sha256*.
 
     Idempotent — returns ``{"removed": False}`` rather than
     raising on a missing row so the frontend's Unpair button
@@ -263,7 +266,8 @@ async def edit_pairing_endpoint(
     hostname: str,
     port: int,
 ) -> PairingSummary:
-    """Manually rebind *pin_sha256*'s pairing onto new (*hostname*, *port*) coords.
+    """
+    Manually rebind *pin_sha256*'s pairing onto new (*hostname*, *port*) coords.
 
     For cases the auto path can't catch: cross-subnet
     receivers, mDNS disabled, receiver moved to a

--- a/esphome_device_builder/controllers/remote_build/pair_commands.py
+++ b/esphome_device_builder/controllers/remote_build/pair_commands.py
@@ -1,0 +1,321 @@
+"""
+Offloader-side pair-flow WS commands.
+
+Initiator commands that open Noise XX WebSockets to a
+receiver's peer-link endpoint:
+
+- ``preview_pair`` — read-only handshake to capture the
+  receiver's pin for OOB verification.
+- ``request_pair`` — handshake + ``intent="pair_request"``
+  + persist a local :class:`StoredPairing` row.
+- ``unpair`` — drop the local row + tear down listeners.
+- ``edit_pairing_endpoint`` — user-driven analog of the
+  mDNS auto-rebind for receivers the auto path can't catch.
+- ``set_pairing_enabled`` — flip the per-pairing
+  auto-routing toggle without unpairing.
+
+Bodies take :class:`OffloaderController` as the first arg;
+the controller keeps the five ``@api_command``-decorated WS
+methods as thin bound-method delegates so test call-sites
+and the WS dispatch resolve unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...helpers.peer_link_identity import get_or_create_peer_link_identity
+from ...models import (
+    ErrorCode,
+    EventType,
+    IntentResponse,
+    OffloaderPairingEnabledChangedData,
+    PairingSummary,
+    PeerStatus,
+    StoredPairing,
+)
+from ._mdns import endpoints_equal
+from ._models import EDIT_PAIRING_PROBE_ERRORS, RebindProbeOutcome
+from ._validators import (
+    HostFieldContext,
+    PairLabelField,
+    enforce_pin_match,
+    intent_response_to_command_error,
+    validate_bool,
+    validate_hostname,
+    validate_pair_label,
+    validate_pin_sha256,
+    validate_port,
+)
+from .peer_link_client import PeerLinkClientError
+from .peer_link_client import preview_pair as peer_link_preview_pair
+from .peer_link_client import request_pair as peer_link_request_pair
+
+if TYPE_CHECKING:
+    from .offloader import OffloaderController
+
+
+async def set_pairing_enabled(
+    controller: OffloaderController, *, pin_sha256: str, enabled: bool
+) -> PairingSummary:
+    """
+    Flip the per-pairing enable switch for transparent install.
+
+    Distinct from ``unpair`` — the row stays in
+    ``_pairings``, peer-link client keeps its session open,
+    the manual-dispatch surface still works. Disables only
+    the auto-routing in ``pick_build_path``.
+
+    Unknown pin raises ``NOT_FOUND``. Fires
+    ``OFFLOADER_PAIRING_ENABLED_CHANGED`` for cross-tab
+    sync and debounce-saves the pairings store.
+    """
+    clean_pin = validate_pin_sha256(pin_sha256)
+    clean_enabled = validate_bool(
+        enabled, command="remote_build/set_pairing_enabled", field="enabled"
+    )
+    pairing = controller._pairings.get(clean_pin)
+    if pairing is None:
+        msg = f"remote_build/set_pairing_enabled: no pairing for pin_sha256={clean_pin!r}"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    pairing.enabled = clean_enabled
+    payload: OffloaderPairingEnabledChangedData = {
+        "pin_sha256": clean_pin,
+        "enabled": clean_enabled,
+    }
+    controller._db.bus.fire(EventType.OFFLOADER_PAIRING_ENABLED_CHANGED, payload)
+    controller._schedule_pairings_save()
+    return controller._pairing_summary_for(pairing)
+
+
+async def preview_pair(
+    controller: OffloaderController, *, hostname: str, port: int
+) -> dict[str, str]:
+    """Open a brief Noise XX WS to *hostname*:*port* and return the receiver's pin.
+
+    ``intent="preview"`` captures the receiver's static
+    X25519 pubkey from the handshake transcript. The
+    frontend renders the returned ``pin_sha256`` for the
+    user to OOB-verify against the receiver's "Build
+    server" Settings card before calling ``request_pair``.
+
+    Returns ``{"pin_sha256": "<lowercase-hex-64>"}``.
+    """
+    clean_host = validate_hostname(hostname, context=HostFieldContext.RECEIVER)
+    clean_port = validate_port(port, context=HostFieldContext.RECEIVER)
+    loop = asyncio.get_running_loop()
+    identity = await loop.run_in_executor(
+        None,
+        get_or_create_peer_link_identity,
+        controller._db.settings.config_dir,
+    )
+    try:
+        pin = await peer_link_preview_pair(
+            hostname=clean_host,
+            port=clean_port,
+            identity_priv=identity.private_bytes,
+            resolver=controller._peer_link_resolver,
+        )
+    except PeerLinkClientError as exc:
+        raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
+    return {"pin_sha256": pin}
+
+
+async def request_pair(
+    controller: OffloaderController,
+    *,
+    hostname: str,
+    port: int,
+    pin_sha256: str,
+    receiver_label: str,
+    offloader_label: str,
+) -> PairingSummary:
+    """Open a Noise XX WS, send ``intent="pair_request"``, persist a local row.
+
+    Sends ``{"label": offloader_label, "dashboard_id":
+    <ours>}`` in the encrypted msg3; the receiver's response
+    decides what state the local :class:`StoredPairing` row
+    lands in.
+
+    Two labels: *receiver_label* is the offloader-side
+    display name (stored locally, never sent); *offloader_label*
+    is the offloader's self-identification sent to the
+    receiver so its Pairing requests inbox shows a friendly
+    name.
+
+    TOCTOU defense: the *pin_sha256* arg is compared against
+    the receiver's actual pubkey from the live handshake; a
+    mismatch (rotation or MITM) returns
+    ``PRECONDITION_FAILED`` and persists nothing.
+
+    Only APPROVED rows reach disk. PENDING lives in-memory
+    for the offloader process's lifetime; a restart drops
+    them and the user re-runs ``request_pair``.
+    """
+    clean_host = validate_hostname(hostname, context=HostFieldContext.RECEIVER)
+    clean_port = validate_port(port, context=HostFieldContext.RECEIVER)
+    clean_pin = validate_pin_sha256(pin_sha256)
+    clean_receiver_label = validate_pair_label(receiver_label, field=PairLabelField.RECEIVER_LABEL)
+    clean_offloader_label = validate_pair_label(
+        offloader_label, field=PairLabelField.OFFLOADER_LABEL
+    )
+    peer_link_identity, dashboard_identity = await controller._load_offloader_identities_async()
+
+    try:
+        result = await peer_link_request_pair(
+            hostname=clean_host,
+            port=clean_port,
+            identity_priv=peer_link_identity.private_bytes,
+            label=clean_offloader_label,
+            dashboard_id=dashboard_identity.dashboard_id,
+            resolver=controller._peer_link_resolver,
+        )
+    except PeerLinkClientError as exc:
+        raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
+
+    enforce_pin_match(expected=clean_pin, observed=result.pin_sha256)
+    if (err := intent_response_to_command_error(result.status)) is not None:
+        raise err
+    if result.status not in (IntentResponse.PENDING, IntentResponse.APPROVED):
+        msg = f"unexpected receiver intent_response={result.status.value!r}"
+        raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
+
+    # APPROVED here means the receiver short-circuited the
+    # inbox dance (re-pair against a still-APPROVED row).
+    target_status = (
+        PeerStatus.APPROVED if result.status is IntentResponse.APPROVED else PeerStatus.PENDING
+    )
+    pairing = StoredPairing(
+        receiver_hostname=clean_host,
+        receiver_port=clean_port,
+        pin_sha256=result.pin_sha256,
+        static_x25519_pub=result.remote_static_pub,
+        label=clean_receiver_label,
+        paired_at=time.time(),
+        status=target_status,
+    )
+    key = result.pin_sha256
+    # Sweep any stale entry at the same endpoint under a
+    # different pin (rotation, or a different receiver took
+    # the hostname) so the old row's listener + alert don't
+    # orphan under pin-keying.
+    controller._sweep_stale_pairings_at_endpoint(clean_host, clean_port, keep_pin_sha256=key)
+    # Cancel any prior listener for the same pin — its
+    # closure captured the old pairing reference.
+    controller._pairings[key] = pairing
+    controller._cancel_pair_status_listener(key)
+    controller._dismiss_offloader_alert(key, clean_host, clean_port)
+    if target_status is PeerStatus.APPROVED:
+        controller._schedule_pairings_save()
+        controller._spawn_peer_link_client(pairing)
+        return controller._pairing_summary_for(pairing)
+    controller._spawn_pair_status_listener(pairing)
+    return controller._pairing_summary_for(pairing)
+
+
+async def unpair(controller: OffloaderController, *, pin_sha256: str) -> dict[str, bool]:
+    """Drop the local :class:`StoredPairing` row keyed on *pin_sha256*.
+
+    Idempotent — returns ``{"removed": False}`` rather than
+    raising on a missing row so the frontend's Unpair button
+    always succeeds visually.
+
+    Receiver-side state is **not** notified; the receiver's
+    :class:`StoredPeer` row sticks until the receiver's admin
+    clicks Remove. The next ``peer_link`` from this offloader
+    returns ``REJECTED`` because our local row is gone.
+
+    In-flight pair-status / peer-link tasks for this pin are
+    cancelled before mutating the dict so their open Noise WS
+    closes promptly.
+    """
+    key = validate_pin_sha256(pin_sha256)
+
+    # Cancel before mutating the dict so open Noise WSs close
+    # promptly. Idempotent on absent keys.
+    controller._cancel_pair_status_listener(key)
+    controller._cancel_peer_link_client(key)
+    previous = controller._pairings.pop(key, None)
+    if previous is None:
+        return {"removed": False}
+    controller._schedule_pairings_save()
+    controller._fire_offloader_pair_status_changed(
+        previous.receiver_hostname, previous.receiver_port, key, "removed"
+    )
+    controller._dismiss_offloader_alert(key, previous.receiver_hostname, previous.receiver_port)
+    # Drop derived per-peer caches so the snapshot doesn't
+    # surface stale data for a row the user just removed.
+    controller._peer_queue_status.pop(key, None)
+    for job_id, entry in list(controller._offloader_remote_jobs.items()):
+        if entry["pin_sha256"] == key:
+            controller._offloader_remote_jobs.pop(job_id, None)
+    controller._open_peer_links.discard(key)
+    return {"removed": True}
+
+
+async def edit_pairing_endpoint(
+    controller: OffloaderController,
+    *,
+    pin_sha256: str,
+    hostname: str,
+    port: int,
+) -> PairingSummary:
+    """Manually rebind *pin_sha256*'s pairing onto new (*hostname*, *port*) coords.
+
+    For cases the auto path can't catch: cross-subnet
+    receivers, mDNS disabled, receiver moved to a
+    non-broadcast hostname.
+
+    A one-shot ``preview_pair`` probe verifies the new
+    endpoint answers with the same pin
+    :class:`StoredPairing` was paired against. Pin mismatch
+    deliberately doesn't fall through — accepting a new
+    identity under the user's existing trust is what the
+    re-auth wizard exists for.
+
+    Returns the updated :class:`PairingSummary`;
+    ``connected`` typically reads ``False`` because the
+    respawned :class:`PeerLinkClient` is still handshaking
+    when this method returns.
+    """
+    pin = validate_pin_sha256(pin_sha256)
+    clean_host = validate_hostname(hostname, context=HostFieldContext.RECEIVER)
+    clean_port = validate_port(port, context=HostFieldContext.RECEIVER)
+
+    pairing = controller._pairings.get(pin)
+    if pairing is None:
+        msg = f"edit_pairing_endpoint: no pairing for pin_sha256={pin!r}"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    if pairing.status is not PeerStatus.APPROVED:
+        msg = f"edit_pairing_endpoint: pairing status is {pairing.status.value!r}, not APPROVED"
+        raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
+    # System-readiness before user-input semantics: surface
+    # "identity not loaded yet" distinctly rather than a
+    # confusing "matches current" on a startup race.
+    if controller._offloader_peer_link_priv is None:
+        msg = "edit_pairing_endpoint: offloader peer-link identity not loaded yet"
+        raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
+    if endpoints_equal(pairing.receiver_hostname, pairing.receiver_port, clean_host, clean_port):
+        msg = f"edit_pairing_endpoint: new endpoint matches current ({clean_host}:{clean_port})"
+        raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
+
+    result = await controller._probe_pairing_endpoint(
+        pairing=pairing, new_hostname=clean_host, new_port=clean_port
+    )
+    if result.outcome is not RebindProbeOutcome.OK:
+        code, template = EDIT_PAIRING_PROBE_ERRORS[result.outcome]
+        raise CommandError(
+            code,
+            template.format(
+                host=clean_host,
+                port=clean_port,
+                pin=pin,
+                observed=result.observed_pin,
+                error=result.transport_error,
+            ),
+        )
+    controller._commit_endpoint_rebind(pairing, hostname=clean_host, port=clean_port)
+    return controller._pairing_summary_for(pairing)

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -29,7 +29,6 @@ from esphome_device_builder.controllers.remote_build import (
     OffloaderController,
     ReceiverController,
 )
-from esphome_device_builder.controllers.remote_build import offloader as rb
 from esphome_device_builder.controllers.remote_build import rebind as rb_rebind
 from esphome_device_builder.controllers.remote_build import receiver as rb_rcv
 from esphome_device_builder.controllers.remote_build._mdns import (
@@ -469,7 +468,7 @@ async def test_rebind_probe_unreachable_does_not_mutate(
     _patch_probe_internals(
         monkeypatch,
         controller,
-        preview_side_effect=rb.PeerLinkClientError("connect refused"),
+        preview_side_effect=rb_rebind.PeerLinkClientError("connect refused"),
         seed_cooldown_for=pin,
     )
 
@@ -821,7 +820,7 @@ async def test_edit_pairing_endpoint_unreachable_raises_unavailable(
     cancel, spawn = _patch_probe_internals(
         monkeypatch,
         controller,
-        preview_side_effect=rb.PeerLinkClientError("connect refused"),
+        preview_side_effect=rb_rebind.PeerLinkClientError("connect refused"),
     )
 
     with pytest.raises(CommandError) as exc_info:

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -890,7 +890,7 @@ async def test_controller_request_pair_unexpected_status_raises_internal_error(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader.peer_link_request_pair",
+        "esphome_device_builder.controllers.remote_build.pair_commands.peer_link_request_pair",
         _fake_request_pair,
     )
 
@@ -1753,7 +1753,7 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader.peer_link_request_pair",
+        "esphome_device_builder.controllers.remote_build.pair_commands.peer_link_request_pair",
         _fake_request_pair,
     )
     fake_identity = MagicMock()
@@ -1862,7 +1862,7 @@ async def test_request_pair_repair_then_unpair_clean_state(
         return fake_results.pop(0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader.peer_link_request_pair",
+        "esphome_device_builder.controllers.remote_build.pair_commands.peer_link_request_pair",
         _fake_request_pair,
     )
 
@@ -2033,7 +2033,7 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
         )
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.offloader.peer_link_request_pair",
+        "esphome_device_builder.controllers.remote_build.pair_commands.peer_link_request_pair",
         _fake_request_pair,
     )
 


### PR DESCRIPTION
# What does this implement/fix?

Extracts the offloader-side pair-flow WS commands into a new sibling module `controllers/remote_build/pair_commands.py`: `preview_pair`, `request_pair`, `unpair`, `edit_pairing_endpoint`, `set_pairing_enabled`. Sixth PR in the OffloaderController split arc (after #766 + #772 + #774 + #775 + #780).

The five `@api_command`-decorated methods stay on the controller as thin bound-method delegates so WS dispatch and tests resolve unchanged.

## Imports

Moved out of `offloader.py`: `time`, `ErrorCode`, `IntentResponse`, `OffloaderPairingEnabledChangedData`, `endpoints_equal`, `EDIT_PAIRING_PROBE_ERRORS`, `RebindProbeOutcome`, `HostFieldContext`, `PairLabelField`, `enforce_pin_match`, `intent_response_to_command_error`, `validate_hostname`, `validate_pair_label`, `validate_port`, `PeerLinkClientError`, `peer_link_preview_pair`, `peer_link_request_pair`, `CommandError`. Stays imported: `validate_bool` (used by `set_offloader_settings`), `EventType`, `OffloaderRemoteBuildsToggledData`, `OffloaderPairAlertDismissedData` (set_offloader_settings + alert dismissal).

## Test impact

- 4 `peer_link_request_pair` patches in `tests/test_remote_build_peer_link_client.py` move from the `offloader` module to `pair_commands` (full-path strings, no alias needed).
- 2 `rb.PeerLinkClientError` references in `tests/test_remote_build_controller.py` move to `rb_rebind` (the rebind module is where the probe path catches and re-raises; it's where the existing `peer_link_preview_pair` patches already point).

`offloader.py`: **1012 → 767 lines** (-245). Combined with #766 + #772 + #774 + #775 + #780: 1709 → 767 (-942, **-55%**). The controller is now under the 800-line soft cap; the `# noqa: PLR0904` grandfather marker stays (still 21 public methods, one over the 20 cap).

678 remote-build tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the OffloaderController split arc tracked in `offloader_split.md`. Remaining (optional, smaller cleanups): `set_offloader_settings` / `get_offloader_settings`, the bus-event handler cluster.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
