### PR TITLE
Extract automation inline handlers into yaml/inline.py

### DIFF
--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import re
-
 import yaml
 
 # Prefer the libyaml-backed C loader when PyYAML was built against
@@ -33,227 +31,27 @@ except AttributeError:  # pragma: no cover
     FastestSafeLoader = yaml.SafeLoader
 
 
-def upsert_inline_handler(
-    yaml_text: str,
-    *,
-    component_domain: str,
-    component_id: str,
-    handler_key: str,
-    rendered_yaml: str,
-) -> tuple[str, int, int] | None:
-    """
-    Insert or replace ``<handler_key>:`` inline under a configured component.
-
-    Used by the automation writer for inline ``on_*:`` triggers under
-    component instances (``binary_sensor[i].on_press``, ``light[i].on_turn_on``,
-    ...) and for ``effects:`` entries under a light. Returns
-    ``(new_yaml_text, from_line, to_line)`` matching the
-    :class:`automations.YamlDiff` convention — ``from_line <= to_line``
-    for a replace, ``to_line == from_line - 1`` for a pure insert.
-    ``None`` when the component instance can't be located (no
-    ``id:`` match under ``<component_domain>:``).
-
-    Adjacent siblings are preserved: this only touches the lines
-    spanning ``<handler_key>:`` and its indented children. The
-    *rendered_yaml* string is emitted at the same indent as the
-    sibling fields.
-    """
-    lines = yaml_text.splitlines(keepends=True)
-    span = _locate_component_instance(lines, component_domain, component_id)
-    if span is None:
-        return None
-    instance_start, instance_end, child_indent = span
-
-    # Look for an existing ``<handler_key>:`` line under this
-    # instance. The key is at exactly ``child_indent`` columns of
-    # leading whitespace.
-    handler_re = re.compile(rf"^{re.escape(child_indent)}{re.escape(handler_key)}:\s*(?:#.*)?$")
-    handler_start: int | None = None
-    handler_end: int | None = None
-    for idx in range(instance_start, instance_end):
-        if handler_re.match(lines[idx].rstrip("\n\r")):
-            handler_start = idx
-            # Walk forward to find the first sibling-indented line
-            # (or instance end).
-            for jdx in range(idx + 1, instance_end):
-                content = lines[jdx].rstrip("\n\r")
-                if not content:
-                    continue
-                leading = len(content) - len(content.lstrip(" "))
-                if leading <= len(child_indent):
-                    handler_end = jdx
-                    break
-            if handler_end is None:
-                handler_end = instance_end
-            break
-
-    rendered_lines = _indent_block(rendered_yaml, child_indent)
-    rendered_text = "\n".join(rendered_lines) + "\n"
-
-    if handler_start is not None and handler_end is not None:
-        # Replace the existing handler block.
-        new_lines = [*lines[:handler_start], rendered_text, *lines[handler_end:]]
-        new_text = "".join(new_lines)
-        return new_text, handler_start + 1, handler_end
-    # Insert a new handler at the end of the instance, before any
-    # trailing blank lines.
-    insert_at = instance_end
-    while insert_at > instance_start + 1 and not lines[insert_at - 1].strip():
-        insert_at -= 1
-    new_lines = [*lines[:insert_at], rendered_text, *lines[insert_at:]]
-    new_text = "".join(new_lines)
-    # Pure-insert: ``toLine == fromLine - 1`` flags the empty
-    # replaced range. See :class:`automations.YamlDiff`.
-    return new_text, insert_at + 1, insert_at
-
-
-def remove_inline_handler(
-    yaml_text: str,
-    *,
-    component_domain: str,
-    component_id: str,
-    handler_key: str,
-) -> tuple[str, int, int] | None:
-    """
-    Delete an inline handler under a configured component.
-
-    Returns ``(new_yaml_text, from_line, to_line)`` matching the
-    same :class:`automations.YamlDiff` shape ``upsert_inline_handler``
-    emits, or ``None`` when the handler isn't there.
-    """
-    lines = yaml_text.splitlines(keepends=True)
-    span = _locate_component_instance(lines, component_domain, component_id)
-    if span is None:
-        return None
-    instance_start, instance_end, child_indent = span
-    handler_re = re.compile(rf"^{re.escape(child_indent)}{re.escape(handler_key)}:\s*(?:#.*)?$")
-    for idx in range(instance_start, instance_end):
-        if not handler_re.match(lines[idx].rstrip("\n\r")):
-            continue
-        handler_end = instance_end
-        for jdx in range(idx + 1, instance_end):
-            content = lines[jdx].rstrip("\n\r")
-            if not content:
-                continue
-            leading = len(content) - len(content.lstrip(" "))
-            if leading <= len(child_indent):
-                handler_end = jdx
-                break
-        new_lines = [*lines[:idx], *lines[handler_end:]]
-        return "".join(new_lines), idx + 1, handler_end
-    return None
-
-
-def _locate_component_instance(
-    lines: list[str],
-    domain: str,
-    component_id: str,
-) -> tuple[int, int, str] | None:
-    """
-    Find the line range of a specific ``- id: <component_id>`` block.
-
-    Returns ``(start_idx, end_idx, child_indent)`` — dash-line
-    index, one-past-last-line index, and the leading whitespace of
-    the instance's child fields.
-    """
-    header_re = re.compile(rf"^{re.escape(domain)}:\s*(?:#.*)?$")
-    domain_start: int | None = None
-    for idx, line in enumerate(lines):
-        if header_re.match(line.rstrip("\n\r")):
-            domain_start = idx
-            break
-    if domain_start is None:
-        return None
-    domain_end = len(lines)
-    for idx in range(domain_start + 1, len(lines)):
-        stripped = lines[idx].rstrip("\n\r")
-        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
-            domain_end = idx
-            break
-
-    # Walk the domain body looking for a list item whose first child
-    # line carries ``id: <component_id>``. Only column-2 dashes count
-    # as instance starts — deeper dashes are inner action lists.
-    item_indent: str | None = None
-    item_starts: list[int] = []
-    for idx in range(domain_start + 1, domain_end):
-        raw = lines[idx].rstrip("\n\r")
-        stripped = raw.lstrip(" ")
-        if not stripped.startswith("- "):
-            continue
-        prefix = raw[: len(raw) - len(stripped)]
-        if item_indent is None:
-            item_indent = prefix
-        if prefix != item_indent:
-            # Inner action list — deeper indent than the canonical
-            # list-of-instances. Skip.
-            continue
-        item_starts.append(idx)
-
-    for run, start in enumerate(item_starts):
-        end = item_starts[run + 1] if run + 1 < len(item_starts) else domain_end
-        dash_indent = lines[start][: len(lines[start]) - len(lines[start].lstrip(" "))]
-        child_indent = dash_indent + ESPHOME_YAML_INDENT
-        if _instance_id_matches(lines, start, end, child_indent, component_id):
-            return start, end, child_indent
-    return None
-
-
-def _instance_id_matches(
-    lines: list[str],
-    start: int,
-    end: int,
-    child_indent: str,
-    component_id: str,
-) -> bool:
-    """
-    Return True iff the instance at *start* carries ``id: component_id``.
-
-    Two shapes the schema permits: ``- id: <comp_id>`` on the dash
-    line itself, or ``id:`` as a regular child field at
-    ``child_indent`` on a later line.
-    """
-    first_line = lines[start].rstrip("\n\r")
-    inline_match = re.match(r"^\s*-\s*id:\s*(?P<id>\S+)", first_line)
-    if inline_match:
-        return inline_match.group("id") == component_id
-    child_re = re.compile(rf"^{re.escape(child_indent)}id:\s*(?P<id>\S+)")
-    for jdx in range(start, end):
-        m = child_re.match(lines[jdx].rstrip("\n\r"))
-        if m:
-            return m.group("id") == component_id
-    return False
-
-
-def _indent_block(block_text: str, indent: str) -> list[str]:
-    """Return *block_text* with every non-empty line prefixed by *indent*."""
-    out: list[str] = []
-    for line in block_text.splitlines():
-        if not line:
-            out.append("")
-            continue
-        out.append(indent + line)
-    return out
-
-
 # Re-exports at the bottom. Redundant-alias form marks these as
 # intentional re-exports (PEP 484) so external callers'
 # ``from .helpers.yaml import X`` keeps working unchanged across
 # the split arc.
-from .api_encryption import generate_api_encryption_key as generate_api_encryption_key  # noqa: E402
-from .api_encryption import rewrite_api_encryption_key as rewrite_api_encryption_key  # noqa: E402
-from .component import _splice_into_domain_block as _splice_into_domain_block  # noqa: E402
-from .component import generate_component_yaml as generate_component_yaml  # noqa: E402
-from .component import merge_component_yaml as merge_component_yaml  # noqa: E402
-from .scalar import ESPHOME_YAML_INDENT as ESPHOME_YAML_INDENT  # noqa: E402
-from .scalar import YamlUpsertNotSupportedError as YamlUpsertNotSupportedError  # noqa: E402
-from .scalar import _quote as _quote  # noqa: E402
-from .scalar import _safe_yaml_scalar as _safe_yaml_scalar  # noqa: E402
-from .scalar import _strip_yaml_quotes as _strip_yaml_quotes  # noqa: E402
-from .scalar import read_yaml_scalar as read_yaml_scalar  # noqa: E402
-from .scalar import rewrite_yaml_scalar as rewrite_yaml_scalar  # noqa: E402
-from .substitution import parse_substitution_ref as parse_substitution_ref  # noqa: E402
-from .substitution import rewrite_name_or_substitution as rewrite_name_or_substitution  # noqa: E402
-from .top_block import (  # noqa: E402
+from .api_encryption import generate_api_encryption_key as generate_api_encryption_key
+from .api_encryption import rewrite_api_encryption_key as rewrite_api_encryption_key
+from .component import _splice_into_domain_block as _splice_into_domain_block
+from .component import generate_component_yaml as generate_component_yaml
+from .component import merge_component_yaml as merge_component_yaml
+from .inline import _indent_block as _indent_block
+from .inline import remove_inline_handler as remove_inline_handler
+from .inline import upsert_inline_handler as upsert_inline_handler
+from .scalar import ESPHOME_YAML_INDENT as ESPHOME_YAML_INDENT
+from .scalar import YamlUpsertNotSupportedError as YamlUpsertNotSupportedError
+from .scalar import _quote as _quote
+from .scalar import _safe_yaml_scalar as _safe_yaml_scalar
+from .scalar import _strip_yaml_quotes as _strip_yaml_quotes
+from .scalar import read_yaml_scalar as read_yaml_scalar
+from .scalar import rewrite_yaml_scalar as rewrite_yaml_scalar
+from .substitution import parse_substitution_ref as parse_substitution_ref
+from .substitution import rewrite_name_or_substitution as rewrite_name_or_substitution
+from .top_block import (
     upsert_yaml_leaf_under_top_block as upsert_yaml_leaf_under_top_block,
 )

--- a/esphome_device_builder/helpers/yaml/inline.py
+++ b/esphome_device_builder/helpers/yaml/inline.py
@@ -1,0 +1,210 @@
+"""Inline-handler edits: upsert / remove ``on_*:`` blocks under configured components."""
+
+from __future__ import annotations
+
+import re
+
+from .scalar import ESPHOME_YAML_INDENT
+
+
+def upsert_inline_handler(
+    yaml_text: str,
+    *,
+    component_domain: str,
+    component_id: str,
+    handler_key: str,
+    rendered_yaml: str,
+) -> tuple[str, int, int] | None:
+    """
+    Insert or replace ``<handler_key>:`` inline under a configured component.
+
+    Used by the automation writer for inline ``on_*:`` triggers under
+    component instances (``binary_sensor[i].on_press``, ``light[i].on_turn_on``,
+    ...) and for ``effects:`` entries under a light. Returns
+    ``(new_yaml_text, from_line, to_line)`` matching the
+    :class:`automations.YamlDiff` convention — ``from_line <= to_line``
+    for a replace, ``to_line == from_line - 1`` for a pure insert.
+    ``None`` when the component instance can't be located (no
+    ``id:`` match under ``<component_domain>:``).
+
+    Adjacent siblings are preserved: this only touches the lines
+    spanning ``<handler_key>:`` and its indented children. The
+    *rendered_yaml* string is emitted at the same indent as the
+    sibling fields.
+    """
+    lines = yaml_text.splitlines(keepends=True)
+    span = _locate_component_instance(lines, component_domain, component_id)
+    if span is None:
+        return None
+    instance_start, instance_end, child_indent = span
+
+    # Look for an existing ``<handler_key>:`` line under this
+    # instance. The key is at exactly ``child_indent`` columns of
+    # leading whitespace.
+    handler_re = re.compile(rf"^{re.escape(child_indent)}{re.escape(handler_key)}:\s*(?:#.*)?$")
+    handler_start: int | None = None
+    handler_end: int | None = None
+    for idx in range(instance_start, instance_end):
+        if handler_re.match(lines[idx].rstrip("\n\r")):
+            handler_start = idx
+            # Walk forward to find the first sibling-indented line
+            # (or instance end).
+            for jdx in range(idx + 1, instance_end):
+                content = lines[jdx].rstrip("\n\r")
+                if not content:
+                    continue
+                leading = len(content) - len(content.lstrip(" "))
+                if leading <= len(child_indent):
+                    handler_end = jdx
+                    break
+            if handler_end is None:
+                handler_end = instance_end
+            break
+
+    rendered_lines = _indent_block(rendered_yaml, child_indent)
+    rendered_text = "\n".join(rendered_lines) + "\n"
+
+    if handler_start is not None and handler_end is not None:
+        # Replace the existing handler block.
+        new_lines = [*lines[:handler_start], rendered_text, *lines[handler_end:]]
+        new_text = "".join(new_lines)
+        return new_text, handler_start + 1, handler_end
+    # Insert a new handler at the end of the instance, before any
+    # trailing blank lines.
+    insert_at = instance_end
+    while insert_at > instance_start + 1 and not lines[insert_at - 1].strip():
+        insert_at -= 1
+    new_lines = [*lines[:insert_at], rendered_text, *lines[insert_at:]]
+    new_text = "".join(new_lines)
+    # Pure-insert: ``toLine == fromLine - 1`` flags the empty
+    # replaced range. See :class:`automations.YamlDiff`.
+    return new_text, insert_at + 1, insert_at
+
+
+def remove_inline_handler(
+    yaml_text: str,
+    *,
+    component_domain: str,
+    component_id: str,
+    handler_key: str,
+) -> tuple[str, int, int] | None:
+    """
+    Delete an inline handler under a configured component.
+
+    Returns ``(new_yaml_text, from_line, to_line)`` matching the
+    same :class:`automations.YamlDiff` shape ``upsert_inline_handler``
+    emits, or ``None`` when the handler isn't there.
+    """
+    lines = yaml_text.splitlines(keepends=True)
+    span = _locate_component_instance(lines, component_domain, component_id)
+    if span is None:
+        return None
+    instance_start, instance_end, child_indent = span
+    handler_re = re.compile(rf"^{re.escape(child_indent)}{re.escape(handler_key)}:\s*(?:#.*)?$")
+    for idx in range(instance_start, instance_end):
+        if not handler_re.match(lines[idx].rstrip("\n\r")):
+            continue
+        handler_end = instance_end
+        for jdx in range(idx + 1, instance_end):
+            content = lines[jdx].rstrip("\n\r")
+            if not content:
+                continue
+            leading = len(content) - len(content.lstrip(" "))
+            if leading <= len(child_indent):
+                handler_end = jdx
+                break
+        new_lines = [*lines[:idx], *lines[handler_end:]]
+        return "".join(new_lines), idx + 1, handler_end
+    return None
+
+
+def _locate_component_instance(
+    lines: list[str],
+    domain: str,
+    component_id: str,
+) -> tuple[int, int, str] | None:
+    """
+    Find the line range of a specific ``- id: <component_id>`` block.
+
+    Returns ``(start_idx, end_idx, child_indent)`` — dash-line
+    index, one-past-last-line index, and the leading whitespace of
+    the instance's child fields.
+    """
+    header_re = re.compile(rf"^{re.escape(domain)}:\s*(?:#.*)?$")
+    domain_start: int | None = None
+    for idx, line in enumerate(lines):
+        if header_re.match(line.rstrip("\n\r")):
+            domain_start = idx
+            break
+    if domain_start is None:
+        return None
+    domain_end = len(lines)
+    for idx in range(domain_start + 1, len(lines)):
+        stripped = lines[idx].rstrip("\n\r")
+        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
+            domain_end = idx
+            break
+
+    # Walk the domain body looking for a list item whose first child
+    # line carries ``id: <component_id>``. Only column-2 dashes count
+    # as instance starts — deeper dashes are inner action lists.
+    item_indent: str | None = None
+    item_starts: list[int] = []
+    for idx in range(domain_start + 1, domain_end):
+        raw = lines[idx].rstrip("\n\r")
+        stripped = raw.lstrip(" ")
+        if not stripped.startswith("- "):
+            continue
+        prefix = raw[: len(raw) - len(stripped)]
+        if item_indent is None:
+            item_indent = prefix
+        if prefix != item_indent:
+            # Inner action list — deeper indent than the canonical
+            # list-of-instances. Skip.
+            continue
+        item_starts.append(idx)
+
+    for run, start in enumerate(item_starts):
+        end = item_starts[run + 1] if run + 1 < len(item_starts) else domain_end
+        dash_indent = lines[start][: len(lines[start]) - len(lines[start].lstrip(" "))]
+        child_indent = dash_indent + ESPHOME_YAML_INDENT
+        if _instance_id_matches(lines, start, end, child_indent, component_id):
+            return start, end, child_indent
+    return None
+
+
+def _instance_id_matches(
+    lines: list[str],
+    start: int,
+    end: int,
+    child_indent: str,
+    component_id: str,
+) -> bool:
+    """
+    Return True iff the instance at *start* carries ``id: component_id``.
+
+    Two shapes the schema permits: ``- id: <comp_id>`` on the dash
+    line itself, or ``id:`` as a regular child field at
+    ``child_indent`` on a later line.
+    """
+    first_line = lines[start].rstrip("\n\r")
+    inline_match = re.match(r"^\s*-\s*id:\s*(?P<id>\S+)", first_line)
+    if inline_match:
+        return inline_match.group("id") == component_id
+    child_re = re.compile(rf"^{re.escape(child_indent)}id:\s*(?P<id>\S+)")
+    for jdx in range(start, end):
+        m = child_re.match(lines[jdx].rstrip("\n\r"))
+        if m:
+            return m.group("id") == component_id
+    return False
+
+
+def _indent_block(block_text: str, indent: str) -> list[str]:
+    """Return *block_text* with every non-empty line prefixed by *indent*."""
+    out: list[str] = []
+    for line in block_text.splitlines():
+        if not line:
+            out.append("")
+            continue
+        out.append(indent + line)
+    return out


### PR DESCRIPTION
# What does this implement/fix?

Final PR in the `helpers/yaml/` split arc.

Moves `upsert_inline_handler`, `remove_inline_handler`, and their helpers (`_locate_component_instance`, `_instance_id_matches`, `_indent_block`) out of `helpers/yaml/__init__.py` into a dedicated `helpers/yaml/inline.py` submodule. `__init__.py` re-exports the public callables (and `_indent_block`, which `tests/test_automations_branches.py` imports directly) via the PEP 484 redundant-alias form so existing `from .helpers.yaml import upsert_inline_handler` callers keep working unchanged.

Byte-for-byte structural move — no behaviour change. After this PR the `helpers/yaml/` arc is complete; every submodule sits well under the 800-line soft cap:

| File | Lines |
|---|---|
| `__init__.py` | 57 (libyaml loader pick + re-export shell) |
| `api_encryption.py` | 48 |
| `component.py` | 299 |
| `inline.py` | 210 |
| `scalar.py` | 312 |
| `substitution.py` | 83 |
| `top_block.py` | 136 |

**Related issue or feature (if applicable):**

- fixes none (planned split arc — see the helpers/yaml split plan)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
