### PR TITLE
Convert helpers/yaml.py to helpers/yaml/ package

### DIFF
--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -12,7 +12,7 @@ import yaml
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from ..models import ComponentCatalogEntry
+    from ...models import ComponentCatalogEntry
 
 # Prefer the libyaml-backed C loader when PyYAML was built against
 # libyaml. On the M5 MacBook Pro, parsing the full board catalog


### PR DESCRIPTION
# What does this implement/fix?

First PR in the `helpers/yaml.py` split arc (1077 lines). Pure file rename: `helpers/yaml.py` becomes `helpers/yaml/__init__.py` with the same content. Establishes the package shape so subsequent PRs can extract scalar / substitution / top_block / api_encryption / component / inline into named submodules — same cadence as the peer_link arc (#769-#794).

**External imports unchanged.** `from .helpers.yaml import X` still resolves to the same module.

**One mechanical edit:** the `TYPE_CHECKING` import `from ..models import ComponentCatalogEntry` bumps to `from ...models import ComponentCatalogEntry` because `__init__.py` is one directory deeper than `yaml.py` was. That's the only relative import in the file.

Subsequent PRs in the arc (one extraction per PR; full plan in `yaml_split.md`):

1. `substitution.py` — pure regex helpers (~60 lines)
2. `api_encryption.py` — key generator + rewriter (~40 lines)
3. `scalar.py` — read / rewrite / quote / safe-scalar (~210 lines)
4. `top_block.py` — locate + upsert under top block (~125 lines)
5. `component.py` — merge + generate component YAML (~220 lines)
6. `inline.py` — automation inline-handler upsert/remove (~340 lines)

After all six, `__init__.py` shrinks to ~120-150 lines (module docstring + `FastestSafeLoader` + `_PLATFORM_CATEGORIES` + re-exports). 15 external symbols + 4 underscore-prefixed test-imports stay accessible via PEP 484 redundant-alias re-exports.

All 3391 non-e2e tests pass; ruff + mypy clean. No production-side behaviour change.

**Related issue or feature (if applicable):**

- first PR of the helpers/yaml split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
