### PR TITLE
Filter virtual-bridge interfaces from mDNS advertise

### DIFF
--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -118,6 +118,46 @@ def _is_loopback_adapter(adapter: ifaddr.Adapter) -> bool:
     return name.startswith("lo") or "loopback" in nice
 
 
+# Interface-name prefixes whose addresses are scoped to the host's
+# own virtualisation / container bridges and shouldn't reach the LAN
+# in an mDNS announce. Two hosts with the same Docker default
+# (``docker0`` at ``172.17.0.1``) would otherwise have one's mDNS
+# advertise direct the other's peer-link client at its own
+# listener — see the peer-link self-loopback bug.
+#
+# * ``docker``  — Docker default bridge (``docker0``) and named
+#   gateway bridges (``docker_gwbridge``).
+# * ``br-``     — Docker user-defined network bridges
+#   (``br-<network-id>``).
+# * ``veth``    — virtual ethernet pair peer on the host side.
+# * ``cni``     — Kubernetes CNI plugin bridges (``cni0``).
+# * ``virbr``   — libvirt default bridges (``virbr0``).
+# * ``vethernet`` — Windows Hyper-V virtual switches (``vEthernet
+#   (WSL)``, ``vEthernet (Default Switch)``).
+_VIRTUAL_BRIDGE_PREFIXES: tuple[str, ...] = (
+    "docker",
+    "br-",
+    "veth",
+    "cni",
+    "virbr",
+    "vethernet",
+)
+
+
+def _is_virtual_bridge_adapter(adapter: ifaddr.Adapter) -> bool:
+    """
+    Return ``True`` when *adapter* is a virtualisation / container bridge.
+
+    Addresses on these adapters are bridge-namespace-scoped — a
+    peer receiving the IP either has no route to it (mismatched
+    bridge config) or, worse, routes to its own equivalent bridge
+    and lands on its own listener.
+    """
+    name = (adapter.name or "").lower()
+    nice = (adapter.nice_name or "").lower()
+    return any(name.startswith(p) or nice.startswith(p) for p in _VIRTUAL_BRIDGE_PREFIXES)
+
+
 def _local_addresses() -> list[str]:
     """
     Return the IPv4 / IPv6 addresses to advertise.
@@ -125,7 +165,7 @@ def _local_addresses() -> list[str]:
     Enumerates every adapter via :mod:`ifaddr` (already a
     python-zeroconf dependency) and returns the bare addresses as
     plain strings suitable for :class:`~zeroconf.ServiceInfo`'s
-    ``parsed_addresses`` keyword. Drops three classes of addresses
+    ``parsed_addresses`` keyword. Drops four classes of addresses
     that would land on the wire but never help a peer:
 
     * **Loopback interfaces.** Filtering by interface (``lo`` /
@@ -145,6 +185,16 @@ def _local_addresses() -> list[str]:
       comes back. Hosts with many virtual interfaces (VPN, awdl,
       utun*) can carry a dozen link-local addresses that just
       inflate the announcement without adding reachability.
+    * **Virtualisation / container bridges** — Docker default
+      (``docker0``), user-defined networks (``br-*``), virtual
+      ethernet pair peers (``veth*``), Kubernetes CNI (``cni*``),
+      libvirt (``virbr*``), Windows Hyper-V virtual switches
+      (``vEthernet (…)``). The default Docker bridge in particular
+      uses the same RFC 1918 subnet (``172.17.0.0/16``) on most
+      hosts; advertising ``172.17.0.1`` from one host would direct
+      a peer that also has Docker installed at its own equivalent
+      bridge IP — the TCP connect routes locally and the peer hits
+      its own listener, surfacing as a peer-link "pin drift".
 
     Setting ``parsed_addresses`` explicitly is what fixes the
     "127.0.0.1 / ::1 / fe80::1 only" advertise we saw on macOS:
@@ -169,7 +219,7 @@ def _local_addresses() -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
     for adapter in ifaddr.get_adapters():
-        if _is_loopback_adapter(adapter):
+        if _is_loopback_adapter(adapter) or _is_virtual_bridge_adapter(adapter):
             continue
         for ip in adapter.ips:
             # ``ifaddr.IP.ip`` is a ``str`` for IPv4 and a 3-tuple

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -137,7 +137,7 @@ _DOCKER_USER_BRIDGE_RE = re.compile(r"^br-[0-9a-f]{12}$")
 
 
 def _is_virtual_bridge_adapter(adapter: ifaddr.Adapter) -> bool:
-    """Return ``True`` when *adapter*'s name matches a virtual-bridge prefix."""
+    """Match a virtual-bridge prefix or Docker's ``br-<12 hex>`` user-network name."""
     name = (adapter.name or "").lower()
     nice = (adapter.nice_name or "").lower()
     if _DOCKER_USER_BRIDGE_RE.match(name) or _DOCKER_USER_BRIDGE_RE.match(nice):
@@ -173,10 +173,13 @@ def _local_addresses() -> list[str]:
       utun*) can carry a dozen link-local addresses that just
       inflate the announcement without adding reachability.
     * **Virtualisation / container bridges** — ``docker*``,
-      ``br-*``, ``veth*``, ``cni*``, ``virbr*``, ``vEthernet*``.
-      Host-namespace-scoped; advertising ``172.17.0.1`` from
-      ``docker0`` points peers with the same default Docker subnet
-      at their own bridge gateway. See ``_VIRTUAL_BRIDGE_PREFIXES``.
+      ``veth*``, ``cni*``, ``virbr*``, ``vEthernet*`` prefixes
+      plus Docker's ``br-<12 hex>`` user-defined networks (real
+      LAN bridges like ``br-lan`` keep their IP). Host-namespace-
+      scoped; advertising ``172.17.0.1`` from ``docker0`` points
+      peers with the same default Docker subnet at their own
+      bridge gateway. See ``_VIRTUAL_BRIDGE_PREFIXES`` +
+      ``_DOCKER_USER_BRIDGE_RE``.
 
     Setting ``parsed_addresses`` explicitly is what fixes the
     "127.0.0.1 / ::1 / fe80::1 only" advertise we saw on macOS:

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -124,18 +124,24 @@ def _is_loopback_adapter(adapter: ifaddr.Adapter) -> bool:
 # subnet at their own bridge gateway.
 _VIRTUAL_BRIDGE_PREFIXES: tuple[str, ...] = (
     "docker",  # docker0, docker_gwbridge
-    "br-",  # Docker user-defined networks
     "veth",  # virtual ethernet pair peer
     "cni",  # Kubernetes CNI plugin bridges
     "virbr",  # libvirt default bridges
     "vethernet",  # Windows Hyper-V virtual switches
 )
 
+# Docker user-defined networks: ``br-`` plus a 12-hex-char network
+# ID. Anchored so real LAN bridge names (``br-lan``, ``br-guest``
+# on OpenWRT / homelab Linux setups) stay out of the filter.
+_DOCKER_USER_BRIDGE_RE = re.compile(r"^br-[0-9a-f]{12}$")
+
 
 def _is_virtual_bridge_adapter(adapter: ifaddr.Adapter) -> bool:
     """Return ``True`` when *adapter*'s name matches a virtual-bridge prefix."""
     name = (adapter.name or "").lower()
     nice = (adapter.nice_name or "").lower()
+    if _DOCKER_USER_BRIDGE_RE.match(name) or _DOCKER_USER_BRIDGE_RE.match(nice):
+        return True
     return any(name.startswith(p) or nice.startswith(p) for p in _VIRTUAL_BRIDGE_PREFIXES)
 
 

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -118,41 +118,22 @@ def _is_loopback_adapter(adapter: ifaddr.Adapter) -> bool:
     return name.startswith("lo") or "loopback" in nice
 
 
-# Interface-name prefixes whose addresses are scoped to the host's
-# own virtualisation / container bridges and shouldn't reach the LAN
-# in an mDNS announce. Two hosts with the same Docker default
-# (``docker0`` at ``172.17.0.1``) would otherwise have one's mDNS
-# advertise direct the other's peer-link client at its own
-# listener — see the peer-link self-loopback bug.
-#
-# * ``docker``  — Docker default bridge (``docker0``) and named
-#   gateway bridges (``docker_gwbridge``).
-# * ``br-``     — Docker user-defined network bridges
-#   (``br-<network-id>``).
-# * ``veth``    — virtual ethernet pair peer on the host side.
-# * ``cni``     — Kubernetes CNI plugin bridges (``cni0``).
-# * ``virbr``   — libvirt default bridges (``virbr0``).
-# * ``vethernet`` — Windows Hyper-V virtual switches (``vEthernet
-#   (WSL)``, ``vEthernet (Default Switch)``).
+# Interface-name prefixes for virtualisation / container bridges.
+# Their IPs are host-namespace-scoped; advertising e.g. ``docker0``
+# at ``172.17.0.1`` directs peers with the same Docker default
+# subnet at their own bridge gateway.
 _VIRTUAL_BRIDGE_PREFIXES: tuple[str, ...] = (
-    "docker",
-    "br-",
-    "veth",
-    "cni",
-    "virbr",
-    "vethernet",
+    "docker",  # docker0, docker_gwbridge
+    "br-",  # Docker user-defined networks
+    "veth",  # virtual ethernet pair peer
+    "cni",  # Kubernetes CNI plugin bridges
+    "virbr",  # libvirt default bridges
+    "vethernet",  # Windows Hyper-V virtual switches
 )
 
 
 def _is_virtual_bridge_adapter(adapter: ifaddr.Adapter) -> bool:
-    """
-    Return ``True`` when *adapter* is a virtualisation / container bridge.
-
-    Addresses on these adapters are bridge-namespace-scoped — a
-    peer receiving the IP either has no route to it (mismatched
-    bridge config) or, worse, routes to its own equivalent bridge
-    and lands on its own listener.
-    """
+    """Return ``True`` when *adapter*'s name matches a virtual-bridge prefix."""
     name = (adapter.name or "").lower()
     nice = (adapter.nice_name or "").lower()
     return any(name.startswith(p) or nice.startswith(p) for p in _VIRTUAL_BRIDGE_PREFIXES)
@@ -185,16 +166,11 @@ def _local_addresses() -> list[str]:
       comes back. Hosts with many virtual interfaces (VPN, awdl,
       utun*) can carry a dozen link-local addresses that just
       inflate the announcement without adding reachability.
-    * **Virtualisation / container bridges** — Docker default
-      (``docker0``), user-defined networks (``br-*``), virtual
-      ethernet pair peers (``veth*``), Kubernetes CNI (``cni*``),
-      libvirt (``virbr*``), Windows Hyper-V virtual switches
-      (``vEthernet (…)``). The default Docker bridge in particular
-      uses the same RFC 1918 subnet (``172.17.0.0/16``) on most
-      hosts; advertising ``172.17.0.1`` from one host would direct
-      a peer that also has Docker installed at its own equivalent
-      bridge IP — the TCP connect routes locally and the peer hits
-      its own listener, surfacing as a peer-link "pin drift".
+    * **Virtualisation / container bridges** — ``docker*``,
+      ``br-*``, ``veth*``, ``cni*``, ``virbr*``, ``vEthernet*``.
+      Host-namespace-scoped; advertising ``172.17.0.1`` from
+      ``docker0`` points peers with the same default Docker subnet
+      at their own bridge gateway. See ``_VIRTUAL_BRIDGE_PREFIXES``.
 
     Setting ``parsed_addresses`` explicitly is what fixes the
     "127.0.0.1 / ::1 / fe80::1 only" advertise we saw on macOS:

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -312,6 +312,46 @@ def test_local_addresses_drops_loopback_ip_on_real_adapter(monkeypatch: pytest.M
     assert _local_addresses() == ["192.168.1.10"]
 
 
+@pytest.mark.parametrize(
+    "bridge_name",
+    [
+        "docker0",
+        "docker_gwbridge",
+        "br-1a2b3c4d5e6f",
+        "veth1234abcd",
+        "cni0",
+        "virbr0",
+    ],
+    ids=["docker0", "docker-named", "br-userdef", "veth-peer", "cni0", "virbr0"],
+)
+def test_local_addresses_drops_virtual_bridge_by_name(
+    monkeypatch: pytest.MonkeyPatch, bridge_name: str
+) -> None:
+    """Container / virtualisation bridges are filtered by their interface name."""
+    adapters = [
+        _adapter(bridge_name, ips=["172.17.0.1"]),
+        _adapter("en0", ips=["192.168.1.10"]),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    assert _local_addresses() == ["192.168.1.10"]
+
+
+def test_local_addresses_drops_hyperv_virtual_switch_by_nice_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows Hyper-V virtual switches (``vEthernet (...)``) are filtered."""
+    adapters = [
+        _adapter(
+            "\\Device\\NPF_vEthernet_WSL",
+            nice_name="vEthernet (WSL)",
+            ips=["172.20.0.1"],
+        ),
+        _adapter("Ethernet", ips=["192.168.1.10"]),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    assert _local_addresses() == ["192.168.1.10"]
+
+
 def test_local_addresses_skips_unparseable_strings(monkeypatch: pytest.MonkeyPatch) -> None:
     """Garbage from a flaky adapter doesn't blow up the whole walk."""
     adapters = [

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -352,6 +352,21 @@ def test_local_addresses_drops_hyperv_virtual_switch_by_nice_name(
     assert _local_addresses() == ["192.168.1.10"]
 
 
+@pytest.mark.parametrize(
+    "lan_bridge_name",
+    ["br-lan", "br-guest", "br-wan", "br-iot"],
+)
+def test_local_addresses_keeps_non_docker_bridge_names(
+    monkeypatch: pytest.MonkeyPatch, lan_bridge_name: str
+) -> None:
+    """Legitimate LAN bridges (``br-lan`` etc.) survive the Docker filter."""
+    adapters = [
+        _adapter(lan_bridge_name, ips=["192.168.1.10"]),
+    ]
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: adapters)
+    assert _local_addresses() == ["192.168.1.10"]
+
+
 def test_local_addresses_skips_unparseable_strings(monkeypatch: pytest.MonkeyPatch) -> None:
     """Garbage from a flaky adapter doesn't blow up the whole walk."""
     adapters = [


### PR DESCRIPTION
# What does this implement/fix?

Root-cause fix for the peer-link "pin drift" bug diagnosed in
#765 + #771: the receiver's mDNS announce was carrying its
Docker default bridge IP (`172.17.0.1` on `docker0`) in the
advertised A records. An offloader on a second host with its
own Docker install would resolve the receiver's hostname, pick
that A record, and its TCP connect would route locally to its
own `docker0` gateway — landing on the offloader's own
peer-link listener bound `0.0.0.0:6055`. Noise XX completed
with the offloader's own static keypair; the existing pin
check fired drift and the client orphaned. User-visible symptom
in the field: "pairing is lost until I restart the offloader."

`_local_addresses()` already filters loopback and link-local
adapters; this PR extends the filter to virtualisation /
container bridges. Adds `_is_virtual_bridge_adapter` matching
the canonical prefixes:

- `docker*` — Docker default bridge (`docker0`) and named
  gateway bridges (`docker_gwbridge`)
- `br-*` — Docker user-defined network bridges
  (`br-<network-id>`)
- `veth*` — virtual ethernet pair peer on the host side
- `cni*` — Kubernetes CNI plugin bridges (`cni0`)
- `virbr*` — libvirt default bridges (`virbr0`)
- `vEthernet*` (case-insensitive) — Windows Hyper-V virtual
  switches (`vEthernet (WSL)`, `vEthernet (Default Switch)`)

`_local_addresses()` skips those adapters wholesale, the same
shape it already uses for loopback. Test coverage mirrors the
existing loopback / link-local filter tests (parametrised over
each prefix + a dedicated Hyper-V nice-name test).

This is the root-cause fix. The offloader-side self-loopback
guard (#785) catches future routing shapes the prefix list
doesn't anticipate (NAT hairpin loops, overlay-network gateways,
anything else that can land the connect on our own listener)
and is independently useful as defence in depth. Either PR
alone fixes the reporter's case; both together cover the class.

**Related issue or feature (if applicable):**

- root-cause for #765 / #771 / #785
- diagnosis writeup in `handshake_bug_analysis.md` (local
  working doc, not in this PR)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (Filter-logic only; no surface change.)
