### PR TITLE
Codify the State dataclass convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,42 @@ the official ESPHome container and Home Assistant add-on.
   See `controllers/devices/`, `controllers/firmware/`, and
   `controllers/remote_build/` for the canonical shape.
 
+  **State dataclass convention.** Sibling submodules take the
+  controller as their first arg; bound-method delegates on the
+  controller route back into them. The catch is *state* — the
+  dicts and sets a controller mutates over its lifetime get
+  reached into from sibling modules (`controller._pairings.pop(...)`,
+  `controller._open_peer_links.add(...)`), and the underscore
+  prefix on the controller's own attrs reads as "private" exactly
+  where the access is most ubiquitous. Group the mutable domain
+  state into a typed `XxxState` dataclass in
+  `controllers/X/_state.py`; the controller owns
+  `self.state: XxxState`; siblings reach through
+  `controller.state.X`. See `controllers/remote_build/_state.py`
+  (`OffloaderState`) and `controllers/devices/_state.py`
+  (`DevicesState`) for canonical examples.
+
+  What goes on `state` vs the controller:
+
+  * **`state`**: every attr that mutates after `__init__` —
+    domain dicts/sets the siblings touch (`pairings`, `peers`,
+    `open_peer_links`, `regenerate_pending`, …), single-value
+    flags (`remote_builds_enabled`), identity / resolver / browser
+    refs that `start()` populates and `stop()` clears.
+  * **The controller**: `_db` (parent reference, not state),
+    `_listeners` / `_tasks` / `_shutdown_callbacks` (base
+    infrastructure), service refs constructed in `__init__` and
+    never reassigned (`_scanner`, `_state_monitor`,
+    `_pairings_store`, `_yaml_search_cache`, the various
+    locks), bound-method delegates the siblings call back into,
+    `@api_command`-decorated WS methods, snapshot methods.
+
+  When splitting a controller into a package, design with
+  `XxxState` from PR 1 of the split; don't ship the bare
+  free-function-with-controller-arg pattern and add the
+  state dataclass later. Doing it upfront avoids the post-split
+  cleanup cycle that PRs #795 and #797 exist to address.
+
   Existing modules over 800 lines (audit `wc -l` periodically;
   the worst offender at the time of writing was 5176 lines) are
   grandfathered. The split rule is scoped to invasive changes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,34 +120,56 @@ the official ESPHome container and Home Assistant add-on.
   reached into from sibling modules (`controller._pairings.pop(...)`,
   `controller._open_peer_links.add(...)`), and the underscore
   prefix on the controller's own attrs reads as "private" exactly
-  where the access is most ubiquitous. Group the mutable domain
-  state into a typed `XxxState` dataclass in
+  where the access is most ubiquitous. Group the mutable
+  *domain* state into a typed `XxxState` dataclass in
   `controllers/X/_state.py`; the controller owns
   `self.state: XxxState`; siblings reach through
-  `controller.state.X`. See `controllers/remote_build/_state.py`
-  (`OffloaderState`) and `controllers/devices/_state.py`
-  (`DevicesState`) for canonical examples.
+  `controller.state.X`. The canonical examples are
+  `controllers/remote_build/_state.py` (`OffloaderState`),
+  `controllers/devices/_state.py` (`DevicesState`), and
+  `controllers/remote_build/_receiver_state.py`
+  (`ReceiverState`); a controller without a sibling-module
+  package can defer the dataclass until the split, but
+  designing for it from PR 1 of any new split avoids the
+  post-split cleanup cycle.
 
-  What goes on `state` vs the controller:
+  Domain state vs controller-internal lifecycle handles:
 
-  * **`state`**: every attr that mutates after `__init__` —
-    domain dicts/sets the siblings touch (`pairings`, `peers`,
-    `open_peer_links`, `regenerate_pending`, …), single-value
-    flags (`remote_builds_enabled`), identity / resolver / browser
-    refs that `start()` populates and `stop()` clears.
-  * **The controller**: `_db` (parent reference, not state),
-    `_listeners` / `_tasks` / `_shutdown_callbacks` (base
-    infrastructure), service refs constructed in `__init__` and
-    never reassigned (`_scanner`, `_state_monitor`,
-    `_pairings_store`, `_yaml_search_cache`, the various
-    locks), bound-method delegates the siblings call back into,
+  * **`state`**: domain data the sibling modules read and
+    mutate — pairing / peer dicts, queue caches, alert
+    registries (`pairings`, `peers`, `open_peer_links`,
+    `regenerate_pending`, …), single-value domain flags
+    (`remote_builds_enabled`), and identity / resolver /
+    browser refs that `start()` populates and `stop()`
+    clears (`offloader_peer_link_priv`, `peer_link_resolver`,
+    `browser`).
+  * **The controller**: `_db` (parent reference), base
+    infrastructure (`_listeners`, `_tasks`,
+    `_shutdown_callbacks`), service refs constructed in
+    `__init__` and never reassigned (`_scanner`,
+    `_state_monitor`, `_pairings_store`,
+    `_yaml_search_cache`, the various locks),
+    controller-internal lifecycle handles that are reassigned
+    by `start()` / `stop()` but no sibling reaches into
+    (`_unsub_job_completed` is the canonical
+    example — only the controller cares about it),
+    bound-method delegates the siblings call back into,
     `@api_command`-decorated WS methods, snapshot methods.
 
-  When splitting a controller into a package, design with
-  `XxxState` from PR 1 of the split; don't ship the bare
-  free-function-with-controller-arg pattern and add the
-  state dataclass later. Doing it upfront avoids the post-split
-  cleanup cycle that PRs #795 and #797 exist to address.
+  The cut is "is this domain state a sibling module reads or
+  writes" — yes → state; no → controller. Reassignment alone
+  doesn't push something onto `state`; it has to also be
+  cross-module data.
+
+  **Watch out for captured bound methods**: if anything (the
+  controller's own `__init__`, an external listener, etc.)
+  captures `state.X.add` / `state.X.__contains__` / etc.
+  before `start()` populates the value, *don't reassign*
+  `state.X` later — `state.X.clear()` + `state.X.update(...)`
+  preserves the captured method's view. The
+  `DevicesController.state.ignored_devices` loader hit this
+  exact bug pre-State-refactor; see #797 for the regression
+  test pattern.
 
   Existing modules over 800 lines (audit `wc -l` periodically;
   the worst offender at the time of writing was 5176 lines) are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,63 +113,29 @@ the official ESPHome container and Home Assistant add-on.
   See `controllers/devices/`, `controllers/firmware/`, and
   `controllers/remote_build/` for the canonical shape.
 
-  **State dataclass convention.** Sibling submodules take the
-  controller as their first arg; bound-method delegates on the
-  controller route back into them. The catch is *state* — the
-  dicts and sets a controller mutates over its lifetime get
-  reached into from sibling modules (`controller._pairings.pop(...)`,
-  `controller._open_peer_links.add(...)`), and the underscore
-  prefix on the controller's own attrs reads as "private" exactly
-  where the access is most ubiquitous. Group the mutable
-  *domain* state into a typed `XxxState` dataclass in
-  `controllers/X/_state.py`; the controller owns
-  `self.state: XxxState`; siblings reach through
-  `controller.state.X`. The canonical examples are
-  `controllers/remote_build/_state.py` (`OffloaderState`),
-  `controllers/devices/_state.py` (`DevicesState`), and
-  `controllers/remote_build/_receiver_state.py`
-  (`ReceiverState`); a controller without a sibling-module
-  package can defer the dataclass until the split, but
-  designing for it from PR 1 of any new split avoids the
-  post-split cleanup cycle.
+  **State dataclass convention.** Group mutable *domain*
+  state — anything a sibling module reads or writes — into
+  a typed `XxxState` dataclass in `controllers/X/_state.py`;
+  the controller owns `self.state: XxxState`; siblings reach
+  through `controller.state.X` instead of `controller._X`.
+  Canonical examples: `OffloaderState`, `DevicesState`,
+  `ReceiverState`. Controller-internal handles that no
+  sibling touches (`_unsub_job_completed`, `_pairings_store`,
+  base infrastructure like `_db` / `_listeners` / `_tasks`)
+  stay on the controller even when reassigned across
+  `start()` / `stop()`. The cut is cross-module data, not
+  reassignment.
 
-  Domain state vs controller-internal lifecycle handles:
-
-  * **`state`**: domain data the sibling modules read and
-    mutate — pairing / peer dicts, queue caches, alert
-    registries (`pairings`, `peers`, `open_peer_links`,
-    `regenerate_pending`, …), single-value domain flags
-    (`remote_builds_enabled`), and identity / resolver /
-    browser refs that `start()` populates and `stop()`
-    clears (`offloader_peer_link_priv`, `peer_link_resolver`,
-    `browser`).
-  * **The controller**: `_db` (parent reference), base
-    infrastructure (`_listeners`, `_tasks`,
-    `_shutdown_callbacks`), service refs constructed in
-    `__init__` and never reassigned (`_scanner`,
-    `_state_monitor`, `_pairings_store`,
-    `_yaml_search_cache`, the various locks),
-    controller-internal lifecycle handles that are reassigned
-    by `start()` / `stop()` but no sibling reaches into
-    (`_unsub_job_completed` is the canonical
-    example — only the controller cares about it),
-    bound-method delegates the siblings call back into,
-    `@api_command`-decorated WS methods, snapshot methods.
-
-  The cut is "is this domain state a sibling module reads or
-  writes" — yes → state; no → controller. Reassignment alone
-  doesn't push something onto `state`; it has to also be
-  cross-module data.
-
-  **Watch out for captured bound methods**: if anything (the
-  controller's own `__init__`, an external listener, etc.)
-  captures `state.X.add` / `state.X.__contains__` / etc.
-  before `start()` populates the value, *don't reassign*
-  `state.X` later — `state.X.clear()` + `state.X.update(...)`
-  preserves the captured method's view. The
+  When splitting a controller into a package, design with
+  `XxxState` from PR 1 — adding it later forces a
+  post-split cleanup arc (#795, #797). When `start()` /
+  `stop()` repopulates a `state.X` dict/set that something
+  captured a bound method of (`state.X.__contains__`,
+  `state.X.add`), use in-place `.clear()` + `.update(...)`
+  rather than reassignment, or the captured method will
+  point at the original empty container forever (the
   `DevicesController.state.ignored_devices` loader hit this
-  exact bug pre-State-refactor; see #797 for the regression
-  test pattern.
+  pre-refactor; #797 added the regression test).
 
   Existing modules over 800 lines (audit `wc -l` periodically;
   the worst offender at the time of writing was 5176 lines) are


### PR DESCRIPTION
# What does this implement/fix?

Phase 4 of `state_dataclass_plan.md` — adds the `XxxState` extraction pattern to CLAUDE.md's file-size-cap section so future controller splits bake it in from PR 1 instead of running the post-split cleanup arc that #795 and #797 had to.

The new convention paragraph documents:

- The motivation: sibling-module state reach-ins (`controller._pairings.pop(...)`) read as private despite being intentional, and the underscore prefix on the controller's own attrs reads as "private" exactly where access is most ubiquitous.
- The cut between what lives on the State dataclass (mutable domain dicts/sets, single-value flags, identity / resolver refs that `start()` populates and `stop()` clears) vs what stays on the controller (`_db`, base infrastructure, service refs constructed in `__init__` and never reassigned, bound-method delegates, `@api_command` WS methods, snapshot methods).
- Pointers to the canonical examples: `controllers/remote_build/_state.py` (`OffloaderState`) and `controllers/devices/_state.py` (`DevicesState`).
- The convention: design with `XxxState` from PR 1 of any new controller split.

## Test impact

None — docs-only.

**Related issue or feature (if applicable):**

- Phase 4 of `state_dataclass_plan.md`. The remaining phase (Phase 3, applying the State pattern to `ReceiverController`) follows.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
