### PR TITLE
Use esphome.helpers.rmtree for build-tree deletions

### DIFF
--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import re
-import shutil
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any
 
@@ -17,7 +16,7 @@ try:
 except ImportError:  # pragma: no cover; covered by the import below
     from esphome.dashboard.util.text import friendly_name_slugify
 
-from esphome.helpers import sort_ip_addresses
+from esphome.helpers import rmtree, sort_ip_addresses
 from esphome.storage_json import StorageJSON
 
 from ...helpers.api import CommandError
@@ -91,12 +90,17 @@ def _wipe_device_build_dir(configuration: str) -> None:
     Remove the per-device build dir if one exists.
 
     No-op when the StorageJSON sidecar is gone or the device
-    has never been built.
+    has never been built; rmtree failures debug-log + fall
+    through so a partial failure doesn't block the delete flow.
     """
     storage_path = resolve_storage_path(configuration)
     storage = StorageJSON.load(storage_path)
-    if storage is not None and storage.build_path:
-        shutil.rmtree(storage.build_path, ignore_errors=True)
+    if storage is None or not storage.build_path:
+        return
+    try:
+        rmtree(storage.build_path)
+    except OSError as exc:
+        _LOGGER.debug("_wipe_device_build_dir: rmtree(%s) failed: %s", storage.build_path, exc)
 
 
 def _remove_device_sidecars(config_dir: Path, configuration: str) -> None:

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -135,8 +135,9 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             # (esp32 → bk72xx) doesn't leave stale per-platform
             # artefacts that firmware/download could surface as
             # wrong bytes. Best-effort: rmtree failures log + fall
-            # through; the mkdir + extract below recreates the tree
-            # from the upstream tarball regardless.
+            # through; the extract below still overwrites every
+            # member named in the tarball, though stale files the
+            # tarball doesn't mention may survive a failed wipe.
             try:
                 rmtree(build_path)
             except OSError as exc:

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -18,13 +18,13 @@ import io
 import logging
 import os
 import re
-import shutil
 import sys
 import tarfile
 import time
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from esphome.helpers import rmtree
 from esphome.storage_json import StorageJSON
 
 from ..controllers.remote_build.artifacts_tarball import (
@@ -134,8 +134,13 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             # Wipe before extract so a board swap on the same YAML
             # (esp32 → bk72xx) doesn't leave stale per-platform
             # artefacts that firmware/download could surface as
-            # wrong bytes.
-            shutil.rmtree(build_path, ignore_errors=True)
+            # wrong bytes. Best-effort: rmtree failures log + fall
+            # through; the mkdir + extract below recreates the tree
+            # from the upstream tarball regardless.
+            try:
+                rmtree(build_path)
+            except OSError as exc:
+                _LOGGER.debug("materialise: pre-extract rmtree(%s) failed: %s", build_path, exc)
             build_path.mkdir(parents=True, exist_ok=True)
             _safe_extract_excluding(
                 tar,

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -54,7 +54,7 @@ def sweep_remote_builds(
     """Delete cold remote-build subtrees under *config_dir*.
 
     Synchronous; designed to run inside an executor (the
-    filesystem walk + ``shutil.rmtree`` are blocking syscalls).
+    filesystem walk + ``rmtree`` are blocking syscalls).
 
     Args:
         config_dir: The receiver's ``CORE.config_dir`` — the
@@ -183,7 +183,7 @@ def _delete_subtree_and_sibling(key: RemoteBuildPath, config_dir: Path) -> bool:
     try:
         # Via esphome's wrapper so Windows-side read-only files
         # (PIO compile cache, git pack files in cached venvs)
-        # clear instead of raising ``PermissionError``.
+        # get a ``chmod +w`` retry before the OSError propagates.
         rmtree(subtree)
     except OSError as exc:
         _LOGGER.warning("remote-build cleanup: rmtree(%s) failed: %s", subtree, exc)

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -34,9 +34,10 @@ A single bad subtree doesn't kill the sweep for everything else.
 from __future__ import annotations
 
 import logging
-import shutil
 import time
 from pathlib import Path
+
+from esphome.helpers import rmtree
 
 from .remote_build_layout import BUNDLE_SUFFIX, REMOTE_BUILDS_SUBDIR, RemoteBuildPath
 
@@ -180,7 +181,10 @@ def _delete_subtree_and_sibling(key: RemoteBuildPath, config_dir: Path) -> bool:
     subtree = key.subtree(config_dir)
     bundle = key.bundle(config_dir)
     try:
-        shutil.rmtree(subtree)
+        # Via esphome's wrapper so Windows-side read-only files
+        # (PIO compile cache, git pack files in cached venvs)
+        # clear instead of raising ``PermissionError``.
+        rmtree(subtree)
     except OSError as exc:
         _LOGGER.warning("remote-build cleanup: rmtree(%s) failed: %s", subtree, exc)
         return False

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -97,10 +97,10 @@ async def test_archive_wipes_build_directory(
     """An archived device's compile output is dead weight — wipe it.
 
     Same shape as ``_delete_single``: read ``StorageJSON.build_path``
-    and ``shutil.rmtree`` it. Without this the disk savings from
-    archiving a no-longer-used device would be ~the YAML's worth
-    (a few KB), not the build tree's worth (50-200 MB), and users
-    would still complain about disk usage on long-running fleets.
+    and ``rmtree`` it. Without this the disk savings from archiving
+    a no-longer-used device would be ~the YAML's worth (a few KB),
+    not the build tree's worth (50-200 MB), and users would still
+    complain about disk usage on long-running fleets.
     """
     controller = make_controller(tmp_path)
     _, build_path = await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -6,9 +6,9 @@ on archive (``shutil.rmtree(storage_json.build_path, ...)``); the
 new backend skipped it, so repeated create-delete cycles leaked
 hundreds of MB of PlatformIO state per device and a recycled name
 picked up stale build artefacts on the next compile. The fix
-reads ``StorageJSON.build_path`` and ``shutil.rmtree``s it before
-the YAML is unlinked, so a partial failure leaves the user able
-to retry.
+reads ``StorageJSON.build_path`` and ``rmtree``s it before the
+YAML is unlinked, so a partial failure leaves the user able to
+retry.
 """
 
 from __future__ import annotations
@@ -100,6 +100,30 @@ async def test_delete_tolerates_missing_build_directory(
     await controller._delete_single("kitchen.yaml")
 
     assert not yaml_path.exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("redirect_storage_path")
+async def test_delete_tolerates_rmtree_failure(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Windows-style rmtree failure on the build dir doesn't unwind the delete."""
+    controller = make_controller(tmp_path)
+    yaml_path, build_path = _seed_device(tmp_path, "kitchen.yaml")
+
+    def _flaky(path: object, *args: object, **kwargs: object) -> None:
+        raise PermissionError("simulated read-only file on windows")
+
+    monkeypatch.setattr("esphome_device_builder.controllers.devices.helpers.rmtree", _flaky)
+
+    await controller._delete_single("kitchen.yaml")
+
+    # YAML + sidecar still gone; build dir survives because rmtree raised.
+    assert not yaml_path.exists()
+    assert not (tmp_path / ".esphome" / "storage" / "kitchen.yaml.json").exists()
+    assert build_path.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -662,6 +662,34 @@ def test_materialise_idedata_skips_non_dict_flash_image_entry(
     assert isinstance(flash_images[1], dict)
 
 
+def test_materialise_tolerates_pre_extract_rmtree_failure(
+    paired_roots: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Windows-style rmtree failure on the build dir doesn't unwind the materialise."""
+    receiver_root, offloader_root = paired_roots
+    tarball = _pack_in_tmp(receiver_root)
+
+    # First seed an existing build dir + stale file so the wipe
+    # path actually runs (mkdir + extract would otherwise create
+    # everything fresh on first call).
+    stale_build_path = offloader_root / ".esphome" / "build" / "kitchen"
+    stale_build_path.mkdir(parents=True)
+    (stale_build_path / "stale.bin").write_bytes(b"stale")
+
+    def _flaky(path: object, *args: object, **kwargs: object) -> None:
+        raise PermissionError("simulated read-only file on windows")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.remote_artifacts_materialise.rmtree", _flaky
+    )
+
+    # Materialise must not raise; extract proceeds on top of the
+    # un-wiped dir (the mkdir is idempotent, the tar extract
+    # overwrites file-by-file).
+    build_path = _materialise_in_tmp(tarball, offloader_root)
+    assert (build_path / "platformio.ini").is_file()
+
+
 def test_force_idedata_cache_hit_noop_when_files_missing(tmp_path: Path) -> None:
     """``_force_idedata_cache_hit`` returns early when either side doesn't exist."""
     # Neither file exists; helper must not raise.

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from esphome.helpers import rmtree as _esphome_rmtree
 
 from esphome_device_builder.helpers.remote_build_cleanup import (
     _is_cold,
@@ -422,9 +423,10 @@ def test_sweep_continues_after_subtree_rmtree_failure(
     Permission errors / races against a concurrent submit /
     broken symlinks in the tree all happen in production; the
     sweep is best-effort hygiene, a single bad subtree
-    shouldn't poison the rest. Monkeypatches ``shutil.rmtree``
-    to fail on the first call and succeed on the second; the
-    second cold subtree should still get reclaimed.
+    shouldn't poison the rest. Monkeypatches the module's
+    ``rmtree`` binding (the esphome-helpers wrapper) to fail on
+    the first call and succeed on the second; the second cold
+    subtree should still get reclaimed.
     """
     now = 1_000_000.0
     first = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
@@ -432,16 +434,15 @@ def test_sweep_continues_after_subtree_rmtree_failure(
     _populate(tmp_path, first, age_seconds=3600, now=now)
     _populate(tmp_path, second, age_seconds=3600, now=now)
 
-    real_rmtree = __import__("shutil").rmtree
     calls: list[Path] = []
 
     def _flaky(path: str | Path, *args: object, **kwargs: object) -> None:
         calls.append(Path(path))
         if len(calls) == 1:
             raise PermissionError("simulated denied")
-        real_rmtree(path, *args, **kwargs)
+        _esphome_rmtree(path, *args, **kwargs)
 
-    monkeypatch.setattr("esphome_device_builder.helpers.remote_build_cleanup.shutil.rmtree", _flaky)
+    monkeypatch.setattr("esphome_device_builder.helpers.remote_build_cleanup.rmtree", _flaky)
 
     deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     # One success out of two attempts; the failed subtree still


### PR DESCRIPTION
# What does this implement/fix?

Three production callers wiped PIO build trees with raw
`shutil.rmtree`. On Windows the PIO toolchain leaves read-only
files inside (git pack files in cached venvs, generator artefacts
under `.pioenvs/`), and `shutil.rmtree` raises `PermissionError`
on those. Two of the three callers passed `ignore_errors=True`,
which silently swallowed the failure — the cleanup looked
successful but stale per-platform artefacts survived; the third
logged a warning and skipped, accumulating forever on a Windows
receiver.

`esphome.helpers.rmtree` is the documented wrapper for this shape:
clears the read-only bit on `PermissionError` and retries. Switch
all three callers, and replace each `ignore_errors=True` with an
explicit `try/except OSError + _LOGGER.debug` so the swallow stays
deliberate rather than invisible.

## Affected sites

- `controllers/devices/helpers.py:_wipe_device_build_dir` —
  per-device build-dir cleanup on delete. Inherited stale
  artefacts on Windows when a device name was recycled after
  delete.
- `helpers/remote_artifacts_materialise.py:_open_and_extract_build_tree` —
  pre-extract wipe before materialising a receiver tarball. The
  inline comment spelled out the goal ("a board swap on the same
  YAML doesn't leave stale per-platform artefacts that
  firmware/download could surface as wrong bytes"); that
  guarantee was already broken on Windows.
- `helpers/remote_build_cleanup.py:_delete_subtree_and_sibling` —
  receiver-side TTL sweep. Failed rmtree was logged as a
  warning and the subtree skipped; on Windows every cold
  subtree containing a read-only file would skip forever.

## Test coverage

Two new pinning tests cover the deliberate-swallow branches that
the previous `ignore_errors=True` shape gave us for free:

- `test_delete_tolerates_rmtree_failure` — monkeypatches
  the helper-module `rmtree` to raise `PermissionError`; the
  delete still removes the YAML + sidecar.
- `test_materialise_tolerates_pre_extract_rmtree_failure` —
  same shape against the pre-extract wipe; materialise proceeds
  on top of the un-wiped tree (the mkdir is idempotent and the
  tar extract overwrites file-by-file).

The existing `test_sweep_continues_after_subtree_rmtree_failure`
already covers `_delete_subtree_and_sibling`'s defensive arm; the
monkeypatch target moved from
`esphome_device_builder.helpers.remote_build_cleanup.shutil.rmtree`
to `esphome_device_builder.helpers.remote_build_cleanup.rmtree`
(the local binding to the esphome-helpers wrapper).

Full test suite (3383 tests) passes locally.

**Related issue or feature (if applicable):**

- closes #804
- spotted while reviewing the macOS .DS_Store fix (#802) which
  added a third rmtree call to the cleanup module; the audit
  found the two pre-existing latent Windows-correctness bugs

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
