### PR TITLE
Refactor OffloaderController: extract OffloaderState dataclass

### DIFF
--- a/esphome_device_builder/controllers/remote_build/_state.py
+++ b/esphome_device_builder/controllers/remote_build/_state.py
@@ -1,0 +1,71 @@
+"""
+Mutable domain state for :class:`OffloaderController`.
+
+Grouping the controller's mutable state into a typed
+:class:`OffloaderState` dataclass keeps the sibling-module
+helpers (``discovery``, ``rebind``, ``peer_link_lifecycle``,
+``pair_status``, ``submit_job_commands``, ``pair_commands``,
+``settings_commands``, ``bus_handlers``) honest: they reach
+through ``controller.state.X`` rather than a long tail of
+``controller._X`` private attrs.
+
+What lives here vs on the controller:
+
+* **Here**: every attr that mutates after ``__init__``
+  (domain dicts/sets, ``remote_builds_enabled``, identity /
+  resolver / browser refs that ``start()`` populates and
+  ``stop()`` clears).
+* **On the controller**: ``_db``, ``_listeners``, ``_tasks``,
+  ``_shutdown_callbacks`` (base infrastructure),
+  ``_pairings_store`` (constructed once, never reassigned),
+  bound-method delegates, ``@api_command`` WS methods,
+  snapshot methods.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from zeroconf.asyncio import AsyncServiceBrowser
+
+    from ...helpers.peer_link_resolver import PeerLinkDNSResolver
+    from ...models import (
+        OffloaderAlertSnapshotEntry,
+        OffloaderRemoteJobSnapshotEntry,
+        PeerQueueStatusSnapshotEntry,
+        RemoteBuildPeer,
+        StoredPairing,
+    )
+    from ._models import PeerLinkClientHandle
+
+
+@dataclass
+class OffloaderState:
+    """Mutable state for :class:`OffloaderController`."""
+
+    # Pairing + peer-link domain state.
+    pairings: dict[str, StoredPairing] = field(default_factory=dict)
+    peers: dict[str, RemoteBuildPeer] = field(default_factory=dict)
+    peer_link_clients: dict[str, PeerLinkClientHandle] = field(default_factory=dict)
+    pair_status_listeners: dict[str, asyncio.Task[None]] = field(default_factory=dict)
+    open_peer_links: set[str] = field(default_factory=set)
+    offloader_alerts: dict[str, OffloaderAlertSnapshotEntry] = field(default_factory=dict)
+    peer_queue_status: dict[str, PeerQueueStatusSnapshotEntry] = field(default_factory=dict)
+    offloader_remote_jobs: dict[str, OffloaderRemoteJobSnapshotEntry] = field(default_factory=dict)
+    rebind_probe_until: dict[str, float] = field(default_factory=dict)
+    remote_builds_enabled: bool = True
+
+    # Identity / discovery refs reassigned during start() / discovery.
+    # ``offloader_peer_link_priv`` and ``offloader_dashboard_id`` are
+    # cached in :meth:`OffloaderController.start`; WS-command handlers
+    # re-read identities from disk via
+    # :meth:`OffloaderController._load_offloader_identities_async` to
+    # pick up rotations without invalidating the cache.
+    offloader_peer_link_priv: bytes | None = None
+    offloader_dashboard_id: str | None = None
+    peer_link_resolver: PeerLinkDNSResolver | None = None
+    own_instance_name: str | None = None
+    browser: AsyncServiceBrowser | None = None

--- a/esphome_device_builder/controllers/remote_build/_state.py
+++ b/esphome_device_builder/controllers/remote_build/_state.py
@@ -26,20 +26,18 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from zeroconf.asyncio import AsyncServiceBrowser
+from zeroconf.asyncio import AsyncServiceBrowser
 
-    from ...helpers.peer_link_resolver import PeerLinkDNSResolver
-    from ...models import (
-        OffloaderAlertSnapshotEntry,
-        OffloaderRemoteJobSnapshotEntry,
-        PeerQueueStatusSnapshotEntry,
-        RemoteBuildPeer,
-        StoredPairing,
-    )
-    from ._models import PeerLinkClientHandle
+from ...helpers.peer_link_resolver import PeerLinkDNSResolver
+from ...models import (
+    OffloaderAlertSnapshotEntry,
+    OffloaderRemoteJobSnapshotEntry,
+    PeerQueueStatusSnapshotEntry,
+    RemoteBuildPeer,
+    StoredPairing,
+)
+from ._models import PeerLinkClientHandle
 
 
 @dataclass

--- a/esphome_device_builder/controllers/remote_build/_summaries.py
+++ b/esphome_device_builder/controllers/remote_build/_summaries.py
@@ -88,7 +88,7 @@ def pairing_summary(
     sources:
 
     * ``connected``: ``pairing.pin_sha256 in
-      controller._open_peer_links``, the RAM-canonical set the
+      controller.state.open_peer_links``, the RAM-canonical set the
       controller maintains from :class:`PeerLinkClient`-fired
       :attr:`EventType.OFFLOADER_PEER_LINK_OPENED` /
       :attr:`EventType.OFFLOADER_PEER_LINK_CLOSED` events.

--- a/esphome_device_builder/controllers/remote_build/bus_handlers.py
+++ b/esphome_device_builder/controllers/remote_build/bus_handlers.py
@@ -79,7 +79,7 @@ def on_offloader_pair_pin_mismatch(
         "observed_pin": data["observed_pin"],
         "fired_at": time.time(),
     }
-    controller._offloader_alerts[data["pin_sha256"]] = alert
+    controller.state.offloader_alerts[data["pin_sha256"]] = alert
 
 
 def on_offloader_peer_link_opened(
@@ -103,11 +103,11 @@ def on_offloader_peer_link_opened(
     """
     data = event.data
     pin_sha256 = data["pin_sha256"]
-    controller._open_peer_links.add(pin_sha256)
+    controller.state.open_peer_links.add(pin_sha256)
     version = data["esphome_version"]
     if not version or len(version) > PAIRING_VERSION_MAX_LEN:
         return
-    pairing = controller._pairings.get(pin_sha256)
+    pairing = controller.state.pairings.get(pin_sha256)
     if pairing is None or pairing.esphome_version == version:
         return
     pairing.esphome_version = version
@@ -118,7 +118,7 @@ def on_offloader_peer_link_closed(
     controller: OffloaderController, event: Event[OffloaderPeerLinkClosedData]
 ) -> None:
     """Discard ``pin_sha256`` from ``_open_peer_links`` on session close."""
-    controller._open_peer_links.discard(event.data["pin_sha256"])
+    controller.state.open_peer_links.discard(event.data["pin_sha256"])
 
 
 def on_offloader_queue_status_changed(
@@ -126,7 +126,7 @@ def on_offloader_queue_status_changed(
 ) -> None:
     """Update the offloader-side ``_peer_queue_status`` cache from a wire event."""
     data = event.data
-    controller._peer_queue_status[data["pin_sha256"]] = PeerQueueStatusSnapshotEntry(
+    controller.state.peer_queue_status[data["pin_sha256"]] = PeerQueueStatusSnapshotEntry(
         receiver_hostname=data["receiver_hostname"],
         receiver_port=data["receiver_port"],
         pin_sha256=data["pin_sha256"],
@@ -150,9 +150,9 @@ def on_offloader_job_state_changed(
     """
     data = event.data
     if data["status"] in _OFFLOADER_REMOTE_JOB_TERMINAL_STATUSES:
-        controller._offloader_remote_jobs.pop(data["job_id"], None)
+        controller.state.offloader_remote_jobs.pop(data["job_id"], None)
         return
-    controller._offloader_remote_jobs[data["job_id"]] = OffloaderRemoteJobSnapshotEntry(
+    controller.state.offloader_remote_jobs[data["job_id"]] = OffloaderRemoteJobSnapshotEntry(
         receiver_hostname=data["receiver_hostname"],
         receiver_port=data["receiver_port"],
         pin_sha256=data["pin_sha256"],

--- a/esphome_device_builder/controllers/remote_build/discovery.py
+++ b/esphome_device_builder/controllers/remote_build/discovery.py
@@ -63,20 +63,20 @@ def start_discovery(controller: OffloaderController) -> None:
     # advertiser's private layout.
     advertiser = controller._db._dashboard_advertiser
     if advertiser is not None:
-        controller._own_instance_name = advertiser.service_instance_name
+        controller.state.own_instance_name = advertiser.service_instance_name
     # Wrap browser construction so a zeroconf-side failure
     # (e.g. the underlying socket got torn down between
     # ``DeviceStateMonitor.start`` and now, or the cache is in
     # an unexpected state) doesn't abort dashboard startup.
     try:
-        controller._browser = AsyncServiceBrowser(
+        controller.state.browser = AsyncServiceBrowser(
             zeroconf.zeroconf,
             [SERVICE_TYPE],
             handlers=[controller._on_service_state_change],
         )
     except Exception:
         _LOGGER.exception("Could not start remote-build browser; peer discovery disabled")
-        controller._browser = None
+        controller.state.browser = None
 
 
 def on_service_state_change(
@@ -99,16 +99,16 @@ def on_service_state_change(
     :meth:`_resolve_and_apply` once the SRV / TXT round-trip
     completes).
     """
-    if name == controller._own_instance_name:
+    if name == controller.state.own_instance_name:
         return
     if state_change == ServiceStateChange.Removed:
-        popped = controller._peers.pop(name, None)
+        popped = controller.state.peers.pop(name, None)
         if popped is not None:
             # Event keys on the wire-friendly ``peer.name``
             # (leftmost label) so frontend dicts keyed on the
             # ``RemoteBuildPeer.name`` field upsert/delete
             # consistently. The FQDN ``name`` is the
-            # ``controller._peers`` dict key only.
+            # ``controller.state.peers`` dict key only.
             controller._fire_host_removed(popped.name)
         return
     info = AsyncServiceInfo(service_type, name)
@@ -143,7 +143,7 @@ def upsert_host(controller: OffloaderController, name: str, info: AsyncServiceIn
     peer = peer_from_service_info(name, info)
     if controller._is_self_endpoint(peer.hostname, peer.port):
         return
-    controller._peers[name] = peer
+    controller.state.peers[name] = peer
     controller._db.bus.fire(EventType.REMOTE_BUILD_HOST_ADDED, peer.to_dict())
     # mDNS auto-rebind: if this broadcast's pin matches a
     # stored pairing whose ``(host, port)`` differs, the

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -25,14 +25,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from zeroconf import ServiceStateChange
-from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
+from zeroconf.asyncio import AsyncServiceInfo
 
 from ...helpers.api import api_command
 from ...helpers.build_scheduler import BuildSchedulerInputs
 from ...helpers.dashboard_identity import get_or_create_identity
 from ...helpers.event_bus import Event
 from ...helpers.peer_link_identity import get_or_create_peer_link_identity
-from ...helpers.peer_link_resolver import PeerLinkDNSResolver, make_peer_link_resolver
+from ...helpers.peer_link_resolver import make_peer_link_resolver
 from ...helpers.storage import Store
 from ...models import (
     EventType,
@@ -64,6 +64,7 @@ from . import (
 )
 from ._models import RebindProbeResult
 from ._shared import _RemoteBuildBase, drain_tasks
+from ._state import OffloaderState
 from ._storage_codecs import (
     OFFLOADER_PAIRINGS_FILE,
     decode_pairings,
@@ -76,7 +77,6 @@ if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
     from ...helpers.dashboard_identity import DashboardIdentity
     from ...helpers.peer_link_identity import PeerLinkIdentity
-    from ._models import PeerLinkClientHandle
     from .peer_link_client import PeerLinkClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -103,24 +103,7 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
         super().__init__(device_builder)
-        self._browser: AsyncServiceBrowser | None = None
-        self._peer_link_resolver: PeerLinkDNSResolver | None = None
-        self._peers: dict[str, RemoteBuildPeer] = {}
-        self._rebind_probe_until: dict[str, float] = {}
-        self._own_instance_name: str | None = None
-        self._pair_status_listeners: dict[str, asyncio.Task[None]] = {}
-        self._peer_link_clients: dict[str, PeerLinkClientHandle] = {}
-        self._open_peer_links: set[str] = set()
-        # Cached at :meth:`start`; WS-command handlers re-read
-        # from disk via :meth:`_load_offloader_identities_async`
-        # to pick up rotations.
-        self._offloader_dashboard_id: str | None = None
-        self._offloader_peer_link_priv: bytes | None = None
-        self._pairings: dict[str, StoredPairing] = {}
-        self._remote_builds_enabled: bool = True
-        self._offloader_alerts: dict[str, OffloaderAlertSnapshotEntry] = {}
-        self._peer_queue_status: dict[str, PeerQueueStatusSnapshotEntry] = {}
-        self._offloader_remote_jobs: dict[str, OffloaderRemoteJobSnapshotEntry] = {}
+        self.state = OffloaderState()
         self._pairings_store: Store[OffloaderRemoteBuildSettings] = Store(
             self._db.settings.config_dir / OFFLOADER_PAIRINGS_FILE,
             encoder=encode_pairings,
@@ -131,18 +114,19 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
 
     async def start(self) -> None:
         """Seed pairings from disk, cache identities, spawn peer-link clients."""
+        state = self.state
         if (settings := await self._pairings_store.async_load()) is not None:
             for pairing in settings.pairings:
-                self._pairings[pairing.pin_sha256] = pairing
-            self._remote_builds_enabled = settings.remote_builds_enabled
+                state.pairings[pairing.pin_sha256] = pairing
+            state.remote_builds_enabled = settings.remote_builds_enabled
         peer_link_identity, dashboard_identity = await self._load_offloader_identities_async()
-        self._offloader_peer_link_priv = peer_link_identity.private_bytes
-        self._offloader_dashboard_id = dashboard_identity.dashboard_id
+        state.offloader_peer_link_priv = peer_link_identity.private_bytes
+        state.offloader_dashboard_id = dashboard_identity.dashboard_id
         # Wire the resolver before spawning clients so each picks
         # it up at construction; stays None when zeroconf is down
         # and outbound connects fall back to the OS resolver.
         self._setup_peer_link_resolver()
-        for pairing in self._pairings.values():
+        for pairing in state.pairings.values():
             if pairing.status is PeerStatus.APPROVED:
                 self._spawn_peer_link_client(pairing)
         self._listeners.callback(
@@ -179,30 +163,31 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
 
     async def stop(self) -> None:
         """Cancel the browser, drain tasks, flush store, clear dicts."""
-        if self._browser is not None:
+        state = self.state
+        if state.browser is not None:
             try:
-                await self._browser.async_cancel()
+                await state.browser.async_cancel()
             except Exception:
                 _LOGGER.debug("remote-build browser cancel failed", exc_info=True)
-            self._browser = None
+            state.browser = None
         self._listeners.close()
         await drain_tasks(self._tasks)
         self._tasks.clear()
-        await drain_tasks(self._pair_status_listeners.values())
-        self._pair_status_listeners.clear()
+        await drain_tasks(state.pair_status_listeners.values())
+        state.pair_status_listeners.clear()
         # Each peer-link client's CancelledError handler sends a
         # ``client_stopped`` terminate so the receiver doesn't wait
         # on its heartbeat to time out.
-        await drain_tasks(h.task for h in self._peer_link_clients.values())
-        self._peer_link_clients.clear()
+        await drain_tasks(h.task for h in state.peer_link_clients.values())
+        state.peer_link_clients.clear()
         for callback in self._shutdown_callbacks:
             await callback()
-        self._pairings.clear()
-        self._peer_queue_status.clear()
-        self._offloader_remote_jobs.clear()
-        self._open_peer_links.clear()
-        self._rebind_probe_until.clear()
-        self._peers.clear()
+        state.pairings.clear()
+        state.peer_queue_status.clear()
+        state.offloader_remote_jobs.clear()
+        state.open_peer_links.clear()
+        state.rebind_probe_until.clear()
+        state.peers.clear()
         await self._close_peer_link_resolver()
 
     async def _load_offloader_identities_async(
@@ -250,13 +235,13 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         if zeroconf is None:
             return
         try:
-            self._peer_link_resolver = make_peer_link_resolver(zeroconf)
+            self.state.peer_link_resolver = make_peer_link_resolver(zeroconf)
         except Exception:
             _LOGGER.exception(
                 "Could not build peer-link mDNS resolver; outbound peer-link connects "
                 "will fall back to the OS resolver"
             )
-            self._peer_link_resolver = None
+            self.state.peer_link_resolver = None
 
     def _start_discovery(self) -> None:
         """Bring up the mDNS service browser for peer discovery."""
@@ -282,7 +267,7 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
 
     def peer_queue_status_snapshot(self) -> list[PeerQueueStatusSnapshotEntry]:
         """Per-peer queue-status snapshot for ``subscribe_events`` seeding."""
-        return list(self._peer_queue_status.values())
+        return list(self.state.peer_queue_status.values())
 
     def _on_offloader_job_state_changed(self, event: Event[OffloaderJobStateChangedData]) -> None:
         """Maintain the offloader-side in-flight remote-job cache."""
@@ -290,7 +275,7 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
 
     def offloader_remote_jobs_snapshot(self) -> list[OffloaderRemoteJobSnapshotEntry]:
         """In-flight remote-job snapshot for ``subscribe_events`` seeding."""
-        return list(self._offloader_remote_jobs.values())
+        return list(self.state.offloader_remote_jobs.values())
 
     async def _close_peer_link_resolver(self) -> None:
         """Release the shared mDNS-aware aiohttp resolver, if any.
@@ -298,13 +283,13 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         Idempotent. The borrowed :class:`AsyncZeroconf` is
         closed separately by the device-state monitor.
         """
-        if self._peer_link_resolver is None:
+        if self.state.peer_link_resolver is None:
             return
         try:
-            await self._peer_link_resolver.real_close()
+            await self.state.peer_link_resolver.real_close()
         except Exception:
             _LOGGER.debug("peer-link resolver close failed", exc_info=True)
-        self._peer_link_resolver = None
+        self.state.peer_link_resolver = None
 
     # ------------------------------------------------------------------
     # mDNS plumbing
@@ -376,7 +361,7 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
 
     def hosts_snapshot(self) -> list[RemoteBuildPeer]:
         """Return the current mDNS-discovered hosts for ``subscribe_events`` seeding."""
-        return list(self._peers.values())
+        return list(self.state.peers.values())
 
     # ------------------------------------------------------------------
     # API surface
@@ -512,11 +497,11 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
 
     def get_pairing(self, pin_sha256: str) -> StoredPairing | None:
         """Return the :class:`StoredPairing` for *pin_sha256*, or ``None``."""
-        return self._pairings.get(pin_sha256)
+        return self.state.pairings.get(pin_sha256)
 
     def remote_builds_enabled_snapshot(self) -> bool:
         """Return the master toggle for the ``subscribe_events`` initial-state seed."""
-        return self._remote_builds_enabled
+        return self.state.remote_builds_enabled
 
     def build_scheduler_snapshot(self) -> BuildSchedulerInputs:
         """Bundle the scheduler's input state into a shallow immutable snapshot.
@@ -526,15 +511,15 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         same loop tick.
         """
         return BuildSchedulerInputs(
-            remote_builds_enabled=self._remote_builds_enabled,
-            pairings=dict(self._pairings),
-            open_peer_links=frozenset(self._open_peer_links),
-            peer_queue_status=dict(self._peer_queue_status),
+            remote_builds_enabled=self.state.remote_builds_enabled,
+            pairings=dict(self.state.pairings),
+            open_peer_links=frozenset(self.state.open_peer_links),
+            peer_queue_status=dict(self.state.peer_queue_status),
         )
 
     def pairings_snapshot(self) -> list[PairingSummary]:
         """Return the in-memory pairings (PENDING + APPROVED) for ``subscribe_events`` seeding."""
-        return [self._pairing_summary_for(p) for p in self._pairings.values()]
+        return [self._pairing_summary_for(p) for p in self.state.pairings.values()]
 
     def _pairing_summary_for(self, pairing: StoredPairing) -> PairingSummary:
         """Project *pairing* into a wire :class:`PairingSummary`.
@@ -551,17 +536,17 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         branch with all three fields at their connection-quiet
         defaults.
         """
-        handle = self._peer_link_clients.get(pairing.pin_sha256)
+        handle = self.state.peer_link_clients.get(pairing.pin_sha256)
         return pairing_summary(
             pairing,
-            connected=pairing.pin_sha256 in self._open_peer_links,
+            connected=pairing.pin_sha256 in self.state.open_peer_links,
             connecting=handle is not None and handle.client.is_connecting,
             last_connect_error=(handle.client.last_connect_error if handle is not None else ""),
         )
 
     def offloader_alerts_snapshot(self) -> list[OffloaderAlertSnapshotEntry]:
         """Offloader alerts (insertion-ordered, newest last) for ``subscribe_events`` seeding."""
-        return list(self._offloader_alerts.values())
+        return list(self.state.offloader_alerts.values())
 
     def _dismiss_offloader_alert(self, pin_sha256: str, hostname: str, port: int) -> bool:
         """Drop the alert for *pin_sha256* and fire DISMISSED. Returns whether a row was dropped.
@@ -570,7 +555,7 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         and ``unpair`` (row gone → alert moot). No operator-driven
         dismiss surface — re-pair / unpair are the only resolutions.
         """
-        if self._offloader_alerts.pop(pin_sha256, None) is None:
+        if self.state.offloader_alerts.pop(pin_sha256, None) is None:
             return False
         payload: OffloaderPairAlertDismissedData = {
             "receiver_hostname": hostname,
@@ -583,8 +568,8 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     def _serialize_pairings(self) -> OffloaderRemoteBuildSettings:
         """Build the on-disk pairings shape from RAM, dropping PENDING rows."""
         return OffloaderRemoteBuildSettings(
-            pairings=[p for p in self._pairings.values() if p.status is PeerStatus.APPROVED],
-            remote_builds_enabled=self._remote_builds_enabled,
+            pairings=[p for p in self.state.pairings.values() if p.status is PeerStatus.APPROVED],
+            remote_builds_enabled=self.state.remote_builds_enabled,
         )
 
     # ------------------------------------------------------------------

--- a/esphome_device_builder/controllers/remote_build/pair_commands.py
+++ b/esphome_device_builder/controllers/remote_build/pair_commands.py
@@ -77,7 +77,7 @@ async def set_pairing_enabled(
     clean_enabled = validate_bool(
         enabled, command="remote_build/set_pairing_enabled", field="enabled"
     )
-    pairing = controller._pairings.get(clean_pin)
+    pairing = controller.state.pairings.get(clean_pin)
     if pairing is None:
         msg = f"remote_build/set_pairing_enabled: no pairing for pin_sha256={clean_pin!r}"
         raise CommandError(ErrorCode.NOT_FOUND, msg)
@@ -118,7 +118,7 @@ async def preview_pair(
             hostname=clean_host,
             port=clean_port,
             identity_priv=identity.private_bytes,
-            resolver=controller._peer_link_resolver,
+            resolver=controller.state.peer_link_resolver,
         )
     except PeerLinkClientError as exc:
         raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
@@ -173,7 +173,7 @@ async def request_pair(
             identity_priv=peer_link_identity.private_bytes,
             label=clean_offloader_label,
             dashboard_id=dashboard_identity.dashboard_id,
-            resolver=controller._peer_link_resolver,
+            resolver=controller.state.peer_link_resolver,
         )
     except PeerLinkClientError as exc:
         raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
@@ -207,7 +207,7 @@ async def request_pair(
     controller._sweep_stale_pairings_at_endpoint(clean_host, clean_port, keep_pin_sha256=key)
     # Cancel any prior listener for the same pin — its
     # closure captured the old pairing reference.
-    controller._pairings[key] = pairing
+    controller.state.pairings[key] = pairing
     controller._cancel_pair_status_listener(key)
     controller._dismiss_offloader_alert(key, clean_host, clean_port)
     if target_status is PeerStatus.APPROVED:
@@ -241,7 +241,7 @@ async def unpair(controller: OffloaderController, *, pin_sha256: str) -> dict[st
     # promptly. Idempotent on absent keys.
     controller._cancel_pair_status_listener(key)
     controller._cancel_peer_link_client(key)
-    previous = controller._pairings.pop(key, None)
+    previous = controller.state.pairings.pop(key, None)
     if previous is None:
         return {"removed": False}
     controller._schedule_pairings_save()
@@ -251,11 +251,11 @@ async def unpair(controller: OffloaderController, *, pin_sha256: str) -> dict[st
     controller._dismiss_offloader_alert(key, previous.receiver_hostname, previous.receiver_port)
     # Drop derived per-peer caches so the snapshot doesn't
     # surface stale data for a row the user just removed.
-    controller._peer_queue_status.pop(key, None)
-    for job_id, entry in list(controller._offloader_remote_jobs.items()):
+    controller.state.peer_queue_status.pop(key, None)
+    for job_id, entry in list(controller.state.offloader_remote_jobs.items()):
         if entry["pin_sha256"] == key:
-            controller._offloader_remote_jobs.pop(job_id, None)
-    controller._open_peer_links.discard(key)
+            controller.state.offloader_remote_jobs.pop(job_id, None)
+    controller.state.open_peer_links.discard(key)
     return {"removed": True}
 
 
@@ -289,7 +289,7 @@ async def edit_pairing_endpoint(
     clean_host = validate_hostname(hostname, context=HostFieldContext.RECEIVER)
     clean_port = validate_port(port, context=HostFieldContext.RECEIVER)
 
-    pairing = controller._pairings.get(pin)
+    pairing = controller.state.pairings.get(pin)
     if pairing is None:
         msg = f"edit_pairing_endpoint: no pairing for pin_sha256={pin!r}"
         raise CommandError(ErrorCode.NOT_FOUND, msg)
@@ -299,7 +299,7 @@ async def edit_pairing_endpoint(
     # System-readiness before user-input semantics: surface
     # "identity not loaded yet" distinctly rather than a
     # confusing "matches current" on a startup race.
-    if controller._offloader_peer_link_priv is None:
+    if controller.state.offloader_peer_link_priv is None:
         msg = "edit_pairing_endpoint: offloader peer-link identity not loaded yet"
         raise CommandError(ErrorCode.PRECONDITION_FAILED, msg)
     if endpoints_equal(pairing.receiver_hostname, pairing.receiver_port, clean_host, clean_port):

--- a/esphome_device_builder/controllers/remote_build/pair_status.py
+++ b/esphome_device_builder/controllers/remote_build/pair_status.py
@@ -56,10 +56,10 @@ _PAIR_STATUS_RECONNECT_BACKOFF_SECONDS = 2.0
 def spawn_pair_status_listener(controller: OffloaderController, pairing: StoredPairing) -> None:
     """Spawn the pair-status listener task for *pairing* if not already running."""
     key = pairing.pin_sha256
-    existing = controller._pair_status_listeners.get(key)
+    existing = controller.state.pair_status_listeners.get(key)
     if existing is not None and not existing.done():
         return
-    controller._pair_status_listeners[key] = asyncio.create_task(
+    controller.state.pair_status_listeners[key] = asyncio.create_task(
         controller._await_pair_status_flip(pairing),
         name=f"pair-status-{pairing.receiver_hostname}:{pairing.receiver_port}",
     )
@@ -67,7 +67,7 @@ def spawn_pair_status_listener(controller: OffloaderController, pairing: StoredP
 
 def cancel_pair_status_listener(controller: OffloaderController, pin_sha256: str) -> None:
     """Cancel the listener for *pin_sha256*. No-op if none running."""
-    task = controller._pair_status_listeners.pop(pin_sha256, None)
+    task = controller.state.pair_status_listeners.pop(pin_sha256, None)
     if task is not None and not task.done():
         task.cancel()
 
@@ -93,7 +93,7 @@ async def await_pair_status_flip(controller: OffloaderController, pairing: Store
                     port=pairing.receiver_port,
                     identity_priv=peer_link_identity.private_bytes,
                     dashboard_id=dashboard_identity.dashboard_id,
-                    resolver=controller._peer_link_resolver,
+                    resolver=controller.state.peer_link_resolver,
                 )
             except PeerLinkClientError as exc:
                 _LOGGER.debug(
@@ -124,8 +124,8 @@ async def await_pair_status_flip(controller: OffloaderController, pairing: Store
         # orphan it (no entry left for ``unpair`` to cancel,
         # the new listener parks forever).
         key = pairing.pin_sha256
-        if controller._pair_status_listeners.get(key) is asyncio.current_task():
-            del controller._pair_status_listeners[key]
+        if controller.state.pair_status_listeners.get(key) is asyncio.current_task():
+            del controller.state.pair_status_listeners[key]
 
 
 async def apply_pair_status_result(
@@ -141,7 +141,7 @@ async def apply_pair_status_result(
     * Anything else → log + reconnect.
 
     Race-safe against ``unpair``: every branch keys on
-    ``controller._pairings.pop(key, None)``, so if the user
+    ``controller.state.pairings.pop(key, None)``, so if the user
     unpaired between the await and this branch we skip
     promotion + event-firing silently.
     """
@@ -161,7 +161,7 @@ async def apply_pair_status_result(
                 pairing.pin_sha256,
                 result.pin_sha256,
             )
-            if controller._pairings.pop(key, None) is not None:
+            if controller.state.pairings.pop(key, None) is not None:
                 controller._schedule_pairings_save()
                 pin_alert: OffloaderPinMismatchAlert = {
                     "kind": "pin_mismatch",
@@ -173,7 +173,7 @@ async def apply_pair_status_result(
                     "observed_pin": result.pin_sha256,
                     "fired_at": time.time(),
                 }
-                controller._offloader_alerts[key] = pin_alert
+                controller.state.offloader_alerts[key] = pin_alert
                 # Fire diagnostic first so subscribers see
                 # the full payload before the row drops.
                 _fire_offloader_pair_pin_mismatch(
@@ -185,7 +185,7 @@ async def apply_pair_status_result(
         # us between the await and this branch the row's
         # gone; exit silently rather than resurrect state
         # the user just deleted.
-        existing = controller._pairings.get(key)
+        existing = controller.state.pairings.get(key)
         if existing is None:
             return True
         existing.status = PeerStatus.APPROVED
@@ -194,7 +194,7 @@ async def apply_pair_status_result(
         controller._spawn_peer_link_client(existing)
         return True
     if result.status is IntentResponse.REJECTED:
-        if controller._pairings.pop(key, None) is not None:
+        if controller.state.pairings.pop(key, None) is not None:
             controller._schedule_pairings_save()
             revoked_alert: OffloaderPeerRevokedAlert = {
                 "kind": "peer_revoked",
@@ -204,7 +204,7 @@ async def apply_pair_status_result(
                 "receiver_label": label,
                 "fired_at": time.time(),
             }
-            controller._offloader_alerts[key] = revoked_alert
+            controller.state.offloader_alerts[key] = revoked_alert
             _fire_offloader_pair_peer_revoked(controller, host, port, key, label)
             controller._fire_offloader_pair_status_changed(host, port, key, "removed")
         return True

--- a/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
@@ -41,20 +41,20 @@ def spawn_peer_link_client(controller: OffloaderController, pairing: StoredPairi
     path).
     """
     if (
-        controller._offloader_dashboard_id is None
-        or controller._offloader_peer_link_priv is None
+        controller.state.offloader_dashboard_id is None
+        or controller.state.offloader_peer_link_priv is None
         or controller._db.bus is None
     ):
         return
     key = pairing.pin_sha256
-    existing = controller._peer_link_clients.get(key)
+    existing = controller.state.peer_link_clients.get(key)
     if existing is not None and not existing.task.done():
         return
     client = PeerLinkClient(
         receiver_hostname=pairing.receiver_hostname,
         receiver_port=pairing.receiver_port,
-        identity_priv=controller._offloader_peer_link_priv,
-        dashboard_id=controller._offloader_dashboard_id,
+        identity_priv=controller.state.offloader_peer_link_priv,
+        dashboard_id=controller.state.offloader_dashboard_id,
         # Pin the receiver's static pubkey from the
         # OOB-verified pair flow so the long-lived peer-link
         # handshake fails fast on identity drift instead of
@@ -64,18 +64,18 @@ def spawn_peer_link_client(controller: OffloaderController, pairing: StoredPairi
         pin_sha256=pairing.pin_sha256,
         receiver_label=pairing.label,
         bus=controller._db.bus,
-        resolver=controller._peer_link_resolver,
+        resolver=controller.state.peer_link_resolver,
     )
     task = asyncio.create_task(
         client.run(),
         name=f"peer-link-client-{pairing.receiver_hostname}:{pairing.receiver_port}",
     )
-    controller._peer_link_clients[key] = PeerLinkClientHandle(client=client, task=task)
+    controller.state.peer_link_clients[key] = PeerLinkClientHandle(client=client, task=task)
 
 
 def cancel_peer_link_client(controller: OffloaderController, pin_sha256: str) -> None:
     """Cancel the peer-link client for *pin_sha256*. No-op if none running."""
-    handle = controller._peer_link_clients.pop(pin_sha256, None)
+    handle = controller.state.peer_link_clients.pop(pin_sha256, None)
     if handle is not None and not handle.task.done():
         handle.task.cancel()
 
@@ -92,13 +92,13 @@ def lookup_open_peer_link_client(
     retry); the distinguishing reason rides in the log line.
     *label* names the calling op in the error message.
     """
-    pairing = controller._pairings.get(pin_sha256)
+    pairing = controller.state.pairings.get(pin_sha256)
     if pairing is None:
         msg = f"{label}: no pairing for pin_sha256={pin_sha256!r}"
         raise CommandError(ErrorCode.NOT_FOUND, msg)
     if pairing.status is not PeerStatus.APPROVED:
         reason = f"status is {pairing.status.value!r}, not APPROVED"
-    elif (handle := controller._peer_link_clients.get(pin_sha256)) is None:
+    elif (handle := controller.state.peer_link_clients.get(pin_sha256)) is None:
         reason = "client not yet spawned"
     elif handle.task.done():
         reason = "client orphaned (pin mismatch / superseded)"
@@ -126,22 +126,22 @@ def sweep_stale_pairings_at_endpoint(
     pin-drift branch. Snapshots to lists before iterating
     to avoid mutate-during-iteration.
     """
-    for stale_pin, pairing in list(controller._pairings.items()):
+    for stale_pin, pairing in list(controller.state.pairings.items()):
         if stale_pin == keep_pin_sha256:
             continue
         if pairing.receiver_hostname != hostname or pairing.receiver_port != port:
             continue
-        controller._pairings.pop(stale_pin, None)
+        controller.state.pairings.pop(stale_pin, None)
         controller._cancel_pair_status_listener(stale_pin)
         controller._cancel_peer_link_client(stale_pin)
-        controller._peer_queue_status.pop(stale_pin, None)
-        controller._open_peer_links.discard(stale_pin)
+        controller.state.peer_queue_status.pop(stale_pin, None)
+        controller.state.open_peer_links.discard(stale_pin)
     # Alerts can outlive pairings — sweep them in a second
     # pass keyed on the alert's stored ``receiver_hostname``
     # / ``receiver_port`` (also walks the pin-keyed dict so
     # an alert under the keep_pin_sha256 stays put if the
     # user is re-confirming the same identity).
-    for stale_pin, alert in list(controller._offloader_alerts.items()):
+    for stale_pin, alert in list(controller.state.offloader_alerts.items()):
         if stale_pin == keep_pin_sha256:
             continue
         if alert["receiver_hostname"] != hostname or alert["receiver_port"] != port:

--- a/esphome_device_builder/controllers/remote_build/rebind.py
+++ b/esphome_device_builder/controllers/remote_build/rebind.py
@@ -67,19 +67,19 @@ async def probe_pairing_endpoint(
     (captured pairing object still in the dict, still
     APPROVED).
     """
-    assert controller._offloader_peer_link_priv is not None
+    assert controller.state.offloader_peer_link_priv is not None
     try:
         observed_pin = await peer_link_preview_pair(
             hostname=new_hostname,
             port=new_port,
-            identity_priv=controller._offloader_peer_link_priv,
-            resolver=controller._peer_link_resolver,
+            identity_priv=controller.state.offloader_peer_link_priv,
+            resolver=controller.state.peer_link_resolver,
         )
     except PeerLinkClientError as exc:
         return RebindProbeResult(RebindProbeOutcome.UNREACHABLE, transport_error=exc)
     if observed_pin != pairing.pin_sha256:
         return RebindProbeResult(RebindProbeOutcome.PIN_MISMATCH, observed_pin=observed_pin)
-    current = controller._pairings.get(pairing.pin_sha256)
+    current = controller.state.pairings.get(pairing.pin_sha256)
     if current is not pairing:
         return RebindProbeResult(RebindProbeOutcome.PAIRING_REPLACED)
     if current.status is not PeerStatus.APPROVED:
@@ -100,7 +100,7 @@ def commit_endpoint_rebind(
     pairing.receiver_port = port
     controller._schedule_pairings_save()
     _respawn_peer_link_at_new_endpoint(controller, pairing)
-    controller._rebind_probe_until.pop(pairing.pin_sha256, None)
+    controller.state.rebind_probe_until.pop(pairing.pin_sha256, None)
 
 
 def _respawn_peer_link_at_new_endpoint(
@@ -138,18 +138,18 @@ def maybe_schedule_rebind_probe(controller: OffloaderController, peer: RemoteBui
     new_port = peer.remote_build_port
     if not pin or new_port == 0:
         return
-    pairing = controller._pairings.get(pin)
+    pairing = controller.state.pairings.get(pin)
     if pairing is None or pairing.status is not PeerStatus.APPROVED:
         return
     new_hostname = normalize_hostname(peer.hostname)
     if endpoints_equal(pairing.receiver_hostname, pairing.receiver_port, new_hostname, new_port):
         return
-    if controller._offloader_peer_link_priv is None:
+    if controller.state.offloader_peer_link_priv is None:
         return
     now = time.monotonic()
-    if controller._rebind_probe_until.get(pin, 0.0) > now:
+    if controller.state.rebind_probe_until.get(pin, 0.0) > now:
         return
-    controller._rebind_probe_until[pin] = now + _REBIND_PROBE_COOLDOWN_SECONDS
+    controller.state.rebind_probe_until[pin] = now + _REBIND_PROBE_COOLDOWN_SECONDS
     controller._track_task(
         controller._probe_and_rebind_endpoint(
             pairing=pairing, new_hostname=new_hostname, new_port=new_port
@@ -231,7 +231,7 @@ def _clear_cooldown_on_unexpected_exit(controller: OffloaderController, pin: str
     try:
         yield
     except BaseException:
-        controller._rebind_probe_until.pop(pin, None)
+        controller.state.rebind_probe_until.pop(pin, None)
         raise
 
 

--- a/esphome_device_builder/controllers/remote_build/settings_commands.py
+++ b/esphome_device_builder/controllers/remote_build/settings_commands.py
@@ -35,7 +35,7 @@ def offloader_settings_view(
     """
     return OffloaderRemoteBuildSettingsView(
         pairings=controller.pairings_snapshot(),
-        remote_builds_enabled=controller._remote_builds_enabled,
+        remote_builds_enabled=controller.state.remote_builds_enabled,
     )
 
 
@@ -61,7 +61,7 @@ async def set_offloader_settings(
     sync; debounce-saves through ``_pairings_store`` (same
     on-disk shape).
     """
-    controller._remote_builds_enabled = validate_bool(
+    controller.state.remote_builds_enabled = validate_bool(
         remote_builds_enabled,
         command="remote_build/set_offloader_settings",
         field="remote_builds_enabled",

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -273,7 +273,7 @@ async def test_cold_connect_offloader_observes_initial_queue_status_then_picks_r
     inside :meth:`register_peer_link_session`.
 
     The previous shape of this test pre-seeded
-    ``offloader._peer_queue_status[pin]`` to model the
+    ``offloader.state.peer_queue_status[pin]`` to model the
     transition-driven path, masking the cold-connect gap. The
     new test asserts the offloader observes the idle entry by
     waiting on its ``OFFLOADER_QUEUE_STATUS_CHANGED`` event
@@ -382,7 +382,7 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
     )
 
     # 1. submit_job with a real bundle.
-    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
     bundle_bytes = _build_real_bundle()
     ack = await handle.client.submit_job(
         job_id="off-job-1",
@@ -500,7 +500,7 @@ async def test_remote_compile_materialises_for_local_firmware_download(
         f"scheduler picked {decision.path} — expected REMOTE for the e2e to be meaningful"
     )
 
-    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
     ack = await handle.client.submit_job(
         job_id="off-compile-1",
         configuration_filename="kitchen.yaml",
@@ -618,15 +618,13 @@ async def _wait_for_offloader_idle(
         # observes the post-fire cache state below or wakes from
         # the wait_for on the re-set flag.
         queue_status_events.received.clear()
-        entry = paired_instances.offloader._peer_queue_status.get(pin_sha256)
+        entry = paired_instances.offloader.state.peer_queue_status.get(pin_sha256)
         if entry is not None and entry["idle"]:
             return
         remaining = deadline - asyncio.get_running_loop().time()
         if remaining <= 0:
-            msg = (
-                f"offloader's _peer_queue_status never reached idle within "
-                f"{timeout}s: {paired_instances.offloader._peer_queue_status.get(pin_sha256)!r}"
-            )
+            row = paired_instances.offloader.state.peer_queue_status.get(pin_sha256)
+            msg = f"offloader's peer_queue_status never reached idle within {timeout}s: {row!r}"
             raise TimeoutError(msg)
         await asyncio.wait_for(queue_status_events.received.wait(), timeout=remaining)
 
@@ -667,7 +665,7 @@ async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
     # idle before we drive any traffic.
     await _wait_for_offloader_idle(paired_instances, queue_status_events)
 
-    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
     bundle_bytes = _build_real_bundle()
 
     for cycle in range(2):
@@ -697,7 +695,7 @@ async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
         assert decision.path is BuildPath.REMOTE, (
             f"cycle {cycle}: scheduler fell back to LOCAL after a completed "
             f"remote job; cache entry: "
-            f"{paired_instances.offloader._peer_queue_status[paired_instances.pin_sha256]!r}"
+            f"{paired_instances.offloader.state.peer_queue_status[paired_instances.pin_sha256]!r}"
         )
         assert decision.pin_sha256 == paired_instances.pin_sha256
 
@@ -727,7 +725,7 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
     receiver_jobs = _wire_receiver_firmware_recorder(paired_instances)
     await _wait_for_offloader_idle(paired_instances, queue_status_events)
 
-    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
     bundle_bytes = _build_real_bundle()
 
     # Cycle 1: fail.
@@ -789,7 +787,7 @@ async def test_remote_clean_round_trip_lands_clean_job_and_fans_state_back(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
 
-    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
     ack = await handle.client.submit_job(
         job_id="off-clean-1",
         configuration_filename="kitchen.yaml",

--- a/tests/e2e/test_pair_and_session.py
+++ b/tests/e2e/test_pair_and_session.py
@@ -91,7 +91,7 @@ async def test_paired_instances_teardown_closes_session_cleanly(
     assert paired_instances.offloader_closed[0]["reason"] == "client_stopped"
 
     # (b) Offloader's registry drained synchronously by ``stop()``.
-    assert paired_instances.offloader._peer_link_clients == {}
+    assert paired_instances.offloader.state.peer_link_clients == {}
 
     # (c) Receiver's CLOSED carries the offloader's dashboard_id
     # and the registry has dropped the row.

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -197,7 +197,7 @@ async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
     created_jobs = _wire_receiver_firmware_recorder(paired_instances)
 
     bundle_bytes = _build_real_bundle()
-    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
     ack = await handle.client.submit_job(
         job_id="off-job-1",
         configuration_filename="kitchen.yaml",
@@ -250,7 +250,7 @@ async def test_submit_job_round_trip_with_relative_receiver_config_dir(
     created_jobs = _wire_receiver_firmware_recorder(instances)
 
     bundle_bytes = _build_real_bundle()
-    handle = instances.offloader._peer_link_clients[instances.pin_sha256]
+    handle = instances.offloader.state.peer_link_clients[instances.pin_sha256]
     ack = await handle.client.submit_job(
         job_id="off-job-678",
         configuration_filename="kitchen.yaml",
@@ -314,7 +314,7 @@ async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
 
-    ack = await paired_instances.offloader._peer_link_clients[
+    ack = await paired_instances.offloader.state.peer_link_clients[
         paired_instances.pin_sha256
     ].client.submit_job(
         job_id="off-job-1",
@@ -381,7 +381,7 @@ async def test_submit_job_round_trip_carries_display_strings_to_receiver_job(
     await paired_instances.wait_until_session_opened()
     created_jobs = _wire_receiver_firmware_recorder(paired_instances)
 
-    handle = paired_instances.offloader._peer_link_clients[paired_instances.pin_sha256]
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
     ack = await handle.client.submit_job(
         job_id="off-job-display",
         configuration_filename="kitchen.yaml",

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -225,12 +225,12 @@ def test_peer_from_service_info_handles_missing_txt_keys() -> None:
 def test_on_service_state_change_filters_own_advertise(tmp_path: Path) -> None:
     """Our own service-instance name never lands in ``_peers``."""
     controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._own_instance_name = f"self.{SERVICE_TYPE}"
+    controller.offloader.state.own_instance_name = f"self.{SERVICE_TYPE}"
     zeroconf = MagicMock()
     controller.offloader._on_service_state_change(
         zeroconf, SERVICE_TYPE, f"self.{SERVICE_TYPE}", ServiceStateChange.Added
     )
-    assert controller.offloader._peers == {}
+    assert controller.offloader.state.peers == {}
 
 
 def test_is_self_endpoint_matches_advertised_host_and_port(tmp_path: Path) -> None:
@@ -301,7 +301,7 @@ def test_upsert_host_drops_self_endpoint(tmp_path: Path) -> None:
 
     controller.offloader._upsert_host(f"renamed.{SERVICE_TYPE}", info)
 
-    assert controller.offloader._peers == {}
+    assert controller.offloader.state.peers == {}
     controller.offloader._db.bus.fire.assert_not_called()
 
 
@@ -324,9 +324,9 @@ def _make_paired_offloader_controller(
     """
     controller = _make_controller(config_dir=config_dir)
     controller.offloader._db.bus = MagicMock()
-    controller.offloader._offloader_dashboard_id = "offloader-id-aaaa"
-    controller.offloader._offloader_peer_link_priv = b"\x42" * 32
-    controller.offloader._pairings[pairing.pin_sha256] = pairing
+    controller.offloader.state.offloader_dashboard_id = "offloader-id-aaaa"
+    controller.offloader.state.offloader_peer_link_priv = b"\x42" * 32
+    controller.offloader.state.pairings[pairing.pin_sha256] = pairing
     return controller
 
 
@@ -369,7 +369,7 @@ def _patch_probe_internals(
             rb_rebind, "peer_link_preview_pair", AsyncMock(return_value=preview_return)
         )
     if seed_cooldown_for is not None:
-        controller.offloader._rebind_probe_until[seed_cooldown_for] = cooldown_until
+        controller.offloader.state.rebind_probe_until[seed_cooldown_for] = cooldown_until
     return cancel, spawn
 
 
@@ -405,7 +405,7 @@ async def test_rebind_probe_match_mutates_pairing_and_fires_event(
     )
     # Successful rebind clears the cooldown so a future move
     # gets probed immediately rather than waiting out the window.
-    assert pin not in controller.offloader._rebind_probe_until
+    assert pin not in controller.offloader.state.rebind_probe_until
 
 
 @pytest.mark.asyncio
@@ -446,7 +446,7 @@ async def test_rebind_probe_pin_mismatch_does_not_mutate(
     )
     # Cooldown stays in place: a permanent spoof source mustn't
     # trigger one probe per mDNS Updated burst.
-    assert controller.offloader._rebind_probe_until[pin] == 9999.0
+    assert controller.offloader.state.rebind_probe_until[pin] == 9999.0
 
 
 @pytest.mark.asyncio
@@ -479,7 +479,7 @@ async def test_rebind_probe_unreachable_does_not_mutate(
     assert pairing.receiver_hostname == "old.local"
     assert pairing.receiver_port == 6058
     # Cooldown preserved: gates retry on next mDNS event.
-    assert controller.offloader._rebind_probe_until[pin] == 9999.0
+    assert controller.offloader.state.rebind_probe_until[pin] == 9999.0
 
 
 @pytest.mark.asyncio
@@ -500,7 +500,7 @@ async def test_rebind_probe_skips_when_pairing_replaced_mid_probe(
     # Simulate the in-flight re-pair: replace the dict entry
     # with a fresh object before the probe applies its result.
     fresh = _valid_stored_pairing(receiver_hostname="user-typed.local", receiver_port=6060)
-    controller.offloader._pairings[pin] = fresh
+    controller.offloader.state.pairings[pin] = fresh
     cancel, spawn = _patch_probe_internals(monkeypatch, controller, preview_return=pin)
 
     await controller.offloader._probe_and_rebind_endpoint(
@@ -578,7 +578,7 @@ async def test_rebind_probe_unexpected_exception_clears_cooldown(
             pairing=pairing, new_hostname="new.local", new_port=7000
         )
 
-    assert pin not in controller.offloader._rebind_probe_until
+    assert pin not in controller.offloader.state.rebind_probe_until
 
 
 @pytest.mark.asyncio
@@ -591,14 +591,14 @@ async def test_rebind_probe_skips_when_pairing_unpaired_mid_probe(
     controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
     # Simulate the in-flight unpair: drop the dict entry
     # before the probe's mutate step.
-    controller.offloader._pairings.pop(pin)
+    controller.offloader.state.pairings.pop(pin)
     cancel, spawn = _patch_probe_internals(monkeypatch, controller, preview_return=pin)
 
     await controller.offloader._probe_and_rebind_endpoint(
         pairing=pairing, new_hostname="new.local", new_port=7000
     )
 
-    assert pin not in controller.offloader._pairings
+    assert pin not in controller.offloader.state.pairings
     cancel.assert_not_called()
     spawn.assert_not_called()
 
@@ -621,7 +621,7 @@ def test_maybe_schedule_rebind_probe_skips_when_endpoint_matches(
     )
     controller.offloader._maybe_schedule_rebind_probe(peer)
 
-    assert pin not in controller.offloader._rebind_probe_until
+    assert pin not in controller.offloader.state.rebind_probe_until
     assert controller.offloader._tasks == set()
 
 
@@ -713,7 +713,7 @@ def test_maybe_schedule_rebind_probe_skips_without_priv(tmp_path: Path) -> None:
     pin = "a" * 64
     pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
     controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
-    controller.offloader._offloader_peer_link_priv = None
+    controller.offloader.state.offloader_peer_link_priv = None
 
     peer = RemoteBuildPeer(
         name="moved",
@@ -726,7 +726,7 @@ def test_maybe_schedule_rebind_probe_skips_without_priv(tmp_path: Path) -> None:
     controller.offloader._maybe_schedule_rebind_probe(peer)
 
     assert controller.offloader._tasks == set()
-    assert pin not in controller.offloader._rebind_probe_until
+    assert pin not in controller.offloader.state.rebind_probe_until
 
 
 # ---------------------------------------------------------------------------
@@ -841,7 +841,7 @@ async def test_edit_pairing_endpoint_unknown_pin_raises_not_found(tmp_path: Path
     """A pin with no stored pairing raises NOT_FOUND before the probe runs."""
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
-    controller.offloader._offloader_peer_link_priv = b"\x42" * 32
+    controller.offloader.state.offloader_peer_link_priv = b"\x42" * 32
 
     with pytest.raises(CommandError) as exc_info:
         await controller.offloader.edit_pairing_endpoint(
@@ -922,7 +922,7 @@ async def test_edit_pairing_endpoint_raises_not_found_when_pairing_replaced_mid_
         # Simulate the in-flight re-pair: replace the dict entry
         # with a fresh object before the probe applies its
         # result.
-        controller.offloader._pairings[pin] = fresh
+        controller.offloader.state.pairings[pin] = fresh
         return pin
 
     monkeypatch.setattr(rb_rebind, "peer_link_preview_pair", _replace_during_preview)
@@ -959,7 +959,7 @@ async def test_edit_pairing_endpoint_without_priv_raises_precondition_failed(
     pin = "a" * 64
     pairing = _valid_stored_pairing(receiver_hostname="old.local", receiver_port=6058)
     controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
-    controller.offloader._offloader_peer_link_priv = None
+    controller.offloader.state.offloader_peer_link_priv = None
 
     with pytest.raises(CommandError) as exc_info:
         await controller.offloader.edit_pairing_endpoint(
@@ -1047,7 +1047,7 @@ async def test_edit_pairing_endpoint_invalid_args_rejected_before_lookup(
     """
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
-    controller.offloader._offloader_peer_link_priv = b"\x42" * 32
+    controller.offloader.state.offloader_peer_link_priv = b"\x42" * 32
 
     with pytest.raises(CommandError) as exc_info:
         await controller.offloader.edit_pairing_endpoint(**kwargs)
@@ -1120,7 +1120,7 @@ def test_on_service_state_change_removed_drops_peer(
     """A ``Removed`` event clears the peer entry and fires ``REMOTE_BUILD_HOST_REMOVED``."""
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
-    controller.offloader._peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
+    controller.offloader.state.peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
         name="desktop",
         hostname="desktop.local.",
         port=6052,
@@ -1129,7 +1129,7 @@ def test_on_service_state_change_removed_drops_peer(
     controller.offloader._on_service_state_change(
         MagicMock(), SERVICE_TYPE, f"desktop.{SERVICE_TYPE}", ServiceStateChange.Removed
     )
-    assert controller.offloader._peers == {}
+    assert controller.offloader.state.peers == {}
     # Event keys on the wire-friendly label (matches
     # ``RemoteBuildPeer.name``), not the FQDN dict key.
     controller.offloader._db.bus.fire.assert_called_once_with(
@@ -1172,8 +1172,8 @@ def test_on_service_state_change_uses_cache_when_available(
     controller.offloader._on_service_state_change(
         zeroconf, SERVICE_TYPE, f"desktop.{SERVICE_TYPE}", ServiceStateChange.Added
     )
-    assert f"desktop.{SERVICE_TYPE}" in controller.offloader._peers
-    assert controller.offloader._peers[f"desktop.{SERVICE_TYPE}"].name == "desktop"
+    assert f"desktop.{SERVICE_TYPE}" in controller.offloader.state.peers
+    assert controller.offloader.state.peers[f"desktop.{SERVICE_TYPE}"].name == "desktop"
     # No async resolve task was spawned.
     assert controller.offloader._tasks == set()
     # Event fired with the full peer projection so the frontend
@@ -1195,13 +1195,13 @@ def test_on_service_state_change_uses_cache_when_available(
 def test_hosts_snapshot_returns_mdns_peers(tmp_path: Path) -> None:
     """``hosts_snapshot`` is a sync read of the in-RAM ``_peers`` dict."""
     controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
+    controller.offloader.state.peers[f"desktop.{SERVICE_TYPE}"] = RemoteBuildPeer(
         name="desktop",
         hostname="desktop.local.",
         port=6052,
         source=RemoteBuildPeerSource.MDNS,
     )
-    controller.offloader._peers[f"laptop.{SERVICE_TYPE}"] = RemoteBuildPeer(
+    controller.offloader.state.peers[f"laptop.{SERVICE_TYPE}"] = RemoteBuildPeer(
         name="laptop",
         hostname="laptop.local.",
         port=6052,
@@ -1339,7 +1339,7 @@ async def test_start_skips_when_devices_controller_missing(tmp_path: Path) -> No
         receiver=ReceiverController(db),
     )
     await controller.start()
-    assert controller.offloader._browser is None
+    assert controller.offloader.state.browser is None
 
 
 @pytest.mark.asyncio
@@ -1348,7 +1348,7 @@ async def test_start_skips_when_zeroconf_unavailable(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.devices.zeroconf = None
     await controller.start()
-    assert controller.offloader._browser is None
+    assert controller.offloader.state.browser is None
 
 
 @pytest.mark.asyncio
@@ -1372,7 +1372,7 @@ async def test_start_leaves_peer_link_resolver_none_when_devices_controller_miss
         receiver=ReceiverController(db),
     )
     await controller.start()
-    assert controller.offloader._peer_link_resolver is None
+    assert controller.offloader.state.peer_link_resolver is None
 
 
 @pytest.mark.asyncio
@@ -1390,7 +1390,7 @@ async def test_start_leaves_peer_link_resolver_none_when_zeroconf_failed_to_bind
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.devices.zeroconf = None
     await controller.start()
-    assert controller.offloader._peer_link_resolver is None
+    assert controller.offloader.state.peer_link_resolver is None
 
 
 @pytest.mark.asyncio
@@ -1422,7 +1422,7 @@ async def test_start_swallows_peer_link_resolver_construction_errors(
     ):
         await controller.start()
     try:
-        assert controller.offloader._peer_link_resolver is None
+        assert controller.offloader.state.peer_link_resolver is None
         assert any("Could not build peer-link mDNS resolver" in r.message for r in caplog.records)
     finally:
         await controller.stop()
@@ -1446,17 +1446,17 @@ async def test_stop_swallows_peer_link_resolver_close_failures(
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.devices.zeroconf = MagicMock(spec=AsyncZeroconf)
     await controller.start()
-    assert controller.offloader._peer_link_resolver is not None
+    assert controller.offloader.state.peer_link_resolver is not None
     # Force the close path to raise; the controller should
     # catch + log + clear the reference rather than propagate.
-    controller.offloader._peer_link_resolver.real_close = AsyncMock(  # type: ignore[method-assign]
+    controller.offloader.state.peer_link_resolver.real_close = AsyncMock(  # type: ignore[method-assign]
         side_effect=RuntimeError("aiodns gone")
     )
     with caplog.at_level(
         "DEBUG", logger="esphome_device_builder.controllers.remote_build.offloader"
     ):
         await controller.stop()
-    assert controller.offloader._peer_link_resolver is None
+    assert controller.offloader.state.peer_link_resolver is None
     assert any("peer-link resolver close failed" in r.message for r in caplog.records)
 
 
@@ -1478,11 +1478,11 @@ async def test_start_constructs_peer_link_resolver_when_zeroconf_is_up(
     controller.offloader._db.devices.zeroconf = MagicMock(spec=AsyncZeroconf)
     await controller.start()
     try:
-        assert controller.offloader._peer_link_resolver is not None
-        assert isinstance(controller.offloader._peer_link_resolver, AsyncDualMDNSResolver)
+        assert controller.offloader.state.peer_link_resolver is not None
+        assert isinstance(controller.offloader.state.peer_link_resolver, AsyncDualMDNSResolver)
     finally:
         await controller.stop()
-        assert controller.offloader._peer_link_resolver is None
+        assert controller.offloader.state.peer_link_resolver is None
 
 
 @pytest.mark.asyncio
@@ -1503,7 +1503,7 @@ async def test_start_swallows_browser_construction_errors(
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.devices.zeroconf = MagicMock()
     await controller.start()  # must not raise
-    assert controller.offloader._browser is None
+    assert controller.offloader.state.browser is None
 
 
 @pytest.mark.asyncio
@@ -1530,8 +1530,8 @@ async def test_start_captures_own_instance_name(
     controller.offloader._db._dashboard_advertiser = advertiser
 
     await controller.start()
-    assert controller.offloader._own_instance_name == f"self.{SERVICE_TYPE}"
-    assert controller.offloader._browser is fake_browser
+    assert controller.offloader.state.own_instance_name == f"self.{SERVICE_TYPE}"
+    assert controller.offloader.state.browser is fake_browser
     await controller.stop()
 
 
@@ -1556,7 +1556,7 @@ async def test_start_skips_self_capture_when_advertiser_unregistered(
     controller.offloader._db._dashboard_advertiser = advertiser
 
     await controller.start()
-    assert controller.offloader._own_instance_name is None
+    assert controller.offloader.state.own_instance_name is None
     await controller.stop()
 
 
@@ -1576,7 +1576,7 @@ async def test_start_skips_self_capture_when_no_advertiser(
     controller.offloader._db._dashboard_advertiser = None
 
     await controller.start()
-    assert controller.offloader._own_instance_name is None
+    assert controller.offloader.state.own_instance_name is None
     await controller.stop()
 
 
@@ -1595,7 +1595,7 @@ async def test_stop_swallows_browser_cancel_errors(
     controller.offloader._db.devices.zeroconf = MagicMock()
     await controller.start()
     await controller.stop()  # must not raise
-    assert controller.offloader._browser is None
+    assert controller.offloader.state.browser is None
 
 
 @pytest.mark.asyncio
@@ -1621,7 +1621,7 @@ async def test_on_service_state_change_spawns_resolve_task_on_cache_miss(
     pending = list(controller.offloader._tasks)
     assert len(pending) == 1
     await asyncio.gather(*pending)
-    assert f"desktop.{SERVICE_TYPE}" in controller.offloader._peers
+    assert f"desktop.{SERVICE_TYPE}" in controller.offloader.state.peers
     assert controller.offloader._tasks == set()
     # Event fired after the async resolve succeeded.
     controller.offloader._db.bus.fire.assert_called_once()
@@ -1636,7 +1636,7 @@ async def test_resolve_and_apply_swallows_errors(tmp_path: Path) -> None:
     fake_info = _fake_service_info(name="desktop")
     fake_info.async_request = AsyncMock(side_effect=RuntimeError("network down"))
     await controller.offloader._resolve_and_apply(MagicMock(), fake_info, f"desktop.{SERVICE_TYPE}")
-    assert controller.offloader._peers == {}
+    assert controller.offloader.state.peers == {}
 
 
 @pytest.mark.asyncio
@@ -1646,7 +1646,7 @@ async def test_resolve_and_apply_skips_when_resolution_returns_false(tmp_path: P
     fake_info = _fake_service_info(name="desktop")
     fake_info.async_request = AsyncMock(return_value=False)
     await controller.offloader._resolve_and_apply(MagicMock(), fake_info, f"desktop.{SERVICE_TYPE}")
-    assert controller.offloader._peers == {}
+    assert controller.offloader.state.peers == {}
 
 
 @pytest.mark.asyncio
@@ -3834,7 +3834,7 @@ def test_on_offloader_pair_pin_mismatch_caches_alert(tmp_path: Path) -> None:
     }
     controller.offloader._on_offloader_pair_pin_mismatch(MagicMock(data=payload))
 
-    cached = controller.offloader._offloader_alerts["a" * 64]
+    cached = controller.offloader.state.offloader_alerts["a" * 64]
     assert cached["kind"] == "pin_mismatch"
     assert cached["receiver_hostname"] == "host.local"
     assert cached["receiver_port"] == 6055
@@ -3858,7 +3858,7 @@ def test_on_offloader_queue_status_changed_caches_snapshot(tmp_path: Path) -> No
     }
     controller.offloader._on_offloader_queue_status_changed(MagicMock(data=payload))
 
-    cached = controller.offloader._peer_queue_status["a" * 64]
+    cached = controller.offloader.state.peer_queue_status["a" * 64]
     assert cached["receiver_hostname"] == "192.168.1.10"
     assert cached["receiver_port"] == 6055
     assert cached["pin_sha256"] == "a" * 64
@@ -3890,16 +3890,16 @@ def test_on_offloader_queue_status_changed_overwrites_prior(tmp_path: Path) -> N
     controller.offloader._on_offloader_queue_status_changed(MagicMock(data=first))
     controller.offloader._on_offloader_queue_status_changed(MagicMock(data=second))
 
-    cached = controller.offloader._peer_queue_status[pin]
+    cached = controller.offloader.state.peer_queue_status[pin]
     assert cached["queue_depth"] == 5
     assert cached["running"] is True
-    assert len(controller.offloader._peer_queue_status) == 1
+    assert len(controller.offloader.state.peer_queue_status) == 1
 
 
 def test_peer_queue_status_snapshot_returns_list(tmp_path: Path) -> None:
     """``peer_queue_status_snapshot`` returns a list of cached entries."""
     controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._peer_queue_status["a" * 64] = {
+    controller.offloader.state.peer_queue_status["a" * 64] = {
         "receiver_hostname": "a",
         "receiver_port": 6055,
         "pin_sha256": "a" * 64,
@@ -3907,7 +3907,7 @@ def test_peer_queue_status_snapshot_returns_list(tmp_path: Path) -> None:
         "running": False,
         "queue_depth": 0,
     }
-    controller.offloader._peer_queue_status["b" * 64] = {
+    controller.offloader.state.peer_queue_status["b" * 64] = {
         "receiver_hostname": "b",
         "receiver_port": 6055,
         "pin_sha256": "b" * 64,
@@ -4140,9 +4140,9 @@ def test_build_scheduler_snapshot_returns_immutable_view(tmp_path: Path) -> None
     """
     controller = _make_controller(config_dir=tmp_path)
     pairing = _valid_stored_pairing()
-    controller.offloader._pairings[pairing.pin_sha256] = pairing
-    controller.offloader._open_peer_links.add(pairing.pin_sha256)
-    controller.offloader._peer_queue_status[pairing.pin_sha256] = PeerQueueStatusSnapshotEntry(
+    controller.offloader.state.pairings[pairing.pin_sha256] = pairing
+    controller.offloader.state.open_peer_links.add(pairing.pin_sha256)
+    controller.offloader.state.peer_queue_status[pairing.pin_sha256] = PeerQueueStatusSnapshotEntry(
         receiver_hostname=pairing.receiver_hostname,
         receiver_port=pairing.receiver_port,
         pin_sha256=pairing.pin_sha256,
@@ -4174,14 +4174,14 @@ def test_build_scheduler_snapshot_decouples_from_live_state(tmp_path: Path) -> N
     """
     controller = _make_controller(config_dir=tmp_path)
     initial = _valid_stored_pairing(label="initial")
-    controller.offloader._pairings[initial.pin_sha256] = initial
+    controller.offloader.state.pairings[initial.pin_sha256] = initial
 
     snapshot = controller.offloader.build_scheduler_snapshot()
 
     # Mutations after the snapshot don't bleed through.
-    controller.offloader._pairings.clear()
-    controller.offloader._open_peer_links.add("some-other-pin")
-    controller.offloader._peer_queue_status["pin-2"] = PeerQueueStatusSnapshotEntry(
+    controller.offloader.state.pairings.clear()
+    controller.offloader.state.open_peer_links.add("some-other-pin")
+    controller.offloader.state.peer_queue_status["pin-2"] = PeerQueueStatusSnapshotEntry(
         receiver_hostname="other.local",
         receiver_port=6055,
         pin_sha256="pin-2",
@@ -4199,7 +4199,7 @@ def test_get_pairing_returns_matching_row(tmp_path: Path) -> None:
     """``get_pairing(pin)`` returns the stored row; missing pins return ``None``."""
     controller = _make_controller(config_dir=tmp_path)
     pairing = _valid_stored_pairing(label="desktop")
-    controller.offloader._pairings[pairing.pin_sha256] = pairing
+    controller.offloader.state.pairings[pairing.pin_sha256] = pairing
 
     assert controller.offloader.get_pairing(pairing.pin_sha256) is pairing
     assert controller.offloader.get_pairing("b" * 64) is None
@@ -4279,7 +4279,7 @@ async def test_set_pairing_enabled_flips_field_and_fires_event(tmp_path: Path) -
     """
     controller = _make_controller(config_dir=tmp_path, real_bus=True)
     pairing = _valid_stored_pairing(label="desktop")
-    controller.offloader._pairings[pairing.pin_sha256] = pairing
+    controller.offloader.state.pairings[pairing.pin_sha256] = pairing
     captured: list[Any] = []
     controller.offloader._db.bus.add_listener(
         EventType.OFFLOADER_PAIRING_ENABLED_CHANGED,
@@ -4314,7 +4314,7 @@ async def test_set_pairing_enabled_rejects_non_bool(tmp_path: Path) -> None:
     """Strict ``bool`` validation matches the master-toggle command."""
     controller = _make_controller(config_dir=tmp_path)
     pairing = _valid_stored_pairing()
-    controller.offloader._pairings[pairing.pin_sha256] = pairing
+    controller.offloader.state.pairings[pairing.pin_sha256] = pairing
 
     with pytest.raises(CommandError) as exc:
         await controller.offloader.set_pairing_enabled(
@@ -4335,8 +4335,8 @@ async def test_get_offloader_settings_returns_master_plus_pairings(tmp_path: Pat
     """
     controller = _make_controller(config_dir=tmp_path)
     pairing = _valid_stored_pairing(label="desktop")
-    controller.offloader._pairings[pairing.pin_sha256] = pairing
-    controller.offloader._remote_builds_enabled = False
+    controller.offloader.state.pairings[pairing.pin_sha256] = pairing
+    controller.offloader.state.remote_builds_enabled = False
 
     view = await controller.offloader.get_offloader_settings()
 
@@ -4360,8 +4360,8 @@ def test_pairing_summary_surfaces_enabled_field(tmp_path: Path) -> None:
     # distinct pin so both rows can coexist.
     object.__setattr__(disabled_pairing, "pin_sha256", "b" * 64)
     disabled_pairing.enabled = False
-    controller.offloader._pairings[enabled_pairing.pin_sha256] = enabled_pairing
-    controller.offloader._pairings[disabled_pairing.pin_sha256] = disabled_pairing
+    controller.offloader.state.pairings[enabled_pairing.pin_sha256] = enabled_pairing
+    controller.offloader.state.pairings[disabled_pairing.pin_sha256] = disabled_pairing
 
     summaries = {s.pin_sha256: s for s in controller.offloader.pairings_snapshot()}
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -788,7 +788,7 @@ async def test_controller_request_pair_persists_pending_row(
     # dict; the persisted file stays APPROVED-only so a malicious
     # receiver can't bloat the offloader's settings file.
     assert await _saved_pairings(offloader) == []
-    assert expected_pin in offloader._pairings
+    assert expected_pin in offloader.state.pairings
 
 
 @pytest.mark.asyncio
@@ -956,7 +956,7 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
     # A no-op listener task standing in for the real long-poll
     # task; the test verifies cancel + cleanup, not the wire flow.
     park = asyncio.Event()
@@ -965,7 +965,7 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
         await park.wait()
 
     listener = asyncio.create_task(_park())
-    offloader._pair_status_listeners["a" * 64] = listener
+    offloader.state.pair_status_listeners["a" * 64] = listener
     # Settle one event-loop tick so the create_task is actually
     # scheduled before unpair tries to cancel it.
     await asyncio.sleep(0)
@@ -973,10 +973,10 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     result = await offloader.unpair(pin_sha256="a" * 64)
 
     assert result == {"removed": True}
-    assert "a" * 64 not in offloader._pairings
+    assert "a" * 64 not in offloader.state.pairings
     # ``unpair`` popped the listener entry from the registry —
     # the row is gone from the pin-keyed dict.
-    assert "a" * 64 not in offloader._pair_status_listeners
+    assert "a" * 64 not in offloader.state.pair_status_listeners
     # The captured task reference was cancelled by ``unpair``'s
     # ``_cancel_pair_status_listener``; drain via ``gather`` so
     # the cancellation propagates without surfacing as a test
@@ -1005,7 +1005,7 @@ async def test_unpair_drops_persisted_row(
     )
     # Land the row in RAM + force-flush an initial save so the
     # unpair has something to drop on disk too.
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
     offloader._pairings_store.async_delay_save(offloader._serialize_pairings, delay=0.0)
     for cb in offloader._shutdown_callbacks:
         await cb()
@@ -1061,8 +1061,8 @@ async def test_pairings_snapshot_returns_ram_dict(
         label="approved-receiver",
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings["a" * 64] = pending
-    offloader._pairings["b" * 64] = approved
+    offloader.state.pairings["a" * 64] = pending
+    offloader.state.pairings["b" * 64] = approved
 
     rows = offloader.pairings_snapshot()
 
@@ -1101,10 +1101,10 @@ async def test_pairings_snapshot_marks_open_link_as_connected(
         pin_sha256=pin_b,
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[pin_a] = a
-    offloader._pairings[pin_b] = b
+    offloader.state.pairings[pin_a] = a
+    offloader.state.pairings[pin_b] = b
     # Only ``a`` has an open peer-link session.
-    offloader._open_peer_links.add(pin_a)
+    offloader.state.open_peer_links.add(pin_a)
 
     rows = {row.receiver_hostname: row for row in offloader.pairings_snapshot()}
 
@@ -1134,7 +1134,7 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
         "esphome_version": "",
     }
     offloader._on_offloader_peer_link_opened(MagicMock(data=opened))
-    assert pin in offloader._open_peer_links
+    assert pin in offloader.state.open_peer_links
 
     closed: OffloaderPeerLinkClosedData = {
         "receiver_hostname": "host.local",
@@ -1143,14 +1143,14 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
         "reason": "peer_hung_up",
     }
     offloader._on_offloader_peer_link_closed(MagicMock(data=closed))
-    assert pin not in offloader._open_peer_links
+    assert pin not in offloader.state.open_peer_links
 
     # ``discard`` semantics: a CLOSED for a key we never saw
     # OPENED is a no-op rather than raising. Covers the
     # cold-start race where a stale CLOSED arrives before the
     # listener is ready.
     offloader._on_offloader_peer_link_closed(MagicMock(data=closed))
-    assert pin not in offloader._open_peer_links
+    assert pin not in offloader.state.open_peer_links
 
 
 @pytest.mark.parametrize(
@@ -1221,7 +1221,7 @@ async def test_peer_link_opened_refreshes_stored_pairing_version(
         pin_sha256=pin,
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[pin] = pairing
+    offloader.state.pairings[pin] = pairing
     offloader._pairings_save_scheduled = False
 
     # Mock the save scheduler so the test doesn't have to
@@ -1343,7 +1343,7 @@ async def test_start_seeds_pairings_dict_from_disk(
         static_x25519_pub=pubkey,
         status=PeerStatus.APPROVED,
     )
-    seeder._pairings[pin] = seeded
+    seeder.state.pairings[pin] = seeded
     seeder._pairings_store.async_delay_save(seeder._serialize_pairings, delay=0.0)
     for cb in seeder._shutdown_callbacks:
         await cb()
@@ -1359,8 +1359,8 @@ async def test_start_seeds_pairings_dict_from_disk(
     fresh._db.devices = None  # short-circuit the post-load branches.
     await fresh.start()
 
-    assert pin in fresh._pairings
-    loaded = fresh._pairings[pin]
+    assert pin in fresh.state.pairings
+    loaded = fresh.state.pairings[pin]
     assert loaded.pin_sha256 == pin
     assert loaded.static_x25519_pub == pubkey
     assert loaded.status is PeerStatus.APPROVED
@@ -1388,7 +1388,7 @@ async def test_apply_pair_status_result_approved_promotes_and_fires(
         static_x25519_pub=pubkey,
         status=PeerStatus.PENDING,
     )
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.APPROVED, pin_sha256=pin
     )
@@ -1398,7 +1398,7 @@ async def test_apply_pair_status_result_approved_promotes_and_fires(
     assert terminal is True
     # Row stays in the dict with promoted status — the unified
     # ``_pairings`` map carries both PENDING and APPROVED.
-    assert offloader._pairings["a" * 64].status is PeerStatus.APPROVED
+    assert offloader.state.pairings["a" * 64].status is PeerStatus.APPROVED
     saved = await _saved_pairings(offloader)
     assert len(saved) == 1
     assert saved[0].pin_sha256 == pin
@@ -1421,7 +1421,7 @@ async def test_apply_pair_status_result_approved_pin_drift_drops_and_fires_remov
         pin_sha256="a" * 64,
         label="lab-pc",
     )
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
     # Receiver returned APPROVED but its pubkey hash doesn't match
     # what we stored; treat as peer-revoked rather than silently
     # adopting the new identity.
@@ -1432,7 +1432,7 @@ async def test_apply_pair_status_result_approved_pin_drift_drops_and_fires_remov
     terminal = await offloader._apply_pair_status_result(pairing, result)
 
     assert terminal is True
-    assert "a" * 64 not in offloader._pairings
+    assert "a" * 64 not in offloader.state.pairings
     assert await _saved_pairings(offloader) == []
     # Two events should have fired in order: the discriminator
     # (PIN_MISMATCH) carrying the diagnostic detail + label,
@@ -1469,7 +1469,7 @@ async def test_apply_pair_status_result_rejected_drops_and_fires_removed(
         receiver_port=6055,
         label="lab-pc",
     )
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.REJECTED, pin_sha256="a" * 64
     )
@@ -1477,7 +1477,7 @@ async def test_apply_pair_status_result_rejected_drops_and_fires_removed(
     terminal = await offloader._apply_pair_status_result(pairing, result)
 
     assert terminal is True
-    assert "a" * 64 not in offloader._pairings
+    assert "a" * 64 not in offloader.state.pairings
     # Same fire-discriminator-first ordering as the pin-drift
     # branch: PEER_REVOKED carrying the row label, then
     # STATUS_CHANGED("removed") that drops the row.
@@ -1517,7 +1517,7 @@ async def test_apply_pair_status_result_pin_drift_seeds_offloader_alert(
         pin_sha256="a" * 64,
         label="lab-pc",
     )
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.APPROVED, pin_sha256="b" * 64
     )
@@ -1554,7 +1554,7 @@ async def test_apply_pair_status_result_rejected_seeds_offloader_alert(
         receiver_port=6055,
         label="lab-pc",
     )
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.REJECTED, pin_sha256="a" * 64
     )
@@ -1579,8 +1579,8 @@ async def test_unpair_clears_offloader_alert_and_fires_dismissed(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings["a" * 64] = pairing
-    offloader._offloader_alerts["a" * 64] = {
+    offloader.state.pairings["a" * 64] = pairing
+    offloader.state.offloader_alerts["a" * 64] = {
         "kind": "peer_revoked",
         "receiver_hostname": "rcv.local",
         "receiver_port": 6055,
@@ -1608,7 +1608,7 @@ async def test_apply_pair_status_result_unexpected_status_logs_and_continues(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.OK, pin_sha256="a" * 64
     )
@@ -1618,7 +1618,7 @@ async def test_apply_pair_status_result_unexpected_status_logs_and_continues(
     # Not terminal — the listener loop reconnects after a backoff.
     assert terminal is False
     # Pending entry untouched.
-    assert "a" * 64 in offloader._pairings
+    assert "a" * 64 in offloader.state.pairings
     offloader._db.bus.fire.assert_not_called()
 
 
@@ -1652,7 +1652,7 @@ async def test_apply_pair_status_result_approved_after_unpair_does_not_resurrect
     # Simulate the unpair path: dict entry was already popped.
     # The pairing in the listener's closure is what remains
     # (captured at spawn time).
-    assert "a" * 64 not in offloader._pairings
+    assert "a" * 64 not in offloader.state.pairings
 
     result = remote_build_peer_link_client.PairStatusResult(
         status=IntentResponse.APPROVED, pin_sha256=pin
@@ -1684,17 +1684,17 @@ async def test_unpair_cancels_listener_before_disk_transaction(
 
     key = "a" * 64
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings[key] = pairing
+    offloader.state.pairings[key] = pairing
     listener = asyncio.create_task(_park())
-    offloader._pair_status_listeners[key] = listener
+    offloader.state.pair_status_listeners[key] = listener
     await asyncio.sleep(0)
 
     await offloader.unpair(pin_sha256="a" * 64)
 
     with pytest.raises(asyncio.CancelledError):
         await listener
-    assert key not in offloader._pairings
-    assert key not in offloader._pair_status_listeners
+    assert key not in offloader.state.pairings
+    assert key not in offloader.state.pair_status_listeners
 
 
 @pytest.mark.asyncio
@@ -1711,7 +1711,7 @@ async def test_unpair_fires_offloader_pair_status_changed_removed(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
-    offloader._pairings["a" * 64] = pairing
+    offloader.state.pairings["a" * 64] = pairing
 
     result = await offloader.unpair(pin_sha256="a" * 64)
 
@@ -1781,7 +1781,7 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
 
     # Pre-seed an alert as if a prior pair-status detection had
     # registered one against this receiver.
-    offloader._offloader_alerts["a" * 64] = {
+    offloader.state.offloader_alerts["a" * 64] = {
         "kind": "pin_mismatch",
         "receiver_hostname": "rcv.local",
         "receiver_port": 6055,
@@ -1808,7 +1808,7 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
     assert EventType.OFFLOADER_PAIR_ALERT_DISMISSED in fire_event_types
 
     # Cleanup: cancel the listener so the test exits clean.
-    listener = offloader._pair_status_listeners.get(pin)
+    listener = offloader.state.pair_status_listeners.get(pin)
     if listener is not None:
         listener.cancel()
         await asyncio.gather(listener, return_exceptions=True)
@@ -1909,7 +1909,7 @@ async def test_request_pair_repair_then_unpair_clean_state(
         receiver_label="rcv-1",
         offloader_label="off",
     )
-    listener_v1 = offloader._pair_status_listeners[pin1]
+    listener_v1 = offloader.state.pair_status_listeners[pin1]
 
     # Wait until ``listener_v1`` has actually reached its
     # ``await peer_link_await_pair_status`` parked state.
@@ -1933,7 +1933,7 @@ async def test_request_pair_repair_then_unpair_clean_state(
         receiver_label="rcv-2",
         offloader_label="off",
     )
-    listener_v2 = offloader._pair_status_listeners[pin2]
+    listener_v2 = offloader.state.pair_status_listeners[pin2]
     assert listener_v2 is not listener_v1
     # Drain the cancelled v1 task — same cancel-and-gather
     # shape ``OffloaderController.stop()`` uses for its
@@ -1942,15 +1942,15 @@ async def test_request_pair_repair_then_unpair_clean_state(
     assert listener_v1.cancelled()
     # Re-pair under a new pin landed a new entry under pin2;
     # the sweep dropped the old entry under pin1.
-    assert offloader._pairings[pin2].pin_sha256 == pin2
-    assert pin1 not in offloader._pairings
+    assert offloader.state.pairings[pin2].pin_sha256 == pin2
+    assert pin1 not in offloader.state.pairings
 
     # Unpair cancels listener_v2 + clears the dict.
     await offloader.unpair(pin_sha256=pin2)
     await asyncio.gather(listener_v2, return_exceptions=True)
     assert listener_v2.cancelled()
-    assert offloader._pairings == {}
-    assert offloader._pair_status_listeners == {}
+    assert offloader.state.pairings == {}
+    assert offloader.state.pair_status_listeners == {}
 
 
 @pytest.mark.asyncio
@@ -1967,7 +1967,7 @@ async def test_spawn_pair_status_listener_is_idempotent_on_running_task(
 
     key = "a" * 64
     existing = asyncio.create_task(_park())
-    offloader._pair_status_listeners[key] = existing
+    offloader.state.pair_status_listeners[key] = existing
     await asyncio.sleep(0)  # schedule the task
     pairing = _stub_pairing(receiver_hostname="rcv.local", receiver_port=6055)
 
@@ -1975,7 +1975,7 @@ async def test_spawn_pair_status_listener_is_idempotent_on_running_task(
 
     # The dict still points at the original task — the spawn was
     # a no-op because a listener was already running for this key.
-    assert offloader._pair_status_listeners[key] is existing
+    assert offloader.state.pair_status_listeners[key] is existing
     park.set()
     await existing
 
@@ -2015,9 +2015,9 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
     old_pairing = _stub_pairing(
         receiver_hostname="rcv.local", receiver_port=6055, pin_sha256="a" * 64
     )
-    offloader._pairings[key_old] = old_pairing
+    offloader.state.pairings[key_old] = old_pairing
     old_listener = asyncio.create_task(_park())
-    offloader._pair_status_listeners[key_old] = old_listener
+    offloader.state.pair_status_listeners[key_old] = old_listener
     await asyncio.sleep(0)
 
     # Stub the wire round-trip so request_pair completes without
@@ -2051,18 +2051,18 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
     await asyncio.gather(old_listener, return_exceptions=True)
     assert old_listener.cancelled()
     # New listener spawned with the fresh pairing under the new pin key.
-    new_listener = offloader._pair_status_listeners.get(new_pin)
+    new_listener = offloader.state.pair_status_listeners.get(new_pin)
     assert new_listener is not None
     assert new_listener is not old_listener
     new_listener.cancel()
     await asyncio.gather(new_listener, return_exceptions=True)
     assert new_listener.cancelled()
     # The dict entry now holds the new pin.
-    assert offloader._pairings[new_pin].pin_sha256 == new_pin
+    assert offloader.state.pairings[new_pin].pin_sha256 == new_pin
     assert summary.pin_sha256 == new_pin
     # Old (pin-keyed) entry is gone — re-pair under a new pin
     # creates a fresh row, doesn't shadow the old one.
-    assert key_old not in offloader._pairings
+    assert key_old not in offloader.state.pairings
 
 
 @pytest.mark.asyncio
@@ -2119,7 +2119,7 @@ async def test_request_pair_already_approved_persists_to_disk(
     assert saved[0].pin_sha256 == expected_pin
     # The row stays in the unified dict with APPROVED status —
     # no separate PENDING entry, no double-counting on the wire.
-    assert offloader._pairings[expected_pin].status is PeerStatus.APPROVED
+    assert offloader.state.pairings[expected_pin].status is PeerStatus.APPROVED
 
 
 @pytest.mark.asyncio
@@ -2281,8 +2281,8 @@ async def test_stop_cancels_pair_status_listeners(
 
     task_a = asyncio.create_task(_park())
     task_b = asyncio.create_task(_park())
-    offloader._pair_status_listeners[("a.local", 6055)] = task_a
-    offloader._pair_status_listeners[("b.local", 6055)] = task_b
+    offloader.state.pair_status_listeners[("a.local", 6055)] = task_a
+    offloader.state.pair_status_listeners[("b.local", 6055)] = task_b
     await asyncio.sleep(0)  # schedule both
 
     await offloader.stop()
@@ -2290,7 +2290,7 @@ async def test_stop_cancels_pair_status_listeners(
     # Both tasks completed (cancelled) and the dict was cleared.
     assert task_a.done()
     assert task_b.done()
-    assert offloader._pair_status_listeners == {}
+    assert offloader.state.pair_status_listeners == {}
 
 
 @pytest.mark.asyncio
@@ -2320,7 +2320,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
         pin_sha256=pin,
         static_x25519_pub=pubkey,
     )
-    offloader._pairings[pin] = pairing
+    offloader.state.pairings[pin] = pairing
 
     calls = 0
 
@@ -2353,7 +2353,7 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
     assert calls == 2
     # Terminal branch ran: row stays in the dict but is now
     # APPROVED, and an approved event fired.
-    assert offloader._pairings[pin].status is PeerStatus.APPROVED
+    assert offloader.state.pairings[pin].status is PeerStatus.APPROVED
 
 
 @pytest.mark.asyncio
@@ -2380,7 +2380,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
         pin_sha256=pin,
         static_x25519_pub=pubkey,
     )
-    offloader._pairings[pin] = pairing
+    offloader.state.pairings[pin] = pairing
 
     calls = 0
 
@@ -2413,7 +2413,7 @@ async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
 
     # Two poll attempts (OK → backoff → REJECTED → terminal).
     assert calls == 2
-    assert pin not in offloader._pairings
+    assert pin not in offloader.state.pairings
 
 
 # ---------------------------------------------------------------------------
@@ -3578,8 +3578,8 @@ def _prime_offloader_identity_for_spawn(controller: OffloaderController) -> None
     explicitly on the test (typically to a ``MagicMock`` or
     ``EventBus`` depending on what's being asserted).
     """
-    controller._offloader_dashboard_id = "test-dashboard"
-    controller._offloader_peer_link_priv = secrets.token_bytes(32)
+    controller.state.offloader_dashboard_id = "test-dashboard"
+    controller.state.offloader_peer_link_priv = secrets.token_bytes(32)
 
 
 @pytest.mark.asyncio
@@ -3613,13 +3613,13 @@ async def test_await_pair_status_flip_self_removes_listener_on_terminal_exit(
         static_x25519_pub=pubkey,
         status=PeerStatus.PENDING,
     )
-    offloader._pairings[pin] = pairing
+    offloader.state.pairings[pin] = pairing
     offloader._spawn_pair_status_listener(pairing)
-    listener = offloader._pair_status_listeners[pin]
+    listener = offloader.state.pair_status_listeners[pin]
 
     await listener
 
-    assert pin not in offloader._pair_status_listeners
+    assert pin not in offloader.state.pair_status_listeners
 
 
 @pytest.mark.asyncio
@@ -3650,12 +3650,12 @@ async def test_spawn_peer_link_client_idempotent_when_task_running(
 
     offloader._spawn_peer_link_client(pairing)
     await asyncio.sleep(0)
-    first_handle = offloader._peer_link_clients["a" * 64]
+    first_handle = offloader.state.peer_link_clients["a" * 64]
 
     offloader._spawn_peer_link_client(pairing)
     await asyncio.sleep(0)
 
-    assert offloader._peer_link_clients["a" * 64] is first_handle
+    assert offloader.state.peer_link_clients["a" * 64] is first_handle
     park.set()
     await cancel_and_drain(first_handle.task)
 
@@ -3687,11 +3687,11 @@ async def test_cancel_peer_link_client_cancels_running_task(
     )
     offloader._spawn_peer_link_client(pairing)
     await asyncio.sleep(0)
-    handle = offloader._peer_link_clients["a" * 64]
+    handle = offloader.state.peer_link_clients["a" * 64]
 
     offloader._cancel_peer_link_client("a" * 64)
 
-    assert "a" * 64 not in offloader._peer_link_clients
+    assert "a" * 64 not in offloader.state.peer_link_clients
     with pytest.raises(asyncio.CancelledError):
         await handle.task
 
@@ -3730,12 +3730,12 @@ async def test_stop_drains_peer_link_clients(
             )
         )
     await asyncio.sleep(0)
-    tasks = [h.task for h in offloader._peer_link_clients.values()]
+    tasks = [h.task for h in offloader.state.peer_link_clients.values()]
     assert len(tasks) == 2
 
     await offloader.stop()
 
-    assert offloader._peer_link_clients == {}
+    assert offloader.state.peer_link_clients == {}
     for task in tasks:
         assert task.done()
     # ``stop()`` already drained these tasks; gather one more time
@@ -4230,7 +4230,7 @@ def _seed_open_peer_link_client(
         await park.wait()
 
     task: asyncio.Task[None] = asyncio.create_task(_park())
-    offloader._peer_link_clients[pairing.pin_sha256] = rb_models.PeerLinkClientHandle(
+    offloader.state.peer_link_clients[pairing.pin_sha256] = rb_models.PeerLinkClientHandle(
         client=client, task=task
     )
     # Caller is responsible for cancelling ``task`` at end-of-test.
@@ -4249,7 +4249,7 @@ async def test_controller_submit_job_returns_ack_on_accept(
         receiver_port=6055,
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     # Drop a stub YAML at the expected path so ``rel_path`` resolves.
     yaml_path = Path(offloader._db.settings.config_dir) / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
@@ -4287,9 +4287,9 @@ async def test_controller_submit_job_returns_ack_on_accept(
         )
     finally:
         # Drain the parked task spun up by ``_seed_open_peer_link_client``.
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
 
@@ -4311,7 +4311,7 @@ async def test_controller_submit_job_passes_through_reject_reason(
         receiver_port=6055,
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     (Path(offloader._db.settings.config_dir) / "kitchen.yaml").write_text(
         "esphome:\n  name: kitchen\n", encoding="utf-8"
     )
@@ -4341,9 +4341,9 @@ async def test_controller_submit_job_passes_through_reject_reason(
             target="upload",
         )
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
 
@@ -4394,7 +4394,7 @@ async def test_controller_submit_job_pending_pairing_raises_precondition_failed(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.PENDING)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     (Path(offloader._db.settings.config_dir) / "kitchen.yaml").write_text(
         "esphome:\n  name: kitchen\n", encoding="utf-8"
     )
@@ -4418,7 +4418,7 @@ async def test_controller_submit_job_no_session_raises_precondition_failed(
         receiver_hostname="rcv.local",
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     (Path(offloader._db.settings.config_dir) / "kitchen.yaml").write_text(
         "esphome:\n  name: kitchen\n", encoding="utf-8"
     )
@@ -4443,7 +4443,7 @@ async def test_controller_submit_job_timeout_maps_to_unavailable(
         receiver_hostname="rcv.local",
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     (Path(offloader._db.settings.config_dir) / "kitchen.yaml").write_text(
         "esphome:\n  name: kitchen\n", encoding="utf-8"
     )
@@ -4469,9 +4469,9 @@ async def test_controller_submit_job_timeout_maps_to_unavailable(
                 target="compile",
             )
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.UNAVAILABLE
@@ -4632,7 +4632,7 @@ async def test_controller_submit_job_yaml_invalid_maps_to_invalid_args(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     (Path(offloader._db.settings.config_dir) / "kitchen.yaml").write_text(
         "esphome:\n  name: kitchen\n", encoding="utf-8"
     )
@@ -4654,9 +4654,9 @@ async def test_controller_submit_job_yaml_invalid_maps_to_invalid_args(
                 target="compile",
             )
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.INVALID_ARGS
@@ -4670,7 +4670,7 @@ async def test_controller_submit_job_missing_yaml_maps_to_not_found(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     (Path(offloader._db.settings.config_dir) / "kitchen.yaml").write_text(
         "esphome:\n  name: kitchen\n", encoding="utf-8"
     )
@@ -4692,9 +4692,9 @@ async def test_controller_submit_job_missing_yaml_maps_to_not_found(
                 target="compile",
             )
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.NOT_FOUND
@@ -4708,7 +4708,7 @@ async def test_controller_submit_job_orphaned_client_raises_precondition_failed(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     # Build a handle whose task is already finished (orphaned).
     bus = MagicMock()
     client = PeerLinkClient(
@@ -4728,7 +4728,7 @@ async def test_controller_submit_job_orphaned_client_raises_precondition_failed(
     finished_task = asyncio.create_task(_exit_immediately())
     await asyncio.sleep(0)
     assert finished_task.done()
-    offloader._peer_link_clients[pairing.pin_sha256] = rb_models.PeerLinkClientHandle(
+    offloader.state.peer_link_clients[pairing.pin_sha256] = rb_models.PeerLinkClientHandle(
         client=client, task=finished_task
     )
 
@@ -4759,7 +4759,7 @@ async def test_controller_submit_job_session_closed_branch_in_lookup(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     bus = MagicMock()
     client = PeerLinkClient(
         receiver_hostname=pairing.receiver_hostname,
@@ -4778,7 +4778,7 @@ async def test_controller_submit_job_session_closed_branch_in_lookup(
         await park.wait()
 
     task: asyncio.Task[None] = asyncio.create_task(_park())
-    offloader._peer_link_clients[pairing.pin_sha256] = rb_models.PeerLinkClientHandle(
+    offloader.state.peer_link_clients[pairing.pin_sha256] = rb_models.PeerLinkClientHandle(
         client=client, task=task
     )
 
@@ -4813,7 +4813,7 @@ async def test_controller_submit_job_no_session_during_send_maps_to_precondition
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     (Path(offloader._db.settings.config_dir) / "kitchen.yaml").write_text(
         "esphome:\n  name: kitchen\n", encoding="utf-8"
     )
@@ -4839,9 +4839,9 @@ async def test_controller_submit_job_no_session_during_send_maps_to_precondition
                 target="compile",
             )
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.PRECONDITION_FAILED
@@ -4918,7 +4918,7 @@ async def test_offloader_remote_jobs_cache_cleared_on_unpair(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     _fire_offloader_job_state(
         offloader, pin_sha256=pairing.pin_sha256, job_id="j-pin-a", status="running"
     )
@@ -4979,7 +4979,7 @@ async def test_controller_cancel_job_dispatches_via_client(
         receiver_port=6055,
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     client = _seed_open_peer_link_client(offloader, pairing)
 
     captured_kwargs: dict[str, Any] = {}
@@ -4993,9 +4993,9 @@ async def test_controller_cancel_job_dispatches_via_client(
     try:
         result = await offloader.cancel_job(pin_sha256=pairing.pin_sha256, job_id="j-1")
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert result == {"sent": True}
@@ -5034,7 +5034,7 @@ async def test_controller_cancel_job_no_session_raises_precondition_failed(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     client = _seed_open_peer_link_client(offloader, pairing)
 
     async def _stub_cancel(**_kwargs: Any) -> bool:
@@ -5046,9 +5046,9 @@ async def test_controller_cancel_job_no_session_raises_precondition_failed(
         with pytest.raises(CommandError) as exc_info:
             await offloader.cancel_job(pin_sha256=pairing.pin_sha256, job_id="j-1")
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.PRECONDITION_FAILED
@@ -5499,7 +5499,7 @@ async def test_controller_download_artifacts_returns_unpacked_response(
         receiver_port=6055,
         status=PeerStatus.APPROVED,
     )
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     client = _seed_open_peer_link_client(offloader, pairing)
 
     extras = [{"path": "/build/.pioenvs/x/bootloader.bin", "offset": "0x1000"}]
@@ -5518,9 +5518,9 @@ async def test_controller_download_artifacts_returns_unpacked_response(
             job_id="job-42",
         )
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
 
@@ -5566,7 +5566,7 @@ async def test_controller_download_artifacts_no_session_raises_precondition_fail
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     client = _seed_open_peer_link_client(offloader, pairing)
 
     async def _stub_download(**_kwargs: Any) -> DownloadArtifactsResult:
@@ -5578,9 +5578,9 @@ async def test_controller_download_artifacts_no_session_raises_precondition_fail
         with pytest.raises(CommandError) as exc_info:
             await offloader.download_artifacts(pin_sha256=pairing.pin_sha256, job_id="j-1")
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.PRECONDITION_FAILED
@@ -5594,7 +5594,7 @@ async def test_controller_download_artifacts_session_lost_maps_to_unavailable(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     client = _seed_open_peer_link_client(offloader, pairing)
 
     async def _stub_download(**_kwargs: Any) -> DownloadArtifactsResult:
@@ -5606,9 +5606,9 @@ async def test_controller_download_artifacts_session_lost_maps_to_unavailable(
         with pytest.raises(CommandError) as exc_info:
             await offloader.download_artifacts(pin_sha256=pairing.pin_sha256, job_id="j-1")
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.UNAVAILABLE
@@ -5636,7 +5636,7 @@ async def test_controller_download_artifacts_maps_receiver_reasons(
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     client = _seed_open_peer_link_client(offloader, pairing)
 
     async def _stub_download(**_kwargs: Any) -> DownloadArtifactsResult:
@@ -5648,9 +5648,9 @@ async def test_controller_download_artifacts_maps_receiver_reasons(
         with pytest.raises(CommandError) as exc_info:
             await offloader.download_artifacts(pin_sha256=pairing.pin_sha256, job_id="j-1")
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == expected_code
@@ -5664,7 +5664,7 @@ async def test_controller_download_artifacts_malformed_tarball_maps_to_invalid_a
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
     offloader._db.bus = MagicMock()
     pairing = _stub_pairing(receiver_hostname="rcv.local", status=PeerStatus.APPROVED)
-    offloader._pairings[pairing.pin_sha256] = pairing
+    offloader.state.pairings[pairing.pin_sha256] = pairing
     client = _seed_open_peer_link_client(offloader, pairing)
 
     async def _stub_download(**_kwargs: Any) -> DownloadArtifactsResult:
@@ -5676,9 +5676,9 @@ async def test_controller_download_artifacts_malformed_tarball_maps_to_invalid_a
         with pytest.raises(CommandError) as exc_info:
             await offloader.download_artifacts(pin_sha256=pairing.pin_sha256, job_id="j-1")
     finally:
-        offloader._peer_link_clients[pairing.pin_sha256].task.cancel()
+        offloader.state.peer_link_clients[pairing.pin_sha256].task.cancel()
         await asyncio.gather(
-            offloader._peer_link_clients[pairing.pin_sha256].task,
+            offloader.state.peer_link_clients[pairing.pin_sha256].task,
             return_exceptions=True,
         )
     assert exc_info.value.code == ErrorCode.INVALID_ARGS


### PR DESCRIPTION
# What does this implement/fix?

Groups `OffloaderController`'s mutable domain state into a typed `OffloaderState` dataclass in `controllers/remote_build/_state.py`. The 14 cross-module state attrs (`pairings`, `peers`, `peer_link_clients`, `pair_status_listeners`, `open_peer_links`, `offloader_alerts`, `peer_queue_status`, `offloader_remote_jobs`, `rebind_probe_until`, `remote_builds_enabled`, `offloader_peer_link_priv`, `offloader_dashboard_id`, `peer_link_resolver`, `own_instance_name`, `browser`) move from `controller._X` to `controller.state.X`. Sibling modules now reach through `controller.state.X` instead of a long tail of `controller._X` private attrs — addresses the encapsulation concern Copilot flagged on #789.

## What stays on the controller

- `_db`, `_listeners`, `_tasks`, `_shutdown_callbacks` — base infrastructure from `_RemoteBuildBase`.
- `_pairings_store: Store` — constructed in `__init__`, never reassigned.
- All bound-method delegates — the test-instance-patch hooks and cross-concern routing methods.
- All `@api_command`-decorated WS methods.
- All snapshot methods — part of the WS subscribe-events initial_state contract.

## Test impact

~280 mechanical attr renames across `test_remote_build_controller.py`, `test_remote_build_peer_link_client.py`, and three e2e files (`test_install_round_trip.py`, `test_pair_and_session.py`, `test_submit_job.py`). `\boffloader\._<state>\b` → `offloader.state.<state>` across the 15 attrs; `_pairings_store` and the bound-method delegates stay private.

Behaviour-free; all **404 controller + client + e2e tests pass**. Pre-commit clean.

`offloader.py`: **650 → 635 lines** (-15). Combined with the eight prior split PRs: 1709 → 635 (-1074, **-63%**).

**Related issue or feature (if applicable):**

- Phase 1 of `state_dataclass_plan.md` (the post-split abstraction cleanup). Phase 2 applies the same shape to `DevicesController` (which has the same problem from its earlier split arc); phase 3 designs `ReceiverController` with a State dataclass from PR 1 of its eventual split. Phase 4 codifies the convention in CLAUDE.md so future splits bake it in from the start.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
