### PR TITLE
Split OffloaderController: extract bus event handlers

### DIFF
--- a/esphome_device_builder/controllers/remote_build/bus_handlers.py
+++ b/esphome_device_builder/controllers/remote_build/bus_handlers.py
@@ -52,7 +52,8 @@ _OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES: frozenset[str] = frozenset(
 def on_offloader_pair_pin_mismatch(
     controller: OffloaderController, event: Event[OffloaderPairPinMismatchData]
 ) -> None:
-    """Cache the alert in ``_offloader_alerts`` for late-subscriber snapshot.
+    """
+    Cache the alert in ``_offloader_alerts`` for late-subscriber snapshot.
 
     Keyed on ``pin_sha256`` (matches the synchronous
     mutation site in :meth:`_apply_pair_status_result`).
@@ -84,7 +85,8 @@ def on_offloader_pair_pin_mismatch(
 def on_offloader_peer_link_opened(
     controller: OffloaderController, event: Event[OffloaderPeerLinkOpenedData]
 ) -> None:
-    """Add ``pin_sha256`` to ``_open_peer_links`` and refresh the receiver version.
+    """
+    Add ``pin_sha256`` to ``_open_peer_links`` and refresh the receiver version.
 
     Receiver's ``esphome_version`` rides on every
     ``intent_response`` so a receiver upgrade picks up on
@@ -137,7 +139,8 @@ def on_offloader_queue_status_changed(
 def on_offloader_job_state_changed(
     controller: OffloaderController, event: Event[OffloaderJobStateChangedData]
 ) -> None:
-    """Maintain the offloader-side in-flight remote-job cache.
+    """
+    Maintain the offloader-side in-flight remote-job cache.
 
     Upserts the entry on ``queued`` / ``running``; drops on
     terminal (``completed`` / ``failed`` / ``cancelled``)

--- a/esphome_device_builder/controllers/remote_build/bus_handlers.py
+++ b/esphome_device_builder/controllers/remote_build/bus_handlers.py
@@ -1,0 +1,159 @@
+"""
+Offloader-side bus event handler bodies.
+
+Five callbacks the controller registers in :meth:`start`:
+- ``_on_offloader_pair_pin_mismatch`` — caches the alert for
+  late-subscriber snapshot.
+- ``_on_offloader_peer_link_opened`` — tracks open sessions
+  and refreshes the receiver's ``esphome_version``.
+- ``_on_offloader_peer_link_closed`` — clears the open-session
+  tracking.
+- ``_on_offloader_queue_status_changed`` — updates the
+  per-peer queue-status cache.
+- ``_on_offloader_job_state_changed`` — maintains the
+  in-flight remote-job cache.
+
+Bodies take :class:`OffloaderController` as the first arg;
+the controller keeps the five ``_on_offloader_*`` methods as
+thin bound-method delegates so the
+``self._db.bus.add_listener(EventType.X, self._on_x)``
+registrations in :meth:`OffloaderController.start` continue
+to resolve and tests can instance-call them.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from ...helpers.event_bus import Event
+from ...models import (
+    PAIRING_VERSION_MAX_LEN,
+    OffloaderJobStateChangedData,
+    OffloaderPairPinMismatchData,
+    OffloaderPeerLinkClosedData,
+    OffloaderPeerLinkOpenedData,
+    OffloaderPinMismatchAlert,
+    OffloaderQueueStatusChangedData,
+    OffloaderRemoteJobSnapshotEntry,
+    PeerQueueStatusSnapshotEntry,
+)
+
+if TYPE_CHECKING:
+    from .offloader import OffloaderController
+
+# Terminal status set for the offloader-side remote-job cache
+# drop-on-terminal logic.
+_OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {"completed", "failed", "cancelled"}
+)
+
+
+def on_offloader_pair_pin_mismatch(
+    controller: OffloaderController, event: Event[OffloaderPairPinMismatchData]
+) -> None:
+    """Cache the alert in ``_offloader_alerts`` for late-subscriber snapshot.
+
+    Keyed on ``pin_sha256`` (matches the synchronous
+    mutation site in :meth:`_apply_pair_status_result`).
+    The alert payload adds ``kind`` + ``fired_at`` to the
+    bus event's wire fields so the snapshot row survives
+    the event drop.
+    """
+    data = event.data
+    # Build the typed alert explicitly rather than as a bare
+    # dict literal: ``_offloader_alerts`` is typed
+    # ``dict[..., OffloaderAlertSnapshotEntry]`` (a union of
+    # ``OffloaderPinMismatchAlert`` / ``OffloaderPeerRevokedAlert``
+    # discriminated by ``kind``), and a bare literal under
+    # strict mypy can fall back to ``dict[str, object]``
+    # rather than narrowing into the right TypedDict variant.
+    alert: OffloaderPinMismatchAlert = {
+        "kind": "pin_mismatch",
+        "receiver_hostname": data["receiver_hostname"],
+        "receiver_port": data["receiver_port"],
+        "pin_sha256": data["pin_sha256"],
+        "receiver_label": data["receiver_label"],
+        "expected_pin": data["expected_pin"],
+        "observed_pin": data["observed_pin"],
+        "fired_at": time.time(),
+    }
+    controller._offloader_alerts[data["pin_sha256"]] = alert
+
+
+def on_offloader_peer_link_opened(
+    controller: OffloaderController, event: Event[OffloaderPeerLinkOpenedData]
+) -> None:
+    """Add ``pin_sha256`` to ``_open_peer_links`` and refresh the receiver version.
+
+    Receiver's ``esphome_version`` rides on every
+    ``intent_response`` so a receiver upgrade picks up on
+    next session-open without operator action.
+    ``pick_build_path``'s deferred version-compat gate reads
+    this field.
+
+    Empty / oversize versions are dropped silently rather
+    than clobbering — empty would lose the captured value
+    after a reconnect from a pre-feature receiver; oversize
+    is defense-in-depth against the
+    :data:`PAIRING_VERSION_MAX_LEN` cap that the storage
+    validator enforces on disk-load.
+    """
+    data = event.data
+    pin_sha256 = data["pin_sha256"]
+    controller._open_peer_links.add(pin_sha256)
+    version = data["esphome_version"]
+    if not version or len(version) > PAIRING_VERSION_MAX_LEN:
+        return
+    pairing = controller._pairings.get(pin_sha256)
+    if pairing is None or pairing.esphome_version == version:
+        return
+    pairing.esphome_version = version
+    controller._schedule_pairings_save()
+
+
+def on_offloader_peer_link_closed(
+    controller: OffloaderController, event: Event[OffloaderPeerLinkClosedData]
+) -> None:
+    """Discard ``pin_sha256`` from ``_open_peer_links`` on session close."""
+    controller._open_peer_links.discard(event.data["pin_sha256"])
+
+
+def on_offloader_queue_status_changed(
+    controller: OffloaderController, event: Event[OffloaderQueueStatusChangedData]
+) -> None:
+    """Update the offloader-side ``_peer_queue_status`` cache from a wire event."""
+    data = event.data
+    controller._peer_queue_status[data["pin_sha256"]] = PeerQueueStatusSnapshotEntry(
+        receiver_hostname=data["receiver_hostname"],
+        receiver_port=data["receiver_port"],
+        pin_sha256=data["pin_sha256"],
+        idle=data["idle"],
+        running=data["running"],
+        queue_depth=data["queue_depth"],
+    )
+
+
+def on_offloader_job_state_changed(
+    controller: OffloaderController, event: Event[OffloaderJobStateChangedData]
+) -> None:
+    """Maintain the offloader-side in-flight remote-job cache.
+
+    Upserts the entry on ``queued`` / ``running``; drops on
+    terminal (``completed`` / ``failed`` / ``cancelled``)
+    so the snapshot only ever carries actively-running
+    rows. The :class:`PeerLinkClient` receive loop already
+    validated the wire shape before firing this event.
+    """
+    data = event.data
+    if data["status"] in _OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES:
+        controller._offloader_remote_jobs.pop(data["job_id"], None)
+        return
+    controller._offloader_remote_jobs[data["job_id"]] = OffloaderRemoteJobSnapshotEntry(
+        receiver_hostname=data["receiver_hostname"],
+        receiver_port=data["receiver_port"],
+        pin_sha256=data["pin_sha256"],
+        job_id=data["job_id"],
+        status=data["status"],
+        error_message=data["error_message"],
+    )

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -36,7 +35,6 @@ from ...helpers.peer_link_identity import get_or_create_peer_link_identity
 from ...helpers.peer_link_resolver import PeerLinkDNSResolver, make_peer_link_resolver
 from ...helpers.storage import Store
 from ...models import (
-    PAIRING_VERSION_MAX_LEN,
     EventType,
     OffloaderAlertSnapshotEntry,
     OffloaderJobStateChangedData,
@@ -44,7 +42,6 @@ from ...models import (
     OffloaderPairPinMismatchData,
     OffloaderPeerLinkClosedData,
     OffloaderPeerLinkOpenedData,
-    OffloaderPinMismatchAlert,
     OffloaderQueueStatusChangedData,
     OffloaderRemoteBuildSettings,
     OffloaderRemoteBuildSettingsView,
@@ -56,6 +53,7 @@ from ...models import (
     StoredPairing,
 )
 from . import (
+    bus_handlers,
     discovery,
     pair_commands,
     pair_status,
@@ -94,12 +92,6 @@ def _load_offloader_identities(
     """
     return get_or_create_peer_link_identity(config_dir), get_or_create_identity(config_dir)
 
-
-# Terminal status set for the offloader-side remote-job cache
-# drop-on-terminal logic.
-_OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES: frozenset[str] = frozenset(
-    {"completed", "failed", "cancelled"}
-)
 
 # Debounce window for the offloader-side pairings-store write
 # so a burst of approvals collapses to one disk write.
@@ -271,105 +263,30 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         discovery.start_discovery(self)
 
     def _on_offloader_pair_pin_mismatch(self, event: Event[OffloaderPairPinMismatchData]) -> None:
-        """Cache the alert in ``_offloader_alerts`` for late-subscriber snapshot.
-
-        Keyed on ``pin_sha256`` (matches the synchronous
-        mutation site in :meth:`_apply_pair_status_result`).
-        The alert payload adds ``kind`` + ``fired_at`` to the
-        bus event's wire fields so the snapshot row survives
-        the event drop.
-        """
-        data = event.data
-        # Build the typed alert explicitly rather than as a bare
-        # dict literal: ``_offloader_alerts`` is typed
-        # ``dict[..., OffloaderAlertSnapshotEntry]`` (a union of
-        # ``OffloaderPinMismatchAlert`` / ``OffloaderPeerRevokedAlert``
-        # discriminated by ``kind``), and a bare literal under
-        # strict mypy can fall back to ``dict[str, object]``
-        # rather than narrowing into the right TypedDict variant.
-        alert: OffloaderPinMismatchAlert = {
-            "kind": "pin_mismatch",
-            "receiver_hostname": data["receiver_hostname"],
-            "receiver_port": data["receiver_port"],
-            "pin_sha256": data["pin_sha256"],
-            "receiver_label": data["receiver_label"],
-            "expected_pin": data["expected_pin"],
-            "observed_pin": data["observed_pin"],
-            "fired_at": time.time(),
-        }
-        self._offloader_alerts[data["pin_sha256"]] = alert
+        """Cache the alert in ``_offloader_alerts`` for late-subscriber snapshot."""
+        bus_handlers.on_offloader_pair_pin_mismatch(self, event)
 
     def _on_offloader_peer_link_opened(self, event: Event[OffloaderPeerLinkOpenedData]) -> None:
-        """Add ``pin_sha256`` to ``_open_peer_links`` and refresh the receiver version.
-
-        Receiver's ``esphome_version`` rides on every
-        ``intent_response`` so a receiver upgrade picks up on
-        next session-open without operator action.
-        ``pick_build_path``'s deferred version-compat gate reads
-        this field.
-
-        Empty / oversize versions are dropped silently rather
-        than clobbering — empty would lose the captured value
-        after a reconnect from a pre-feature receiver; oversize
-        is defense-in-depth against the
-        :data:`PAIRING_VERSION_MAX_LEN` cap that the storage
-        validator enforces on disk-load.
-        """
-        data = event.data
-        pin_sha256 = data["pin_sha256"]
-        self._open_peer_links.add(pin_sha256)
-        version = data["esphome_version"]
-        if not version or len(version) > PAIRING_VERSION_MAX_LEN:
-            return
-        pairing = self._pairings.get(pin_sha256)
-        if pairing is None or pairing.esphome_version == version:
-            return
-        pairing.esphome_version = version
-        self._schedule_pairings_save()
+        """Add ``pin_sha256`` to ``_open_peer_links`` and refresh the receiver version."""
+        bus_handlers.on_offloader_peer_link_opened(self, event)
 
     def _on_offloader_peer_link_closed(self, event: Event[OffloaderPeerLinkClosedData]) -> None:
         """Discard ``pin_sha256`` from ``_open_peer_links`` on session close."""
-        self._open_peer_links.discard(event.data["pin_sha256"])
+        bus_handlers.on_offloader_peer_link_closed(self, event)
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]
     ) -> None:
         """Update the offloader-side ``_peer_queue_status`` cache from a wire event."""
-        data = event.data
-        self._peer_queue_status[data["pin_sha256"]] = PeerQueueStatusSnapshotEntry(
-            receiver_hostname=data["receiver_hostname"],
-            receiver_port=data["receiver_port"],
-            pin_sha256=data["pin_sha256"],
-            idle=data["idle"],
-            running=data["running"],
-            queue_depth=data["queue_depth"],
-        )
+        bus_handlers.on_offloader_queue_status_changed(self, event)
 
     def peer_queue_status_snapshot(self) -> list[PeerQueueStatusSnapshotEntry]:
         """Per-peer queue-status snapshot for ``subscribe_events`` seeding."""
         return list(self._peer_queue_status.values())
 
     def _on_offloader_job_state_changed(self, event: Event[OffloaderJobStateChangedData]) -> None:
-        """Maintain the offloader-side in-flight remote-job cache.
-
-        Upserts the entry on ``queued`` / ``running``; drops on
-        terminal (``completed`` / ``failed`` / ``cancelled``)
-        so the snapshot only ever carries actively-running
-        rows. The :class:`PeerLinkClient` receive loop already
-        validated the wire shape before firing this event.
-        """
-        data = event.data
-        if data["status"] in _OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES:
-            self._offloader_remote_jobs.pop(data["job_id"], None)
-            return
-        self._offloader_remote_jobs[data["job_id"]] = OffloaderRemoteJobSnapshotEntry(
-            receiver_hostname=data["receiver_hostname"],
-            receiver_port=data["receiver_port"],
-            pin_sha256=data["pin_sha256"],
-            job_id=data["job_id"],
-            status=data["status"],
-            error_message=data["error_message"],
-        )
+        """Maintain the offloader-side in-flight remote-job cache."""
+        bus_handlers.on_offloader_job_state_changed(self, event)
 
     def offloader_remote_jobs_snapshot(self) -> list[OffloaderRemoteJobSnapshotEntry]:
         """In-flight remote-job snapshot for ``subscribe_events`` seeding."""


### PR DESCRIPTION
# What does this implement/fix?

Extracts the five offloader-side bus event handler bodies into a new sibling module `controllers/remote_build/bus_handlers.py`. Eighth and **final** PR in the OffloaderController split arc (after #766 + #772 + #774 + #775 + #780 + #782 + #787).

**Methods extracted** (all kept as bound delegates on the controller):
- `on_offloader_pair_pin_mismatch`
- `on_offloader_peer_link_opened`
- `on_offloader_peer_link_closed`
- `on_offloader_queue_status_changed`
- `on_offloader_job_state_changed`

All five stay as bound delegates on the controller because (a) `self._db.bus.add_listener(EventType.X, self._on_x)` in `start()` registers them by reference and (b) tests heavily instance-call them.

## Imports

Moved out of `offloader.py`: `time`, `PAIRING_VERSION_MAX_LEN`, `OffloaderPinMismatchAlert`, plus the `_OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES` constant (only the job-state handler used it). Stays imported: `Event`, the five event-data TypedDicts (delegate signatures), and `PeerQueueStatusSnapshotEntry` / `OffloaderRemoteJobSnapshotEntry` (controller `__init__` dict annotations).

## Test impact

Zero test changes. All five delegates remain bound methods on the controller; tests instance-call them.

`offloader.py`: **733 → 650 lines** (-83). Combined with the seven prior PRs: 1709 → 650 (-1059, **-62%**).

678 remote-build tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Final PR in the OffloaderController split arc tracked in `offloader_split.md`. The plan is now complete; the controller is split into 9 sibling modules (discovery, rebind, peer_link_lifecycle, pair_status, submit_job_commands, pair_commands, settings_commands, bus_handlers + the orchestrator floor in offloader.py).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
