### PR TITLE
Tighten channel.py docstrings

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/channel.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/channel.py
@@ -87,14 +87,15 @@ class PeerLinkChannel:
         Send a structured ``terminate`` frame and close the WS, best-effort.
 
         The frame routes through :meth:`send_frame` so the encrypt
-        + lock invariants hold. The close that follows must
-        suppress ``aiohttp.ClientError`` too: offloader-side
+        + lock invariants hold. The close must also suppress
+        ``aiohttp.ClientError``: offloader-side
         ``ClientWebSocketResponse.close()`` raises it when the peer
         has gone away, and an escape here would block
         ``CancelledError`` propagation inside
         :meth:`PeerLinkClient._run_one_session`'s cancel handler.
-        ``CancelledError`` doesn't inherit from ``Exception`` since
-        Py3.8, so the wider suppression stays no-swallow safe.
+        The suppression is narrow (``OSError``, ``RuntimeError``,
+        ``aiohttp.ClientError`` — all ``Exception`` subclasses), so
+        cancellation propagates unaffected.
         """
         await self.send_frame({"type": AppMessageType.TERMINATE.value, "reason": reason})
         with contextlib.suppress(OSError, RuntimeError, aiohttp.ClientError):

--- a/esphome_device_builder/controllers/remote_build/peer_link/channel.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/channel.py
@@ -32,13 +32,10 @@ class PeerLinkChannel:
     """
     Wire-level send / parse / terminate seam shared by both ends.
 
-    Wraps the post-handshake :class:`PeerLinkNoiseSession` plus
-    its WS endpoint and a send lock. Each side's session class
-    composes one of these so the encrypt-then-send pattern (and
-    the validate-decrypt-parse-dict-check parse pattern, and the
-    structured terminate-frame-then-close pattern) only lives in
-    one module. ``log_label`` is what callers want in their log
-    lines: receiver passes its ``dashboard_id``, offloader
+    Wraps the post-handshake :class:`PeerLinkNoiseSession`, its
+    WS endpoint, and a send lock so the encrypt-then-send pattern
+    lives in one place. ``log_label`` is what each side wants in
+    its log lines: receiver passes its ``dashboard_id``, offloader
     passes ``"<hostname>:<port>"``.
     """
 
@@ -78,14 +75,7 @@ class PeerLinkChannel:
             return await _send_bytes_safely(self.ws, ciphertext, log_label="app frame")
 
     def parse_frame(self, msg: Any) -> dict[str, Any] | None:
-        """
-        Validate, decrypt, and JSON-parse one inbound frame.
-
-        Thin wrapper around :func:`parse_app_frame` so callers
-        don't have to thread :attr:`noise` and :attr:`log_label`
-        through. See :func:`parse_app_frame` for the per-branch
-        log + ``None``-on-malformed contract.
-        """
+        """Validate, decrypt, and JSON-parse one inbound frame; ``None`` on malformed."""
         # Lazy import: ``session.py`` imports ``PeerLinkChannel``
         # from this module — a top-level import would be circular.
         from .session import parse_app_frame  # noqa: PLC0415
@@ -96,23 +86,15 @@ class PeerLinkChannel:
         """
         Send a structured ``terminate`` frame and close the WS, best-effort.
 
-        The terminate frame routes through :meth:`send_frame` so
-        the encrypt + lock invariants hold; the close that
-        follows is best-effort because a peer that has already
-        gone away won't accept either, and we want the call site
-        idempotent across "WS still up" and "WS dead" states.
-        Narrow suppress to transport-level errors only — including
-        :class:`aiohttp.ClientError` because this channel runs on
-        both sides of the wire (offloader side's ``self.ws`` is a
-        :class:`aiohttp.ClientWebSocketResponse` whose ``.close()``
-        can raise ``ClientConnectionError`` / ``ClientError``
-        when the peer has already gone away). A ``ClientError``
-        escaping here would block the caller's
-        :class:`CancelledError` propagation when used inside a
-        :meth:`PeerLinkClient._run_one_session` cancellation
-        handler. Python 3.8+ already excludes ``CancelledError``
-        from ``Exception``, so the wider suppression below stays
-        compatible with the no-swallow contract.
+        The frame routes through :meth:`send_frame` so the encrypt
+        + lock invariants hold. The close that follows must
+        suppress ``aiohttp.ClientError`` too: offloader-side
+        ``ClientWebSocketResponse.close()`` raises it when the peer
+        has gone away, and an escape here would block
+        ``CancelledError`` propagation inside
+        :meth:`PeerLinkClient._run_one_session`'s cancel handler.
+        ``CancelledError`` doesn't inherit from ``Exception`` since
+        Py3.8, so the wider suppression stays no-swallow safe.
         """
         await self.send_frame({"type": AppMessageType.TERMINATE.value, "reason": reason})
         with contextlib.suppress(OSError, RuntimeError, aiohttp.ClientError):


### PR DESCRIPTION
# What does this implement/fix?

Docstring cleanup follow-up to #773 (`PeerLinkChannel` extraction). #773 preserved bodies byte-for-byte; this is the deferred prose pass.

Changes:

* **`PeerLinkChannel` class docstring** — drops the body-restating parenthetical ("and the validate-decrypt-parse-dict-check parse pattern, and the structured terminate-frame-then-close pattern"). Keeps the shared-seam summary + `log_label` contract.
* **`parse_frame`** — collapses from 6 lines to 1. "Thin wrapper around `parse_app_frame`" is body restatement; the one-liner says what's load-bearing (returns `None` on malformed).
* **`send_terminate`** — keeps the load-bearing contract (why the `contextlib.suppress` must include `aiohttp.ClientError`, and why the wider suppression stays no-swallow safe under Py3.8+ `CancelledError` semantics) but collapses the narrative from two paragraphs to one tight paragraph.

`send_frame` left alone — the "Noise nonce advances in one direction only" + "Noise cipher state is not safe to share across concurrent encrypts" is contract-worthy thread-safety invariant, not narrative.

Pure prose change; no behaviour change. All peer-link tests pass.

**Related issue or feature (if applicable):**

- follow-up to #773; per-module cleanup PR in the peer_link split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
