### PR TITLE
Split ReceiverController: extract peer-link sessions

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_sessions.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_sessions.py
@@ -1,0 +1,248 @@
+"""Receiver-side peer-link session lifecycle + queue-status broadcast."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from ...helpers.api import CommandError
+from ...helpers.event_bus import Event
+from ...helpers.peer_link_frames import frame_schema, is_valid_frame
+from ...models import (
+    EventType,
+    QueueStatusFrameData,
+    ReceiverPeerLinkSessionClosedData,
+    ReceiverPeerLinkSessionOpenedData,
+)
+from .peer_link import PeerLinkSession, TerminateReason
+
+if TYPE_CHECKING:
+    from .receiver import ReceiverController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Required fields on inbound ``cancel_job`` peer-link frames.
+_CANCEL_JOB_SCHEMA = frame_schema({"job_id": str})
+
+
+def on_firmware_queue_transition(controller: ReceiverController, event: Event[Any]) -> None:
+    """Bus listener: broadcast ``queue_status`` to paired offloaders.
+
+    Called on every ``JOB_QUEUED`` / ``JOB_STARTED`` /
+    terminal event. Builds a snapshot from the firmware
+    controller's RAM state (sync read, no awaitables in the
+    bus listener) and schedules a per-session broadcast as a
+    background task. The broadcast itself runs async because
+    it sends across N peer-link sessions and we don't want a
+    slow socket on one session to block other listeners
+    observing the same event.
+    """
+    if controller._db.firmware is None:
+        return
+    idle, running, queue_depth = controller._db.firmware.queue_status_snapshot()
+    if not controller.state.peer_link_sessions:
+        return
+    controller._db.create_background_task(
+        broadcast_queue_status(controller, idle, running, queue_depth)
+    )
+
+
+async def broadcast_queue_status(
+    controller: ReceiverController, idle: bool, running: bool, queue_depth: int
+) -> None:
+    """Send a ``queue_status`` frame to every active peer-link session.
+
+    Snapshot the registry to a list before iterating so a
+    concurrent register / unregister mid-walk doesn't mutate
+    the dict under us. Each ``send_app_frame`` is gated on
+    the session's ``_closing`` flag, so a ``terminate``-in-
+    progress session no-ops cleanly here without raising.
+    Per-session failures (``send_app_frame`` returns
+    ``False``) are logged at the channel layer; we don't
+    retry — a session that can't accept the latest snapshot
+    will pick up the next transition's broadcast on its
+    next successful frame.
+    """
+    sessions = list(controller.state.peer_link_sessions.values())
+    payload = QueueStatusFrameData(
+        type="queue_status",
+        idle=idle,
+        running=running,
+        queue_depth=queue_depth,
+    )
+    for session in sessions:
+        # Per-session try/except so one flaky peer can't
+        # starve broadcasts to its siblings; the next queue
+        # transition will retry.
+        try:
+            await session.send_app_frame(dict(payload))
+        except Exception:
+            _LOGGER.exception(
+                "queue_status broadcast to session %s raised; continuing with siblings",
+                session.dashboard_id,
+            )
+
+
+async def register_peer_link_session(
+    controller: ReceiverController, session: PeerLinkSession
+) -> None:
+    """Register *session*; evict a stale same-``dashboard_id`` slot via SUPERSEDED.
+
+    Install runs before the terminate await so concurrent
+    dispatches see the freshest entry. Pushes an initial
+    ``queue_status`` to the offloader — without it,
+    cold-connected pairings never get an entry in
+    ``_peer_queue_status`` and ``pick_build_path`` silently
+    falls back to LOCAL (#568 regression).
+    """
+    existing = controller.state.peer_link_sessions.get(session.dashboard_id)
+    controller.state.peer_link_sessions[session.dashboard_id] = session
+    if existing is not None and existing is not session:
+        await existing.terminate(TerminateReason.SUPERSEDED)
+    if controller._db.firmware is not None:
+        try:
+            idle, running, queue_depth = controller._db.firmware.queue_status_snapshot()
+        except Exception:
+            # Best-effort: the transition-driven broadcast
+            # catches up the offloader on the next change.
+            _LOGGER.exception(
+                "firmware.queue_status_snapshot() raised on session register; "
+                "skipping initial queue_status push to %s",
+                session.dashboard_id,
+            )
+        else:
+            controller._db.create_background_task(
+                _send_initial_queue_status(session, idle, running, queue_depth)
+            )
+    # Fire AFTER the dict insert so subscriber lookups see
+    # the just-registered session.
+    if controller._db.bus is not None:
+        controller._db.bus.fire(
+            EventType.RECEIVER_PEER_LINK_SESSION_OPENED,
+            ReceiverPeerLinkSessionOpenedData(dashboard_id=session.dashboard_id),
+        )
+
+
+async def _send_initial_queue_status(
+    session: PeerLinkSession,
+    idle: bool,
+    running: bool,
+    queue_depth: int,
+) -> None:
+    """Push a one-shot ``queue_status`` frame to a freshly-connected session.
+
+    Single-session counterpart of :func:`broadcast_queue_status` —
+    invoked from :func:`register_peer_link_session` so the
+    offloader gets an idle / running signal on cold-connect
+    rather than waiting for the receiver's next firmware
+    queue transition. Best-effort: a session that has already
+    torn down between the registry insert and this send
+    no-ops cleanly (``send_app_frame`` is gated on the
+    session's ``_closing`` flag) and the offloader's next
+    reconnect tries again.
+    """
+    payload = QueueStatusFrameData(
+        type="queue_status",
+        idle=idle,
+        running=running,
+        queue_depth=queue_depth,
+    )
+    try:
+        await session.send_app_frame(dict(payload))
+    except Exception:
+        _LOGGER.exception(
+            "initial queue_status to session %s raised; "
+            "offloader will catch up on the next queue transition",
+            session.dashboard_id,
+        )
+
+
+def unregister_peer_link_session(controller: ReceiverController, session: PeerLinkSession) -> None:
+    """
+    Drop *session* from the active peer-link registry.
+
+    No-op when a different session has taken the slot (the
+    :func:`register_peer_link_session` dedupe path replaces
+    the entry before the old session's loop unwinds; the old
+    loop's ``finally`` calls this and would otherwise evict
+    the new entry). Sync because it's just a dict pop — the
+    actual WS close + Noise teardown happens in the session
+    loop's ``finally`` chain.
+    """
+    if controller.state.peer_link_sessions.get(session.dashboard_id) is session:
+        del controller.state.peer_link_sessions[session.dashboard_id]
+        # Drop any in-flight ``submit_job`` upload state so a
+        # bundle reception that was mid-stream when the
+        # session ended doesn't outlive the session that owns
+        # it. ``submit_job_receiver`` is set in :meth:`start`;
+        # this branch only runs for sessions registered after
+        # ``start`` (live wire), so the attribute is always
+        # populated by the time we get here.
+        if controller.state.submit_job_receiver is not None:
+            controller.state.submit_job_receiver.discard_session(session.dashboard_id)
+        # Same shape — discard any in-flight artifacts
+        # download for this session so the slot doesn't
+        # outlive the session it was streaming over.
+        if controller.state.artifacts_download_sender is not None:
+            controller.state.artifacts_download_sender.discard_session(session.dashboard_id)
+        # Fire only when we actually dropped the slot — the
+        # no-op path (a SUPERSEDED-evicted session running its
+        # finally-block after the new session has taken its
+        # place) would double-fire CLOSED for a single
+        # logical close otherwise.
+        if controller._db.bus is not None:
+            controller._db.bus.fire(
+                EventType.RECEIVER_PEER_LINK_SESSION_CLOSED,
+                ReceiverPeerLinkSessionClosedData(dashboard_id=session.dashboard_id),
+            )
+
+
+async def handle_cancel_job(
+    controller: ReceiverController, session: PeerLinkSession, frame: dict[str, Any]
+) -> None:
+    """Receiver-side dispatch for inbound ``cancel_job`` frames.
+
+    Resolves the offloader's ``job_id`` to the receiver-local
+    :class:`FirmwareJob` via :class:`JobFanout` and routes
+    through :meth:`FirmwareController.cancel` — same path as
+    an operator-driven cancel. No wire ack; the fan-out's
+    ``job_state_changed{cancelled}`` carries the result.
+
+    Silent debug-log drops for malformed frames, unknown
+    correlations (race with a terminal transition), and
+    :class:`CommandError` from cancel (already-terminal).
+    """
+    if not is_valid_frame(_CANCEL_JOB_SCHEMA, frame):
+        _LOGGER.debug(
+            "peer-link cancel_job from %s: malformed frame; dropping: %r",
+            session.dashboard_id,
+            frame,
+        )
+        return
+    if controller.state.job_fanout is None or controller._db.firmware is None:
+        _LOGGER.debug(
+            "peer-link cancel_job from %s before controller fully started; dropping",
+            session.dashboard_id,
+        )
+        return
+    remote_job_id = cast(str, frame["job_id"])
+    firmware_job_id = controller.state.job_fanout.resolve_firmware_job_id(
+        session.dashboard_id, remote_job_id
+    )
+    if firmware_job_id is None:
+        _LOGGER.debug(
+            "peer-link cancel_job from %s: no firmware job for remote_job_id=%r; dropping",
+            session.dashboard_id,
+            remote_job_id,
+        )
+        return
+    try:
+        await controller._db.firmware.cancel(job_id=firmware_job_id)
+    except CommandError as exc:
+        _LOGGER.debug(
+            "peer-link cancel_job from %s: firmware refused cancel for job %s: %s",
+            session.dashboard_id,
+            firmware_job_id,
+            exc.message,
+        )

--- a/esphome_device_builder/controllers/remote_build/peer_link_sessions.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_sessions.py
@@ -91,10 +91,9 @@ async def register_peer_link_session(
 
     Install runs before the terminate await so concurrent
     dispatches see the freshest entry. Pushes an initial
-    ``queue_status`` to the offloader — without it,
-    cold-connected pairings never get an entry in
-    ``_peer_queue_status`` and ``pick_build_path`` silently
-    falls back to LOCAL (#568 regression).
+    ``queue_status`` to the offloader so cold-connected
+    pairings get an idle / running signal without waiting
+    on the next firmware transition.
     """
     existing = controller.state.peer_link_sessions.get(session.dashboard_id)
     controller.state.peer_link_sessions[session.dashboard_id] = session
@@ -124,40 +123,6 @@ async def register_peer_link_session(
         )
 
 
-async def _send_initial_queue_status(
-    session: PeerLinkSession,
-    idle: bool,
-    running: bool,
-    queue_depth: int,
-) -> None:
-    """Push a one-shot ``queue_status`` frame to a freshly-connected session.
-
-    Single-session counterpart of :func:`broadcast_queue_status` —
-    invoked from :func:`register_peer_link_session` so the
-    offloader gets an idle / running signal on cold-connect
-    rather than waiting for the receiver's next firmware
-    queue transition. Best-effort: a session that has already
-    torn down between the registry insert and this send
-    no-ops cleanly (``send_app_frame`` is gated on the
-    session's ``_closing`` flag) and the offloader's next
-    reconnect tries again.
-    """
-    payload = QueueStatusFrameData(
-        type="queue_status",
-        idle=idle,
-        running=running,
-        queue_depth=queue_depth,
-    )
-    try:
-        await session.send_app_frame(dict(payload))
-    except Exception:
-        _LOGGER.exception(
-            "initial queue_status to session %s raised; "
-            "offloader will catch up on the next queue transition",
-            session.dashboard_id,
-        )
-
-
 def unregister_peer_link_session(controller: ReceiverController, session: PeerLinkSession) -> None:
     """
     Drop *session* from the active peer-link registry.
@@ -181,9 +146,6 @@ def unregister_peer_link_session(controller: ReceiverController, session: PeerLi
         # populated by the time we get here.
         if controller.state.submit_job_receiver is not None:
             controller.state.submit_job_receiver.discard_session(session.dashboard_id)
-        # Same shape — discard any in-flight artifacts
-        # download for this session so the slot doesn't
-        # outlive the session it was streaming over.
         if controller.state.artifacts_download_sender is not None:
             controller.state.artifacts_download_sender.discard_session(session.dashboard_id)
         # Fire only when we actually dropped the slot — the
@@ -245,4 +207,27 @@ async def handle_cancel_job(
             session.dashboard_id,
             firmware_job_id,
             exc.message,
+        )
+
+
+async def _send_initial_queue_status(
+    session: PeerLinkSession,
+    idle: bool,
+    running: bool,
+    queue_depth: int,
+) -> None:
+    """Push a one-shot ``queue_status`` frame to a freshly-connected session."""
+    payload = QueueStatusFrameData(
+        type="queue_status",
+        idle=idle,
+        running=running,
+        queue_depth=queue_depth,
+    )
+    try:
+        await session.send_app_frame(dict(payload))
+    except Exception:
+        _LOGGER.exception(
+            "initial queue_status to session %s raised; "
+            "offloader will catch up on the next queue transition",
+            session.dashboard_id,
         )

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -22,13 +22,12 @@ import asyncio
 import logging
 import time
 from collections.abc import Callable, Hashable
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 from ...helpers import dashboard_identity as _dashboard_identity_helper
 from ...helpers.api import CommandError, api_command
 from ...helpers.dashboard_identity import get_or_create_identity
 from ...helpers.event_bus import Event
-from ...helpers.peer_link_frames import frame_schema, is_valid_frame
 from ...helpers.storage import Store
 from ...models import (
     MAX_CLEANUP_TTL_SECONDS,
@@ -41,9 +40,6 @@ from ...models import (
     PairingWindowState,
     PeerStatus,
     PeerSummary,
-    QueueStatusFrameData,
-    ReceiverPeerLinkSessionClosedData,
-    ReceiverPeerLinkSessionOpenedData,
     ReceiverPeers,
     RemoteBuildIdentityRotatedData,
     RemoteBuildPairingWindowChangedData,
@@ -57,7 +53,7 @@ from ..config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
 )
-from . import cleanup_loop
+from . import cleanup_loop, peer_link_sessions
 from ._receiver_state import ReceiverState
 from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
@@ -83,9 +79,6 @@ _LOGGER = logging.getLogger(__name__)
 # Pairing-window lifetime. Auto-closes after this much idle;
 # the frontend extends on each activity tick.
 _PAIRING_WINDOW_DURATION_SECONDS = 300.0
-
-# Required fields on inbound ``cancel_job`` peer-link frames.
-_CANCEL_JOB_SCHEMA = frame_schema({"job_id": str})
 
 # Debounce window for the receiver-side peers-store write so a
 # burst of approvals collapses to one disk write.
@@ -183,214 +176,20 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         )
 
     def _on_firmware_queue_transition(self, event: Event[Any]) -> None:
-        """Bus listener: broadcast ``queue_status`` to paired offloaders.
-
-        Called on every ``JOB_QUEUED`` / ``JOB_STARTED`` /
-        terminal event. Builds a snapshot from the firmware
-        controller's RAM state (sync read, no awaitables in the
-        bus listener) and schedules a per-session broadcast as a
-        background task. The broadcast itself runs async because
-        it sends across N peer-link sessions and we don't want a
-        slow socket on one session to block other listeners
-        observing the same event.
-        """
-        if self._db.firmware is None:
-            return
-        idle, running, queue_depth = self._db.firmware.queue_status_snapshot()
-        if not self.state.peer_link_sessions:
-            return
-        self._db.create_background_task(self._broadcast_queue_status(idle, running, queue_depth))
-
-    async def _broadcast_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
-        """Send a ``queue_status`` frame to every active peer-link session.
-
-        Snapshot the registry to a list before iterating so a
-        concurrent register / unregister mid-walk doesn't mutate
-        the dict under us. Each ``send_app_frame`` is gated on
-        the session's ``_closing`` flag, so a ``terminate``-in-
-        progress session no-ops cleanly here without raising.
-        Per-session failures (``send_app_frame`` returns
-        ``False``) are logged at the channel layer; we don't
-        retry — a session that can't accept the latest snapshot
-        will pick up the next transition's broadcast on its
-        next successful frame.
-        """
-        sessions = list(self.state.peer_link_sessions.values())
-        payload = QueueStatusFrameData(
-            type="queue_status",
-            idle=idle,
-            running=running,
-            queue_depth=queue_depth,
-        )
-        for session in sessions:
-            # Per-session try/except so one flaky peer can't
-            # starve broadcasts to its siblings; the next queue
-            # transition will retry.
-            try:
-                await session.send_app_frame(dict(payload))
-            except Exception:
-                _LOGGER.exception(
-                    "queue_status broadcast to session %s raised; continuing with siblings",
-                    session.dashboard_id,
-                )
+        """Bus listener: broadcast ``queue_status`` to paired offloaders."""
+        peer_link_sessions.on_firmware_queue_transition(self, event)
 
     async def register_peer_link_session(self, session: PeerLinkSession) -> None:
-        """Register *session*; evict a stale same-``dashboard_id`` slot via SUPERSEDED.
-
-        Install runs before the terminate await so concurrent
-        dispatches see the freshest entry. Pushes an initial
-        ``queue_status`` to the offloader — without it,
-        cold-connected pairings never get an entry in
-        ``_peer_queue_status`` and ``pick_build_path`` silently
-        falls back to LOCAL (#568 regression).
-        """
-        existing = self.state.peer_link_sessions.get(session.dashboard_id)
-        self.state.peer_link_sessions[session.dashboard_id] = session
-        if existing is not None and existing is not session:
-            await existing.terminate(TerminateReason.SUPERSEDED)
-        if self._db.firmware is not None:
-            try:
-                idle, running, queue_depth = self._db.firmware.queue_status_snapshot()
-            except Exception:
-                # Best-effort: the transition-driven broadcast
-                # catches up the offloader on the next change.
-                _LOGGER.exception(
-                    "firmware.queue_status_snapshot() raised on session register; "
-                    "skipping initial queue_status push to %s",
-                    session.dashboard_id,
-                )
-            else:
-                self._db.create_background_task(
-                    self._send_initial_queue_status(session, idle, running, queue_depth)
-                )
-        # Fire AFTER the dict insert so subscriber lookups see
-        # the just-registered session.
-        if self._db.bus is not None:
-            self._db.bus.fire(
-                EventType.RECEIVER_PEER_LINK_SESSION_OPENED,
-                ReceiverPeerLinkSessionOpenedData(dashboard_id=session.dashboard_id),
-            )
-
-    async def _send_initial_queue_status(
-        self,
-        session: PeerLinkSession,
-        idle: bool,
-        running: bool,
-        queue_depth: int,
-    ) -> None:
-        """Push a one-shot ``queue_status`` frame to a freshly-connected session.
-
-        Mirror of :meth:`_broadcast_queue_status` but addressed
-        to a single session — invoked from
-        :meth:`register_peer_link_session` so the offloader gets
-        an idle / running signal on cold-connect rather than
-        waiting for the receiver's next firmware queue
-        transition. Best-effort: a session that has already
-        torn down between the registry insert and this send
-        no-ops cleanly (``send_app_frame`` is gated on the
-        session's ``_closing`` flag) and the offloader's next
-        reconnect tries again.
-        """
-        payload = QueueStatusFrameData(
-            type="queue_status",
-            idle=idle,
-            running=running,
-            queue_depth=queue_depth,
-        )
-        try:
-            await session.send_app_frame(dict(payload))
-        except Exception:
-            _LOGGER.exception(
-                "initial queue_status to session %s raised; "
-                "offloader will catch up on the next queue transition",
-                session.dashboard_id,
-            )
+        """Register *session*; evict a stale same-``dashboard_id`` slot via SUPERSEDED."""
+        await peer_link_sessions.register_peer_link_session(self, session)
 
     def unregister_peer_link_session(self, session: PeerLinkSession) -> None:
-        """
-        Drop *session* from the active peer-link registry.
-
-        No-op when a different session has taken the slot (the
-        :meth:`register_peer_link_session` dedupe path replaces
-        the entry before the old session's loop unwinds; the old
-        loop's ``finally`` calls this and would otherwise evict
-        the new entry). Sync because it's just a dict pop — the
-        actual WS close + Noise teardown happens in the session
-        loop's ``finally`` chain.
-        """
-        if self.state.peer_link_sessions.get(session.dashboard_id) is session:
-            del self.state.peer_link_sessions[session.dashboard_id]
-            # Drop any in-flight ``submit_job`` upload state so a
-            # bundle reception that was mid-stream when the
-            # session ended doesn't outlive the session that owns
-            # it. ``_submit_job_receiver`` is set in :meth:`start`;
-            # this branch only runs for sessions registered after
-            # ``start`` (live wire), so the attribute is always
-            # populated by the time we get here.
-            if self.state.submit_job_receiver is not None:
-                self.state.submit_job_receiver.discard_session(session.dashboard_id)
-            # Same shape — discard any in-flight artifacts
-            # download for this session so the slot doesn't
-            # outlive the session it was streaming over.
-            if self.state.artifacts_download_sender is not None:
-                self.state.artifacts_download_sender.discard_session(session.dashboard_id)
-            # Fire only when we actually dropped the slot — the
-            # no-op path (a SUPERSEDED-evicted session running its
-            # finally-block after the new session has taken its
-            # place) would double-fire CLOSED for a single
-            # logical close otherwise.
-            if self._db.bus is not None:
-                self._db.bus.fire(
-                    EventType.RECEIVER_PEER_LINK_SESSION_CLOSED,
-                    ReceiverPeerLinkSessionClosedData(dashboard_id=session.dashboard_id),
-                )
+        """Drop *session* from the active peer-link registry."""
+        peer_link_sessions.unregister_peer_link_session(self, session)
 
     async def handle_cancel_job(self, session: PeerLinkSession, frame: dict[str, Any]) -> None:
-        """Receiver-side dispatch for inbound ``cancel_job`` frames.
-
-        Resolves the offloader's ``job_id`` to the receiver-local
-        :class:`FirmwareJob` via :class:`JobFanout` and routes
-        through :meth:`FirmwareController.cancel` — same path as
-        an operator-driven cancel. No wire ack; the fan-out's
-        ``job_state_changed{cancelled}`` carries the result.
-
-        Silent debug-log drops for malformed frames, unknown
-        correlations (race with a terminal transition), and
-        :class:`CommandError` from cancel (already-terminal).
-        """
-        if not is_valid_frame(_CANCEL_JOB_SCHEMA, frame):
-            _LOGGER.debug(
-                "peer-link cancel_job from %s: malformed frame; dropping: %r",
-                session.dashboard_id,
-                frame,
-            )
-            return
-        if self.state.job_fanout is None or self._db.firmware is None:
-            _LOGGER.debug(
-                "peer-link cancel_job from %s before controller fully started; dropping",
-                session.dashboard_id,
-            )
-            return
-        remote_job_id = cast(str, frame["job_id"])
-        firmware_job_id = self.state.job_fanout.resolve_firmware_job_id(
-            session.dashboard_id, remote_job_id
-        )
-        if firmware_job_id is None:
-            _LOGGER.debug(
-                "peer-link cancel_job from %s: no firmware job for remote_job_id=%r; dropping",
-                session.dashboard_id,
-                remote_job_id,
-            )
-            return
-        try:
-            await self._db.firmware.cancel(job_id=firmware_job_id)
-        except CommandError as exc:
-            _LOGGER.debug(
-                "peer-link cancel_job from %s: firmware refused cancel for job %s: %s",
-                session.dashboard_id,
-                firmware_job_id,
-                exc.message,
-            )
+        """Receiver-side dispatch for inbound ``cancel_job`` frames."""
+        await peer_link_sessions.handle_cancel_job(self, session, frame)
 
     def get_submit_job_receiver(self) -> SubmitJobReceiver:
         """Return the receiver-side ``submit_job`` flow handler, raising if not started.

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -29,6 +29,9 @@ from esphome_device_builder.controllers.remote_build import (
     OffloaderController,
     ReceiverController,
 )
+from esphome_device_builder.controllers.remote_build import (
+    peer_link_sessions as rb_peer_link_sessions,
+)
 from esphome_device_builder.controllers.remote_build import rebind as rb_rebind
 from esphome_device_builder.controllers.remote_build import receiver as rb_rcv
 from esphome_device_builder.controllers.remote_build._mdns import (
@@ -3784,10 +3787,10 @@ async def test_broadcast_queue_status_continues_past_failed_session(
     session (race with concurrent terminate), a transport
     error, or any other unexpected raise on one session must
     not cancel the broadcast for the others. The per-session
-    ``try/except`` in :meth:`_broadcast_queue_status` swallows
-    the raise (logged) and moves on. Without this contract a
-    single flaky peer would starve every paired offloader of
-    queue-status updates.
+    ``try/except`` in :func:`peer_link_sessions.broadcast_queue_status`
+    swallows the raise (logged) and moves on. Without this
+    contract a single flaky peer would starve every paired
+    offloader of queue-status updates.
     """
     controller = _make_controller(config_dir=tmp_path)
 
@@ -3798,7 +3801,9 @@ async def test_broadcast_queue_status_continues_past_failed_session(
     controller.receiver.state.peer_link_sessions["beta"] = beta
 
     with caplog.at_level("ERROR"):
-        await controller.receiver._broadcast_queue_status(idle=False, running=True, queue_depth=1)
+        await rb_peer_link_sessions.broadcast_queue_status(
+            controller.receiver, idle=False, running=True, queue_depth=1
+        )
     alpha.send_app_frame.assert_awaited_once()
     # Sibling session received the snapshot despite alpha raising.
     beta.send_app_frame.assert_awaited_once_with(


### PR DESCRIPTION
# What does this implement/fix?

Second in the receiver-split arc (after #809 cleanup loop). Extracts the peer-link session lifecycle plus the queue-status broadcast cluster into a new sibling module `controllers/remote_build/peer_link_sessions.py`:

- `register_peer_link_session` — registers a new session, evicts a stale same-`dashboard_id` slot via SUPERSEDED, pushes an initial queue_status push.
- `unregister_peer_link_session` — drops a session from the registry, fires CLOSED.
- `handle_cancel_job` — receiver-side dispatch for inbound `cancel_job` peer-link frames.
- `on_firmware_queue_transition` — bus listener that schedules a per-session queue_status broadcast on every firmware lifecycle event.
- `broadcast_queue_status` — fans the snapshot out to every active session.
- `_send_initial_queue_status` — single-session counterpart used by `register_peer_link_session`; module-private (only the register path uses it).

The four public entry points stay as bound-method delegates on the controller (`start()` registers the firmware listener with `self._on_firmware_queue_transition`; peer-link session entry points are part of the cross-controller surface). Bodies take `ReceiverController` as the first arg; sibling state goes through `controller.state.X`.

## Imports

Moved out of `receiver.py`: `cast`, `frame_schema` / `is_valid_frame`, `QueueStatusFrameData`, `ReceiverPeerLinkSessionClosedData` / `ReceiverPeerLinkSessionOpenedData`, and the `_CANCEL_JOB_SCHEMA` constant.

## Test impact

1 test that called `controller.receiver._broadcast_queue_status(...)` directly moved to `rb_peer_link_sessions.broadcast_queue_status(receiver, ...)`. The other 3 tests calling `_on_firmware_queue_transition` go through the bound delegate unchanged.

`receiver.py`: **1043 → 842 lines** (-201). Combined with #809: 1083 → 842 (-241, **-22%**). All 3412 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the ReceiverController split arc. Remaining concern groups: pairing window, pair flow / lookup, peer CRUD WS commands, settings WS commands, identity WS commands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
