### PR TITLE
Extract peer-link session machinery into session.py

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/__init__.py
@@ -53,32 +53,37 @@ round-trip costs anything, and that's bounded by LAN latency.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
-from aiohttp import WSMsgType, web
+from aiohttp import web
 
 from ....api.ws import WEBSOCKETS_KEY
 from ....helpers.peer_link_identity import get_or_create_peer_link_identity
-from ....helpers.peer_link_noise import NOISE_ERRORS, PeerLinkNoiseSession
-from ....models import SubmitJobChunkFrameData, SubmitJobFrameData
 
 # Redundant aliases mark these as intentional re-exports for both
 # ruff (F401) and mypy (no-redef) — preserves external imports like
 # ``from .peer_link import TerminateReason`` without an ``__all__``
 # that would also accidentally narrow ``import *`` semantics. Tests
-# import the underscore-prefixed handshake-driver symbols this way.
+# import the underscore-prefixed handshake-driver + session symbols
+# this way.
+from .channel import PeerLinkChannel as PeerLinkChannel
 from .handshake import _dispatch_intent as _dispatch_intent
 from .handshake import _DispatchInput as _DispatchInput
 from .handshake import _drive_peer_link_session as _drive_peer_link_session
 from .handshake import _HandshakeStep as _HandshakeStep
+from .session import APP_FRAME_MAX_BYTES as APP_FRAME_MAX_BYTES
+from .session import HEARTBEAT_DEAD_AFTER_SECONDS as HEARTBEAT_DEAD_AFTER_SECONDS
+from .session import HEARTBEAT_INTERVAL_SECONDS as HEARTBEAT_INTERVAL_SECONDS
+from .session import HEARTBEAT_MISS_THRESHOLD as HEARTBEAT_MISS_THRESHOLD
+from .session import PeerLinkSession as PeerLinkSession
+from .session import _run_peer_link_session as _run_peer_link_session
+from .session import parse_app_frame as parse_app_frame
+from .session import run_peer_link_heartbeat as run_peer_link_heartbeat
 from .wire import AppMessageType as AppMessageType
 from .wire import TerminateReason as TerminateReason
-from .wire_io import _parse_json
 
 if TYPE_CHECKING:
     from ..receiver import ReceiverController
@@ -86,40 +91,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 PEER_LINK_PATH = "/remote-build/peer-link"
-
-# Heartbeat cadence for the long-lived peer-link session. The
-# receiver sends an encrypted ``ping`` frame every 30s and expects
-# the offloader to echo it back with a ``pong`` carrying the same
-# ``nonce``. Three consecutive missed pongs (90s of silence) close
-# the session so a half-open TCP connection — common on LANs with
-# dropped routes / sleeping middleboxes — doesn't pin a session
-# slot indefinitely. Picked to match the receiver-pinged 30s /
-# 90s-miss pattern called out in the issue's "Connection
-# lifecycle" section.
-HEARTBEAT_INTERVAL_SECONDS = 30.0
-HEARTBEAT_MISS_THRESHOLD = 3
-HEARTBEAT_DEAD_AFTER_SECONDS = HEARTBEAT_INTERVAL_SECONDS * HEARTBEAT_MISS_THRESHOLD
-
-# Cap inbound application-frame size at 60 KiB. The cap is
-# applied to the WS BINARY frame's bytes (``msg.data``) before
-# Noise decrypt, so it bounds ciphertext + AEAD tag, not
-# plaintext. The Noise framework spec's hard ceiling is 65535
-# bytes per encrypted frame; 60 KiB leaves ~4 KiB headroom for
-# the AEAD tag (16 bytes) plus any future protocol overhead.
-#
-# 5c bundle chunks are the actual sizing driver: a 32 KiB raw
-# slice base64-inflates to ~43 KiB inside a JSON envelope
-# around 43.5 KiB, fitting under 60 KiB with ~16 KiB further
-# headroom for unusually long ``job_id`` / header fields.
-# Smaller messages (heartbeat, queue_status, pair frames) are
-# tiny (~30-200 bytes) and unaffected.
-#
-# The cap keeps a misbehaving / hostile peer from pinning
-# memory before the dispatch loop sees the frame; raised from
-# the original 32 KiB now that 5c has actual sizing
-# requirements (the original comment anticipated this bump).
-# Forward-compatible: smaller frames are always accepted.
-APP_FRAME_MAX_BYTES = 60 * 1024
 
 
 async def make_peer_link_handler(
@@ -171,349 +142,3 @@ async def make_peer_link_handler(
         return ws
 
     return handler
-
-
-# ---------------------------------------------------------------------------
-# Long-lived peer-link session (post-handshake, ``intent="peer_link"`` only)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class PeerLinkSession:
-    """
-    State for one active receiver-side peer-link WS session.
-
-    Owned by :class:`ReceiverController` (registered via
-    :meth:`register_peer_link_session`, dropped via
-    :meth:`unregister_peer_link_session`). Held while the
-    underlying handler coroutine is running its receive loop;
-    cleared the moment the loop returns.
-
-    Composes a :class:`PeerLinkChannel` for the wire-level
-    encrypt / send / parse / terminate operations — the same
-    channel shape the offloader-side :class:`PeerLinkClient`
-    uses, so both ends share one validation / framing seam.
-    Sends from the controller (e.g. ``queue_status`` pushes in
-    5b) go through :meth:`send_app_frame`; the
-    :attr:`_closing` short-circuit there protects against a
-    heartbeat / app sender racing a final frame onto the wire
-    after :meth:`terminate` has flipped the close decision.
-    """
-
-    dashboard_id: str
-    ws: web.WebSocketResponse
-    noise: PeerLinkNoiseSession
-    peer_ip: str
-    # Loop-monotonic timestamp of the most recent pong (or session
-    # start if no pong has landed yet). The heartbeat loop seeds
-    # this just before its first sleep so a slow first pong
-    # doesn't trip the miss threshold instantly.
-    last_pong_at: float = 0.0
-    # Set by :meth:`terminate` when something other than the
-    # session loop's natural exit (peer close, heartbeat timeout)
-    # closes the session — used by the loop to skip the
-    # heartbeat-timeout terminate frame on a path where the
-    # caller already sent its own.
-    _closing: bool = False
-    _channel: PeerLinkChannel = field(init=False)
-
-    def __post_init__(self) -> None:
-        """Build the wire-level :class:`PeerLinkChannel` over (noise, ws)."""
-        self._channel = PeerLinkChannel(noise=self.noise, ws=self.ws, log_label=self.dashboard_id)
-
-    async def send_app_frame(self, payload: dict[str, Any]) -> bool:
-        """Encrypt + send under the channel's lock; gated on ``_closing``.
-
-        Returns ``True`` on success, ``False`` on encrypt /
-        WS-side failure or once :meth:`terminate` has flipped
-        the close decision (a heartbeat / app sender that wakes
-        from ``asyncio.sleep`` after a controller-driven close
-        mustn't race a final ``ping`` onto the wire after the
-        ``terminate`` frame). The terminate frame itself routes
-        through the channel directly — :meth:`PeerLinkChannel.send_terminate`
-        bypasses the gate.
-        """
-        if self._closing:
-            return False
-        return await self._channel.send_frame(payload)
-
-    async def terminate(self, reason: TerminateReason) -> None:
-        """
-        Send a ``terminate`` frame and close the WS.
-
-        Idempotent. Used by the controller's session-registry
-        dedupe path (kick the older session on a duplicate
-        connect) and by ``stop()`` (drain everything before
-        shutdown).
-
-        Sets :attr:`_closing` *before* delegating to
-        :meth:`PeerLinkChannel.send_terminate` so any racing
-        :meth:`send_app_frame` call short-circuits cleanly; the
-        terminate-frame send itself goes through the channel
-        directly, bypassing the gate.
-        """
-        if self._closing:
-            return
-        self._closing = True
-        await self._channel.send_terminate(reason.value)
-
-
-async def _run_peer_link_session(
-    controller: ReceiverController,
-    ws: web.WebSocketResponse,
-    session: PeerLinkNoiseSession,
-    dashboard_id: str,
-    peer_ip: str,
-) -> None:
-    """
-    Run the post-handshake receive loop + heartbeat for one peer-link session.
-
-    Returns when the session ends — peer close, heartbeat
-    timeout, controller shutdown, or a malformed frame. Always
-    cleans up the controller-side registration in its ``finally``
-    so a session is unregistered the moment its coroutine exits,
-    even on uncaught exceptions.
-
-    Heartbeat is receiver-driven (per the issue's "Connection
-    lifecycle" spec): the receiver pings every
-    :data:`HEARTBEAT_INTERVAL_SECONDS`, the offloader replies
-    with a ``pong`` carrying the same ``nonce``, three consecutive
-    misses (:data:`HEARTBEAT_DEAD_AFTER_SECONDS` of silence) close
-    the session.
-    """
-    peer_link_session = PeerLinkSession(
-        dashboard_id=dashboard_id,
-        ws=ws,
-        noise=session,
-        peer_ip=peer_ip,
-    )
-    # Register before spawning the heartbeat — a duplicate connect
-    # arriving in the same loop tick MUST find this session in the
-    # registry so it can kick it. The dedupe runs synchronously
-    # inside :meth:`register_peer_link_session` so the
-    # registration is observed atomically.
-    await controller.register_peer_link_session(peer_link_session)
-    peer_link_session.last_pong_at = _monotonic()
-
-    async def _send_ping(nonce: int) -> bool:
-        return await peer_link_session.send_app_frame(
-            {"type": AppMessageType.PING.value, "nonce": nonce}
-        )
-
-    async def _on_dead() -> None:
-        await peer_link_session.terminate(TerminateReason.HEARTBEAT_TIMEOUT)
-
-    heartbeat_task = asyncio.create_task(
-        run_peer_link_heartbeat(
-            send_ping=_send_ping,
-            last_pong_at=lambda: peer_link_session.last_pong_at,
-            on_dead=_on_dead,
-        ),
-        name=f"peer-link-heartbeat[{dashboard_id}]",
-    )
-    try:
-        await _receive_loop(peer_link_session, controller)
-    finally:
-        heartbeat_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await heartbeat_task
-        controller.unregister_peer_link_session(peer_link_session)
-
-
-async def _receive_loop(session: PeerLinkSession, controller: ReceiverController) -> None:
-    """
-    Read frames off the WS, decrypt, parse, and dispatch.
-
-    aiohttp's ``WebSocketResponse`` is async-iterable; the
-    iterator yields only message frames (BINARY / TEXT / PING /
-    PONG) and exits cleanly on CLOSE / CLOSING / ERROR, so we
-    don't have to spell those transitions out.
-
-    Returns on peer close, malformed frame (after firing the
-    structured ``terminate``), or controller-driven session close
-    (the registry's :meth:`PeerLinkSession.terminate` flips
-    ``_closing`` so a CLOSE frame doesn't trigger a redundant
-    terminate). Dispatches ``ping`` / ``pong`` / ``terminate``
-    keepalive frames plus ``submit_job`` / ``submit_job_chunk``
-    against the controller's :class:`SubmitJobReceiver`. Other
-    types log at debug and are ignored.
-    """
-    async for msg in session.ws:
-        parsed = session._channel.parse_frame(msg)
-        if parsed is None:
-            await session.terminate(TerminateReason.MALFORMED_FRAME)
-            return
-        msg_type = parsed.get("type")
-        if msg_type == AppMessageType.PONG.value:
-            session.last_pong_at = _monotonic()
-            continue
-        if msg_type == AppMessageType.PING.value:
-            # Mirror the offloader's ping nonce so a peer that
-            # also runs heartbeat from its end gets pong
-            # parity without us defining a separate keepalive
-            # protocol per direction.
-            nonce = parsed.get("nonce")
-            await session.send_app_frame({"type": AppMessageType.PONG.value, "nonce": nonce})
-            continue
-        if msg_type == AppMessageType.TERMINATE.value:
-            # Peer-initiated close. Don't echo a terminate back;
-            # the WS will drain via the next ``CLOSE`` frame.
-            session._closing = True
-            return
-        if msg_type == AppMessageType.SUBMIT_JOB.value:
-            # Header validation lives inside the receiver. The
-            # `cast` here is the dispatch boundary's "the wire
-            # parse said this is a submit_job; treat it as the
-            # matching TypedDict" hand-off — runtime field
-            # validation is the receiver's job.
-            await controller.get_submit_job_receiver().handle_submit_job(
-                session, cast(SubmitJobFrameData, parsed)
-            )
-            continue
-        if msg_type == AppMessageType.SUBMIT_JOB_CHUNK.value:
-            await controller.get_submit_job_receiver().handle_submit_job_chunk(
-                session, cast(SubmitJobChunkFrameData, parsed)
-            )
-            continue
-        if msg_type == AppMessageType.CANCEL_JOB.value:
-            # 5d cooperative cancel from the offloader. Frame
-            # carries the offloader-supplied ``job_id`` we
-            # stashed as ``FirmwareJob.remote_job_id`` at
-            # submit time; the controller's handler resolves
-            # it back through :class:`JobFanout` and routes
-            # through ``FirmwareController.cancel``. No ack
-            # frame — the resulting ``JOB_CANCELLED`` bus
-            # event fans out a ``job_state_changed{cancelled}``
-            # which the offloader already plumbs.
-            await controller.handle_cancel_job(session, parsed)
-            continue
-        if msg_type == AppMessageType.DOWNLOAD_ARTIFACTS.value:
-            # Offloader is requesting the built-firmware
-            # artifact set for a previously-completed job. The
-            # sender packs idedata.json + every flash image
-            # listed in ``idedata.flash_images`` into a
-            # gzipped tarball + streams it back via
-            # ``artifacts_start`` → chunks → ``artifacts_end``.
-            await controller.get_artifacts_download_sender().handle_download_artifacts(
-                session, parsed
-            )
-            continue
-        _LOGGER.debug(
-            "peer-link unknown app frame type %r from %s; ignoring",
-            msg_type,
-            session.dashboard_id,
-        )
-
-
-def parse_app_frame(
-    noise: PeerLinkNoiseSession, msg: Any, *, log_label: str
-) -> dict[str, Any] | None:
-    """
-    Validate, decrypt, and JSON-parse one inbound peer-link frame.
-
-    Returns the parsed dict on success or ``None`` on any of the
-    malformed-frame branches: wrong WS message type (not BINARY),
-    oversize body, Noise decrypt failure, or post-decrypt JSON
-    that isn't an object. Concentrating the per-branch logging
-    here keeps each side's dispatch loop a single straight line —
-    receiver and offloader callers both respond to ``None`` by
-    closing the session (the offloader maps it to
-    ``transport_error``, the receiver to a structured
-    ``terminate{malformed_frame}`` frame).
-
-    Public so the offloader-side :class:`PeerLinkClient` can share
-    the same validation seam with the receiver-side
-    :class:`PeerLinkSession` without duplicating the four
-    log-and-return branches. ``log_label`` is what each side wants
-    in its log lines — the receiver passes its
-    ``dashboard_id``, the offloader passes
-    ``"<hostname>:<port>"``.
-    """
-    if msg.type != WSMsgType.BINARY:
-        _LOGGER.debug(
-            "peer-link expected binary frame from %s; got %s",
-            log_label,
-            msg.type,
-        )
-        return None
-    if len(msg.data) > APP_FRAME_MAX_BYTES:
-        _LOGGER.warning(
-            "peer-link oversize frame from %s (%d bytes); closing",
-            log_label,
-            len(msg.data),
-        )
-        return None
-    try:
-        plaintext = noise.decrypt(msg.data)
-    except NOISE_ERRORS:
-        _LOGGER.warning(
-            "peer-link Noise decrypt failed from %s",
-            log_label,
-            exc_info=True,
-        )
-        return None
-    parsed = _parse_json(plaintext)
-    if not isinstance(parsed, dict):
-        _LOGGER.debug(
-            "peer-link frame from %s did not decode to a JSON object",
-            log_label,
-        )
-        return None
-    return parsed
-
-
-async def run_peer_link_heartbeat(
-    *,
-    send_ping: Callable[[int], Awaitable[bool]],
-    last_pong_at: Callable[[], float],
-    on_dead: Callable[[], Awaitable[None]],
-) -> None:
-    """
-    Run a heartbeat loop driving either end of a peer-link session.
-
-    Sleeps :data:`HEARTBEAT_INTERVAL_SECONDS`, then either bails
-    out via *on_dead* (if no pong has landed within
-    :data:`HEARTBEAT_DEAD_AFTER_SECONDS`) or sends a ping via
-    *send_ping*. ``send_ping`` returns whether the wire write
-    succeeded; a ``False`` return triggers *on_dead* too (the WS
-    is presumed dead so the session shouldn't keep trying).
-
-    Lets :class:`asyncio.CancelledError` propagate out of
-    ``asyncio.sleep`` — callers spawn this as a task and cancel
-    it under ``contextlib.suppress(CancelledError)``; catching
-    here would swallow the signal at the wrong layer.
-
-    Each side's *on_dead* is what differs: the receiver sends a
-    structured ``terminate{heartbeat_timeout}`` via the session
-    registry's close path, the offloader just calls
-    ``ws.close()`` (the receive loop sees the close and unwinds
-    naturally). Each side's *send_ping* is what gates the send —
-    the receiver routes through :meth:`PeerLinkSession.send_app_frame`
-    so the ``_closing`` short-circuit holds; the offloader routes
-    through :meth:`PeerLinkChannel.send_frame` directly because
-    its lifecycle has no equivalent gate.
-    """
-    nonce = 0
-    while True:
-        await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
-        # Liveness check first — if we haven't heard a pong in
-        # the threshold window, bail before sending another ping.
-        if _monotonic() - last_pong_at() > HEARTBEAT_DEAD_AFTER_SECONDS:
-            await on_dead()
-            return
-        nonce += 1
-        if not await send_ping(nonce):
-            # send_ping already logged; the WS is presumed dead.
-            await on_dead()
-            return
-
-
-def _monotonic() -> float:
-    """Indirection so tests can monkey-patch the clock under the heartbeat loop."""
-    return asyncio.get_running_loop().time()
-
-
-# Re-export at the bottom: ``channel.py``'s lazy import looks up
-# ``parse_app_frame`` as a package attribute, so the channel module
-# must load after it's defined above.
-from .channel import PeerLinkChannel as PeerLinkChannel  # noqa: E402

--- a/esphome_device_builder/controllers/remote_build/peer_link/channel.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/channel.py
@@ -86,7 +86,9 @@ class PeerLinkChannel:
         through. See :func:`parse_app_frame` for the per-branch
         log + ``None``-on-malformed contract.
         """
-        from . import parse_app_frame  # noqa: PLC0415
+        # Lazy import: ``session.py`` imports ``PeerLinkChannel``
+        # from this module — a top-level import would be circular.
+        from .session import parse_app_frame  # noqa: PLC0415
 
         return parse_app_frame(self.noise, msg, log_label=self.log_label)
 

--- a/esphome_device_builder/controllers/remote_build/peer_link/handshake.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/handshake.py
@@ -25,6 +25,7 @@ from ....helpers.peer_link_noise import (
     pin_sha256_for_pubkey,
 )
 from ....models import IntentResponse, PeerLinkIntent
+from .session import _run_peer_link_session
 from .wire_io import (
     _normalize_label,
     _parse_intent,
@@ -164,11 +165,6 @@ async def _drive_peer_link_session(  # noqa: PLR0911 — the early-returns are t
     # intent — including a ``REJECTED`` peer_link — closes the WS
     # via the handler's ``finally`` (the legacy one-shot shape).
     if intent is PeerLinkIntent.PEER_LINK and response is IntentResponse.OK:
-        # Lazy import: ``_run_peer_link_session`` lives in the
-        # parent package's ``__init__.py``, which imports this
-        # module — a top-level import would deadlock the load.
-        from . import _run_peer_link_session  # noqa: PLC0415
-
         await _run_peer_link_session(
             controller=controller,
             ws=ws,

--- a/esphome_device_builder/controllers/remote_build/peer_link/session.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/session.py
@@ -143,6 +143,109 @@ class PeerLinkSession:
         await self._channel.send_terminate(reason.value)
 
 
+def parse_app_frame(
+    noise: PeerLinkNoiseSession, msg: Any, *, log_label: str
+) -> dict[str, Any] | None:
+    """
+    Validate, decrypt, and JSON-parse one inbound peer-link frame.
+
+    Returns the parsed dict on success or ``None`` on any of the
+    malformed-frame branches: wrong WS message type (not BINARY),
+    oversize body, Noise decrypt failure, or post-decrypt JSON
+    that isn't an object. Concentrating the per-branch logging
+    here keeps each side's dispatch loop a single straight line —
+    receiver and offloader callers both respond to ``None`` by
+    closing the session (the offloader maps it to
+    ``transport_error``, the receiver to a structured
+    ``terminate{malformed_frame}`` frame).
+
+    Public so the offloader-side :class:`PeerLinkClient` can share
+    the same validation seam with the receiver-side
+    :class:`PeerLinkSession` without duplicating the four
+    log-and-return branches. ``log_label`` is what each side wants
+    in its log lines — the receiver passes its
+    ``dashboard_id``, the offloader passes
+    ``"<hostname>:<port>"``.
+    """
+    if msg.type != WSMsgType.BINARY:
+        _LOGGER.debug(
+            "peer-link expected binary frame from %s; got %s",
+            log_label,
+            msg.type,
+        )
+        return None
+    if len(msg.data) > APP_FRAME_MAX_BYTES:
+        _LOGGER.warning(
+            "peer-link oversize frame from %s (%d bytes); closing",
+            log_label,
+            len(msg.data),
+        )
+        return None
+    try:
+        plaintext = noise.decrypt(msg.data)
+    except NOISE_ERRORS:
+        _LOGGER.warning(
+            "peer-link Noise decrypt failed from %s",
+            log_label,
+            exc_info=True,
+        )
+        return None
+    parsed = _parse_json(plaintext)
+    if not isinstance(parsed, dict):
+        _LOGGER.debug(
+            "peer-link frame from %s did not decode to a JSON object",
+            log_label,
+        )
+        return None
+    return parsed
+
+
+async def run_peer_link_heartbeat(
+    *,
+    send_ping: Callable[[int], Awaitable[bool]],
+    last_pong_at: Callable[[], float],
+    on_dead: Callable[[], Awaitable[None]],
+) -> None:
+    """
+    Run a heartbeat loop driving either end of a peer-link session.
+
+    Sleeps :data:`HEARTBEAT_INTERVAL_SECONDS`, then either bails
+    out via *on_dead* (if no pong has landed within
+    :data:`HEARTBEAT_DEAD_AFTER_SECONDS`) or sends a ping via
+    *send_ping*. ``send_ping`` returns whether the wire write
+    succeeded; a ``False`` return triggers *on_dead* too (the WS
+    is presumed dead so the session shouldn't keep trying).
+
+    Lets :class:`asyncio.CancelledError` propagate out of
+    ``asyncio.sleep`` — callers spawn this as a task and cancel
+    it under ``contextlib.suppress(CancelledError)``; catching
+    here would swallow the signal at the wrong layer.
+
+    Each side's *on_dead* is what differs: the receiver sends a
+    structured ``terminate{heartbeat_timeout}`` via the session
+    registry's close path, the offloader just calls
+    ``ws.close()`` (the receive loop sees the close and unwinds
+    naturally). Each side's *send_ping* is what gates the send —
+    the receiver routes through :meth:`PeerLinkSession.send_app_frame`
+    so the ``_closing`` short-circuit holds; the offloader routes
+    through :meth:`PeerLinkChannel.send_frame` directly because
+    its lifecycle has no equivalent gate.
+    """
+    nonce = 0
+    while True:
+        await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+        # Liveness check first — if we haven't heard a pong in
+        # the threshold window, bail before sending another ping.
+        if _monotonic() - last_pong_at() > HEARTBEAT_DEAD_AFTER_SECONDS:
+            await on_dead()
+            return
+        nonce += 1
+        if not await send_ping(nonce):
+            # send_ping already logged; the WS is presumed dead.
+            await on_dead()
+            return
+
+
 async def _run_peer_link_session(
     controller: ReceiverController,
     ws: web.WebSocketResponse,
@@ -288,109 +391,6 @@ async def _receive_loop(session: PeerLinkSession, controller: ReceiverController
             msg_type,
             session.dashboard_id,
         )
-
-
-def parse_app_frame(
-    noise: PeerLinkNoiseSession, msg: Any, *, log_label: str
-) -> dict[str, Any] | None:
-    """
-    Validate, decrypt, and JSON-parse one inbound peer-link frame.
-
-    Returns the parsed dict on success or ``None`` on any of the
-    malformed-frame branches: wrong WS message type (not BINARY),
-    oversize body, Noise decrypt failure, or post-decrypt JSON
-    that isn't an object. Concentrating the per-branch logging
-    here keeps each side's dispatch loop a single straight line —
-    receiver and offloader callers both respond to ``None`` by
-    closing the session (the offloader maps it to
-    ``transport_error``, the receiver to a structured
-    ``terminate{malformed_frame}`` frame).
-
-    Public so the offloader-side :class:`PeerLinkClient` can share
-    the same validation seam with the receiver-side
-    :class:`PeerLinkSession` without duplicating the four
-    log-and-return branches. ``log_label`` is what each side wants
-    in its log lines — the receiver passes its
-    ``dashboard_id``, the offloader passes
-    ``"<hostname>:<port>"``.
-    """
-    if msg.type != WSMsgType.BINARY:
-        _LOGGER.debug(
-            "peer-link expected binary frame from %s; got %s",
-            log_label,
-            msg.type,
-        )
-        return None
-    if len(msg.data) > APP_FRAME_MAX_BYTES:
-        _LOGGER.warning(
-            "peer-link oversize frame from %s (%d bytes); closing",
-            log_label,
-            len(msg.data),
-        )
-        return None
-    try:
-        plaintext = noise.decrypt(msg.data)
-    except NOISE_ERRORS:
-        _LOGGER.warning(
-            "peer-link Noise decrypt failed from %s",
-            log_label,
-            exc_info=True,
-        )
-        return None
-    parsed = _parse_json(plaintext)
-    if not isinstance(parsed, dict):
-        _LOGGER.debug(
-            "peer-link frame from %s did not decode to a JSON object",
-            log_label,
-        )
-        return None
-    return parsed
-
-
-async def run_peer_link_heartbeat(
-    *,
-    send_ping: Callable[[int], Awaitable[bool]],
-    last_pong_at: Callable[[], float],
-    on_dead: Callable[[], Awaitable[None]],
-) -> None:
-    """
-    Run a heartbeat loop driving either end of a peer-link session.
-
-    Sleeps :data:`HEARTBEAT_INTERVAL_SECONDS`, then either bails
-    out via *on_dead* (if no pong has landed within
-    :data:`HEARTBEAT_DEAD_AFTER_SECONDS`) or sends a ping via
-    *send_ping*. ``send_ping`` returns whether the wire write
-    succeeded; a ``False`` return triggers *on_dead* too (the WS
-    is presumed dead so the session shouldn't keep trying).
-
-    Lets :class:`asyncio.CancelledError` propagate out of
-    ``asyncio.sleep`` — callers spawn this as a task and cancel
-    it under ``contextlib.suppress(CancelledError)``; catching
-    here would swallow the signal at the wrong layer.
-
-    Each side's *on_dead* is what differs: the receiver sends a
-    structured ``terminate{heartbeat_timeout}`` via the session
-    registry's close path, the offloader just calls
-    ``ws.close()`` (the receive loop sees the close and unwinds
-    naturally). Each side's *send_ping* is what gates the send —
-    the receiver routes through :meth:`PeerLinkSession.send_app_frame`
-    so the ``_closing`` short-circuit holds; the offloader routes
-    through :meth:`PeerLinkChannel.send_frame` directly because
-    its lifecycle has no equivalent gate.
-    """
-    nonce = 0
-    while True:
-        await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
-        # Liveness check first — if we haven't heard a pong in
-        # the threshold window, bail before sending another ping.
-        if _monotonic() - last_pong_at() > HEARTBEAT_DEAD_AFTER_SECONDS:
-            await on_dead()
-            return
-        nonce += 1
-        if not await send_ping(nonce):
-            # send_ping already logged; the WS is presumed dead.
-            await on_dead()
-            return
 
 
 def _monotonic() -> float:

--- a/esphome_device_builder/controllers/remote_build/peer_link/session.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/session.py
@@ -1,0 +1,398 @@
+"""
+Long-lived peer-link session (post-handshake, ``intent="peer_link"`` only).
+
+Owns :class:`PeerLinkSession`, the receive loop, the encrypted
+ping / pong heartbeat, and the inbound-frame validator
+``parse_app_frame`` shared by both wire ends.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from aiohttp import WSMsgType, web
+
+from ....helpers.peer_link_noise import NOISE_ERRORS, PeerLinkNoiseSession
+from ....models import SubmitJobChunkFrameData, SubmitJobFrameData
+from .channel import PeerLinkChannel
+from .wire import AppMessageType, TerminateReason
+from .wire_io import _parse_json
+
+if TYPE_CHECKING:
+    from ..receiver import ReceiverController
+
+_LOGGER = logging.getLogger(__name__)
+
+# Heartbeat cadence for the long-lived peer-link session. The
+# receiver sends an encrypted ``ping`` frame every 30s and expects
+# the offloader to echo it back with a ``pong`` carrying the same
+# ``nonce``. Three consecutive missed pongs (90s of silence) close
+# the session so a half-open TCP connection — common on LANs with
+# dropped routes / sleeping middleboxes — doesn't pin a session
+# slot indefinitely. Picked to match the receiver-pinged 30s /
+# 90s-miss pattern called out in the issue's "Connection
+# lifecycle" section.
+HEARTBEAT_INTERVAL_SECONDS = 30.0
+HEARTBEAT_MISS_THRESHOLD = 3
+HEARTBEAT_DEAD_AFTER_SECONDS = HEARTBEAT_INTERVAL_SECONDS * HEARTBEAT_MISS_THRESHOLD
+
+# Cap inbound application-frame size at 60 KiB. The cap is
+# applied to the WS BINARY frame's bytes (``msg.data``) before
+# Noise decrypt, so it bounds ciphertext + AEAD tag, not
+# plaintext. The Noise framework spec's hard ceiling is 65535
+# bytes per encrypted frame; 60 KiB leaves ~4 KiB headroom for
+# the AEAD tag (16 bytes) plus any future protocol overhead.
+#
+# 5c bundle chunks are the actual sizing driver: a 32 KiB raw
+# slice base64-inflates to ~43 KiB inside a JSON envelope
+# around 43.5 KiB, fitting under 60 KiB with ~16 KiB further
+# headroom for unusually long ``job_id`` / header fields.
+# Smaller messages (heartbeat, queue_status, pair frames) are
+# tiny (~30-200 bytes) and unaffected.
+#
+# The cap keeps a misbehaving / hostile peer from pinning
+# memory before the dispatch loop sees the frame; raised from
+# the original 32 KiB now that 5c has actual sizing
+# requirements (the original comment anticipated this bump).
+# Forward-compatible: smaller frames are always accepted.
+APP_FRAME_MAX_BYTES = 60 * 1024
+
+
+@dataclass
+class PeerLinkSession:
+    """
+    State for one active receiver-side peer-link WS session.
+
+    Owned by :class:`ReceiverController` (registered via
+    :meth:`register_peer_link_session`, dropped via
+    :meth:`unregister_peer_link_session`). Held while the
+    underlying handler coroutine is running its receive loop;
+    cleared the moment the loop returns.
+
+    Composes a :class:`PeerLinkChannel` for the wire-level
+    encrypt / send / parse / terminate operations — the same
+    channel shape the offloader-side :class:`PeerLinkClient`
+    uses, so both ends share one validation / framing seam.
+    Sends from the controller (e.g. ``queue_status`` pushes in
+    5b) go through :meth:`send_app_frame`; the
+    :attr:`_closing` short-circuit there protects against a
+    heartbeat / app sender racing a final frame onto the wire
+    after :meth:`terminate` has flipped the close decision.
+    """
+
+    dashboard_id: str
+    ws: web.WebSocketResponse
+    noise: PeerLinkNoiseSession
+    peer_ip: str
+    # Loop-monotonic timestamp of the most recent pong (or session
+    # start if no pong has landed yet). The heartbeat loop seeds
+    # this just before its first sleep so a slow first pong
+    # doesn't trip the miss threshold instantly.
+    last_pong_at: float = 0.0
+    # Set by :meth:`terminate` when something other than the
+    # session loop's natural exit (peer close, heartbeat timeout)
+    # closes the session — used by the loop to skip the
+    # heartbeat-timeout terminate frame on a path where the
+    # caller already sent its own.
+    _closing: bool = False
+    _channel: PeerLinkChannel = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Build the wire-level :class:`PeerLinkChannel` over (noise, ws)."""
+        self._channel = PeerLinkChannel(noise=self.noise, ws=self.ws, log_label=self.dashboard_id)
+
+    async def send_app_frame(self, payload: dict[str, Any]) -> bool:
+        """Encrypt + send under the channel's lock; gated on ``_closing``.
+
+        Returns ``True`` on success, ``False`` on encrypt /
+        WS-side failure or once :meth:`terminate` has flipped
+        the close decision (a heartbeat / app sender that wakes
+        from ``asyncio.sleep`` after a controller-driven close
+        mustn't race a final ``ping`` onto the wire after the
+        ``terminate`` frame). The terminate frame itself routes
+        through the channel directly — :meth:`PeerLinkChannel.send_terminate`
+        bypasses the gate.
+        """
+        if self._closing:
+            return False
+        return await self._channel.send_frame(payload)
+
+    async def terminate(self, reason: TerminateReason) -> None:
+        """
+        Send a ``terminate`` frame and close the WS.
+
+        Idempotent. Used by the controller's session-registry
+        dedupe path (kick the older session on a duplicate
+        connect) and by ``stop()`` (drain everything before
+        shutdown).
+
+        Sets :attr:`_closing` *before* delegating to
+        :meth:`PeerLinkChannel.send_terminate` so any racing
+        :meth:`send_app_frame` call short-circuits cleanly; the
+        terminate-frame send itself goes through the channel
+        directly, bypassing the gate.
+        """
+        if self._closing:
+            return
+        self._closing = True
+        await self._channel.send_terminate(reason.value)
+
+
+async def _run_peer_link_session(
+    controller: ReceiverController,
+    ws: web.WebSocketResponse,
+    session: PeerLinkNoiseSession,
+    dashboard_id: str,
+    peer_ip: str,
+) -> None:
+    """
+    Run the post-handshake receive loop + heartbeat for one peer-link session.
+
+    Returns when the session ends — peer close, heartbeat
+    timeout, controller shutdown, or a malformed frame. Always
+    cleans up the controller-side registration in its ``finally``
+    so a session is unregistered the moment its coroutine exits,
+    even on uncaught exceptions.
+
+    Heartbeat is receiver-driven (per the issue's "Connection
+    lifecycle" spec): the receiver pings every
+    :data:`HEARTBEAT_INTERVAL_SECONDS`, the offloader replies
+    with a ``pong`` carrying the same ``nonce``, three consecutive
+    misses (:data:`HEARTBEAT_DEAD_AFTER_SECONDS` of silence) close
+    the session.
+    """
+    peer_link_session = PeerLinkSession(
+        dashboard_id=dashboard_id,
+        ws=ws,
+        noise=session,
+        peer_ip=peer_ip,
+    )
+    # Register before spawning the heartbeat — a duplicate connect
+    # arriving in the same loop tick MUST find this session in the
+    # registry so it can kick it. The dedupe runs synchronously
+    # inside :meth:`register_peer_link_session` so the
+    # registration is observed atomically.
+    await controller.register_peer_link_session(peer_link_session)
+    peer_link_session.last_pong_at = _monotonic()
+
+    async def _send_ping(nonce: int) -> bool:
+        return await peer_link_session.send_app_frame(
+            {"type": AppMessageType.PING.value, "nonce": nonce}
+        )
+
+    async def _on_dead() -> None:
+        await peer_link_session.terminate(TerminateReason.HEARTBEAT_TIMEOUT)
+
+    heartbeat_task = asyncio.create_task(
+        run_peer_link_heartbeat(
+            send_ping=_send_ping,
+            last_pong_at=lambda: peer_link_session.last_pong_at,
+            on_dead=_on_dead,
+        ),
+        name=f"peer-link-heartbeat[{dashboard_id}]",
+    )
+    try:
+        await _receive_loop(peer_link_session, controller)
+    finally:
+        heartbeat_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await heartbeat_task
+        controller.unregister_peer_link_session(peer_link_session)
+
+
+async def _receive_loop(session: PeerLinkSession, controller: ReceiverController) -> None:
+    """
+    Read frames off the WS, decrypt, parse, and dispatch.
+
+    aiohttp's ``WebSocketResponse`` is async-iterable; the
+    iterator yields only message frames (BINARY / TEXT / PING /
+    PONG) and exits cleanly on CLOSE / CLOSING / ERROR, so we
+    don't have to spell those transitions out.
+
+    Returns on peer close, malformed frame (after firing the
+    structured ``terminate``), or controller-driven session close
+    (the registry's :meth:`PeerLinkSession.terminate` flips
+    ``_closing`` so a CLOSE frame doesn't trigger a redundant
+    terminate). Dispatches ``ping`` / ``pong`` / ``terminate``
+    keepalive frames plus ``submit_job`` / ``submit_job_chunk``
+    against the controller's :class:`SubmitJobReceiver`. Other
+    types log at debug and are ignored.
+    """
+    async for msg in session.ws:
+        parsed = session._channel.parse_frame(msg)
+        if parsed is None:
+            await session.terminate(TerminateReason.MALFORMED_FRAME)
+            return
+        msg_type = parsed.get("type")
+        if msg_type == AppMessageType.PONG.value:
+            session.last_pong_at = _monotonic()
+            continue
+        if msg_type == AppMessageType.PING.value:
+            # Mirror the offloader's ping nonce so a peer that
+            # also runs heartbeat from its end gets pong
+            # parity without us defining a separate keepalive
+            # protocol per direction.
+            nonce = parsed.get("nonce")
+            await session.send_app_frame({"type": AppMessageType.PONG.value, "nonce": nonce})
+            continue
+        if msg_type == AppMessageType.TERMINATE.value:
+            # Peer-initiated close. Don't echo a terminate back;
+            # the WS will drain via the next ``CLOSE`` frame.
+            session._closing = True
+            return
+        if msg_type == AppMessageType.SUBMIT_JOB.value:
+            # Header validation lives inside the receiver. The
+            # `cast` here is the dispatch boundary's "the wire
+            # parse said this is a submit_job; treat it as the
+            # matching TypedDict" hand-off — runtime field
+            # validation is the receiver's job.
+            await controller.get_submit_job_receiver().handle_submit_job(
+                session, cast(SubmitJobFrameData, parsed)
+            )
+            continue
+        if msg_type == AppMessageType.SUBMIT_JOB_CHUNK.value:
+            await controller.get_submit_job_receiver().handle_submit_job_chunk(
+                session, cast(SubmitJobChunkFrameData, parsed)
+            )
+            continue
+        if msg_type == AppMessageType.CANCEL_JOB.value:
+            # 5d cooperative cancel from the offloader. Frame
+            # carries the offloader-supplied ``job_id`` we
+            # stashed as ``FirmwareJob.remote_job_id`` at
+            # submit time; the controller's handler resolves
+            # it back through :class:`JobFanout` and routes
+            # through ``FirmwareController.cancel``. No ack
+            # frame — the resulting ``JOB_CANCELLED`` bus
+            # event fans out a ``job_state_changed{cancelled}``
+            # which the offloader already plumbs.
+            await controller.handle_cancel_job(session, parsed)
+            continue
+        if msg_type == AppMessageType.DOWNLOAD_ARTIFACTS.value:
+            # Offloader is requesting the built-firmware
+            # artifact set for a previously-completed job. The
+            # sender packs idedata.json + every flash image
+            # listed in ``idedata.flash_images`` into a
+            # gzipped tarball + streams it back via
+            # ``artifacts_start`` → chunks → ``artifacts_end``.
+            await controller.get_artifacts_download_sender().handle_download_artifacts(
+                session, parsed
+            )
+            continue
+        _LOGGER.debug(
+            "peer-link unknown app frame type %r from %s; ignoring",
+            msg_type,
+            session.dashboard_id,
+        )
+
+
+def parse_app_frame(
+    noise: PeerLinkNoiseSession, msg: Any, *, log_label: str
+) -> dict[str, Any] | None:
+    """
+    Validate, decrypt, and JSON-parse one inbound peer-link frame.
+
+    Returns the parsed dict on success or ``None`` on any of the
+    malformed-frame branches: wrong WS message type (not BINARY),
+    oversize body, Noise decrypt failure, or post-decrypt JSON
+    that isn't an object. Concentrating the per-branch logging
+    here keeps each side's dispatch loop a single straight line —
+    receiver and offloader callers both respond to ``None`` by
+    closing the session (the offloader maps it to
+    ``transport_error``, the receiver to a structured
+    ``terminate{malformed_frame}`` frame).
+
+    Public so the offloader-side :class:`PeerLinkClient` can share
+    the same validation seam with the receiver-side
+    :class:`PeerLinkSession` without duplicating the four
+    log-and-return branches. ``log_label`` is what each side wants
+    in its log lines — the receiver passes its
+    ``dashboard_id``, the offloader passes
+    ``"<hostname>:<port>"``.
+    """
+    if msg.type != WSMsgType.BINARY:
+        _LOGGER.debug(
+            "peer-link expected binary frame from %s; got %s",
+            log_label,
+            msg.type,
+        )
+        return None
+    if len(msg.data) > APP_FRAME_MAX_BYTES:
+        _LOGGER.warning(
+            "peer-link oversize frame from %s (%d bytes); closing",
+            log_label,
+            len(msg.data),
+        )
+        return None
+    try:
+        plaintext = noise.decrypt(msg.data)
+    except NOISE_ERRORS:
+        _LOGGER.warning(
+            "peer-link Noise decrypt failed from %s",
+            log_label,
+            exc_info=True,
+        )
+        return None
+    parsed = _parse_json(plaintext)
+    if not isinstance(parsed, dict):
+        _LOGGER.debug(
+            "peer-link frame from %s did not decode to a JSON object",
+            log_label,
+        )
+        return None
+    return parsed
+
+
+async def run_peer_link_heartbeat(
+    *,
+    send_ping: Callable[[int], Awaitable[bool]],
+    last_pong_at: Callable[[], float],
+    on_dead: Callable[[], Awaitable[None]],
+) -> None:
+    """
+    Run a heartbeat loop driving either end of a peer-link session.
+
+    Sleeps :data:`HEARTBEAT_INTERVAL_SECONDS`, then either bails
+    out via *on_dead* (if no pong has landed within
+    :data:`HEARTBEAT_DEAD_AFTER_SECONDS`) or sends a ping via
+    *send_ping*. ``send_ping`` returns whether the wire write
+    succeeded; a ``False`` return triggers *on_dead* too (the WS
+    is presumed dead so the session shouldn't keep trying).
+
+    Lets :class:`asyncio.CancelledError` propagate out of
+    ``asyncio.sleep`` — callers spawn this as a task and cancel
+    it under ``contextlib.suppress(CancelledError)``; catching
+    here would swallow the signal at the wrong layer.
+
+    Each side's *on_dead* is what differs: the receiver sends a
+    structured ``terminate{heartbeat_timeout}`` via the session
+    registry's close path, the offloader just calls
+    ``ws.close()`` (the receive loop sees the close and unwinds
+    naturally). Each side's *send_ping* is what gates the send —
+    the receiver routes through :meth:`PeerLinkSession.send_app_frame`
+    so the ``_closing`` short-circuit holds; the offloader routes
+    through :meth:`PeerLinkChannel.send_frame` directly because
+    its lifecycle has no equivalent gate.
+    """
+    nonce = 0
+    while True:
+        await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+        # Liveness check first — if we haven't heard a pong in
+        # the threshold window, bail before sending another ping.
+        if _monotonic() - last_pong_at() > HEARTBEAT_DEAD_AFTER_SECONDS:
+            await on_dead()
+            return
+        nonce += 1
+        if not await send_ping(nonce):
+            # send_ping already logged; the WS is presumed dead.
+            await on_dead()
+            return
+
+
+def _monotonic() -> float:
+    """Indirection so tests can monkey-patch the clock under the heartbeat loop."""
+    return asyncio.get_running_loop().time()

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -54,9 +54,12 @@ from esphome_device_builder.controllers.remote_build.peer_link import (
     _DispatchInput,
     _drive_peer_link_session,
     _HandshakeStep,
-    _receive_loop,
     make_peer_link_handler,
 )
+from esphome_device_builder.controllers.remote_build.peer_link import (
+    session as _peer_link_session_module,
+)
+from esphome_device_builder.controllers.remote_build.peer_link.session import _receive_loop
 from esphome_device_builder.controllers.remote_build.peer_link.wire_io import (
     _PEER_LABEL_MAX_CHARS,
     _normalize_label,
@@ -723,7 +726,7 @@ async def test_drive_session_handshake_not_complete_logs_and_returns(
 
     real_session = PeerLinkNoiseSession.responder(responder_priv)
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.peer_link.PeerLinkNoiseSession.responder",
+        "esphome_device_builder.controllers.remote_build.peer_link.handshake.PeerLinkNoiseSession.responder",
         lambda priv: real_session,
     )
 
@@ -2031,9 +2034,9 @@ async def test_run_peer_link_heartbeat_terminates_on_pong_timeout(
     the miss threshold on the next ``_monotonic`` read so the
     very first iteration trips the timeout branch.
     """
-    monkeypatch.setattr(_peer_link_module, "HEARTBEAT_INTERVAL_SECONDS", 0.001)
-    monkeypatch.setattr(_peer_link_module, "HEARTBEAT_DEAD_AFTER_SECONDS", 0.0)
-    monkeypatch.setattr(_peer_link_module, "_monotonic", lambda: 1000.0)
+    monkeypatch.setattr(_peer_link_session_module, "HEARTBEAT_INTERVAL_SECONDS", 0.001)
+    monkeypatch.setattr(_peer_link_session_module, "HEARTBEAT_DEAD_AFTER_SECONDS", 0.0)
+    monkeypatch.setattr(_peer_link_session_module, "_monotonic", lambda: 1000.0)
 
     pings: list[int] = []
     deaths: list[bool] = []
@@ -2045,7 +2048,7 @@ async def test_run_peer_link_heartbeat_terminates_on_pong_timeout(
     async def _on_dead() -> None:
         deaths.append(True)
 
-    await _peer_link_module.run_peer_link_heartbeat(
+    await _peer_link_session_module.run_peer_link_heartbeat(
         send_ping=_send_ping,
         last_pong_at=lambda: 0.0,
         on_dead=_on_dead,
@@ -2063,8 +2066,8 @@ async def test_run_peer_link_heartbeat_terminates_on_send_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """If ``send_ping`` reports failure (WS dead), the heartbeat invokes ``on_dead``."""
-    monkeypatch.setattr(_peer_link_module, "HEARTBEAT_INTERVAL_SECONDS", 0.001)
-    monkeypatch.setattr(_peer_link_module, "_monotonic", lambda: 0.0)
+    monkeypatch.setattr(_peer_link_session_module, "HEARTBEAT_INTERVAL_SECONDS", 0.001)
+    monkeypatch.setattr(_peer_link_session_module, "_monotonic", lambda: 0.0)
 
     deaths: list[bool] = []
 
@@ -2074,7 +2077,7 @@ async def test_run_peer_link_heartbeat_terminates_on_send_failure(
     async def _on_dead() -> None:
         deaths.append(True)
 
-    await _peer_link_module.run_peer_link_heartbeat(
+    await _peer_link_session_module.run_peer_link_heartbeat(
         send_ping=_send_ping_fail,
         last_pong_at=lambda: 0.0,
         on_dead=_on_dead,
@@ -2129,7 +2132,7 @@ async def test_run_peer_link_session_heartbeat_closures_route_to_session(
         # Park until the test signals via cancellation.
         await asyncio.Event().wait()
 
-    monkeypatch.setattr(_peer_link_module, "run_peer_link_heartbeat", _capturing_heartbeat)
+    monkeypatch.setattr(_peer_link_session_module, "run_peer_link_heartbeat", _capturing_heartbeat)
 
     run_task = asyncio.create_task(
         _peer_link_module._run_peer_link_session(
@@ -2187,8 +2190,8 @@ async def test_run_peer_link_heartbeat_propagates_cancellation(
     """
     # Use a long interval so the task is reliably parked in
     # ``asyncio.sleep`` when we cancel.
-    monkeypatch.setattr(_peer_link_module, "HEARTBEAT_INTERVAL_SECONDS", 10.0)
-    monkeypatch.setattr(_peer_link_module, "_monotonic", lambda: 0.0)
+    monkeypatch.setattr(_peer_link_session_module, "HEARTBEAT_INTERVAL_SECONDS", 10.0)
+    monkeypatch.setattr(_peer_link_session_module, "_monotonic", lambda: 0.0)
 
     async def _noop_send(_nonce: int) -> bool:
         return True
@@ -2197,7 +2200,7 @@ async def test_run_peer_link_heartbeat_propagates_cancellation(
         pass
 
     task = asyncio.create_task(
-        _peer_link_module.run_peer_link_heartbeat(
+        _peer_link_session_module.run_peer_link_heartbeat(
             send_ping=_noop_send,
             last_pong_at=lambda: 0.0,
             on_dead=_noop_dead,


### PR DESCRIPTION
# What does this implement/fix?

**Sixth and final PR in the `peer_link` split arc** (follows #769 + #770 + #773 + #781 + #783; plan: `peer_link_split.md`). Moves the long-lived post-handshake session machinery byte-for-byte from `peer_link/__init__.py` into a new `peer_link/session.py` submodule.

**Moved:**

* `PeerLinkSession` dataclass + `send_app_frame` / `terminate`
* `_run_peer_link_session` driver
* `_receive_loop` frame dispatcher
* `parse_app_frame` validation seam (shared with offloader-side)
* `run_peer_link_heartbeat` (drives either end)
* `_monotonic` clock indirection (test hook)
* Constants: `HEARTBEAT_INTERVAL_SECONDS`, `HEARTBEAT_MISS_THRESHOLD`, `HEARTBEAT_DEAD_AFTER_SECONDS`, `APP_FRAME_MAX_BYTES`

**Lazy imports cleaned up:**

* `handshake.py`'s `_run_peer_link_session` lazy import becomes a module-level `from .session import _run_peer_link_session`.
* `channel.py`'s lazy `parse_app_frame` import redirects to `.session` — `channel.py` is imported BY `session.py` (PeerLinkSession composes a `PeerLinkChannel`), so this one stays lazy to avoid the circular load.

`__init__.py` drops the heartbeat + frame-cap constant blocks (both moved to `session.py`) and the section-divider comment. Its remaining content is just the public WS handler factory (`make_peer_link_handler`), `PEER_LINK_PATH`, and the re-exports that keep external imports stable.

**Test redirects** (the HIGH-risk part of this PR — ~10 sites total):

* `_peer_link_module` monkey-patches against `HEARTBEAT_*`, `_monotonic`, `run_peer_link_heartbeat` redirect to a new `_peer_link_session_module` reference (the actual binding site).
* Direct calls `_peer_link_module.run_peer_link_heartbeat(...)` redirect to `_peer_link_session_module` so they see the patched function.
* `PeerLinkNoiseSession.responder` patch redirects from `peer_link.PeerLinkNoiseSession` to `peer_link.handshake.PeerLinkNoiseSession` (where the responder call actually lives after #783).
* `_receive_loop` test import redirects to `peer_link.session._receive_loop` (private, not re-exported from the package).

* **`__init__.py`**: 519 → **144 lines** (−375).
* **`session.py`** (new): 398 lines.

**Full peer_link arc**: 1071-line single file → six cohesive submodules with `__init__.py` at 144 lines (just the public WS factory + re-exports).

| Submodule | Lines | Concern |
|---|---|---|
| `__init__.py` | 144 | Public WS handler factory + re-exports |
| `wire.py` | 110 | `TerminateReason`, `AppMessageType` |
| `channel.py` | 119 | `PeerLinkChannel` shared by both ends |
| `wire_io.py` | 190 | Low-level WS / Noise plumbing |
| `handshake.py` | 236 | Noise XX driver + intent dispatch |
| `session.py` | 398 | Long-lived session + heartbeat + frame parse |

All 3391 non-e2e tests pass; ruff + mypy clean.

**Related issue or feature (if applicable):**

- follow-up to #769 + #770 + #773 + #781 + #783; sixth and final PR of the peer_link split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
