### PR TITLE
Purge macOS .DS_Store / AppleDouble before remote-build prune

### DIFF
--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -252,8 +252,39 @@ def _reclaim_orphan_bundle(
 
 
 def _prune_empty_dir(directory: Path) -> None:
-    """Remove *directory* if empty; debug-log + continue otherwise."""
+    """Remove *directory* if empty; debug-log + continue otherwise.
+
+    macOS Finder drops ``.DS_Store`` into every directory it
+    browses, and AppleDouble ``._<name>`` resource-fork shadows
+    accumulate on cross-FS copies; both pin the rmdir with
+    ENOTEMPTY long after the device subtrees + bundle tarballs
+    are gone. Purge those disposable metadata entries before the
+    rmdir so a Finder-browsed dashboard_id parent on a macOS
+    host can actually be reclaimed.
+    """
+    _purge_macos_metadata(directory)
     try:
         directory.rmdir()
     except OSError as exc:
         _LOGGER.debug("remote-build cleanup: rmdir(%s) skipped: %s", directory, exc)
+
+
+def _purge_macos_metadata(directory: Path) -> None:
+    """Unlink macOS metadata files (``.DS_Store``, ``._*``) under *directory*.
+
+    Skips symlinks: only real files matching the metadata
+    pattern are touched. Per-entry unlink failures are logged at
+    debug and the sweep continues; the worst case is that the
+    rmdir below also fails and the directory survives this
+    cycle (next cycle will try again).
+    """
+    for entry in _safe_iterdir(directory):
+        if entry.is_symlink():
+            continue
+        name = entry.name
+        if name != ".DS_Store" and not name.startswith("._"):
+            continue
+        try:
+            entry.unlink()
+        except OSError as exc:
+            _LOGGER.debug("remote-build cleanup: unlink macOS metadata(%s) failed: %s", entry, exc)

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -252,39 +252,21 @@ def _reclaim_orphan_bundle(
 
 
 def _prune_empty_dir(directory: Path) -> None:
-    """Remove *directory* if empty; debug-log + continue otherwise.
-
-    macOS Finder drops ``.DS_Store`` into every directory it
-    browses, and AppleDouble ``._<name>`` resource-fork shadows
-    accumulate on cross-FS copies; both pin the rmdir with
-    ENOTEMPTY long after the device subtrees + bundle tarballs
-    are gone. Purge those disposable metadata entries before the
-    rmdir so a Finder-browsed dashboard_id parent on a macOS
-    host can actually be reclaimed.
-    """
-    _purge_macos_metadata(directory)
-    try:
-        directory.rmdir()
-    except OSError as exc:
-        _LOGGER.debug("remote-build cleanup: rmdir(%s) skipped: %s", directory, exc)
-
-
-def _purge_macos_metadata(directory: Path) -> None:
-    """Unlink macOS metadata files (``.DS_Store``, ``._*``) under *directory*.
-
-    Skips symlinks: only real files matching the metadata
-    pattern are touched. Per-entry unlink failures are logged at
-    debug and the sweep continues; the worst case is that the
-    rmdir below also fails and the directory survives this
-    cycle (next cycle will try again).
-    """
+    """Remove *directory* when empty or holding only macOS metadata."""
+    metadata: list[Path] = []
     for entry in _safe_iterdir(directory):
         if entry.is_symlink():
-            continue
+            return
         name = entry.name
         if name != ".DS_Store" and not name.startswith("._"):
-            continue
+            return
+        metadata.append(entry)
+    for entry in metadata:
         try:
             entry.unlink()
         except OSError as exc:
             _LOGGER.debug("remote-build cleanup: unlink macOS metadata(%s) failed: %s", entry, exc)
+    try:
+        directory.rmdir()
+    except OSError as exc:
+        _LOGGER.debug("remote-build cleanup: rmdir(%s) skipped: %s", directory, exc)

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -99,14 +99,7 @@ def test_sweep_prunes_empty_dashboard_parent(tmp_path: Path) -> None:
 
 
 def test_sweep_prunes_dashboard_parent_with_macos_metadata(tmp_path: Path) -> None:
-    """A dashboard_id parent containing only macOS .DS_Store / AppleDouble is still pruned.
-
-    Finder drops ``.DS_Store`` into every directory it browses
-    on a macOS dashboard host; without the metadata purge in
-    ``_prune_empty_dir`` these files would pin the parent
-    forever with ENOTEMPTY after the last device subtree is
-    swept.
-    """
+    """Dashboard_id parent holding only ``.DS_Store`` / ``._*`` still rmdirs."""
     now = 1_000_000.0
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
     _populate(tmp_path, key, age_seconds=3600, now=now)
@@ -116,6 +109,23 @@ def test_sweep_prunes_dashboard_parent_with_macos_metadata(tmp_path: Path) -> No
 
     sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert not dashboard_dir.exists()
+
+
+def test_sweep_leaves_macos_metadata_alongside_warm_subtree(tmp_path: Path) -> None:
+    """Metadata purge is scoped to metadata-only parents, not non-empty ones."""
+    now = 1_000_000.0
+    warm = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, warm, age_seconds=60, now=now)
+    dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    ds_store = dashboard_dir / ".DS_Store"
+    apple_double = dashboard_dir / "._kitchen"
+    ds_store.write_bytes(b"\x00\x00\x00\x01Bud1")
+    apple_double.write_bytes(b"AppleDouble")
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert warm.subtree(tmp_path).is_dir()
+    assert ds_store.is_file()
+    assert apple_double.is_file()
 
 
 def test_sweep_keeps_dashboard_parent_when_sibling_still_warm(tmp_path: Path) -> None:

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -98,6 +98,26 @@ def test_sweep_prunes_empty_dashboard_parent(tmp_path: Path) -> None:
     assert not parent.exists()
 
 
+def test_sweep_prunes_dashboard_parent_with_macos_metadata(tmp_path: Path) -> None:
+    """A dashboard_id parent containing only macOS .DS_Store / AppleDouble is still pruned.
+
+    Finder drops ``.DS_Store`` into every directory it browses
+    on a macOS dashboard host; without the metadata purge in
+    ``_prune_empty_dir`` these files would pin the parent
+    forever with ENOTEMPTY after the last device subtree is
+    swept.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)
+    dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    (dashboard_dir / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1")
+    (dashboard_dir / "._kitchen").write_bytes(b"AppleDouble")
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert not dashboard_dir.exists()
+
+
 def test_sweep_keeps_dashboard_parent_when_sibling_still_warm(tmp_path: Path) -> None:
     """A dashboard with one cold + one warm device keeps the parent."""
     now = 1_000_000.0

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -444,6 +444,33 @@ def test_sweep_logs_orphan_unlink_failure(tmp_path: Path, monkeypatch: pytest.Mo
     assert bundle.is_file()
 
 
+def test_sweep_logs_macos_metadata_unlink_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Failed ``.DS_Store`` unlink + the follow-on rmdir failure both stay debug-logs."""
+    now = 1_000_000.0
+    dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    dashboard_dir.mkdir(parents=True)
+    ds_store = dashboard_dir / ".DS_Store"
+    ds_store.write_bytes(b"junk")
+
+    real_unlink = Path.unlink
+
+    def _flaky_unlink(self: Path, *args: object, **kwargs: object) -> object:
+        if self == ds_store:
+            raise PermissionError("simulated denied")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _flaky_unlink)
+
+    # Should not raise. Both defensive arms fire: the unlink
+    # OSError is logged, then the rmdir OSError (dir still
+    # holds the .DS_Store) is logged too.
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert dashboard_dir.is_dir()
+    assert ds_store.is_file()
+
+
 def test_sweep_continues_after_subtree_rmtree_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

On a macOS dashboard host, Finder drops `.DS_Store` into every
directory it browses (and cross-FS copies leave `._<name>`
AppleDouble shadows behind). When the receiver-side TTL sweep
runs `_prune_empty_dir` against a `<dashboard_id>/` parent
whose device subtrees have all been reclaimed, the leftover
metadata pins `rmdir` with `ENOTEMPTY` forever:

```
remote-build cleanup: rmdir(.../.remote_builds/8Ja02_-QQeziVZemmcO2BZOnaLAaVSgq) skipped: [Errno 66] Directory not empty
```

`.DS_Store` and `._*` are unconditionally disposable on macOS
(Finder regenerates `.DS_Store` on next browse; AppleDouble
shadows are only meaningful on non-HFS filesystems), so the fix
is to purge them inside the existing `_prune_empty_dir` step
before the `rmdir` attempt. Scope stays narrow: the main sweep
loop is unchanged, and the purge only fires on the directory
we're about to reclaim — we don't go around touching metadata
files in directories the operator still owns.

Test mirrors the existing `test_sweep_prunes_empty_dashboard_parent`
shape and plants both a `.DS_Store` and a `._kitchen` AppleDouble
next to the cold subtree; verified the test fails on `main` with
`AssertionError: assert not True` and passes with the fix.

**Related issue or feature (if applicable):**

- N/A (caught from operator logs on a macOS dashboard host)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
