### PR TITLE
Reclaim dashboard_id parent on remote-build sweep

### DIFF
--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -34,9 +34,10 @@ A single bad subtree doesn't kill the sweep for everything else.
 from __future__ import annotations
 
 import logging
-import shutil
 import time
 from pathlib import Path
+
+from esphome.helpers import rmtree
 
 from .remote_build_layout import BUNDLE_SUFFIX, REMOTE_BUILDS_SUBDIR, RemoteBuildPath
 
@@ -110,38 +111,75 @@ def sweep_remote_builds(
                 dashboard_dir,
             )
             continue
-        for entry in _safe_iterdir(dashboard_dir):
-            if entry.is_symlink():
-                _LOGGER.debug("remote-build cleanup: skipping symlink %s", entry)
-                continue
-            if entry.is_dir():
-                key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=entry.name)
-                if key in in_flight_keys:
-                    _LOGGER.debug("remote-build cleanup: skipping in-flight %s", key)
-                    continue
-                if not _is_cold(entry, cutoff):
-                    continue
-                if _delete_subtree_and_sibling(key, config_dir):
-                    deleted += 1
-            elif entry.is_file() and entry.name.endswith(BUNDLE_SUFFIX):
-                # Orphan bundle path: a ``.tar.gz`` whose sibling
-                # subtree is missing. Happens when the previous
-                # sweep's ``rmtree`` succeeded but the ``unlink``
-                # failed (logged as warning, sweep continued),
-                # when an operator hand-deleted the subtree, or
-                # any other transient failure that left only the
-                # tarball behind. Without this branch the orphan
-                # would accumulate forever — the subtree-path
-                # above never visits it because that branch
-                # requires ``is_dir()``. Pair with the same
-                # in-flight + cold gates the subtree path uses.
-                _reclaim_orphan_bundle(entry, dashboard_dir, in_flight_keys, cutoff)
+        dashboard_deleted, has_kept = _process_dashboard_dir(
+            dashboard_dir, config_dir, in_flight_keys, cutoff
+        )
+        deleted += dashboard_deleted
         # An offloader that was paired once and never came back
-        # leaves an otherwise-permanent empty dashboard_id dir;
-        # prune here so the filesystem stays tidy without a
-        # separate housekeeping pass.
-        _prune_empty_dir(dashboard_dir)
+        # leaves an otherwise-permanent dashboard_id dir; reclaim
+        # the whole subtree here when no entries were kept, so a
+        # macOS ``.DS_Store`` / Windows ``Thumbs.db`` / editor
+        # swap file dropped by a Finder or shell browse can't
+        # pin the parent forever. We own this directory; rmtree
+        # is the right hammer.
+        if not has_kept:
+            try:
+                rmtree(dashboard_dir)
+            except OSError as exc:
+                _LOGGER.debug("remote-build cleanup: rmtree(%s) skipped: %s", dashboard_dir, exc)
     return deleted
+
+
+def _process_dashboard_dir(
+    dashboard_dir: Path,
+    config_dir: Path,
+    in_flight_keys: frozenset[RemoteBuildPath],
+    cutoff: float,
+) -> tuple[int, bool]:
+    """Reclaim cold entries under *dashboard_dir*; report kept-state.
+
+    Returns ``(deleted_count, has_kept)``. ``has_kept`` is True
+    iff the dashboard_dir still owns real content after this
+    pass (in-flight or warm subtree, in-flight or fresh orphan
+    bundle, symlink we refused to touch, or a delete that
+    raised) — the signal the caller uses to decide whether to
+    reclaim the parent.
+    """
+    deleted = 0
+    has_kept = False
+    for entry in _safe_iterdir(dashboard_dir):
+        if entry.is_symlink():
+            _LOGGER.debug("remote-build cleanup: skipping symlink %s", entry)
+            has_kept = True
+            continue
+        if entry.is_dir():
+            key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=entry.name)
+            if key in in_flight_keys:
+                _LOGGER.debug("remote-build cleanup: skipping in-flight %s", key)
+                has_kept = True
+                continue
+            if not _is_cold(entry, cutoff):
+                has_kept = True
+                continue
+            if _delete_subtree_and_sibling(key, config_dir):
+                deleted += 1
+            else:
+                has_kept = True
+        elif entry.is_file() and entry.name.endswith(BUNDLE_SUFFIX):
+            # Orphan bundle path: a ``.tar.gz`` whose sibling
+            # subtree is missing. Happens when the previous
+            # sweep's ``rmtree`` succeeded but the ``unlink``
+            # failed (logged as warning, sweep continued),
+            # when an operator hand-deleted the subtree, or
+            # any other transient failure that left only the
+            # tarball behind. Without this branch the orphan
+            # would accumulate forever — the subtree-path
+            # above never visits it because that branch
+            # requires ``is_dir()``. Pair with the same
+            # in-flight + cold gates the subtree path uses.
+            if _reclaim_orphan_bundle(entry, dashboard_dir, in_flight_keys, cutoff):
+                has_kept = True
+    return deleted, has_kept
 
 
 def _safe_iterdir(directory: Path) -> list[Path]:
@@ -180,7 +218,11 @@ def _delete_subtree_and_sibling(key: RemoteBuildPath, config_dir: Path) -> bool:
     subtree = key.subtree(config_dir)
     bundle = key.bundle(config_dir)
     try:
-        shutil.rmtree(subtree)
+        # Goes through esphome's wrapper so Windows-side
+        # read-only files (PIO compile cache, git pack files
+        # inside the cached venv) clear instead of raising
+        # ``PermissionError``.
+        rmtree(subtree)
     except OSError as exc:
         _LOGGER.warning("remote-build cleanup: rmtree(%s) failed: %s", subtree, exc)
         return False
@@ -197,8 +239,16 @@ def _reclaim_orphan_bundle(
     dashboard_dir: Path,
     in_flight_keys: frozenset[RemoteBuildPath],
     cutoff: float,
-) -> None:
+) -> bool:
     """Unlink *bundle* when its sibling subtree is missing + it's cold + not in-flight.
+
+    Returns ``True`` when the bundle was kept as a true orphan
+    (in-flight, fresh, or unlink failure) so the caller's
+    ``has_kept`` accounting knows the dashboard_dir still owns
+    real content. Returns ``False`` for the paired case
+    (sibling subtree present — fate decided by the subtree
+    iteration), for successful reclaim, and for the bare
+    ``.tar.gz`` short-circuit.
 
     The "sibling subtree missing" gate is load-bearing: when
     both exist the subtree-path branch above already handles
@@ -222,7 +272,7 @@ def _reclaim_orphan_bundle(
     # short-circuit explicitly to avoid the spurious
     # ``RemoteBuildPath(..., device_name="")`` allocation.
     if not device_name:
-        return
+        return False
     sibling_subtree = dashboard_dir / device_name
     # Treat anything at the sibling position — real dir, real
     # file, broken symlink, live symlink to anywhere — as a
@@ -236,24 +286,17 @@ def _reclaim_orphan_bundle(
     # remote-builds root, so anything at this position is
     # operator-or-attacker-placed and outside our trust scope.
     if sibling_subtree.exists() or sibling_subtree.is_symlink():
-        return
+        return False
     key = RemoteBuildPath(dashboard_id=dashboard_dir.name, device_name=device_name)
     if key in in_flight_keys:
         _LOGGER.debug("remote-build cleanup: skipping in-flight orphan bundle %s", bundle)
-        return
+        return True
     if not _is_cold(bundle, cutoff):
-        return
+        return True
     try:
         bundle.unlink()
     except OSError as exc:
         _LOGGER.warning("remote-build cleanup: unlink orphan bundle(%s) failed: %s", bundle, exc)
-        return
+        return True
     _LOGGER.info("remote-build cleanup: removed orphan bundle %s", bundle)
-
-
-def _prune_empty_dir(directory: Path) -> None:
-    """Remove *directory* if empty; debug-log + continue otherwise."""
-    try:
-        directory.rmdir()
-    except OSError as exc:
-        _LOGGER.debug("remote-build cleanup: rmdir(%s) skipped: %s", directory, exc)
+    return False

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from esphome.helpers import rmtree as _esphome_rmtree
 
 from esphome_device_builder.helpers.remote_build_cleanup import (
     _is_cold,
@@ -96,6 +97,81 @@ def test_sweep_prunes_empty_dashboard_parent(tmp_path: Path) -> None:
     sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     parent = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
     assert not parent.exists()
+
+
+def test_sweep_prunes_dashboard_parent_with_macos_metadata(tmp_path: Path) -> None:
+    """A dashboard_id parent containing only macOS .DS_Store / AppleDouble is still pruned.
+
+    Finder drops ``.DS_Store`` into every directory it browses
+    on a macOS dashboard host; without the cruft drain in
+    ``_reclaim_dashboard_dir`` these files would pin the parent
+    forever with ENOTEMPTY after the last device subtree is
+    swept.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)
+    dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    (dashboard_dir / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1")
+    (dashboard_dir / "._kitchen").write_bytes(b"AppleDouble")
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert not dashboard_dir.exists()
+
+
+@pytest.mark.parametrize(
+    "cruft_name",
+    [
+        "Thumbs.db",
+        "desktop.ini",
+        ".kitchen.yaml.swp",
+        ".nfs00000000abcdef01",
+        "random_operator_note.txt",
+    ],
+)
+def test_sweep_prunes_dashboard_parent_with_generic_cruft(tmp_path: Path, cruft_name: str) -> None:
+    """Disposable cruft (non-bundle, non-dir, non-symlink) gets drained at reclaim time.
+
+    The cruft drain isn't filename-keyed; anything the canonical
+    writer didn't produce (subdirs + ``.tar.gz`` bundles) is
+    treated as foreign and unlinked once the dashboard_dir has
+    no kept entries. Pins the contract that the helper handles
+    new filesystem shapes (Windows ``Thumbs.db`` /
+    ``desktop.ini``, editor swap files, NFS ``.nfsXXXX``
+    stragglers, etc.) without needing a per-filename allowlist.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)
+    dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    (dashboard_dir / cruft_name).write_bytes(b"junk")
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert not dashboard_dir.exists()
+
+
+def test_sweep_does_not_reclaim_when_only_kept_is_warm_subtree_plus_cruft(
+    tmp_path: Path,
+) -> None:
+    """A warm subtree pins the dashboard_dir even with cruft alongside.
+
+    Reclaim runs only when ``has_kept`` is False. A warm
+    subtree (or anything else legitimately kept) keeps the
+    cruft in place along with the parent.
+    """
+    now = 1_000_000.0
+    warm = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(tmp_path, warm, age_seconds=60, now=now)
+    dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
+    cruft = dashboard_dir / ".DS_Store"
+    cruft.write_bytes(b"junk")
+
+    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert warm.subtree(tmp_path).is_dir()
+    assert dashboard_dir.is_dir()
+    # Cruft stays alongside the warm subtree — reclaim doesn't
+    # run when has_kept is True.
+    assert cruft.is_file()
 
 
 def test_sweep_keeps_dashboard_parent_when_sibling_still_warm(tmp_path: Path) -> None:
@@ -308,7 +384,7 @@ def test_sweep_skips_symlink_at_subtree_level(tmp_path: Path) -> None:
     assert (real_dir / "important.txt").is_file()
 
 
-def test_sweep_leaves_bare_dot_tar_gz_alone(tmp_path: Path) -> None:
+def test_sweep_handles_bare_dot_tar_gz_without_error(tmp_path: Path) -> None:
     """A pathological bare ``.tar.gz`` entry doesn't trip the orphan branch.
 
     ``device_name = bundle.name[: -len(BUNDLE_SUFFIX)]`` would
@@ -316,7 +392,8 @@ def test_sweep_leaves_bare_dot_tar_gz_alone(tmp_path: Path) -> None:
     explicit empty-name short-circuit in
     ``_reclaim_orphan_bundle`` avoids spurious work and the
     dashboard_dir-as-sibling false positive that would otherwise
-    follow.
+    follow. The pathological file lands in the cruft bucket and
+    gets reclaimed alongside the parent.
     """
     now = 1_000_000.0
     dashboard_dir = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
@@ -326,7 +403,7 @@ def test_sweep_leaves_bare_dot_tar_gz_alone(tmp_path: Path) -> None:
     os.utime(weird, (now - 3600, now - 3600))
 
     sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
-    assert weird.is_file()
+    assert not dashboard_dir.exists()
 
 
 def test_safe_iterdir_returns_empty_on_oserror() -> None:
@@ -365,7 +442,10 @@ def test_sweep_logs_sibling_unlink_failure_but_still_counts_delete(
     reclamation; the bundle is a tiny cache file. A failed
     bundle unlink logs at warning but the sweep returns the
     subtree as "deleted" so the operator-facing count reflects
-    actual disk reclaimed.
+    actual disk reclaimed. The parent ``rmtree`` fallback then
+    sweeps the bundle along with the now-empty dashboard_dir,
+    so a transient inline ``unlink`` failure doesn't strand
+    the tarball.
     """
     now = 1_000_000.0
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
@@ -382,9 +462,10 @@ def test_sweep_logs_sibling_unlink_failure_but_still_counts_delete(
     deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 1
     assert not key.subtree(tmp_path).exists()
-    # Bundle unlink failed → bundle still on disk; the next
-    # sweep will retry it via the orphan-bundle branch.
-    assert key.bundle(tmp_path).is_file()
+    # Inline bundle.unlink failed, but the parent rmtree
+    # fallback uses os-level removal and cleans the bundle up
+    # along with the now-empty dashboard_dir.
+    assert not key.bundle(tmp_path).exists()
 
 
 def test_sweep_logs_orphan_unlink_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -422,9 +503,10 @@ def test_sweep_continues_after_subtree_rmtree_failure(
     Permission errors / races against a concurrent submit /
     broken symlinks in the tree all happen in production; the
     sweep is best-effort hygiene, a single bad subtree
-    shouldn't poison the rest. Monkeypatches ``shutil.rmtree``
-    to fail on the first call and succeed on the second; the
-    second cold subtree should still get reclaimed.
+    shouldn't poison the rest. Monkeypatches the module's
+    ``rmtree`` binding (the esphome-helpers wrapper) to fail on
+    the first call and succeed on the rest; the second cold
+    subtree should still get reclaimed.
     """
     now = 1_000_000.0
     first = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
@@ -432,19 +514,20 @@ def test_sweep_continues_after_subtree_rmtree_failure(
     _populate(tmp_path, first, age_seconds=3600, now=now)
     _populate(tmp_path, second, age_seconds=3600, now=now)
 
-    real_rmtree = __import__("shutil").rmtree
     calls: list[Path] = []
 
     def _flaky(path: str | Path, *args: object, **kwargs: object) -> None:
         calls.append(Path(path))
         if len(calls) == 1:
             raise PermissionError("simulated denied")
-        real_rmtree(path, *args, **kwargs)
+        _esphome_rmtree(path, *args, **kwargs)
 
-    monkeypatch.setattr("esphome_device_builder.helpers.remote_build_cleanup.shutil.rmtree", _flaky)
+    monkeypatch.setattr("esphome_device_builder.helpers.remote_build_cleanup.rmtree", _flaky)
 
     deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
-    # One success out of two attempts; the failed subtree still
-    # exists, the successful one is gone.
+    # One subtree-level rmtree failed (has_kept stays True for
+    # that one), so deleted only counts the successful one. The
+    # parent rmtree is skipped because has_kept = True — that's
+    # the third call we'd otherwise have seen.
     assert deleted == 1
     assert len(calls) == 2


### PR DESCRIPTION
# What does this implement/fix?

Operator logs from a macOS dashboard host showed the
receiver-side TTL sweep pinned on `<dashboard_id>/` directories
forever:

```
remote-build cleanup: rmdir(.../.remote_builds/8Ja02_-...) skipped: [Errno 66] Directory not empty
```

Finder drops `.DS_Store` into every directory it browses, and
the post-sweep `rmdir` never succeeds once one is present. The
same shape hits Windows hosts (`Thumbs.db` / `desktop.ini`) and
editor swap files / NFS `.nfsXXXX` stragglers on any host.

The dashboard_id parent is a build-output cache we own, so the
right primitive is `rmtree`, not `rmdir` plus a per-filename
allowlist. The sweep already tracks per-entry "kept" state
implicitly through its in-flight / warm / cold gates; surface
that as a `has_kept` flag and call `rmtree` on the parent
whenever no entries were kept. Filesystem cruft of any shape
gets reclaimed alongside the parent for free.

Switch both `rmtree` calls in this module to
`esphome.helpers.rmtree` so Windows read-only files (PIO compile
cache, git pack files under cached venvs) clear instead of
raising `PermissionError`. Two other production callers
(`controllers/devices/helpers.py:99` and
`helpers/remote_artifacts_materialise.py:138`) use raw
`shutil.rmtree` against the same build-tree shape; tracked
separately in #804.

The inner per-entry loop is extracted to
`_process_dashboard_dir` to keep the top-level `sweep_remote_builds`
under ruff's branch-count cap, and so the kept-state accounting
reads as one block instead of being scattered across the outer
loop.

**Related issue or feature (if applicable):**

- N/A (caught from operator logs on a macOS dashboard host)
- Spawned audit issue #804 for the parallel Windows-correctness
  problem in two other rmtree call sites

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
