### PR TITLE
Render list-of-scalars as YAML flow style in _emit_field

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -246,6 +246,26 @@ def _format_yaml_value(value: Any) -> str:
     return str(value)
 
 
+def _format_flow_yaml_value(value: Any) -> str:
+    """
+    Format *value* for emission inside a YAML flow sequence ``[...]``.
+
+    Flow context makes ``,`` and ``[ ] { }`` syntactically significant —
+    a plain string like ``"a,b"`` parses as two flow items. Quote
+    strings carrying any of those characters so the sequence round
+    trips as a single element. Bools / numbers and strings already
+    quoted by :func:`_format_yaml_value` pass through unchanged.
+    """
+    formatted = _format_yaml_value(value)
+    if (
+        isinstance(value, str)
+        and not formatted.startswith('"')
+        and any(c in value for c in ",[]{}")
+    ):
+        return f'"{value}"'
+    return formatted
+
+
 def _emit_field(key: str, value: Any, indent: str) -> list[str]:
     """
     Emit a single ``key: value`` pair as one or more YAML lines.
@@ -274,7 +294,7 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
                 first = False
         return lines
     if isinstance(value, list):
-        rendered = ", ".join(_format_yaml_value(item) for item in value)
+        rendered = ", ".join(_format_flow_yaml_value(item) for item in value)
         return [f"{indent}{key}: [{rendered}]"]
     return [f"{indent}{key}: {_format_yaml_value(value)}"]
 

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -273,6 +273,9 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
                 lines.append(f"{prefix}{sub_key}: {_format_yaml_value(sub_value)}")
                 first = False
         return lines
+    if isinstance(value, list):
+        rendered = ", ".join(_format_yaml_value(item) for item in value)
+        return [f"{indent}{key}: [{rendered}]"]
     return [f"{indent}{key}: {_format_yaml_value(value)}"]
 
 

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1143,6 +1143,20 @@ def test_generate_component_yaml_emits_list_of_ints_as_flow_style() -> None:
     assert "  ids: [1, 2, 3]" in out
 
 
+def test_generate_component_yaml_quotes_flow_string_with_flow_indicator() -> None:
+    """
+    Strings carrying ``,`` / ``[`` / ``]`` / ``{`` / ``}`` get quoted inside a flow list.
+
+    In flow context those characters are syntactically significant —
+    an unquoted ``a,b`` would round-trip as two items rather than one
+    string. Pin the quoting so a list whose element contains a comma
+    stays one element on parse.
+    """
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"items": ["a,b", "c"]})
+    assert '  items: ["a,b", c]' in out
+
+
 # ---------------------------------------------------------------------------
 # _splice_into_domain_block — defensive guards
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1116,6 +1116,33 @@ def test_generate_component_yaml_emits_list_of_dicts_as_block_sequence() -> None
     assert "      b: y" in out
 
 
+def test_generate_component_yaml_emits_list_of_strings_as_flow_style() -> None:
+    """A list of strings renders as ``[a, b]`` flow-style, not Python repr."""
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"modes": ["heat", "cool"]})
+    assert "  modes: [heat, cool]" in out
+
+
+def test_generate_component_yaml_emits_list_of_booleans_lowercased() -> None:
+    """
+    A list of booleans renders as ``[true, false]``.
+
+    Python ``True`` / ``False`` would be invalid YAML; the flow-style
+    branch routes each element through ``_format_yaml_value`` so the
+    bool→``true`` / ``false`` lowering applies inside the brackets too.
+    """
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"levels": [True, False]})
+    assert "  levels: [true, false]" in out
+
+
+def test_generate_component_yaml_emits_list_of_ints_as_flow_style() -> None:
+    """A list of ints renders as ``[1, 2, 3]`` flow-style."""
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"ids": [1, 2, 3]})
+    assert "  ids: [1, 2, 3]" in out
+
+
 # ---------------------------------------------------------------------------
 # _splice_into_domain_block — defensive guards
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

`_emit_field` only special-cased list-of-dicts; lists of scalars fell through to `_format_yaml_value(value)`, which delegates to `str(value)` for non-bool / non-str types and emits Python's `list.__repr__`. The load-bearing failure is `[True, False]` → `[True, False]` (Python booleans, invalid YAML); `["heat", "cool"]` rendered as single-quoted Python-repr (parses but not flow style); `[1, 2, 3]` was accidentally valid.

The docstring already claimed flow-style; the implementation never matched it. Pre-existing — confirmed via `git log -p` to predate both the helpers/yaml split arc (#796) and the `component.py` extraction (#813) that carried this code byte-for-byte. Copilot flagged the mismatch during #813's structural-move review and the fix was deferred to this follow-up per the project's strict split-then-clean cadence.

**Fix.** Add a list branch right after the list-of-dicts branch that routes each element through `_format_yaml_value` and joins with `, ` inside brackets:

```python
if isinstance(value, list):
    rendered = ", ".join(_format_yaml_value(item) for item in value)
    return [f"{indent}{key}: [{rendered}]"]
```

Bool→`true`/`false` lowering, string-keyword quoting, and numeric `str()` pass-through all apply consistently to scalar-list elements now.

**Tests.** Three pinning tests added to `tests/test_yaml_helpers.py` in the existing `_emit_field` branches section, driven end-to-end through `generate_component_yaml` to mirror the file's existing pattern (the section header at line 1056 explicitly anchors on the public function rather than the private helper):

- `["heat", "cool"]` → `modes: [heat, cool]`
- `[True, False]` → `levels: [true, false]`
- `[1, 2, 3]` → `ids: [1, 2, 3]`

**Related issue or feature (if applicable):**

- fixes #814

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
