### PR TITLE
Preserve tab indent in upsert_yaml_leaf_under_top_block

### DIFF
--- a/esphome_device_builder/helpers/yaml/top_block.py
+++ b/esphome_device_builder/helpers/yaml/top_block.py
@@ -62,7 +62,11 @@ def _locate_top_block(lines: list[str], block_key: str) -> tuple[int, int, str] 
         if stripped.lstrip().startswith("#"):
             continue
         if not indent_captured:
-            indent = " " * (len(stripped) - len(stripped.lstrip(" ")))
+            # Capture the literal leading-whitespace prefix (spaces, tabs, or
+            # a mix) rather than rebuilding a spaces-only string of the same
+            # column width — a tab-indented block needs the insert to land
+            # at the same tab depth or it lands at column 0.
+            indent = stripped[: len(stripped) - len(stripped.lstrip())]
             indent_captured = True
     if start is None:
         return None

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -219,6 +219,20 @@ def test_upsert_yaml_leaf_matches_existing_child_indent() -> None:
     assert "    friendly_name: Reading Lamp\n" in out
 
 
+def test_upsert_yaml_leaf_preserves_tab_indent() -> None:
+    """
+    Tab-indented children get a tab-indented insert, not column 0.
+
+    PyYAML (and ESPHome's own loader) accept tab-indented YAML, so
+    we need to round-trip it; a spaces-only indent-capture step
+    collapsed the prefix to ``""`` and emitted the new leaf at
+    column 0, producing a sibling top-level key outside the block.
+    """
+    before = "esphome:\n\tname: kitchen\n"
+    after = upsert_yaml_leaf_under_top_block(before, "esphome", "friendly_name", "Kitchen")
+    assert after == "esphome:\n\tname: kitchen\n\tfriendly_name: Kitchen\n"
+
+
 def test_upsert_yaml_leaf_prepends_new_block_when_missing() -> None:
     """No ``esphome:`` block at all — prepend a fresh one with the leaf.
 


### PR DESCRIPTION
# What does this implement/fix?

`_locate_top_block`'s exit condition uses `isspace()` (which accepts tabs), so tab-indented lines were correctly treated as block-internal. But the indent-capture step used `lstrip(" ")` (spaces only):

```python
indent = " " * (len(stripped) - len(stripped.lstrip(" ")))
```

For a tab-prefixed child line, `stripped.lstrip(" ")` returns the original string (no leading spaces to strip), the difference is `0`, and `indent` becomes `""`. `upsert_yaml_leaf_under_top_block` then emitted the new leaf at column 0 — outside the block, as a sibling top-level key:

```python
before = "esphome:\n\tname: kitchen\n"
upsert_yaml_leaf_under_top_block(before, "esphome", "friendly_name", "Kitchen")
# "esphome:\n\tname: kitchen\nfriendly_name: Kitchen\n"
#                             ^ column 0 — wrong block, malformed
```

Pre-existing — confirmed via `git log -p` to predate both the helpers/yaml split arc and the `top_block.py` extraction (#806) that carried this code byte-for-byte. Copilot flagged the mismatch during #806's structural-move review and the fix was deferred to this follow-up per the project's strict split-then-clean cadence.

**Fix.** Slice the literal leading-whitespace prefix via `lstrip()` (no argument) so the capture picks up the full run regardless of whether the existing child uses spaces, tabs, or a mix:

```python
indent = stripped[: len(stripped) - len(stripped.lstrip())]
```

PyYAML and ESPHome's own loader both accept tab-indented YAML, so round-tripping the user's indent choice (option A from the issue) is the right behaviour. The wizard / `dashboard_import` paths still emit space-indented YAML, so existing space-indent behaviour is unchanged.

**Test.** One pinning test added to `tests/test_yaml_helpers.py` alongside the existing `test_upsert_yaml_leaf_matches_existing_child_indent` test (same family — "matches existing indent style"):

- `"esphome:\n\tname: kitchen\n"` + `friendly_name: Kitchen` → `"esphome:\n\tname: kitchen\n\tfriendly_name: Kitchen\n"`

**Related issue or feature (if applicable):**

- fixes #812

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
