### PR TITLE
Detect peer-link self-loopback and retry instead of orphaning

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -31,6 +31,7 @@ from ....helpers.peer_link_noise import (
     NOISE_ERRORS,
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
+    public_bytes_for_priv,
 )
 from ....helpers.peer_link_resolver import make_peer_link_http_session
 from ....models import (
@@ -128,6 +129,12 @@ class PeerLinkClient:
         self._hostname = receiver_hostname
         self._port = receiver_port
         self._identity_priv = identity_priv
+        # Cached at construction so the self-loopback guard in
+        # :meth:`_run_one_session` can compare against
+        # ``session.remote_static_pub`` without re-deriving on
+        # every reconnect. Shares the X25519 derive cache with
+        # the Noise session itself.
+        self._identity_pub = public_bytes_for_priv(identity_priv)
         self._dashboard_id = dashboard_id
         # ``None`` falls back to aiohttp's default resolver —
         # the only viable shape for unit tests that don't
@@ -360,6 +367,28 @@ class PeerLinkClient:
                 # legitimate rotation or a MITM / mDNS spoof.
                 # Abort either way before any application frames.
                 observed = session.remote_static_pub
+                if observed == self._identity_pub:
+                    # mDNS resolved the receiver's hostname to an
+                    # IP that routes back to this process's own
+                    # peer-link listener (the canonical case is a
+                    # shared Docker bridge gateway like ``172.17.0.1``
+                    # on both hosts; the receiver advertises it,
+                    # the offloader's routing reaches its own
+                    # listener instead). Refuse and return a
+                    # transport-error close so the reconnect loop
+                    # keeps trying — the next resolution may pick
+                    # a different (correct) A record.
+                    _LOGGER.error(
+                        "peer-link client to %s:%d looped back to own listener "
+                        "(peer=%s pin=%s); check mDNS / routing — the receiver's "
+                        "hostname is resolving to one of this host's own IPs",
+                        self._hostname,
+                        self._port,
+                        ws.get_extra_info("peername"),
+                        self._pin_sha256,
+                    )
+                    self._last_connect_error = "self loopback"
+                    return _LOCAL_CLOSE_TRANSPORT_ERROR
                 if observed != self._pinned_static_x25519_pub:
                     # ``stored_pin`` is the sha256 written to disk at
                     # pair time; ``expected_pin`` is what the raw

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -33,7 +33,7 @@ from ....helpers.peer_link_noise import (
     pin_sha256_for_pubkey,
     public_bytes_for_priv,
 )
-from ....helpers.peer_link_resolver import make_peer_link_http_session
+from ....helpers.peer_link_resolver import _BlocklistingResolver, make_peer_link_http_session
 from ....models import (
     IntentResponse,
     PeerLinkIntent,
@@ -135,6 +135,14 @@ class PeerLinkClient:
         # every reconnect. Shares the X25519 derive cache with
         # the Noise session itself.
         self._identity_pub = public_bytes_for_priv(identity_priv)
+        # Peer IPs we've observed self-loopback against. aiohttp's
+        # ``TCPConnector`` caches resolutions (10s) and happy-eyeballs
+        # tries the addresses in order, so without this filter a
+        # reconnect after self-loopback would land on the same bad
+        # IP. The resolver wrapper in ``_run_one_session`` reads this
+        # set on every resolve; a new entry takes effect on the next
+        # reconnect attempt.
+        self._blocked_peer_ips: set[str] = set()
         self._dashboard_id = dashboard_id
         # ``None`` falls back to aiohttp's default resolver —
         # the only viable shape for unit tests that don't
@@ -340,9 +348,18 @@ class PeerLinkClient:
         # Handshake reads are bounded with ``asyncio.wait_for``
         # downstream so a stalled handshake still fails fast.
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=_DEFAULT_TIMEOUT_SECONDS)
+        # Wrap so any peer IP we've previously self-loopbacked against
+        # gets stripped from this attempt's resolution. ``None`` falls
+        # through to aiohttp's default resolver (test path; the
+        # self-loopback bug only manifests via mDNS).
+        resolver = (
+            _BlocklistingResolver(self._resolver, self._blocked_peer_ips)
+            if self._resolver is not None
+            else None
+        )
         try:
             async with (
-                make_peer_link_http_session(timeout=timeout, resolver=self._resolver) as http,
+                make_peer_link_http_session(timeout=timeout, resolver=resolver) as http,
                 http.ws_connect(url, max_msg_size=APP_FRAME_MAX_BYTES) as ws,
             ):
                 _LOGGER.info(
@@ -374,17 +391,20 @@ class PeerLinkClient:
                     # shared Docker bridge gateway like ``172.17.0.1``
                     # on both hosts; the receiver advertises it,
                     # the offloader's routing reaches its own
-                    # listener instead). Refuse and return a
-                    # transport-error close so the reconnect loop
-                    # keeps trying — the next resolution may pick
-                    # a different (correct) A record.
+                    # listener instead). Refuse, blocklist the peer
+                    # IP so the next reconnect's resolver wrapper
+                    # skips it, and return a transport-error close
+                    # so the reconnect loop keeps trying.
+                    peer = ws.get_extra_info("peername")
+                    if isinstance(peer, tuple) and peer and isinstance(peer[0], str):
+                        self._blocked_peer_ips.add(peer[0])
                     _LOGGER.error(
                         "peer-link client to %s:%d looped back to own listener "
                         "(peer=%s pin=%s); check mDNS / routing — the receiver's "
                         "hostname is resolving to one of this host's own IPs",
                         self._hostname,
                         self._port,
-                        ws.get_extra_info("peername"),
+                        peer,
                         self._pin_sha256,
                     )
                     self._last_connect_error = "self loopback"

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -33,7 +33,7 @@ from ....helpers.peer_link_noise import (
     pin_sha256_for_pubkey,
     public_bytes_for_priv,
 )
-from ....helpers.peer_link_resolver import _BlocklistingResolver, make_peer_link_http_session
+from ....helpers.peer_link_resolver import _SkipHostsResolver, make_peer_link_http_session
 from ....models import (
     IntentResponse,
     PeerLinkIntent,
@@ -133,14 +133,15 @@ class PeerLinkClient:
         # Peer IPs we've self-loopbacked against. Read live by the
         # resolver wrapper below so the next reconnect picks a
         # different A record from aiohttp's cached resolution.
-        self._blocked_peer_ips: set[str] = set()
+        # IPv4-shaped: IPv6 doesn't manifest the docker-bridge
+        # self-loopback shape (no shared default ULA prefix) so
+        # we don't normalise v6 representations here.
+        self._self_loopback_ips: set[str] = set()
         # ``None`` falls back to aiohttp's default resolver — the
         # only viable shape for unit tests that don't construct a
         # real Zeroconf.
         self._http_resolver: AbstractResolver | None = (
-            _BlocklistingResolver(resolver, self._blocked_peer_ips)
-            if resolver is not None
-            else None
+            _SkipHostsResolver(resolver, self._self_loopback_ips) if resolver is not None else None
         )
         self._dashboard_id = dashboard_id
         # Compared against ``session.remote_static_pub``
@@ -624,10 +625,10 @@ class PeerLinkClient:
     def _fire_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
         _dispatch.fire_queue_status(self, idle, running, queue_depth)
 
-    def _on_self_static_observed(self, peer: object) -> str:
-        """Blocklist *peer*'s IP, log ERROR, return the transport-error close reason."""
+    def _on_self_static_observed(self, peer: Any) -> str:
+        """Skip *peer*'s IP next resolve, log ERROR, return the transport-error close reason."""
         if isinstance(peer, tuple) and peer and isinstance(peer[0], str):
-            self._blocked_peer_ips.add(peer[0])
+            self._self_loopback_ips.add(peer[0])
         _LOGGER.error(
             "peer-link client to %s:%d observed our own static pubkey from the responder "
             "(peer=%s pin=%s); check mDNS / routing (hostname resolves to one of this "

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -129,19 +129,10 @@ class PeerLinkClient:
         self._hostname = receiver_hostname
         self._port = receiver_port
         self._identity_priv = identity_priv
-        # Cached at construction so the self-loopback guard in
-        # :meth:`_run_one_session` can compare against
-        # ``session.remote_static_pub`` without re-deriving on
-        # every reconnect. Shares the X25519 derive cache with
-        # the Noise session itself.
         self._identity_pub = public_bytes_for_priv(identity_priv)
-        # Peer IPs we've observed self-loopback against. aiohttp's
-        # ``TCPConnector`` caches resolutions (10s) and happy-eyeballs
-        # tries the addresses in order, so without this filter a
-        # reconnect after self-loopback would land on the same bad
-        # IP. The resolver wrapper in ``_run_one_session`` reads this
-        # set on every resolve; a new entry takes effect on the next
-        # reconnect attempt.
+        # Peer IPs we've self-loopbacked against. Read live by the
+        # resolver wrapper in :meth:`_run_one_session` so the next
+        # reconnect picks a different A record from the cached set.
         self._blocked_peer_ips: set[str] = set()
         self._dashboard_id = dashboard_id
         # ``None`` falls back to aiohttp's default resolver —
@@ -348,10 +339,6 @@ class PeerLinkClient:
         # Handshake reads are bounded with ``asyncio.wait_for``
         # downstream so a stalled handshake still fails fast.
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=_DEFAULT_TIMEOUT_SECONDS)
-        # Wrap so any peer IP we've previously self-loopbacked against
-        # gets stripped from this attempt's resolution. ``None`` falls
-        # through to aiohttp's default resolver (test path; the
-        # self-loopback bug only manifests via mDNS).
         resolver = (
             _BlocklistingResolver(self._resolver, self._blocked_peer_ips)
             if self._resolver is not None
@@ -639,31 +626,7 @@ class PeerLinkClient:
         _dispatch.fire_queue_status(self, idle, running, queue_depth)
 
     def _on_self_static_observed(self, peer: object) -> str:
-        """
-        Handle a handshake where the responder presented our own static key.
-
-        Two production causes lead here, neither involving the other
-        peer's identity going wrong:
-
-        * **Routing loopback** (the canonical case). mDNS resolved
-          the receiver's hostname to an IP that routes back to this
-          process's own peer-link listener — e.g. a shared Docker
-          bridge gateway like ``172.17.0.1`` present on both hosts:
-          the receiver's announce carries it, the offloader's
-          routing reaches its own listener instead.
-        * **Identity collision.** The receiver was misconfigured
-          with a copy of this dashboard's
-          ``.device-builder-peer-link-key.bin`` — two peers can't
-          share one X25519 identity. Operator action: rotate
-          identity on one side.
-
-        Blocklist the peer IP so the next reconnect's resolver
-        wrapper skips it (recovers automatically from the
-        loopback case); the identity-collision case keeps firing
-        until the operator fixes the receiver side, but the
-        ``check mDNS / routing or identity collision`` text
-        steers them at both causes.
-        """
+        """Blocklist *peer*'s IP, log ERROR, return the transport-error close reason."""
         if isinstance(peer, tuple) and peer and isinstance(peer[0], str):
             self._blocked_peer_ips.add(peer[0])
         _LOGGER.error(

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -362,11 +362,12 @@ class PeerLinkClient:
                 make_peer_link_http_session(timeout=timeout, resolver=resolver) as http,
                 http.ws_connect(url, max_msg_size=APP_FRAME_MAX_BYTES) as ws,
             ):
+                peer = ws.get_extra_info("peername")
                 _LOGGER.info(
                     "peer-link client connected to %s:%d (peer=%s)",
                     self._hostname,
                     self._port,
-                    ws.get_extra_info("peername"),
+                    peer,
                 )
                 session = PeerLinkNoiseSession.initiator(self._identity_priv)
                 msg3_payload = _json.dumps({"dashboard_id": self._dashboard_id})
@@ -385,30 +386,7 @@ class PeerLinkClient:
                 # Abort either way before any application frames.
                 observed = session.remote_static_pub
                 if observed == self._identity_pub:
-                    # mDNS resolved the receiver's hostname to an
-                    # IP that routes back to this process's own
-                    # peer-link listener (the canonical case is a
-                    # shared Docker bridge gateway like ``172.17.0.1``
-                    # on both hosts; the receiver advertises it,
-                    # the offloader's routing reaches its own
-                    # listener instead). Refuse, blocklist the peer
-                    # IP so the next reconnect's resolver wrapper
-                    # skips it, and return a transport-error close
-                    # so the reconnect loop keeps trying.
-                    peer = ws.get_extra_info("peername")
-                    if isinstance(peer, tuple) and peer and isinstance(peer[0], str):
-                        self._blocked_peer_ips.add(peer[0])
-                    _LOGGER.error(
-                        "peer-link client to %s:%d looped back to own listener "
-                        "(peer=%s pin=%s); check mDNS / routing — the receiver's "
-                        "hostname is resolving to one of this host's own IPs",
-                        self._hostname,
-                        self._port,
-                        peer,
-                        self._pin_sha256,
-                    )
-                    self._last_connect_error = "self loopback"
-                    return _LOCAL_CLOSE_TRANSPORT_ERROR
+                    return self._on_self_static_observed(peer)
                 if observed != self._pinned_static_x25519_pub:
                     # ``stored_pin`` is the sha256 written to disk at
                     # pair time; ``expected_pin`` is what the raw
@@ -659,3 +637,44 @@ class PeerLinkClient:
 
     def _fire_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
         _dispatch.fire_queue_status(self, idle, running, queue_depth)
+
+    def _on_self_static_observed(self, peer: object) -> str:
+        """
+        Handle a handshake where the responder presented our own static key.
+
+        Two production causes lead here, neither involving the other
+        peer's identity going wrong:
+
+        * **Routing loopback** (the canonical case). mDNS resolved
+          the receiver's hostname to an IP that routes back to this
+          process's own peer-link listener — e.g. a shared Docker
+          bridge gateway like ``172.17.0.1`` present on both hosts:
+          the receiver's announce carries it, the offloader's
+          routing reaches its own listener instead.
+        * **Identity collision.** The receiver was misconfigured
+          with a copy of this dashboard's
+          ``.device-builder-peer-link-key.bin`` — two peers can't
+          share one X25519 identity. Operator action: rotate
+          identity on one side.
+
+        Blocklist the peer IP so the next reconnect's resolver
+        wrapper skips it (recovers automatically from the
+        loopback case); the identity-collision case keeps firing
+        until the operator fixes the receiver side, but the
+        ``check mDNS / routing or identity collision`` text
+        steers them at both causes.
+        """
+        if isinstance(peer, tuple) and peer and isinstance(peer[0], str):
+            self._blocked_peer_ips.add(peer[0])
+        _LOGGER.error(
+            "peer-link client to %s:%d observed our own static pubkey from the responder "
+            "(peer=%s pin=%s); check mDNS / routing (hostname resolves to one of this "
+            "host's own IPs) or identity collision (receiver running with a copy of our "
+            "peer-link key)",
+            self._hostname,
+            self._port,
+            peer,
+            self._pin_sha256,
+        )
+        self._last_connect_error = "self loopback"
+        return _LOCAL_CLOSE_TRANSPORT_ERROR

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -131,14 +131,18 @@ class PeerLinkClient:
         self._identity_priv = identity_priv
         self._identity_pub = public_bytes_for_priv(identity_priv)
         # Peer IPs we've self-loopbacked against. Read live by the
-        # resolver wrapper in :meth:`_run_one_session` so the next
-        # reconnect picks a different A record from the cached set.
+        # resolver wrapper below so the next reconnect picks a
+        # different A record from aiohttp's cached resolution.
         self._blocked_peer_ips: set[str] = set()
+        # ``None`` falls back to aiohttp's default resolver — the
+        # only viable shape for unit tests that don't construct a
+        # real Zeroconf.
+        self._http_resolver: AbstractResolver | None = (
+            _BlocklistingResolver(resolver, self._blocked_peer_ips)
+            if resolver is not None
+            else None
+        )
         self._dashboard_id = dashboard_id
-        # ``None`` falls back to aiohttp's default resolver —
-        # the only viable shape for unit tests that don't
-        # construct a real Zeroconf.
-        self._resolver = resolver
         # Compared against ``session.remote_static_pub``
         # post-handshake on every connect so an attacker with
         # their own keypair can't complete Noise XX against this
@@ -339,14 +343,9 @@ class PeerLinkClient:
         # Handshake reads are bounded with ``asyncio.wait_for``
         # downstream so a stalled handshake still fails fast.
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=_DEFAULT_TIMEOUT_SECONDS)
-        resolver = (
-            _BlocklistingResolver(self._resolver, self._blocked_peer_ips)
-            if self._resolver is not None
-            else None
-        )
         try:
             async with (
-                make_peer_link_http_session(timeout=timeout, resolver=resolver) as http,
+                make_peer_link_http_session(timeout=timeout, resolver=self._http_resolver) as http,
                 http.ws_connect(url, max_msg_size=APP_FRAME_MAX_BYTES) as ws,
             ):
                 peer = ws.get_extra_info("peername")

--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -279,14 +279,8 @@ def pin_sha256_for_pubkey(static_x25519_pub: bytes) -> str:
 
 
 def public_bytes_for_priv(static_priv: bytes) -> bytes:
-    """Return the cached raw 32-byte X25519 pubkey derived from *static_priv*.
-
-    Wraps in ``bytes(...)`` so the return is an immutable view of
-    noiseprotocol's internal buffer, matching the contract elsewhere
-    in this module (``rs.public_bytes`` is also bytes-wrapped before
-    we stash it).
-    """
-    return bytes(_cached_static_keypair(static_priv).public_bytes)
+    """Return the cached raw 32-byte X25519 pubkey derived from *static_priv*."""
+    return _cached_static_keypair(static_priv).public_bytes
 
 
 def _install_cached_static_keypair(nc: NoiseConnection, static_priv: bytes) -> None:

--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -279,8 +279,14 @@ def pin_sha256_for_pubkey(static_x25519_pub: bytes) -> str:
 
 
 def public_bytes_for_priv(static_priv: bytes) -> bytes:
-    """Return the cached raw 32-byte X25519 pubkey derived from *static_priv*."""
-    return _cached_static_keypair(static_priv).public_bytes
+    """Return the cached raw 32-byte X25519 pubkey derived from *static_priv*.
+
+    Wraps in ``bytes(...)`` so the return is an immutable view of
+    noiseprotocol's internal buffer, matching the contract elsewhere
+    in this module (``rs.public_bytes`` is also bytes-wrapped before
+    we stash it).
+    """
+    return bytes(_cached_static_keypair(static_priv).public_bytes)
 
 
 def _install_cached_static_keypair(nc: NoiseConnection, static_priv: bytes) -> None:

--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -280,7 +280,7 @@ def pin_sha256_for_pubkey(static_x25519_pub: bytes) -> str:
 
 def public_bytes_for_priv(static_priv: bytes) -> bytes:
     """Return the cached raw 32-byte X25519 pubkey derived from *static_priv*."""
-    return _cached_static_keypair(static_priv).public_bytes
+    return cast(bytes, _cached_static_keypair(static_priv).public_bytes)
 
 
 def _install_cached_static_keypair(nc: NoiseConnection, static_priv: bytes) -> None:

--- a/esphome_device_builder/helpers/peer_link_noise.py
+++ b/esphome_device_builder/helpers/peer_link_noise.py
@@ -278,12 +278,17 @@ def pin_sha256_for_pubkey(static_x25519_pub: bytes) -> str:
     return hashlib.sha256(static_x25519_pub).hexdigest()
 
 
+def public_bytes_for_priv(static_priv: bytes) -> bytes:
+    """Return the cached raw 32-byte X25519 pubkey derived from *static_priv*."""
+    return _cached_static_keypair(static_priv).public_bytes
+
+
 def _install_cached_static_keypair(nc: NoiseConnection, static_priv: bytes) -> None:
     """Install our cached static keypair on *nc* (skips the X25519 derive)."""
     nc.noise_protocol.keypairs[_NOISE_LOCAL_STATIC] = _cached_static_keypair(static_priv)
 
 
-@lru_cache(maxsize=8)
+@lru_cache(maxsize=32)
 def _cached_static_keypair(static_priv: bytes) -> KeyPair25519:
     """Return the derived ``KeyPair25519`` for *static_priv*, building once."""
     return KeyPair25519.from_private_bytes(static_priv)

--- a/esphome_device_builder/helpers/peer_link_resolver.py
+++ b/esphome_device_builder/helpers/peer_link_resolver.py
@@ -60,14 +60,14 @@ duplicating across call sites.
 
 from __future__ import annotations
 
+import socket
 from typing import TYPE_CHECKING
 
 import aiohttp
+from aiohttp.abc import AbstractResolver, ResolveResult
 from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
 
 if TYPE_CHECKING:
-    from aiohttp.abc import ResolveResult
-    from aiohttp.resolver import AbstractResolver
     from zeroconf.asyncio import AsyncZeroconf
 
 
@@ -92,14 +92,16 @@ class PeerLinkDNSResolver(AsyncDualMDNSResolver):
         """No-op so per-request connectors don't tear down the shared resolver."""
 
 
-class _BlocklistingResolver:
+class _BlocklistingResolver(AbstractResolver):
     """Wraps an aiohttp resolver; drops results whose host is in the *blocked* set."""
 
     def __init__(self, inner: AbstractResolver, blocked: set[str]) -> None:
         self._inner = inner
         self._blocked = blocked
 
-    async def resolve(self, host: str, port: int = 0, family: int = 0) -> list[ResolveResult]:
+    async def resolve(
+        self, host: str, port: int = 0, family: socket.AddressFamily = socket.AF_INET
+    ) -> list[ResolveResult]:
         results = await self._inner.resolve(host, port, family)
         return [r for r in results if r.get("host") not in self._blocked]
 

--- a/esphome_device_builder/helpers/peer_link_resolver.py
+++ b/esphome_device_builder/helpers/peer_link_resolver.py
@@ -66,6 +66,7 @@ import aiohttp
 from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
 
 if TYPE_CHECKING:
+    from aiohttp.abc import ResolveResult
     from aiohttp.resolver import AbstractResolver
     from zeroconf.asyncio import AsyncZeroconf
 
@@ -89,6 +90,30 @@ class PeerLinkDNSResolver(AsyncDualMDNSResolver):
 
     async def close(self) -> None:
         """No-op so per-request connectors don't tear down the shared resolver."""
+
+
+class _BlocklistingResolver:
+    """
+    Wraps an aiohttp resolver; drops resolution results whose host is blocklisted.
+
+    Used by the peer-link offloader client to skip A records that
+    resolved to one of the offloader's own interface IPs on a
+    previous attempt (the self-loopback case where mDNS handed back
+    a shared Docker-bridge gateway IP). The blocklist is a shared
+    mutable set so the owning client can append to it between
+    resolves without re-wiring the connector.
+    """
+
+    def __init__(self, inner: AbstractResolver, blocked: set[str]) -> None:
+        self._inner = inner
+        self._blocked = blocked
+
+    async def resolve(self, host: str, port: int = 0, family: int = 0) -> list[ResolveResult]:
+        results = await self._inner.resolve(host, port, family)
+        return [r for r in results if r.get("host") not in self._blocked]
+
+    async def close(self) -> None:
+        """No-op so per-request connector close doesn't kill the shared inner resolver."""
 
 
 def make_peer_link_resolver(async_zeroconf: AsyncZeroconf) -> PeerLinkDNSResolver:

--- a/esphome_device_builder/helpers/peer_link_resolver.py
+++ b/esphome_device_builder/helpers/peer_link_resolver.py
@@ -93,16 +93,7 @@ class PeerLinkDNSResolver(AsyncDualMDNSResolver):
 
 
 class _BlocklistingResolver:
-    """
-    Wraps an aiohttp resolver; drops resolution results whose host is blocklisted.
-
-    Used by the peer-link offloader client to skip A records that
-    resolved to one of the offloader's own interface IPs on a
-    previous attempt (the self-loopback case where mDNS handed back
-    a shared Docker-bridge gateway IP). The blocklist is a shared
-    mutable set so the owning client can append to it between
-    resolves without re-wiring the connector.
-    """
+    """Wraps an aiohttp resolver; drops results whose host is in the *blocked* set."""
 
     def __init__(self, inner: AbstractResolver, blocked: set[str]) -> None:
         self._inner = inner

--- a/esphome_device_builder/helpers/peer_link_resolver.py
+++ b/esphome_device_builder/helpers/peer_link_resolver.py
@@ -92,18 +92,18 @@ class PeerLinkDNSResolver(AsyncDualMDNSResolver):
         """No-op so per-request connectors don't tear down the shared resolver."""
 
 
-class _BlocklistingResolver(AbstractResolver):
-    """Wraps an aiohttp resolver; drops results whose host is in the *blocked* set."""
+class _SkipHostsResolver(AbstractResolver):
+    """Wraps an aiohttp resolver; drops results whose host is in *skip_hosts*."""
 
-    def __init__(self, inner: AbstractResolver, blocked: set[str]) -> None:
+    def __init__(self, inner: AbstractResolver, skip_hosts: set[str]) -> None:
         self._inner = inner
-        self._blocked = blocked
+        self._skip_hosts = skip_hosts
 
     async def resolve(
         self, host: str, port: int = 0, family: socket.AddressFamily = socket.AF_INET
     ) -> list[ResolveResult]:
         results = await self._inner.resolve(host, port, family)
-        return [r for r in results if r.get("host") not in self._blocked]
+        return [r for r in results if r.get("host") not in self._skip_hosts]
 
     async def close(self) -> None:
         """No-op so per-request connector close doesn't kill the shared inner resolver."""

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -2498,6 +2498,7 @@ def _make_offloader_client(
     *,
     receiver_hostname: str = "receiver.local",
     receiver_port: int = 6055,
+    identity_priv: bytes | None = None,
     pinned_static_x25519_pub: bytes = b"\x00" * 32,
     pin_sha256: str = "a" * 64,
     receiver_label: str = "test-receiver",
@@ -2507,14 +2508,16 @@ def _make_offloader_client(
 
     Every constructor-arg has a default; tests that need a
     non-default ``receiver_hostname`` / ``pin_sha256`` /
-    ``pinned_static_x25519_pub`` pass overrides. The 8-line
+    ``pinned_static_x25519_pub`` pass overrides. ``identity_priv``
+    defaults to a fresh random 32 bytes; pass an explicit value to
+    model self-loopback / same-identity scenarios. The 8-line
     construction was repeated ~30 times across the file before
     this helper.
     """
     return PeerLinkClient(
         receiver_hostname=receiver_hostname,
         receiver_port=receiver_port,
-        identity_priv=secrets.token_bytes(32),
+        identity_priv=identity_priv if identity_priv is not None else secrets.token_bytes(32),
         dashboard_id=dashboard_id,
         pinned_static_x25519_pub=pinned_static_x25519_pub,
         pin_sha256=pin_sha256,
@@ -3280,6 +3283,55 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
             assert f"expected_bytes={wrong_pub.hex()}" in msg
             assert f"observed_pin={pin_sha256_for_pubkey(receiver_pub)}" in msg
             assert f"observed_bytes={receiver_pub.hex()}" in msg
+        finally:
+            await cancel_and_drain(task)
+
+
+@pytest.mark.asyncio
+async def test_peer_link_client_self_loopback_logs_error_and_retries(
+    receiver_server: tuple[TestServer, ReceiverController, str, bytes],
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Handshake against our own listener logs ERROR, closes transport_error, retries."""
+    server, _, _, receiver_pub = receiver_server
+    # Same priv on both sides models a TCP connect that landed on
+    # our own listener; the post-handshake ``observed`` is then our
+    # own ``_identity_pub``.
+    identity = await asyncio.get_running_loop().run_in_executor(
+        None, get_or_create_peer_link_identity, tmp_path
+    )
+    bus = EventBus()
+    opened = capture_events(bus, EventType.OFFLOADER_PEER_LINK_OPENED)
+    closed = capture_events(bus, EventType.OFFLOADER_PEER_LINK_CLOSED)
+    pin_mismatch = capture_events(bus, EventType.OFFLOADER_PAIR_PIN_MISMATCH)
+    other_pub = bytes([receiver_pub[0] ^ 0x01]) + receiver_pub[1:]
+    client = _make_offloader_client(
+        bus,
+        receiver_hostname="127.0.0.1",
+        receiver_port=server.port,
+        identity_priv=identity.private_bytes,
+        pinned_static_x25519_pub=other_pub,
+        pin_sha256=pin_sha256_for_pubkey(other_pub),
+        receiver_label="my-laptop",
+    )
+    with caplog.at_level(
+        "ERROR",
+        logger="esphome_device_builder.controllers.remote_build.peer_link_client.client",
+    ):
+        task = asyncio.create_task(client.run())
+        try:
+            await asyncio.wait_for(closed.received.wait(), timeout=2.0)
+            assert closed[0]["reason"] == "transport_error"
+            assert len(pin_mismatch) == 0
+            assert len(opened) == 0
+            assert client.is_orphaned is False
+            loopback = [
+                rec for rec in caplog.records if "looped back to own listener" in rec.getMessage()
+            ]
+            assert len(loopback) >= 1
+            assert loopback[0].levelname == "ERROR"
+            assert "check mDNS / routing" in loopback[0].getMessage()
         finally:
             await cancel_and_drain(task)
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -26,7 +26,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Iterator
 from contextlib import asynccontextmanager, closing
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
@@ -83,6 +83,7 @@ from esphome_device_builder.helpers.peer_link_noise import (
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
+from esphome_device_builder.helpers.peer_link_resolver import _BlocklistingResolver
 from esphome_device_builder.models import (
     PAIRING_VERSION_MAX_LEN,
     ErrorCode,
@@ -3326,6 +3327,10 @@ async def test_peer_link_client_self_loopback_logs_error_and_retries(
             assert len(pin_mismatch) == 0
             assert len(opened) == 0
             assert client.is_orphaned is False
+            # Offending peer IP is captured so the next reconnect's
+            # resolver wrapper skips it (aiohttp would otherwise serve
+            # the same cached resolution and land on this IP forever).
+            assert "127.0.0.1" in client._blocked_peer_ips
             loopback = [
                 rec for rec in caplog.records if "looped back to own listener" in rec.getMessage()
             ]
@@ -3334,6 +3339,27 @@ async def test_peer_link_client_self_loopback_logs_error_and_retries(
             assert "check mDNS / routing" in loopback[0].getMessage()
         finally:
             await cancel_and_drain(task)
+
+
+@pytest.mark.asyncio
+async def test_blocklisting_resolver_strips_blocked_hosts_live() -> None:
+    """``_BlocklistingResolver.resolve`` filters blocked entries, picking up live edits."""
+    inner = MagicMock()
+    inner.resolve = AsyncMock(
+        return_value=[
+            {"host": "192.168.1.10", "port": 6055, "family": 0, "flags": 0, "hostname": "x"},
+            {"host": "172.17.0.1", "port": 6055, "family": 0, "flags": 0, "hostname": "x"},
+        ]
+    )
+    blocked: set[str] = {"172.17.0.1"}
+    wrapper = _BlocklistingResolver(inner, blocked)
+
+    assert [r["host"] for r in await wrapper.resolve("x", 6055)] == ["192.168.1.10"]
+    # Live mutation: the owning client appends to the set between
+    # resolves; the wrapper must read it fresh, not snapshot at
+    # construction.
+    blocked.add("192.168.1.10")
+    assert await wrapper.resolve("x", 6055) == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -83,7 +83,7 @@ from esphome_device_builder.helpers.peer_link_noise import (
     PeerLinkNoiseSession,
     pin_sha256_for_pubkey,
 )
-from esphome_device_builder.helpers.peer_link_resolver import _BlocklistingResolver
+from esphome_device_builder.helpers.peer_link_resolver import _SkipHostsResolver
 from esphome_device_builder.models import (
     PAIRING_VERSION_MAX_LEN,
     ErrorCode,
@@ -3332,7 +3332,7 @@ async def test_peer_link_client_self_loopback_logs_error_and_retries(
             # Offending peer IP is captured so the next reconnect's
             # resolver wrapper skips it (aiohttp would otherwise serve
             # the same cached resolution and land on this IP forever).
-            assert "127.0.0.1" in client._blocked_peer_ips
+            assert "127.0.0.1" in client._self_loopback_ips
             loopback = [
                 rec
                 for rec in caplog.records
@@ -3348,8 +3348,8 @@ async def test_peer_link_client_self_loopback_logs_error_and_retries(
 
 
 @pytest.mark.asyncio
-async def test_blocklisting_resolver_strips_blocked_hosts_live() -> None:
-    """``_BlocklistingResolver.resolve`` filters blocked entries, picking up live edits."""
+async def test_skip_hosts_resolver_strips_skipped_entries_live() -> None:
+    """``_SkipHostsResolver.resolve`` filters skipped entries, picking up live edits."""
     inner = MagicMock()
     inner.resolve = AsyncMock(
         return_value=[
@@ -3357,14 +3357,14 @@ async def test_blocklisting_resolver_strips_blocked_hosts_live() -> None:
             {"host": "172.17.0.1", "port": 6055, "family": 0, "flags": 0, "hostname": "x"},
         ]
     )
-    blocked: set[str] = {"172.17.0.1"}
-    wrapper = _BlocklistingResolver(inner, blocked)
+    skip_hosts: set[str] = {"172.17.0.1"}
+    wrapper = _SkipHostsResolver(inner, skip_hosts)
 
     assert [r["host"] for r in await wrapper.resolve("x", 6055)] == ["192.168.1.10"]
     # Live mutation: the owning client appends to the set between
     # resolves; the wrapper must read it fresh, not snapshot at
     # construction.
-    blocked.add("192.168.1.10")
+    skip_hosts.add("192.168.1.10")
     assert await wrapper.resolve("x", 6055) == []
 
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -3294,11 +3294,13 @@ async def test_peer_link_client_self_loopback_logs_error_and_retries(
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
-    """Handshake against our own listener logs ERROR, closes transport_error, retries."""
+    """Responder presenting our own static key logs ERROR, closes transport_error, retries."""
     server, _, _, receiver_pub = receiver_server
-    # Same priv on both sides models a TCP connect that landed on
-    # our own listener; the post-handshake ``observed`` is then our
-    # own ``_identity_pub``.
+    # Same priv on both sides exercises the ``observed ==
+    # _identity_pub`` branch — production hits this either via
+    # routing loopback (mDNS resolves to our own listener) or
+    # via identity collision (receiver running with a copy of
+    # this dashboard's peer-link key).
     identity = await asyncio.get_running_loop().run_in_executor(
         None, get_or_create_peer_link_identity, tmp_path
     )
@@ -3332,11 +3334,15 @@ async def test_peer_link_client_self_loopback_logs_error_and_retries(
             # the same cached resolution and land on this IP forever).
             assert "127.0.0.1" in client._blocked_peer_ips
             loopback = [
-                rec for rec in caplog.records if "looped back to own listener" in rec.getMessage()
+                rec
+                for rec in caplog.records
+                if "observed our own static pubkey" in rec.getMessage()
             ]
             assert len(loopback) >= 1
             assert loopback[0].levelname == "ERROR"
-            assert "check mDNS / routing" in loopback[0].getMessage()
+            msg = loopback[0].getMessage()
+            assert "check mDNS / routing" in msg
+            assert "identity collision" in msg
         finally:
             await cancel_and_drain(task)
 


### PR DESCRIPTION
# What does this implement/fix?

Defense-in-depth guard for the peer-link "pin drift" bug
diagnosed in #765 + #771: the offloader's mDNS resolution can
land its TCP connect on a local interface IP that routes back to
its own peer-link listener. The canonical shape is identical
default Docker bridge gateway `172.17.0.1` on both hosts — the
receiver advertises the bridge IP from `_local_addresses()`,
the offloader's routing reaches its own `0.0.0.0:6055`
listener, Noise XX completes against the offloader's own static
keypair, the existing pin check fires drift, and the client
orphans.

This PR adds a check before the pin comparison:

```
observed = session.remote_static_pub
if observed == self._identity_pub:
    _LOGGER.error(
        "peer-link client to %s:%d looped back to own listener "
        "(peer=%s pin=%s); check mDNS / routing — the receiver's "
        "hostname is resolving to one of this host's own IPs",
        self._hostname, self._port,
        ws.get_extra_info("peername"),
        self._pin_sha256,
    )
    self._last_connect_error = "self loopback"
    return _LOCAL_CLOSE_TRANSPORT_ERROR
```

Close-reason classification matters: self-loopback is
**recoverable** — the next reconnect after backoff may pick a
correct A record from the same mDNS resolution. Returning
`_LOCAL_CLOSE_TRANSPORT_ERROR` keeps the reconnect loop running.
Returning `_LOCAL_CLOSE_PIN_MISMATCH` (what the existing path
does) would orphan the pairing one-shot and require manual
re-pair. The previous fix from the user side — restart the
offloader — is now an unnecessary step.

The receiver-side mDNS-advertise filter is the root-cause fix
and is being worked separately; that work stops the misrouted
resolution from ever happening when both peers run the new
build. This PR catches the same shape from any future routing
surprise the advertise filter doesn't anticipate (NAT hairpin,
overlay-network gateways, libvirt bridges, Hyper-V default
switches, etc.).

### Other changes folded in

- New `helpers.peer_link_noise.public_bytes_for_priv(priv)` so
  `PeerLinkClient.__init__` derives the offloader's own static
  pubkey via the existing `_cached_static_keypair` lru_cache
  instead of re-deriving on every construction.
- Bump `_cached_static_keypair`'s `lru_cache(maxsize=8)` to 32.
  A combined offloader+receiver dashboard with multiple paired
  peers + the occasional identity rotation can churn past 8
  entries; 32 keeps the derivation hot across realistic fleet
  sizes at the cost of a single dict slot per entry.
- Extend the existing `_make_offloader_client` test helper to
  accept an `identity_priv` override (defaulting to a fresh
  random 32 bytes so existing callers are unchanged), so the
  new self-loopback test can model "TCP connect landed on our
  own listener" by feeding the receiver's priv to the
  offloader.

**Related issue or feature (if applicable):**

- defense-in-depth for #765 / #771
- root-cause analysis in `handshake_bug_analysis.md` (local
  working doc, not in this PR)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (Behaviour-only; no surface change.)
