### PR TITLE
Refactor ReceiverController: extract ReceiverState dataclass

### DIFF
--- a/esphome_device_builder/controllers/remote_build/_receiver_state.py
+++ b/esphome_device_builder/controllers/remote_build/_receiver_state.py
@@ -1,25 +1,4 @@
-"""
-Mutable domain state for :class:`ReceiverController`.
-
-Receiver-side counterpart to :class:`OffloaderState` in
-``_state.py``. Single-file controller today; the State
-extraction is upfront so when the eventual sibling-module
-split happens, sibling helpers reach through
-``controller.state.X`` from PR 1 instead of relitigating the
-abstraction post-split.
-
-What lives here vs on the controller:
-
-* **Here**: every attr that mutates after ``__init__``
-  (pairing-window dicts + handle, pending / approved peer
-  registries, peer-link session table, the rotation
-  in-flight flag, the lifecycle service refs that
-  ``start()`` constructs and ``stop()`` clears).
-* **On the controller**: ``_db``, base infrastructure
-  (``_listeners``, ``_tasks``, ``_shutdown_callbacks``),
-  ``_peers_store`` (constructed once in ``__init__``,
-  never reassigned).
-"""
+"""Mutable domain state for :class:`ReceiverController`."""
 
 from __future__ import annotations
 

--- a/esphome_device_builder/controllers/remote_build/_receiver_state.py
+++ b/esphome_device_builder/controllers/remote_build/_receiver_state.py
@@ -1,0 +1,65 @@
+"""
+Mutable domain state for :class:`ReceiverController`.
+
+Receiver-side counterpart to :class:`OffloaderState` in
+``_state.py``. Single-file controller today; the State
+extraction is upfront so when the eventual sibling-module
+split happens, sibling helpers reach through
+``controller.state.X`` from PR 1 instead of relitigating the
+abstraction post-split.
+
+What lives here vs on the controller:
+
+* **Here**: every attr that mutates after ``__init__``
+  (pairing-window dicts + handle, pending / approved peer
+  registries, peer-link session table, the rotation
+  in-flight flag, the lifecycle service refs that
+  ``start()`` constructs and ``stop()`` clears).
+* **On the controller**: ``_db``, base infrastructure
+  (``_listeners``, ``_tasks``, ``_shutdown_callbacks``),
+  ``_peers_store`` (constructed once in ``__init__``,
+  never reassigned).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Hashable
+from dataclasses import dataclass, field
+
+from ...models import StoredPeer
+from .artifacts_download import ArtifactsDownloadSender
+from .job_fanout import JobFanout
+from .peer_link import PeerLinkSession
+from .submit_job import SubmitJobReceiver
+
+
+@dataclass
+class ReceiverState:
+    """Mutable state for :class:`ReceiverController`."""
+
+    # True while ``rotate_identity`` is in flight. Second caller
+    # gets ``ALREADY_EXISTS`` rather than queuing — interleaved
+    # teardowns can leave no listener at all, and back-to-back
+    # rotation is almost always an accidental double-click.
+    rotation_in_flight: bool = False
+
+    # Pairing window: gates ``pair_request``, refcounted by WS
+    # client so multi-tab admins extend together.
+    pairing_window_clients: dict[Hashable, float] = field(default_factory=dict)
+    pairing_window_handle: asyncio.TimerHandle | None = None
+
+    # PENDING StoredPeer rows keyed on ``dashboard_id``; never
+    # persisted, cleared on window auto-close.
+    pending_peers: dict[str, StoredPeer] = field(default_factory=dict)
+    # RAM-canonical APPROVED peers keyed on ``dashboard_id``;
+    # disk is just persistence.
+    approved_peers: dict[str, StoredPeer] = field(default_factory=dict)
+    peer_link_sessions: dict[str, PeerLinkSession] = field(default_factory=dict)
+
+    # Receiver-side handlers; constructed in
+    # :meth:`ReceiverController.start` once the firmware
+    # controller is available.
+    submit_job_receiver: SubmitJobReceiver | None = None
+    artifacts_download_sender: ArtifactsDownloadSender | None = None
+    job_fanout: JobFanout | None = None

--- a/esphome_device_builder/controllers/remote_build/job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build/job_fanout.py
@@ -86,7 +86,7 @@ class JobFanout:
 
     The session lookup keys on ``FirmwareJob.remote_peer`` (the
     offloader's ``dashboard_id``) against
-    ``ReceiverController._peer_link_sessions``. A job whose
+    ``ReceiverController.state.peer_link_sessions``. A job whose
     ``remote_peer`` is empty is local-only and skipped before
     any session lookup.
     """
@@ -250,7 +250,7 @@ class JobFanout:
         log_job_id: str,
     ) -> None:
         """Send a ``job_state_changed`` frame to *remote_peer*'s session, best-effort."""
-        session = self._controller._peer_link_sessions.get(remote_peer)
+        session = self._controller.state.peer_link_sessions.get(remote_peer)
         if session is None:
             _LOGGER.debug(
                 "%s for remote peer %s (job %s): no active session; dropping fan-out",
@@ -286,7 +286,7 @@ class JobFanout:
         if entry is None:
             return
         remote_peer, remote_job_id = entry
-        session = self._controller._peer_link_sessions.get(remote_peer)
+        session = self._controller.state.peer_link_sessions.get(remote_peer)
         if session is None:
             return
         # The firmware controller's ``JOB_OUTPUT`` doesn't

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -60,6 +60,7 @@ from ..config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
 )
+from ._receiver_state import ReceiverState
 from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
     RECEIVER_PEERS_FILE,
@@ -102,28 +103,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
         super().__init__(device_builder)
-        # True while ``rotate_identity`` is in flight. Second
-        # caller gets ``ALREADY_EXISTS`` rather than queuing —
-        # interleaved teardowns can leave no listener at all,
-        # and back-to-back rotation is almost always an
-        # accidental double-click.
-        self._rotation_in_flight = False
-        # Pairing window: gates ``pair_request``, refcounted by
-        # WS client so multi-tab admins extend together.
-        self._pairing_window_clients: dict[Hashable, float] = {}
-        self._pairing_window_handle: asyncio.TimerHandle | None = None
-        # PENDING StoredPeer rows keyed on ``dashboard_id``;
-        # never persisted, cleared on window auto-close.
-        self._pending_peers: dict[str, StoredPeer] = {}
-        # RAM-canonical APPROVED peers keyed on ``dashboard_id``;
-        # disk is just persistence.
-        self._approved_peers: dict[str, StoredPeer] = {}
-        self._peer_link_sessions: dict[str, PeerLinkSession] = {}
-        # Receiver-side handlers; constructed in :meth:`start`
-        # once the firmware controller is available.
-        self._submit_job_receiver: SubmitJobReceiver | None = None
-        self._artifacts_download_sender: ArtifactsDownloadSender | None = None
-        self._job_fanout: JobFanout | None = None
+        self.state = ReceiverState()
         self._peers_store: Store[ReceiverPeers] = Store(
             self._db.settings.config_dir / RECEIVER_PEERS_FILE,
             encoder=encode_peers,
@@ -135,22 +115,22 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
     async def start(self) -> None:
         """Bring up the receiver-side handlers, seed RAM from disk."""
         if self._db.firmware is not None:
-            self._submit_job_receiver = SubmitJobReceiver(
+            self.state.submit_job_receiver = SubmitJobReceiver(
                 config_dir=self._db.settings.config_dir,
                 firmware_controller=self._db.firmware,
             )
-            self._artifacts_download_sender = ArtifactsDownloadSender(
+            self.state.artifacts_download_sender = ArtifactsDownloadSender(
                 firmware_controller=self._db.firmware,
             )
-            self._job_fanout = JobFanout(self)
-            self._job_fanout.start()
+            self.state.job_fanout = JobFanout(self)
+            self.state.job_fanout.start()
             self._track_task(
                 self._run_cleanup_loop(),
                 name=f"{type(self).__name__}._run_cleanup_loop",
             )
         if (peers_state := await self._peers_store.async_load()) is not None:
             for peer in peers_state.peers:
-                self._approved_peers[peer.dashboard_id] = peer
+                self.state.approved_peers[peer.dashboard_id] = peer
         # JOB_OUTPUT / JOB_PROGRESS deliberately omitted: high-rate
         # streaming events that don't change queue_status shape.
         for event_type in (
@@ -165,28 +145,28 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
     async def stop(self) -> None:
         """Close listeners, terminate sessions, drain tasks, flush store."""
         self._listeners.close()
-        if self._job_fanout is not None:
-            self._job_fanout.stop()
-            self._job_fanout = None
+        if self.state.job_fanout is not None:
+            self.state.job_fanout.stop()
+            self.state.job_fanout = None
         await drain_tasks(self._tasks)
         self._tasks.clear()
-        if self._pairing_window_handle is not None:
-            self._pairing_window_handle.cancel()
-            self._pairing_window_handle = None
-        self._pairing_window_clients.clear()
+        if self.state.pairing_window_handle is not None:
+            self.state.pairing_window_handle.cancel()
+            self.state.pairing_window_handle = None
+        self.state.pairing_window_clients.clear()
         # Snapshot to a list before iterating — each terminate
         # unwinds via ``unregister_peer_link_session`` which
         # mutates the dict.
-        for peer_link_session in list(self._peer_link_sessions.values()):
+        for peer_link_session in list(self.state.peer_link_sessions.values()):
             await peer_link_session.terminate(TerminateReason.SERVER_SHUTTING_DOWN)
-        self._peer_link_sessions.clear()
+        self.state.peer_link_sessions.clear()
         # Fire ``status="removed"`` for each PENDING peer so
         # in-flight pair_status long-polls on a still-alive bus
         # see the cancellation (matters for the soft-reload path).
         self._clear_pending_peers_on_window_close()
         for callback in self._shutdown_callbacks:
             await callback()
-        self._approved_peers.clear()
+        self.state.approved_peers.clear()
 
     async def _load_settings_async(self) -> RemoteBuildSettings:
         """Read the receiver-side settings sidecar off the executor.
@@ -216,7 +196,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         if self._db.firmware is None:
             return
         idle, running, queue_depth = self._db.firmware.queue_status_snapshot()
-        if not self._peer_link_sessions:
+        if not self.state.peer_link_sessions:
             return
         self._db.create_background_task(self._broadcast_queue_status(idle, running, queue_depth))
 
@@ -234,7 +214,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         will pick up the next transition's broadcast on its
         next successful frame.
         """
-        sessions = list(self._peer_link_sessions.values())
+        sessions = list(self.state.peer_link_sessions.values())
         payload = QueueStatusFrameData(
             type="queue_status",
             idle=idle,
@@ -263,8 +243,8 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         ``_peer_queue_status`` and ``pick_build_path`` silently
         falls back to LOCAL (#568 regression).
         """
-        existing = self._peer_link_sessions.get(session.dashboard_id)
-        self._peer_link_sessions[session.dashboard_id] = session
+        existing = self.state.peer_link_sessions.get(session.dashboard_id)
+        self.state.peer_link_sessions[session.dashboard_id] = session
         if existing is not None and existing is not session:
             await existing.terminate(TerminateReason.SUPERSEDED)
         if self._db.firmware is not None:
@@ -337,8 +317,8 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         actual WS close + Noise teardown happens in the session
         loop's ``finally`` chain.
         """
-        if self._peer_link_sessions.get(session.dashboard_id) is session:
-            del self._peer_link_sessions[session.dashboard_id]
+        if self.state.peer_link_sessions.get(session.dashboard_id) is session:
+            del self.state.peer_link_sessions[session.dashboard_id]
             # Drop any in-flight ``submit_job`` upload state so a
             # bundle reception that was mid-stream when the
             # session ended doesn't outlive the session that owns
@@ -346,13 +326,13 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
             # this branch only runs for sessions registered after
             # ``start`` (live wire), so the attribute is always
             # populated by the time we get here.
-            if self._submit_job_receiver is not None:
-                self._submit_job_receiver.discard_session(session.dashboard_id)
+            if self.state.submit_job_receiver is not None:
+                self.state.submit_job_receiver.discard_session(session.dashboard_id)
             # Same shape — discard any in-flight artifacts
             # download for this session so the slot doesn't
             # outlive the session it was streaming over.
-            if self._artifacts_download_sender is not None:
-                self._artifacts_download_sender.discard_session(session.dashboard_id)
+            if self.state.artifacts_download_sender is not None:
+                self.state.artifacts_download_sender.discard_session(session.dashboard_id)
             # Fire only when we actually dropped the slot — the
             # no-op path (a SUPERSEDED-evicted session running its
             # finally-block after the new session has taken its
@@ -384,14 +364,14 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
                 frame,
             )
             return
-        if self._job_fanout is None or self._db.firmware is None:
+        if self.state.job_fanout is None or self._db.firmware is None:
             _LOGGER.debug(
                 "peer-link cancel_job from %s before controller fully started; dropping",
                 session.dashboard_id,
             )
             return
         remote_job_id = cast(str, frame["job_id"])
-        firmware_job_id = self._job_fanout.resolve_firmware_job_id(
+        firmware_job_id = self.state.job_fanout.resolve_firmware_job_id(
             session.dashboard_id, remote_job_id
         )
         if firmware_job_id is None:
@@ -419,17 +399,17 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         at startup; a property getter would fire pre-``start``
         and raise.
         """
-        if self._submit_job_receiver is None:
+        if self.state.submit_job_receiver is None:
             msg = "submit_job_receiver accessed before ReceiverController.start()"
             raise RuntimeError(msg)
-        return self._submit_job_receiver
+        return self.state.submit_job_receiver
 
     def get_artifacts_download_sender(self) -> ArtifactsDownloadSender:
         """Return the receiver-side ``download_artifacts`` flow handler, raising if not started."""
-        if self._artifacts_download_sender is None:
+        if self.state.artifacts_download_sender is None:
             msg = "artifacts_download_sender accessed before ReceiverController.start()"
             raise RuntimeError(msg)
-        return self._artifacts_download_sender
+        return self.state.artifacts_download_sender
 
     async def _run_cleanup_loop(self) -> None:
         """Sweep cold remote-build subtrees every ``_CLEANUP_SWEEP_INTERVAL_SECONDS``.
@@ -478,9 +458,9 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         """Project receiver settings to wire view, merging in-memory peers.
 
         The peer list is RAM-canonical: PENDING entries live in
-        ``self._pending_peers`` for the active pairing window's
+        ``self.state.pending_peers`` for the active pairing window's
         lifetime (never hit disk) and APPROVED entries live in
-        ``self._approved_peers`` / its per-file ``Store``.
+        ``self.state.approved_peers`` / its per-file ``Store``.
         ``settings`` is consulted for the master ``enabled``
         toggle.
         """
@@ -498,18 +478,18 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         ``connected=False`` since the peer-link dispatch
         refuses non-APPROVED rows.
         """
-        sessions = self._peer_link_sessions
+        sessions = self.state.peer_link_sessions
         return [
             peer_summary(p, status=PeerStatus.PENDING, connected=False)
-            for p in self._pending_peers.values()
+            for p in self.state.pending_peers.values()
         ] + [
             peer_summary(p, status=PeerStatus.APPROVED, connected=p.dashboard_id in sessions)
-            for p in self._approved_peers.values()
+            for p in self.state.approved_peers.values()
         ]
 
     def approved_peer_label(self, dashboard_id: str) -> str:
         """Return the APPROVED peer's display label, or ``""`` if not found."""
-        peer = self._approved_peers.get(dashboard_id)
+        peer = self.state.approved_peers.get(dashboard_id)
         return peer.label if peer is not None else ""
 
     def peers_snapshot(self) -> list[PeerSummary]:
@@ -638,10 +618,10 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         double-click.
         """
         # Check+set is atomic on the single asyncio loop.
-        if self._rotation_in_flight:
+        if self.state.rotation_in_flight:
             msg = "remote_build: an identity rotation is already in progress"
             raise CommandError(ErrorCode.ALREADY_EXISTS, msg)
-        self._rotation_in_flight = True
+        self.state.rotation_in_flight = True
         try:
             loop = asyncio.get_running_loop()
             identity = await loop.run_in_executor(
@@ -659,7 +639,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
             )
             return identity_view(identity, listener_bound=listener_bound)
         finally:
-            self._rotation_in_flight = False
+            self.state.rotation_in_flight = False
 
     # ------------------------------------------------------------------
     # Peer CRUD — receiver-UI surface for the Pairing requests inbox.
@@ -686,19 +666,19 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         """
         clean_id = validate_dashboard_id(dashboard_id)
 
-        pending = self._pending_peers.pop(clean_id, None)
+        pending = self.state.pending_peers.pop(clean_id, None)
         if pending is None:
             # Differentiate "already approved" from "never existed"
             # so the frontend can decide whether to refresh or
             # surface an error. Both reads short-circuit through
             # RAM — no disk I/O.
-            if clean_id in self._approved_peers:
+            if clean_id in self.state.approved_peers:
                 msg = f"peer is already approved: {clean_id}"
                 raise CommandError(ErrorCode.INVALID_ARGS, msg)
             msg = f"no pending peer with dashboard_id: {clean_id}"
             raise CommandError(ErrorCode.NOT_FOUND, msg)
 
-        self._approved_peers[clean_id] = pending
+        self.state.approved_peers[clean_id] = pending
         self._peers_store.async_delay_save(self._serialize_peers, delay=_PEERS_SAVE_DELAY_SECONDS)
         self._fire_pair_status_changed(clean_id, "approved")
         return await self._current_settings_view()
@@ -729,11 +709,11 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
         # PENDING: in-memory, no disk write needed (PENDING never
         # reaches the peers store).
-        if self._pending_peers.pop(clean_id, None) is not None:
+        if self.state.pending_peers.pop(clean_id, None) is not None:
             self._fire_pair_status_changed(clean_id, "removed")
             return await self._current_settings_view()
 
-        if self._approved_peers.pop(clean_id, None) is None:
+        if self.state.approved_peers.pop(clean_id, None) is None:
             msg = f"no peer with dashboard_id: {clean_id}"
             raise CommandError(ErrorCode.NOT_FOUND, msg)
         self._peers_store.async_delay_save(self._serialize_peers, delay=_PEERS_SAVE_DELAY_SECONDS)
@@ -742,7 +722,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
     def _serialize_peers(self) -> ReceiverPeers:
         """Build the on-disk peers shape from the in-RAM ``_approved_peers`` dict."""
-        return ReceiverPeers(peers=list(self._approved_peers.values()))
+        return ReceiverPeers(peers=list(self.state.approved_peers.values()))
 
     async def _current_settings_view(self) -> RemoteBuildSettingsView:
         """Load settings from disk and project to the wire view (post-mutation response)."""
@@ -787,7 +767,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         # Already-APPROVED row: re-pair against existing trust
         # bypasses the window. Pin mismatch is refused regardless
         # (rotation or impersonation).
-        approved_peer = self._approved_peers.get(dashboard_id)
+        approved_peer = self.state.approved_peers.get(dashboard_id)
         if approved_peer is not None:
             if approved_peer.pin_sha256 != pin_sha256:
                 return IntentResponse.REJECTED
@@ -802,7 +782,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         # check at approve-time is the load-bearing gate, but
         # silent overwrite enables a DoS). Same-pubkey retries
         # refresh label / peer_ip / paired_at via the path below.
-        existing = self._pending_peers.get(dashboard_id)
+        existing = self.state.pending_peers.get(dashboard_id)
         if existing is not None and existing.static_x25519_pub != static_x25519_pub:
             _LOGGER.warning(
                 "pair_request from %s claims dashboard_id=%s but presented "
@@ -815,7 +795,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
             return IntentResponse.REJECTED
 
         paired_at = time.time()
-        self._pending_peers[dashboard_id] = StoredPeer(
+        self.state.pending_peers[dashboard_id] = StoredPeer(
             dashboard_id=dashboard_id,
             pin_sha256=pin_sha256,
             static_x25519_pub=static_x25519_pub,
@@ -928,12 +908,12 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         # peers polling pair_status. Both lookups are RAM reads
         # (the APPROVED list moved off disk into ``_approved_peers``
         # at startup).
-        pending = self._pending_peers.get(dashboard_id)
+        pending = self.state.pending_peers.get(dashboard_id)
         if pending is not None:
             if pending.pin_sha256 != pin_sha256:
                 return IntentResponse.REJECTED
             return IntentResponse.PENDING
-        peer = self._approved_peers.get(dashboard_id)
+        peer = self.state.approved_peers.get(dashboard_id)
         if peer is None or peer.pin_sha256 != pin_sha256:
             return IntentResponse.REJECTED
         return approved_response
@@ -976,11 +956,11 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
         was_open = self.is_pairing_window_open()
         if open:
-            self._pairing_window_clients[client] = time.monotonic()
+            self.state.pairing_window_clients[client] = time.monotonic()
         else:
-            self._pairing_window_clients.pop(client, None)
+            self.state.pairing_window_clients.pop(client, None)
         self._reschedule_pairing_window_close()
-        is_open = bool(self._pairing_window_clients)
+        is_open = bool(self.state.pairing_window_clients)
 
         # Fire on state transitions AND on every extend (so the
         # frontend countdown re-syncs against the bumped deadline).
@@ -993,14 +973,14 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
     def is_pairing_window_open(self) -> bool:
         """Return whether the pairing window is currently open (post-prune)."""
         self._prune_stale_pairing_window_clients()
-        return bool(self._pairing_window_clients)
+        return bool(self.state.pairing_window_clients)
 
     def _pairing_window_remaining(self) -> float | None:
         """Seconds until the latest-extend deadline, or ``None`` if closed."""
         self._prune_stale_pairing_window_clients()
-        if not self._pairing_window_clients:
+        if not self.state.pairing_window_clients:
             return None
-        latest_extend = max(self._pairing_window_clients.values())
+        latest_extend = max(self.state.pairing_window_clients.values())
         return max(0.0, latest_extend + _PAIRING_WINDOW_DURATION_SECONDS - time.monotonic())
 
     def _pairing_window_state(self) -> PairingWindowState:
@@ -1031,12 +1011,12 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
     def _prune_stale_pairing_window_clients(self) -> None:
         """Drop client entries whose last-extend timestamp aged out."""
-        if not self._pairing_window_clients:
+        if not self.state.pairing_window_clients:
             return
         cutoff = time.monotonic() - _PAIRING_WINDOW_DURATION_SECONDS
-        self._pairing_window_clients = {
+        self.state.pairing_window_clients = {
             client: extended_at
-            for client, extended_at in self._pairing_window_clients.items()
+            for client, extended_at in self.state.pairing_window_clients.items()
             if extended_at >= cutoff
         }
 
@@ -1055,14 +1035,16 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         the last client just dropped out), no new handle is
         scheduled and ``_pairing_window_handle`` stays ``None``.
         """
-        if self._pairing_window_handle is not None:
-            self._pairing_window_handle.cancel()
-            self._pairing_window_handle = None
+        if self.state.pairing_window_handle is not None:
+            self.state.pairing_window_handle.cancel()
+            self.state.pairing_window_handle = None
         remaining = self._pairing_window_remaining()
         if remaining is None:
             return
         loop = asyncio.get_running_loop()
-        self._pairing_window_handle = loop.call_later(remaining, self._on_pairing_window_deadline)
+        self.state.pairing_window_handle = loop.call_later(
+            remaining, self._on_pairing_window_deadline
+        )
 
     def _on_pairing_window_deadline(self) -> None:
         """
@@ -1075,8 +1057,8 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         in-memory PENDING peers dict, fire the close event +
         cancellation events, done.
         """
-        self._pairing_window_handle = None
-        self._pairing_window_clients.clear()
+        self.state.pairing_window_handle = None
+        self.state.pairing_window_clients.clear()
         self._fire_pairing_window_changed()
         self._clear_pending_peers_on_window_close()
 
@@ -1086,9 +1068,9 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         Wakes any in-flight ``lookup_peer_for_status`` long-poll
         so its offloader sees REJECTED.
         """
-        if not self._pending_peers:
+        if not self.state.pending_peers:
             return
-        cleared = list(self._pending_peers)
-        self._pending_peers.clear()
+        cleared = list(self.state.pending_peers)
+        self.state.pending_peers.clear()
         for dashboard_id in cleared:
             self._fire_pair_status_changed(dashboard_id, "removed")

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -148,6 +148,12 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         if self.state.job_fanout is not None:
             self.state.job_fanout.stop()
             self.state.job_fanout = None
+        # Drop the receiver-side handler refs so a subsequent
+        # ``get_*`` call after ``stop()`` fails its
+        # ``RuntimeError`` guard cleanly instead of returning a
+        # stale firmware-controller-bound instance.
+        self.state.submit_job_receiver = None
+        self.state.artifacts_download_sender = None
         await drain_tasks(self._tasks)
         self._tasks.clear()
         if self.state.pairing_window_handle is not None:
@@ -173,8 +179,9 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
         Carries the ``enabled`` master toggle +
         ``cleanup_ttl_seconds`` knobs, which aren't mirrored in
-        RAM (the RAM-canonical state is :attr:`_approved_peers`
-        / :attr:`_pairings`).
+        RAM (the RAM-canonical state is
+        :attr:`ReceiverState.approved_peers` /
+        :attr:`ReceiverState.pending_peers`).
         """
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(
@@ -474,7 +481,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         """Merge PENDING + APPROVED into a single ``PeerSummary`` list.
 
         APPROVED rows read ``connected`` off
-        ``_peer_link_sessions``; PENDING always
+        ``state.peer_link_sessions``; PENDING always
         ``connected=False`` since the peer-link dispatch
         refuses non-APPROVED rows.
         """
@@ -653,7 +660,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         Promote a PENDING peer to APPROVED.
 
         Pops the in-memory PENDING entry, inserts it into the
-        RAM-canonical ``_approved_peers`` dict, schedules a
+        RAM-canonical ``state.approved_peers`` dict, schedules a
         debounced write to the receiver-peers store, and fires
         :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED` with
         ``{dashboard_id, status: "approved"}``. The offloader's
@@ -696,7 +703,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
           ``status="removed"`` event so any offloader currently
           long-polling pair_status sees the cancellation and
           drops its local state.
-        * Removing an APPROVED row from ``_approved_peers``
+        * Removing an APPROVED row from ``state.approved_peers``
           (RAM-canonical, debounced to disk) is *revocation* —
           fires the same
           :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED`
@@ -721,7 +728,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         return await self._current_settings_view()
 
     def _serialize_peers(self) -> ReceiverPeers:
-        """Build the on-disk peers shape from the in-RAM ``_approved_peers`` dict."""
+        """Build the on-disk peers shape from the in-RAM ``state.approved_peers`` dict."""
         return ReceiverPeers(peers=list(self.state.approved_peers.values()))
 
     async def _current_settings_view(self) -> RemoteBuildSettingsView:
@@ -906,8 +913,8 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         """
         # PENDING dict first — most pair-flow traffic is pending
         # peers polling pair_status. Both lookups are RAM reads
-        # (the APPROVED list moved off disk into ``_approved_peers``
-        # at startup).
+        # (the APPROVED list moved off disk into
+        # ``state.approved_peers`` at startup).
         pending = self.state.pending_peers.get(dashboard_id)
         if pending is not None:
             if pending.pin_sha256 != pin_sha256:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -273,7 +273,7 @@ async def _paired_instances_ctx(
     #    fires so the receiver's APPROVED → offloader's
     #    pair-status listener → status-flip-event chain can be
     #    awaited deterministically rather than spun on.
-    [pending_dashboard_id] = list(receiver.receiver._pending_peers.keys())
+    [pending_dashboard_id] = list(receiver.receiver.state.pending_peers.keys())
     pair_status_changed = capture_events(offloader_bus, EventType.OFFLOADER_PAIR_STATUS_CHANGED)
     await receiver.receiver.approve_peer(dashboard_id=pending_dashboard_id)
 

--- a/tests/e2e/test_pair_and_session.py
+++ b/tests/e2e/test_pair_and_session.py
@@ -49,7 +49,7 @@ async def test_paired_instances_open_peer_link_session(
         paired_instances.receiver_opened[0]["dashboard_id"]
         == paired_instances.offloader_dashboard_id
     )
-    sessions = paired_instances.receiver._peer_link_sessions
+    sessions = paired_instances.receiver.state.peer_link_sessions
     assert paired_instances.offloader_dashboard_id in sessions
 
 
@@ -77,7 +77,7 @@ async def test_paired_instances_teardown_closes_session_cleanly(
     """
     await paired_instances.wait_until_session_opened()
     receiver_key = paired_instances.offloader_dashboard_id
-    assert receiver_key in paired_instances.receiver._peer_link_sessions
+    assert receiver_key in paired_instances.receiver.state.peer_link_sessions
 
     await paired_instances.offloader.stop()
     await paired_instances.wait_until_session_closed()
@@ -96,7 +96,7 @@ async def test_paired_instances_teardown_closes_session_cleanly(
     # (c) Receiver's CLOSED carries the offloader's dashboard_id
     # and the registry has dropped the row.
     assert paired_instances.receiver_closed[0]["dashboard_id"] == receiver_key
-    assert receiver_key not in paired_instances.receiver._peer_link_sessions
+    assert receiver_key not in paired_instances.receiver.state.peer_link_sessions
 
     # (d) Clean-stop close path doesn't populate ``error_detail``;
     # the category-level ``client_stopped`` reason already

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -338,7 +338,7 @@ async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
     # the cache update via a background task) trips this
     # assertion instead of producing flaky CI behaviour at the
     # JOB_STARTED fan-out check below.
-    assert job.job_id in paired_instances.receiver._job_fanout._remote_jobs
+    assert job.job_id in paired_instances.receiver.state.job_fanout._remote_jobs
     paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
 
     # JOB_QUEUED now fans out as ``queued`` ahead of ``running``;

--- a/tests/e2e/test_submit_job_fanout.py
+++ b/tests/e2e/test_submit_job_fanout.py
@@ -66,7 +66,7 @@ async def test_remote_peer_job_lifecycle_fans_out_to_offloader_bus(
        ``(remote_peer, remote_job_id)`` correlation.
     2. Receiver fires :attr:`EventType.JOB_STARTED`; the
        fan-out looks up the session for ``remote_peer`` in
-       :attr:`ReceiverController._peer_link_sessions`,
+       :attr:`ReceiverController.state.peer_link_sessions`,
        sends a typed :class:`JobStateChangedFrameData` over the
        live peer-link channel.
     3. Offloader's receive loop deserialises the frame, validates

--- a/tests/manual/_mock_remote_e2e.py
+++ b/tests/manual/_mock_remote_e2e.py
@@ -184,7 +184,7 @@ async def _run_pair_flow(
         receiver_label="receiver",
         offloader_label="offloader",
     )
-    [pending_dashboard_id] = list(receiver.remote_build_receiver._pending_peers.keys())
+    [pending_dashboard_id] = list(receiver.remote_build_receiver.state.pending_peers.keys())
 
     pair_event = asyncio.Event()
     queue_status_event = asyncio.Event()

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2011,7 +2011,7 @@ async def test_rotate_identity_clears_in_flight_flag_on_failure(tmp_path: Path) 
 
     # Flag must be back to False; otherwise every subsequent
     # rotate attempt would 409 forever.
-    assert controller.receiver._rotation_in_flight is False
+    assert controller.receiver.state.rotation_in_flight is False
 
 
 # ---------------------------------------------------------------------------
@@ -2061,7 +2061,7 @@ def _seed_peer(controller: RemoteBuildController, peer: StoredPeer) -> None:
     :meth:`start` would do after an :meth:`approve_peer` flow,
     and lets the test stay sync.
     """
-    controller.receiver._approved_peers[peer.dashboard_id] = peer
+    controller.receiver.state.approved_peers[peer.dashboard_id] = peer
 
 
 def _seed_pending_peer(controller: RemoteBuildController, peer: StoredPeer) -> None:
@@ -2073,7 +2073,7 @@ def _seed_pending_peer(controller: RemoteBuildController, peer: StoredPeer) -> N
     in place of :func:`_seed_peer` for tests that exercise the
     PENDING path; the persistent list stays APPROVED-only.
     """
-    controller.receiver._pending_peers[peer.dashboard_id] = peer
+    controller.receiver.state.pending_peers[peer.dashboard_id] = peer
 
 
 def test_peers_snapshot_returns_empty_when_none_stored(tmp_path: Path) -> None:
@@ -2162,7 +2162,7 @@ def test_peers_snapshot_marks_approved_with_active_session_connected(
     # but offline.
     session = MagicMock()
     session.dashboard_id = "alpha"
-    controller.receiver._peer_link_sessions["alpha"] = session
+    controller.receiver.state.peer_link_sessions["alpha"] = session
 
     rows = {row.dashboard_id: row for row in controller.receiver.peers_snapshot()}
 
@@ -2187,7 +2187,7 @@ def test_peers_snapshot_pending_row_is_never_connected(tmp_path: Path) -> None:
     _seed_pending_peer(controller, _stored_peer(dashboard_id="pending"))
     session = MagicMock()
     session.dashboard_id = "pending"
-    controller.receiver._peer_link_sessions["pending"] = session
+    controller.receiver.state.peer_link_sessions["pending"] = session
 
     [row] = controller.receiver.peers_snapshot()
 
@@ -2283,7 +2283,7 @@ async def test_start_seeds_approved_peers_dict_from_disk(tmp_path: Path) -> None
     seeder.offloader._db.devices = None  # short-circuit the post-load branches.
     pubkey = b"\xee" * 32
     pin = hashlib.sha256(pubkey).hexdigest()
-    seeder.receiver._approved_peers["alpha"] = _stored_peer(
+    seeder.receiver.state.approved_peers["alpha"] = _stored_peer(
         dashboard_id="alpha",
         pin_sha256=pin,
         static_x25519_pub=pubkey,
@@ -2305,8 +2305,8 @@ async def test_start_seeds_approved_peers_dict_from_disk(tmp_path: Path) -> None
     fresh.offloader._db.devices = None
     await fresh.start()
 
-    assert "alpha" in fresh.receiver._approved_peers
-    loaded = fresh.receiver._approved_peers["alpha"]
+    assert "alpha" in fresh.receiver.state.approved_peers
+    loaded = fresh.receiver.state.approved_peers["alpha"]
     assert loaded.pin_sha256 == pin
     assert loaded.static_x25519_pub == pubkey
     # ``peer_ip`` survives the on-disk round-trip — the IP an
@@ -2335,7 +2335,7 @@ async def test_start_recovers_to_empty_on_corrupt_peers_file(tmp_path: Path) -> 
     controller.offloader._db.devices = None
     await controller.start()
 
-    assert controller.receiver._approved_peers == {}
+    assert controller.receiver.state.approved_peers == {}
 
 
 @pytest.mark.asyncio
@@ -2364,8 +2364,8 @@ async def test_start_loads_legacy_peers_file_without_peer_ip(tmp_path: Path) -> 
     controller.offloader._db.devices = None
     await controller.start()
 
-    assert "alpha" in controller.receiver._approved_peers
-    assert controller.receiver._approved_peers["alpha"].peer_ip == ""
+    assert "alpha" in controller.receiver.state.approved_peers
+    assert controller.receiver.state.approved_peers["alpha"].peer_ip == ""
 
 
 @pytest.mark.asyncio
@@ -2377,11 +2377,11 @@ async def test_approve_peer_promotes_pending_to_approved(tmp_path: Path) -> None
     view = await controller.receiver.approve_peer(dashboard_id="alpha")
 
     assert view.peers[0].status == PeerStatus.APPROVED
-    assert "alpha" not in controller.receiver._pending_peers
+    assert "alpha" not in controller.receiver.state.pending_peers
     # APPROVED is RAM-canonical now; the disk write happens
     # through the debounced peers Store.
-    assert "alpha" in controller.receiver._approved_peers
-    assert controller.receiver._approved_peers["alpha"].dashboard_id == "alpha"
+    assert "alpha" in controller.receiver.state.approved_peers
+    assert controller.receiver.state.approved_peers["alpha"].dashboard_id == "alpha"
 
 
 @pytest.mark.asyncio
@@ -2467,7 +2467,7 @@ async def test_remove_peer_drops_pending_and_fires_removed(tmp_path: Path) -> No
     view = await controller.receiver.remove_peer(dashboard_id="alpha")
 
     assert view.peers == []
-    assert "alpha" not in controller.receiver._pending_peers
+    assert "alpha" not in controller.receiver.state.pending_peers
     fire = controller.offloader._db.bus.fire
     fire.assert_called_once()
     event_type, payload = fire.call_args.args
@@ -2602,13 +2602,13 @@ async def test_set_pairing_window_extend_refreshes_deadline_and_fires(tmp_path: 
     controller.offloader._db.bus = MagicMock()
 
     first = await controller.receiver.set_pairing_window(open=True, client="tab-1")
-    first_extend_ts = controller.receiver._pairing_window_clients["tab-1"]
+    first_extend_ts = controller.receiver.state.pairing_window_clients["tab-1"]
     # tiny sleep so the second extend's monotonic timestamp is
     # strictly later than the first's (microsecond resolution
     # makes 10ms reliably non-flaky)
     await asyncio.sleep(0.01)
     second = await controller.receiver.set_pairing_window(open=True, client="tab-1")
-    second_extend_ts = controller.receiver._pairing_window_clients["tab-1"]
+    second_extend_ts = controller.receiver.state.pairing_window_clients["tab-1"]
 
     assert first.expires_in_seconds is not None
     assert second.expires_in_seconds is not None
@@ -2740,11 +2740,11 @@ async def test_stop_cancels_pairing_window_handle(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
     await controller.receiver.set_pairing_window(open=True, client="tab-1")
-    assert controller.receiver._pairing_window_handle is not None
+    assert controller.receiver.state.pairing_window_handle is not None
 
     await controller.stop()
 
-    assert controller.receiver._pairing_window_handle is None
+    assert controller.receiver.state.pairing_window_handle is None
     assert controller.receiver.is_pairing_window_open() is False
 
 
@@ -2787,7 +2787,7 @@ async def test_explicit_close_cancels_handle_no_duplicate_event(
     # Two events: open + close. After this point, the handle should
     # be None (explicit close cancelled it; no replacement scheduled
     # because the client map is empty).
-    assert controller.receiver._pairing_window_handle is None
+    assert controller.receiver.state.pairing_window_handle is None
     initial_fire_count = controller.offloader._db.bus.fire.call_count
     assert initial_fire_count == 2  # open + explicit close
 
@@ -2803,7 +2803,7 @@ async def test_explicit_close_cancels_handle_no_duplicate_event(
     await asyncio.sleep(0)
 
     assert controller.offloader._db.bus.fire.call_count == initial_fire_count
-    assert controller.receiver._pairing_window_handle is None
+    assert controller.receiver.state.pairing_window_handle is None
 
 
 # ---------------------------------------------------------------------------
@@ -2831,8 +2831,8 @@ async def test_record_pair_request_creates_pending_row(tmp_path: Path) -> None:
 
     assert response == "pending"
     # PENDING entries live in-memory; APPROVED dict is empty.
-    assert controller.receiver._approved_peers == {}
-    pending = controller.receiver._pending_peers["alpha"]
+    assert controller.receiver.state.approved_peers == {}
+    pending = controller.receiver.state.pending_peers["alpha"]
     assert pending.pin_sha256 == pin
     assert pending.static_x25519_pub == pubkey
     assert pending.label == "alpha"
@@ -2864,7 +2864,7 @@ async def test_record_pair_request_fires_event(tmp_path: Path) -> None:
     # got — the controller emits a single timestamp into both so
     # a frontend rebuilding the inbox row from the event matches
     # the snapshot. Verify by reading the stored value back.
-    stored = controller.receiver._pending_peers["alpha"]
+    stored = controller.receiver.state.pending_peers["alpha"]
     assert payload == {
         "dashboard_id": "alpha",
         "pin_sha256": pin,
@@ -2917,7 +2917,7 @@ async def test_record_pair_request_refreshes_existing_pending_row(tmp_path: Path
 
     assert response == "pending"
     # PENDING refresh updates the in-memory dict, not disk.
-    refreshed = controller.receiver._pending_peers["alpha"]
+    refreshed = controller.receiver.state.pending_peers["alpha"]
     assert refreshed.pin_sha256 == pin
     assert refreshed.static_x25519_pub == pubkey
     assert refreshed.label == "renamed"
@@ -2928,7 +2928,7 @@ async def test_record_pair_request_refreshes_existing_pending_row(tmp_path: Path
     # current handshake came from.
     assert refreshed.peer_ip == "10.0.0.1"
     # APPROVED dict stays empty — refresh is PENDING-only.
-    assert controller.receiver._approved_peers == {}
+    assert controller.receiver.state.approved_peers == {}
 
 
 @pytest.mark.asyncio
@@ -2992,7 +2992,7 @@ async def test_record_pair_request_pending_pubkey_mismatch_returns_rejected(
     # security-critical invariant: the operator's view of the
     # legitimate pair_request can't be silently mutated by an
     # adversary.
-    untouched = controller.receiver._pending_peers["alpha"]
+    untouched = controller.receiver.state.pending_peers["alpha"]
     assert untouched.static_x25519_pub == legit_pubkey
     assert untouched.pin_sha256 == legit_pin
     assert untouched.label == "legit"
@@ -3048,7 +3048,7 @@ async def test_record_pair_request_already_approved_same_pin_returns_approved(
     )
 
     assert response == "approved"
-    [peer] = controller.receiver._approved_peers.values()
+    [peer] = controller.receiver.state.approved_peers.values()
     assert peer.pin_sha256 == pin
     assert peer.label == "alpha"
     assert peer.paired_at == 1.0
@@ -3082,8 +3082,8 @@ async def test_record_pair_request_unknown_dashboard_id_closed_window_returns_no
 
     assert response is IntentResponse.NO_PAIRING_WINDOW
     # No row was created — the gate fired before the insert.
-    assert controller.receiver._approved_peers == {}
-    assert controller.receiver._pending_peers == {}
+    assert controller.receiver.state.approved_peers == {}
+    assert controller.receiver.state.pending_peers == {}
     # No event fired either — the pair_request_received event is
     # for surfacing rows in the inbox, and no row was created.
     controller.offloader._db.bus.fire.assert_not_called()
@@ -3169,7 +3169,7 @@ async def test_record_pair_request_already_approved_different_pin_returns_reject
     )
 
     assert response == "rejected"
-    [peer] = controller.receiver._approved_peers.values()
+    [peer] = controller.receiver.state.approved_peers.values()
     # Original row untouched.
     assert peer.pin_sha256 == original_pin
     assert peer.static_x25519_pub == original_pubkey
@@ -3714,8 +3714,8 @@ async def test_on_firmware_queue_transition_broadcasts_to_every_session(
 
     alpha = _make_session_stub("alpha")
     beta = _make_session_stub("beta")
-    controller.receiver._peer_link_sessions["alpha"] = alpha
-    controller.receiver._peer_link_sessions["beta"] = beta
+    controller.receiver.state.peer_link_sessions["alpha"] = alpha
+    controller.receiver.state.peer_link_sessions["beta"] = beta
 
     controller.receiver._on_firmware_queue_transition(
         MagicMock(event_type=EventType.JOB_STARTED, data={"job_id": "j1"})
@@ -3794,8 +3794,8 @@ async def test_broadcast_queue_status_continues_past_failed_session(
     alpha = _make_session_stub("alpha")
     alpha.send_app_frame = AsyncMock(side_effect=RuntimeError("boom"))
     beta = _make_session_stub("beta")
-    controller.receiver._peer_link_sessions["alpha"] = alpha
-    controller.receiver._peer_link_sessions["beta"] = beta
+    controller.receiver.state.peer_link_sessions["alpha"] = alpha
+    controller.receiver.state.peer_link_sessions["beta"] = beta
 
     with caplog.at_level("ERROR"):
         await controller.receiver._broadcast_queue_status(idle=False, running=True, queue_depth=1)
@@ -3952,7 +3952,7 @@ def test_get_artifacts_download_sender_returns_installed_sender(tmp_path: Path) 
     """After installation, ``get_artifacts_download_sender`` returns the live sender."""
     controller = _make_controller(config_dir=tmp_path)
     installed = ArtifactsDownloadSender(firmware_controller=MagicMock())
-    controller.receiver._artifacts_download_sender = installed
+    controller.receiver.state.artifacts_download_sender = installed
 
     assert controller.receiver.get_artifacts_download_sender() is installed
 

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -85,7 +85,7 @@ def _make_controller(*, bus: EventBus, sessions: dict[str, Any] | None = None) -
 
     controller = MagicMock()
     controller._db = db
-    controller._peer_link_sessions = sessions or {}
+    controller.state.peer_link_sessions = sessions or {}
     controller.background_tasks = background_tasks
     return controller
 

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -104,7 +104,7 @@ def _make_controller(*, config_dir: Any = None) -> RemoteBuildController:
 
 def _seed_peer(controller: RemoteBuildController, peer: StoredPeer) -> None:
     """Insert *peer* into the controller's RAM-canonical APPROVED dict."""
-    controller.receiver._approved_peers[peer.dashboard_id] = peer
+    controller.receiver.state.approved_peers[peer.dashboard_id] = peer
 
 
 async def _wait_until(condition: Callable[[], bool], *, timeout: float = 2.0) -> None:
@@ -210,8 +210,8 @@ async def test_dispatch_pair_request_closed_window_returns_no_pairing_window(
     controller.offloader._db.bus.fire.assert_not_called()
     # No row was created since the window gate fired first.
 
-    assert controller.receiver._approved_peers == {}
-    assert controller.receiver._pending_peers == {}
+    assert controller.receiver.state.approved_peers == {}
+    assert controller.receiver.state.pending_peers == {}
 
 
 @pytest.mark.asyncio
@@ -275,8 +275,8 @@ async def test_dispatch_pair_request_empty_dashboard_id_returns_rejected(tmp_pat
 
     assert response is IntentResponse.REJECTED
     controller.offloader._db.bus.fire.assert_not_called()
-    assert controller.receiver._approved_peers == {}
-    assert controller.receiver._pending_peers == {}
+    assert controller.receiver.state.approved_peers == {}
+    assert controller.receiver.state.pending_peers == {}
     await controller.stop()
 
 
@@ -313,8 +313,8 @@ async def test_dispatch_pair_request_malformed_dashboard_id_returns_rejected(
 
     assert response is IntentResponse.REJECTED
     controller.offloader._db.bus.fire.assert_not_called()
-    assert controller.receiver._approved_peers == {}
-    assert controller.receiver._pending_peers == {}
+    assert controller.receiver.state.approved_peers == {}
+    assert controller.receiver.state.pending_peers == {}
     await controller.stop()
 
 
@@ -903,8 +903,8 @@ async def test_e2e_pair_request_open_window_creates_row(
 
     # PENDING entries land in the in-memory dict; APPROVED dict
     # stays empty until admin clicks Accept.
-    assert controller.receiver._approved_peers == {}
-    pending = controller.receiver._pending_peers["alpha"]
+    assert controller.receiver.state.approved_peers == {}
+    pending = controller.receiver.state.pending_peers["alpha"]
     assert pending.label == "alpha"
     # The receiver's controller derived the pin from the
     # handshake transcript's authenticated initiator static
@@ -932,8 +932,8 @@ async def test_e2e_pair_request_closed_window_returns_no_pairing_window(
     )
 
     # Closed window short-circuits before any RAM mutation.
-    assert controller.receiver._approved_peers == {}
-    assert controller.receiver._pending_peers == {}
+    assert controller.receiver.state.approved_peers == {}
+    assert controller.receiver.state.pending_peers == {}
 
 
 @pytest.mark.asyncio
@@ -1147,7 +1147,7 @@ async def test_e2e_peer_link_session_stays_open_after_intent_response(
         # registration happens just before. If the WS closed
         # instead, ``"alpha"`` would never land in the dict and
         # the wait would time out (deterministic failure).
-        await _wait_until(lambda: "alpha" in controller.receiver._peer_link_sessions)
+        await _wait_until(lambda: "alpha" in controller.receiver.state.peer_link_sessions)
         assert not ws.closed
     finally:
         await ws.close()
@@ -1229,7 +1229,7 @@ async def test_e2e_peer_link_session_kicks_old_on_duplicate_connect(
         close_msg = await asyncio.wait_for(old_ws.receive(), timeout=2.0)
         assert close_msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING)
         # The registry now holds the NEW session; the old one is gone.
-        assert "alpha" in controller.receiver._peer_link_sessions
+        assert "alpha" in controller.receiver.state.peer_link_sessions
     finally:
         await new_ws.close()
 
@@ -1249,13 +1249,13 @@ async def test_e2e_peer_link_session_unregistered_on_peer_close(
     _session, ws, _ = await _drive_peer_link_session_open(
         client, dashboard_id="alpha", initiator_priv=initiator_priv
     )
-    await _wait_until(lambda: "alpha" in controller.receiver._peer_link_sessions)
+    await _wait_until(lambda: "alpha" in controller.receiver.state.peer_link_sessions)
 
     await ws.close()
 
     # The receiver's session loop sees the close, exits, and
     # ``unregister_peer_link_session`` runs in its ``finally``.
-    await _wait_until(lambda: "alpha" not in controller.receiver._peer_link_sessions)
+    await _wait_until(lambda: "alpha" not in controller.receiver.state.peer_link_sessions)
 
 
 @pytest.mark.asyncio
@@ -1281,7 +1281,7 @@ async def test_e2e_peer_link_session_drained_on_controller_stop(
         client, dashboard_id="alpha", initiator_priv=initiator_priv
     )
     try:
-        await _wait_until(lambda: "alpha" in controller.receiver._peer_link_sessions)
+        await _wait_until(lambda: "alpha" in controller.receiver.state.peer_link_sessions)
 
         # ``stop()`` runs in the same loop; the test fixture
         # also calls ``stop()`` on teardown but we drive it
@@ -1295,7 +1295,7 @@ async def test_e2e_peer_link_session_drained_on_controller_stop(
         assert terminate["reason"] == TerminateReason.SERVER_SHUTTING_DOWN.value
 
         await stop_task
-        assert controller.receiver._peer_link_sessions == {}
+        assert controller.receiver.state.peer_link_sessions == {}
     finally:
         await ws.close()
 
@@ -1376,7 +1376,7 @@ def _install_stub_submit_job_receiver(
 
     firmware_stub._create_job = MagicMock(side_effect=_create_job)
     firmware_stub._enqueue = AsyncMock(side_effect=_enqueue)
-    controller.receiver._submit_job_receiver = SubmitJobReceiver(
+    controller.receiver.state.submit_job_receiver = SubmitJobReceiver(
         config_dir=controller.offloader._db.settings.config_dir,
         firmware_controller=firmware_stub,
     )
@@ -1603,11 +1603,11 @@ async def test_register_peer_link_session_kicks_existing(tmp_path: Path) -> None
     new.terminate = AsyncMock()
 
     await controller.receiver.register_peer_link_session(old)
-    assert controller.receiver._peer_link_sessions["alpha"] is old
+    assert controller.receiver.state.peer_link_sessions["alpha"] is old
     old.terminate.assert_not_called()
 
     await controller.receiver.register_peer_link_session(new)
-    assert controller.receiver._peer_link_sessions["alpha"] is new
+    assert controller.receiver.state.peer_link_sessions["alpha"] is new
     old.terminate.assert_awaited_once_with(TerminateReason.SUPERSEDED)
     new.terminate.assert_not_called()
 
@@ -1704,7 +1704,7 @@ async def test_register_peer_link_session_swallows_snapshot_exception(tmp_path: 
 
     # Push skipped, but the session is registered.
     session.send_app_frame.assert_not_called()
-    assert controller.receiver._peer_link_sessions["alpha"] is session
+    assert controller.receiver.state.peer_link_sessions["alpha"] is session
 
 
 @pytest.mark.asyncio
@@ -1741,7 +1741,7 @@ async def test_register_peer_link_session_swallows_send_app_frame_exception(
 
     session.send_app_frame.assert_awaited_once()
     # Session still registered — the failed push doesn't roll it back.
-    assert controller.receiver._peer_link_sessions["alpha"] is session
+    assert controller.receiver.state.peer_link_sessions["alpha"] is session
 
 
 def test_unregister_peer_link_session_no_op_when_replaced(tmp_path: Path) -> None:
@@ -1753,11 +1753,11 @@ def test_unregister_peer_link_session_no_op_when_replaced(tmp_path: Path) -> Non
     new = MagicMock(spec=PeerLinkSession)
     new.dashboard_id = "alpha"
 
-    controller.receiver._peer_link_sessions["alpha"] = new
+    controller.receiver.state.peer_link_sessions["alpha"] = new
     controller.receiver.unregister_peer_link_session(old)
     # New session still in place — the old session's late
     # cleanup didn't evict the replacement.
-    assert controller.receiver._peer_link_sessions["alpha"] is new
+    assert controller.receiver.state.peer_link_sessions["alpha"] is new
 
 
 def test_unregister_peer_link_session_removes_when_current(tmp_path: Path) -> None:
@@ -1766,10 +1766,10 @@ def test_unregister_peer_link_session_removes_when_current(tmp_path: Path) -> No
 
     session = MagicMock(spec=PeerLinkSession)
     session.dashboard_id = "alpha"
-    controller.receiver._peer_link_sessions["alpha"] = session
+    controller.receiver.state.peer_link_sessions["alpha"] = session
 
     controller.receiver.unregister_peer_link_session(session)
-    assert controller.receiver._peer_link_sessions == {}
+    assert controller.receiver.state.peer_link_sessions == {}
 
 
 @pytest.mark.asyncio
@@ -2228,7 +2228,7 @@ def _make_receiver_with_fanout(tmp_path: Path) -> RemoteBuildController:
     controller = make_remote_build_controller(config_dir=tmp_path)
     controller.offloader._db.firmware = MagicMock()
     controller.offloader._db.firmware.cancel = AsyncMock()
-    controller.receiver._job_fanout = JobFanout(controller)
+    controller.receiver.state.job_fanout = JobFanout(controller)
     return controller
 
 
@@ -2243,8 +2243,8 @@ def _cancel_session(dashboard_id: str = "alpha") -> Any:
 async def test_handle_cancel_job_routes_to_firmware_cancel(tmp_path: Path) -> None:
     """Happy path: resolve offloader job_id → firmware job_id → fire ``firmware.cancel``."""
     controller = _make_receiver_with_fanout(tmp_path)
-    assert controller.receiver._job_fanout is not None
-    controller.receiver._job_fanout._remote_jobs["fw-abc"] = ("offloader-1", "remote-xyz")
+    assert controller.receiver.state.job_fanout is not None
+    controller.receiver.state.job_fanout._remote_jobs["fw-abc"] = ("offloader-1", "remote-xyz")
 
     await controller.receiver.handle_cancel_job(
         _cancel_session(dashboard_id="offloader-1"),
@@ -2275,8 +2275,8 @@ async def test_handle_cancel_job_pin_to_wrong_session_no_cancel(tmp_path: Path) 
     from a different peer doesn't resolve.
     """
     controller = _make_receiver_with_fanout(tmp_path)
-    assert controller.receiver._job_fanout is not None
-    controller.receiver._job_fanout._remote_jobs["fw-abc"] = ("offloader-1", "j-1")
+    assert controller.receiver.state.job_fanout is not None
+    controller.receiver.state.job_fanout._remote_jobs["fw-abc"] = ("offloader-1", "j-1")
     await controller.receiver.handle_cancel_job(
         _cancel_session(dashboard_id="offloader-2"),  # different peer
         {"type": "cancel_job", "job_id": "j-1"},
@@ -2310,7 +2310,7 @@ async def test_handle_cancel_job_before_controller_started_drops_silently(
     explicitly.
     """
     controller = _make_receiver_with_fanout(tmp_path)
-    controller.receiver._job_fanout = None  # simulate pre-start
+    controller.receiver.state.job_fanout = None  # simulate pre-start
     await controller.receiver.handle_cancel_job(
         _cancel_session(dashboard_id="offloader-1"),
         {"type": "cancel_job", "job_id": "j-1"},
@@ -2322,8 +2322,8 @@ async def test_handle_cancel_job_before_controller_started_drops_silently(
 async def test_handle_cancel_job_swallows_firmware_command_error(tmp_path: Path) -> None:
     """A ``CommandError`` from ``firmware.cancel`` (e.g. already-terminal) is swallowed."""
     controller = _make_receiver_with_fanout(tmp_path)
-    assert controller.receiver._job_fanout is not None
-    controller.receiver._job_fanout._remote_jobs["fw-abc"] = ("offloader-1", "j-1")
+    assert controller.receiver.state.job_fanout is not None
+    controller.receiver.state.job_fanout._remote_jobs["fw-abc"] = ("offloader-1", "j-1")
     controller.offloader._db.firmware.cancel = AsyncMock(
         side_effect=CommandError(ErrorCode.INVALID_ARGS, "Cannot cancel a completed job")
     )

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -2100,7 +2100,7 @@ async def test_request_pair_already_approved_persists_to_disk(
 
     # Promote the receiver-side row to APPROVED so the next
     # request_pair gets the short-circuit path.
-    [pending_peer] = receiver_controller._pending_peers.values()
+    [pending_peer] = receiver_controller.state.pending_peers.values()
     await receiver_controller.approve_peer(dashboard_id=pending_peer.dashboard_id)
 
     # Second pair: receiver returns APPROVED immediately; the
@@ -2137,7 +2137,7 @@ async def test_lookup_peer_for_status_pending_dict_pin_mismatch_returns_rejected
     pubkey = b"\x44" * 32
     real_pin = "a" * 64
     await controller.set_pairing_window(open=True, client="receiver-tab")
-    controller._pending_peers["alpha"] = StoredPeer(
+    controller.state.pending_peers["alpha"] = StoredPeer(
         dashboard_id="alpha",
         pin_sha256=real_pin,
         static_x25519_pub=pubkey,
@@ -2226,7 +2226,7 @@ def _seed_approved_peer_sync(
     pubkey: bytes,
 ) -> None:
     """Sync helper: drop+rewrite the receiver's APPROVED peer dict."""
-    controller._approved_peers[dashboard_id] = StoredPeer(
+    controller.state.approved_peers[dashboard_id] = StoredPeer(
         dashboard_id=dashboard_id,
         pin_sha256=pin,
         static_x25519_pub=pubkey,
@@ -2574,7 +2574,7 @@ async def _seed_approved_peer_for_initiator(
     initiator_pub = (
         X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
     )
-    receiver_controller._approved_peers[dashboard_id] = StoredPeer(
+    receiver_controller.state.approved_peers[dashboard_id] = StoredPeer(
         dashboard_id=dashboard_id,
         pin_sha256=hashlib.sha256(initiator_pub).hexdigest(),
         static_x25519_pub=initiator_pub,


### PR DESCRIPTION
# What does this implement/fix?

Phase 3 of `state_dataclass_plan.md` — applies the same `State` extraction pattern that #795 (offloader) and #797 (devices) introduced, now to the receiver. Single-file controller today; doing the State extraction upfront so when `ReceiverController` eventually splits into a sibling-module package, sibling helpers reach through `controller.state.X` from PR 1 instead of relitigating the abstraction post-split.

## State (in `controllers/remote_build/_receiver_state.py`)

Mutable domain state:
- `rotation_in_flight`
- `pairing_window_clients`
- `pairing_window_handle`
- `pending_peers`
- `approved_peers`
- `peer_link_sessions`

Lifecycle service refs constructed in `start()`, torn down in `stop()` (mirrors how the offloader's `browser` / `peer_link_resolver` went into `OffloaderState`):
- `submit_job_receiver`
- `artifacts_download_sender`
- `job_fanout`

## What stays on the controller

- `_db`, base infrastructure (`_listeners`, `_tasks`, `_shutdown_callbacks`).
- `_peers_store` — constructed once in `__init__`, never reassigned.
- `get_submit_job_receiver` / `get_artifacts_download_sender` delegate methods.

## Other touched code

- `job_fanout.py`: the cross-module `ReceiverController` reference now reads through `controller.state.peer_link_sessions` instead of `controller._peer_link_sessions`.

## Test impact

~85 attr renames across 9 test files (mechanical sed across `*\._<attr>\b` for the 9 state attrs, with `(?<!state)` to avoid double-state).

Behaviour-free; **all 3391 tests pass** (full suite excluding benchmarks). Pre-commit clean.

**Related issue or feature (if applicable):**

- Closes the `state_dataclass_plan.md` arc; phase 4 (CLAUDE.md convention codification) is in #799.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
