### PR TITLE
Extract substitution helpers into yaml/substitution.py

### DIFF
--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -398,78 +398,6 @@ def _strip_yaml_quotes(value: str) -> str:
     return stripped
 
 
-# ESPHome substitutions are referenced as ``$name`` or ``${name}`` —
-# the ``${name}`` form is the canonical one the wizard emits and
-# what users following the upstream docs will write. We only treat
-# a value as a substitution reference when the *entire* value is
-# the reference (``"$devicename"`` / ``"${devicename}"``); a
-# value with extra glue (``"my-${suffix}"``) stays as a literal
-# rewrite target — replacing the substitution there would replace
-# the suffix's expansion across every other consumer.
-_PURE_SUBSTITUTION_REF = re.compile(r"\A(?:\$\{([A-Za-z_]\w*)\}|\$([A-Za-z_]\w*))\Z")
-
-
-def parse_substitution_ref(value: str) -> str | None:
-    """
-    Return the substitution name when *value* is a pure ``$var``.
-
-    Also accepts ``${var}``. Surrounding whitespace and matched
-    quotes are stripped before the test. ``"my-${suffix}"`` returns
-    ``None`` because only part of the value is the substitution.
-    """
-    m = _PURE_SUBSTITUTION_REF.match(_strip_yaml_quotes(value))
-    if not m:
-        return None
-    return m.group(1) or m.group(2)
-
-
-def rewrite_name_or_substitution(
-    yaml_text: str,
-    leaf_path: Sequence[str],
-    new_value: str,
-) -> str:
-    """
-    Land *new_value* at *leaf_path* or at the substitution it references.
-
-    Two real-world ESPHome patterns drive this:
-
-    1. **Direct literal** — ``esphome.name: kitchen``. The leaf
-       line carries the value directly; rewrite it.
-    2. **Substitution reference** — ``esphome.name: ${devicename}``
-       paired with ``substitutions.devicename: kitchen`` (the
-       standard wizard / ``dashboard_import`` shape). The leaf
-       carries the indirection name; the actual value lives in
-       the substitutions block. Rewriting the leaf with a literal
-       would silently orphan the substitution and break any other
-       consumer (sensor named ``${devicename}_temp``, etc.).
-
-    When the leaf's current value is a *pure* substitution
-    reference (``$var`` / ``${var}`` with no surrounding glue) the
-    helper walks to ``substitutions.<var>`` and rewrites that
-    leaf instead. Mixed values (``${prefix}-suffix``) and any
-    other shape fall through to the leaf rewrite — we have no
-    way to split a partial reference without changing what the
-    other half resolves to elsewhere.
-
-    Returns the original text unchanged when neither the leaf
-    nor the substitution leaf exists.
-    """
-    rendered = _safe_yaml_scalar(new_value)
-    raw = read_yaml_scalar(yaml_text, leaf_path)
-    var = parse_substitution_ref(raw) if raw is not None else None
-    if var is not None:
-        sub_path: tuple[str, ...] = ("substitutions", var)
-        # Only redirect when the substitution definition is in
-        # *this* file's top-level ``substitutions:`` block. A
-        # ``!include``d substitutions file or a package-supplied
-        # variable wouldn't be visible here; falling through to the
-        # leaf lands the literal in our YAML and leaves the
-        # remote definition untouched.
-        if read_yaml_scalar(yaml_text, sub_path) is not None:
-            return rewrite_yaml_scalar(yaml_text, sub_path, lambda _raw: rendered)
-    return rewrite_yaml_scalar(yaml_text, leaf_path, lambda _raw: rendered)
-
-
 def _locate_top_block(lines: list[str], block_key: str) -> tuple[int, int, str] | None:
     """
     Find the column-0 ``block_key:`` block; return ``(start, end, child_indent)``.
@@ -1075,3 +1003,13 @@ def _generate_id(component_id: str, name: str | None = None) -> str:
     if slug == component_id or slug.startswith(f"{component_id}_"):
         return slug
     return f"{component_id}_{slug}"
+
+
+# Re-export at the bottom: ``substitution.py`` imports the scalar
+# helpers as package attributes, so the submodule must load after
+# the scalar definitions above. Redundant-alias form marks these
+# as intentional re-exports (PEP 484) so external callers'
+# ``from .helpers.yaml import parse_substitution_ref`` keeps
+# working unchanged.
+from .substitution import parse_substitution_ref as parse_substitution_ref  # noqa: E402
+from .substitution import rewrite_name_or_substitution as rewrite_name_or_substitution  # noqa: E402

--- a/esphome_device_builder/helpers/yaml/substitution.py
+++ b/esphome_device_builder/helpers/yaml/substitution.py
@@ -1,0 +1,83 @@
+"""Substitution-aware YAML rewriters: ``$var`` / ``${var}`` indirection."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from . import _safe_yaml_scalar, _strip_yaml_quotes, read_yaml_scalar, rewrite_yaml_scalar
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+# ESPHome substitutions are referenced as ``$name`` or ``${name}`` —
+# the ``${name}`` form is the canonical one the wizard emits and
+# what users following the upstream docs will write. We only treat
+# a value as a substitution reference when the *entire* value is
+# the reference (``"$devicename"`` / ``"${devicename}"``); a
+# value with extra glue (``"my-${suffix}"``) stays as a literal
+# rewrite target — replacing the substitution there would replace
+# the suffix's expansion across every other consumer.
+_PURE_SUBSTITUTION_REF = re.compile(r"\A(?:\$\{([A-Za-z_]\w*)\}|\$([A-Za-z_]\w*))\Z")
+
+
+def parse_substitution_ref(value: str) -> str | None:
+    """
+    Return the substitution name when *value* is a pure ``$var``.
+
+    Also accepts ``${var}``. Surrounding whitespace and matched
+    quotes are stripped before the test. ``"my-${suffix}"`` returns
+    ``None`` because only part of the value is the substitution.
+    """
+    m = _PURE_SUBSTITUTION_REF.match(_strip_yaml_quotes(value))
+    if not m:
+        return None
+    return m.group(1) or m.group(2)
+
+
+def rewrite_name_or_substitution(
+    yaml_text: str,
+    leaf_path: Sequence[str],
+    new_value: str,
+) -> str:
+    """
+    Land *new_value* at *leaf_path* or at the substitution it references.
+
+    Two real-world ESPHome patterns drive this:
+
+    1. **Direct literal** — ``esphome.name: kitchen``. The leaf
+       line carries the value directly; rewrite it.
+    2. **Substitution reference** — ``esphome.name: ${devicename}``
+       paired with ``substitutions.devicename: kitchen`` (the
+       standard wizard / ``dashboard_import`` shape). The leaf
+       carries the indirection name; the actual value lives in
+       the substitutions block. Rewriting the leaf with a literal
+       would silently orphan the substitution and break any other
+       consumer (sensor named ``${devicename}_temp``, etc.).
+
+    When the leaf's current value is a *pure* substitution
+    reference (``$var`` / ``${var}`` with no surrounding glue) the
+    helper walks to ``substitutions.<var>`` and rewrites that
+    leaf instead. Mixed values (``${prefix}-suffix``) and any
+    other shape fall through to the leaf rewrite — we have no
+    way to split a partial reference without changing what the
+    other half resolves to elsewhere.
+
+    Returns the original text unchanged when neither the leaf
+    nor the substitution leaf exists.
+    """
+    rendered = _safe_yaml_scalar(new_value)
+    raw = read_yaml_scalar(yaml_text, leaf_path)
+    var = parse_substitution_ref(raw) if raw is not None else None
+    if var is not None:
+        sub_path: tuple[str, ...] = ("substitutions", var)
+        # Only redirect when the substitution definition is in
+        # *this* file's top-level ``substitutions:`` block. A
+        # ``!include``d substitutions file or a package-supplied
+        # variable wouldn't be visible here; falling through to the
+        # leaf lands the literal in our YAML and leaves the
+        # remote definition untouched.
+        if read_yaml_scalar(yaml_text, sub_path) is not None:
+            return rewrite_yaml_scalar(yaml_text, sub_path, lambda _raw: rendered)
+    return rewrite_yaml_scalar(yaml_text, leaf_path, lambda _raw: rendered)


### PR DESCRIPTION
# What does this implement/fix?

Second PR in the `helpers/yaml` split arc (follows #796; plan: `yaml_split.md`). Moves `parse_substitution_ref` and `rewrite_name_or_substitution` byte-for-byte from `yaml/__init__.py` into a new `yaml/substitution.py` submodule, plus the `_PURE_SUBSTITUTION_REF` regex they share.

`substitution.py` imports the four scalar helpers it needs (`_safe_yaml_scalar`, `_strip_yaml_quotes`, `read_yaml_scalar`, `rewrite_yaml_scalar`) from the parent package via `from . import ...`. Those will move into `scalar.py` in PR 4; the import path stays valid because `__init__.py` will re-export the same names from `scalar.py` at that point.

**The re-export goes at the bottom of `__init__.py`** (after the scalar definitions) so `substitution.py`'s package-attribute imports resolve correctly when the submodule loads. PEP 484 redundant-alias form so ruff / mypy treat them as intentional re-exports — external callers (`devices/mutations_clone.py`, tests) keep using `from .helpers.yaml import parse_substitution_ref` unchanged.

* **`__init__.py`**: 1077 → 1015 lines (−62).
* **`substitution.py`** (new): 83 lines.

Subsequent PRs in the arc:

* `api_encryption.py` — key generator + rewriter (~40 lines)
* `scalar.py` — read / rewrite / quote / safe-scalar (~210 lines)
* `top_block.py` — locate + upsert under top block (~125 lines)
* `component.py` — merge + generate component YAML (~220 lines)
* `inline.py` — automation inline-handler upsert/remove (~340 lines)

All 3391 non-e2e tests pass; ruff + mypy clean.

**Related issue or feature (if applicable):**

- follow-up to #796; second PR of the helpers/yaml split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
