### PR TITLE
Split OffloaderController: extract settings commands

### DIFF
--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -48,7 +48,6 @@ from ...models import (
     OffloaderQueueStatusChangedData,
     OffloaderRemoteBuildSettings,
     OffloaderRemoteBuildSettingsView,
-    OffloaderRemoteBuildsToggledData,
     OffloaderRemoteJobSnapshotEntry,
     PairingSummary,
     PeerQueueStatusSnapshotEntry,
@@ -62,6 +61,7 @@ from . import (
     pair_status,
     peer_link_lifecycle,
     rebind,
+    settings_commands,
     submit_job_commands,
 )
 from ._models import RebindProbeResult
@@ -72,7 +72,6 @@ from ._storage_codecs import (
     encode_pairings,
 )
 from ._summaries import pairing_summary
-from ._validators import validate_bool
 from .peer_link_client import PairStatusResult
 
 if TYPE_CHECKING:
@@ -466,22 +465,10 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     # API surface
     # ------------------------------------------------------------------
 
-    def _offloader_settings_view(self) -> OffloaderRemoteBuildSettingsView:
-        """Project the in-RAM offloader-side state to its wire view.
-
-        Pure sync RAM read off :attr:`_pairings` +
-        :attr:`_remote_builds_enabled`, which are canonical
-        after :meth:`start` seeds them from disk.
-        """
-        return OffloaderRemoteBuildSettingsView(
-            pairings=self.pairings_snapshot(),
-            remote_builds_enabled=self._remote_builds_enabled,
-        )
-
     @api_command("remote_build/get_offloader_settings")
     async def get_offloader_settings(self, **kwargs: Any) -> OffloaderRemoteBuildSettingsView:
         """Return the offloader-side settings view (master toggle + pairings list)."""
-        return self._offloader_settings_view()
+        return await settings_commands.get_offloader_settings(self)
 
     @api_command("remote_build/set_offloader_settings")
     async def set_offloader_settings(
@@ -490,29 +477,10 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         remote_builds_enabled: bool,
         **kwargs: Any,
     ) -> OffloaderRemoteBuildSettingsView:
-        """
-        Flip the offloader-side master toggle for transparent install.
-
-        ``False`` short-circuits :func:`pick_build_path` to
-        LOCAL; peer-link sessions stay open and the manual
-        Send-builds dialog still works. The intent is "keep the
-        pairings but stop auto-routing for now."
-
-        Fires ``OFFLOADER_REMOTE_BUILDS_TOGGLED`` for cross-tab
-        sync; debounce-saves through ``_pairings_store`` (same
-        on-disk shape).
-        """
-        self._remote_builds_enabled = validate_bool(
-            remote_builds_enabled,
-            command="remote_build/set_offloader_settings",
-            field="remote_builds_enabled",
+        """Flip the offloader-side master toggle for transparent install."""
+        return await settings_commands.set_offloader_settings(
+            self, remote_builds_enabled=remote_builds_enabled
         )
-        toggled: OffloaderRemoteBuildsToggledData = {
-            "remote_builds_enabled": remote_builds_enabled,
-        }
-        self._db.bus.fire(EventType.OFFLOADER_REMOTE_BUILDS_TOGGLED, toggled)
-        self._schedule_pairings_save()
-        return self._offloader_settings_view()
 
     @api_command("remote_build/set_pairing_enabled")
     async def set_pairing_enabled(

--- a/esphome_device_builder/controllers/remote_build/settings_commands.py
+++ b/esphome_device_builder/controllers/remote_build/settings_commands.py
@@ -1,0 +1,74 @@
+"""
+Offloader-side ``get_offloader_settings`` / ``set_offloader_settings`` WS commands.
+
+The two settings WS commands plus their shared
+:func:`offloader_settings_view` projection. Bodies take
+:class:`OffloaderController` as the first arg; the controller
+keeps the two ``@api_command``-decorated methods as thin
+bound-method delegates.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...models import (
+    EventType,
+    OffloaderRemoteBuildSettingsView,
+    OffloaderRemoteBuildsToggledData,
+)
+from ._validators import validate_bool
+
+if TYPE_CHECKING:
+    from .offloader import OffloaderController
+
+
+def offloader_settings_view(
+    controller: OffloaderController,
+) -> OffloaderRemoteBuildSettingsView:
+    """Project the in-RAM offloader-side state to its wire view.
+
+    Pure sync RAM read off :attr:`_pairings` +
+    :attr:`_remote_builds_enabled`, which are canonical
+    after :meth:`OffloaderController.start` seeds them from
+    disk.
+    """
+    return OffloaderRemoteBuildSettingsView(
+        pairings=controller.pairings_snapshot(),
+        remote_builds_enabled=controller._remote_builds_enabled,
+    )
+
+
+async def get_offloader_settings(
+    controller: OffloaderController,
+) -> OffloaderRemoteBuildSettingsView:
+    """Return the offloader-side settings view (master toggle + pairings list)."""
+    return offloader_settings_view(controller)
+
+
+async def set_offloader_settings(
+    controller: OffloaderController, *, remote_builds_enabled: bool
+) -> OffloaderRemoteBuildSettingsView:
+    """
+    Flip the offloader-side master toggle for transparent install.
+
+    ``False`` short-circuits :func:`pick_build_path` to
+    LOCAL; peer-link sessions stay open and the manual
+    Send-builds dialog still works. The intent is "keep the
+    pairings but stop auto-routing for now."
+
+    Fires ``OFFLOADER_REMOTE_BUILDS_TOGGLED`` for cross-tab
+    sync; debounce-saves through ``_pairings_store`` (same
+    on-disk shape).
+    """
+    controller._remote_builds_enabled = validate_bool(
+        remote_builds_enabled,
+        command="remote_build/set_offloader_settings",
+        field="remote_builds_enabled",
+    )
+    toggled: OffloaderRemoteBuildsToggledData = {
+        "remote_builds_enabled": remote_builds_enabled,
+    }
+    controller._db.bus.fire(EventType.OFFLOADER_REMOTE_BUILDS_TOGGLED, toggled)
+    controller._schedule_pairings_save()
+    return offloader_settings_view(controller)


### PR DESCRIPTION
# What does this implement/fix?

Extracts the offloader-side `get_offloader_settings` / `set_offloader_settings` WS commands plus their shared `offloader_settings_view` projection into a new sibling module `controllers/remote_build/settings_commands.py`. Seventh PR in the OffloaderController split arc (after #766 + #772 + #774 + #775 + #780 + #782).

Bodies take `OffloaderController` as the first arg; the controller keeps the two `@api_command`-decorated methods as thin bound delegates so WS dispatch resolves unchanged.

## Imports

Moved out of `offloader.py`: `validate_bool`, `OffloaderRemoteBuildsToggledData`. The `_offloader_settings_view` private helper had no cross-module callers (only the two now-extracted WS commands used it), so it moves cleanly as a free `offloader_settings_view` in the new module.

## Test impact

Zero test changes. Both methods are bound delegates and no tests patched `_offloader_settings_view`.

`offloader.py`: **767 → 733 lines** (-34). Combined with #766 + #772 + #774 + #775 + #780 + #782: 1709 → 733 (-976, **-57%**). `# noqa: PLR0904` stays — public-method count is still 21 (the move only dropped the private helper, not a public method, since both delegates remain).

678 remote-build tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the OffloaderController split arc tracked in `offloader_split.md`. One optional cleanup remains (the bus-event handler cluster); this PR completes the WS-command extractions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
