### PR TITLE
Split ReceiverController: extract cleanup loop

### DIFF
--- a/esphome_device_builder/controllers/remote_build/cleanup_loop.py
+++ b/esphome_device_builder/controllers/remote_build/cleanup_loop.py
@@ -1,0 +1,60 @@
+"""Receiver-side periodic cleanup sweep for cold remote-build subtrees."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from functools import partial
+from typing import TYPE_CHECKING
+
+from ...helpers.remote_build_cleanup import sweep_remote_builds
+from ...helpers.remote_build_layout import parse_from_configuration
+
+if TYPE_CHECKING:
+    from .receiver import ReceiverController
+
+_LOGGER = logging.getLogger(__name__)
+
+# Cleanup-sweep cadence — TTL itself is the
+# operator-tunable knob (:data:`DEFAULT_CLEANUP_TTL_SECONDS`).
+_CLEANUP_SWEEP_INTERVAL_SECONDS = 60 * 60
+
+
+async def run_cleanup_loop(controller: ReceiverController) -> None:
+    """Sweep cold remote-build subtrees every ``_CLEANUP_SWEEP_INTERVAL_SECONDS``.
+
+    Sleeps before the first cycle — a fresh install has no
+    subtrees to reclaim and the TTL is 24h. Per-cycle
+    failures are logged and the loop continues; cancel via
+    :meth:`ReceiverController.stop` settles cleanly through
+    the sleep.
+    """
+    config_dir = controller._db.settings.config_dir
+    loop = asyncio.get_running_loop()
+    while True:
+        await asyncio.sleep(_CLEANUP_SWEEP_INTERVAL_SECONDS)
+        try:
+            # Re-check firmware narrows the type for mypy and
+            # survives a future spawn/start decoupling.
+            firmware = controller._db.firmware
+            if firmware is None:
+                continue
+            settings = await controller._load_settings_async()
+            in_flight_keys = frozenset(
+                rbp
+                for job in firmware.active_remote_peer_jobs()
+                if (rbp := parse_from_configuration(job.configuration)) is not None
+            )
+            deleted = await loop.run_in_executor(
+                None,
+                partial(
+                    sweep_remote_builds,
+                    config_dir,
+                    ttl_seconds=settings.cleanup_ttl_seconds,
+                    in_flight_keys=in_flight_keys,
+                ),
+            )
+            if deleted:
+                _LOGGER.info("remote-build cleanup: swept %d cold subtree(s)", deleted)
+        except Exception:
+            _LOGGER.exception("remote-build cleanup sweep failed")

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -413,7 +413,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         return self.state.artifacts_download_sender
 
     async def _run_cleanup_loop(self) -> None:
-        """Sweep cold remote-build subtrees every ``_CLEANUP_SWEEP_INTERVAL_SECONDS``."""
+        """Sweep cold remote-build subtrees on a periodic cadence."""
         await cleanup_loop.run_cleanup_loop(self)
 
     @api_command("remote_build/get_settings")

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -22,7 +22,6 @@ import asyncio
 import logging
 import time
 from collections.abc import Callable, Hashable
-from functools import partial
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ...helpers import dashboard_identity as _dashboard_identity_helper
@@ -30,8 +29,6 @@ from ...helpers.api import CommandError, api_command
 from ...helpers.dashboard_identity import get_or_create_identity
 from ...helpers.event_bus import Event
 from ...helpers.peer_link_frames import frame_schema, is_valid_frame
-from ...helpers.remote_build_cleanup import sweep_remote_builds
-from ...helpers.remote_build_layout import parse_from_configuration
 from ...helpers.storage import Store
 from ...models import (
     MAX_CLEANUP_TTL_SECONDS,
@@ -60,6 +57,7 @@ from ..config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
 )
+from . import cleanup_loop
 from ._receiver_state import ReceiverState
 from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
@@ -88,10 +86,6 @@ _PAIRING_WINDOW_DURATION_SECONDS = 300.0
 
 # Required fields on inbound ``cancel_job`` peer-link frames.
 _CANCEL_JOB_SCHEMA = frame_schema({"job_id": str})
-
-# Cleanup-sweep cadence — TTL itself is the
-# operator-tunable knob (:data:`DEFAULT_CLEANUP_TTL_SECONDS`).
-_CLEANUP_SWEEP_INTERVAL_SECONDS = 60 * 60
 
 # Debounce window for the receiver-side peers-store write so a
 # burst of approvals collapses to one disk write.
@@ -419,42 +413,8 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         return self.state.artifacts_download_sender
 
     async def _run_cleanup_loop(self) -> None:
-        """Sweep cold remote-build subtrees every ``_CLEANUP_SWEEP_INTERVAL_SECONDS``.
-
-        Sleeps before the first cycle — a fresh install has no
-        subtrees to reclaim and the TTL is 24h. Per-cycle
-        failures are logged and the loop continues; cancel via
-        :meth:`stop` settles cleanly through the sleep.
-        """
-        config_dir = self._db.settings.config_dir
-        loop = asyncio.get_running_loop()
-        while True:
-            await asyncio.sleep(_CLEANUP_SWEEP_INTERVAL_SECONDS)
-            try:
-                # Re-check firmware narrows the type for mypy and
-                # survives a future spawn/start decoupling.
-                firmware = self._db.firmware
-                if firmware is None:
-                    continue
-                settings = await self._load_settings_async()
-                in_flight_keys = frozenset(
-                    rbp
-                    for job in firmware.active_remote_peer_jobs()
-                    if (rbp := parse_from_configuration(job.configuration)) is not None
-                )
-                deleted = await loop.run_in_executor(
-                    None,
-                    partial(
-                        sweep_remote_builds,
-                        config_dir,
-                        ttl_seconds=settings.cleanup_ttl_seconds,
-                        in_flight_keys=in_flight_keys,
-                    ),
-                )
-                if deleted:
-                    _LOGGER.info("remote-build cleanup: swept %d cold subtree(s)", deleted)
-            except Exception:
-                _LOGGER.exception("remote-build cleanup sweep failed")
+        """Sweep cold remote-build subtrees every ``_CLEANUP_SWEEP_INTERVAL_SECONDS``."""
+        await cleanup_loop.run_cleanup_loop(self)
 
     @api_command("remote_build/get_settings")
     async def get_settings(self, **kwargs: Any) -> RemoteBuildSettingsView:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -4049,7 +4049,7 @@ async def test_run_cleanup_loop_logs_per_cycle_exception_and_continues(
         return 0
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.receiver.sweep_remote_builds",
+        "esphome_device_builder.controllers.remote_build.cleanup_loop.sweep_remote_builds",
         _flaky_sweep,
     )
 
@@ -4098,7 +4098,7 @@ async def test_run_cleanup_loop_short_circuits_when_firmware_missing(
         return 0
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.receiver.sweep_remote_builds",
+        "esphome_device_builder.controllers.remote_build.cleanup_loop.sweep_remote_builds",
         _record_sweep,
     )
 


### PR DESCRIPTION
# What does this implement/fix?

First in the receiver-split arc, mirroring the offloader split (#766 onwards) and devices split (#663 onwards). The `ReceiverState` dataclass already landed (#801), so sibling-module helpers can take `controller` as their first arg and reach through `controller.state.X` from PR 1.

Extracts `_run_cleanup_loop` into `controllers/remote_build/cleanup_loop.py` as `run_cleanup_loop(controller)`. The controller keeps a thin bound-method delegate (`_run_cleanup_loop`) because `start()` schedules it via `self._track_task(self._run_cleanup_loop(), …)`.

## Imports

Moved out of `receiver.py`: `functools.partial`, `sweep_remote_builds`, `parse_from_configuration`, and the `_CLEANUP_SWEEP_INTERVAL_SECONDS` constant.

## Test impact

2 `monkeypatch.setattr` sites in `test_remote_build_controller.py` move from `rb_receiver.sweep_remote_builds` to `rb_cleanup_loop.sweep_remote_builds`. The `offloader.asyncio.sleep` patches stay as-is — those work by patching the global `asyncio.sleep` (any module's `import asyncio` reference is the same module object), so both `offloader` and `cleanup_loop` see the patched sleep.

`receiver.py`: **1083 → 1043 lines** (-40). All 3405 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- First in the ReceiverController split arc. Remaining concern groups: peer-link sessions + queue-status broadcast, pairing window, pair flow / lookup, peer CRUD WS commands, settings WS commands, identity WS commands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
