### PR TITLE
Extract peer-link handshake driver into handshake.py

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
@@ -57,86 +57,28 @@ import contextlib
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import WSMsgType, web
 
 from ....api.ws import WEBSOCKETS_KEY
-from ....helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
 from ....helpers.peer_link_identity import get_or_create_peer_link_identity
-from ....helpers.peer_link_noise import (
-    NOISE_ERRORS,
-    HandshakeNotCompleteError,
-    PeerLinkNoiseSession,
-    pin_sha256_for_pubkey,
-)
-from ....models import (
-    IntentResponse,
-    PeerLinkIntent,
-    SubmitJobChunkFrameData,
-    SubmitJobFrameData,
-)
+from ....helpers.peer_link_noise import NOISE_ERRORS, PeerLinkNoiseSession
+from ....models import SubmitJobChunkFrameData, SubmitJobFrameData
 
 # Redundant aliases mark these as intentional re-exports for both
 # ruff (F401) and mypy (no-redef) — preserves external imports like
 # ``from .peer_link import TerminateReason`` without an ``__all__``
-# that would also accidentally narrow ``import *`` semantics.
+# that would also accidentally narrow ``import *`` semantics. Tests
+# import the underscore-prefixed handshake-driver symbols this way.
+from .handshake import _dispatch_intent as _dispatch_intent
+from .handshake import _DispatchInput as _DispatchInput
+from .handshake import _drive_peer_link_session as _drive_peer_link_session
+from .handshake import _HandshakeStep as _HandshakeStep
 from .wire import AppMessageType as AppMessageType
 from .wire import TerminateReason as TerminateReason
-from .wire_io import (
-    _normalize_label,
-    _parse_intent,
-    _parse_json,
-    _read_handshake_message,
-    _send_handshake_message,
-    _send_response,
-    _str_or_empty,
-)
-
-
-class _HandshakeStep(StrEnum):
-    """
-    The three Noise XX handshake messages, in order.
-
-    Used as a label-typed argument to ``_read_handshake_message``
-    / ``_send_handshake_message`` so log lines and timeout-error
-    messages identify the specific step. Members are the wire-
-    convention short names from the Noise spec (``e`` for the
-    initiator's ephemeral on msg1, ``e, ee, s, es`` for msg2's
-    composite, ``s, se`` for msg3) but we name them ``MSG1`` /
-    ``MSG2`` / ``MSG3`` for grep-readability against any
-    debugger / log output.
-    """
-
-    MSG1 = "msg1"
-    MSG2 = "msg2"
-    MSG3 = "msg3"
-
-
-@dataclass(frozen=True)
-class _DispatchInput:
-    """
-    Per-session inputs to :func:`_dispatch_intent`.
-
-    Bundles the six values ``_drive_peer_link_session`` extracts
-    from the Noise handshake transcript + msg3 payload + WS
-    request: the intent discriminator, the offloader-supplied
-    metadata (dashboard_id, label), the handshake-derived
-    identity (pin_sha256 + static_x25519_pub) and the connection
-    metadata (peer_ip). Frozen because the dispatcher only reads;
-    a single object beats threading six kwargs through the call
-    site.
-    """
-
-    intent: PeerLinkIntent
-    dashboard_id: str
-    label: str
-    pin_sha256: str
-    static_x25519_pub: bytes
-    peer_ip: str
-
+from .wire_io import _parse_json
 
 if TYPE_CHECKING:
     from ..receiver import ReceiverController
@@ -229,158 +171,6 @@ async def make_peer_link_handler(
         return ws
 
     return handler
-
-
-async def _drive_peer_link_session(  # noqa: PLR0911 — the early-returns are the handshake's natural failure cliffs
-    controller: ReceiverController,
-    ws: web.WebSocketResponse,
-    peer_ip: str,
-    identity_priv: bytes,
-) -> None:
-    """
-    Drive one peer-link Noise session from handshake to response.
-
-    Split out of the handler so tests can exercise the dispatch
-    against a fake ``WebSocketResponse`` without standing up an
-    aiohttp server.
-    """
-    _LOGGER.info("peer-link WS accepted from %s", peer_ip)
-    session = PeerLinkNoiseSession.responder(identity_priv)
-
-    # --- handshake msg1 (offloader → receiver, plaintext payload) ---
-    msg1_payload = await _read_handshake_message(session, ws, _HandshakeStep.MSG1)
-    if msg1_payload is None:
-        return
-    intent = _parse_intent(msg1_payload)
-    if intent is None:
-        # Complete the handshake before rejecting so the offloader
-        # can see the rejection in an authenticated frame rather
-        # than as a raw transport close. Send empty msg2, expect
-        # msg3, then send the rejection.
-        if not await _send_handshake_message(session, ws, b"", _HandshakeStep.MSG2):
-            return
-        if await _read_handshake_message(session, ws, _HandshakeStep.MSG3) is None:
-            return
-        await _send_response(session, ws, IntentResponse.REJECTED)
-        return
-
-    # --- handshake msg2 (receiver → offloader, empty encrypted) ---
-    if not await _send_handshake_message(session, ws, b"", _HandshakeStep.MSG2):
-        return
-
-    # --- handshake msg3 (offloader → receiver, encrypted payload) ---
-    msg3_payload = await _read_handshake_message(session, ws, _HandshakeStep.MSG3)
-    if msg3_payload is None:
-        return
-    parsed = _parse_json(msg3_payload)
-    msg3 = parsed if isinstance(parsed, dict) else {}
-
-    try:
-        remote_static_pub = session.remote_static_pub
-    except HandshakeNotCompleteError:
-        _LOGGER.warning(
-            "peer-link handshake from %s did not yield remote static pubkey",
-            peer_ip,
-        )
-        return
-    pin = pin_sha256_for_pubkey(remote_static_pub)
-    dashboard_id = _str_or_empty(msg3.get("dashboard_id"))
-    label = _normalize_label(msg3.get("label"))
-    _LOGGER.info(
-        "peer-link handshake from %s ok (intent=%s dashboard_id=%s observed_offloader_pin=%s)",
-        peer_ip,
-        intent.value,
-        dashboard_id,
-        pin,
-    )
-
-    response = await _dispatch_intent(
-        controller,
-        _DispatchInput(
-            intent=intent,
-            dashboard_id=dashboard_id,
-            label=label,
-            pin_sha256=pin,
-            static_x25519_pub=remote_static_pub,
-            peer_ip=peer_ip,
-        ),
-    )
-    await _send_response(session, ws, response)
-
-    # Hand off to the long-lived application session for
-    # ``intent="peer_link"`` on a successful auth. Every other
-    # intent — including a ``REJECTED`` peer_link — closes the WS
-    # via the handler's ``finally`` (the legacy one-shot shape).
-    if intent is PeerLinkIntent.PEER_LINK and response is IntentResponse.OK:
-        await _run_peer_link_session(
-            controller=controller,
-            ws=ws,
-            session=session,
-            dashboard_id=dashboard_id,
-            peer_ip=peer_ip,
-        )
-
-
-async def _dispatch_intent(
-    controller: ReceiverController,
-    inp: _DispatchInput,
-) -> IntentResponse:
-    """
-    Resolve a single peer-link intent into a typed :class:`IntentResponse`.
-
-    Pure dispatch logic, callable directly from tests so the
-    intent → controller-call routing is verified without the WS /
-    Noise plumbing in the loop. See :class:`IntentResponse` for the
-    per-intent response semantics. The caller (the WS driver) has
-    already validated the wire string into a :class:`PeerLinkIntent`
-    member; an unknown wire value returns ``IntentResponse.REJECTED``
-    before reaching this function.
-    """
-    if inp.intent is PeerLinkIntent.PREVIEW:
-        # Preview captures the responder's static pubkey via the
-        # handshake transcript; nothing else to do server-side
-        # and the offloader doesn't need a dashboard_id yet.
-        return IntentResponse.OK
-
-    # Every other intent identifies the offloader by dashboard_id;
-    # an empty / missing / malformed value would create or look up
-    # nonsense rows, so reject before any controller call. The
-    # alphabet + length contract is the same one
-    # :func:`controllers.remote_build._validators.validate_dashboard_id`
-    # enforces on the WS-command path; both consumers import the
-    # constants from ``helpers.dashboard_identity`` so they can't
-    # drift.
-    if (
-        not inp.dashboard_id
-        or len(inp.dashboard_id) > DASHBOARD_ID_MAX_CHARS
-        or not DASHBOARD_ID_PATTERN.fullmatch(inp.dashboard_id)
-    ):
-        return IntentResponse.REJECTED
-
-    if inp.intent is PeerLinkIntent.PAIR_REQUEST:
-        # The pairing-window gate lives inside ``record_pair_request``
-        # rather than here so it can short-circuit only the cases
-        # where new admin authorization is actually being requested
-        # (new PENDING row created, or pubkey rotated under an
-        # existing PENDING / APPROVED row). A re-pair against an
-        # already-APPROVED row whose pubkey still matches doesn't
-        # need admin action and bypasses the window check — the
-        # offloader is just re-establishing existing trust.
-        return await controller.record_pair_request(
-            dashboard_id=inp.dashboard_id,
-            pin_sha256=inp.pin_sha256,
-            static_x25519_pub=inp.static_x25519_pub,
-            label=inp.label,
-            peer_ip=inp.peer_ip,
-        )
-    if inp.intent is PeerLinkIntent.PEER_LINK:
-        return await controller.lookup_peer_for_session(
-            dashboard_id=inp.dashboard_id, pin_sha256=inp.pin_sha256
-        )
-    # PeerLinkIntent.PAIR_STATUS — exhaustive enum match.
-    return await controller.lookup_peer_for_status(
-        dashboard_id=inp.dashboard_id, pin_sha256=inp.pin_sha256
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/remote_build/peer_link/handshake.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/handshake.py
@@ -1,0 +1,240 @@
+"""
+Peer-link Noise XX handshake driver + intent dispatch.
+
+Reads the three-step XX handshake off the WS, parses the
+offloader's ``intent`` discriminator out of msg1 (plaintext) +
+msg3 (encrypted payload), and routes to the controller's
+record / lookup helpers. Hands off to the long-lived session
+loop for a successful ``peer_link`` intent; one-shot for
+``preview`` / ``pair_request`` / ``pair_status``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+from ....helpers.dashboard_identity import DASHBOARD_ID_MAX_CHARS, DASHBOARD_ID_PATTERN
+from ....helpers.peer_link_noise import (
+    HandshakeNotCompleteError,
+    PeerLinkNoiseSession,
+    pin_sha256_for_pubkey,
+)
+from ....models import IntentResponse, PeerLinkIntent
+from .wire_io import (
+    _normalize_label,
+    _parse_intent,
+    _parse_json,
+    _read_handshake_message,
+    _send_handshake_message,
+    _send_response,
+    _str_or_empty,
+)
+
+if TYPE_CHECKING:
+    from ..receiver import ReceiverController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _HandshakeStep(StrEnum):
+    """
+    The three Noise XX handshake messages, in order.
+
+    Used as a label-typed argument to ``_read_handshake_message``
+    / ``_send_handshake_message`` so log lines and timeout-error
+    messages identify the specific step. Members are the wire-
+    convention short names from the Noise spec (``e`` for the
+    initiator's ephemeral on msg1, ``e, ee, s, es`` for msg2's
+    composite, ``s, se`` for msg3) but we name them ``MSG1`` /
+    ``MSG2`` / ``MSG3`` for grep-readability against any
+    debugger / log output.
+    """
+
+    MSG1 = "msg1"
+    MSG2 = "msg2"
+    MSG3 = "msg3"
+
+
+@dataclass(frozen=True)
+class _DispatchInput:
+    """
+    Per-session inputs to :func:`_dispatch_intent`.
+
+    Bundles the six values ``_drive_peer_link_session`` extracts
+    from the Noise handshake transcript + msg3 payload + WS
+    request: the intent discriminator, the offloader-supplied
+    metadata (dashboard_id, label), the handshake-derived
+    identity (pin_sha256 + static_x25519_pub) and the connection
+    metadata (peer_ip). Frozen because the dispatcher only reads;
+    a single object beats threading six kwargs through the call
+    site.
+    """
+
+    intent: PeerLinkIntent
+    dashboard_id: str
+    label: str
+    pin_sha256: str
+    static_x25519_pub: bytes
+    peer_ip: str
+
+
+async def _drive_peer_link_session(  # noqa: PLR0911 — the early-returns are the handshake's natural failure cliffs
+    controller: ReceiverController,
+    ws: web.WebSocketResponse,
+    peer_ip: str,
+    identity_priv: bytes,
+) -> None:
+    """
+    Drive one peer-link Noise session from handshake to response.
+
+    Split out of the handler so tests can exercise the dispatch
+    against a fake ``WebSocketResponse`` without standing up an
+    aiohttp server.
+    """
+    _LOGGER.info("peer-link WS accepted from %s", peer_ip)
+    session = PeerLinkNoiseSession.responder(identity_priv)
+
+    # --- handshake msg1 (offloader → receiver, plaintext payload) ---
+    msg1_payload = await _read_handshake_message(session, ws, _HandshakeStep.MSG1)
+    if msg1_payload is None:
+        return
+    intent = _parse_intent(msg1_payload)
+    if intent is None:
+        # Complete the handshake before rejecting so the offloader
+        # can see the rejection in an authenticated frame rather
+        # than as a raw transport close. Send empty msg2, expect
+        # msg3, then send the rejection.
+        if not await _send_handshake_message(session, ws, b"", _HandshakeStep.MSG2):
+            return
+        if await _read_handshake_message(session, ws, _HandshakeStep.MSG3) is None:
+            return
+        await _send_response(session, ws, IntentResponse.REJECTED)
+        return
+
+    # --- handshake msg2 (receiver → offloader, empty encrypted) ---
+    if not await _send_handshake_message(session, ws, b"", _HandshakeStep.MSG2):
+        return
+
+    # --- handshake msg3 (offloader → receiver, encrypted payload) ---
+    msg3_payload = await _read_handshake_message(session, ws, _HandshakeStep.MSG3)
+    if msg3_payload is None:
+        return
+    parsed = _parse_json(msg3_payload)
+    msg3 = parsed if isinstance(parsed, dict) else {}
+
+    try:
+        remote_static_pub = session.remote_static_pub
+    except HandshakeNotCompleteError:
+        _LOGGER.warning(
+            "peer-link handshake from %s did not yield remote static pubkey",
+            peer_ip,
+        )
+        return
+    pin = pin_sha256_for_pubkey(remote_static_pub)
+    dashboard_id = _str_or_empty(msg3.get("dashboard_id"))
+    label = _normalize_label(msg3.get("label"))
+    _LOGGER.info(
+        "peer-link handshake from %s ok (intent=%s dashboard_id=%s observed_offloader_pin=%s)",
+        peer_ip,
+        intent.value,
+        dashboard_id,
+        pin,
+    )
+
+    response = await _dispatch_intent(
+        controller,
+        _DispatchInput(
+            intent=intent,
+            dashboard_id=dashboard_id,
+            label=label,
+            pin_sha256=pin,
+            static_x25519_pub=remote_static_pub,
+            peer_ip=peer_ip,
+        ),
+    )
+    await _send_response(session, ws, response)
+
+    # Hand off to the long-lived application session for
+    # ``intent="peer_link"`` on a successful auth. Every other
+    # intent — including a ``REJECTED`` peer_link — closes the WS
+    # via the handler's ``finally`` (the legacy one-shot shape).
+    if intent is PeerLinkIntent.PEER_LINK and response is IntentResponse.OK:
+        # Lazy import: ``_run_peer_link_session`` lives in the
+        # parent package's ``__init__.py``, which imports this
+        # module — a top-level import would deadlock the load.
+        from . import _run_peer_link_session  # noqa: PLC0415
+
+        await _run_peer_link_session(
+            controller=controller,
+            ws=ws,
+            session=session,
+            dashboard_id=dashboard_id,
+            peer_ip=peer_ip,
+        )
+
+
+async def _dispatch_intent(
+    controller: ReceiverController,
+    inp: _DispatchInput,
+) -> IntentResponse:
+    """
+    Resolve a single peer-link intent into a typed :class:`IntentResponse`.
+
+    Pure dispatch logic, callable directly from tests so the
+    intent → controller-call routing is verified without the WS /
+    Noise plumbing in the loop. See :class:`IntentResponse` for the
+    per-intent response semantics. The caller (the WS driver) has
+    already validated the wire string into a :class:`PeerLinkIntent`
+    member; an unknown wire value returns ``IntentResponse.REJECTED``
+    before reaching this function.
+    """
+    if inp.intent is PeerLinkIntent.PREVIEW:
+        # Preview captures the responder's static pubkey via the
+        # handshake transcript; nothing else to do server-side
+        # and the offloader doesn't need a dashboard_id yet.
+        return IntentResponse.OK
+
+    # Every other intent identifies the offloader by dashboard_id;
+    # an empty / missing / malformed value would create or look up
+    # nonsense rows, so reject before any controller call. The
+    # alphabet + length contract is the same one
+    # :func:`controllers.remote_build._validators.validate_dashboard_id`
+    # enforces on the WS-command path; both consumers import the
+    # constants from ``helpers.dashboard_identity`` so they can't
+    # drift.
+    if (
+        not inp.dashboard_id
+        or len(inp.dashboard_id) > DASHBOARD_ID_MAX_CHARS
+        or not DASHBOARD_ID_PATTERN.fullmatch(inp.dashboard_id)
+    ):
+        return IntentResponse.REJECTED
+
+    if inp.intent is PeerLinkIntent.PAIR_REQUEST:
+        # The pairing-window gate lives inside ``record_pair_request``
+        # rather than here so it can short-circuit only the cases
+        # where new admin authorization is actually being requested
+        # (new PENDING row created, or pubkey rotated under an
+        # existing PENDING / APPROVED row). A re-pair against an
+        # already-APPROVED row whose pubkey still matches doesn't
+        # need admin action and bypasses the window check — the
+        # offloader is just re-establishing existing trust.
+        return await controller.record_pair_request(
+            dashboard_id=inp.dashboard_id,
+            pin_sha256=inp.pin_sha256,
+            static_x25519_pub=inp.static_x25519_pub,
+            label=inp.label,
+            peer_ip=inp.peer_ip,
+        )
+    if inp.intent is PeerLinkIntent.PEER_LINK:
+        return await controller.lookup_peer_for_session(
+            dashboard_id=inp.dashboard_id, pin_sha256=inp.pin_sha256
+        )
+    # PeerLinkIntent.PAIR_STATUS — exhaustive enum match.
+    return await controller.lookup_peer_for_status(
+        dashboard_id=inp.dashboard_id, pin_sha256=inp.pin_sha256
+    )

--- a/esphome_device_builder/controllers/remote_build/peer_link/wire_io.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/wire_io.py
@@ -21,7 +21,7 @@ from ....helpers.peer_link_noise import NOISE_ERRORS, PeerLinkNoiseSession
 from ....models import IntentResponse, PeerLinkIntent
 
 if TYPE_CHECKING:
-    from . import _HandshakeStep
+    from .handshake import _HandshakeStep
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
# What does this implement/fix?

Fifth PR in the `peer_link` split arc (follows #769 + #770 + #773 + #781; plan: `peer_link_split.md`). Moves the Noise XX handshake driver + intent-dispatch unit byte-for-byte from `peer_link/__init__.py` into a new `peer_link/handshake.py` submodule.

**Moved:**

* Private types: `_HandshakeStep`, `_DispatchInput`
* Driver: `_drive_peer_link_session`
* Dispatcher: `_dispatch_intent`

The handshake driver's only callback into the parent package is `_run_peer_link_session` (still in `__init__.py` until PR 6 extracts the session machinery); imported lazily inside the `peer_link`-intent branch to avoid the circular-load that a top-level import would trigger. Same pattern `channel.py` used for its `parse_app_frame` lazy import.

`__init__.py` re-exports the four handshake symbols (PEP 484 redundant-alias form) so existing test imports stay valid. `wire_io.py`'s `TYPE_CHECKING` reference to `_HandshakeStep` follows the symbol from the package to the handshake submodule.

Drops the now-unused top-level imports from `__init__.py` that were only consumed by the moved code (`StrEnum`, plus `DASHBOARD_ID_*`, `HandshakeNotCompleteError`, `pin_sha256_for_pubkey`, `IntentResponse`, `PeerLinkIntent` are now imported in `handshake.py` only). `dataclass` + `field` stayed because `PeerLinkSession` (still in `__init__.py` until PR 6) needs them.

**Test redirects: none.** `_drive_peer_link_session` is still called from `make_peer_link_handler` (which stays in `__init__.py`), so the existing `peer_link._drive_peer_link_session` monkeypatch target is unchanged — patching the package-level re-export reaches `make_peer_link_handler`'s own scope inside `__init__.py`. I initially redirected it to `peer_link.handshake._drive_peer_link_session` and a test failed; reverted.

* **`__init__.py`**: 729 → 519 lines (−210).
* **`handshake.py`** (new): 240 lines.

Last PR in the arc: `session.py` — `PeerLinkSession` + receive loop + heartbeat (~330 lines, HIGH risk; ~8 test monkey-patch redirects).

All 3391 non-e2e tests pass; ruff + mypy clean.

**Related issue or feature (if applicable):**

- follow-up to #769 + #770 + #773 + #781; fifth PR of the peer_link split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
