### PR TITLE
Refactor DevicesController: extract DevicesState dataclass

### DIFF
--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -306,8 +306,8 @@ def create_legacy_routes() -> web.RouteTableDef:
 
         importable = [
             imp.to_dict()
-            for name, imp in devices_ctrl.import_result.items()
-            if name not in devices_ctrl.ignored_devices
+            for name, imp in devices_ctrl.state.import_result.items()
+            if name not in devices_ctrl.state.ignored_devices
         ]
 
         return json_response({"configured": configured, "importable": importable})

--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -1,0 +1,60 @@
+"""
+Mutable domain state for :class:`DevicesController`.
+
+Grouping the controller's mutable state into a typed
+:class:`DevicesState` dataclass keeps the sibling-module
+helpers (``storage_regen``, ``scan_change``, ``validate``,
+``logs``, ``importable``) honest: they reach through
+``controller.state.X`` rather than ``controller._X`` /
+``controller.X`` private attrs.
+
+What lives here vs on the controller:
+
+* **Here**: every attr that mutates after ``__init__``
+  (``esphome_cmd`` is rewritten in ``start()``; the discovery
+  / regen dicts and sets mutate as devices are observed and
+  YAMLs are regenerated; ``import_result`` and
+  ``ignored_devices`` mutate as discovery events arrive).
+* **On the controller**: ``_db``, base infrastructure,
+  service refs constructed in ``__init__`` and never
+  reassigned (``_scanner``, ``_state_monitor``,
+  ``_reachability``, ``_build_size``, ``_mqtt_coordinator``,
+  ``_yaml_search_cache``, ``_yaml_search_lock``,
+  ``_regenerate_lock``), bound-method delegates,
+  ``@api_command`` WS methods. ``_unsub_job_completed`` also
+  stays on the controller — only ``start()`` / ``stop()``
+  touch it and the sibling modules don't reach in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ...models import AdoptableDevice
+
+
+@dataclass
+class DevicesState:
+    """Mutable state for :class:`DevicesController`."""
+
+    # ``esphome`` CLI invocation discovered at ``start()`` —
+    # ``[sys.executable, "-m", "esphome"]`` or the on-PATH
+    # ``esphome`` binary, whichever ``_find_esphome_cmd``
+    # picks first.
+    esphome_cmd: list[str] = field(default_factory=list)
+
+    # Background ``--only-generate`` bookkeeping. Three guards:
+    # ``regenerate_pending`` blocks duplicate schedules while
+    # the subprocess is in flight; ``regenerate_failed`` blocks
+    # retries until the YAML changes (cleared on
+    # ``ScanChange.UPDATED``); the controller's
+    # ``_regenerate_lock`` (kept on the controller) serialises
+    # the actual subprocess.
+    regenerate_pending: set[str] = field(default_factory=set)
+    regenerate_failed: set[str] = field(default_factory=set)
+
+    # Discovery / import state. Keyed by ``device.name`` so the
+    # WebSocket layer and ``devices/ignore`` can address entries
+    # without juggling full mDNS service-instance names.
+    import_result: dict[str, AdoptableDevice] = field(default_factory=dict)
+    ignored_devices: set[str] = field(default_factory=set)

--- a/esphome_device_builder/controllers/devices/api_key.py
+++ b/esphome_device_builder/controllers/devices/api_key.py
@@ -46,9 +46,7 @@ async def resolve_via_esphome_config(controller: DevicesController, configuratio
     and ``yaml.safe_load`` would treat the wrapped string as the
     key. Returns ``""`` on every failure path.
     """
-    # Defensive ``getattr``: bypass-init test controllers skip
-    # ``__init__`` (which is what creates the attribute).
-    esphome_cmd: list[str] | None = getattr(controller, "_esphome_cmd", None)
+    esphome_cmd = controller.state.esphome_cmd
     if not esphome_cmd:
         return ""
     config_path = str(controller._db.settings.rel_path(configuration))

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -26,7 +26,6 @@ from ...helpers.event_bus import Event
 from ...helpers.storage_path import resolve_storage_path
 from ...models import (
     AddComponentResponse,
-    AdoptableDevice,
     Device,
     DeviceEventData,
     DeviceReachabilityData,
@@ -62,6 +61,7 @@ from . import (
     storage_regen,
     validate,
 )
+from ._state import DevicesState
 from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
     _build_address_cache_args,
@@ -71,7 +71,7 @@ from .metadata import DeviceMetadataBase
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
-    from ...models import BoardCatalogEntry
+    from ...models import AdoptableDevice, BoardCatalogEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,32 +95,24 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
         super().__init__(device_builder)
-        self._esphome_cmd: list[str] = []
+        self.state = DevicesState()
         # Unsubscribe handle for the firmware-job-completion listener
         # wired up in start(); held so stop() can detach cleanly.
         self._unsub_job_completed: Any = None
-
-        # Discovery / import state. Keyed by ``device.name`` so the
-        # WebSocket layer and ``devices/ignore`` can address entries
-        # without juggling full mDNS service-instance names. Filled by
-        # ``DeviceStateMonitor`` callbacks.
-        self.import_result: dict[str, AdoptableDevice] = {}
-        self.ignored_devices: set[str] = set()
 
         # Background ``--only-generate`` bookkeeping. ``--only-generate``
         # validates a YAML and writes its ``StorageJSON`` without doing
         # a real build; we trigger it whenever a YAML is saved or
         # first-seen with no compile output. Three guards stop us from
         # spinning:
-        #   * ``_regenerate_pending`` — configurations already in flight
-        #     (scheduled but not yet finished). Skip duplicate schedules.
-        #   * ``_regenerate_failed`` — YAMLs whose last attempt failed.
-        #     Don't retry until the file changes (cleared on
+        #   * ``state.regenerate_pending`` — configurations already in
+        #     flight (scheduled but not yet finished). Skip duplicate
+        #     schedules.
+        #   * ``state.regenerate_failed`` — YAMLs whose last attempt
+        #     failed. Don't retry until the file changes (cleared on
         #     ``ScanChange.UPDATED``).
         #   * ``_regenerate_lock`` — serialises the actual subprocess
         #     so we don't spawn N esphome compiles in parallel.
-        self._regenerate_pending: set[str] = set()
-        self._regenerate_failed: set[str] = set()
         self._regenerate_lock = asyncio.Lock()
 
         # ``yaml/search`` per-file cache. The class owns its own
@@ -173,7 +165,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             on_mac_address_change=self._on_mac_address_change,
             on_importable_added=self._on_importable_added,
             on_importable_removed=self._on_importable_removed,
-            is_ignored=self.ignored_devices.__contains__,
+            is_ignored=self.state.ignored_devices.__contains__,
             presence=self._db.subscriber_presence,
         )
         # Per-signal freshness tracker (mDNS / ping / MQTT last-seen,
@@ -213,7 +205,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     async def start(self) -> None:
         """Initialise — load state, scan files, start mDNS + ping + MQTT discovery."""
-        self._esphome_cmd = _find_esphome_cmd()
+        self.state.esphome_cmd = _find_esphome_cmd()
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._load_ignored_devices)
         await self._scanner.scan()
@@ -305,7 +297,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         # devices when the discovery callback fires; this guard catches
         # the race where a YAML appeared between the callback and this
         # listing.
-        importable = [d for d in self.import_result.values() if d.name not in configured_names]
+        importable = [
+            d for d in self.state.import_result.values() if d.name not in configured_names
+        ]
         return DevicesResponse(configured=configured, importable=importable)
 
     @api_command("devices/get_states")

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -48,10 +48,10 @@ async def import_device(
     # rename-during-adopt case (the ``import_result`` key no
     # longer matches the chosen YAML name); fall through to
     # Wi-Fi when no row matches at all.
-    adoptable = controller.import_result.get(name) or next(
+    adoptable = controller.state.import_result.get(name) or next(
         (
             d
-            for d in controller.import_result.values()
+            for d in controller.state.import_result.values()
             if d.package_import_url == package_import_url
         ),
         None,
@@ -106,7 +106,9 @@ async def import_device(
     # and remember the broadcast name for the zeroconf-cache
     # lookup below.
     cached_names = [
-        n for n, d in controller.import_result.items() if d.package_import_url == package_import_url
+        n
+        for n, d in controller.state.import_result.items()
+        if d.package_import_url == package_import_url
     ]
     for cached_name in cached_names:
         controller._on_importable_removed(cached_name)
@@ -133,18 +135,18 @@ async def import_device(
 async def toggle_ignore(controller: DevicesController, *, name: str, ignore: bool) -> None:
     """Mark a discovered device as ignored / visible in the import list."""
     if ignore:
-        controller.ignored_devices.add(name)
+        controller.state.ignored_devices.add(name)
     else:
-        controller.ignored_devices.discard(name)
+        controller.state.ignored_devices.discard(name)
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, controller._save_ignored_devices)
     # Mirror the new flag onto the cached AdoptableDevice and
     # re-publish ADDED so subscribed frontends update the badge
     # without waiting for a full re-discovery cycle.
-    existing = controller.import_result.get(name)
+    existing = controller.state.import_result.get(name)
     if existing is not None and existing.ignored != ignore:
         updated = replace(existing, ignored=ignore)
-        controller.import_result[name] = updated
+        controller.state.import_result[name] = updated
         controller._db.bus.fire(
             EventType.IMPORTABLE_DEVICE_ADDED, ImportableDeviceAddedData(device=updated)
         )
@@ -152,7 +154,7 @@ async def toggle_ignore(controller: DevicesController, *, name: str, ignore: boo
 
 def on_importable_added(controller: DevicesController, device: AdoptableDevice) -> None:
     """Stash a newly-discovered importable device and notify subscribers."""
-    controller.import_result[device.name] = device
+    controller.state.import_result[device.name] = device
     controller._db.bus.fire(
         EventType.IMPORTABLE_DEVICE_ADDED, ImportableDeviceAddedData(device=device)
     )
@@ -160,7 +162,7 @@ def on_importable_added(controller: DevicesController, device: AdoptableDevice) 
 
 def on_importable_removed(controller: DevicesController, name: str) -> None:
     """Forget an importable device that disappeared from mDNS."""
-    if controller.import_result.pop(name, None) is None:
+    if controller.state.import_result.pop(name, None) is None:
         return
     controller._db.bus.fire(
         EventType.IMPORTABLE_DEVICE_REMOVED, ImportableDeviceRemovedData(name=name)
@@ -170,11 +172,11 @@ def on_importable_removed(controller: DevicesController, name: str) -> None:
 def get_importable_devices(controller: DevicesController) -> list[AdoptableDevice]:
     """Snapshot of importable devices, filtered against the configured-name set."""
     configured_names = {d.name for d in controller._scanner.devices}
-    return [d for d in controller.import_result.values() if d.name not in configured_names]
+    return [d for d in controller.state.import_result.values() if d.name not in configured_names]
 
 
 def load_ignored_devices(controller: DevicesController) -> None:
-    """Populate ``controller.ignored_devices`` from the on-disk JSON file."""
+    """Populate ``controller.state.ignored_devices`` from the on-disk JSON file."""
     storage_path = ignored_devices_storage_path()
     try:
         raw = storage_path.read_bytes()
@@ -204,14 +206,14 @@ def load_ignored_devices(controller: DevicesController) -> None:
             "field; resetting to an empty set",
             storage_path,
         )
-        controller.ignored_devices = set()
+        controller.state.ignored_devices = set()
         return
-    controller.ignored_devices = {name for name in ignored if isinstance(name, str)}
+    controller.state.ignored_devices = {name for name in ignored if isinstance(name, str)}
 
 
 def save_ignored_devices(controller: DevicesController) -> None:
-    """Persist ``controller.ignored_devices`` to the on-disk JSON file."""
+    """Persist ``controller.state.ignored_devices`` to the on-disk JSON file."""
     storage_path = ignored_devices_storage_path()
     storage_path.write_bytes(
-        dumps_indent({"ignored_devices": sorted(controller.ignored_devices)}),
+        dumps_indent({"ignored_devices": sorted(controller.state.ignored_devices)}),
     )

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -199,6 +199,12 @@ def load_ignored_devices(controller: DevicesController) -> None:
             storage_path,
         )
         return
+    # Mutate the set in place rather than replacing it. The
+    # ``DeviceStateMonitor`` captures
+    # ``state.ignored_devices.__contains__`` at controller
+    # ``__init__`` time, before this loader runs in
+    # ``start()``; replacing the set here would leave the
+    # monitor checking a stale empty set forever.
     ignored = data.get("ignored_devices", [])
     if not isinstance(ignored, list):
         _LOGGER.warning(
@@ -206,9 +212,10 @@ def load_ignored_devices(controller: DevicesController) -> None:
             "field; resetting to an empty set",
             storage_path,
         )
-        controller.state.ignored_devices = set()
+        controller.state.ignored_devices.clear()
         return
-    controller.state.ignored_devices = {name for name in ignored if isinstance(name, str)}
+    controller.state.ignored_devices.clear()
+    controller.state.ignored_devices.update(name for name in ignored if isinstance(name, str))
 
 
 def save_ignored_devices(controller: DevicesController) -> None:

--- a/esphome_device_builder/controllers/devices/logs.py
+++ b/esphome_device_builder/controllers/devices/logs.py
@@ -41,7 +41,7 @@ async def stream_logs(
     # --mdns/--dns-address-cache on the top-level parser.
     cache_args = controller.get_ota_address_cache_args(configuration, resolved_port)
     cmd = [
-        *controller._esphome_cmd,
+        *controller.state.esphome_cmd,
         "--dashboard",
         *cache_args,
         "logs",

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -32,7 +32,7 @@ def on_scan_change(controller: DevicesController, kind: ScanChange, device: Devi
         # marker so the next edit gets a fresh chance at
         # ``--only-generate`` (and re-creating a deleted file
         # later doesn't inherit the old failure).
-        controller._regenerate_failed.discard(device.configuration)
+        controller.state.regenerate_failed.discard(device.configuration)
     # First-sight devices with no compile output carry the
     # ``<filename>.local`` address fallback and an empty
     # ``loaded_integrations`` list. Schedule a background

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -34,18 +34,18 @@ def schedule(controller: DevicesController, configuration: str) -> None:
     (cross-restart, TTL-gated), and ``_regenerate_lock``
     serialising the subprocess itself.
     """
-    if not controller._esphome_cmd:
+    if not controller.state.esphome_cmd:
         return  # ``start()`` hasn't run yet.
-    if configuration in controller._regenerate_pending:
+    if configuration in controller.state.regenerate_pending:
         return  # already scheduled.
-    if configuration in controller._regenerate_failed:
+    if configuration in controller.state.regenerate_failed:
         # Same-session retry would replay the same error.
         return
 
     # Mark synchronously so a second same-tick call sees the
     # marker before the coroutine yields. ``_run``'s finally
     # discards on completion.
-    controller._regenerate_pending.add(configuration)
+    controller.state.regenerate_pending.add(configuration)
     controller._db.create_background_task(_run(controller, configuration))
 
 
@@ -55,7 +55,7 @@ async def _run(controller: DevicesController, configuration: str) -> None:
         # tests patching any of the four async helpers on the
         # class still intercept.
         if await controller._regen_already_failed_recently_async(configuration):
-            controller._regenerate_failed.add(configuration)
+            controller.state.regenerate_failed.add(configuration)
             return
         async with controller._regenerate_lock:
             success = await controller._spawn_only_generate(configuration)
@@ -63,10 +63,10 @@ async def _run(controller: DevicesController, configuration: str) -> None:
             await controller._finalize_regen_success(configuration)
             await controller._scanner.reload(configuration)
         else:
-            controller._regenerate_failed.add(configuration)
+            controller.state.regenerate_failed.add(configuration)
             await controller._stamp_regen_failure(configuration)
     finally:
-        controller._regenerate_pending.discard(configuration)
+        controller.state.regenerate_pending.discard(configuration)
 
 
 async def spawn_only_generate(controller: DevicesController, configuration: str) -> bool:
@@ -78,7 +78,7 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
     persist-failure-stamp branch.
     """
     config_path = str(controller._db.settings.rel_path(configuration))
-    cmd = [*controller._esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
+    cmd = [*controller.state.esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
     try:
         proc = await create_subprocess_exec(
             *cmd,

--- a/esphome_device_builder/controllers/devices/validate.py
+++ b/esphome_device_builder/controllers/devices/validate.py
@@ -30,7 +30,7 @@ async def validate_config(
     WS handler.
     """
     config_path = str(controller._db.settings.rel_path(configuration))
-    cmd = [*controller._esphome_cmd, "--dashboard", "config", config_path]
+    cmd = [*controller.state.esphome_cmd, "--dashboard", "config", config_path]
     line_transform: Callable[[str], str] | None = None
     if show_secrets:
         cmd.append("--show-secrets")

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -147,12 +147,13 @@ def _make_devices_mock(
     devices = MagicMock(spec=DevicesController)
     devices.poll = AsyncMock()
     devices.get_devices = MagicMock(return_value=list(configured or []))
-    # See the docstring caveat above: these setattrs succeed
-    # regardless of the spec because ``spec=`` doesn't enforce
-    # instance-attribute existence. They mirror what the real
-    # controller's ``__init__`` puts on the instance.
-    devices.import_result = importable or {}
-    devices.ignored_devices = ignored or set()
+    # ``spec=DevicesController`` doesn't auto-include attributes
+    # set in ``__init__``; ``state`` is one of those, so attach a
+    # bare ``MagicMock`` and populate the dict/set fields the
+    # legacy ``/devices`` route reads off it.
+    devices.state = MagicMock()
+    devices.state.import_result = importable or {}
+    devices.state.ignored_devices = ignored or set()
     return devices
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices._state import DevicesState
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.remote_build import (
     OffloaderController,
@@ -655,6 +656,7 @@ def make_devices_controller_with_bus(
         bus.add_listener(event_type, captured.append)
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
+    controller.state = DevicesState()
     if create_background_task is not None:
         controller._db.create_background_task = MagicMock(side_effect=create_background_task)
     controller._db.bus = bus

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -26,6 +26,7 @@ import pytest
 from esphome_device_builder.controllers._reachability_tracker import ReachabilityTracker
 from esphome_device_builder.controllers.config import set_device_metadata
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices._state import DevicesState
 from esphome_device_builder.controllers.devices._yaml_search_cache import YamlSearchCache
 from esphome_device_builder.helpers.device_yaml import configuration_stem
 from esphome_device_builder.helpers.event_bus import Event, EventBus
@@ -442,6 +443,7 @@ def make_controller() -> MakeControllerFactory:
     ) -> DevicesController:
         controller = DevicesController.__new__(DevicesController)
         controller._db = MagicMock()
+        controller.state = DevicesState()
         controller._db.settings.config_dir = config_dir
         controller._db.settings.rel_path = lambda configuration: config_dir / configuration
         # Default the editor's ``validate_yaml`` to a passing result
@@ -488,11 +490,11 @@ def make_controller() -> MakeControllerFactory:
 
             controller._db.create_background_task = _create_bg
             controller._spawned_tasks = spawned_tasks  # type: ignore[attr-defined]
-            controller._regenerate_pending = set()
-            controller._regenerate_failed = set()
+            controller.state.regenerate_pending = set()
+            controller.state.regenerate_failed = set()
             controller._regenerate_lock = asyncio.Lock()
 
-        controller._esphome_cmd = esphome_cmd if esphome_cmd is not None else []
+        controller.state.esphome_cmd = esphome_cmd if esphome_cmd is not None else []
 
         return controller
 

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -796,12 +796,12 @@ def test_on_scan_change_updated_clears_regenerate_failed_marker(
     storage refresh forever.
     """
     controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
-    controller._regenerate_failed.add("kitchen.yaml")
+    controller.state.regenerate_failed.add("kitchen.yaml")
     device = _device("kitchen")
 
     controller._on_scan_change(ScanChange.UPDATED, device)
 
-    assert "kitchen.yaml" not in controller._regenerate_failed
+    assert "kitchen.yaml" not in controller.state.regenerate_failed
 
 
 def test_on_scan_change_removed_revisits_importables(

--- a/tests/controllers/devices/test_ignored_devices_load.py
+++ b/tests/controllers/devices/test_ignored_devices_load.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices._state import DevicesState
 
 
 @pytest.fixture
@@ -40,7 +41,8 @@ def _stub_controller(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Devices
     )
     ctrl = DevicesController.__new__(DevicesController)
     ctrl._db = MagicMock()  # type: ignore[attr-defined]
-    ctrl.ignored_devices = {"will-be-overwritten"}
+    ctrl.state = DevicesState()
+    ctrl.state.ignored_devices = {"will-be-overwritten"}
     return ctrl
 
 
@@ -57,7 +59,7 @@ async def test_missing_file_starts_empty(
     await _load(_stub_controller)
     # The fixture pre-populated a sentinel value to prove the loader
     # leaves the in-memory set alone when there's nothing on disk.
-    assert _stub_controller.ignored_devices == {"will-be-overwritten"}
+    assert _stub_controller.state.ignored_devices == {"will-be-overwritten"}
     assert caplog.records == []
 
 
@@ -70,7 +72,7 @@ async def test_corrupt_json_resets_with_warning(
     (tmp_path / "ignored-devices.json").write_bytes(b"{not-json")
     caplog.set_level(logging.WARNING, "esphome_device_builder.controllers.devices")
     await _load(_stub_controller)
-    assert _stub_controller.ignored_devices == {"will-be-overwritten"}
+    assert _stub_controller.state.ignored_devices == {"will-be-overwritten"}
     assert any("corrupt" in r.message for r in caplog.records)
 
 
@@ -83,7 +85,7 @@ async def test_top_level_not_object_resets_with_warning(
     (tmp_path / "ignored-devices.json").write_bytes(b'["not", "a", "dict"]')
     caplog.set_level(logging.WARNING, "esphome_device_builder.controllers.devices")
     await _load(_stub_controller)
-    assert _stub_controller.ignored_devices == {"will-be-overwritten"}
+    assert _stub_controller.state.ignored_devices == {"will-be-overwritten"}
     assert any("isn't a JSON object" in r.message for r in caplog.records)
 
 
@@ -98,7 +100,7 @@ async def test_non_list_field_resets_with_warning(
     )
     caplog.set_level(logging.WARNING, "esphome_device_builder.controllers.devices")
     await _load(_stub_controller)
-    assert _stub_controller.ignored_devices == set()
+    assert _stub_controller.state.ignored_devices == set()
     assert any("non-list" in r.message for r in caplog.records)
 
 
@@ -110,7 +112,7 @@ async def test_mixed_entry_types_filtered_to_strings(
         b'{"ignored_devices": ["kitchen", 42, null, "garage"]}',
     )
     await _load(_stub_controller)
-    assert _stub_controller.ignored_devices == {"kitchen", "garage"}
+    assert _stub_controller.state.ignored_devices == {"kitchen", "garage"}
 
 
 async def test_happy_path(_stub_controller: DevicesController, tmp_path: Path) -> None:
@@ -119,4 +121,4 @@ async def test_happy_path(_stub_controller: DevicesController, tmp_path: Path) -
         b'{"ignored_devices": ["one", "two", "three"]}',
     )
     await _load(_stub_controller)
-    assert _stub_controller.ignored_devices == {"one", "two", "three"}
+    assert _stub_controller.state.ignored_devices == {"one", "two", "three"}

--- a/tests/controllers/devices/test_ignored_devices_load.py
+++ b/tests/controllers/devices/test_ignored_devices_load.py
@@ -122,3 +122,27 @@ async def test_happy_path(_stub_controller: DevicesController, tmp_path: Path) -
     )
     await _load(_stub_controller)
     assert _stub_controller.state.ignored_devices == {"one", "two", "three"}
+
+
+async def test_loader_mutates_set_in_place_for_pre_captured_contains(
+    _stub_controller: DevicesController, tmp_path: Path
+) -> None:
+    """The loader mutates the existing set, not replace it.
+
+    ``DeviceStateMonitor`` captures
+    ``state.ignored_devices.__contains__`` at controller
+    ``__init__`` time, before ``_load_ignored_devices`` runs
+    in ``start()``. If the loader replaced the set, the
+    monitor's captured callable would point at the original
+    empty set and never see persisted entries.
+    """
+    captured_contains = _stub_controller.state.ignored_devices.__contains__
+    original_set = _stub_controller.state.ignored_devices
+    (tmp_path / "ignored-devices.json").write_bytes(
+        b'{"ignored_devices": ["one", "two"]}',
+    )
+    await _load(_stub_controller)
+    assert _stub_controller.state.ignored_devices is original_set
+    assert captured_contains("one")
+    assert captured_contains("two")
+    assert not captured_contains("three")

--- a/tests/controllers/devices/test_ignored_devices_load.py
+++ b/tests/controllers/devices/test_ignored_devices_load.py
@@ -127,15 +127,7 @@ async def test_happy_path(_stub_controller: DevicesController, tmp_path: Path) -
 async def test_loader_mutates_set_in_place_for_pre_captured_contains(
     _stub_controller: DevicesController, tmp_path: Path
 ) -> None:
-    """The loader mutates the existing set, not replace it.
-
-    ``DeviceStateMonitor`` captures
-    ``state.ignored_devices.__contains__`` at controller
-    ``__init__`` time, before ``_load_ignored_devices`` runs
-    in ``start()``. If the loader replaced the set, the
-    monitor's captured callable would point at the original
-    empty set and never see persisted entries.
-    """
+    """A pre-load capture of ``__contains__`` sees post-load entries."""
     captured_contains = _stub_controller.state.ignored_devices.__contains__
     original_set = _stub_controller.state.ignored_devices
     (tmp_path / "ignored-devices.json").write_bytes(

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -40,7 +40,7 @@ def _seed_import_state(controller: DevicesController) -> None:
     AdoptableDevice — production wires this up in ``__init__``,
     but the bypass-init factory leaves it unset.
     """
-    controller.import_result = {}
+    controller.state.import_result = {}
 
 
 def _import_config_stub(
@@ -138,7 +138,7 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
-    ctrl.import_result["olimex-poe-aabbcc"] = AdoptableDevice(
+    ctrl.state.import_result["olimex-poe-aabbcc"] = AdoptableDevice(
         name="olimex-poe-aabbcc",
         friendly_name="Olimex PoE",
         package_import_url="github://olimex/esp32-poe.yaml",
@@ -187,7 +187,7 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
     # Two Apollo PLT-1s — same firmware, different network types.
     # The import dict's insertion order would otherwise pick whichever
     # arrived first; the direct-name lookup ignores order.
-    ctrl.import_result["apollo-plt-1-aabbcc"] = AdoptableDevice(
+    ctrl.state.import_result["apollo-plt-1-aabbcc"] = AdoptableDevice(
         name="apollo-plt-1-aabbcc",
         friendly_name="Apollo PLT-1 (Wi-Fi)",
         package_import_url="github://apollo/plt-1.yaml",
@@ -196,7 +196,7 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
         network="wifi",
         ignored=False,
     )
-    ctrl.import_result["apollo-plt-1-ddeeff"] = AdoptableDevice(
+    ctrl.state.import_result["apollo-plt-1-ddeeff"] = AdoptableDevice(
         name="apollo-plt-1-ddeeff",
         friendly_name="Apollo PLT-1 (Ethernet)",
         package_import_url="github://apollo/plt-1.yaml",
@@ -235,7 +235,7 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
-    ctrl.import_result["legacy-bulb-001122"] = AdoptableDevice(
+    ctrl.state.import_result["legacy-bulb-001122"] = AdoptableDevice(
         name="legacy-bulb-001122",
         friendly_name="Legacy Bulb",
         package_import_url="github://vendor/old.yaml",
@@ -590,7 +590,7 @@ async def test_import_device_drops_matching_import_result_entry(
         network="wifi",
         ignored=False,
     )
-    ctrl.import_result["apollo-plt-1-983300"] = discovered
+    ctrl.state.import_result["apollo-plt-1-983300"] = discovered
 
     await ctrl.import_device(
         # User typed a shorter name (without the MAC suffix).
@@ -599,7 +599,7 @@ async def test_import_device_drops_matching_import_result_entry(
         package_import_url="github://apollo/plt-1.yaml",
     )
 
-    assert "apollo-plt-1-983300" not in ctrl.import_result
+    assert "apollo-plt-1-983300" not in ctrl.state.import_result
     # Removal is broadcast so subscribed frontends drop the card.
     # Pin both count and payload so a future double-fire / regression
     # surfaces here — there's exactly one matching import_result entry,

--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -167,8 +167,8 @@ async def test_start_runs_full_initialisation_chain(
     with _capture_inner_lifecycle(controller) as log:
         await controller.start()
 
-    assert controller._esphome_cmd == ["python", "-m", "esphome"]
-    assert controller.ignored_devices == {"already-ignored"}
+    assert controller.state.esphome_cmd == ["python", "-m", "esphome"]
+    assert controller.state.ignored_devices == {"already-ignored"}
     # Fact-of-call AND ordering in one assertion: scan first (the
     # state monitor's first sweep reads ``self._scanner.devices``
     # so a swap would have it iterate over an empty list at

--- a/tests/controllers/devices/test_listing_api.py
+++ b/tests/controllers/devices/test_listing_api.py
@@ -125,7 +125,7 @@ async def test_list_devices_scans_then_returns_configured_and_importable(
     """
     controller = make_controller(tmp_path)
     controller._scanner.devices = [_device("kitchen")]
-    controller.import_result = {"kitchen-1a2b3c": _adoptable()}
+    controller.state.import_result = {"kitchen-1a2b3c": _adoptable()}
 
     response = await controller.list_devices()
 
@@ -150,7 +150,7 @@ async def test_list_devices_filters_importable_already_configured(
     controller = make_controller(tmp_path)
     controller._scanner.devices = [_device("kitchen-1a2b3c")]
     # Same name as the configured device — should be filtered out.
-    controller.import_result = {"kitchen-1a2b3c": _adoptable("kitchen-1a2b3c")}
+    controller.state.import_result = {"kitchen-1a2b3c": _adoptable("kitchen-1a2b3c")}
 
     response = await controller.list_devices()
 
@@ -177,13 +177,13 @@ def test_on_importable_added_stashes_and_fires_event(
     entries by ``name``.
     """
     controller = make_controller(tmp_path)
-    controller.import_result = {}
+    controller.state.import_result = {}
     captured = capture_devices_events(controller, EventType.IMPORTABLE_DEVICE_ADDED)
     adoptable = _adoptable()
 
     controller._on_importable_added(adoptable)
 
-    assert controller.import_result == {"kitchen-1a2b3c": adoptable}
+    assert controller.state.import_result == {"kitchen-1a2b3c": adoptable}
     assert len(captured) == 1
     assert captured[0].event_type is EventType.IMPORTABLE_DEVICE_ADDED
     assert captured[0].data == {"device": adoptable}
@@ -201,12 +201,12 @@ def test_on_importable_removed_drops_entry_and_fires_event(
     that the cache entry actually goes away.
     """
     controller = make_controller(tmp_path)
-    controller.import_result = {"kitchen-1a2b3c": _adoptable()}
+    controller.state.import_result = {"kitchen-1a2b3c": _adoptable()}
     captured = capture_devices_events(controller, EventType.IMPORTABLE_DEVICE_REMOVED)
 
     controller._on_importable_removed("kitchen-1a2b3c")
 
-    assert controller.import_result == {}
+    assert controller.state.import_result == {}
     assert len(captured) == 1
     assert captured[0].event_type is EventType.IMPORTABLE_DEVICE_REMOVED
     assert captured[0].data == {"name": "kitchen-1a2b3c"}
@@ -226,7 +226,7 @@ def test_on_importable_removed_ignores_unknown_name(
     panel for nothing.
     """
     controller = make_controller(tmp_path)
-    controller.import_result = {}
+    controller.state.import_result = {}
     captured = capture_devices_events(controller, EventType.IMPORTABLE_DEVICE_REMOVED)
 
     controller._on_importable_removed("never-seen")
@@ -246,7 +246,7 @@ def test_get_importable_devices_filters_already_configured(
     """
     controller = make_controller(tmp_path)
     controller._scanner.devices = [_device("kitchen-1a2b3c")]
-    controller.import_result = {
+    controller.state.import_result = {
         "kitchen-1a2b3c": _adoptable("kitchen-1a2b3c"),
         "bedroom-d4e5f6": _adoptable("bedroom-d4e5f6"),
     }

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -20,6 +20,7 @@ import pytest
 
 from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices._state import DevicesState
 from esphome_device_builder.models import Device, EventType
 from tests._storage_fixtures import write_synthetic_device
 
@@ -146,7 +147,8 @@ def test_added_device_without_hash_triggers_regenerate(
     """
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
-    controller._regenerate_failed = set()
+    controller.state = DevicesState()
+    controller.state.regenerate_failed = set()
     controller._state_monitor = RecordingStateMonitor()
     regenerated: list[str] = []
     monkeypatch.setattr(
@@ -185,7 +187,8 @@ def test_added_device_fully_populated_does_not_regenerate(
     """
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
-    controller._regenerate_failed = set()
+    controller.state = DevicesState()
+    controller.state.regenerate_failed = set()
     controller._state_monitor = MagicMock()
     regenerated: list[str] = []
     monkeypatch.setattr(

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -126,9 +126,9 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
     reload_calls = [c for c in controller._scanner.calls if c[0] == "reload"]
     assert reload_calls == [("reload", "kitchen.yaml")]
     # Pending guard cleared in the ``finally``.
-    assert controller._regenerate_pending == set()
+    assert controller.state.regenerate_pending == set()
     # Success → not in failed set.
-    assert controller._regenerate_failed == set()
+    assert controller.state.regenerate_failed == set()
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +151,7 @@ def test_regenerate_skips_when_esphome_cmd_unset(
     controller._schedule_storage_regenerate("kitchen.yaml")
 
     assert controller._spawned_tasks == []  # type: ignore[attr-defined]
-    assert controller._regenerate_pending == set()
+    assert controller.state.regenerate_pending == set()
 
 
 def test_regenerate_skips_duplicate_schedule(
@@ -164,7 +164,7 @@ def test_regenerate_skips_duplicate_schedule(
     same YAML.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    controller._regenerate_pending.add("kitchen.yaml")
+    controller.state.regenerate_pending.add("kitchen.yaml")
 
     controller._schedule_storage_regenerate("kitchen.yaml")
 
@@ -182,7 +182,7 @@ def test_regenerate_skips_after_failed_marker(
     bad input.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    controller._regenerate_failed.add("kitchen.yaml")
+    controller.state.regenerate_failed.add("kitchen.yaml")
 
     controller._schedule_storage_regenerate("kitchen.yaml")
 
@@ -228,9 +228,9 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     # Failure → reload skipped, persist skipped, failed marker set.
     assert not any(c[0] == "reload" for c in controller._scanner.calls)
     assert persist_calls == []
-    assert controller._regenerate_failed == {"kitchen.yaml"}
+    assert controller.state.regenerate_failed == {"kitchen.yaml"}
     # Pending cleared via the ``finally``.
-    assert controller._regenerate_pending == set()
+    assert controller.state.regenerate_pending == set()
 
 
 @pytest.mark.asyncio
@@ -268,8 +268,8 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     await _drain(controller)
 
     assert not any(c[0] == "reload" for c in controller._scanner.calls)
-    assert controller._regenerate_failed == {"kitchen.yaml"}
-    assert controller._regenerate_pending == set()
+    assert controller.state.regenerate_failed == {"kitchen.yaml"}
+    assert controller.state.regenerate_pending == set()
 
 
 # ---------------------------------------------------------------------------
@@ -314,10 +314,10 @@ async def test_regenerate_dedupes_same_tick_calls(
     assert len(controller._spawned_tasks) == 1  # type: ignore[attr-defined]
     # Sync ``.add()`` in ``schedule`` is the load-bearing piece —
     # without it the second call wouldn't see the marker yet.
-    assert controller._regenerate_pending == {"kitchen.yaml"}
+    assert controller.state.regenerate_pending == {"kitchen.yaml"}
 
     await _drain(controller)
-    assert controller._regenerate_pending == set()
+    assert controller.state.regenerate_pending == set()
 
 
 @pytest.mark.asyncio
@@ -355,7 +355,7 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
 
     controller._schedule_storage_regenerate("kitchen.yaml")
     await asyncio.wait_for(in_flight.wait(), timeout=2.0)
-    assert controller._regenerate_pending == {"kitchen.yaml"}
+    assert controller.state.regenerate_pending == {"kitchen.yaml"}
 
     # Second schedule while the first is still inside ``communicate``.
     controller._schedule_storage_regenerate("kitchen.yaml")
@@ -364,7 +364,7 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
 
     release.set()
     await _drain(controller)
-    assert controller._regenerate_pending == set()
+    assert controller.state.regenerate_pending == set()
 
 
 # ---------------------------------------------------------------------------
@@ -556,7 +556,7 @@ async def test_regenerate_skips_when_stamp_fresh_and_mtime_matches(
     # The skip path also seeds the in-memory set so subsequent
     # same-session schedules hit the cheaper guard instead of
     # re-reading the sidecar.
-    assert controller._regenerate_failed == {"kitchen.yaml"}
+    assert controller.state.regenerate_failed == {"kitchen.yaml"}
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_subscribe_reachability.py
+++ b/tests/controllers/devices/test_subscribe_reachability.py
@@ -470,7 +470,7 @@ def test_scan_change_removed_clears_tracker(
     # don't have to hand-build an import_discovery. The tracker
     # clear is what we're pinning down.
     controller._state_monitor.revisit_all_importables = MagicMock()
-    controller._regenerate_failed = set()
+    controller.state.regenerate_failed = set()
 
     controller._on_scan_change(ScanChange.REMOVED, device)
 

--- a/tests/controllers/devices/test_toggle_ignore.py
+++ b/tests/controllers/devices/test_toggle_ignore.py
@@ -54,8 +54,8 @@ def _seed_for_toggle(
     is subscribed since that's the toggle path's only broadcast.
     """
     fired = capture_devices_events(controller, EventType.IMPORTABLE_DEVICE_ADDED)
-    controller.import_result = {}
-    controller.ignored_devices = set()
+    controller.state.import_result = {}
+    controller.state.ignored_devices = set()
     return fired, tmp_path / "ignored-devices.json"
 
 
@@ -88,7 +88,7 @@ async def test_toggle_ignore_true_adds_to_set_and_persists(
 
     await controller.toggle_ignore(name="kitchen-1a2b3c")
 
-    assert "kitchen-1a2b3c" in controller.ignored_devices
+    assert "kitchen-1a2b3c" in controller.state.ignored_devices
     # Persist landed on disk via the executor.
     assert ignored_path.exists()
     payload = json.loads(ignored_path.read_text("utf-8"))
@@ -111,11 +111,11 @@ async def test_toggle_ignore_false_removes_and_persists(
     """
     controller = make_controller(tmp_path)
     _fired, ignored_path = _seed_for_toggle(controller, tmp_path, capture_devices_events)
-    controller.ignored_devices.add("kitchen-1a2b3c")
+    controller.state.ignored_devices.add("kitchen-1a2b3c")
 
     await controller.toggle_ignore(name="kitchen-1a2b3c", ignore=False)
 
-    assert "kitchen-1a2b3c" not in controller.ignored_devices
+    assert "kitchen-1a2b3c" not in controller.state.ignored_devices
     payload = json.loads(ignored_path.read_text("utf-8"))
     assert payload == {"ignored_devices": []}
 
@@ -140,7 +140,7 @@ async def test_toggle_ignore_mirrors_flag_onto_cached_adoptable_and_fires(
     """
     controller = make_controller(tmp_path)
     fired, _ignored_path = _seed_for_toggle(controller, tmp_path, capture_devices_events)
-    controller.import_result["kitchen-1a2b3c"] = AdoptableDevice(
+    controller.state.import_result["kitchen-1a2b3c"] = AdoptableDevice(
         name="kitchen-1a2b3c",
         friendly_name="Kitchen",
         package_import_url="github://acme/firmware.yaml",
@@ -152,7 +152,7 @@ async def test_toggle_ignore_mirrors_flag_onto_cached_adoptable_and_fires(
 
     await controller.toggle_ignore(name="kitchen-1a2b3c", ignore=True)
 
-    cached = controller.import_result["kitchen-1a2b3c"]
+    cached = controller.state.import_result["kitchen-1a2b3c"]
     assert cached.ignored is True
     # Other identity fields survive — only ``ignored`` was flipped.
     assert cached.name == "kitchen-1a2b3c"
@@ -180,7 +180,7 @@ async def test_toggle_ignore_does_not_fire_when_state_unchanged(
     """
     controller = make_controller(tmp_path)
     fired, _ignored_path = _seed_for_toggle(controller, tmp_path, capture_devices_events)
-    controller.import_result["kitchen-1a2b3c"] = AdoptableDevice(
+    controller.state.import_result["kitchen-1a2b3c"] = AdoptableDevice(
         name="kitchen-1a2b3c",
         friendly_name="Kitchen",
         package_import_url="github://acme/firmware.yaml",
@@ -189,12 +189,12 @@ async def test_toggle_ignore_does_not_fire_when_state_unchanged(
         network="wifi",
         ignored=True,  # already ignored
     )
-    controller.ignored_devices.add("kitchen-1a2b3c")
+    controller.state.ignored_devices.add("kitchen-1a2b3c")
 
     # Re-asserting the same value.
     await controller.toggle_ignore(name="kitchen-1a2b3c", ignore=True)
 
     # Cache untouched.
-    assert controller.import_result["kitchen-1a2b3c"].ignored is True
+    assert controller.state.import_result["kitchen-1a2b3c"].ignored is True
     # No event fired — the state didn't change.
     assert fired == []

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -24,6 +24,7 @@ import pytest
 
 from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices._state import DevicesState
 from esphome_device_builder.controllers.devices.helpers import (
     _apply_featured_presets,
     _drop_unconfigured_dependent_fields,
@@ -643,11 +644,12 @@ def _make_controller(catalog: ComponentCatalog, tmp_path: Any) -> DevicesControl
     """Build a DevicesController with just enough plumbing for ``add_component``."""
     ctrl = DevicesController.__new__(DevicesController)
     ctrl._db = MagicMock()
+    ctrl.state = DevicesState()
     ctrl._db.settings.rel_path = lambda name: tmp_path / name
     ctrl._db.components = catalog
     ctrl._scanner = MagicMock()
     ctrl._scanner.scan = AsyncMock()
-    ctrl._esphome_cmd = []
+    ctrl.state.esphome_cmd = []
     return ctrl
 
 


### PR DESCRIPTION
# What does this implement/fix?

Phase 2 of `state_dataclass_plan.md` — applies the same `State` dataclass extraction pattern that #795 introduced for the offloader. Groups `DevicesController`'s mutable domain state into a typed `DevicesState` dataclass in `controllers/devices/_state.py`:

- `esphome_cmd` (CLI invocation, populated in `start()`)
- `regenerate_pending` (`--only-generate` in-flight schedules)
- `regenerate_failed` (`--only-generate` failed YAMLs to skip)
- `import_result` (mDNS-discovered importable devices)
- `ignored_devices` (user-ignored device names)

Sibling modules (`storage_regen`, `scan_change`, `validate`, `logs`, `importable`) and the legacy `/devices` REST route reach through `controller.state.X` instead of `controller._X` / `controller.X` private attrs.

## What stays on the controller

- `_db` and base infrastructure.
- Service refs constructed in `__init__` and never reassigned: `_scanner`, `_state_monitor`, `_reachability`, `_build_size`, `_mqtt_coordinator`, `_yaml_search_cache`, `_yaml_search_lock`, `_regenerate_lock`.
- `_unsub_job_completed` (controller-internal, no sibling reaches in).
- All bound-method delegates and `@api_command` WS methods.

## Other touched code

- `api_key.get_api_key` dropped its defensive `getattr(_, "_esphome_cmd", None)` since bypass-init test controllers now go through `DevicesState()` — the attribute is always present.
- Legacy REST `/devices` route in `api/legacy.py` reads `state.import_result` / `state.ignored_devices`.

## Test impact

- ~70 attr renames across 13 test files.
- Tests that construct controllers via `DevicesController.__new__()` (bypassing `__init__`) gained a `ctrl.state = DevicesState()` line.
- The `MagicMock(spec=DevicesController)` case in `test_legacy.py` explicitly attaches `devices.state = MagicMock()` since `spec=` doesn't auto-include attrs set in `__init__`.

`EditorController` and `FirmwareController` have their own `_esphome_cmd` attrs that this refactor doesn't touch; the test sed was reverted in those test files.

Behaviour-free; **all 3391 tests pass** (full suite excluding benchmarks). Pre-commit clean.

**Related issue or feature (if applicable):**

- Phase 2 of `state_dataclass_plan.md`. Phase 3 designs `ReceiverController` with a State dataclass from PR 1 of its eventual split. Phase 4 codifies the convention in CLAUDE.md.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
