### PR TITLE
Preserve inline comment on value-less leaf in rewrite_yaml_scalar

### DIFF
--- a/esphome_device_builder/helpers/yaml/scalar.py
+++ b/esphome_device_builder/helpers/yaml/scalar.py
@@ -32,11 +32,16 @@ class YamlUpsertNotSupportedError(ValueError):
 
 
 # Mapping-key line: optional leading whitespace, an unquoted scalar
-# key, ``:``, optional whitespace, optional value, optional trailing
-# comment. List items (``- foo: bar``) are excluded — none of the
-# rewrite paths we care about land inside a list, and the key stack
-# below assumes parent → child mapping nesting only.
-_MAPPING_KEY_LINE = re.compile(r"^(?P<indent>\s*)(?P<key>[A-Za-z_][\w-]*):\s*(?P<rest>.*)$")
+# key, ``:``, and then everything else verbatim — ``rest`` keeps the
+# post-colon whitespace so :func:`_split_value_and_comment` can see
+# the ``\s+#`` separator on a value-less line like ``name: # TODO``.
+# Folding the whitespace into ``rest`` rather than dropping it means
+# a comment-only leaf returns ``("", " # …")`` instead of mis-reading
+# the ``#`` as a leading character of the value. List items
+# (``- foo: bar``) are excluded — none of the rewrite paths we care
+# about land inside a list, and the key stack below assumes
+# parent → child mapping nesting only.
+_MAPPING_KEY_LINE = re.compile(r"^(?P<indent>\s*)(?P<key>[A-Za-z_][\w-]*):(?P<rest>.*)$")
 
 
 def _split_value_and_comment(rest: str) -> tuple[str, str]:

--- a/esphome_device_builder/helpers/yaml/scalar.py
+++ b/esphome_device_builder/helpers/yaml/scalar.py
@@ -32,14 +32,11 @@ class YamlUpsertNotSupportedError(ValueError):
 
 
 # Mapping-key line: optional leading whitespace, an unquoted scalar
-# key, ``:``, and then everything else verbatim — ``rest`` keeps the
-# post-colon whitespace so :func:`_split_value_and_comment` can see
-# the ``\s+#`` separator on a value-less line like ``name: # TODO``.
-# Folding the whitespace into ``rest`` rather than dropping it means
-# a comment-only leaf returns ``("", " # …")`` instead of mis-reading
-# the ``#`` as a leading character of the value. List items
-# (``- foo: bar``) are excluded — none of the rewrite paths we care
-# about land inside a list, and the key stack below assumes
+# key, ``:``, and the rest of the line verbatim — ``rest`` keeps the
+# post-colon whitespace so :func:`_split_value_and_comment` sees the
+# ``\s+#`` separator on a value-less line (``name: # TODO``). List
+# items (``- foo: bar``) are excluded — none of the rewrite paths we
+# care about land inside a list, and the key stack below assumes
 # parent → child mapping nesting only.
 _MAPPING_KEY_LINE = re.compile(r"^(?P<indent>\s*)(?P<key>[A-Za-z_][\w-]*):(?P<rest>.*)$")
 

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -349,6 +349,12 @@ def test_read_yaml_scalar_returns_empty_string_for_empty_value() -> None:
     assert read_yaml_scalar(yaml, ("esphome", "name")) == ""
 
 
+def test_read_yaml_scalar_returns_empty_for_comment_only_leaf() -> None:
+    """``name: # placeholder`` reads as empty, not as ``"# placeholder"``."""
+    yaml = "esphome:\n  name: # placeholder\n"
+    assert read_yaml_scalar(yaml, ("esphome", "name")) == ""
+
+
 # ---------------------------------------------------------------------------
 # rewrite_yaml_scalar (the generic walker)
 # ---------------------------------------------------------------------------
@@ -433,6 +439,13 @@ def test_rewrite_yaml_scalar_only_rewrites_first_match() -> None:
     # ESPHome at compile time — the helper doesn't fix duplicate
     # keys, just doesn't make them worse).
     assert "  name: second\n" in out
+
+
+def test_rewrite_yaml_scalar_preserves_comment_only_leaf() -> None:
+    """A value-less leaf with a trailing comment keeps the comment after rewrite."""
+    before = "esphome:\n  name: # placeholder\n"
+    after = rewrite_yaml_scalar(before, ("esphome", "name"), lambda _raw: "kitchen")
+    assert after == "esphome:\n  name: kitchen # placeholder\n"
 
 
 def test_rewrite_yaml_scalar_empty_path_is_a_noop() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`rewrite_yaml_scalar` silently dropped an inline trailing
comment when the leaf line had no value (only a comment after
the colon), and `read_yaml_scalar` returned the comment text
itself as the raw value instead of `""`:

```python
before = "esphome:\n  name: # placeholder\n"
after = rewrite_yaml_scalar(before, ("esphome", "name"), lambda _raw: "kitchen")
# Expected: "esphome:\n  name: kitchen # placeholder\n"
# Actual:   "esphome:\n  name: kitchen\n"

read_yaml_scalar(before, ("esphome", "name"))
# Expected: ""
# Actual:   "# placeholder"
```

Root cause is in `helpers/yaml/scalar.py`. `_MAPPING_KEY_LINE`'s
``rest`` group greedily consumed every space after the colon:

```python
_MAPPING_KEY_LINE = re.compile(r"^(?P<indent>\s*)(?P<key>[A-Za-z_][\w-]*):\s*(?P<rest>.*)$")
```

So `name: # placeholder` produced `rest = "# placeholder"`
with no leading whitespace. `_split_value_and_comment`'s
comment-opener gate requires whitespace immediately before
the `#`:

```python
elif ch == "#" and i > 0 and rest[i - 1] in " \t":
```

The `i > 0` check fails when `rest[0] == "#"`, so the
splitter falls through to the no-comment-found return and
treats the whole `# placeholder` as the value. The rewriter
emits `name: <new>` with the comment lost; the reader returns
the comment text as if it were the scalar value.

Fix: drop `\s*` from the rest-capturing group. Post-colon
whitespace stays in `rest`, the splitter sees a real `\s+#`
separator at `i = 1`, and the contract is restored. The
rewriter's emit format string already pads `: {replacement}`
on the way out so render shape stays canonical.

Two pinning tests:

- `test_rewrite_yaml_scalar_preserves_comment_only_leaf` —
  rewrite preserves the trailing comment.
- `test_read_yaml_scalar_returns_empty_for_comment_only_leaf` —
  read returns `""` instead of the comment text.

Verified the existing 108-test yaml-helper suite still passes
(no regressions on quoted-value, embedded-`#`, friendly-name,
or `!secret` cases), and the broader 3384-test suite passes too.

**Related issue or feature (if applicable):**

- closes #807
- pre-existing bug surfaced during Copilot review of the
  `helpers/yaml/` structural split in #803; deferred to this
  follow-up per the project's split-then-clean cadence

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
