### PR TITLE
Tighten handshake.py docstrings + inline comments

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/handshake.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/handshake.py
@@ -177,9 +177,9 @@ async def _dispatch_intent(
 
     # Reject malformed dashboard_id before any controller call.
     # Same alphabet + length contract as
-    # :func:`_validators.validate_dashboard_id` on the WS-command
-    # path; both consume from ``helpers.dashboard_identity`` so
-    # they can't drift.
+    # :func:`controllers.remote_build._validators.validate_dashboard_id`
+    # on the WS-command path; both consume from
+    # ``helpers.dashboard_identity`` so they can't drift.
     if (
         not inp.dashboard_id
         or len(inp.dashboard_id) > DASHBOARD_ID_MAX_CHARS

--- a/esphome_device_builder/controllers/remote_build/peer_link/handshake.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/handshake.py
@@ -46,14 +46,10 @@ class _HandshakeStep(StrEnum):
     """
     The three Noise XX handshake messages, in order.
 
-    Used as a label-typed argument to ``_read_handshake_message``
-    / ``_send_handshake_message`` so log lines and timeout-error
-    messages identify the specific step. Members are the wire-
-    convention short names from the Noise spec (``e`` for the
-    initiator's ephemeral on msg1, ``e, ee, s, es`` for msg2's
-    composite, ``s, se`` for msg3) but we name them ``MSG1`` /
-    ``MSG2`` / ``MSG3`` for grep-readability against any
-    debugger / log output.
+    Threaded as a label-typed argument through the wire I/O
+    helpers so log lines and timeout-error messages identify the
+    specific step; ``MSG1`` / ``MSG2`` / ``MSG3`` rather than the
+    Noise-spec tokens for grep-readability in logs.
     """
 
     MSG1 = "msg1"
@@ -63,18 +59,7 @@ class _HandshakeStep(StrEnum):
 
 @dataclass(frozen=True)
 class _DispatchInput:
-    """
-    Per-session inputs to :func:`_dispatch_intent`.
-
-    Bundles the six values ``_drive_peer_link_session`` extracts
-    from the Noise handshake transcript + msg3 payload + WS
-    request: the intent discriminator, the offloader-supplied
-    metadata (dashboard_id, label), the handshake-derived
-    identity (pin_sha256 + static_x25519_pub) and the connection
-    metadata (peer_ip). Frozen because the dispatcher only reads;
-    a single object beats threading six kwargs through the call
-    site.
-    """
+    """Per-session inputs to :func:`_dispatch_intent`; frozen, read-only."""
 
     intent: PeerLinkIntent
     dashboard_id: str
@@ -107,9 +92,8 @@ async def _drive_peer_link_session(  # noqa: PLR0911 — the early-returns are t
     intent = _parse_intent(msg1_payload)
     if intent is None:
         # Complete the handshake before rejecting so the offloader
-        # can see the rejection in an authenticated frame rather
-        # than as a raw transport close. Send empty msg2, expect
-        # msg3, then send the rejection.
+        # sees the rejection in an authenticated frame, not a raw
+        # transport close.
         if not await _send_handshake_message(session, ws, b"", _HandshakeStep.MSG2):
             return
         if await _read_handshake_message(session, ws, _HandshakeStep.MSG3) is None:
@@ -160,10 +144,9 @@ async def _drive_peer_link_session(  # noqa: PLR0911 — the early-returns are t
     )
     await _send_response(session, ws, response)
 
-    # Hand off to the long-lived application session for
-    # ``intent="peer_link"`` on a successful auth. Every other
-    # intent — including a ``REJECTED`` peer_link — closes the WS
-    # via the handler's ``finally`` (the legacy one-shot shape).
+    # Hand off to the long-lived application session on an
+    # OK-authed peer_link; every other intent (incl. REJECTED
+    # peer_link) closes the WS via the handler's ``finally``.
     if intent is PeerLinkIntent.PEER_LINK and response is IntentResponse.OK:
         await _run_peer_link_session(
             controller=controller,
@@ -181,28 +164,22 @@ async def _dispatch_intent(
     """
     Resolve a single peer-link intent into a typed :class:`IntentResponse`.
 
-    Pure dispatch logic, callable directly from tests so the
-    intent → controller-call routing is verified without the WS /
-    Noise plumbing in the loop. See :class:`IntentResponse` for the
-    per-intent response semantics. The caller (the WS driver) has
-    already validated the wire string into a :class:`PeerLinkIntent`
-    member; an unknown wire value returns ``IntentResponse.REJECTED``
-    before reaching this function.
+    Pure dispatch — callable directly from tests without the WS /
+    Noise plumbing. The WS driver has already validated the wire
+    string into a :class:`PeerLinkIntent`; unknown wire values map
+    to ``REJECTED`` before reaching here.
     """
     if inp.intent is PeerLinkIntent.PREVIEW:
         # Preview captures the responder's static pubkey via the
-        # handshake transcript; nothing else to do server-side
-        # and the offloader doesn't need a dashboard_id yet.
+        # handshake transcript; no controller call + no
+        # dashboard_id needed.
         return IntentResponse.OK
 
-    # Every other intent identifies the offloader by dashboard_id;
-    # an empty / missing / malformed value would create or look up
-    # nonsense rows, so reject before any controller call. The
-    # alphabet + length contract is the same one
-    # :func:`controllers.remote_build._validators.validate_dashboard_id`
-    # enforces on the WS-command path; both consumers import the
-    # constants from ``helpers.dashboard_identity`` so they can't
-    # drift.
+    # Reject malformed dashboard_id before any controller call.
+    # Same alphabet + length contract as
+    # :func:`_validators.validate_dashboard_id` on the WS-command
+    # path; both consume from ``helpers.dashboard_identity`` so
+    # they can't drift.
     if (
         not inp.dashboard_id
         or len(inp.dashboard_id) > DASHBOARD_ID_MAX_CHARS
@@ -211,14 +188,11 @@ async def _dispatch_intent(
         return IntentResponse.REJECTED
 
     if inp.intent is PeerLinkIntent.PAIR_REQUEST:
-        # The pairing-window gate lives inside ``record_pair_request``
-        # rather than here so it can short-circuit only the cases
-        # where new admin authorization is actually being requested
-        # (new PENDING row created, or pubkey rotated under an
-        # existing PENDING / APPROVED row). A re-pair against an
-        # already-APPROVED row whose pubkey still matches doesn't
-        # need admin action and bypasses the window check — the
-        # offloader is just re-establishing existing trust.
+        # Pairing-window gate lives inside ``record_pair_request``,
+        # not here — only new-admin-authorization cases (new PENDING
+        # row or pubkey rotation) should short-circuit on the window.
+        # A re-pair against an already-APPROVED row whose pubkey
+        # matches bypasses the window check.
         return await controller.record_pair_request(
             dashboard_id=inp.dashboard_id,
             pin_sha256=inp.pin_sha256,


### PR DESCRIPTION
# What does this implement/fix?

Docstring/comment cleanup follow-up to #783 (peer-link handshake driver extraction). #783 preserved bodies byte-for-byte; this is the deferred prose pass.

Changes:

* **`_HandshakeStep`** — drops the Noise-spec token explanation (`e`, `e, ee, s, es`, `s, se`). Keeps the load-bearing grep-readability rationale (why `MSG1` / `MSG2` / `MSG3` names instead).
* **`_DispatchInput`** — collapses from 10 lines to 1. "Bundles the six values..." is body restatement; "frozen, read-only" is the contract.
* **`_drive_peer_link_session`** — kept as-is, short and explains why it's split out.
* **`_dispatch_intent`** — tightens the docstring to keep the load-bearing "caller has already validated" precondition; drops the `See IntentResponse` cross-reference (callers read the return type).
* **Inline comments inside `_drive_peer_link_session`** — tightens the rejection-via-authenticated-frame paragraph and the peer_link handoff paragraph.
* **Inline comments inside `_dispatch_intent`** — tightens both the dashboard_id validation cross-reference and the `pair_request` window-gate-placement note. Both keep the load-bearing contract (don't move the gate; don't drift the alphabet).

Pure prose change; no behaviour change. All peer-link tests pass.

**Related issue or feature (if applicable):**

- follow-up to #783; per-module cleanup PR in the peer_link split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
